### PR TITLE
fix: improve sort chip visibility

### DIFF
--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -49,8 +49,9 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
                           ? Colors.white
                           : Theme.of(context).brightness == Brightness.dark
                               ? Colors.white70
-                              : FreightFairColors.primaryText,
+                              : Colors.black87,
                       fontWeight: FontWeight.w600,
+                      fontSize: 15,
                     ),
                   ),
                   selected: selected,
@@ -58,18 +59,23 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
                   selectedColor: FreightFairColors.accent,
                   backgroundColor:
                       Theme.of(context).brightness == Brightness.dark
-                          ? const Color(0xFF2A2A2A)
+                          ? FreightFairColors.darkBackground
                           : Colors.white,
                   side: BorderSide(
                     color: selected
                         ? FreightFairColors.accent
-                        : FreightFairColors.border,
+                        : Colors.grey.shade300,
+                    width: 1.2,
                   ),
                   shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(16),
                   ),
-                  showCheckmark: false,
-                  padding: const EdgeInsets.symmetric(horizontal: 14),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  showCheckmark: true,
+                  checkmarkColor: Colors.white,
                 );
               },
             ),

--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:freightfair/theme/app_theme.dart';
 
 import '../data/mock_data.dart';
 import '../models/app_models.dart';
@@ -22,8 +23,12 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('12 trucks found'),
-        leading: IconButton(onPressed: () => Navigator.of(context).pop(), icon: const Icon(Icons.arrow_back_rounded)),
-        actions: [IconButton(onPressed: () {}, icon: const Icon(Icons.sort_rounded))],
+        leading: IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: const Icon(Icons.arrow_back_rounded)),
+        actions: [
+          IconButton(onPressed: () {}, icon: const Icon(Icons.sort_rounded))
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
@@ -37,9 +42,34 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
               itemBuilder: (context, index) {
                 final selected = index == _selectedSort;
                 return ChoiceChip(
-                  label: Text(_sortChips[index]),
+                  label: Text(
+                    _sortChips[index],
+                    style: TextStyle(
+                      color: selected
+                          ? Colors.white
+                          : Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white70
+                              : FreightFairColors.primaryText,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                   selected: selected,
                   onSelected: (_) => setState(() => _selectedSort = index),
+                  selectedColor: FreightFairColors.accent,
+                  backgroundColor:
+                      Theme.of(context).brightness == Brightness.dark
+                          ? const Color(0xFF2A2A2A)
+                          : Colors.white,
+                  side: BorderSide(
+                    color: selected
+                        ? FreightFairColors.accent
+                        : FreightFairColors.border,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  showCheckmark: false,
+                  padding: const EdgeInsets.symmetric(horizontal: 14),
                 );
               },
             ),
@@ -64,4 +94,3 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
     );
   }
 }
-


### PR DESCRIPTION
## Description

Improved the visibility and contrast of sorting/filter chips in the Truck Results screen to enhance readability and maintain better consistency with the overall app theme.

### Changes made

* Improved inactive chip text visibility
* Enhanced contrast between selected and unselected chip states
* Updated chip styling for better readability and accessibility
* Preserved existing responsiveness and layout behavior
* Maintained consistency with the current UI design system

### Benefits

* Better readability and accessibility
* Improved visual hierarchy for sorting controls
* Cleaner and more polished UI experience

Closes #231

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-28 at 22 33 13" src="https://github.com/user-attachments/assets/7c375349-7ccd-450f-9192-f1438539cbec" />
