### PR TITLE
fix(auth): reject BYPASS_AUTH when NODE_ENV=production (#307) [GSSoC'26]

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -9,6 +9,11 @@ export async function authenticate(req, res, next) {
 
   // Support local development bypass mode
   if (bypassAuth) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({
+        error: 'BYPASS_AUTH is enabled in production. This is a misconfiguration and must be disabled before serving traffic.'
+      });
+    }
     const testUserId = req.headers['x-user-id']; // e.g. a Supabase profile UUID
     const testUserRole = req.headers['x-user-role'] || 'customer'; // customer or driver
     const testFullName = req.headers['x-user-name'] || 'Test User';


### PR DESCRIPTION
## Summary

Closes #307 — `BYPASS_AUTH=true` disables Firebase authentication entirely. When this env leaks into production (via `.env` copy-paste, hosting dashboard misconfiguration, or build-log exposure), the entire auth system is silently bypassed with no audit trail.

This fix adds a `NODE_ENV` guard: if `BYPASS_AUTH=true` AND `NODE_ENV=production`, the middleware returns HTTP 503 and refuses to process the request.

## What changed

- `backend/api/src/middleware/auth.js` — added 5 lines at the top of the bypass block

## How to verify

1. Set `BYPASS_AUTH=true` and `NODE_ENV=production` in `.env`
2. Start the server
3. Send any request to a protected endpoint
4. **Before**: request proceeds as authenticated (bypass active)
5. **After**: server returns `503 BYPASS_AUTH is enabled in production`

## Checklist

- [x] One file changed, 5 insertions
- [x] No test harness changes needed (existing tests use `NODE_ENV=test`)
- [x] Follows existing error-response format

[GSSoC'26]