### PR TITLE
fix(ui): make earnings chart bar height responsive [ GSSoC 26 ]

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -281,8 +281,8 @@ class _EarningsScreenState extends State<EarningsScreen> {
                                 final isSelected = index == _selectedBarIndex;
                                 final isHighest = item.amount.toDouble() == maxAmount;
 
-                                // Height proportion calculation (max height is 80px)
-                                final double barHeight = (item.amount.toDouble() / maxAmount) * 80;
+                                // Responsive bar height calculation based on screen size.
+                                final double barHeight = (item.amount.toDouble() / maxAmount) * (MediaQuery.sizeOf(context).height/14.1);
 
                                 return Expanded(
                                   child: Column(


### PR DESCRIPTION
## Fix Bottom Overflow in Driver App Earnings Bar Chart

### Related Issue
Closes #260

## Description

This PR fixes a bottom overflow issue in the **Driver App Earnings Bar Chart**.

The chart previously used a hardcoded maximum bar height of `80px`, which could cause a bottom overflow on certain screen sizes. To improve responsiveness and prevent overflow, the fixed height calculation has been replaced with a screen-size-based responsive calculation.

## Changes Made

- Replaced the hardcoded bar height (`80px`) with a responsive calculation using `MediaQuery`.
- Updated the code comments to reflect the new behavior.
- Improved chart responsiveness across different device sizes.
- Fixed the bottom overflow issue.

## Code Changes

### Before

```dart
// Height proportion calculation (max height is 80px)
final double barHeight =
    (item.amount.toDouble() / maxAmount) * 80;
```

### After

```dart
// Calculate bar height proportionally using screen height
// to ensure responsive sizing and prevent overflow on smaller devices.
final double barHeight =
    (item.amount.toDouble() / maxAmount) *
    (MediaQuery.sizeOf(context).height / 14.1);
```

## 📸 UI Comparison

| Before | After |
|---------|---------|
| <img width="220" alt="Before" src="https://github.com/user-attachments/assets/691deabe-bf32-449d-a3c9-f7cd23f6ef84" /> | <img width="220" alt="After" src="https://github.com/user-attachments/assets/94a947f1-ada9-4149-806c-cb42546ff2c9" /> |


<!-- Add screenshot showing the resolved UI -->

## Benefits

- ✅ Prevents bottom overflow on smaller screens.
- ✅ Improves responsiveness across different device sizes.
- ✅ Maintains proportional bar chart visualization.
- ✅ Enhances overall user experience in the Driver App.

## Testing

- Verified that the overflow issue no longer occurs.
- Tested the earnings chart after implementing the responsive height calculation.
- Confirmed consistent chart rendering across different screen sizes.