### PR TITLE
Update app logo branding to Truxify #167

### DIFF
--- a/apps/customer/lib/widgets/app_logo.dart
+++ b/apps/customer/lib/widgets/app_logo.dart
@@ -25,7 +25,7 @@ class AppLogo extends StatelessWidget {
         ),
         const SizedBox(width: 10),
         Text(
-          'FreightFair',
+          'Truxify',
           style: textStyle ?? const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
         ),
       ],


### PR DESCRIPTION
Hello @KanishJebaMathewM , I’ve updated the app logo branding to use Truxify instead of FreightFair while keeping the existing UI and styling intact.

Could you please add the appropriate GSSOC labels to this PR as well so it can be tracked correctly? Thank you.
in all of your issues teh gssoc labels are missing !!!

