### PR TITLE
fix: move faqs list outside build method

### DIFF
--- a/apps/customer/lib/screens/help_support_screen.dart
+++ b/apps/customer/lib/screens/help_support_screen.dart
@@ -13,9 +13,7 @@ class _FaqItem {
 class HelpSupportScreen extends StatelessWidget {
   const HelpSupportScreen({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    const faqs = [
+  static const List<_FaqItem> faqs = [
       _FaqItem(
         question: 'How do I book a truck?',
         answer: 'To book a truck, go to Home, enter your pickup and drop locations, select a truck, and confirm your booking.',
@@ -33,6 +31,9 @@ class HelpSupportScreen extends StatelessWidget {
         answer: 'You can track your shipment in real-time from the Orders section using the live tracking feature.',
       ),
     ];
+
+  @override
+  Widget build(BuildContext context) {
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Description

Moved the faqs list outside the build() method to avoid unnecessary re-allocation during widget rebuilds.

## Changes Made

- Moved faqs data to a static class-level constant
- Preserved existing UI and functionality
- Eliminated repeated list creation on rebuilds

## Benefits

- Improved widget efficiency
- Cleaner separation of UI and data
- Addresses flutter-analysis issue

Closes #147