### PR TITLE
refactor(customer): move documents data out of build

### DIFF
--- a/apps/customer/lib/screens/my_documents_screen.dart
+++ b/apps/customer/lib/screens/my_documents_screen.dart
@@ -91,7 +91,7 @@ class MyDocumentsScreen extends StatelessWidget {
                               child: Text(
                                 doc['status'] as String,
                                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                      color: doc['statusColor'],
+                                      color: doc['statusColor'] as Color,
                                       fontWeight: FontWeight.w600,
                                       fontSize: 10,
                                     ),

--- a/apps/customer/lib/screens/my_documents_screen.dart
+++ b/apps/customer/lib/screens/my_documents_screen.dart
@@ -5,35 +5,35 @@ import '../theme/app_theme.dart';
 class MyDocumentsScreen extends StatelessWidget {
   const MyDocumentsScreen({super.key});
 
+  static const List<Map<String, Object>> _documents = [
+    {
+      'name': 'Aadhar Card',
+      'status': 'Verified',
+      'icon': Icons.card_membership_rounded,
+      'statusColor': Colors.green,
+    },
+    {
+      'name': 'PAN Card',
+      'status': 'Verified',
+      'icon': Icons.credit_card_rounded,
+      'statusColor': Colors.green,
+    },
+    {
+      'name': 'Business License',
+      'status': 'Pending',
+      'icon': Icons.description_rounded,
+      'statusColor': Colors.orange,
+    },
+    {
+      'name': 'Bank Account',
+      'status': 'Verified',
+      'icon': Icons.account_balance_rounded,
+      'statusColor': Colors.green,
+    },
+  ];
+
   @override
   Widget build(BuildContext context) {
-    final documents = <Map<String, dynamic>>[
-      {
-        'name': 'Aadhar Card',
-        'status': 'Verified',
-        'icon': Icons.card_membership_rounded,
-        'statusColor': Colors.green,
-      },
-      {
-        'name': 'PAN Card',
-        'status': 'Verified',
-        'icon': Icons.credit_card_rounded,
-        'statusColor': Colors.green,
-      },
-      {
-        'name': 'Business License',
-        'status': 'Pending',
-        'icon': Icons.description_rounded,
-        'statusColor': Colors.orange,
-      },
-      {
-        'name': 'Bank Account',
-        'status': 'Verified',
-        'icon': Icons.account_balance_rounded,
-        'statusColor': Colors.green,
-      },
-    ];
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Documents'),
@@ -48,10 +48,10 @@ class MyDocumentsScreen extends StatelessWidget {
             ListView.separated(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
-              itemCount: documents.length,
+              itemCount: _documents.length,
               separatorBuilder: (_, __) => const SizedBox(height: 10),
               itemBuilder: (context, index) {
-                final doc = documents[index];
+                final doc = _documents[index];
                 return Container(
                   decoration: BoxDecoration(
                     border: Border.all(color: (Theme.of(context).brightness == Brightness.dark ? TruxifyColors.darkBorder : TruxifyColors.border)),


### PR DESCRIPTION
## Summary

Refactored the My Documents screen by moving the hardcoded documents list out of the `build()` method.

### Changes Made

* Extracted the documents list into a class-level `static const` collection.
* Updated the screen to use the extracted data source.
* Preserved all existing UI behavior and document rendering.

### Benefits

* Prevents unnecessary list re-allocation on every widget rebuild.
* Improves maintainability and readability.
* Aligns with Flutter performance and code structure best practices.

### Verification

* Documents list is no longer created inside `build()`.
* Existing document cards render exactly as before.
* No functionality or UI changes were introduced.
* No unrelated refactors were included.

Closes #158
