### PR TITLE
feat: add safe GSSoC PR labeler

### DIFF
--- a/.github/pr-labeler-rules.json
+++ b/.github/pr-labeler-rules.json
@@ -22,24 +22,26 @@
     "type:api",
     "type:bug",
     "type:design",
+    "type:docs",
     "type:feature",
     "type:refactor",
     "type:security",
     "type:testing",
+    "type:performance",
+    "type:devops",
     "customer-app",
     "driver-app",
     "backend",
     "blockchain",
     "ml",
     "automation",
-    "documentation",
     "dependencies",
     "nsoc",
     "nsoc26"
   ],
   "titleRules": [
     {
-      "pattern": "^(fix|bug|hotfix|security)",
+      "pattern": "^(fix|bug|hotfix)",
       "labels": ["type:bug"]
     },
     {
@@ -56,11 +58,27 @@
     },
     {
       "pattern": "^(docs|doc|documentation)",
-      "labels": ["documentation"]
+      "labels": ["type:docs"]
     },
     {
       "pattern": "(xss|csrf|ssrf|auth|vulnerability|security|secret|token)",
       "labels": ["type:security"]
+    },
+    {
+      "pattern": "^(perf|performance)",
+      "labels": ["type:performance"]
+    },
+    {
+      "pattern": "^(design|ui|ux)",
+      "labels": ["type:design"]
+    },
+    {
+      "pattern": "^(ci|cd|devops|build|infra)",
+      "labels": ["type:devops"]
+    },
+    {
+      "pattern": "^(a11y|accessibility)",
+      "labels": ["type:accessibility"]
     }
   ],
   "pathRules": [
@@ -90,7 +108,7 @@
     },
     {
       "pattern": "(^docs/|README|CONTRIBUTING|\\.md$)",
-      "labels": ["documentation"]
+      "labels": ["type:docs"]
     },
     {
       "pattern": "(^test/|/test/|\\.test\\.|_test\\.)",

--- a/.github/pr-labeler-rules.json
+++ b/.github/pr-labeler-rules.json
@@ -1,0 +1,104 @@
+{
+  "programSignals": [
+    "gssoc",
+    "gssoc 2026",
+    "gssoc'26",
+    "gssoc26",
+    "nsoc",
+    "nsoc26"
+  ],
+  "programLabels": [
+    "gssoc:approved"
+  ],
+  "inheritLabels": [
+    "gssoc:approved",
+    "level:beginner",
+    "level:intermediate",
+    "level:advanced",
+    "level:critical",
+    "quality:clean",
+    "quality:exceptional",
+    "type:accessibility",
+    "type:api",
+    "type:bug",
+    "type:design",
+    "type:feature",
+    "type:refactor",
+    "type:security",
+    "type:testing",
+    "customer-app",
+    "driver-app",
+    "backend",
+    "blockchain",
+    "ml",
+    "automation",
+    "documentation",
+    "dependencies",
+    "nsoc",
+    "nsoc26"
+  ],
+  "titleRules": [
+    {
+      "pattern": "^(fix|bug|hotfix|security)",
+      "labels": ["type:bug"]
+    },
+    {
+      "pattern": "^(feat|feature)",
+      "labels": ["type:feature"]
+    },
+    {
+      "pattern": "^refactor",
+      "labels": ["type:refactor"]
+    },
+    {
+      "pattern": "^(test|tests)",
+      "labels": ["type:testing"]
+    },
+    {
+      "pattern": "^(docs|doc|documentation)",
+      "labels": ["documentation"]
+    },
+    {
+      "pattern": "(xss|csrf|ssrf|auth|vulnerability|security|secret|token)",
+      "labels": ["type:security"]
+    }
+  ],
+  "pathRules": [
+    {
+      "pattern": "^apps/customer/",
+      "labels": ["customer-app", "flutter"]
+    },
+    {
+      "pattern": "^apps/driver/",
+      "labels": ["driver-app", "flutter"]
+    },
+    {
+      "pattern": "^backend/api/",
+      "labels": ["backend", "type:api"]
+    },
+    {
+      "pattern": "^backend/ml/",
+      "labels": ["ml"]
+    },
+    {
+      "pattern": "^blockchain/",
+      "labels": ["blockchain"]
+    },
+    {
+      "pattern": "^automation/",
+      "labels": ["automation"]
+    },
+    {
+      "pattern": "(^docs/|README|CONTRIBUTING|\\.md$)",
+      "labels": ["documentation"]
+    },
+    {
+      "pattern": "(^test/|/test/|\\.test\\.|_test\\.)",
+      "labels": ["type:testing"]
+    },
+    {
+      "pattern": "(package-lock\\.json|pubspec\\.lock|dependabot\\.yml)",
+      "labels": ["dependencies"]
+    }
+  ]
+}

--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_RULES_PATH = path.join(__dirname, '..', 'pr-labeler-rules.json');
+
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function loadRules(rulesPath = DEFAULT_RULES_PATH) {
+  return JSON.parse(fs.readFileSync(rulesPath, 'utf8'));
+}
+
+function hasProgramSignal({ title = '', body = '', rules }) {
+  const source = normalize(`${title}\n${body}`);
+  return (rules.programSignals || []).some((signal) => source.includes(normalize(signal)));
+}
+
+function findLinkedIssueNumbers(text = '') {
+  const issueNumbers = new Set();
+  const closingKeyword =
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/gi;
+
+  let match;
+  while ((match = closingKeyword.exec(text)) !== null) {
+    issueNumbers.add(Number(match[1]));
+  }
+
+  return [...issueNumbers].filter(Number.isInteger);
+}
+
+function addLabels(target, labels) {
+  for (const label of labels || []) {
+    if (label) target.add(label);
+  }
+}
+
+function labelsMatchingRules(value, rules = []) {
+  const labels = new Set();
+  for (const rule of rules) {
+    const pattern = new RegExp(rule.pattern, 'i');
+    if (pattern.test(value)) {
+      addLabels(labels, rule.labels);
+    }
+  }
+  return labels;
+}
+
+function selectLabels({
+  prTitle = '',
+  prBody = '',
+  changedFiles = [],
+  linkedIssueLabels = [],
+  currentLabels = [],
+  availableLabels = [],
+  rules = loadRules()
+}) {
+  const selected = new Set();
+  const current = new Set(currentLabels.map(normalize));
+  const available = new Set(availableLabels.map(normalize));
+  const inherited = new Set((rules.inheritLabels || []).map(normalize));
+
+  for (const label of linkedIssueLabels) {
+    if (inherited.has(normalize(label))) {
+      selected.add(label);
+    }
+  }
+
+  if (hasProgramSignal({ title: prTitle, body: prBody, rules })) {
+    addLabels(selected, rules.programLabels);
+  }
+
+  addLabels(selected, labelsMatchingRules(prTitle, rules.titleRules));
+
+  for (const file of changedFiles) {
+    addLabels(selected, labelsMatchingRules(file, rules.pathRules));
+  }
+
+  return [...selected]
+    .filter((label) => available.has(normalize(label)))
+    .filter((label) => !current.has(normalize(label)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function fetchPaginatedLabels(github, owner, repo) {
+  const labels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+    owner,
+    repo,
+    per_page: 100
+  });
+  return labels.map((label) => label.name);
+}
+
+async function fetchPullRequestFiles(github, owner, repo, pullNumber) {
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100
+  });
+  return files.map((file) => file.filename);
+}
+
+async function fetchIssueLabels(github, owner, repo, issueNumbers) {
+  const labels = new Set();
+  for (const issueNumber of issueNumbers) {
+    try {
+      const response = await github.rest.issues.get({
+        owner,
+        repo,
+        issue_number: issueNumber
+      });
+      addLabels(
+        labels,
+        (response.data.labels || []).map((label) =>
+          typeof label === 'string' ? label : label.name
+        )
+      );
+    } catch (error) {
+      // Missing or cross-repository issue references should not block PR labeling.
+      continue;
+    }
+  }
+  return [...labels];
+}
+
+async function run({ github, context, core, rulesPath = DEFAULT_RULES_PATH, dryRun = false }) {
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest) {
+    core.info('No pull_request payload found; skipping PR labeler.');
+    return [];
+  }
+
+  const { owner, repo } = context.repo;
+  const pullNumber = pullRequest.number;
+  const rules = loadRules(rulesPath);
+  const availableLabels = await fetchPaginatedLabels(github, owner, repo);
+  const changedFiles = await fetchPullRequestFiles(github, owner, repo, pullNumber);
+  const linkedIssueNumbers = findLinkedIssueNumbers(`${pullRequest.title}\n${pullRequest.body || ''}`);
+  const linkedIssueLabels = await fetchIssueLabels(github, owner, repo, linkedIssueNumbers);
+  const currentLabels = (pullRequest.labels || []).map((label) => label.name);
+
+  const labelsToAdd = selectLabels({
+    prTitle: pullRequest.title,
+    prBody: pullRequest.body || '',
+    changedFiles,
+    linkedIssueLabels,
+    currentLabels,
+    availableLabels,
+    rules
+  });
+
+  core.info(`Changed files: ${changedFiles.join(', ') || 'none'}`);
+  core.info(`Linked issues: ${linkedIssueNumbers.join(', ') || 'none'}`);
+  core.info(`Linked issue labels: ${linkedIssueLabels.join(', ') || 'none'}`);
+  core.info(`Labels selected: ${labelsToAdd.join(', ') || 'none'}`);
+
+  if (labelsToAdd.length === 0 || dryRun) {
+    if (dryRun) core.info('Dry run enabled; labels were not applied.');
+    return labelsToAdd;
+  }
+
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    labels: labelsToAdd
+  });
+
+  return labelsToAdd;
+}
+
+module.exports = {
+  findLinkedIssueNumbers,
+  hasProgramSignal,
+  loadRules,
+  run,
+  selectLabels
+};

