### PR TITLE
fix(customer): use order data for rebook route

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -149,11 +149,15 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
           PrimaryButton(
             label: 'Rebook This Route',
             onPressed: () {
+              final routeParts = widget.order.route.split(' → ');
+              final pickup = routeParts.length == 2 ? routeParts.first : widget.order.route;
+              final drop = routeParts.length == 2 ? routeParts.last : widget.order.route;
+
               FreightFairScope.of(context).openFindTrucks(
                 draft: RouteDraft(
-                  pickup: 'Surat, Gujarat',
-                  drop: 'Pune, Maharashtra',
-                  dateLabel: 'Tomorrow, 6:00 AM',
+                  pickup: pickup,
+                  drop: drop,
+                  dateLabel: widget.order.date,
                   goodsType: 'Textile',
                   weightTonnes: '3',
                   dimensions: '12 × 6 × 6',


### PR DESCRIPTION
## Summary

Replaced hardcoded route values in the rebook flow with data derived from the current order.

### Changes Made

* Removed hardcoded pickup location
* Removed hardcoded drop location
* Removed hardcoded date label
* Derived pickup and drop from `widget.order.route`
* Used `widget.order.date` for the rebook date

### Benefits

* Rebook flow now reflects the actual order being viewed
* Improves maintainability
* Eliminates hardcoded route data
* Preserves existing user experience

Closes #159 