### PR TITLE
fix(customer): safely handle nullable tab controller

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -43,7 +43,10 @@ class _OrdersScreenState extends State<OrdersScreen> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    final tabController = _tabController!;
+    final tabController = _tabController;
+    if (tabController == null) {
+      return const SizedBox.shrink();
+    }
 
     return SafeArea(
       child: Column(


### PR DESCRIPTION
## Summary

Removed unsafe force unwrapping of the nullable TabController in OrdersScreen.

### Changes Made
- Replaced `_tabController!` in `build()`
- Added a null guard before using the controller
- Returned `SizedBox.shrink()` when the controller is unavailable

### Benefits
- Prevents potential runtime crashes
- Improves null safety
- Preserves existing behavior

Closes #161