### PR TITLE
[GSSoC'26] fix(tracking): trust authenticated driver id (#309)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -127,11 +127,20 @@ export function initWebSocketServer(server) {
 /**
  * Handle incoming GPS coordinate telemetry from a driver app
  */
-async function handleLocationPing(ws, data) {
-  const { driver_id, order_display_id, latitude, longitude, speed, bearing, device_timestamp } = data;
+export async function handleLocationPing(ws, data) {
+  const { driver_id: payloadDriverId, order_display_id, latitude, longitude, speed, bearing, device_timestamp } = data;
+  const driver_id = ws.driverId;
 
-  if (!driver_id || !latitude || !longitude) {
-    return ws.send(JSON.stringify({ error: 'Missing mandatory tracking parameters (driver_id, lat, lng).' }));
+  if (!driver_id) {
+    return ws.send(JSON.stringify({ error: 'Unauthorized: Missing authenticated WebSocket identity.' }));
+  }
+
+  if (payloadDriverId && payloadDriverId !== driver_id) {
+    return ws.send(JSON.stringify({ error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.' }));
+  }
+
+  if (!latitude || !longitude) {
+    return ws.send(JSON.stringify({ error: 'Missing mandatory tracking parameters (lat, lng).' }));
   }
 
   // 🛡️ ADJUSTMENT 2: Device Timestamp Strict Validation

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/config/db.js', () => ({
+  mongoDb: null,
+  redisClient: null,
+  firebaseAdmin: null,
+}));
+
+const { handleLocationPing } = await import('../../src/sockets/tracker.js');
+
+describe('tracker WebSocket telemetry authorization', () => {
+  it('rejects a driver_id that does not match the authenticated socket', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'authenticated-driver',
+      send(message) {
+        sentMessages.push(JSON.parse(message));
+      },
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'spoofed-driver',
+      order_display_id: 'ORDER-123',
+      latitude: 12.9716,
+      longitude: 77.5946,
+      speed: 42,
+      bearing: 90,
+    });
+
+    expect(sentMessages).toEqual([
+      {
+        error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Uses the authenticated WebSocket `ws.driverId` as the canonical driver identifier for `location_ping` telemetry.
- Rejects payloads where client-supplied `driver_id` does not match the authenticated socket identity.
- Adds a Vitest regression test for spoofed `driver_id` rejection.

## Why
`location_ping` previously trusted `data.driver_id` from the client payload after WebSocket authentication. An authenticated driver could submit another driver's ID and poison Redis/Mongo telemetry or broadcast spoofed locations.

## Verification
- `npm --prefix backend/api run test:unit -- test/unit/tracker.test.js`
- `npm --prefix backend/api test`
- `node --check backend/api/src/sockets/tracker.js`
- `node --check backend/api/test/unit/tracker.test.js`

AI assistance was used to inspect the assigned issue, implement the fix, and add the regression test; changes were reviewed and verified locally.

@KanishJebaMathewM I am assigned to this issue and have opened this PR as part of GSSoC '26.

Closes #309