### PR TITLE
chore: add local PostGIS compose service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-service-role
 # Format: postgresql://postgres.[project-id]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true
 DATABASE_URL=postgresql://postgres.your-project-id:your-db-password@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true
 
+# Local PostgreSQL/PostGIS via docker-compose
+# Use this DATABASE_URL instead when running the backend inside Docker Compose:
+# DATABASE_URL=postgresql://postgres:postgrespassword@db:5432/truxify
+# Use this host URL for local CLI tools running outside Docker:
+# LOCAL_DATABASE_URL=postgresql://postgres:postgrespassword@localhost:5432/truxify
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgrespassword
+POSTGRES_DB=truxify
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # 2. MONGODB ATLAS (High-Volume Live GPS Pings, Activity logs, ML Training Data)

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -12,6 +12,31 @@ npm install
 npm run dev            # nodemon + node src/index.js
 ```
 
+## Local PostgreSQL/PostGIS
+
+Supabase remains the primary hosted PostgreSQL path, but contributors can run a
+local PostGIS database for offline relational database work:
+
+```bash
+docker compose up -d db
+```
+
+Default Docker Compose credentials:
+
+| Setting | Value |
+| ------- | ----- |
+| Host from containers | `db` |
+| Host from your machine | `localhost` |
+| Port | `5432` |
+| Database | `truxify` |
+| User | `postgres` |
+| Password | `postgrespassword` |
+
+Use `postgresql://postgres:postgrespassword@db:5432/truxify` when the backend
+runs inside Docker Compose. Use
+`postgresql://postgres:postgrespassword@localhost:5432/truxify` for host CLI
+tools. Data persists in the `postgres_data` Docker volume across restarts.
+
 ## Test
 
 Vitest + supertest. No live Supabase / Redis / MongoDB required — the test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,18 @@ services:
     depends_on:
       - mongo
       - redis
+      - db
+
+  db:
+    image: postgis/postgis:15-3.3-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgrespassword}
+      POSTGRES_DB: ${POSTGRES_DB:-truxify}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   mongo:
     image: mongo:6-jammy
@@ -30,3 +42,4 @@ services:
 
 volumes:
   mongo_data:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a local PostGIS PostgreSQL service to docker-compose.yml
- persist database data in a postgres_data Docker volume
- document default local database credentials and container/host connection strings
- add local PostgreSQL env values to .env.example without removing the Supabase path

Closes #339

## Verification
- git diff --check
- docker compose config could not be run in this environment because Docker is not installed/available (spawn docker ENOENT).