### PR TITLE
fix: Hardcoded marker color ignores app theme

### DIFF
--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -307,7 +307,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                             point: _selectedPoint!,
                             width: 44,
                             height: 44,
-                            child: const Icon(Icons.place_rounded, color: Colors.green, size: 34),
+                            child: Icon(Icons.place_rounded, color: Theme.of(context).colorScheme.primary, size: 34),
                           ),
                         ],
                       ),

--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -307,7 +307,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                             point: _selectedPoint!,
                             width: 44,
                             height: 44,
-                            child: const Icon(Icons.place_rounded, color: Colors.redAccent, size: 34),
+                            child: const Icon(Icons.place_rounded, color: Colors.green, size: 34),
                           ),
                         ],
                       ),


### PR DESCRIPTION
Summary
--
Fixes #156 

What changed
--
Replaced hardcoded Colors.redAccent with Colors.green in location marker

Files Changed
--
apps/customer/lib/screens/location_picker_screen.dart

After changes Screenshot
--
<img width="1365" height="631" alt="image" src="https://github.com/user-attachments/assets/bde75d21-ec88-45f4-9dd1-49617a74f580" />

testing
--
- [x] Verified marker appears green when tapping on map
- [x] App compiles and runs without errors