### PR TITLE
fix: replace FreightFair colors with theme primary in AppLogo

### DIFF
--- a/apps/customer/lib/widgets/app_logo.dart
+++ b/apps/customer/lib/widgets/app_logo.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
 
 class AppLogo extends StatelessWidget {
-  const AppLogo({super.key, this.centered = false, this.textStyle, this.iconSize = 22});
+  const AppLogo({
+    super.key,
+    this.centered = false,
+    this.textStyle,
+    this.iconSize = 22,
+  });
 
   final bool centered;
   final TextStyle? textStyle;
@@ -18,14 +23,18 @@ class AppLogo extends StatelessWidget {
           width: iconSize + 10,
           height: iconSize + 10,
           decoration: BoxDecoration(
-            color: FreightFairColors.accentLight,
+            color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.15),
             borderRadius: BorderRadius.circular(12),
           ),
-          child: Icon(Icons.local_shipping_rounded, color: FreightFairColors.accentDark, size: iconSize),
+          child: Icon(
+            Icons.local_shipping_rounded,
+            color: Theme.of(context).colorScheme.primary,
+            size: iconSize,
+          ),
         ),
         const SizedBox(width: 10),
         Text(
-          'FreightFair',
+          'Truxify',
           style: textStyle ?? const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
         ),
       ],


### PR DESCRIPTION
Closes #168 

## Summary
Replaced hardcoded FreightFair color references in AppLogo with theme-based primary color to ensure consistency with app branding.

## Changes
- Updated icon background to use Theme.primaryColor
- Updated icon color to use theme primary color
- Replaced old brand-specific styling with Truxify theme system

## Issue
Fixes branding inconsistency in AppLogo widget.

## Notes
No functional changes, only UI/theme alignment.