### PR TITLE
Rename FreightFairColors to TruxifyColors

### DIFF
--- a/apps/customer/lib/screens/about_screen.dart
+++ b/apps/customer/lib/screens/about_screen.dart
@@ -23,12 +23,12 @@ class AboutScreen extends StatelessWidget {
                 width: 100,
                 height: 100,
                 decoration: BoxDecoration(
-                  color: FreightFairColors.accentLight,
+                  color: TruxifyColors.accentLight,
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: const Icon(
                   Icons.local_shipping_rounded,
-                  color: FreightFairColors.accent,
+                  color: TruxifyColors.accent,
                   size: 50,
                 ),
               ),
@@ -41,14 +41,14 @@ class AboutScreen extends StatelessWidget {
                     'Truxify',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.w700,
-                          color: FreightFairColors.accent,
+                          color: TruxifyColors.accent,
                         ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     'Version 1.0.0',
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: FreightFairColors.adaptiveSecondaryText(context),
+                          color: TruxifyColors.adaptiveSecondaryText(context),
                         ),
                   ),
                 ],
@@ -68,14 +68,14 @@ class AboutScreen extends StatelessWidget {
                     'About Us',
                     style: Theme.of(context).textTheme.labelMedium?.copyWith(
                           fontWeight: FontWeight.w600,
-                          color: FreightFairColors.accent,
+                          color: TruxifyColors.accent,
                         ),
                   ),
                   const SizedBox(height: 8),
                   Text(
                     'Truxify is a modern freight management platform connecting shippers with verified truck owners. We simplify logistics with real-time tracking, transparent pricing, and reliable service.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: FreightFairColors.adaptiveSecondaryText(context),
+                          color: TruxifyColors.adaptiveSecondaryText(context),
                           height: 1.6,
                         ),
                   ),
@@ -96,14 +96,14 @@ class AboutScreen extends StatelessWidget {
                     'Our Mission',
                     style: Theme.of(context).textTheme.labelMedium?.copyWith(
                           fontWeight: FontWeight.w600,
-                          color: FreightFairColors.accent,
+                          color: TruxifyColors.accent,
                         ),
                   ),
                   const SizedBox(height: 8),
                   Text(
                     'To revolutionize the logistics industry by making freight transportation safe, affordable, and sustainable for everyone.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: FreightFairColors.adaptiveSecondaryText(context),
+                          color: TruxifyColors.adaptiveSecondaryText(context),
                           height: 1.6,
                         ),
                   ),
@@ -151,7 +151,7 @@ class AboutScreen extends StatelessWidget {
               child: Text(
                 '© 2024 Truxify. All rights reserved.',
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: FreightFairColors.adaptiveSecondaryText(context),
+                      color: TruxifyColors.adaptiveSecondaryText(context),
                     ),
               ),
             ),
@@ -181,10 +181,10 @@ class _ContactRow extends StatelessWidget {
           width: 40,
           height: 40,
           decoration: BoxDecoration(
-            color: FreightFairColors.accentLight,
+            color: TruxifyColors.accentLight,
             borderRadius: BorderRadius.circular(8),
           ),
-          child: Icon(icon, color: FreightFairColors.accent, size: 18),
+          child: Icon(icon, color: TruxifyColors.accent, size: 18),
         ),
         const SizedBox(width: 12),
         Expanded(
@@ -194,7 +194,7 @@ class _ContactRow extends StatelessWidget {
               Text(
                 label,
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: FreightFairColors.adaptiveSecondaryText(context),
+                      color: TruxifyColors.adaptiveSecondaryText(context),
                     ),
               ),
               const SizedBox(height: 2),
@@ -223,10 +223,11 @@ class _SocialIcon extends StatelessWidget {
       width: 40,
       height: 40,
       decoration: BoxDecoration(
-        color: FreightFairColors.accentLight,
+        color: TruxifyColors.accentLight,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Icon(icon, color: FreightFairColors.accent, size: 18),
+      child: Icon(icon, color: TruxifyColors.accent, size: 18),
     );
   }
 }
+

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -91,7 +91,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen> w
                 const SizedBox(height: 8),
                 Row(
                   children: [
-                    const Icon(Icons.lock_rounded, color: FreightFairColors.accentDark, size: 18),
+                    const Icon(Icons.lock_rounded, color: TruxifyColors.accentDark, size: 18),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
@@ -102,7 +102,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen> w
                   ],
                 ),
                 const SizedBox(height: 6),
-                Text('Released only on delivery', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                Text('Released only on delivery', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               ],
             ),
           ),
@@ -147,7 +147,7 @@ class _SummaryRow extends StatelessWidget {
         children: [
           SizedBox(
             width: 88,
-            child: Text(label, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+            child: Text(label, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
           ),
           Expanded(child: Text(value, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700))),
         ],
@@ -173,17 +173,17 @@ class _SuccessPanel extends StatelessWidget {
             width: double.infinity,
             padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
             decoration: BoxDecoration(
-              color: FreightFairColors.accentLight,
+              color: TruxifyColors.accentLight,
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: FreightFairColors.accent.withValues(alpha: 0.2)),
+              border: Border.all(color: TruxifyColors.accent.withValues(alpha: 0.2)),
             ),
             child: Column(
               children: [
-                const Icon(Icons.check_circle_rounded, color: FreightFairColors.accentDark, size: 58),
+                const Icon(Icons.check_circle_rounded, color: TruxifyColors.accentDark, size: 58),
                 const SizedBox(height: 10),
                 Text('Booking Confirmed! 🎉', style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 4),
-                Text('Order ID: #FF20241205', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                Text('Order ID: #FF20241205', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               ],
             ),
           ),
@@ -192,3 +192,4 @@ class _SuccessPanel extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -174,8 +174,8 @@ class _SuccessPanel extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
             decoration: BoxDecoration(
               color: Theme.of(context).brightness == Brightness.dark
-        ? FreightFairColors.darkAccentLight
-        : FreightFairColors.accentLight,
+        ? TruxifyColors.darkAccentLight
+        : TruxifyColors.accentLight,
               borderRadius: BorderRadius.circular(16),
               border: Border.all(color: TruxifyColors.accent.withValues(alpha: 0.2)),
             ),
@@ -184,8 +184,8 @@ class _SuccessPanel extends StatelessWidget {
                 Icon(
   Icons.check_circle_rounded,
   color: Theme.of(context).brightness == Brightness.dark
-      ? FreightFairColors.accent
-      : FreightFairColors.accentDark,
+      ? TruxifyColors.accent
+      : TruxifyColors.accentDark,
   size: 58,
 ),
                 const SizedBox(height: 10),

--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -51,7 +51,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                     width: 100,
                     height: 100,
                     decoration: BoxDecoration(
-                      color: FreightFairColors.accentLight,
+                      color: TruxifyColors.accentLight,
                       shape: BoxShape.circle,
                     ),
                     alignment: Alignment.center,
@@ -60,7 +60,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                       style: TextStyle(
                         fontSize: 32,
                         fontWeight: FontWeight.w600,
-                        color: FreightFairColors.accent,
+                        color: TruxifyColors.accent,
                       ),
                     ),
                   ),
@@ -71,7 +71,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                       width: 36,
                       height: 36,
                       decoration: BoxDecoration(
-                        color: FreightFairColors.accent,
+                        color: TruxifyColors.accent,
                         shape: BoxShape.circle,
                       ),
                       child: const Icon(Icons.camera_alt_rounded, color: Colors.white, size: 18),
@@ -84,7 +84,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             Text(
               'Full Name',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: FreightFairColors.primaryText,
+                    color: TruxifyColors.primaryText,
                     fontWeight: FontWeight.w600,
                   ),
             ),
@@ -100,7 +100,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             Text(
               'Company Name',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: FreightFairColors.primaryText,
+                    color: TruxifyColors.primaryText,
                     fontWeight: FontWeight.w600,
                   ),
             ),
@@ -116,7 +116,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             Text(
               'Phone Number',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: FreightFairColors.primaryText,
+                    color: TruxifyColors.primaryText,
                     fontWeight: FontWeight.w600,
                   ),
             ),
@@ -144,3 +144,4 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -299,7 +299,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                     const SizedBox(height: 2),
                     Text(
                       'ML powered matching',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
                     ),
                   ],
                 ),
@@ -308,12 +308,12 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                   width: 48,
                   height: 48,
                   decoration: BoxDecoration(
-                    color: FreightFairColors.accentLight,
+                    color: TruxifyColors.accentLight,
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: IconButton(
                     onPressed: () {},
-                    icon: const Icon(Icons.filter_list_rounded, color: FreightFairColors.accentDark),
+                    icon: const Icon(Icons.filter_list_rounded, color: TruxifyColors.accentDark),
                   ),
                 ),
               ],
@@ -325,7 +325,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               'ROUTE',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.w600,
-                    color: FreightFairColors.adaptiveSecondaryText(context),
+                    color: TruxifyColors.adaptiveSecondaryText(context),
                     letterSpacing: 0.5,
                   ),
             ),
@@ -340,11 +340,11 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                     onTap: () => _openLocationPicker(isPickup: true),
                     decoration: InputDecoration(
                       labelText: 'Pickup Location',
-                      prefixIcon: const Icon(Icons.location_on_rounded, color: FreightFairColors.accentDark),
+                      prefixIcon: const Icon(Icons.location_on_rounded, color: TruxifyColors.accentDark),
                       prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                       suffixIcon: IconButton(
                         onPressed: () => _openLocationPicker(isPickup: true),
-                        icon: const Icon(Icons.map_rounded, color: FreightFairColors.accentDark),
+                        icon: const Icon(Icons.map_rounded, color: TruxifyColors.accentDark),
                       ),
                     ),
                   ),
@@ -363,7 +363,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                             suffixIcon: IconButton(
                               onPressed: () => _openLocationPicker(isPickup: false),
-                              icon: const Icon(Icons.map_rounded, color: FreightFairColors.accentDark),
+                              icon: const Icon(Icons.map_rounded, color: TruxifyColors.accentDark),
                             ),
                           ),
                         ),
