### PR TITLE
refactor(customer): standardize timeline widgets

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -10,6 +10,8 @@ import 'package:latlong2/latlong.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
+import '../widgets/timeline_connector.dart';
+import '../widgets/timeline_milestone.dart';
 
 class LiveTrackingScreen extends StatefulWidget {
   const LiveTrackingScreen({super.key, required this.orderId});
@@ -503,19 +505,19 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                           scrollDirection: Axis.horizontal,
                           child: Row(
                             children: const [
-                              _MilestoneItem(label: 'Order Placed', done: true),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'Truck Assigned', done: true),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'Picked Up', done: true),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'In Transit', done: true, current: true),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'Arriving', done: false),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'Delivered', done: false),
-                              _MilestoneConnector(),
-                              _MilestoneItem(label: 'Payment Released', done: false),
+                              TimelineMilestone(label: 'Order Placed', done: true),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'Truck Assigned', done: true),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'Picked Up', done: true),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'In Transit', done: true, current: true),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'Arriving', done: false),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'Delivered', done: false),
+                              TimelineConnector(),
+                              TimelineMilestone(label: 'Payment Released', done: false),
                             ],
                           ),
                         ),
@@ -544,48 +546,6 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
         ],
       ),
     );
-  }
-}
-
-class _MilestoneItem extends StatelessWidget {
-  const _MilestoneItem({required this.label, required this.done, this.current = false});
-
-  final String label;
-  final bool done;
-  final bool current;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = current ? FreightFairColors.accent : done ? FreightFairColors.accentDark : FreightFairColors.border;
-    return Column(
-      children: [
-        Container(
-          width: 18,
-          height: 18,
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            boxShadow: current
-                ? [BoxShadow(color: FreightFairColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
-                : const [],
-          ),
-        ),
-        const SizedBox(height: 8),
-        SizedBox(
-          width: 70,
-          child: Text(label, textAlign: TextAlign.center, style: Theme.of(context).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.w700, color: color)),
-        ),
-      ],
-    );
-  }
-}
-
-class _MilestoneConnector extends StatelessWidget {
-  const _MilestoneConnector();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(width: 28, height: 2, color: FreightFairColors.border);
   }
 }
 

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -5,6 +5,7 @@ import '../data/mock_data.dart';
 import '../models/app_models.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
+import '../widgets/timeline_row.dart';
 
 class OrderDetailScreen extends StatefulWidget {
   const OrderDetailScreen({super.key, required this.order});
@@ -117,7 +118,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
           ...widget.order.timeline.map(
             (step) => Padding(
               padding: const EdgeInsets.only(bottom: 12),
-              child: _TimelineRow(step: step),
+              child: TimelineRow(step: step),
             ),
           ),
           const SizedBox(height: 4),
@@ -187,47 +188,3 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
   }
 }
 
-class _TimelineRow extends StatelessWidget {
-  const _TimelineRow({required this.step});
-
-  final TimelineStepData step;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Column(
-          children: [
-            Container(
-              width: 14,
-              height: 14,
-              decoration: BoxDecoration(
-                color: step.completed ? FreightFairColors.accentDark : FreightFairColors.border,
-                shape: BoxShape.circle,
-              ),
-            ),
-            Container(width: 2, height: 42, color: FreightFairColors.border),
-          ],
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.only(top: 0),
-            child: InfoCard(
-              padding: const EdgeInsets.all(14),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(step.title, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w800)),
-                  ),
-                  Text(step.timestamp, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}

--- a/apps/customer/lib/widgets/timeline_connector.dart
+++ b/apps/customer/lib/widgets/timeline_connector.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_theme.dart';
+
+class TimelineConnector extends StatelessWidget {
+  const TimelineConnector({
+    super.key,
+    this.color = FreightFairColors.border,
+    this.width = 28,
+    this.height = 2,
+  });
+
+  final Color color;
+  final double width;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(width: width, height: height, color: color);
+  }
+}

--- a/apps/customer/lib/widgets/timeline_milestone.dart
+++ b/apps/customer/lib/widgets/timeline_milestone.dart
@@ -31,7 +31,7 @@ class TimelineMilestone extends StatelessWidget {
             color: color,
             shape: BoxShape.circle,
             boxShadow: current
-                ? [BoxShadow(color: FreightFairColors.accent.withOpacity(0.3), blurRadius: 8, spreadRadius: 1)]
+                ? [BoxShadow(color: FreightFairColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
                 : const [],
           ),
         ),

--- a/apps/customer/lib/widgets/timeline_milestone.dart
+++ b/apps/customer/lib/widgets/timeline_milestone.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_theme.dart';
+
+class TimelineMilestone extends StatelessWidget {
+  const TimelineMilestone({
+    super.key,
+    required this.label,
+    required this.done,
+    this.current = false,
+    this.indicatorSize = 18,
+    this.labelWidth = 70,
+  });
+
+  final String label;
+  final bool done;
+  final bool current;
+  final double indicatorSize;
+  final double labelWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = current ? FreightFairColors.accent : done ? FreightFairColors.accentDark : FreightFairColors.border;
+
+    return Column(
+      children: [
+        Container(
+          width: indicatorSize,
+          height: indicatorSize,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            boxShadow: current
+                ? [BoxShadow(color: FreightFairColors.accent.withOpacity(0.3), blurRadius: 8, spreadRadius: 1)]
+                : const [],
+          ),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: labelWidth,
+          child: Text(
+            label,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.w700, color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/customer/lib/widgets/timeline_row.dart
+++ b/apps/customer/lib/widgets/timeline_row.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../models/app_models.dart';
+import '../theme/app_theme.dart';
+import 'common_widgets.dart';
+import 'timeline_connector.dart';
+
+class TimelineRow extends StatelessWidget {
+  const TimelineRow({
+    super.key,
+    required this.step,
+    this.indicatorSize = 14,
+    this.connectorColor = FreightFairColors.border,
+    this.connectorLength = 42,
+    this.connectorThickness = 2,
+  });
+
+  final TimelineStepData step;
+  final double indicatorSize;
+  final Color connectorColor;
+  final double connectorLength;
+  final double connectorThickness;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = step.completed ? FreightFairColors.accentDark : FreightFairColors.border;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          children: [
+            Container(
+              width: indicatorSize,
+              height: indicatorSize,
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+              ),
+            ),
+            TimelineConnector(
+              color: connectorColor,
+              width: connectorThickness,
+              height: connectorLength,
+            ),
+          ],
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 0),
+            child: InfoCard(
+              padding: const EdgeInsets.all(14),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      step.title,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w800),
+                    ),
+                  ),
+                  Text(
+                    step.timestamp,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: FreightFairColors.adaptiveSecondaryText(context),
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Refactored timeline-related widgets into reusable customer widgets.

### Changes Made

* Extracted `_MilestoneItem` into `TimelineMilestone`
* Extracted `_MilestoneConnector` into `TimelineConnector`
* Extracted `_TimelineRow` into `TimelineRow`
* Moved timeline widgets into `apps/customer/lib/widgets`
* Updated `live_tracking_screen.dart` and `order_detail_screen.dart` to use reusable widgets
* Removed duplicated screen-local implementations

### Benefits

* Cleaner screen implementations
* Better separation of concerns
* Reusable timeline components for future shipment history, trip detail, and order tracking screens
* Improved maintainability and consistency

### Files Added

* `timeline_milestone.dart`
* `timeline_connector.dart`
* `timeline_row.dart`

Closes #215