--- a/.github/scripts/pr-labeler.test.js
+++ b/.github/scripts/pr-labeler.test.js
@@ -21,7 +21,11 @@ const availableLabels = [
   'flutter',
   'backend',
   'type:api',
-  'documentation',
+  'type:docs',
+  'type:performance',
+  'type:design',
+  'type:devops',
+  'type:accessibility',
   'dependencies'
 ];
 
@@ -96,5 +100,31 @@ test('selectLabels ignores labels that do not exist in the repository', () => {
     availableLabels
   });
 
-  assert.deepEqual(labels, ['documentation']);
+  assert.deepEqual(labels, ['type:docs']);
+});
+
+test('selectLabels matches new performance, design, devops, and accessibility prefixes', () => {
+  const labelsPerf = selectLabels({
+    prTitle: 'perf: optimize load time',
+    availableLabels
+  });
+  assert.deepEqual(labelsPerf, ['type:performance']);
+
+  const labelsDesign = selectLabels({
+    prTitle: 'ui: update dashboard layout',
+    availableLabels
+  });
+  assert.deepEqual(labelsDesign, ['type:design']);
+
+  const labelsDevOps = selectLabels({
+    prTitle: 'ci: add test action',
+    availableLabels
+  });
+  assert.deepEqual(labelsDevOps, ['type:devops']);
+
+  const labelsA11y = selectLabels({
+    prTitle: 'a11y: add screen reader labels',
+    availableLabels
+  });
+  assert.deepEqual(labelsA11y, ['type:accessibility']);
 });

