### PR TITLE
feat: add rate limiting middleware to protect API endpoints [ GSSOC'26 ]

### DIFF
--- a/backend/api/package-lock.json
+++ b/backend/api/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "firebase-admin": "^12.1.1",
         "ioredis": "^5.11.0",
         "mongodb": "^6.7.0",
@@ -1217,6 +1218,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1835,6 +1854,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "firebase-admin": "^12.1.1",
     "ioredis": "^5.11.0",
     "mongodb": "^6.7.0",

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import http from 'http';
 import dotenv from 'dotenv';
 import path from 'path';
+import rateLimit from 'express-rate-limit';
 
 // Pre-load DB config to execute client setups
 import './config/db.js';
@@ -26,6 +27,27 @@ app.use(cors({
 }));
 
 app.use(express.json());
+
+// ============================================================================
+// RATE LIMITING
+// ============================================================================
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,                  // max requests per window per IP
+  standardHeaders: true,     // return RateLimit-* headers
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+const healthLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30,
+  message: { error: 'Health check rate limit exceeded.' }
+});
+
+app.use('/api/', limiter);
+app.use('/api/health', healthLimiter);
 
 // ============================================================================
 // REQUEST LOGGER

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -18,6 +18,7 @@ import driverRoutes from './routes/driverRoutes.js';
 
 const app = express();
 const server = http.createServer(app);
+app.set('trust proxy', 1); // ← add this
 
 // Enable CORS for frontend clients (Flutter Web, mobile, etc.)
 app.use(cors({
@@ -33,21 +34,24 @@ app.use(express.json());
 // ============================================================================
 
 const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100,                  // max requests per window per IP
-  standardHeaders: true,     // return RateLimit-* headers
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
   legacyHeaders: false,
+  skip: (req) => req.originalUrl === '/api/health',
   message: { error: 'Too many requests, please try again later.' }
 });
 
 const healthLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
+  windowMs: 60 * 1000,
   max: 30,
   message: { error: 'Health check rate limit exceeded.' }
 });
 
 app.use('/api/', limiter);
 app.use('/api/health', healthLimiter);
+
+
 
 // ============================================================================
 // REQUEST LOGGER


### PR DESCRIPTION
Summary — protects all API routes from abuse and accidental flooding with zero-config rate limiting.
Changes:

General limiter: 100 requests per 15 minutes per IP on all /api/ routes
Strict limiter: 30 requests per minute on /api/health
Returns standard RateLimit headers for client awareness
Clean JSON error response on limit exceeded

Closes #288 