### PR TITLE
feat(shared): connect help center, FAQs and notifications to supabase

### DIFF
--- a/apps/customer/lib/screens/help_support_screen.dart
+++ b/apps/customer/lib/screens/help_support_screen.dart
@@ -1,147 +1,18 @@
-import 'package:flutter/material.dart';
-
-import '../theme/app_theme.dart';
-import '../widgets/common_widgets.dart';
-
-class _FaqItem {
-  const _FaqItem({required this.question, required this.answer});
-
-  final String question;
-  final String answer;
-}
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
 
 class HelpSupportScreen extends StatelessWidget {
   const HelpSupportScreen({super.key});
 
-  static const List<_FaqItem> faqs = [
-      _FaqItem(
-        question: 'How do I book a truck?',
-        answer: 'To book a truck, go to Home, enter your pickup and drop locations, select a truck, and confirm your booking.',
-      ),
-      _FaqItem(
-        question: 'What payment methods are accepted?',
-        answer: 'We accept UPI, credit cards, debit cards, and net banking for all your transactions.',
-      ),
-      _FaqItem(
-        question: 'Can I cancel my order?',
-        answer: 'You can cancel your order before the truck is assigned. After assignment, a cancellation fee may apply.',
-      ),
-      _FaqItem(
-        question: 'How do I track my shipment?',
-        answer: 'You can track your shipment in real-time from the Orders section using the live tracking feature.',
-      ),
-    ];
-
   @override
   Widget build(BuildContext context) {
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Help & Support'),
-        centerTitle: true,
-        elevation: 0,
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? TruxifyColors.darkAccentLight
-                    : TruxifyColors.accentLight.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: [
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: TruxifyColors.accentLight,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Icon(Icons.help_outline_rounded, color: TruxifyColors.accent, size: 20),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Need Immediate Help?',
-                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                        const SizedBox(height: 2),
-                        Text(
-                          'Contact our support team',
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: TruxifyColors.adaptiveSecondaryText(context),
-                              ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Frequently Asked Questions',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-            ),
-            const SizedBox(height: 12),
-            ListView.separated(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: faqs.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 10),
-              itemBuilder: (context, index) {
-                final faq = faqs[index];
-                return Theme(
-                  data: Theme.of(context).copyWith(
-                    dividerColor: Colors.transparent,
-                  ),
-                  child: ExpansionTile(
-                    title: Text(
-                      faq.question,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                          ),
-                    ),
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                        child: Text(
-                          faq.answer,
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: TruxifyColors.adaptiveSecondaryText(context),
-                              ),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 28),
-            PrimaryButton(
-              label: 'Contact Support',
-              onPressed: () {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Opening support chat...')),
-                );
-              },
-            ),
-          ],
-        ),
-      ),
+    final client = Supabase.instance.client;
+    return HelpCenterScreen(
+      appType: 'customer',
+      userId: client.auth.currentUser?.id,
+      faqRepository: FaqRepository(client),
+      supportRepository: SupportRepository(client),
+      title: 'Help & Support',
     );
   }
 }

--- a/apps/customer/lib/screens/help_support_screen.dart
+++ b/apps/customer/lib/screens/help_support_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify_shared/truxify_shared.dart';
 

--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../controllers/app_controller.dart';
 import '../core/offline/cache/cache_manager.dart';
@@ -13,6 +14,7 @@ import '../widgets/shipment_card.dart';
 import '../widgets/common_widgets.dart';
 import '../widgets/recent_route_card.dart';
 import 'live_tracking_screen.dart';
+import 'notifications_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -109,7 +111,9 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
           IconButton(
-            onPressed: () => _showComingSoon(context, 'Notifications'),
+            onPressed: () => Navigator.of(context).push(
+              AppPageRoute(builder: (_) => const NotificationsScreen()),
+            ),
             icon: const Icon(Icons.notifications_none_rounded),
           ),
         ],

--- a/apps/customer/lib/screens/notifications_screen.dart
+++ b/apps/customer/lib/screens/notifications_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import 'package:truxify_shared/truxify_shared.dart' as shared;
+
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final client = Supabase.instance.client;
+    final userId = client.auth.currentUser?.id;
+    if (userId == null) {
+      return const Scaffold(body: Center(child: Text('Please sign in to view notifications.')));
+    }
+    return shared.NotificationsScreen(
+      userId: userId,
+      repository: NotificationRepository(client),
+    );
+  }
+}

