### PR TITLE
fix(customer): use dynamic truck count in app bar

### DIFF
--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -22,7 +22,7 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('12 trucks found'),
+        title: Text('${mockTruckResults.length} trucks found'),
         leading: IconButton(
             onPressed: () => Navigator.of(context).pop(),
             icon: const Icon(Icons.arrow_back_rounded)),


### PR DESCRIPTION
## Summary

Replaced the hardcoded truck count in the AppBar title with a dynamic value derived from the truck results list.

### Changes Made

* Replaced the hardcoded text `'12 trucks found'`
* Updated the AppBar title to use `mockTruckResults.length`

### Benefits

* AppBar title now reflects the actual number of truck results
* Removes hardcoded UI data
* Improves maintainability and accuracy

Closes #164 