@@ -373,13 +373,13 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         width: 48,
                         height: 48,
                         decoration: BoxDecoration(
-                          color: FreightFairColors.accentLight,
+                          color: TruxifyColors.accentLight,
                           borderRadius: BorderRadius.circular(12),
-                          border: Border.all(color: FreightFairColors.border),
+                          border: Border.all(color: TruxifyColors.border),
                         ),
                         child: IconButton(
                           onPressed: _swapLocations,
-                          icon: const Icon(Icons.swap_vert_rounded, color: FreightFairColors.accentDark),
+                          icon: const Icon(Icons.swap_vert_rounded, color: TruxifyColors.accentDark),
                         ),
                       ),
                     ],
@@ -395,7 +395,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           onTap: _pickDate,
                           decoration: InputDecoration(
                             labelText: 'Date',
-                            prefixIcon: const Icon(Icons.calendar_today_rounded, color: FreightFairColors.accentDark),
+                            prefixIcon: const Icon(Icons.calendar_today_rounded, color: TruxifyColors.accentDark),
                             prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                           ),
                         ),
@@ -408,7 +408,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           onTap: _pickTime,
                           decoration: InputDecoration(
                             labelText: 'Time',
-                            prefixIcon: const Icon(Icons.access_time_rounded, color: FreightFairColors.accentDark),
+                            prefixIcon: const Icon(Icons.access_time_rounded, color: TruxifyColors.accentDark),
                             prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                           ),
                         ),
@@ -425,7 +425,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               'GOODS DETAILS',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.w600,
-                    color: FreightFairColors.adaptiveSecondaryText(context),
+                    color: TruxifyColors.adaptiveSecondaryText(context),
                     letterSpacing: 0.5,
                   ),
             ),
@@ -449,7 +449,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       decoration: const InputDecoration(
                         labelText: 'Describe your goods',
                         hintText: 'e.g. Chemicals, Scrap metal…',
-                        prefixIcon: Icon(Icons.edit_note_rounded, color: FreightFairColors.accentDark),
+                        prefixIcon: Icon(Icons.edit_note_rounded, color: TruxifyColors.accentDark),
                         prefixIconConstraints: BoxConstraints(minWidth: 40, minHeight: 40),
                       ),
                     ),
@@ -542,7 +542,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       'Special requirements',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             fontWeight: FontWeight.w600,
-                            color: FreightFairColors.adaptiveSecondaryText(context),
+                            color: TruxifyColors.adaptiveSecondaryText(context),
                           ),
                     ),
                   ),
@@ -572,29 +572,29 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             decoration: BoxDecoration(
                               color: selected
                                   ? (Theme.of(context).brightness == Brightness.dark
-                                      ? FreightFairColors.darkAccentLight
-                                      : FreightFairColors.accentLight)
+                                      ? TruxifyColors.darkAccentLight
+                                      : TruxifyColors.accentLight)
                                   : Theme.of(context).colorScheme.surfaceContainerHighest,
                               borderRadius: BorderRadius.circular(999),
                               border: Border.all(
-                                color: selected ? Colors.transparent : (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border),
+                                color: selected ? Colors.transparent : (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border),
                               ),
                             ),
                             child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 if (selected)
-                                  Icon(Icons.check_rounded, color: FreightFairColors.accentDark, size: 16)
+                                  Icon(Icons.check_rounded, color: TruxifyColors.accentDark, size: 16)
                                 else
-                                  Icon(Icons.add_rounded, color: FreightFairColors.adaptiveSecondaryText(context), size: 16),
+                                  Icon(Icons.add_rounded, color: TruxifyColors.adaptiveSecondaryText(context), size: 16),
                                 const SizedBox(width: 6),
                                 Text(
                                   label,
                                   style: Theme.of(context).textTheme.labelMedium?.copyWith(
                                         fontWeight: FontWeight.w600,
                                         color: selected
-                                            ? FreightFairColors.accentDark
-                                            : FreightFairColors.adaptiveSecondaryText(context),
+                                            ? TruxifyColors.accentDark
+                                            : TruxifyColors.adaptiveSecondaryText(context),
                                       ),
                                 ),
                               ],
@@ -616,7 +616,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.surface,
                     borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border)),
+                    border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border)),
                     boxShadow: [
                       BoxShadow(
                         color: Colors.black.withOpacity(0.05),
@@ -639,13 +639,13 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           Container(
                             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
-                              color: FreightFairColors.accentLight,
+                              color: TruxifyColors.accentLight,
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Text(
                               'Stable this week',
                               style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: FreightFairColors.accentDark,
+                                    color: TruxifyColors.accentDark,
                                     fontWeight: FontWeight.w600,
                                   ),
                             ),
@@ -658,14 +658,14 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                               fontWeight: FontWeight.w800,
                               color: Theme.of(context).brightness == Brightness.dark
-                                  ? FreightFairColors.accent
-                                  : FreightFairColors.accentDark,
+                                  ? TruxifyColors.accent
+                                  : TruxifyColors.accentDark,
                             ),
                       ),
                       const SizedBox(height: 4),
                       Text(
                         'Based on current demand + route',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
                       ),
                     ],
                   ),