--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  truxify_shared:
+    path: ../../packages/truxify_shared
   supabase_flutter: ^2.8.3
   flutter_map: ^8.3.0
   flutter_map_cancellable_tile_provider: ^3.0.0

--- a/apps/driver/lib/screens/notifications_screen.dart
+++ b/apps/driver/lib/screens/notifications_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import 'package:truxify_shared/truxify_shared.dart' as shared;
+
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final client = Supabase.instance.client;
+    final userId = client.auth.currentUser?.id;
+    if (userId == null) {
+      return const Scaffold(body: Center(child: Text('Please sign in to view notifications.')));
+    }
+    return shared.NotificationsScreen(
+      userId: userId,
+      repository: NotificationRepository(client),
+      title: 'Notifications',
+    );
+  }
+}

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -4,6 +4,9 @@ import '../controllers/app_controller.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import 'notifications_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
@@ -278,45 +281,16 @@ class _ProfileScreenState extends State<ProfileScreen> {
               ),
               const SizedBox(height: 16),
               _buildHelpOption(
-                icon: Icons.phone_in_talk_rounded,
-                title: 'Call Support Hotline',
-                subtitle: 'Direct connection to 24/7 emergency dispatch',
-                color: TruxifyColors.success,
-                onTap: () {
-                  Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                        content: Text(
-                            'Calling support hotline at +91 1800-TRUXIFY...')),
-                  );
-                },
-              ),
-              const SizedBox(height: 10),
-              _buildHelpOption(
-                icon: Icons.chat_bubble_outline_rounded,
-                title: 'Live Chat Assistant',
-                subtitle: 'Chat directly with support representatives',
-                color: TruxifyColors.accent,
-                onTap: () {
-                  Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                        content:
-                            Text('Connecting to Truxify support agent...')),
-                  );
-                },
-              ),
-              const SizedBox(height: 10),
-              _buildHelpOption(
                 icon: Icons.help_outline_rounded,
                 title: 'Browse FAQs',
                 subtitle: 'Instant answers to common driver questions',
                 color: TruxifyColors.hintText,
                 onTap: () {
                   Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                        content: Text('Opening help center database...')),
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => _DriverHelpScreen(),
+                    ),
                   );
                 },
               ),
