### PR TITLE
[GSSoC'26] fix(pricing): use OSRM road distance fallback

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -73,6 +73,7 @@ export function haversineKm(lat1, lon1, lat2, lon2) {
  * @param {number} input.dropLat     - decimal degrees
  * @param {number} input.dropLng     - decimal degrees
  * @param {number} input.weightTonnes - cargo weight in tonnes (> 0)
+ * @param {number} [input.roadDistanceKm] - routed road distance in kilometres
  * @param {boolean} [input.isFragile] - fragile cargo multiplier
  * @param {boolean} [input.isStackable] - stackable cargo discount
  * @param {object} [rateCard] - override rate card (mainly for tests)
@@ -85,14 +86,17 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
   }
   const {
     pickupLat, pickupLng, dropLat, dropLng,
-    weightTonnes, isFragile = false, isStackable = false,
+    weightTonnes, roadDistanceKm, isFragile = false, isStackable = false,
   } = input;
 
   if (!Number.isFinite(weightTonnes) || weightTonnes <= 0) {
     throw new RangeError(`weightTonnes must be a positive number, got ${weightTonnes}`);
   }
 
-  const distanceKm = haversineKm(pickupLat, pickupLng, dropLat, dropLng);
+  const fallbackDistanceKm = haversineKm(pickupLat, pickupLng, dropLat, dropLng);
+  const distanceKm = Number.isFinite(roadDistanceKm) && roadDistanceKm >= 0
+    ? roadDistanceKm
+    : fallbackDistanceKm;
 
   // Base rate scaled by goods class.
   let rate = rateCard.ratePerTonneKm;

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { computeOrderPricing } from '../lib/pricing.js';
+import { getRouteEstimate } from '../services/osrm.js';
 
 const router = express.Router();
 
@@ -44,12 +45,19 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
   // ============================================================================
   let pricing;
   try {
+    const routeEstimate = await getRouteEstimate({
+      pickupLat: Number(pickup_lat),
+      pickupLng: Number(pickup_lng),
+      dropLat: Number(drop_lat),
+      dropLng: Number(drop_lng),
+    });
     pricing = computeOrderPricing({
       pickupLat:  Number(pickup_lat),
       pickupLng:  Number(pickup_lng),
       dropLat:    Number(drop_lat),
       dropLng:    Number(drop_lng),
       weightTonnes: Number(weight_tonnes),
+      roadDistanceKm: routeEstimate?.distanceKm,
       isFragile:   Boolean(is_fragile),
       isStackable: Boolean(is_stackable),
     });

--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -1,0 +1,54 @@
+const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
+const DEFAULT_TIMEOUT_MS = 1500;
+
+function parsePositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
+  const baseUrl = process.env.OSRM_BASE_URL || DEFAULT_OSRM_BASE_URL;
+  const url = new URL('/route/v1/driving/', baseUrl);
+  url.pathname += `${pickupLng},${pickupLat};${dropLng},${dropLat}`;
+  url.searchParams.set('overview', 'false');
+  url.searchParams.set('alternatives', 'false');
+  url.searchParams.set('steps', 'false');
+  return url;
+}
+
+export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng } = {}) {
+  if (
+    !Number.isFinite(pickupLat) || !Number.isFinite(pickupLng) ||
+    !Number.isFinite(dropLat) || !Number.isFinite(dropLng)
+  ) {
+    return null;
+  }
+
+  const timeoutMs = parsePositiveNumber(process.env.OSRM_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }), {
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+
+    const payload = await response.json();
+    const route = Array.isArray(payload?.routes) ? payload.routes[0] : null;
+    if (!route || !Number.isFinite(route.distance) || route.distance < 0) {
+      return null;
+    }
+
+    return {
+      distanceKm: route.distance / 1000,
+      durationSeconds: Number.isFinite(route.duration) ? route.duration : null,
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export const __testing = { buildRouteUrl, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS };

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -16,6 +16,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 
+const routeEstimateMock = vi.fn();
+
 // Hoisted mock: swap supabase out for our in-memory builder.
 const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
 
@@ -33,7 +35,12 @@ vi.mock('../../src/sockets/tracker.js', () => ({
   initWebSocketServer: () => ({}),
 }));
 
+vi.mock('../../src/services/osrm.js', () => ({
+  getRouteEstimate: routeEstimateMock,
+}));
+
 const { default: orderRouter } = await import('../../src/routes/orderRoutes.js');
+const { computeOrderPricing } = await import('../../src/lib/pricing.js');
 import express from 'express';
 
 function buildApp() {
@@ -78,6 +85,8 @@ describe('POST /api/orders — server-side pricing contract', () => {
     m.store.order_timeline = [];
     m.store.load_offers = [];
     m.calls.length = 0;
+    routeEstimateMock.mockReset();
+    routeEstimateMock.mockResolvedValue(null);
   });
 
   it('happy path: 201, server-computed pricing persisted, no client monetary field in store', async () => {
@@ -136,6 +145,36 @@ describe('POST /api/orders — server-side pricing contract', () => {
     // fuelCost + toll_cost + net_profit = baseFreight (the driver-side ledger invariant)
     expect(offerInsert.fuel_cost + offerInsert.toll_cost + offerInsert.net_profit)
       .toBe(offerInsert.freight_value);
+  });
+
+  it('uses OSRM road distance for persisted pricing when routing succeeds', async () => {
+    routeEstimateMock.mockResolvedValueOnce({ distanceKm: 1423.456, durationSeconds: 90000 });
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders')
+      .set(CUSTOMER_HEADERS)
+      .send(validOrderBody);
+
+    expect(res.status).toBe(201);
+    expect(routeEstimateMock).toHaveBeenCalledWith({
+      pickupLat: validOrderBody.pickup_lat,
+      pickupLng: validOrderBody.pickup_lng,
+      dropLat: validOrderBody.drop_lat,
+      dropLng: validOrderBody.drop_lng,
+    });
+
+    const orderInsert = m.calls.find(c => c.table === 'orders' && c.mode === 'insert').payload;
+    const straightLinePricing = computeOrderPricing({
+      pickupLat: validOrderBody.pickup_lat,
+      pickupLng: validOrderBody.pickup_lng,
+      dropLat: validOrderBody.drop_lat,
+      dropLng: validOrderBody.drop_lng,
+      weightTonnes: validOrderBody.weight_tonnes,
+    });
+
+    expect(orderInsert.base_freight).not.toBe(straightLinePricing.baseFreight);
+    expect(orderInsert.toll_estimate).toBe(Math.round(200 * 1423.456));
   });
 
   it('bad coordinates: NaN drop_lat → 400 with a clear pricing error', async () => {

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -144,6 +144,11 @@ describe('pricing lib — computeOrderPricing', () => {
     expect(p.distanceKm).toBe(Math.round(p.distanceKm * 100) / 100);
   });
 
+  it('uses OSRM road distance when a finite roadDistanceKm is supplied', () => {
+    const p = computeOrderPricing({ ...mumbaiDelhi, roadDistanceKm: 1423.456 });
+    expect(p.distanceKm).toBe(1423.46);
+  });
+
   it('Mumbai → Delhi, 10 tonnes, no flags: all-positive amounts, total = base + toll + platform', () => {
     const p = computeOrderPricing(mumbaiDelhi);
     expect(p.distanceKm).toBeGreaterThan(1100);


### PR DESCRIPTION
## Summary

- Added an OSRM routing client with timeout/error fallback.
- Updated order creation to use OSRM road distance for pricing when available.
- Kept Haversine pricing as the fallback when OSRM fails or returns unusable data.

## Files Changed

- `backend/api/src/services/osrm.js`
- `backend/api/src/lib/pricing.js`
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/unit/pricing.test.js`
- `backend/api/test/integration/orders.test.js`

## Testing Performed

```bash
npm --prefix backend/api run test:unit -- test/unit/pricing.test.js
npm --prefix backend/api run test:integration -- test/integration/orders.test.js
node --check backend/api/src/lib/pricing.js
node --check backend/api/src/routes/orderRoutes.js
node --check backend/api/src/services/osrm.js
npm --prefix backend/api test
git diff --check
```

## Known Limitations

- OSRM endpoint is configurable with `OSRM_BASE_URL`; default uses the public OSRM demo server.
- If OSRM is unavailable, slow, or returns invalid data, pricing falls back to Haversine distance.

## GSSoC Label Request

Please keep/add the GSSoC labels for this contribution.

## AI Assistance Disclosure

Substantial AI assistance was used to inspect the codebase, implement the fix, and prepare tests.

Closes #345