@@ -677,7 +677,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                   child: Container(
                     width: 4,
                     decoration: BoxDecoration(
-                      color: FreightFairColors.accentDark,
+                      color: TruxifyColors.accentDark,
                       borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(16),
                         bottomLeft: Radius.circular(16),
@@ -736,11 +736,11 @@ class _ColorToggleButton extends StatelessWidget {
           height: 56,
           decoration: BoxDecoration(
             color: isSelected
-                ? FreightFairColors.accentDark
+                ? TruxifyColors.accentDark
                 : Theme.of(context).colorScheme.surfaceContainerHighest,
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color: isSelected ? FreightFairColors.accentDark : (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border),
+              color: isSelected ? TruxifyColors.accentDark : (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border),
             ),
           ),
           child: Row(
@@ -748,7 +748,7 @@ class _ColorToggleButton extends StatelessWidget {
             children: [
               Icon(
                 icon,
-                color: isSelected ? Colors.white : FreightFairColors.adaptiveSecondaryText(context),
+                color: isSelected ? Colors.white : TruxifyColors.adaptiveSecondaryText(context),
                 size: 24,
               ),
               if (label != null) ...[
@@ -757,7 +757,7 @@ class _ColorToggleButton extends StatelessWidget {
                   label!,
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
-                        color: isSelected ? Colors.white : FreightFairColors.adaptiveSecondaryText(context),
+                        color: isSelected ? Colors.white : TruxifyColors.adaptiveSecondaryText(context),
                       ),
                 ),
               ],
@@ -768,3 +768,4 @@ class _ColorToggleButton extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/help_support_screen.dart
+++ b/apps/customer/lib/screens/help_support_screen.dart
@@ -48,8 +48,8 @@ class HelpSupportScreen extends StatelessWidget {
             Container(
               decoration: BoxDecoration(
                 color: Theme.of(context).brightness == Brightness.dark
-                    ? FreightFairColors.darkAccentLight
-                    : FreightFairColors.accentLight.withValues(alpha: 0.5),
+                    ? TruxifyColors.darkAccentLight
+                    : TruxifyColors.accentLight.withValues(alpha: 0.5),
                 borderRadius: BorderRadius.circular(12),
               ),
               padding: const EdgeInsets.all(16),
@@ -59,10 +59,10 @@ class HelpSupportScreen extends StatelessWidget {
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: FreightFairColors.accentLight,
+                      color: TruxifyColors.accentLight,
                       borderRadius: BorderRadius.circular(8),
                     ),
-                    child: const Icon(Icons.help_outline_rounded, color: FreightFairColors.accent, size: 20),
+                    child: const Icon(Icons.help_outline_rounded, color: TruxifyColors.accent, size: 20),
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -79,7 +79,7 @@ class HelpSupportScreen extends StatelessWidget {
                         Text(
                           'Contact our support team',
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: FreightFairColors.adaptiveSecondaryText(context),
+                                color: TruxifyColors.adaptiveSecondaryText(context),
                               ),
                         ),
                       ],
@@ -120,7 +120,7 @@ class HelpSupportScreen extends StatelessWidget {
                         child: Text(
                           faq.answer,
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: FreightFairColors.adaptiveSecondaryText(context),
+                                color: TruxifyColors.adaptiveSecondaryText(context),
                               ),
                         ),
                       ),
@@ -144,3 +144,4 @@ class HelpSupportScreen extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -59,13 +59,13 @@ class HomeScreen extends StatelessWidget {
                   color: Theme.of(context).colorScheme.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(999),
                   border: Border.all(
-                    color: Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border,
+                    color: Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border,
                   ),
                 ),
                 child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(Icons.place_rounded, size: 16, color: FreightFairColors.accentDark),
+                    Icon(Icons.place_rounded, size: 16, color: TruxifyColors.accentDark),
                     SizedBox(width: 6),
                     Text('Surat, Gujarat', style: TextStyle(fontWeight: FontWeight.w700)),
                   ],
@@ -88,7 +88,7 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 6),
             Text(
               DateFormat('EEEE, d MMMM yyyy').format(now),
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
             ),
             const SizedBox(height: 26),
             SectionHeader(title: 'Active Shipments', actionLabel: 'See all', onActionTap: () => _showComingSoon(context, 'All shipments')),
@@ -157,7 +157,7 @@ class _RecentRouteCard extends StatelessWidget {
     return InfoCard(
       child: Row(
         children: [
-          const Icon(Icons.route_rounded, color: FreightFairColors.accentDark),
+          const Icon(Icons.route_rounded, color: TruxifyColors.accentDark),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -165,7 +165,7 @@ class _RecentRouteCard extends StatelessWidget {
               children: [
                 Text(route.route, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 4),
-                Text('${route.pickup} to ${route.drop}', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                Text('${route.pickup} to ${route.drop}', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               ],
             ),
           ),
@@ -191,3 +191,4 @@ class _RecentRouteAction extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/language_screen.dart
+++ b/apps/customer/lib/screens/language_screen.dart
@@ -49,12 +49,12 @@ class _LanguageScreenState extends State<LanguageScreen> {
                   child: Container(
                     decoration: BoxDecoration(
                       border: Border.all(
-                        color: isSelected ? FreightFairColors.accent : (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border),
+                        color: isSelected ? TruxifyColors.accent : (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border),
                         width: isSelected ? 2 : 1,
                       ),
                       borderRadius: BorderRadius.circular(12),
                       color: isSelected
-                          ? FreightFairColors.accent.withValues(alpha: 0.08)
+                          ? TruxifyColors.accent.withValues(alpha: 0.08)
                           : Theme.of(context).colorScheme.surface,
                     ),
                     padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
@@ -74,14 +74,14 @@ class _LanguageScreenState extends State<LanguageScreen> {
                               Text(
                                 language['native']!,
                                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: FreightFairColors.adaptiveSecondaryText(context),
+                                      color: TruxifyColors.adaptiveSecondaryText(context),
                                     ),
                               ),
                             ],
                           ),
                         ),
                         if (isSelected)
-                          const Icon(Icons.check_circle_rounded, color: FreightFairColors.accent, size: 24),
+                          const Icon(Icons.check_circle_rounded, color: TruxifyColors.accent, size: 24),
                       ],
                     ),
                   ),
@@ -104,3 +104,4 @@ class _LanguageScreenState extends State<LanguageScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -53,16 +53,16 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Container(width: 46, height: 5, decoration: BoxDecoration(color: FreightFairColors.border, borderRadius: BorderRadius.circular(999))),
+              Container(width: 46, height: 5, decoration: BoxDecoration(color: TruxifyColors.border, borderRadius: BorderRadius.circular(999))),
               const SizedBox(height: 18),
-              const CircleAvatar(radius: 34, backgroundColor: FreightFairColors.accentLight, child: Icon(Icons.mic_rounded, color: FreightFairColors.accentDark, size: 34)),
+              const CircleAvatar(radius: 34, backgroundColor: TruxifyColors.accentLight, child: Icon(Icons.mic_rounded, color: TruxifyColors.accentDark, size: 34)),
               const SizedBox(height: 16),
               Text('Voice AI', style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 8),
               Text(
                 'Your truck is near Vadodara, expected by 4:30 PM today',
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
               ),
               const SizedBox(height: 20),
               const SizedBox(
@@ -91,11 +91,11 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
             mainAxisSize: MainAxisSize.min,
             children: [
               const SizedBox(height: 8),
-              const Icon(Icons.call_rounded, color: FreightFairColors.accentDark, size: 42),
+              const Icon(Icons.call_rounded, color: TruxifyColors.accentDark, size: 42),
               const SizedBox(height: 10),
               Text('Calling ${mockLiveTrackers[_selectedTruckIndex].driver}', style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 4),
-              Text(mockLiveTrackers[_selectedTruckIndex].truckNumber, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+              Text(mockLiveTrackers[_selectedTruckIndex].truckNumber, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               const SizedBox(height: 18),
               PrimaryButton(label: 'End Call', onPressed: () => Navigator.of(context).pop()),
             ],
@@ -131,7 +131,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                 InfoCard(
                   child: Row(
                     children: [
-                      const Icon(Icons.attach_money_rounded, color: FreightFairColors.accentDark),
+                      const Icon(Icons.attach_money_rounded, color: TruxifyColors.accentDark),
                       const SizedBox(width: 10),
                       Expanded(child: Text('New estimated price: ₹7,120', style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w700))),
                     ],
@@ -162,13 +162,13 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.warning_amber_rounded, color: FreightFairColors.warning, size: 42),
+              const Icon(Icons.warning_amber_rounded, color: TruxifyColors.warning, size: 42),
               const SizedBox(height: 10),
               Text('Cancellation fee ₹680', style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 6),
-              Text('This fee is charged for cancelling after assignment.', textAlign: TextAlign.center, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+              Text('This fee is charged for cancelling after assignment.', textAlign: TextAlign.center, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               const SizedBox(height: 18),
-              PrimaryButton(label: 'Confirm Cancel', backgroundColor: FreightFairColors.error, onPressed: () => Navigator.of(context).pop()),
+              PrimaryButton(label: 'Confirm Cancel', backgroundColor: TruxifyColors.error, onPressed: () => Navigator.of(context).pop()),
             ],
           ),
         );
@@ -275,13 +275,13 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
         child: Container(
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: isSelected ? FreightFairColors.accentDark : Colors.white,
+            color: isSelected ? TruxifyColors.accentDark : Colors.white,
             border: Border.all(color: Colors.white, width: 2),
             boxShadow: const [BoxShadow(color: Color(0x33000000), blurRadius: 8, offset: Offset(0, 3))],
           ),
           child: Icon(
             Icons.local_shipping_rounded,
-            color: isSelected ? Colors.white : FreightFairColors.accentDark,
+            color: isSelected ? Colors.white : TruxifyColors.accentDark,
             size: 26,
           ),
         ),
@@ -318,7 +318,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                         Polyline(
                           points: _routePoints,
                           strokeWidth: 4,
-                          color: FreightFairColors.accentDark,
+                          color: TruxifyColors.accentDark,
                         ),
                       ],
                     ),
@@ -370,8 +370,8 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                         icon: Icon(
                           Icons.arrow_back_rounded,
                           color: Theme.of(context).brightness == Brightness.dark
-                              ? FreightFairColors.darkPrimaryText
-                              : FreightFairColors.accentDark,
+                              ? TruxifyColors.darkPrimaryText
+                              : TruxifyColors.accentDark,
                         ),
                       ),
                     ),
@@ -407,7 +407,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                                   Row(
                                     children: [
                                       const LiveDot(
-                                        color: FreightFairColors.accent,
+                                        color: TruxifyColors.accent,
                                         size: 8,
                                       ),
                                       const SizedBox(width: 6),
@@ -415,7 +415,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                                         'Live',
                                         style: TextStyle(
                                           fontSize: 12,
-                                          color: FreightFairColors.accent,
+                                          color: TruxifyColors.accent,
                                           fontWeight: FontWeight.w700,
                                         ),
                                       ),
@@ -429,8 +429,8 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                               icon: Icon(
                                 Icons.more_vert_rounded,
                                 color: Theme.of(context).brightness == Brightness.dark
-                                    ? FreightFairColors.darkPrimaryText
-                                    : FreightFairColors.accentDark,
+                                    ? TruxifyColors.darkPrimaryText
+                                    : TruxifyColors.accentDark,
                               ),
                             ),
                           ],
@@ -465,7 +465,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                           child: Container(
                             width: 46,
                             height: 5,
-                            decoration: BoxDecoration(color: FreightFairColors.border, borderRadius: BorderRadius.circular(999)),
+                            decoration: BoxDecoration(color: TruxifyColors.border, borderRadius: BorderRadius.circular(999)),
                           ),
                         ),
                         const SizedBox(height: 14),
@@ -489,15 +489,15 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                         Row(
                           children: [
                             Expanded(child: Text(truck.driver, style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800))),
-                            StatusBadge(label: '⭐ ${truck.rating.toStringAsFixed(1)}', color: FreightFairColors.accentDark, filled: true),
+                            StatusBadge(label: '⭐ ${truck.rating.toStringAsFixed(1)}', color: TruxifyColors.accentDark, filled: true),
                           ],
                         ),
                         const SizedBox(height: 6),
