### PR TITLE
fix(customer): safely handle native language name

### DIFF
--- a/apps/customer/lib/screens/language_screen.dart
+++ b/apps/customer/lib/screens/language_screen.dart
@@ -65,7 +65,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                language['name']!,
+                                language['name'] ?? '',
                                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
                                       fontWeight: FontWeight.w600,
                                     ),

--- a/apps/customer/lib/screens/language_screen.dart
+++ b/apps/customer/lib/screens/language_screen.dart
@@ -72,7 +72,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
                               ),
                               const SizedBox(height: 2),
                               Text(
-                                language['native']!,
+                                language['native'] ?? '',
                                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                       color: FreightFairColors.adaptiveSecondaryText(context),
                                     ),


### PR DESCRIPTION
## Summary

Removed unsafe force unwrapping when displaying native language names.

### Changes Made

* Replaced `language['native']!`
* Updated the lookup to use `language['native'] ?? ''`

### Benefits

* Prevents potential runtime crashes when the key is absent
* Improves null safety
* Preserves existing UI behavior

Closes #188
