### PR TITLE
fix: use local docker database services

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,25 @@ flutter pub get
 flutter run
 ```
 
+### Run the Backend With Docker
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+The Compose stack overrides the cloud MongoDB and Redis placeholders from
+`.env` inside the API container:
+
+```env
+MONGODB_URI=mongodb://mongo:27017
+MONGODB_DB_NAME=truxify_telemetry
+REDIS_URL=redis://redis:6379
+```
+
+This lets the backend use the local `mongo` and `redis` services without
+editing `.env` away from production-style values.
+
 ---
 
 ## 📊 Impact Metrics (Projected)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - "5000:5000"
     env_file:
       - .env
+    environment:
+      MONGODB_URI: mongodb://mongo:27017
+      MONGODB_DB_NAME: truxify_telemetry
+      REDIS_URL: redis://redis:6379
     volumes:
       - ./backend/api:/app
       - /app/node_modules


### PR DESCRIPTION
## Summary
- override cloud MongoDB and Redis values inside the Docker Compose API service
- keep the API container pointed at local `mongo` and `redis` service hostnames
- document the Docker backend startup flow and local service connection values

## Why
The root `.env` can contain MongoDB Atlas and Upstash Redis placeholders. Without Compose-level overrides, `docker compose up` can still make the API try external cloud services even though local containers are running.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("docker-compose.yml"); puts "docker-compose.yml parsed"'`
- `git diff --check`

Note: `docker compose config` could not be run in this environment because the Docker CLI is not installed.

Closes #338