-                        Text(truck.truckNumber, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                        Text(truck.truckNumber, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                         const SizedBox(height: 6),
                         Text('ETA: ${truck.eta}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700)),
                         const SizedBox(height: 6),
-                        Text('Current location: ${truck.location}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                        Text('Current location: ${truck.location}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                         const SizedBox(height: 18),
                         SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
@@ -531,7 +531,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen> with SingleTick
                             _ActionTile(icon: Icons.mic_rounded, label: 'Voice AI', onTap: _showVoiceAi),
                             _ActionTile(icon: Icons.call_rounded, label: 'Call Driver', onTap: _showCallDriver),
                             _ActionTile(icon: Icons.edit_location_alt_rounded, label: 'Change Drop', onTap: _showChangeDrop),
-                            _ActionTile(icon: Icons.close_rounded, label: 'Cancel', color: FreightFairColors.error, onTap: _showCancel),
+                            _ActionTile(icon: Icons.close_rounded, label: 'Cancel', color: TruxifyColors.error, onTap: _showCancel),
                           ],
                         ),
                       ],
@@ -556,7 +556,7 @@ class _MilestoneItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = current ? FreightFairColors.accent : done ? FreightFairColors.accentDark : FreightFairColors.border;
+    final color = current ? TruxifyColors.accent : done ? TruxifyColors.accentDark : TruxifyColors.border;
     return Column(
       children: [
         Container(
@@ -566,7 +566,7 @@ class _MilestoneItem extends StatelessWidget {
             color: color,
             shape: BoxShape.circle,
             boxShadow: current
-                ? [BoxShadow(color: FreightFairColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
+                ? [BoxShadow(color: TruxifyColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
                 : const [],
           ),
         ),
@@ -585,12 +585,12 @@ class _MilestoneConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(width: 28, height: 2, color: FreightFairColors.border);
+    return Container(width: 28, height: 2, color: TruxifyColors.border);
   }
 }
 
 class _ActionTile extends StatelessWidget {
-  const _ActionTile({required this.icon, required this.label, required this.onTap, this.color = FreightFairColors.accentDark});
+  const _ActionTile({required this.icon, required this.label, required this.onTap, this.color = TruxifyColors.accentDark});
 
   final IconData icon;
   final String label;
@@ -616,3 +616,4 @@ class _ActionTile extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -319,7 +319,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                         mini: true,
                         backgroundColor:
                             Theme.of(context).colorScheme.surface,
-                        foregroundColor: FreightFairColors.accentDark,
+                        foregroundColor: TruxifyColors.accentDark,
                         onPressed: _isFetchingCurrentLocation
                             ? null
                             : _useCurrentLocation,
@@ -390,3 +390,4 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -257,7 +257,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.surface,
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border)),
+                border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border)),
               ),
               constraints: const BoxConstraints(maxHeight: 200),
               child: ListView.separated(
@@ -268,7 +268,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                   final suggestion = _suggestions[index];
                   return ListTile(
                     dense: true,
-                    leading: const Icon(Icons.place_rounded, color: FreightFairColors.accentDark),
+                    leading: const Icon(Icons.place_rounded, color: TruxifyColors.accentDark),
                     title: Text(
                       suggestion.address,
                       maxLines: 2,
@@ -326,7 +326,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                   Text(
                     'Selected Address',
                     style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          color: FreightFairColors.adaptiveSecondaryText(context),
+                          color: TruxifyColors.adaptiveSecondaryText(context),
                           fontWeight: FontWeight.w700,
                         ),
                   ),
@@ -373,3 +373,4 @@ class _SearchSuggestion {
   final String address;
   final LatLng point;
 }
+

--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -52,7 +52,7 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: FreightFairColors.secondaryBackground,
+      backgroundColor: TruxifyColors.secondaryBackground,
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 22),
@@ -66,7 +66,7 @@ class _LoginScreenState extends State<LoginScreen> {
               const SizedBox(height: 6),
               Text(
                 'Sign in to manage your freight bookings offline with mock data.',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
               ),
               const SizedBox(height: 28),
               AnimatedSwitcher(
@@ -96,7 +96,7 @@ class _LoginScreenState extends State<LoginScreen> {
               width: 70,
               margin: const EdgeInsets.only(right: 8),
               decoration: const BoxDecoration(
-                border: Border(right: BorderSide(color: FreightFairColors.border)),
+                border: Border(right: BorderSide(color: TruxifyColors.border)),
               ),
               child: const Text('+91', style: TextStyle(fontWeight: FontWeight.w700)),
             ),
@@ -109,12 +109,12 @@ class _LoginScreenState extends State<LoginScreen> {
         InfoCard(
           child: Row(
             children: [
-              const Icon(Icons.lock_rounded, color: FreightFairColors.accentDark),
+              const Icon(Icons.lock_rounded, color: TruxifyColors.accentDark),
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
                   'Mock verification is enabled. Use 1234 on the next screen.',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
                 ),
               ),
             ],
@@ -165,3 +165,4 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -121,7 +121,7 @@ void initState() {
               Text(
                 'Sign in to manage your freight bookings offline with mock data.',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: FreightFairColors.adaptiveSecondaryText(context)),
+                    color: TruxifyColors.adaptiveSecondaryText(context)),
               ),
               const SizedBox(height: 28),
               AnimatedSwitcher(
@@ -162,7 +162,7 @@ void initState() {
               margin: const EdgeInsets.only(right: 8),
               decoration: const BoxDecoration(
                 border:
-                    Border(right: BorderSide(color: FreightFairColors.border)),
+                    Border(right: BorderSide(color: TruxifyColors.border)),
               ),
               child: const Text('+91',
                   style: TextStyle(fontWeight: FontWeight.w700)),
@@ -177,13 +177,13 @@ void initState() {
           child: Row(
             children: [
               const Icon(Icons.lock_rounded,
-                  color: FreightFairColors.accentDark),
+                  color: TruxifyColors.accentDark),
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
                   'Mock verification is enabled. Use 1234 on the next screen.',
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: FreightFairColors.adaptiveSecondaryText(context)),
+                      color: TruxifyColors.adaptiveSecondaryText(context)),
                 ),
               ),
             ],
@@ -244,4 +244,5 @@ void initState() {
     );
   }
 }
+
 

--- a/apps/customer/lib/screens/my_documents_screen.dart
+++ b/apps/customer/lib/screens/my_documents_screen.dart
@@ -54,7 +54,7 @@ class MyDocumentsScreen extends StatelessWidget {
                 final doc = documents[index];
                 return Container(
                   decoration: BoxDecoration(
-                    border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border)),
+                    border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border)),
                     borderRadius: BorderRadius.circular(12),
                     color: Theme.of(context).colorScheme.surface,
                   ),