--- a/.github/scripts/pr-labeler.test.js
+++ b/.github/scripts/pr-labeler.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  findLinkedIssueNumbers,
+  hasProgramSignal,
+  selectLabels
+} = require('./pr-labeler');
+
+const availableLabels = [
+  'gssoc:approved',
+  'level:beginner',
+  'level:intermediate',
+  'type:bug',
+  'type:feature',
+  'type:security',
+  'type:testing',
+  'customer-app',
+  'driver-app',
+  'flutter',
+  'backend',
+  'type:api',
+  'documentation',
+  'dependencies'
+];
+
+test('findLinkedIssueNumbers extracts closing issue references only', () => {
+  assert.deepEqual(
+    findLinkedIssueNumbers('Fixes #320, relates to #12, resolves owner/repo#44 and closes #320'),
+    [320, 44]
+  );
+});
+
+test('hasProgramSignal detects GSSoC and NSoC mentions', () => {
+  const rules = {
+    programSignals: ['gssoc', 'nsoc26']
+  };
+
+  assert.equal(hasProgramSignal({ title: 'feat: add helper', body: 'GSSoC 2026 PR', rules }), true);
+  assert.equal(hasProgramSignal({ title: 'feat: add helper', body: 'regular maintenance', rules }), false);
+});
+
+test('selectLabels inherits approved GSSoC labels from linked issue', () => {
+  const labels = selectLabels({
+    prTitle: 'feat: add customer dashboard',
+    prBody: 'Fixes #320',
+    changedFiles: ['apps/customer/lib/screens/dashboard.dart'],
+    linkedIssueLabels: ['gssoc:approved', 'level:intermediate'],
+    currentLabels: [],
+    availableLabels
+  });
+
+  assert.deepEqual(labels, [
+    'customer-app',
+    'flutter',
+    'gssoc:approved',
+    'level:intermediate',
+    'type:feature'
+  ]);
+});
+
+test('selectLabels adds program label when PR declares GSSoC work', () => {
+  const labels = selectLabels({
+    prTitle: 'fix: guard auth token parsing',
+    prBody: 'Submitted under GSSoC 2026.',
+    changedFiles: ['backend/api/src/middleware/auth.js'],
+    linkedIssueLabels: [],
+    currentLabels: [],
+    availableLabels
+  });
+
+  assert.deepEqual(labels, ['backend', 'gssoc:approved', 'type:api', 'type:bug', 'type:security']);
+});
+
+test('selectLabels does not duplicate labels already present on the PR', () => {
+  const labels = selectLabels({
+    prTitle: 'test: cover shipment route',
+    prBody: 'Fixes #99',
+    changedFiles: ['backend/api/test/unit/shipment.test.js'],
+    linkedIssueLabels: ['gssoc:approved'],
+    currentLabels: ['gssoc:approved', 'backend'],
+    availableLabels
+  });
+
+  assert.deepEqual(labels, ['type:api', 'type:testing']);
+});
+
+test('selectLabels ignores labels that do not exist in the repository', () => {
+  const labels = selectLabels({
+    prTitle: 'docs: update setup',
+    prBody: 'Fixes #101',
+    changedFiles: ['README.md'],
+    linkedIssueLabels: ['level:critical'],
+    currentLabels: [],
+    availableLabels
+  });
+
+  assert.deepEqual(labels, ['documentation']);
+});

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,39 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply safe PR labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out trusted labeler code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Apply labels from issue, title, and changed paths
+        uses: actions/github-script@v8
+        env:
+          PR_LABELER_DRY_RUN: ${{ vars.PR_LABELER_DRY_RUN || 'false' }}
+        with:
+          script: |
+            const labeler = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-labeler.js`);
+            await labeler.run({
+              github,
+              context,
+              core,
+              dryRun: process.env.PR_LABELER_DRY_RUN === 'true'
+            });

--- a/docs/pr-labeling.md
+++ b/docs/pr-labeling.md
@@ -7,8 +7,8 @@ Truxify uses `.github/workflows/pr-labeler.yml` to add safe, review-friendly lab
 The labeler uses three inputs:
 
 1. Linked issue labels from closing keywords such as `Fixes #320`.
