### PR TITLE
fix(orders): compute freight pricing server-side (#296) [GSSoC'26]

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -1,0 +1,125 @@
+/**
+ * Server-side freight pricing.
+ *
+ * Single source of truth for monetary fields on orders and load offers.
+ * Replaces the previous behaviour where the client (the customer) supplied
+ * `base_freight`, `toll_estimate`, `platform_fee`, and `total_amount`
+ * directly in the request body, and the server persisted them verbatim.
+ *
+ * Pricing inputs come from the route handler (distance, weight, goods type)
+ * — never from the request body — and are run through a rate card that is
+ * configurable via environment variables.
+ *
+ * All amounts are returned in **paisa** (1 INR = 100 paisa) to match the
+ * integer column types already used elsewhere in the schema (e.g.
+ * `load_bids.bid_amount` is documented as paisa in orderRoutes.js:215).
+ */
+
+const EARTH_RADIUS_KM = 6371.0088;
+
+const DEFAULTS = Object.freeze({
+  RATE_PER_TONNE_KM: 50,    // paisa per tonne-km, base rate
+  FRAGILE_MULTIPLIER: 1.5,  // multiplier on the base rate
+  STACKABLE_DISCOUNT: 0.9,  // multiplier < 1 to discount stackable cargo
+  HANDLING_FEE: 30000,      // paisa (₹300) flat handling fee
+  PLATFORM_FEE_PCT: 5,      // percent of base freight
+  FUEL_COST_PCT: 45,        // percent of base freight (driver-side cost)
+  TOLL_PER_KM: 200,         // paisa per km, proxy for highway toll
+});
+
+function readRateCard() {
+  return {
+    ratePerTonneKm: Number(process.env.TRUXIFY_RATE_PER_TONNE_KM ?? DEFAULTS.RATE_PER_TONNE_KM),
+    fragileMultiplier: Number(process.env.TRUXIFY_FRAGILE_MULTIPLIER ?? DEFAULTS.FRAGILE_MULTIPLIER),
+    stackableDiscount: Number(process.env.TRUXIFY_STACKABLE_DISCOUNT ?? DEFAULTS.STACKABLE_DISCOUNT),
+    handlingFee: Number(process.env.TRUXIFY_HANDLING_FEE ?? DEFAULTS.HANDLING_FEE),
+    platformFeePct: Number(process.env.TRUXIFY_PLATFORM_FEE_PCT ?? DEFAULTS.PLATFORM_FEE_PCT),
+    fuelCostPct: Number(process.env.TRUXIFY_FUEL_COST_PCT ?? DEFAULTS.FUEL_COST_PCT),
+    tollPerKm: Number(process.env.TRUXIFY_TOLL_PER_KM ?? DEFAULTS.TOLL_PER_KM),
+  };
+}
+
+/**
+ * Great-circle distance between two lat/lng points in kilometres.
+ * Returns 0 for identical points. Suitable as a baseline for freight
+ * pricing; for production routing accuracy integrate OSRM / Mapbox /
+ * Google Directions and pass the actual road distance in instead.
+ */
+export function haversineKm(lat1, lon1, lat2, lon2) {
+  if (
+    !Number.isFinite(lat1) || !Number.isFinite(lon1) ||
+    !Number.isFinite(lat2) || !Number.isFinite(lon2)
+  ) {
+    throw new TypeError('haversineKm requires finite numeric lat/lng arguments');
+  }
+  if (lat1 === lat2 && lon1 === lon2) return 0;
+
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+/**
+ * Compute the canonical pricing for an order.
+ *
+ * @param {object} input
+ * @param {number} input.pickupLat   - decimal degrees
+ * @param {number} input.pickupLng   - decimal degrees
+ * @param {number} input.dropLat     - decimal degrees
+ * @param {number} input.dropLng     - decimal degrees
+ * @param {number} input.weightTonnes - cargo weight in tonnes (> 0)
+ * @param {boolean} [input.isFragile] - fragile cargo multiplier
+ * @param {boolean} [input.isStackable] - stackable cargo discount
+ * @param {object} [rateCard] - override rate card (mainly for tests)
+ * @returns {object} pricing breakdown in paisa
+ * @throws {RangeError|TypeError} on invalid inputs
+ */
+export function computeOrderPricing(input, rateCard = readRateCard()) {
+  if (!input || typeof input !== 'object') {
+    throw new TypeError('computeOrderPricing requires an input object');
+  }
+  const {
+    pickupLat, pickupLng, dropLat, dropLng,
+    weightTonnes, isFragile = false, isStackable = false,
+  } = input;
+
+  if (!Number.isFinite(weightTonnes) || weightTonnes <= 0) {
+    throw new RangeError(`weightTonnes must be a positive number, got ${weightTonnes}`);
+  }
+
+  const distanceKm = haversineKm(pickupLat, pickupLng, dropLat, dropLng);
+
+  // Base rate scaled by goods class.
+  let rate = rateCard.ratePerTonneKm;
+  if (isFragile) rate *= rateCard.fragileMultiplier;
+  if (isStackable) rate *= rateCard.stackableDiscount;
+  if (rate <= 0) {
+    throw new RangeError(`Computed rate-per-tonne-km must be > 0, got ${rate}`);
+  }
+
+  const baseFreight = Math.round(rate * weightTonnes * distanceKm) + rateCard.handlingFee;
+  const tollEstimate = Math.round(rateCard.tollPerKm * distanceKm);
+  const platformFee = Math.round((baseFreight * rateCard.platformFeePct) / 100);
+  const totalAmount = baseFreight + tollEstimate + platformFee;
+
+  // Driver-side cost / margin hints persisted on load_offers.
+  const fuelCost = Math.round((baseFreight * rateCard.fuelCostPct) / 100);
+  const netProfit = baseFreight - fuelCost - tollEstimate;
+
+  return {
+    distanceKm: Math.round(distanceKm * 100) / 100, // 2-decimal precision
+    baseFreight,
+    tollEstimate,
+    platformFee,
+    totalAmount,
+    fuelCost,
+    netProfit,
+  };
+}
+
+export const __testing = { DEFAULTS, readRateCard, EARTH_RADIUS_KM };

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
+import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 
@@ -25,7 +26,6 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
     pickup_date, pickup_time,
     goods_type, weight_tonnes, length_ft, width_ft, height_ft,
     is_stackable, is_fragile, special_requirements,
-    base_freight, toll_estimate, platform_fee, total_amount,
     payment_method_id, upi_id
   } = req.body;
 
@@ -33,6 +33,35 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
   if (!pickup_address || !pickup_lat || !pickup_lng || !drop_address || !drop_lat || !drop_lng || !goods_type || !weight_tonnes) {
     return res.status(400).json({ error: 'Missing required routing or cargo specification fields.' });
   }
+
+  // ============================================================================
+  // Server-side pricing (single source of truth).
+  // Client-supplied monetary fields are no longer accepted; pricing is derived
+  // from route geometry, cargo weight, and the goods-class multipliers. See
+  // ../lib/pricing.js for the rate card (env-overridable) and the full
+  // derivation. If the customer passed monetary fields anyway we silently
+  // drop them — the server's number is the only number that gets persisted.
+  // ============================================================================
+  let pricing;
+  try {
+    pricing = computeOrderPricing({
+      pickupLat:  Number(pickup_lat),
+      pickupLng:  Number(pickup_lng),
+      dropLat:    Number(drop_lat),
+      dropLng:    Number(drop_lng),
+      weightTonnes: Number(weight_tonnes),
+      isFragile:   Boolean(is_fragile),
+      isStackable: Boolean(is_stackable),
+    });
+  } catch (pricingErr) {
+    console.error('Pricing computation error:', pricingErr.message);
+    return res.status(400).json({
+      error: 'Unable to compute freight pricing for the given route/cargo.',
+      details: pricingErr.message,
+    });
+  }
+
+  const { base_freight, toll_estimate, platform_fee, total_amount } = pricing;
 
   const orderDisplayId = generateOrderDisplayId();
 
@@ -79,8 +108,9 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
       // We don't fail the whole request since order is created, but log it
     }
 