@@ -65,10 +65,10 @@ class MyDocumentsScreen extends StatelessWidget {
                         width: 44,
                         height: 44,
                         decoration: BoxDecoration(
-                          color: FreightFairColors.accentLight,
+                          color: TruxifyColors.accentLight,
                           borderRadius: BorderRadius.circular(10),
                         ),
-                        child: Icon(doc['icon'] as IconData, color: FreightFairColors.accent, size: 22),
+                        child: Icon(doc['icon'] as IconData, color: TruxifyColors.accent, size: 22),
                       ),
                       const SizedBox(width: 14),
                       Expanded(
@@ -122,3 +122,4 @@ class MyDocumentsScreen extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -73,13 +73,13 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               children: [
                 Text(widget.order.orderId, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 8),
-                Text(widget.order.route, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                Text(widget.order.route, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                 const SizedBox(height: 8),
                 Text('Date: ${widget.order.date}', style: Theme.of(context).textTheme.bodyMedium),
                 const SizedBox(height: 8),
                 StatusBadge(
                   label: widget.order.status == 'Delivered' ? '✅ Delivered' : '❌ Cancelled',
-                  color: delivered ? FreightFairColors.accentDark : FreightFairColors.error,
+                  color: delivered ? TruxifyColors.accentDark : TruxifyColors.error,
                   filled: true,
                 ),
               ],
@@ -92,8 +92,8 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                 Container(
                   width: 54,
                   height: 54,
-                  decoration: const BoxDecoration(color: FreightFairColors.accentLight, shape: BoxShape.circle),
-                  child: const Icon(Icons.person_rounded, color: FreightFairColors.accentDark),
+                  decoration: const BoxDecoration(color: TruxifyColors.accentLight, shape: BoxShape.circle),
+                  child: const Icon(Icons.person_rounded, color: TruxifyColors.accentDark),
                 ),
                 const SizedBox(width: 14),
                 Expanded(
@@ -102,9 +102,9 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                     children: [
                       Text(widget.order.driver, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                       const SizedBox(height: 4),
-                      Text('⭐ 4.8', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                      Text('⭐ 4.8', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                       const SizedBox(height: 4),
-                      Text(widget.order.truckNumber, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                      Text(widget.order.truckNumber, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                     ],
                   ),
                 ),
@@ -203,11 +203,11 @@ class _TimelineRow extends StatelessWidget {
               width: 14,
               height: 14,
               decoration: BoxDecoration(
-                color: step.completed ? FreightFairColors.accentDark : FreightFairColors.border,
+                color: step.completed ? TruxifyColors.accentDark : TruxifyColors.border,
                 shape: BoxShape.circle,
               ),
             ),
-            Container(width: 2, height: 42, color: FreightFairColors.border),
+            Container(width: 2, height: 42, color: TruxifyColors.border),
           ],
         ),
         const SizedBox(width: 12),
@@ -221,7 +221,7 @@ class _TimelineRow extends StatelessWidget {
                   Expanded(
                     child: Text(step.title, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w800)),
                   ),
-                  Text(step.timestamp, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                  Text(step.timestamp, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                 ],
               ),
             ),
@@ -231,3 +231,4 @@ class _TimelineRow extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -127,15 +127,15 @@ class _ActiveOrderCard extends StatelessWidget {
                 Expanded(
                   child: Text(order.orderId, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 ),
-                StatusBadge(label: order.milestone, color: FreightFairColors.accent, filled: true),
+                StatusBadge(label: order.milestone, color: TruxifyColors.accent, filled: true),
               ],
             ),
             const SizedBox(height: 10),
-            Text(order.route, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+            Text(order.route, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
             const SizedBox(height: 8),
             Text('Driver: ${order.driver}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700)),
             const SizedBox(height: 4),
-            Text('ETA: ${order.eta}', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+            Text('ETA: ${order.eta}', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
             const SizedBox(height: 14),
             PrimaryButton(label: 'Track Live', onPressed: onTap),
           ],
@@ -153,7 +153,7 @@ class _HistoryOrderCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final statusColor = order.status == 'Delivered' ? FreightFairColors.accentDark : FreightFairColors.error;
+    final statusColor = order.status == 'Delivered' ? TruxifyColors.accentDark : TruxifyColors.error;
     return GestureDetector(
       onTap: onTap,
       child: InfoCard(
@@ -165,7 +165,7 @@ class _HistoryOrderCard extends StatelessWidget {
                 Expanded(
                   child: Text(order.route, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 ),
-                Text(order.date, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+                Text(order.date, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
               ],
             ),
             const SizedBox(height: 10),
@@ -174,15 +174,15 @@ class _HistoryOrderCard extends StatelessWidget {
                 Text(order.amount, style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.w800,
                   color: Theme.of(context).brightness == Brightness.dark
-                      ? FreightFairColors.accent
-                      : FreightFairColors.accentDark,
+                      ? TruxifyColors.accent
+                      : TruxifyColors.accentDark,
                 )),
                 const SizedBox(width: 10),
                 StatusBadge(label: order.status == 'Delivered' ? '✅ Delivered' : '❌ Cancelled', color: statusColor, filled: true),
               ],
             ),
             const SizedBox(height: 12),
-            Text('Driver: ${order.driver}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context))),
+            Text('Driver: ${order.driver}', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
             const SizedBox(height: 14),
             Align(
               alignment: Alignment.centerRight,
@@ -198,3 +198,4 @@ class _HistoryOrderCard extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/screens/payment_methods_screen.dart
+++ b/apps/customer/lib/screens/payment_methods_screen.dart
@@ -58,12 +58,12 @@ class _PaymentMethodsScreenState extends State<PaymentMethodsScreen> {
                   child: Container(
                     decoration: BoxDecoration(
                       border: Border.all(
-                        color: isSelected ? FreightFairColors.accent : (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border),
+                        color: isSelected ? TruxifyColors.accent : (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border),
                         width: isSelected ? 2 : 1,
                       ),
                       borderRadius: BorderRadius.circular(12),
                       color: isSelected
-                          ? FreightFairColors.accent.withValues(alpha: 0.08)
+                          ? TruxifyColors.accent.withValues(alpha: 0.08)
                           : Theme.of(context).colorScheme.surface,
                     ),
                     padding: const EdgeInsets.all(14),
@@ -73,10 +73,10 @@ class _PaymentMethodsScreenState extends State<PaymentMethodsScreen> {
                           width: 44,
                           height: 44,
                           decoration: BoxDecoration(
-                            color: FreightFairColors.accentLight,
+                            color: TruxifyColors.accentLight,
                             borderRadius: BorderRadius.circular(10),
                           ),
-                          child: Icon(method['icon'], color: FreightFairColors.accent, size: 22),
+                          child: Icon(method['icon'], color: TruxifyColors.accent, size: 22),
                         ),
                         const SizedBox(width: 14),
                         Expanded(
@@ -93,14 +93,14 @@ class _PaymentMethodsScreenState extends State<PaymentMethodsScreen> {
                               Text(
                                 method['identifier'],
                                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: FreightFairColors.adaptiveSecondaryText(context),
+                                      color: TruxifyColors.adaptiveSecondaryText(context),
                                     ),
                               ),
                             ],
                           ),
                         ),
                         if (isSelected)
-                          const Icon(Icons.check_circle_rounded, color: FreightFairColors.accent, size: 24),
+                          const Icon(Icons.check_circle_rounded, color: TruxifyColors.accent, size: 24),
                       ],
                     ),
                   ),
@@ -128,3 +128,4 @@ class _PaymentMethodsScreenState extends State<PaymentMethodsScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -39,7 +39,7 @@ class ProfileScreen extends StatelessWidget {
                   width: double.infinity,
                   padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
                   decoration: const BoxDecoration(
-                    color: FreightFairColors.accent,
+                    color: TruxifyColors.accent,
                   ),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
@@ -58,7 +58,7 @@ class ProfileScreen extends StatelessWidget {
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.w500,
-                            color: FreightFairColors.accent,
+                            color: TruxifyColors.accent,
                           ),
                         ),
                       ),
@@ -171,9 +171,9 @@ class ProfileScreen extends StatelessWidget {
                   _MenuItem(
                     icon: Icons.logout_rounded,
                     label: 'Logout',
-                    iconBackgroundColor: FreightFairColors.error.withValues(alpha: 0.12),
-                    iconColor: FreightFairColors.error,
-                    textColor: FreightFairColors.error,
+                    iconBackgroundColor: TruxifyColors.error.withValues(alpha: 0.12),
+                    iconColor: TruxifyColors.error,
+                    textColor: TruxifyColors.error,
                     showChevron: false,
                     showDivider: false,
                     onTap: () => _logout(context),
@@ -202,7 +202,7 @@ class _SectionLabel extends StatelessWidget {
       child: Text(
         text.toUpperCase(),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: FreightFairColors.adaptiveSecondaryText(context),
+              color: TruxifyColors.adaptiveSecondaryText(context),
               fontSize: 11,
               letterSpacing: 0.06 * 11,
               fontWeight: FontWeight.w500,
@@ -216,7 +216,7 @@ class _StatsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final surface = Theme.of(context).colorScheme.surface;
-    final dividerColor = (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border);
+    final dividerColor = (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border);
     return Container(
       decoration: BoxDecoration(
         color: surface,
@@ -266,7 +266,7 @@ class _StatColumn extends StatelessWidget {
     required this.label,
     required this.valueSize,
     this.addRightDivider = false,
-    this.dividerColor = FreightFairColors.border,
+    this.dividerColor = TruxifyColors.border,
   });
 
   final String value;
@@ -288,7 +288,7 @@ class _StatColumn extends StatelessWidget {
           Text(
             value,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: FreightFairColors.accent,
+                  color: TruxifyColors.accent,
                   fontWeight: FontWeight.w500,
                   fontSize: valueSize,
                 ),
@@ -297,7 +297,7 @@ class _StatColumn extends StatelessWidget {
           Text(
             label,
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: FreightFairColors.adaptiveSecondaryText(context),
+                  color: TruxifyColors.adaptiveSecondaryText(context),
                   fontSize: 11,
                 ),
           ),
@@ -335,7 +335,7 @@ class _MenuItem extends StatelessWidget {
     required this.onTap,
     this.trailing,
     this.iconBackgroundColor,
-    this.iconColor = FreightFairColors.accent,
+    this.iconColor = TruxifyColors.accent,
     this.textColor,
     this.showChevron = true,
     this.showDivider = true,
@@ -355,7 +355,7 @@ class _MenuItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final resolvedIconBg = iconBackgroundColor ??
-        (isDark ? FreightFairColors.darkAccentLight : FreightFairColors.accentLight);
+        (isDark ? TruxifyColors.darkAccentLight : TruxifyColors.accentLight);
     final resolvedTextColor = textColor ?? Theme.of(context).textTheme.bodyMedium?.color;
     return InkWell(
       onTap: onTap,
@@ -392,8 +392,8 @@ class _MenuItem extends StatelessWidget {
                       trailing!,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: isDark
-                                ? FreightFairColors.darkSecondaryText
-                                : FreightFairColors.secondaryText,
+                                ? TruxifyColors.darkSecondaryText
+                                : TruxifyColors.secondaryText,
                             fontSize: 13,
                           ),
                     ),
@@ -402,7 +402,7 @@ class _MenuItem extends StatelessWidget {
                   Icon(
                     Icons.chevron_right_rounded,
                     size: 16,
-                    color: isDark ? FreightFairColors.darkSecondaryText : const Color(0xFFB0B0B0),
+                    color: isDark ? TruxifyColors.darkSecondaryText : const Color(0xFFB0B0B0),
                   ),
               ],
             ),
@@ -411,7 +411,7 @@ class _MenuItem extends StatelessWidget {
             Divider(
               height: 1,
               thickness: 1,
-              color: isDark ? FreightFairColors.darkBorder : FreightFairColors.border,
+              color: isDark ? TruxifyColors.darkBorder : TruxifyColors.border,
             ),
         ],
       ),
@@ -426,7 +426,7 @@ class _DarkModeMenuItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = FreightFairScope.of(context);
     final isDark = controller.isDarkMode;
-    final iconBg = isDark ? FreightFairColors.darkAccentLight : FreightFairColors.accentLight;
+    final iconBg = isDark ? TruxifyColors.darkAccentLight : TruxifyColors.accentLight;
     return Column(
       children: [
         Padding(
@@ -440,7 +440,7 @@ class _DarkModeMenuItem extends StatelessWidget {
                   color: iconBg,
                   borderRadius: BorderRadius.circular(10),
                 ),
-                child: const Icon(Icons.dark_mode_rounded, size: 17, color: FreightFairColors.accent),
+                child: const Icon(Icons.dark_mode_rounded, size: 17, color: TruxifyColors.accent),
               ),
               const SizedBox(width: 12),
               Expanded(
@@ -455,7 +455,7 @@ class _DarkModeMenuItem extends StatelessWidget {
               Switch(
                 value: isDark,
                 onChanged: (_) => controller.toggleDarkMode(),
-                activeThumbColor: FreightFairColors.accent,
+                activeThumbColor: TruxifyColors.accent,
               ),
             ],
           ),
@@ -463,9 +463,10 @@ class _DarkModeMenuItem extends StatelessWidget {
         Divider(
           height: 1,
           thickness: 1,
-          color: isDark ? FreightFairColors.darkBorder : FreightFairColors.border,
+          color: isDark ? TruxifyColors.darkBorder : TruxifyColors.border,
         ),
       ],
     );
   }
 }
+

--- a/apps/customer/lib/screens/saved_addresses_screen.dart
+++ b/apps/customer/lib/screens/saved_addresses_screen.dart
@@ -58,12 +58,12 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
                   child: Container(
                     decoration: BoxDecoration(
                       border: Border.all(
-                        color: isSelected ? FreightFairColors.accent : (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border),
+                        color: isSelected ? TruxifyColors.accent : (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border),
                         width: isSelected ? 2 : 1,
                       ),
                       borderRadius: BorderRadius.circular(12),
                       color: isSelected
-                          ? FreightFairColors.accent.withValues(alpha: 0.08)
+                          ? TruxifyColors.accent.withValues(alpha: 0.08)
                           : Theme.of(context).colorScheme.surface,
                     ),
                     padding: const EdgeInsets.all(14),
@@ -73,10 +73,10 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
                           width: 44,
                           height: 44,
                           decoration: BoxDecoration(
-                            color: FreightFairColors.accentLight,
+                            color: TruxifyColors.accentLight,
                             borderRadius: BorderRadius.circular(10),
                           ),
-                          child: Icon(address['icon'], color: FreightFairColors.accent, size: 22),
+                          child: Icon(address['icon'], color: TruxifyColors.accent, size: 22),
                         ),
                         const SizedBox(width: 14),
                         Expanded(
@@ -93,7 +93,7 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
                               Text(
                                 address['address'],
                                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: FreightFairColors.adaptiveSecondaryText(context),
+                                      color: TruxifyColors.adaptiveSecondaryText(context),
                                     ),
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
@@ -102,7 +102,7 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
                           ),
                         ),
                         if (isSelected)
-                          const Icon(Icons.check_circle_rounded, color: FreightFairColors.accent, size: 24),
+                          const Icon(Icons.check_circle_rounded, color: TruxifyColors.accent, size: 24),
                       ],
                     ),
                   ),
@@ -130,3 +130,4 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/shell_screen.dart
+++ b/apps/customer/lib/screens/shell_screen.dart
@@ -37,7 +37,7 @@ class _FreightFairShellScreenState extends State<FreightFairShellScreen> {
       bottomNavigationBar: Container(
         decoration: BoxDecoration(
           color: Theme.of(context).navigationBarTheme.backgroundColor,
-          border: Border(top: BorderSide(color: (Theme.of(context).brightness == Brightness.dark ? FreightFairColors.darkBorder : FreightFairColors.border), width: 1)),
+          border: Border(top: BorderSide(color: (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border), width: 1)),
         ),
         child: NavigationBar(
           selectedIndex: controller.currentTab,
@@ -63,3 +63,4 @@ class _FreightFairShellScreenState extends State<FreightFairShellScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/splash_screen.dart
+++ b/apps/customer/lib/screens/splash_screen.dart
@@ -35,7 +35,7 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: FreightFairColors.secondaryBackground,
+      backgroundColor: TruxifyColors.secondaryBackground,
       body: Container(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
@@ -72,3 +72,4 @@ class _SplashScreenState extends State<SplashScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -56,14 +56,14 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
                   ),
                   selected: selected,
                   onSelected: (_) => setState(() => _selectedSort = index),
-                  selectedColor: FreightFairColors.accent,
+                  selectedColor: TruxifyColors.accent,
                   backgroundColor:
                       Theme.of(context).brightness == Brightness.dark
-                          ? FreightFairColors.darkBackground
+                          ? TruxifyColors.darkBackground
                           : Colors.white,
                   side: BorderSide(
                     color: selected
-                        ? FreightFairColors.accent
+                        ? TruxifyColors.accent
                         : Colors.grey.shade300,
                     width: 1.2,
                   ),
@@ -100,3 +100,4 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
     );
   }
 }
+

--- a/apps/customer/lib/theme/app_theme.dart
+++ b/apps/customer/lib/theme/app_theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-class FreightFairColors {
+class TruxifyColors {
   // Light mode
   static const background = Color(0xFFFFFFFF);
   static const secondaryBackground = Color(0xFFF5F5F5);
@@ -42,61 +42,61 @@ class FreightFairTheme {
     final base = ThemeData(
       useMaterial3: true,
       colorScheme: ColorScheme.fromSeed(
-        seedColor: FreightFairColors.accent,
+        seedColor: TruxifyColors.accent,
         brightness: Brightness.light,
-        primary: FreightFairColors.accent,
-        secondary: FreightFairColors.accentDark,
-        surface: FreightFairColors.background,
-        surfaceContainerHighest: FreightFairColors.secondaryBackground,
-        outlineVariant: FreightFairColors.border,
+        primary: TruxifyColors.accent,
+        secondary: TruxifyColors.accentDark,
+        surface: TruxifyColors.background,
+        surfaceContainerHighest: TruxifyColors.secondaryBackground,
+        outlineVariant: TruxifyColors.border,
       ),
     );
 
     return base.copyWith(
-      scaffoldBackgroundColor: FreightFairColors.secondaryBackground,
+      scaffoldBackgroundColor: TruxifyColors.secondaryBackground,
       textTheme: GoogleFonts.dmSansTextTheme(base.textTheme).apply(
-        bodyColor: FreightFairColors.primaryText,
-        displayColor: FreightFairColors.primaryText,
+        bodyColor: TruxifyColors.primaryText,
+        displayColor: TruxifyColors.primaryText,
       ),
       cardTheme: CardThemeData(
-        color: FreightFairColors.background,
+        color: TruxifyColors.background,
         elevation: 0,
         shadowColor: Colors.black.withValues(alpha: 0.06),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),
       ),
-      dividerTheme: const DividerThemeData(color: FreightFairColors.border, thickness: 1),
+      dividerTheme: const DividerThemeData(color: TruxifyColors.border, thickness: 1),
       appBarTheme: const AppBarTheme(
-        backgroundColor: FreightFairColors.background,
-        foregroundColor: FreightFairColors.primaryText,
+        backgroundColor: TruxifyColors.background,
+        foregroundColor: TruxifyColors.primaryText,
         elevation: 0,
         centerTitle: false,
-        surfaceTintColor: FreightFairColors.background,
-        shape: Border(bottom: BorderSide(color: FreightFairColors.border, width: 1)),
+        surfaceTintColor: TruxifyColors.background,
+        shape: Border(bottom: BorderSide(color: TruxifyColors.border, width: 1)),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: FreightFairColors.background,
-        hintStyle: const TextStyle(color: FreightFairColors.secondaryText),
-        labelStyle: const TextStyle(color: FreightFairColors.secondaryText),
+        fillColor: TruxifyColors.background,
+        hintStyle: const TextStyle(color: TruxifyColors.secondaryText),
+        labelStyle: const TextStyle(color: TruxifyColors.secondaryText),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.border),
+          borderSide: const BorderSide(color: TruxifyColors.border),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.border),
+          borderSide: const BorderSide(color: TruxifyColors.border),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.accent, width: 1.4),
+          borderSide: const BorderSide(color: TruxifyColors.accent, width: 1.4),
         ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: FreightFairColors.accent,
+          backgroundColor: TruxifyColors.accent,
           foregroundColor: Colors.white,
           elevation: 0,
           minimumSize: const Size.fromHeight(52),
@@ -106,8 +106,8 @@ class FreightFairTheme {
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: FreightFairColors.accentDark,
-          side: const BorderSide(color: FreightFairColors.border),
+          foregroundColor: TruxifyColors.accentDark,
+          side: const BorderSide(color: TruxifyColors.border),
           minimumSize: const Size.fromHeight(52),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           textStyle: GoogleFonts.dmSans(fontWeight: FontWeight.w700, fontSize: 16),
@@ -115,50 +115,50 @@ class FreightFairTheme {
       ),
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
-          foregroundColor: FreightFairColors.accentDark,
+          foregroundColor: TruxifyColors.accentDark,
           textStyle: GoogleFonts.dmSans(fontWeight: FontWeight.w700),
         ),
       ),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: FreightFairColors.background,
-        selectedItemColor: FreightFairColors.accent,
-        unselectedItemColor: FreightFairColors.secondaryText,
+        backgroundColor: TruxifyColors.background,
+        selectedItemColor: TruxifyColors.accent,
+        unselectedItemColor: TruxifyColors.secondaryText,
         type: BottomNavigationBarType.fixed,
         elevation: 10,
       ),
       navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: FreightFairColors.background,
-        indicatorColor: FreightFairColors.accentLight,
+        backgroundColor: TruxifyColors.background,
+        indicatorColor: TruxifyColors.accentLight,
         iconTheme: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return IconThemeData(
             size: 22,
-            color: selected ? FreightFairColors.accentDark : FreightFairColors.secondaryText,
+            color: selected ? TruxifyColors.accentDark : TruxifyColors.secondaryText,
           );
         }),
         labelTextStyle: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return TextStyle(
             fontSize: 10,
-            color: selected ? FreightFairColors.accentDark : FreightFairColors.secondaryText,
+            color: selected ? TruxifyColors.accentDark : TruxifyColors.secondaryText,
             fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
           );
         }),
       ),
       chipTheme: base.chipTheme.copyWith(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
-        backgroundColor: FreightFairColors.secondaryBackground,
-        selectedColor: FreightFairColors.accentLight,
+        backgroundColor: TruxifyColors.secondaryBackground,
+        selectedColor: TruxifyColors.accentLight,
         labelStyle: GoogleFonts.dmSans(fontWeight: FontWeight.w600),
-        side: const BorderSide(color: FreightFairColors.border),
+        side: const BorderSide(color: TruxifyColors.border),
       ),
       tabBarTheme: const TabBarThemeData(
-        labelColor: FreightFairColors.accentDark,
-        unselectedLabelColor: FreightFairColors.secondaryText,
-        indicatorColor: FreightFairColors.accent,
-        dividerColor: FreightFairColors.border,
+        labelColor: TruxifyColors.accentDark,
+        unselectedLabelColor: TruxifyColors.secondaryText,
+        indicatorColor: TruxifyColors.accent,
+        dividerColor: TruxifyColors.border,
       ),
-      iconTheme: const IconThemeData(color: FreightFairColors.primaryText),
+      iconTheme: const IconThemeData(color: TruxifyColors.primaryText),
     );
   }
 
@@ -166,25 +166,25 @@ class FreightFairTheme {
     final base = ThemeData(
       useMaterial3: true,
       colorScheme: ColorScheme.fromSeed(
-        seedColor: FreightFairColors.accent,
+        seedColor: TruxifyColors.accent,
         brightness: Brightness.dark,
-        primary: FreightFairColors.accent,
-        secondary: FreightFairColors.accent,
-        surface: FreightFairColors.darkCardBackground,
-        surfaceContainerHighest: FreightFairColors.darkSecondaryBackground,
-        onSurface: FreightFairColors.darkPrimaryText,
-        outlineVariant: FreightFairColors.darkBorder,
+        primary: TruxifyColors.accent,
+        secondary: TruxifyColors.accent,
+        surface: TruxifyColors.darkCardBackground,
+        surfaceContainerHighest: TruxifyColors.darkSecondaryBackground,
+        onSurface: TruxifyColors.darkPrimaryText,
+        outlineVariant: TruxifyColors.darkBorder,
       ),
     );
 
     return base.copyWith(
-      scaffoldBackgroundColor: FreightFairColors.darkBackground,
+      scaffoldBackgroundColor: TruxifyColors.darkBackground,
       textTheme: GoogleFonts.dmSansTextTheme(base.textTheme).apply(
-        bodyColor: FreightFairColors.darkPrimaryText,
-        displayColor: FreightFairColors.darkPrimaryText,
+        bodyColor: TruxifyColors.darkPrimaryText,
+        displayColor: TruxifyColors.darkPrimaryText,
       ),
       cardTheme: CardThemeData(
-        color: FreightFairColors.darkCardBackground,
+        color: TruxifyColors.darkCardBackground,
         elevation: 0,
         shadowColor: Colors.black.withValues(alpha: 0.4),
         shape: RoundedRectangleBorder(
@@ -192,39 +192,39 @@ class FreightFairTheme {
         ),
       ),
       dividerTheme: const DividerThemeData(
-        color: FreightFairColors.darkBorder,
+        color: TruxifyColors.darkBorder,
         thickness: 1,
       ),
       appBarTheme: const AppBarTheme(
-        backgroundColor: FreightFairColors.darkSecondaryBackground,
-        foregroundColor: FreightFairColors.darkPrimaryText,
+        backgroundColor: TruxifyColors.darkSecondaryBackground,
+        foregroundColor: TruxifyColors.darkPrimaryText,
         elevation: 0,
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
-        shape: Border(bottom: BorderSide(color: FreightFairColors.darkBorder, width: 1)),
+        shape: Border(bottom: BorderSide(color: TruxifyColors.darkBorder, width: 1)),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: FreightFairColors.darkSecondaryBackground,
-        hintStyle: const TextStyle(color: FreightFairColors.darkSecondaryText),
-        labelStyle: const TextStyle(color: FreightFairColors.darkSecondaryText),
+        fillColor: TruxifyColors.darkSecondaryBackground,
+        hintStyle: const TextStyle(color: TruxifyColors.darkSecondaryText),
+        labelStyle: const TextStyle(color: TruxifyColors.darkSecondaryText),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.darkBorder),
+          borderSide: const BorderSide(color: TruxifyColors.darkBorder),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.darkBorder),
+          borderSide: const BorderSide(color: TruxifyColors.darkBorder),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: FreightFairColors.accent, width: 1.4),
+          borderSide: const BorderSide(color: TruxifyColors.accent, width: 1.4),
         ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: FreightFairColors.accent,
+          backgroundColor: TruxifyColors.accent,
           foregroundColor: Colors.white,
           elevation: 0,
           minimumSize: const Size.fromHeight(52),
@@ -234,8 +234,8 @@ class FreightFairTheme {
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: FreightFairColors.accent,
-          side: const BorderSide(color: FreightFairColors.darkBorder),
+          foregroundColor: TruxifyColors.accent,
+          side: const BorderSide(color: TruxifyColors.darkBorder),
           minimumSize: const Size.fromHeight(52),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           textStyle: GoogleFonts.dmSans(fontWeight: FontWeight.w700, fontSize: 16),
@@ -243,56 +243,57 @@ class FreightFairTheme {
       ),
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
-          foregroundColor: FreightFairColors.accent,
+          foregroundColor: TruxifyColors.accent,
           textStyle: GoogleFonts.dmSans(fontWeight: FontWeight.w700),
         ),
       ),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: FreightFairColors.darkSecondaryBackground,
-        selectedItemColor: FreightFairColors.accent,
-        unselectedItemColor: FreightFairColors.darkSecondaryText,
+        backgroundColor: TruxifyColors.darkSecondaryBackground,
+        selectedItemColor: TruxifyColors.accent,
+        unselectedItemColor: TruxifyColors.darkSecondaryText,
         type: BottomNavigationBarType.fixed,
         elevation: 0,
       ),
       navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: FreightFairColors.darkSecondaryBackground,
