### PR TITLE
fix:improve Driver App logout flow and handle missing Supabase configuration

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -4,7 +4,9 @@ import '../controllers/app_controller.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
-
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_driver/screens/login_screen.dart';
+import '../../core/supabase_config.dart';
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
     super.key,
@@ -717,14 +719,27 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
           const SizedBox(height: 18),
           AppCard(
-            onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Logged out successfully'),
-                  backgroundColor: TruxifyColors.success,
-                ),
-              );
-            },
+           onTap: () async {
+  try {
+    if (SupabaseConfig.isConfigured) {
+      await Supabase.instance.client.auth.signOut();
+    }
+
+    if (context.mounted) {
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (_) => const LoginScreen(),
+        ),
+        (route) => false,
+      );
+    }
+  } catch (e) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Logout failed: $e')),
+    );
+  }
+},
             child: Row(
               children: [
                 const Icon(Icons.logout_rounded, color: TruxifyColors.error),

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -7,6 +7,9 @@ import '../widgets/common_widgets.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify_driver/screens/login_screen.dart';
 import '../../core/supabase_config.dart';
+import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen;
+import 'notifications_screen.dart';
+
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
     super.key,
@@ -720,27 +723,29 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
           const SizedBox(height: 18),
           AppCard(
-           onTap: () async {
-  try {
-    if (SupabaseConfig.isConfigured) {
-      await Supabase.instance.client.auth.signOut();
-    }
+            onTap: () async {
+              try {
+                if (SupabaseConfig.isConfigured) {
+                  await Supabase.instance.client.auth.signOut();
+                }
 
-    if (context.mounted) {
-      Navigator.pushAndRemoveUntil(
-        context,
-        MaterialPageRoute(
-          builder: (_) => const LoginScreen(),
-        ),
-        (route) => false,
-      );
-    }
-  } catch (e) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Logout failed: $e')),
-    );
-  }
-},
+                if (context.mounted) {
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const LoginScreen(),
+                    ),
+                    (route) => false,
+                  );
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Logout failed: $e')),
+                  );
+                }
+              }
+            },
             child: Row(
               children: [
                 const Icon(Icons.logout_rounded, color: TruxifyColors.error),


### PR DESCRIPTION
## Summary

This PR fixes the logout flow in the Driver App by preventing runtime exceptions when Supabase is not configured and ensuring users are properly redirected to the Login screen after logout.

## Changes Made

* Imported `supabase_config.dart` and route dependencies required for logout flow.
* Added a check for `SupabaseConfig.isConfigured` before calling `Supabase.instance.client.auth.signOut()`.
* Prevented runtime exceptions when Supabase initialization is skipped.
* Redirected users to the Login screen after logout.
* Cleared the navigation stack after logout to prevent access to authenticated screens using back navigation.

## Problem

Previously, the logout action could throw the following exception when Supabase credentials were not configured:

`You must initialize the supabase instance before calling Supabase.instance`

Additionally, the logout flow did not reliably return users to the Login screen.

## Solution

The logout flow now:

1. Verifies that Supabase is configured before attempting to sign out.
2. Safely handles environments where Supabase credentials are unavailable.
3. Redirects users to the Login screen after logout.
4. Removes all previous routes from the navigation stack.

## Acceptance Criteria Covered

* [x] Logout action no longer throws errors when Supabase is not configured.
* [x] `SupabaseConfig.isConfigured` is checked before calling `signOut()`.
* [x] User is redirected to the Login screen after logout.
* [x] Navigation history is cleared after logout.
* [x] Users cannot return to authenticated screens using back navigation.

## Testing

* Tested logout flow with Supabase credentials configured.
* Tested logout flow without Supabase credentials configured.
* Verified successful navigation to Login screen.
* Verified back navigation does not return to authenticated screens.

Fixes #313 