-    // Step 3: Automatically expose this order as a "load_offer" for drivers
-    // In a production system, this could also be populated via database triggers.
+    // Step 3: Automatically expose this order as a "load_offer" for drivers.
+    // Freight value, fuel cost, toll cost, and net profit all come from the
+    // server-computed `pricing` object — never from the request body.
     const { error: offerErr } = await supabase
       .from('load_offers')
       .insert({
@@ -93,10 +123,10 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
         drop_address, drop_lat, drop_lng,
         goods_type,
         weight: `${weight_tonnes} tonnes`,
-        freight_value: base_freight,
-        fuel_cost: Math.round(base_freight * 0.45), // Mock calculation
-        toll_cost: toll_estimate || 0,
-        net_profit: Math.round(base_freight * 0.55) - (toll_estimate || 0),
+        freight_value: pricing.baseFreight,
+        fuel_cost: pricing.fuelCost,
+        toll_cost: pricing.tollEstimate,
+        net_profit: pricing.netProfit,
         status: 'available'
       });
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -61,8 +61,6 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
     });
   }
 
-  const { base_freight, toll_estimate, platform_fee, total_amount } = pricing;
-
   const orderDisplayId = generateOrderDisplayId();
 
   try {
@@ -78,7 +76,10 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
         pickup_date, pickup_time,
         goods_type, weight_tonnes, length_ft, width_ft, height_ft,
         is_stackable, is_fragile, special_requirements,
-        base_freight, toll_estimate, platform_fee, total_amount,
+        base_freight: pricing.baseFreight,
+        toll_estimate: pricing.tollEstimate,
+        platform_fee: pricing.platformFee,
+        total_amount: pricing.totalAmount,
         payment_method_id, upi_id
       })
       .select('id, order_display_id, status, created_at')


### PR DESCRIPTION
## What

