### PR TITLE
[NSOC'26][GSSOC'26] Fix(customer): brand name mismatch in mock data and About screen [#143]

### DIFF
--- a/apps/customer/lib/data/mock_data.dart
+++ b/apps/customer/lib/data/mock_data.dart
@@ -207,6 +207,6 @@ const mockProfileMenu = <ProfileMenuData>[
   ProfileMenuData(icon: Icons.description_rounded, title: 'My Documents'),
   ProfileMenuData(icon: Icons.language_rounded, title: 'Language', subtitle: 'English / हिंदी / தமிழ்'),
   ProfileMenuData(icon: Icons.help_outline_rounded, title: 'Help & Support'),
-  ProfileMenuData(icon: Icons.info_outline_rounded, title: 'About FreightFair'),
+  ProfileMenuData(icon: Icons.info_outline_rounded, title: 'About Truxify'),
   ProfileMenuData(icon: Icons.logout_rounded, title: 'Logout', isDanger: true),
 ];

--- a/apps/customer/lib/screens/about_screen.dart
+++ b/apps/customer/lib/screens/about_screen.dart
@@ -9,7 +9,7 @@ class AboutScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('About Truckify'),
+        title: const Text('About Truxify'),
         centerTitle: true,
         elevation: 0,
       ),
@@ -38,7 +38,7 @@ class AboutScreen extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'Truckify',
+                    'Truxify',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.w700,
                           color: FreightFairColors.accent,
@@ -73,7 +73,7 @@ class AboutScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Truckify is a modern freight management platform connecting shippers with verified truck owners. We simplify logistics with real-time tracking, transparent pricing, and reliable service.',
+                    'Truxify is a modern freight management platform connecting shippers with verified truck owners. We simplify logistics with real-time tracking, transparent pricing, and reliable service.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: FreightFairColors.adaptiveSecondaryText(context),
                           height: 1.6,
@@ -121,7 +121,7 @@ class AboutScreen extends StatelessWidget {
             _ContactRow(
               icon: Icons.email_rounded,
               label: 'Email',
-              value: 'support@truckify.com',
+              value: 'support@truxify.com',
             ),
             const SizedBox(height: 12),
             _ContactRow(
@@ -133,7 +133,7 @@ class AboutScreen extends StatelessWidget {
             _ContactRow(
               icon: Icons.public_rounded,
               label: 'Website',
-              value: 'www.truckify.com',
+              value: 'www.truxify.com',
             ),
             const SizedBox(height: 24),
             Row(
@@ -149,7 +149,7 @@ class AboutScreen extends StatelessWidget {
             const SizedBox(height: 24),
             Center(
               child: Text(
-                '© 2024 Truckify. All rights reserved.',
+                '© 2024 Truxify. All rights reserved.',
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
                       color: FreightFairColors.adaptiveSecondaryText(context),
                     ),

--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -156,7 +156,7 @@ class ProfileScreen extends StatelessWidget {
                   ),
                   _MenuItem(
                     icon: Icons.info_outline_rounded,
-                    label: 'About FreightFair',
+                    label: 'About Truxify',
                     showDivider: false,
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const AboutScreen())),
                   ),


### PR DESCRIPTION
## Summary
Fixes the brand name inconsistency reported in issue #143.

## Changes
- `mock_data.dart`: `'About FreightFair'` → `'About Truxify'` in `mockProfileMenu`
- `profile_screen.dart`: `'About FreightFair'` → `'About Truxify'` in hardcoded UI menu item
- `about_screen.dart`: All `'Truckify'` occurrences (typo) replaced with `'Truxify'`
  — covers AppBar title, app name heading, About Us body, email, website, and copyright footer

## Test
- `flutter test` — ✅ All tests passed
- `flutter analyze` — ✅ No new issues introduced

Closes #143