-        indicatorColor: FreightFairColors.darkAccentLight,
+        backgroundColor: TruxifyColors.darkSecondaryBackground,
+        indicatorColor: TruxifyColors.darkAccentLight,
         iconTheme: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return IconThemeData(
             size: 22,
-            color: selected ? FreightFairColors.accent : FreightFairColors.darkSecondaryText,
+            color: selected ? TruxifyColors.accent : TruxifyColors.darkSecondaryText,
           );
         }),
         labelTextStyle: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return TextStyle(
             fontSize: 10,
-            color: selected ? FreightFairColors.accent : FreightFairColors.darkSecondaryText,
+            color: selected ? TruxifyColors.accent : TruxifyColors.darkSecondaryText,
             fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
           );
         }),
       ),
       chipTheme: base.chipTheme.copyWith(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
-        backgroundColor: FreightFairColors.darkSecondaryBackground,
-        selectedColor: FreightFairColors.darkAccentLight,
+        backgroundColor: TruxifyColors.darkSecondaryBackground,
+        selectedColor: TruxifyColors.darkAccentLight,
         labelStyle: GoogleFonts.dmSans(
           fontWeight: FontWeight.w600,
-          color: FreightFairColors.darkPrimaryText,
+          color: TruxifyColors.darkPrimaryText,
         ),
-        side: const BorderSide(color: FreightFairColors.darkBorder),
+        side: const BorderSide(color: TruxifyColors.darkBorder),
       ),
       tabBarTheme: const TabBarThemeData(
-        labelColor: FreightFairColors.accent,
-        unselectedLabelColor: FreightFairColors.darkSecondaryText,
-        indicatorColor: FreightFairColors.accent,
-        dividerColor: FreightFairColors.darkBorder,
+        labelColor: TruxifyColors.accent,
+        unselectedLabelColor: TruxifyColors.darkSecondaryText,
+        indicatorColor: TruxifyColors.accent,
+        dividerColor: TruxifyColors.darkBorder,
         labelStyle: TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
         unselectedLabelStyle: TextStyle(fontWeight: FontWeight.w500, fontSize: 14),
       ),
