### PR TITLE
fix: block WebSocket BYPASS_AUTH in production (#327)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -35,6 +35,10 @@ export function initWebSocketServer(server) {
     const bypassAuth = process.env.BYPASS_AUTH === 'true';
 
     if (bypassAuth) {
+      if (process.env.NODE_ENV === 'production') {
+        ws.close(4003, 'BYPASS_AUTH is not allowed in production');
+        return;
+      }
       ws.driverId = reqUrl.searchParams.get('driver_id') || 'test_driver';
       console.log(`🔓 WS Auth bypassed for driver: ${ws.driverId}`);
     } else {


### PR DESCRIPTION
## Description
This PR adds a NODE_ENV guard to the WebSocket BYPASS_AUTH mode, matching the existing REST middleware protection in `auth.js`.

## Changes
- Added production mode check in WebSocket BYPASS_AUTH handler
- Closes connection with 4003 if BYPASS_AUTH is enabled in production
- Aligns with existing REST middleware guard in `auth.js:12-16`

## Security Impact
Prevents driver impersonation via WebSocket in production environments.

## Issue
Closes #327

## AI Assistance
- Used AI assistance for bug detection and fix implementation
- All changes verified by the contributor

[GSSoC'26]