### PR TITLE
[NSOC'26][GSSOC'26] Persist language selection state in controller

### DIFF
--- a/apps/customer/lib/controllers/app_controller.dart
+++ b/apps/customer/lib/controllers/app_controller.dart
@@ -7,11 +7,37 @@ class FreightFairController extends ChangeNotifier {
   int ordersTabIndex = 0;
   RouteDraft? pendingRouteDraft;
   bool _isDarkMode = false;
+  String _selectedLanguageCode = 'en';
 
   bool get isDarkMode => _isDarkMode;
+  String get selectedLanguageCode => _selectedLanguageCode;
+
+  String get selectedLanguageName {
+    switch (_selectedLanguageCode) {
+      case 'hi':
+        return 'Hindi';
+      case 'gu':
+        return 'Gujarati';
+      case 'mr':
+        return 'Marathi';
+      case 'ta':
+        return 'Tamil';
+      case 'te':
+        return 'Telugu';
+      case 'en':
+      default:
+        return 'English';
+    }
+  }
 
   void toggleDarkMode() {
     _isDarkMode = !_isDarkMode;
+    notifyListeners();
+  }
+
+  void changeLanguage(String code) {
+    if (_selectedLanguageCode == code) return;
+    _selectedLanguageCode = code;
     notifyListeners();
   }
 

--- a/apps/customer/lib/screens/language_screen.dart
+++ b/apps/customer/lib/screens/language_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../controllers/app_controller.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
 
@@ -12,6 +13,31 @@ class LanguageScreen extends StatefulWidget {
 
 class _LanguageScreenState extends State<LanguageScreen> {
   int _selectedLanguageIndex = 0;
+  bool _isInitialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_isInitialized) {
+      final controller = FreightFairScope.of(context);
+      final index = _languages.indexWhere((lang) => lang['code'] == controller.selectedLanguageCode);
+      if (index != -1) {
+        _selectedLanguageIndex = index;
+      }
+      _isInitialized = true;
+    }
+  }
+
+  void _applyLanguage() {
+    final controller = FreightFairScope.of(context);
+    final selectedLanguage = _languages[_selectedLanguageIndex];
+    controller.changeLanguage(selectedLanguage['code']!);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Language changed to ${selectedLanguage['name']}')),
+    );
+    Navigator.of(context).pop();
+  }
 
   final List<Map<String, String>> _languages = [
     {'code': 'en', 'name': 'English', 'native': 'English'},
@@ -91,12 +117,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
             const SizedBox(height: 32),
             PrimaryButton(
               label: 'Apply',
-              onPressed: () {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Language changed to ${_languages[_selectedLanguageIndex]['name']}')),
-                );
-                Navigator.of(context).pop();
-              },
+              onPressed: _applyLanguage,
             ),
           ],
         ),

--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -146,7 +146,7 @@ class ProfileScreen extends StatelessWidget {
                   _MenuItem(
                     icon: Icons.language_rounded,
                     label: 'Language',
-                    trailing: 'English',
+                    trailing: FreightFairScope.of(context).selectedLanguageName,
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const LanguageScreen())),
                   ),
                   _MenuItem(


### PR DESCRIPTION
## Problem
The language selection screen previously only updated local UI state, resetting selection back to English upon re-entering the screen and leaving the profile screen's language label hardcoded.

## Solution
- Added `_selectedLanguageCode` and setter/getter to `FreightFairController`.
- Hooked the language screen up to read from and write to the controller.
- Updated `ProfileScreen` to display the active language dynamically.


### Closes #153