### PR TITLE
Fix/login phone validation

### DIFF
--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -15,8 +15,11 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  final TextEditingController _phoneController = TextEditingController(text: mockPhoneNumber.replaceFirst('+91 ', ''));
-  final List<TextEditingController> _otpControllers = List.generate(4, (_) => TextEditingController());
+  final TextEditingController _phoneController = TextEditingController(
+    text: mockPhoneNumber.replaceFirst('+91 ', '').replaceAll(' ', ''),
+  );
+  final List<TextEditingController> _otpControllers =
+      List.generate(4, (_) => TextEditingController());
   final List<FocusNode> _otpFocusNodes = List.generate(4, (_) => FocusNode());
   bool _showOtp = false;
 
@@ -36,26 +39,38 @@ class _LoginScreenState extends State<LoginScreen> {
     FocusScope.of(context).unfocus();
     final phone = _phoneController.text.replaceAll(' ', '').trim();
 
-  if (phone.isEmpty) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Please enter phone number')),
-    );
-    return;
-  }
+    if (phone.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter phone number')),
+      );
+      return;
+    }
 
-  if (phone.length != 10 || int.tryParse(phone) == null) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Enter a valid 10-digit phone number')),
-    );
-    return;
-  }
+    if (phone.length != 10) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Phone number must be exactly 10 digits'),
+        ),
+      );
+      return;
+    }
+
+    if (int.tryParse(phone) == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Phone number can only contain digits'),
+        ),
+      );
+      return;
+    }
     setState(() => _showOtp = true);
   }
 
   void _verifyOtp() {
     final otp = _otpControllers.map((controller) => controller.text).join();
     if (otp == mockOtp) {
-      Navigator.of(context).pushReplacement(AppPageRoute(builder: (_) => const FreightFairShellScreen()));
+      Navigator.of(context).pushReplacement(
+          AppPageRoute(builder: (_) => const FreightFairShellScreen()));
       return;
     }
 
@@ -77,16 +92,23 @@ class _LoginScreenState extends State<LoginScreen> {
               const SizedBox(height: 12),
               const AppLogo(iconSize: 24),
               const SizedBox(height: 28),
-              Text('Welcome back', style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800)),
+              Text('Welcome back',
+                  style: Theme.of(context)
+                      .textTheme
+                      .headlineSmall
+                      ?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 6),
               Text(
                 'Sign in to manage your freight bookings offline with mock data.',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: FreightFairColors.adaptiveSecondaryText(context)),
               ),
               const SizedBox(height: 28),
               AnimatedSwitcher(
                 duration: const Duration(milliseconds: 240),
-                child: _showOtp ? _buildOtpForm(context) : _buildPhoneForm(context),
+                child: _showOtp
+                    ? _buildOtpForm(context)
+                    : _buildPhoneForm(context),
               ),
             ],
           ),
