### PR TITLE
fix(customer): use model order ids for navigation

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -106,7 +106,7 @@ class HomeScreen extends StatelessWidget {
                     shipment: shipment,
                     onTap: () {
                       Navigator.of(context).push(
-                        AppPageRoute(builder: (_) => LiveTrackingScreen(orderId: index == 0 ? '#FF20241205' : '#FF20241198')),
+                        AppPageRoute(builder: (_) => LiveTrackingScreen(orderId: mockActiveOrders[index].orderId)),
                       );
                     },
                   );


### PR DESCRIPTION
## Summary

Removed hardcoded order IDs from the HomeScreen shipment navigation flow.

### Changes Made

* Replaced hardcoded order ID values passed to `LiveTrackingScreen`
* Updated navigation to use `mockActiveOrders[index].orderId`

### Benefits

* Eliminates hardcoded navigation data
* Uses model-driven order IDs
* Improves maintainability and scalability

Closes #186 