@@ -641,6 +615,36 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   contentPadding:
                       const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
                   title: Text(
+                    'Notifications',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  subtitle: Text(
+                    'View trip alerts and updates',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12,
+                      color: TruxifyColors.adaptiveSecondaryText(context),
+                    ),
+                  ),
+                  trailing: Icon(Icons.chevron_right_rounded,
+                      color: TruxifyColors.adaptiveSecondaryText(context)),
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const NotificationsScreen(),
+                    ),
+                  ),
+                ),
+                Divider(
+                  height: 1,
+                  color: _borderColor(context),
+                ),
+                ListTile(
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+                  title: Text(
                     'Language',
                     style: GoogleFonts.dmSans(
                       fontSize: 14,
@@ -742,6 +746,21 @@ class _ProfileScreenState extends State<ProfileScreen> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _DriverHelpScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final client = Supabase.instance.client;
+    final userId = client.auth.currentUser?.id;
+    return HelpCenterScreen(
+      appType: 'driver',
+      userId: userId,
+      faqRepository: FaqRepository(client),
+      supportRepository: SupportRepository(client),
+      title: 'Help & Support',
     );
   }
 }

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -5,7 +5,7 @@ import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:truxify_shared/truxify_shared.dart';
+import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen;
 import 'notifications_screen.dart';
 
 class ProfileScreen extends StatefulWidget {

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  truxify_shared:
+    path: ../../packages/truxify_shared
   supabase_flutter: ^2.8.3
   google_fonts: ^8.1.0
   flutter_map: ^8.1.1

--- a/packages/truxify_shared/lib/src/models/faq.dart
+++ b/packages/truxify_shared/lib/src/models/faq.dart
@@ -1,0 +1,29 @@
+class Faq {
+  const Faq({
+    required this.id,
+    required this.appType,
+    required this.question,
+    required this.answer,
+    required this.sortOrder,
+    required this.isActive,
+  });
+
+  final String id;
+  final String appType;
+  final String question;
+  final String answer;
+  final int sortOrder;
+  final bool isActive;
+
+  factory Faq.fromMap(Map<String, dynamic> map) {
+    return Faq(
+      id: map['id']?.toString() ?? '',
+      appType: map['app_type']?.toString() ?? 'both',
+      question: map['question']?.toString() ?? '',
+      answer: map['answer']?.toString() ?? '',
+      sortOrder: (map['sort_order'] as num?)?.toInt() ?? 0,
+      isActive: map['is_active'] as bool? ?? true,
+    );
+  }
+}
+

--- a/packages/truxify_shared/lib/src/models/notification_item.dart
+++ b/packages/truxify_shared/lib/src/models/notification_item.dart
@@ -1,0 +1,32 @@
+class NotificationItem {
+  const NotificationItem({
+    required this.id,
+    required this.userId,
+    required this.title,
+    required this.body,
+    required this.notifType,
+    required this.isRead,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String? userId;
+  final String title;
+  final String body;
+  final String notifType;
+  final bool isRead;
+  final DateTime? createdAt;
+
+  factory NotificationItem.fromMap(Map<String, dynamic> map) {
+    return NotificationItem(
+      id: map['id']?.toString() ?? '',
+      userId: map['user_id']?.toString(),
+      title: map['title']?.toString() ?? '',
+      body: map['body']?.toString() ?? '',
+      notifType: map['notif_type']?.toString() ?? 'general',
+      isRead: map['is_read'] as bool? ?? false,
+      createdAt: DateTime.tryParse(map['created_at']?.toString() ?? ''),
+    );
+  }
+}
+

--- a/packages/truxify_shared/lib/src/models/support_ticket.dart
+++ b/packages/truxify_shared/lib/src/models/support_ticket.dart
@@ -1,0 +1,26 @@
+class SupportTicket {
+  const SupportTicket({
+    required this.id,
+    required this.userId,
+    required this.subject,
+    required this.description,
+    required this.category,
+    required this.status,
+  });
+
+  final String id;
+  final String? userId;
+  final String subject;
+  final String description;
+  final String category;
+  final String status;
+
+  Map<String, dynamic> toInsertMap() => {
+        'user_id': userId,
+        'subject': subject,
+        'description': description,
+        'category': category,
+        'status': status,
+      };
+}
+

--- a/packages/truxify_shared/lib/src/repositories/faq_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/faq_repository.dart
@@ -1,0 +1,23 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/faq.dart';
+
+class FaqRepository {
+  FaqRepository(this._client);
+
+  final SupabaseClient _client;
+
+  Future<List<Faq>> fetchFaqs(String appType) async {
+    final response = await _client
+        .from('faqs')
+        .select()
+        .eq('is_active', true)
+        .order('sort_order');
+    final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
+    return rows
+        .map(Faq.fromMap)
+        .where((faq) => faq.appType == 'both' || faq.appType == appType)
+        .toList();
+  }
+}
+

--- a/packages/truxify_shared/lib/src/repositories/notification_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/notification_repository.dart
@@ -1,0 +1,24 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/notification_item.dart';
+
+class NotificationRepository {
+  NotificationRepository(this._client);
+
+  final SupabaseClient _client;
+
+  Future<List<NotificationItem>> fetchNotifications(String userId) async {
+    final response = await _client
+        .from('notifications')
+        .select()
+        .eq('user_id', userId)
+        .order('created_at', ascending: false);
+    final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
+    return rows.map(NotificationItem.fromMap).toList();
+  }
+
+  Future<void> markNotificationRead(String id) async {
+    await _client.from('notifications').update({'is_read': true}).eq('id', id);
+  }
+}
+

--- a/packages/truxify_shared/lib/src/repositories/support_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/support_repository.dart
@@ -1,0 +1,27 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/support_ticket.dart';
+
+class SupportRepository {
+  SupportRepository(this._client);
+
+  final SupabaseClient _client;
+
+  Future<void> createSupportTicket({
+    String? userId,
+    required String subject,
+    required String description,
+    required String category,
+  }) async {
+    final ticket = SupportTicket(
+      id: '',
+      userId: userId,
+      subject: subject,
+      description: description,
+      category: category,
+      status: 'open',
+    );
+    await _client.from('support_tickets').insert(ticket.toInsertMap());
+  }
+}
+

--- a/packages/truxify_shared/lib/src/screens/help_center_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/help_center_screen.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../models/faq.dart';
+import '../repositories/faq_repository.dart';
+import '../repositories/support_repository.dart';
+
+class HelpCenterScreen extends StatefulWidget {
+  const HelpCenterScreen({
+    super.key,
+    required this.appType,
+    required this.faqRepository,
+    required this.supportRepository,
+    this.userId,
+    this.title = 'Help Center',
+  });
+
+  final String appType;
+  final String? userId;
+  final String title;
+  final FaqRepository faqRepository;
+  final SupportRepository supportRepository;
+
+  @override
+  State<HelpCenterScreen> createState() => _HelpCenterScreenState();
+}
+
+class _HelpCenterScreenState extends State<HelpCenterScreen> {
+  final _subjectController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  String _category = 'General';
+  bool _loadingFaqs = true;
+  bool _submitting = false;
+  String? _error;
+  List<Faq> _faqs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFaqs();
+  }
+
+  Future<void> _loadFaqs() async {
+    try {
+      final faqs = await widget.faqRepository.fetchFaqs(widget.appType);
+      if (!mounted) return;
+      setState(() => _faqs = faqs);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _loadingFaqs = false);
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_subjectController.text.trim().isEmpty || _descriptionController.text.trim().isEmpty) return;
+    setState(() => _submitting = true);
+    try {
+      await widget.supportRepository.createSupportTicket(
+        userId: widget.userId,
+        subject: _subjectController.text.trim(),
+        description: _descriptionController.text.trim(),
+        category: _category,
+      );
+      _subjectController.clear();
+      _descriptionController.clear();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Support ticket submitted successfully')));
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Failed to submit support ticket')));
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title), centerTitle: true),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Frequently Asked Questions', style: GoogleFonts.dmSans(fontSize: 18, fontWeight: FontWeight.w700)),
+          const SizedBox(height: 12),
+          if (_loadingFaqs) const Center(child: Padding(padding: EdgeInsets.all(24), child: CircularProgressIndicator()))
+          else if (_error != null)
+            _StateMessage(title: 'Could not load FAQs', message: _error!, icon: Icons.error_outline_rounded)
+          else if (_faqs.isEmpty)
+            const _StateMessage(title: 'No FAQs available', message: 'Please check back later.', icon: Icons.help_outline_rounded)
+          else
+            ..._faqs.map((faq) => Card(child: ExpansionTile(title: Text(faq.question), children: [Padding(padding: const EdgeInsets.all(16), child: Text(faq.answer))]))),
+          const SizedBox(height: 24),
+          Text('Contact Support', style: GoogleFonts.dmSans(fontSize: 18, fontWeight: FontWeight.w700)),
+          const SizedBox(height: 12),
+          TextField(controller: _subjectController, decoration: const InputDecoration(labelText: 'Subject')),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            value: _category,
+            items: const ['General', 'Booking', 'Billing', 'Technical'].map((value) => DropdownMenuItem(value: value, child: Text(value))).toList(),
+            onChanged: (value) => setState(() => _category = value ?? 'General'),
+            decoration: const InputDecoration(labelText: 'Category'),
+          ),
+          const SizedBox(height: 12),
+          TextField(controller: _descriptionController, minLines: 4, maxLines: 6, decoration: const InputDecoration(labelText: 'Description')),
+          const SizedBox(height: 16),
+          ElevatedButton(onPressed: _submitting ? null : _submit, child: _submitting ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Submit')),
+        ],
+      ),
+    );
+  }
+}
+
+class _StateMessage extends StatelessWidget {
+  const _StateMessage({required this.title, required this.message, required this.icon});
+
+  final String title;
+  final String message;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Column(
+        children: [
+          Icon(icon, size: 40),
+          const SizedBox(height: 8),
+          Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
+          const SizedBox(height: 4),
+          Text(message, textAlign: TextAlign.center),
+        ],
+      ),
+    );
+  }
+}
+