@@ -100,7 +122,11 @@ class _LoginScreenState extends State<LoginScreen> {
       key: const ValueKey('phone'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Phone number', style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800)),
+        Text('Phone number',
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall
+                ?.copyWith(fontWeight: FontWeight.w800)),
         const SizedBox(height: 12),
         TextField(
           controller: _phoneController,
@@ -108,16 +134,18 @@ class _LoginScreenState extends State<LoginScreen> {
           keyboardType: TextInputType.phone,
           inputFormatters: [
             FilteringTextInputFormatter.digitsOnly,
-     ],
+          ],
           decoration: InputDecoration(
             prefixIcon: Container(
               alignment: Alignment.center,
               width: 70,
               margin: const EdgeInsets.only(right: 8),
               decoration: const BoxDecoration(
-                border: Border(right: BorderSide(color: FreightFairColors.border)),
+                border:
+                    Border(right: BorderSide(color: FreightFairColors.border)),
               ),
-              child: const Text('+91', style: TextStyle(fontWeight: FontWeight.w700)),
+              child: const Text('+91',
+                  style: TextStyle(fontWeight: FontWeight.w700)),
             ),
             hintText: '9876543210',
           ),
@@ -128,12 +156,14 @@ class _LoginScreenState extends State<LoginScreen> {
         InfoCard(
           child: Row(
             children: [
-              const Icon(Icons.lock_rounded, color: FreightFairColors.accentDark),
+              const Icon(Icons.lock_rounded,
+                  color: FreightFairColors.accentDark),
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
                   'Mock verification is enabled. Use 1234 on the next screen.',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: FreightFairColors.adaptiveSecondaryText(context)),
                 ),
               ),
             ],
@@ -148,7 +178,11 @@ class _LoginScreenState extends State<LoginScreen> {
       key: const ValueKey('otp'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Enter OTP', style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800)),
+        Text('Enter OTP',
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall
+                ?.copyWith(fontWeight: FontWeight.w800)),
         const SizedBox(height: 12),
         Row(
           children: List.generate(4, (index) {
@@ -161,7 +195,10 @@ class _LoginScreenState extends State<LoginScreen> {
                   keyboardType: TextInputType.number,
                   textAlign: TextAlign.center,
                   maxLength: 1,
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleLarge
+                      ?.copyWith(fontWeight: FontWeight.w800),
                   decoration: const InputDecoration(counterText: ''),
                   onChanged: (value) {
                     if (value.isNotEmpty && index < 3) {

--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter/services.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_logo.dart';
@@ -34,6 +34,21 @@ class _LoginScreenState extends State<LoginScreen> {
 
   void _sendOtp() {
     FocusScope.of(context).unfocus();
+    final phone = _phoneController.text.replaceAll(' ', '').trim();
+
+  if (phone.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Please enter phone number')),
+    );
+    return;
+  }
+
+  if (phone.length != 10 || int.tryParse(phone) == null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Enter a valid 10-digit phone number')),
+    );
+    return;
+  }
     setState(() => _showOtp = true);
   }
 
@@ -89,7 +104,11 @@ class _LoginScreenState extends State<LoginScreen> {
         const SizedBox(height: 12),
         TextField(
           controller: _phoneController,
+          maxLength: 10,
           keyboardType: TextInputType.phone,
+          inputFormatters: [
+            FilteringTextInputFormatter.digitsOnly,
+     ],
           decoration: InputDecoration(
             prefixIcon: Container(
               alignment: Alignment.center,
@@ -100,7 +119,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
               child: const Text('+91', style: TextStyle(fontWeight: FontWeight.w700)),
             ),
-            hintText: '98765 43210',
+            hintText: '9876543210',
           ),
         ),
         const SizedBox(height: 18),

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -14,7 +14,8 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  final TextEditingController _phoneController = TextEditingController(text: '9876543210');
+  final TextEditingController _phoneController =
+      TextEditingController(text: '9876543210');
   bool _loading = false;
 
   @override
@@ -26,19 +27,19 @@ class _LoginScreenState extends State<LoginScreen> {
   void _sendOtp() async {
     final phone = _phoneController.text.replaceAll(' ', '').trim();
 
-  if (phone.isEmpty) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Please enter phone number')),
-    );
-    return;
-  }
+    if (phone.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter phone number')),
+      );
+      return;
+    }
 
-  if (phone.length != 10 || int.tryParse(phone) == null) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Enter a valid 10-digit phone number')),
-    );
-    return;
-  }
+    if (phone.length != 10 || int.tryParse(phone) == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Enter a valid 10-digit phone number')),
+      );
+      return;
+    }
 
     setState(() => _loading = true);
     await Future<void>.delayed(const Duration(milliseconds: 400));
@@ -46,7 +47,7 @@ class _LoginScreenState extends State<LoginScreen> {
       return;
     }
     setState(() => _loading = false);
-    Navigator.of(context).pushNamed(AppRoutes.otp,  arguments: phone);
+    Navigator.of(context).pushNamed(AppRoutes.otp, arguments: phone);
   }
 
   @override
@@ -66,11 +67,15 @@ class _LoginScreenState extends State<LoginScreen> {
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
               const SizedBox(height: 8),
-              Text(loginSubtitle, style: Theme.of(context).textTheme.bodyMedium),
+              Text(loginSubtitle,
+                  style: Theme.of(context).textTheme.bodyMedium),
               const SizedBox(height: 28),
               Text(
                 'Phone Number',
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(color: TruxifyColors.secondaryText),
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge
+                    ?.copyWith(color: TruxifyColors.secondaryText),
               ),
               const SizedBox(height: 10),
               TextField(
@@ -95,12 +100,16 @@ class _LoginScreenState extends State<LoginScreen> {
                 padding: const EdgeInsets.all(18),
                 child: Row(
                   children: [
-                    const Icon(Icons.shield_outlined, color: TruxifyColors.accent),
+                    const Icon(Icons.shield_outlined,
+                        color: TruxifyColors.accent),
                     const SizedBox(width: 12),
                     Expanded(
                       child: Text(
                         'Mock login is enabled for the offline driver demo. OTP 1234 always works.',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.primaryText),
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(color: TruxifyColors.primaryText),
                       ),
                     ),
                   ],

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter/services.dart';
 import '../core/app_routes.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
@@ -14,7 +14,7 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  final TextEditingController _phoneController = TextEditingController(text: '98765 43210');
+  final TextEditingController _phoneController = TextEditingController(text: '9876543210');
   bool _loading = false;
 
   @override
@@ -24,13 +24,29 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   void _sendOtp() async {
+    final phone = _phoneController.text.replaceAll(' ', '').trim();
+
+  if (phone.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Please enter phone number')),
+    );
+    return;
+  }
+
+  if (phone.length != 10 || int.tryParse(phone) == null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Enter a valid 10-digit phone number')),
+    );
+    return;
+  }
+
     setState(() => _loading = true);
     await Future<void>.delayed(const Duration(milliseconds: 400));
     if (!mounted) {
       return;
     }
     setState(() => _loading = false);
-    Navigator.of(context).pushNamed(AppRoutes.otp, arguments: _phoneController.text.trim());
+    Navigator.of(context).pushNamed(AppRoutes.otp,  arguments: phone);
   }
 
   @override
@@ -59,10 +75,14 @@ class _LoginScreenState extends State<LoginScreen> {
               const SizedBox(height: 10),
               TextField(
                 controller: _phoneController,
+                maxLength: 10,
+                inputFormatters: [
+                  FilteringTextInputFormatter.digitsOnly,
+                ],
                 keyboardType: TextInputType.phone,
                 decoration: const InputDecoration(
                   prefixText: '+91  ',
-                  hintText: '98765 43210',
+                  hintText: '9876543210',
                 ),
               ),
               const SizedBox(height: 20),


### PR DESCRIPTION
## Summary

Adds proper phone number validation on the login screen before navigating to the OTP screen.

Fixes invalid OTP flow when the phone number is empty, incomplete, or contains non-numeric characters.

Fixes #229

## Changes Made

* Added empty phone number validation
* Added 10-digit phone number validation
* Restricted input to digits only
* Added max length restriction for phone number input
* Prevented OTP navigation for invalid input
* Passed cleaned phone number to OTP screen
* Improved overall login form validation UX

## Files Changed

* `apps/customer/lib/screens/login_screen.dart`
* `apps/driver/lib/screens/login_screen.dart`

## Testing

* Verified empty phone number shows error message
* Verified invalid phone number shows error message
* Verified only numeric input is accepted
* Verified valid 10-digit number proceeds to OTP screen
* Verified existing login flow remains unchanged

## Video



https://github.com/user-attachments/assets/81c13fe1-ba27-4136-87f8-8865f9b94ec0