-      iconTheme: const IconThemeData(color: FreightFairColors.darkPrimaryText),
+      iconTheme: const IconThemeData(color: TruxifyColors.darkPrimaryText),
     );
   }
 }
+
 

--- a/apps/customer/lib/widgets/app_logo.dart
+++ b/apps/customer/lib/widgets/app_logo.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../theme/app_theme.dart';
+
 class AppLogo extends StatelessWidget {
   const AppLogo({super.key, this.centered = false, this.textStyle, this.iconSize = 22});
 

--- a/apps/customer/lib/widgets/app_logo.dart
+++ b/apps/customer/lib/widgets/app_logo.dart
@@ -18,10 +18,10 @@ class AppLogo extends StatelessWidget {
           width: iconSize + 10,
           height: iconSize + 10,
           decoration: BoxDecoration(
-            color: FreightFairColors.accentLight,
+            color: TruxifyColors.accentLight,
             borderRadius: BorderRadius.circular(12),
           ),
-          child: Icon(Icons.local_shipping_rounded, color: FreightFairColors.accentDark, size: iconSize),
+          child: Icon(Icons.local_shipping_rounded, color: TruxifyColors.accentDark, size: iconSize),
         ),
         const SizedBox(width: 10),
         Text(
@@ -35,3 +35,4 @@ class AppLogo extends StatelessWidget {
     return Center(child: logo);
   }
 }
+

--- a/apps/customer/lib/widgets/common_widgets.dart
+++ b/apps/customer/lib/widgets/common_widgets.dart
@@ -78,7 +78,7 @@ class PrimaryButton extends StatelessWidget {
       width: double.infinity,
       child: ElevatedButton(
         onPressed: onPressed,
-        style: ElevatedButton.styleFrom(backgroundColor: backgroundColor ?? FreightFairColors.accent),
+        style: ElevatedButton.styleFrom(backgroundColor: backgroundColor ?? TruxifyColors.accent),
         child: child,
       ),
     );
@@ -97,14 +97,14 @@ class AccentPill extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
-        color: backgroundColor ?? FreightFairColors.accentLight,
+        color: backgroundColor ?? TruxifyColors.accentLight,
         borderRadius: BorderRadius.circular(999),
       ),
       child: Text(
         label,
         style: Theme.of(context).textTheme.labelMedium?.copyWith(
               fontWeight: FontWeight.w700,
-              color: textColor ?? FreightFairColors.accentDark,
+              color: textColor ?? TruxifyColors.accentDark,
             ),
       ),
     );
@@ -124,19 +124,19 @@ class StatCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: elevatedSurfaceDecoration(
-        color: isDark ? FreightFairColors.darkAccentLight : FreightFairColors.accentLight,
+        color: isDark ? TruxifyColors.darkAccentLight : TruxifyColors.accentLight,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(icon, color: isDark ? FreightFairColors.accent : FreightFairColors.accentDark, size: 20),
+          Icon(icon, color: isDark ? TruxifyColors.accent : TruxifyColors.accentDark, size: 20),
           const SizedBox(height: 12),
           Text(value, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
           const SizedBox(height: 4),
           Text(
             title,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: isDark ? FreightFairColors.darkSecondaryText : FreightFairColors.secondaryText,
+              color: isDark ? TruxifyColors.darkSecondaryText : TruxifyColors.secondaryText,
             ),
           ),
         ],
@@ -190,7 +190,7 @@ class StatusBadge extends StatelessWidget {
 }
 
 class LiveDot extends StatefulWidget {
-  const LiveDot({super.key, this.color = FreightFairColors.accent, this.size = 10});
+  const LiveDot({super.key, this.color = TruxifyColors.accent, this.size = 10});
 
   final Color color;
   final double size;
@@ -238,3 +238,4 @@ class _LiveDotState extends State<LiveDot> with SingleTickerProviderStateMixin {
     );
   }
 }
+