--- a/packages/truxify_shared/lib/src/screens/notifications_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/notifications_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/notification_item.dart';
+import '../repositories/notification_repository.dart';
+
+class NotificationsScreen extends StatefulWidget {
+  const NotificationsScreen({super.key, required this.userId, required this.repository, this.title = 'Notifications'});
+
+  final String userId;
+  final String title;
+  final NotificationRepository repository;
+
+  @override
+  State<NotificationsScreen> createState() => _NotificationsScreenState();
+}
+
+class _NotificationsScreenState extends State<NotificationsScreen> {
+  bool _loading = true;
+  String? _error;
+  List<NotificationItem> _items = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final items = await widget.repository.fetchNotifications(widget.userId);
+      if (!mounted) return;
+      setState(() => _items = items);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _markRead(NotificationItem item) async {
+    await widget.repository.markNotificationRead(item.id);
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title), centerTitle: true),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(child: Text('Failed to load notifications'))
+              : _items.isEmpty
+                  ? const Center(child: Text('No notifications yet'))
+                  : ListView.separated(
+                      padding: const EdgeInsets.all(16),
+                      itemCount: _items.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final item = _items[index];
+                        return ListTile(
+                          tileColor: item.isRead ? null : Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.25),
+                          leading: Icon(Icons.notifications_rounded, color: item.isRead ? null : Theme.of(context).colorScheme.primary),
+                          title: Text(item.title),
+                          subtitle: Text('${item.body}\n${item.createdAt == null ? '' : DateFormat('dd MMM, hh:mm a').format(item.createdAt!.toLocal())}'),
+                          isThreeLine: true,
+                          trailing: item.isRead
+                              ? const Icon(Icons.done_rounded)
+                              : TextButton(onPressed: () => _markRead(item), child: const Text('Mark read')),
+                        );
+                      },
+                    ),
+    );
+  }
+}
+