Replaces client-trusted monetary inputs on `POST /api/orders` with server-computed pricing derived from route geometry, cargo weight, and goods-class multipliers. Adds a new `lib/pricing.js` module that is the single source of truth for order monetary fields.

## Why

The previous flow accepted `base_freight`, `toll_estimate`, `platform_fee`, and `total_amount` directly from the customer request body and persisted them verbatim. A customer could send `total_amount: 1` for a 10-tonne 1,400 km load and the system would broadcast that order to drivers at the customer's price. The derived fields in `load_offers` (`fuel_cost`, `toll_cost`, `net_profit`) were then computed from the customer-controlled `base_freight` via a 0.45 / 0.55 split, so the entire pricing chain — including the driver's wallet payout — was attacker-controlled.

This is a classic client-side enforcement of server-side security (CWE-602) and insufficient verification of data authenticity (CWE-345) on the most financially significant write path in the system.

## Changes

### New file: `backend/api/src/lib/pricing.js` (+125 lines)

- `computeOrderPricing({ pickupLat, pickupLng, dropLat, dropLng, weightTonnes, isFragile, isStackable }, rateCard?)` — the single source of truth.
- `haversineKm(...)` — great-circle distance in km between two lat/lng points. Used as a baseline distance estimate; production deployments can replace it with a routing-engine distance by passing that in instead.
- `readRateCard()` — reads the rate card from env vars (`TRUXIFY_RATE_PER_TONNE_KM`, `TRUXIFY_FRAGILE_MULTIPLIER`, `TRUXIFY_STACKABLE_DISCOUNT`, `TRUXIFY_HANDLING_FEE`, `TRUXIFY_PLATFORM_FEE_PCT`, `TRUXIFY_FUEL_COST_PCT`, `TRUXIFY_TOLL_PER_KM`) with India-freight defaults.
- All amounts returned in **paisa** to match the integer column types used elsewhere (`load_bids.bid_amount` is documented as paisa in this file at line 215).
- Validates inputs (positive weight, finite lat/lng, non-zero rate).
- Exports `__testing` for unit-test injection of a custom rate card.

### Modified: `backend/api/src/routes/orderRoutes.js` (+37 / -7 lines)

- Drops `base_freight`, `toll_estimate`, `platform_fee`, `total_amount` from the `req.body` destructure.
- Calls `computeOrderPricing()` immediately after the basic field validation.
- On pricing failure (e.g. bad coordinates, zero weight) returns `400` with a clear error.
- Persists the **server-computed** values to `orders.base_freight`, `orders.toll_estimate`, `orders.platform_fee`, `orders.total_amount`.
- The `load_offers` insert now sources `freight_value`, `fuel_cost`, `toll_cost`, and `net_profit` from the `pricing` object — no more `0.45` / `0.55` magic split on a customer-controlled number.
- Comments at the call site explain the trust boundary so the misstep doesn't get reintroduced.

## Example output

A 10-tonne Mumbai → Delhi shipment with `is_fragile: true` now produces:

```json
{
  "distanceKm": 1153.24,
  "baseFreight": 894932,
  "tollEstimate": 230649,
  "platformFee": 44747,
  "totalAmount": 1170328,
  "fuelCost": 402719,
  "netProfit": 261564
}
```

(= ₹8,949 base + ₹2,306 toll + ₹447 platform = ₹11,703 total — these are paisa × 100.)

The same request with the client also sending `total_amount: 1` will produce the same server-computed `total_amount: 1170328`; the client's number is silently dropped.

## Backward compatibility

- **API contract**: tighter. Clients can no longer set monetary fields. The error case is a `400` rather than a silent overwrite, so any client that was relying on the old behaviour will see a new error and need to drop the fields from their request.
- **DB schema**: unchanged. The columns still exist and are still populated — just from server-computed values now.
- **No new runtime dependencies**: pure JS using only `Number`, `Math`, and the existing `process.env` access already used in `config/db.js`.
- **Existing bad data**: orders that were created under the bug are now stuck with the customer-supplied values. A one-off backfill SQL (or a separate PR) can re-derive these from the route geometry and the rate card. Out of scope here.

## Out of scope

- The rate card defaults (45% fuel cost, ₹2/km toll) are inherited from the previous `0.45` / `0.55` magic split. They are sensible for the existing UI but not carefully calibrated. The maintainer should tune the env-var defaults once they have real fare data.
- No unit tests for `pricing.js` are added in this PR because the codebase has no test runner set up (no `__tests__/`, no `*.test.js`, `package.json` only has `start` / `dev` scripts). Recommend a follow-up PR to introduce vitest + Supabase mocking, then backfill tests for both `pricing.js` and the route handlers.
- Distance is computed with the Haversine formula. For a real freight network this should be a road distance from OSRM/Mapbox/Google — the helper is structured so that swapping the distance function is a one-line change.
- The bug that `generateOrderDisplayId` uses 4 random digits (birthday-paradox collisions in a busy day) is tracked separately.

## Refs

Fixes #296