--- a/apps/customer/lib/widgets/map_placeholder.dart
+++ b/apps/customer/lib/widgets/map_placeholder.dart
@@ -50,12 +50,12 @@ class MapPlaceholder extends StatelessWidget {
           Positioned(
             left: 18,
             top: 18,
-            child: _MapPin(label: pickup, color: FreightFairColors.accentDark, icon: Icons.my_location_rounded),
+            child: _MapPin(label: pickup, color: TruxifyColors.accentDark, icon: Icons.my_location_rounded),
           ),
           Positioned(
             right: 18,
             bottom: 96,
-            child: _MapPin(label: drop, color: FreightFairColors.warning, icon: Icons.place_rounded),
+            child: _MapPin(label: drop, color: TruxifyColors.warning, icon: Icons.place_rounded),
           ),
           Positioned.fill(
             child: LayoutBuilder(
@@ -72,11 +72,11 @@ class MapPlaceholder extends StatelessWidget {
                         width: 42,
                         height: 42,
                         decoration: BoxDecoration(
-                          color: FreightFairColors.accent,
+                          color: TruxifyColors.accent,
                           shape: BoxShape.circle,
                           boxShadow: [
                             BoxShadow(
-                              color: FreightFairColors.accent.withValues(alpha: 0.25),
+                              color: TruxifyColors.accent.withValues(alpha: 0.25),
                               blurRadius: 18,
                               spreadRadius: 2,
                             ),
@@ -100,7 +100,7 @@ class MapPlaceholder extends StatelessWidget {
                         ),
                         child: Row(
                           children: [
-                            const Icon(Icons.gps_fixed_rounded, color: FreightFairColors.accentDark, size: 18),
+                            const Icon(Icons.gps_fixed_rounded, color: TruxifyColors.accentDark, size: 18),
                             const SizedBox(width: 10),
                             Expanded(
                               child: Text(
@@ -180,7 +180,7 @@ class _RoutePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final pathPaint = Paint()
-      ..color = FreightFairColors.accentDark.withValues(alpha: 0.28)
+      ..color = TruxifyColors.accentDark.withValues(alpha: 0.28)
       ..strokeWidth = 4
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round;
@@ -191,7 +191,7 @@ class _RoutePainter extends CustomPainter {
     canvas.drawPath(path, pathPaint);
 
     final dashPaint = Paint()
-      ..color = FreightFairColors.accent.withValues(alpha: 0.55)
+      ..color = TruxifyColors.accent.withValues(alpha: 0.55)
       ..strokeWidth = 2
       ..style = PaintingStyle.stroke;
 
@@ -211,3 +211,4 @@ class _RoutePainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant _RoutePainter oldDelegate) => oldDelegate.progress != progress;
 }
+

--- a/apps/customer/lib/widgets/order_card.dart
+++ b/apps/customer/lib/widgets/order_card.dart
@@ -35,7 +35,7 @@ class ActiveOrderCard extends StatelessWidget {
                 ),
                 StatusBadge(
                   label: order.milestone,
-                  color: FreightFairColors.accent,
+                  color: TruxifyColors.accent,
                   filled: true,
                 ),
               ],
@@ -45,7 +45,7 @@ class ActiveOrderCard extends StatelessWidget {
               order.route,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color:
-                        FreightFairColors.adaptiveSecondaryText(context),
+                        TruxifyColors.adaptiveSecondaryText(context),
                   ),
             ),
             const SizedBox(height: 8),
@@ -61,7 +61,7 @@ class ActiveOrderCard extends StatelessWidget {
               'ETA: ${order.eta}',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color:
-                        FreightFairColors.adaptiveSecondaryText(context),
+                        TruxifyColors.adaptiveSecondaryText(context),
                   ),
             ),
             const SizedBox(height: 14),
@@ -89,8 +89,8 @@ class HistoryOrderCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final statusColor = order.status == 'Delivered'
-        ? FreightFairColors.accentDark
-        : FreightFairColors.error;
+        ? TruxifyColors.accentDark
+        : TruxifyColors.error;
 
     return GestureDetector(
       onTap: onTap,
@@ -115,7 +115,7 @@ class HistoryOrderCard extends StatelessWidget {
                       .textTheme
                       .bodySmall
                       ?.copyWith(
-                        color: FreightFairColors
+                        color: TruxifyColors
                             .adaptiveSecondaryText(context),
                       ),
                 ),
@@ -134,8 +134,8 @@ class HistoryOrderCard extends StatelessWidget {
                         color:
                             Theme.of(context).brightness ==
                                     Brightness.dark
-                                ? FreightFairColors.accent
-                                : FreightFairColors.accentDark,
+                                ? TruxifyColors.accent
+                                : TruxifyColors.accentDark,
                       ),
                 ),
                 const SizedBox(width: 10),
@@ -156,7 +156,7 @@ class HistoryOrderCard extends StatelessWidget {
                   .bodyMedium
                   ?.copyWith(
                     color:
-                        FreightFairColors.adaptiveSecondaryText(context),
+                        TruxifyColors.adaptiveSecondaryText(context),
                   ),
             ),
             const SizedBox(height: 14),

--- a/apps/customer/lib/widgets/recent_route_card.dart
+++ b/apps/customer/lib/widgets/recent_route_card.dart
@@ -20,7 +20,7 @@ class RecentRouteCard extends StatelessWidget {
     return InfoCard(
       child: Row(
         children: [
-          const Icon(Icons.route_rounded, color: FreightFairColors.accentDark),
+          const Icon(Icons.route_rounded, color: TruxifyColors.accentDark),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -30,7 +30,7 @@ class RecentRouteCard extends StatelessWidget {
                 const SizedBox(height: 4),
                 Text(
                   '${route.pickup} to ${route.drop}',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: FreightFairColors.adaptiveSecondaryText(context)),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context)),
                 ),
               ],
             ),
@@ -42,3 +42,4 @@ class RecentRouteCard extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/widgets/shipment_card.dart
+++ b/apps/customer/lib/widgets/shipment_card.dart
@@ -46,7 +46,7 @@ class ShipmentCard extends StatelessWidget {
               shipment.driver,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color:
-                        FreightFairColors.adaptiveSecondaryText(context),
+                        TruxifyColors.adaptiveSecondaryText(context),
                   ),
             ),
             const Spacer(),
@@ -74,7 +74,7 @@ class ShipmentCard extends StatelessWidget {
               'Truck ${shipment.truckNumber}',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color:
-                        FreightFairColors.adaptiveSecondaryText(context),
+                        TruxifyColors.adaptiveSecondaryText(context),
                   ),
             ),
           ],

--- a/apps/customer/lib/widgets/timeline_connector.dart
+++ b/apps/customer/lib/widgets/timeline_connector.dart
@@ -5,7 +5,7 @@ import '../theme/app_theme.dart';
 class TimelineConnector extends StatelessWidget {
   const TimelineConnector({
     super.key,
-    this.color = FreightFairColors.border,
+    this.color = TruxifyColors.border,
     this.width = 28,
     this.height = 2,
   });
@@ -19,3 +19,4 @@ class TimelineConnector extends StatelessWidget {
     return Container(width: width, height: height, color: color);
   }
 }
+

--- a/apps/customer/lib/widgets/timeline_milestone.dart
+++ b/apps/customer/lib/widgets/timeline_milestone.dart
@@ -20,7 +20,7 @@ class TimelineMilestone extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = current ? FreightFairColors.accent : done ? FreightFairColors.accentDark : FreightFairColors.border;
+    final color = current ? TruxifyColors.accent : done ? TruxifyColors.accentDark : TruxifyColors.border;
 
     return Column(
       children: [
@@ -31,7 +31,7 @@ class TimelineMilestone extends StatelessWidget {
             color: color,
             shape: BoxShape.circle,
             boxShadow: current
-                ? [BoxShadow(color: FreightFairColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
+                ? [BoxShadow(color: TruxifyColors.accent.withValues(alpha: 0.3), blurRadius: 8, spreadRadius: 1)]
                 : const [],
           ),
         ),
@@ -48,3 +48,4 @@ class TimelineMilestone extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/widgets/timeline_row.dart
+++ b/apps/customer/lib/widgets/timeline_row.dart
@@ -10,7 +10,7 @@ class TimelineRow extends StatelessWidget {
     super.key,
     required this.step,
     this.indicatorSize = 14,
-    this.connectorColor = FreightFairColors.border,
+    this.connectorColor = TruxifyColors.border,
     this.connectorLength = 42,
     this.connectorThickness = 2,
   });
@@ -23,7 +23,7 @@ class TimelineRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = step.completed ? FreightFairColors.accentDark : FreightFairColors.border;
+    final color = step.completed ? TruxifyColors.accentDark : TruxifyColors.border;
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -62,7 +62,7 @@ class TimelineRow extends StatelessWidget {
                   Text(
                     step.timestamp,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: FreightFairColors.adaptiveSecondaryText(context),
+                          color: TruxifyColors.adaptiveSecondaryText(context),
                         ),
                   ),
                 ],
@@ -74,3 +74,4 @@ class TimelineRow extends StatelessWidget {
     );
   }
 }
+

--- a/apps/customer/lib/widgets/truck_card.dart
+++ b/apps/customer/lib/widgets/truck_card.dart
@@ -47,7 +47,7 @@ class TruckCard extends StatelessWidget {
           Text(
             '${truck.truck}  |  ${truck.capacity}',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: FreightFairColors.adaptiveSecondaryText(context),
+                  color: TruxifyColors.adaptiveSecondaryText(context),
                 ),
           ),
           const SizedBox(height: 12),
@@ -56,7 +56,7 @@ class TruckCard extends StatelessWidget {
               Text(
                 'Available space',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: FreightFairColors.adaptiveSecondaryText(context),
+                      color: TruxifyColors.adaptiveSecondaryText(context),
                     ),
               ),
               const Spacer(),
@@ -75,9 +75,9 @@ class TruckCard extends StatelessWidget {
             child: LinearProgressIndicator(
               minHeight: 10,
               value: truck.freeSpacePercent / 100,
-              backgroundColor: FreightFairColors.accentLight,
+              backgroundColor: TruxifyColors.accentLight,
               valueColor: const AlwaysStoppedAnimation(
-                FreightFairColors.accent,
+                TruxifyColors.accent,
               ),
             ),
           ),
@@ -92,8 +92,8 @@ class TruckCard extends StatelessWidget {
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.w800,
                           color: Theme.of(context).brightness == Brightness.dark
-                              ? FreightFairColors.accent
-                              : FreightFairColors.accentDark,
+                              ? TruxifyColors.accent
+                              : TruxifyColors.accentDark,
                         ),
                   ),
                   const SizedBox(height: 3),
@@ -101,7 +101,7 @@ class TruckCard extends StatelessWidget {
                     'ETA to pickup: ${truck.eta}',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color:
-                              FreightFairColors.adaptiveSecondaryText(context),
+                              TruxifyColors.adaptiveSecondaryText(context),
                         ),
                   ),
                 ],
@@ -130,3 +130,4 @@ class TruckCard extends StatelessWidget {
     );
   }
 }
+


### PR DESCRIPTION
Summary
This PR resolves issue #165 by aligning customer-app theme naming with Truxify branding.

What changed
Renamed FreightFairColors to TruxifyColors in apps/customer/lib/theme/app_theme.dart
Updated all customer-app references to use TruxifyColors for consistency
Why
The previous class name contradicted the app branding (Truxify), which caused naming inconsistency and potential confusion for maintainers.

Validation
Ran flutter analyze lib inside apps/customer
No rename-related errors introduced (only existing info-level deprecation notices remain)
Scope
Customer app theme and usage references only
No behavior/UI logic changes intended beyond naming consistency
Issue
Closes #165