### PR TITLE
Fix unsafe map value access in language screen

### DIFF
--- a/apps/customer/lib/screens/language_screen.dart
+++ b/apps/customer/lib/screens/language_screen.dart
@@ -65,14 +65,14 @@ class _LanguageScreenState extends State<LanguageScreen> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                language['name']!,
+                                language['name'] ?? '',
                                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
                                       fontWeight: FontWeight.w600,
                                     ),
                               ),
                               const SizedBox(height: 2),
                               Text(
-                                language['native']!,
+                                language['native'] ?? '',
                                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                       color: FreightFairColors.adaptiveSecondaryText(context),
                                     ),


### PR DESCRIPTION
## Summary

* Replaced unsafe force unwrapping on language map values
* Added null-safe fallbacks using `?? ''`
* Prevents potential runtime crashes if keys are missing

## Changes

* Updated `language['name']!` to `language['name'] ?? ''`
* Updated `language['native']!` to `language['native'] ?? ''`


Closes #187