### PR TITLE
fix: restrict CORS to allowed origins in production (#326)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -19,8 +19,12 @@ const app = express();
 const server = http.createServer(app);
 
 // Enable CORS for frontend clients (Flutter Web, mobile, etc.)
+const corsOrigins = process.env.NODE_ENV === 'production'
+  ? (process.env.ALLOWED_ORIGINS || '').split(',').filter(Boolean)
+  : '*';
+
 app.use(cors({
-  origin: '*', // Allow all origins for development; tighten in production
+  origin: corsOrigins,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'x-user-id', 'x-user-role', 'x-user-name']
 }));


### PR DESCRIPTION
## Description
This PR fixes the CORS wildcard vulnerability by replacing `origin: '*'` with environment-based configuration.

## Changes
- In development (`NODE_ENV !== 'production'`): allows all origins (`*`)
- In production: restricts to origins listed in `ALLOWED_ORIGINS` env var (comma-separated)

## Usage
Set `ALLOWED_ORIGINS=https://yourdomain.com,https://another.com` in production.

## Issue
Closes #326

## AI Assistance
- Used AI assistance for bug detection and fix implementation
- All changes verified by the contributor

[GSSoC'26]