### PR TITLE
fix(customer): replace hardcoded customer ID with authenticated user ID

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -70,7 +70,7 @@ class OrderService {
     debugPrint('Orders response: $response');
 
     return List<Map<String, dynamic>>.from(response);
-  } 
+  }
 
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
     String orderDisplayId,
@@ -104,12 +104,12 @@ class OrderService {
         .select()
         .eq('customer_id', userId)
         .inFilter('status', [
-          'completed',
-          'delivered',
-          'payment_released',
-          'cancelled',
-        ]);
+      'completed',
+      'delivered',
+      'payment_released',
+      'cancelled',
+    ]);
 
     return List<Map<String, dynamic>>.from(response);
   }
-  }
+}

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'supabase_service.dart';
 
 class OrderService {
   OrderService({SupabaseClient? client}) : _providedClient = client;
@@ -25,7 +26,7 @@ class OrderService {
   }) async {
     await _client.from('orders').insert({
       'order_display_id': orderDisplayId,
-      'customer_id': '11111111-1111-1111-1111-111111111111',
+      'customer_id': SupabaseService.requireUserId(),
       'driver_id': driverId,
       'truck_id': truckId,
       'status': 'pending',
@@ -55,15 +56,18 @@ class OrderService {
   }
 
   Future<List<Map<String, dynamic>>> fetchOrders() async {
-    final response = await _client
-        .from('orders')
-        .select()
-        .order('pickup_date', ascending: false);
+  final userId = SupabaseService.requireUserId();
 
-    debugPrint('Orders response: $response');
+  final response = await _client
+      .from('orders')
+      .select()
+      .eq('customer_id', userId)
+      .order('pickup_date', ascending: false);
 
-    return List<Map<String, dynamic>>.from(response);
-  }
+  debugPrint('Orders response: $response');
+
+  return List<Map<String, dynamic>>.from(response);
+}
 
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
     String orderDisplayId,
@@ -78,22 +82,31 @@ class OrderService {
   }
 
   Future<List<Map<String, dynamic>>> fetchActiveOrders() async {
-    final response = await _client
-        .from('orders')
-        .select()
-        .inFilter('status', ['pending', 'active', 'in_transit']);
+  final userId = SupabaseService.requireUserId();
 
-    return List<Map<String, dynamic>>.from(response);
-  }
+  final response = await _client
+      .from('orders')
+      .select()
+      .eq('customer_id', userId)
+      .inFilter('status', ['pending', 'active', 'in_transit']);
+
+  return List<Map<String, dynamic>>.from(response);
+}
 
   Future<List<Map<String, dynamic>>> fetchHistoryOrders() async {
-    final response = await _client.from('orders').select().inFilter('status', [
-      'completed',
-      'delivered',
-      'payment_released',
-      'cancelled',
-    ]);
+  final userId = SupabaseService.requireUserId();
 
-    return List<Map<String, dynamic>>.from(response);
-  }
+  final response = await _client
+      .from('orders')
+      .select()
+      .eq('customer_id', userId)
+      .inFilter('status', [
+        'completed',
+        'delivered',
+        'payment_released',
+        'cancelled',
+      ]);
+
+  return List<Map<String, dynamic>>.from(response);
+}
 }

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -70,7 +70,7 @@ class OrderService {
     debugPrint('Orders response: $response');
 
     return List<Map<String, dynamic>>.from(response);
-}
+  } 
 
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
     String orderDisplayId,

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -46,27 +46,30 @@ class OrderService {
   }
 
   Future<Map<String, dynamic>?> fetchOrderById(String orderDisplayId) async {
+    final userId = SupabaseService.requireUserId();
+
     final response = await _client
         .from('orders')
         .select()
         .eq('order_display_id', orderDisplayId)
+        .eq('customer_id', userId)
         .maybeSingle();
 
     return response;
   }
 
   Future<List<Map<String, dynamic>>> fetchOrders() async {
-  final userId = SupabaseService.requireUserId();
+    final userId = SupabaseService.requireUserId();
 
-  final response = await _client
-      .from('orders')
-      .select()
-      .eq('customer_id', userId)
-      .order('pickup_date', ascending: false);
+    final response = await _client
+        .from('orders')
+        .select()
+        .eq('customer_id', userId)
+        .order('pickup_date', ascending: false);
 
-  debugPrint('Orders response: $response');
+    debugPrint('Orders response: $response');
 
-  return List<Map<String, dynamic>>.from(response);
+    return List<Map<String, dynamic>>.from(response);
 }
 
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
@@ -82,31 +85,31 @@ class OrderService {
   }
 
   Future<List<Map<String, dynamic>>> fetchActiveOrders() async {
-  final userId = SupabaseService.requireUserId();
+    final userId = SupabaseService.requireUserId();
 
-  final response = await _client
-      .from('orders')
-      .select()
-      .eq('customer_id', userId)
-      .inFilter('status', ['pending', 'active', 'in_transit']);
+    final response = await _client
+        .from('orders')
+        .select()
+        .eq('customer_id', userId)
+        .inFilter('status', ['pending', 'active', 'in_transit']);
 
-  return List<Map<String, dynamic>>.from(response);
-}
+    return List<Map<String, dynamic>>.from(response);
+  }
 
   Future<List<Map<String, dynamic>>> fetchHistoryOrders() async {
-  final userId = SupabaseService.requireUserId();
+    final userId = SupabaseService.requireUserId();
 
-  final response = await _client
-      .from('orders')
-      .select()
-      .eq('customer_id', userId)
-      .inFilter('status', [
-        'completed',
-        'delivered',
-        'payment_released',
-        'cancelled',
-      ]);
+    final response = await _client
+        .from('orders')
+        .select()
+        .eq('customer_id', userId)
+        .inFilter('status', [
+          'completed',
+          'delivered',
+          'payment_released',
+          'cancelled',
+        ]);
 
-  return List<Map<String, dynamic>>.from(response);
-}
-}
+    return List<Map<String, dynamic>>.from(response);
+  }
+  }


### PR DESCRIPTION
## Description

This PR fixes the customer order creation flow by replacing the hardcoded mock customer UUID with the authenticated user's ID obtained through Supabase authentication.

Fixes #356

## Problem

The customer order creation flow was using a hardcoded customer ID:

```dart
'customer_id': '11111111-1111-1111-1111-111111111111'
```
As a result, every order created through the customer app was stored under the same customer record regardless of the logged-in user.

This caused incorrect order ownership, inconsistent booking history, and prevented proper user-specific order tracking.

## Changes Made
**Order Creation**

Replaced the hardcoded customer UUID with:

```dart
SupabaseService.requireUserId()
```
Orders are now created using the authenticated user's ID.
**Order Retrieval**

Updated order queries to return only orders belonging to the authenticated user:

```dart
fetchOrders()
fetchActiveOrders()
fetchHistoryOrders()
```

This ensures users only see their own bookings and order history.

## Benefits

- Correct order ownership tracking.
- Different users can create and manage their own orders independently.
- Prevents all orders from being associated with a single mock customer.
- Improves database consistency and data integrity.
- Removes hardcoded customer identifiers from the customer order flow.


## Files Changed
apps/customer/lib/services/order_service.dart

## Acceptance Criteria Checklist
 

- [x] Orders are created using the authenticated user's ID.
- [x]  Different users see only their own bookings.
- [x]  No hardcoded customer identifiers remain in the order creation flow.
 