### PR TITLE
feat(api): add driver milestone update endpoint

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -492,5 +492,87 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
+// ============================================================================
+// 7. UPDATE ORDER MILESTONE (ASSIGNED DRIVER)
+// ============================================================================
+router.put('/:id/milestones', authenticate, requireRole(['driver']), async (req, res) => {
+  const orderId = req.params.id;
+  const { milestone } = req.body;
+
+  const milestoneMap = {
+    'En Route to Pickup': 'truck_assigned',
+    'Goods Loaded': 'picked_up',
+    'In Transit': 'in_transit',
+    'Delivered': 'delivered',
+  };
+
+  if (!milestone || !milestoneMap[milestone]) {
+    return res.status(400).json({
+      error: 'Invalid milestone supplied.'
+    });
+  }
+
+  try {
+    const { data: order } = await supabase
+      .from('orders')
+      .select('driver_id, order_display_id')
+      .eq('id', orderId)
+      .maybeSingle();
+
+    if (!order) {
+      return res.status(404).json({
+        error: 'Order not found.'
+      });
+    }
+
+    if (order.driver_id !== req.user.id) {
+      return res.status(403).json({
+        error: 'Access Denied: You are not assigned to this order.'
+      });
+    }
+
+    const status = milestoneMap[milestone];
+
+    const { error: orderErr } = await supabase
+  .from('orders')
+  .update({
+    status,
+    updated_at: new Date().toISOString()
+  })
+  .eq('id', orderId);
+
+if (orderErr) {
+  return res.status(500).json({
+    error: orderErr.message
+  });
+}
+
+const { error: timelineErr } = await supabase
+  .from('order_timeline')
+  .update({
+    completed: true,
+    milestone_time: new Date().toISOString()
+  })
+  .eq('order_display_id', order.order_display_id)
+  .eq('milestone', milestone);
+
+if (timelineErr) {
+  return res.status(500).json({
+    error: timelineErr.message
+  });
+}
+
+    return res.status(200).json({
+      message: 'Milestone updated successfully.',
+      milestone,
+      status
+    });
+
+  } catch (err) {
+    return res.status(500).json({
+      error: 'Internal Server Error'
+    });
+  }
+});
 
 export default router;

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -135,6 +135,28 @@ class SupabaseQueryBuilder {
       }
       return { data: rows, error: null };
     }
+    if (this._mode === 'update') {
+  let rows = this._store[this._table] ?? [];
+
+  for (const row of rows) {
+    const matches = this._filters.every(f => {
+      const v = row[f.col];
+
+      switch (f.op) {
+        case 'eq':
+          return v === f.val;
+        default:
+          return true;
+      }
+    });
+
+    if (matches) {
+      Object.assign(row, this._payload);
+    }
+  }
+
+  return { data: rows, error: null };
+}
 
     if (this._mode === 'select' || this._mode === null) {
       let rows = (this._store[this._table] ?? []).slice();

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -188,4 +188,56 @@ describe('POST /api/orders — server-side pricing contract', () => {
     expect(orderInsert.platform_fee).not.toBe(99999);
     expect(orderInsert.total_amount).not.toBe(99999);
   });
+  it('driver can update milestone when assigned to order', async () => {
+  m.store.orders = [{
+    id: 'order-1',
+    driver_id: 'driver-123',
+    order_display_id: 'ORD001',
+    status: 'truck_assigned'
+  }];
+
+  m.store.order_timeline = [{
+    order_display_id: 'ORD001',
+    milestone: 'Goods Loaded',
+    completed: false
+  }];
+
+  const app = buildApp();
+
+  const res = await request(app)
+    .put('/api/orders/order-1/milestones')
+    .set({
+      'x-user-id': 'driver-123',
+      'x-user-role': 'driver'
+    })
+    .send({
+      milestone: 'Goods Loaded'
+    });
+
+  expect(res.status).toBe(200);
+expect(res.body.message).toMatch(/Milestone updated successfully/i);
+});
+
+it('returns 403 when driver is not assigned to order', async () => {
+  m.store.orders = [{
+    id: 'order-1',
+    driver_id: 'driver-999',
+    order_display_id: 'ORD001'
+  }];
+
+  const app = buildApp();
+
+  const res = await request(app)
+    .put('/api/orders/order-1/milestones')
+    .set({
+      'x-user-id': 'driver-123',
+      'x-user-role': 'driver'
+    })
+    .send({
+      milestone: 'Goods Loaded'
+    });
+
+  expect(res.status).toBe(403);
+});
+
 });


### PR DESCRIPTION
## Description

Adds a new driver-only endpoint to update order milestones during delivery progress.

### Changes Made

* Added `PUT /api/orders/:id/milestones`
* Restricted access to authenticated drivers only
* Ensures only the assigned driver can update milestones
* Maps milestone names to internal order statuses
* Updates the `orders` table status
* Updates the corresponding `order_timeline` milestone entry
* Added error handling for invalid milestones, missing orders, and unauthorized drivers

### Tests Added

* Driver can update milestone when assigned to the order (`200`)
* Driver receives `403` when not assigned to the order

### Test Results

```bash
9 tests passed
1 test file passed
```

closes #341 


### Checklist

* [x] Endpoint implemented
* [x] Authorization enforced
* [x] Timeline updates implemented
* [x] Tests added
* [x] Tests passing
