### PR TITLE
Add current location support in location picker

### DIFF
--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -301,28 +301,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
             ),
           ),
 
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: TextButton.icon(
-                onPressed:
-                    _isFetchingCurrentLocation ? null : _useCurrentLocation,
-                icon: _isFetchingCurrentLocation
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.my_location_rounded),
-                label: Text(
-                  _isFetchingCurrentLocation
-                      ? 'Fetching location...'
-                      : 'Use Current Location',
-                ),
-              ),
-            ),
-          ),
+
           if (_suggestions.isNotEmpty)
             Container(
               margin: const EdgeInsets.symmetric(horizontal: 16),
@@ -357,7 +336,9 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(16),
-                child: FlutterMap(
+                child: Stack(
+                  children:[
+                FlutterMap(
                   mapController: _mapController,
                   options: MapOptions(
                     initialCenter: center,
@@ -385,9 +366,34 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                       ),
                   ],
                 ),
+                 Positioned(
+                      right: 16,
+                      bottom: 16,
+                      child: FloatingActionButton(
+                        mini: true,
+                        backgroundColor:
+                            Theme.of(context).colorScheme.surface,
+                        foregroundColor: FreightFairColors.accentDark,
+                        onPressed: _isFetchingCurrentLocation
+                            ? null
+                            : _useCurrentLocation,
+                        child: _isFetchingCurrentLocation
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.my_location_rounded),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
+          
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
             child: InfoCard(

--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
+import 'package:geolocator/geolocator.dart';
 
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
@@ -45,6 +46,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   bool _isResolvingAddress = false;
   LatLng? _selectedPoint;
   String? _selectedAddress;
+  bool _isFetchingCurrentLocation = false;
 
   @override
   void initState() {
@@ -222,6 +224,53 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     _searchController.text = address;
   }
 
+  Future<void> _useCurrentLocation() async {
+  setState(() {
+    _isFetchingCurrentLocation = true;
+  });
+
+  try {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+
+    if (!serviceEnabled) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enable location service')),
+      );
+      return;
+    }
+
+    LocationPermission permission = await Geolocator.checkPermission();
+
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Location permission denied')),
+      );
+      return;
+    }
+
+    final position = await Geolocator.getCurrentPosition();
+
+    final point = LatLng(position.latitude, position.longitude);
+
+    await _setLocation(point);
+  } catch (_) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Unable to fetch current location')),
+    );
+  } finally {
+    if (mounted) {
+      setState(() {
+        _isFetchingCurrentLocation = false;
+      });
+    }
+  }
+}
+
   @override
   Widget build(BuildContext context) {
     final center = _selectedPoint ?? _defaultCenter;
@@ -248,6 +297,29 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                         ),
                       )
                     : null,
+              ),
+            ),
+          ),
+
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed:
+                    _isFetchingCurrentLocation ? null : _useCurrentLocation,
+                icon: _isFetchingCurrentLocation
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.my_location_rounded),
+                label: Text(
+                  _isFetchingCurrentLocation
+                      ? 'Fetching location...'
+                      : 'Use Current Location',
+                ),
               ),
             ),
           ),

--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -233,6 +233,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     final serviceEnabled = await Geolocator.isLocationServiceEnabled();
 
     if (!serviceEnabled) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Please enable location service')),
       );
@@ -247,6 +248,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
 
     if (permission == LocationPermission.denied ||
         permission == LocationPermission.deniedForever) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Location permission denied')),
       );
@@ -259,6 +261,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
 
     await _setLocation(point);
   } catch (_) {
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Unable to fetch current location')),
     );

--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   intl: ^0.20.2
   latlong2: ^0.9.1
   http: ^1.2.2
+  geocoding: ^4.0.0
+  geolocator: ^10.1.1
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
## Summary

Adds current/live location support in the location picker screen.

Users can now quickly use their current GPS location instead of manually searching or selecting a location from the map.

Fixes #229

## Changes Made

* Added `geolocator` dependency
* Added “Use Current Location” button in `LocationPickerScreen`
* Implemented location permission handling
* Fetches user's current GPS coordinates
* Automatically updates selected location on the map
* Added loading and error states for better UX

## Files Changed

* `apps/customer/lib/screens/location_picker_screen.dart`
* `apps/customer/pubspec.yaml`

## Android Permission Notes

For full Android device support, add the following permissions inside `AndroidManifest.xml` under the `<manifest>` tag:

```xml
<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
```

## Testing

* Verified current location button flow
* Verified permission handling
* Verified map updates to fetched location
* Verified selected address updates correctly

## Video

https://github.com/user-attachments/assets/0eff54bd-e6a0-49b5-98b3-a0fde3fb3a46


