### PR TITLE
refactor: extract reusable MenuItem and MenuCard widgets

### DIFF
--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:truxify/widgets/menu_card.dart';
+import 'package:truxify/widgets/menu_item.dart';
 
 import '../controllers/app_controller.dart';
 import '../theme/app_theme.dart';
@@ -114,19 +116,19 @@ class ProfileScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _MenuCard(
+              child: MenuCard(
                 children: [
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.credit_card_rounded,
                     label: 'Payment Methods',
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const PaymentMethodsScreen())),
                   ),
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.description_rounded,
                     label: 'My Documents',
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const MyDocumentsScreen())),
                   ),
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.location_on_rounded,
                     label: 'Saved Addresses',
                     showDivider: false,
@@ -140,21 +142,21 @@ class ProfileScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _MenuCard(
+              child: MenuCard(
                 children: [
                   _DarkModeMenuItem(),
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.language_rounded,
                     label: 'Language',
                     trailing: 'English',
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const LanguageScreen())),
                   ),
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.help_outline_rounded,
                     label: 'Help & Support',
                     onTap: () => Navigator.of(context).push(AppPageRoute(builder: (_) => const HelpSupportScreen())),
                   ),
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.info_outline_rounded,
                     label: 'About Truxify',
                     showDivider: false,
@@ -166,9 +168,9 @@ class ProfileScreen extends StatelessWidget {
             const SizedBox(height: 12),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _MenuCard(
+              child: MenuCard(
                 children: [
-                  _MenuItem(
+                  MenuItem(
                     icon: Icons.logout_rounded,
                     label: 'Logout',
                     iconBackgroundColor: TruxifyColors.error.withValues(alpha: 0.12),
@@ -301,118 +303,6 @@ class _StatColumn extends StatelessWidget {
                   fontSize: 11,
                 ),
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _MenuCard extends StatelessWidget {
-  const _MenuCard({required this.children});
-
-  final List<Widget> children;
-
-  @override
-  Widget build(BuildContext context) {
-    final surface = Theme.of(context).colorScheme.surface;
-    return Container(
-      decoration: BoxDecoration(
-        color: surface,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: const [
-          BoxShadow(color: Color(0x0F000000), blurRadius: 8, offset: Offset(0, 2)),
-        ],
-      ),
-      child: Column(children: children),
-    );
-  }
-}
-
-class _MenuItem extends StatelessWidget {
-  const _MenuItem({
-    required this.icon,
-    required this.label,
-    required this.onTap,
-    this.trailing,
-    this.iconBackgroundColor,
-    this.iconColor = TruxifyColors.accent,
-    this.textColor,
-    this.showChevron = true,
-    this.showDivider = true,
-  });
-
-  final IconData icon;
-  final String label;
-  final VoidCallback onTap;
-  final String? trailing;
-  final Color? iconBackgroundColor;
-  final Color iconColor;
-  final Color? textColor;
-  final bool showChevron;
-  final bool showDivider;
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final resolvedIconBg = iconBackgroundColor ??
-        (isDark ? TruxifyColors.darkAccentLight : TruxifyColors.accentLight);
-    final resolvedTextColor = textColor ?? Theme.of(context).textTheme.bodyMedium?.color;
-    return InkWell(
-      onTap: onTap,
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-            child: Row(
-              children: [
-                Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: resolvedIconBg,
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Icon(icon, size: 17, color: iconColor),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    label,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: resolvedTextColor,
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                        ),
-                  ),
-                ),
-                if (trailing != null)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 6),
-                    child: Text(
-                      trailing!,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: isDark
-                                ? TruxifyColors.darkSecondaryText
-                                : TruxifyColors.secondaryText,
-                            fontSize: 13,
-                          ),
-                    ),
-                  ),
-                if (showChevron)
-                  Icon(
-                    Icons.chevron_right_rounded,
-                    size: 16,
-                    color: isDark ? TruxifyColors.darkSecondaryText : const Color(0xFFB0B0B0),
-                  ),
-              ],
-            ),
-          ),
-          if (showDivider)
-            Divider(
-              height: 1,
-              thickness: 1,
-              color: isDark ? TruxifyColors.darkBorder : TruxifyColors.border,
-            ),
         ],
       ),
     );

--- a/apps/customer/lib/widgets/menu_card.dart
+++ b/apps/customer/lib/widgets/menu_card.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class MenuCard extends StatelessWidget {
+  const MenuCard({
+    super.key,
+    required this.children,
+  });
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final surface = Theme.of(context).colorScheme.surface;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0F000000),
+            blurRadius: 8,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(children: children),
+    );
+  }
+}

--- a/apps/customer/lib/widgets/menu_item.dart
+++ b/apps/customer/lib/widgets/menu_item.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import '../theme/app_theme.dart';
+
+class MenuItem extends StatelessWidget {
+  const MenuItem({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.trailing,
+    this.iconBackgroundColor,
+    this.iconColor = TruxifyColors.accent,
+    this.textColor,
+    this.showChevron = true,
+    this.showDivider = true,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final String? trailing;
+  final Color? iconBackgroundColor;
+  final Color iconColor;
+  final Color? textColor;
+  final bool showChevron;
+  final bool showDivider;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final resolvedIconBg = iconBackgroundColor ??
+        (isDark
+            ? TruxifyColors.darkAccentLight
+            : TruxifyColors.accentLight);
+    final resolvedTextColor =
+        textColor ?? Theme.of(context).textTheme.bodyMedium?.color;
+    return InkWell(
+      onTap: onTap,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            child: Row(
+              children: [
+                Container(
+                  width: 34,
+                  height: 34,
+                  decoration: BoxDecoration(
+                    color: resolvedIconBg,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(icon, size: 17, color: iconColor),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: resolvedTextColor,
+                          fontWeight: FontWeight.w500,
+                          fontSize: 14,
+                        ),
+                  ),
+                ),
+                if (trailing != null)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: Text(
+                      trailing!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: isDark
+                                ? TruxifyColors.darkSecondaryText
+                                : TruxifyColors.secondaryText,
+                            fontSize: 13,
+                          ),
+                    ),
+                  ),
+                if (showChevron)
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    size: 16,
+                    color: isDark
+                        ? TruxifyColors.darkSecondaryText
+                        : const Color(0xFFB0B0B0),
+                  ),
+              ],
+            ),
+          ),
+          if (showDivider)
+            Divider(
+              height: 1,
+              thickness: 1,
+              color: isDark
+                  ? TruxifyColors.darkBorder
+                  : TruxifyColors.border,
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Extracted MenuItem and MenuCard into reusable widget files to improve code reusability and reduce duplicated UI logic.

## Changes Made

- Moved _MenuItem to widgets/menu_item.dart
- Moved _MenuCard to widgets/menu_card.dart
- Renamed widgets to MenuItem and MenuCard
- Updated ProfileScreen to use the shared widgets
- Preserved existing UI behavior and styling

## Benefits

- Improved widget reusability
- Cleaner profile/settings screen architecture
- Reduced duplicated styling logic
- Easier maintenance and future feature expansion

Closes #218