### PR TITLE
fix(customer): avoid force-unwrap on location confirm (#191)

### DIFF
--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -348,9 +348,13 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                     onPressed: _selectedPoint == null || _selectedAddress == null
                         ? null
                         : () {
-                            Navigator.of(context).pop(
-                              LocationPickResult(address: _selectedAddress!, point: _selectedPoint!),
-                            );
+                            final point = _selectedPoint;
+                            final addr = _selectedAddress;
+                            if (point != null && addr != null) {
+                              Navigator.of(context).pop(
+                                LocationPickResult(address: addr, point: point),
+                              );
+                            }
                           },
                   ),
                 ],


### PR DESCRIPTION
## Summary
Fixes #191 by removing force-unwrap on `_selectedAddress` and `_selectedPoint` in the Confirm Location callback.

## Test plan
- [ ] Open location picker, pick a place on map or search
- [ ] Tap Confirm Location and verify it returns the address