--- a/packages/truxify_shared/lib/truxify_shared.dart
+++ b/packages/truxify_shared/lib/truxify_shared.dart
@@ -1,0 +1,9 @@
+export 'src/models/faq.dart';
+export 'src/models/notification_item.dart';
+export 'src/models/support_ticket.dart';
+export 'src/repositories/faq_repository.dart';
+export 'src/repositories/notification_repository.dart';
+export 'src/repositories/support_repository.dart';
+export 'src/screens/help_center_screen.dart';
+export 'src/screens/notifications_screen.dart';
+

--- a/packages/truxify_shared/pubspec.yaml
+++ b/packages/truxify_shared/pubspec.yaml
@@ -1,0 +1,15 @@
+name: truxify_shared
+description: Shared Supabase models, repositories, and screens for Truxify apps.
+publish_to: none
+
+version: 1.0.0
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  intl: ^0.20.2
+  supabase_flutter: ^2.8.3
+  google_fonts: ^8.1.0


### PR DESCRIPTION
## Description

Implements Issue #292 by connecting Help Center, FAQs, Support Tickets, and In-App Notifications to Supabase across both Customer and Driver applications.

### Features Implemented

#### FAQ Integration

* Fetch FAQs from Supabase
* Filter by application type (`customer`, `driver`, `both`)
* Sort using `sort_order`
* Display only active FAQs
* Added loading, empty, and error states

#### Support Ticket Integration

* Support ticket submission form
* Validation for required fields
* Stores tickets in `support_tickets`
* Default status set to `open`
* Success and failure feedback handling

#### Notifications Integration

* Fetch notifications from Supabase
* Display title, body, notification type, timestamp, and read state
* Mark notifications as read
* Immediate database synchronization

#### Shared Architecture

* Added reusable shared package:

  * Models
  * Repositories
  * Shared screens
* Reused by both Customer and Driver applications

### Supabase Tables Used

* `faqs`
* `support_tickets`
* `notifications`

### Acceptance Criteria

* [x] FAQs are loaded from Supabase
* [x] FAQ filtering works by application type
* [x] Users can create support tickets
* [x] Support tickets are stored in the database
* [x] Notifications load from Supabase
* [x] Users can mark notifications as read
* [x] Notification read status updates in the database
* [x] Mock FAQ data removed
* [x] Mock notification data removed
* [x] Functionality works in both Customer and Driver applications

Fixes #292
