### PR TITLE
refactor: extract reusable order card widgets

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:freightfair/widgets/order_card.dart';
 
 import '../controllers/app_controller.dart';
 import '../data/mock_data.dart';
-import '../models/app_models.dart';
-import '../theme/app_theme.dart';
 import '../widgets/app_page_route.dart';
-import '../widgets/common_widgets.dart';
 import 'live_tracking_screen.dart';
 import 'order_detail_screen.dart';
 
@@ -77,7 +75,7 @@ class _OrdersScreenState extends State<OrdersScreen> with SingleTickerProviderSt
                   separatorBuilder: (_, __) => const SizedBox(height: 14),
                   itemBuilder: (context, index) {
                     final order = mockActiveOrders[index];
-                    return _ActiveOrderCard(
+                    return ActiveOrderCard(
                       order: order,
                       onTap: () => Navigator.of(context).push(
                         AppPageRoute(builder: (_) => LiveTrackingScreen(orderId: order.orderId)),
@@ -91,7 +89,7 @@ class _OrdersScreenState extends State<OrdersScreen> with SingleTickerProviderSt
                   separatorBuilder: (_, __) => const SizedBox(height: 14),
                   itemBuilder: (context, index) {
                     final order = mockHistoryOrders[index];
-                    return _HistoryOrderCard(
+                    return HistoryOrderCard(
                       order: order,
                       onTap: () => Navigator.of(context).push(
                         AppPageRoute(builder: (_) => OrderDetailScreen(order: order)),
@@ -103,97 +101,6 @@ class _OrdersScreenState extends State<OrdersScreen> with SingleTickerProviderSt
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _ActiveOrderCard extends StatelessWidget {
-  const _ActiveOrderCard({required this.order, required this.onTap});
-
-  final ActiveOrderData order;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: InfoCard(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(order.orderId, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
-                ),
-                StatusBadge(label: order.milestone, color: FreightFairColors.accent, filled: true),
-              ],
-            ),
-            const SizedBox(height: 10),
-            Text(order.route, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
-            const SizedBox(height: 8),
-            Text('Driver: ${order.driver}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700)),
-            const SizedBox(height: 4),
-            Text('ETA: ${order.eta}', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
-            const SizedBox(height: 14),
-            PrimaryButton(label: 'Track Live', onPressed: onTap),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _HistoryOrderCard extends StatelessWidget {
-  const _HistoryOrderCard({required this.order, required this.onTap});
-
-  final HistoryOrderData order;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final statusColor = order.status == 'Delivered' ? FreightFairColors.accentDark : FreightFairColors.error;
-    return GestureDetector(
-      onTap: onTap,
-      child: InfoCard(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(order.route, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
-                ),
-                Text(order.date, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
-              ],
-            ),
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Text(order.amount, style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w800,
-                  color: Theme.of(context).brightness == Brightness.dark
-                      ? FreightFairColors.accent
-                      : FreightFairColors.accentDark,
-                )),
-                const SizedBox(width: 10),
-                StatusBadge(label: order.status == 'Delivered' ? '✅ Delivered' : '❌ Cancelled', color: statusColor, filled: true),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Text('Driver: ${order.driver}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
-            const SizedBox(height: 14),
-            Align(
-              alignment: Alignment.centerRight,
-              child: OutlinedButton(
-                onPressed: onTap,
-                style: OutlinedButton.styleFrom(minimumSize: const Size(0, 42), padding: const EdgeInsets.symmetric(horizontal: 14)),
-                child: const Text('View Details'),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/apps/customer/lib/widgets/order_card.dart
+++ b/apps/customer/lib/widgets/order_card.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+
+import '../models/app_models.dart';
+import '../theme/app_theme.dart';
+import 'common_widgets.dart';
+
+class ActiveOrderCard extends StatelessWidget {
+  const ActiveOrderCard({
+    super.key,
+    required this.order,
+    required this.onTap,
+  });
+
+  final ActiveOrderData order;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: InfoCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    order.orderId,
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w800),
+                  ),
+                ),
+                StatusBadge(
+                  label: order.milestone,
+                  color: FreightFairColors.accent,
+                  filled: true,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              order.route,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color:
+                        FreightFairColors.adaptiveSecondaryText(context),
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Driver: ${order.driver}',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'ETA: ${order.eta}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color:
+                        FreightFairColors.adaptiveSecondaryText(context),
+                  ),
+            ),
+            const SizedBox(height: 14),
+            PrimaryButton(
+              label: 'Track Live',
+              onPressed: onTap,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class HistoryOrderCard extends StatelessWidget {
+  const HistoryOrderCard({
+    super.key,
+    required this.order,
+    required this.onTap,
+  });
+
+  final HistoryOrderData order;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = order.status == 'Delivered'
+        ? FreightFairColors.accentDark
+        : FreightFairColors.error;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: InfoCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    order.route,
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w800),
+                  ),
+                ),
+                Text(
+                  order.date,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(
+                        color: FreightFairColors
+                            .adaptiveSecondaryText(context),
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Text(
+                  order.amount,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(
+                        fontWeight: FontWeight.w800,
+                        color:
+                            Theme.of(context).brightness ==
+                                    Brightness.dark
+                                ? FreightFairColors.accent
+                                : FreightFairColors.accentDark,
+                      ),
+                ),
+                const SizedBox(width: 10),
+                StatusBadge(
+                  label: order.status == 'Delivered'
+                      ? '✅ Delivered'
+                      : '❌ Cancelled',
+                  color: statusColor,
+                  filled: true,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Driver: ${order.driver}',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(
+                    color:
+                        FreightFairColors.adaptiveSecondaryText(context),
+                  ),
+            ),
+            const SizedBox(height: 14),
+            Align(
+              alignment: Alignment.centerRight,
+              child: OutlinedButton(
+                onPressed: onTap,
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size(0, 42),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 14),
+                ),
+                child: const Text('View Details'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Refactored the order-related card components by extracting `ActiveOrderCard` and `HistoryOrderCard` into a shared reusable widget file.

### Changes made

* Extracted `_ActiveOrderCard` into `widgets/order_card.dart`
* Extracted `_HistoryOrderCard` into `widgets/order_card.dart`
* Renamed widgets to `ActiveOrderCard` and `HistoryOrderCard`
* Updated `OrdersScreen` to use the shared reusable widgets
* Preserved existing UI, behavior, and functionality

### Benefits

* Improved widget reusability
* Reduced duplicated UI logic
* Cleaner screen architecture
* Easier maintenance and future feature expansion
* Better separation of UI concerns

Closes #216