-2. Pull request title/body signals such as `feat:`, `fix:`, `test:`, `security`, `GSSoC`, or `NSoC`.
-3. Changed file paths such as `apps/customer/`, `apps/driver/`, `backend/api/`, `backend/ml/`, `blockchain/`, `automation/`, `docs/`, and test files.
+2. Pull request title/body signals mapped to type labels: `type:bug` (fix/bug), `type:feature` (feat/feature), `type:docs` (docs), `type:testing` (test), `type:security` (security/auth), `type:performance` (perf), `type:design` (design/ui), `type:refactor` (refactor), `type:devops` (ci/cd/build), and `type:accessibility` (a11y).
+3. Changed file paths such as `apps/customer/`, `apps/driver/`, `backend/api/`, `backend/ml/`, `blockchain/`, `automation/`, docs/markdown files (mapped to `type:docs`), and test files.
 
 The labeler never removes or overwrites labels that maintainers added manually. It also skips any configured label that does not already exist in the repository.
 

--- a/docs/pr-labeling.md
+++ b/docs/pr-labeling.md
@@ -1,0 +1,38 @@
+# Automatic PR Labeling
+
+Truxify uses `.github/workflows/pr-labeler.yml` to add safe, review-friendly labels to pull requests. The workflow runs on `pull_request_target`, but it only checks trusted repository code, pull request metadata, linked issue labels, and the list of changed file paths. It does not execute code from contributor branches.
+
+## Label Sources
+
+The labeler uses three inputs:
+
+1. Linked issue labels from closing keywords such as `Fixes #320`.
+2. Pull request title/body signals such as `feat:`, `fix:`, `test:`, `security`, `GSSoC`, or `NSoC`.
+3. Changed file paths such as `apps/customer/`, `apps/driver/`, `backend/api/`, `backend/ml/`, `blockchain/`, `automation/`, `docs/`, and test files.
+
+The labeler never removes or overwrites labels that maintainers added manually. It also skips any configured label that does not already exist in the repository.
+
+## GSSoC Behavior
+
+The workflow applies `gssoc:approved` when:
+
+- the linked issue already has `gssoc:approved`; or
+- the pull request title/body clearly says it is a GSSoC or NSoC contribution.
+
+This keeps GSSoC PRs trackable while still avoiding broad guesses on unrelated maintenance pull requests.
+
+## Updating Rules
+
+Edit `.github/pr-labeler-rules.json` to add path mappings, title patterns, inherited labels, or program signals. Keep rules conservative: prefer adding labels only when the source signal is clear.
+
+## Dry Run
+
+Set the repository variable `PR_LABELER_DRY_RUN` to `true` to log selected labels without applying them. This is useful when testing rule changes before allowing the workflow to label new pull requests automatically.
+
+## Local Test
+
+Run the unit tests before changing the workflow:
+
+```bash
+node --test .github/scripts/pr-labeler.test.js
+```


### PR DESCRIPTION
## Summary
- add a safe pull_request_target labeler that reads trusted repo code only and labels PRs from metadata, linked issue labels, and changed file paths
- apply gssoc:approved when a linked issue already has it or the PR explicitly declares GSSoC/NSoC work, matching the maintainer request in #320
- document the workflow, dry-run mode, and rule updates in docs/pr-labeling.md

## Safety notes
- does not check out or execute contributor branch code
- does not remove or overwrite maintainer-added labels
- skips configured labels that do not exist in the repository

## Tests
- node --test .github/scripts/pr-labeler.test.js
- node --check .github/scripts/pr-labeler.js
- python3 -m json.tool .github/pr-labeler-rules.json >/dev/null
- git diff --check

Fixes #320