### PR TITLE
[GSSoC'26] fix(tracking): authorize WebSocket subscriptions

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1,5 +1,5 @@
 import { WebSocketServer } from 'ws';
-import { mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
+import { mongoDb, redisClient, firebaseAdmin, supabase } from '../config/db.js';
 
 // In-memory mapping of active client subscriptions
 const trackingSubscriptions = new Map();
@@ -40,6 +40,10 @@ export function initWebSocketServer(server) {
         return;
       }
       ws.driverId = reqUrl.searchParams.get('driver_id') || 'test_driver';
+      ws.user = {
+        id: reqUrl.searchParams.get('user_id') || ws.driverId,
+        role: reqUrl.searchParams.get('user_role') || 'driver',
+      };
       console.log(`🔓 WS Auth bypassed for driver: ${ws.driverId}`);
     } else {
       if (!token) {
@@ -48,8 +52,30 @@ export function initWebSocketServer(server) {
       }
       try {
         const decoded = await firebaseAdmin.auth().verifyIdToken(token);
-        ws.driverId = decoded.uid;
-        console.log(`✅ WS Authenticated driver: ${ws.driverId}`);
+        if (!supabase) {
+          ws.close(4001, 'Unauthorized: Profile lookup is not configured');
+          return;
+        }
+
+        const { data: profile, error } = await supabase
+          .from('profiles')
+          .select('id, firebase_uid, role')
+          .eq('firebase_uid', decoded.uid)
+          .eq('is_active', true)
+          .maybeSingle();
+
+        if (error || !profile) {
+          ws.close(4001, 'Unauthorized: User profile not found');
+          return;
+        }
+
+        ws.user = {
+          id: profile.id,
+          uid: profile.firebase_uid,
+          role: profile.role,
+        };
+        ws.driverId = profile.id;
+        console.log(`✅ WS Authenticated user: ${ws.user.id}`);
       } catch (e) {
         console.error('WS Auth failed:', e.message);
         ws.close(4001, 'Unauthorized: Invalid token');
@@ -79,7 +105,7 @@ export function initWebSocketServer(server) {
             break;
 
           case 'subscribe_tracking':
-            handleSubscribe(ws, data);
+            await handleSubscribe(ws, data);
             break;
 
           case 'unsubscribe_tracking':
@@ -288,12 +314,18 @@ function initTelemetryScheduler() {
   }, BUFFER_FLUSH_INTERVAL_MS);
 }
 
-function handleSubscribe(ws, data) {
+export async function handleSubscribe(ws, data) {
   const { order_display_id, driver_id } = data;
   const targetId = order_display_id || driver_id;
 
   if (!targetId) {
     return ws.send(JSON.stringify({ error: 'Subscription target (order_display_id or driver_id) is missing.' }));
+  }
+
+  const authorized = await canSubscribe(ws, { order_display_id, driver_id });
+
+  if (!authorized) {
+    return ws.send(JSON.stringify({ error: 'Forbidden: You are not authorized to subscribe to this tracking target.' }));
   }
 
   if (!trackingSubscriptions.has(targetId)) {
@@ -303,6 +335,43 @@ function handleSubscribe(ws, data) {
   trackingSubscriptions.get(targetId).add(ws);
   console.log(`🔌 Client subscribed to telemetry updates for: "${targetId}"`);
   ws.send(JSON.stringify({ status: 'subscribed', target: targetId }));
+}
+
+async function canSubscribe(ws, { order_display_id, driver_id }) {
+  const userId = ws.user?.id || ws.driverId;
+  const userRole = ws.user?.role;
+
+  if (!userId) {
+    return false;
+  }
+
+  if (driver_id) {
+    return driver_id === userId || driver_id === ws.driverId;
+  }
+
+  if (!order_display_id || !supabase) {
+    return false;
+  }
+
+  const { data: order, error } = await supabase
+    .from('orders')
+    .select('customer_id, driver_id')
+    .eq('order_display_id', order_display_id)
+    .maybeSingle();
+
+  if (error || !order) {
+    return false;
+  }
+
+  if (userRole === 'customer') {
+    return order.customer_id === userId;
+  }
+
+  if (userRole === 'driver') {
+    return order.driver_id === userId;
+  }
+
+  return order.customer_id === userId || order.driver_id === userId;
 }
 
 function handleUnsubscribe(ws, data) {
@@ -327,3 +396,9 @@ function removeClientFromAllSubscriptions(ws) {
     }
   });
 }
+
+export const __testing = {
+  resetTrackingSubscriptions() {
+    trackingSubscriptions.clear();
+  },
+};

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1,14 +1,48 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => ({
+  store: {
+    orders: [],
+  },
+  calls: [],
+}));
 
 vi.mock('../../src/config/db.js', () => ({
   mongoDb: null,
   redisClient: null,
   firebaseAdmin: null,
+  supabase: {
+    from(table) {
+      const filters = [];
+      return {
+        select() {
+          return this;
+        },
+        eq(column, value) {
+          filters.push({ column, value });
+          return this;
+        },
+        async maybeSingle() {
+          dbMock.calls.push({ table, filters });
+          const row = (dbMock.store[table] ?? []).find((candidate) =>
+            filters.every(({ column, value }) => candidate[column] === value)
+          );
+          return { data: row ?? null, error: null };
+        },
+      };
+    },
+  },
 }));
 
-const { handleLocationPing } = await import('../../src/sockets/tracker.js');
+const { handleLocationPing, handleSubscribe, __testing } = await import('../../src/sockets/tracker.js');
 
 describe('tracker WebSocket telemetry authorization', () => {
+  beforeEach(() => {
+    dbMock.store.orders = [];
+    dbMock.calls = [];
+    __testing.resetTrackingSubscriptions();
+  });
+
   it('rejects a driver_id that does not match the authenticated socket', async () => {
     const sentMessages = [];
     const ws = {
@@ -32,5 +66,69 @@ describe('tracker WebSocket telemetry authorization', () => {
         error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.',
       },
     ]);
+  });
+
+  it('rejects an order subscription when the authenticated user is not assigned to the order', async () => {
+    dbMock.store.orders.push({
+      order_display_id: 'ORDER-123',
+      customer_id: 'customer-owner',
+      driver_id: 'driver-owner',
+    });
+    const sentMessages = [];
+    const ws = {
+      user: { id: 'different-customer', role: 'customer' },
+      readyState: 1,
+      send(message) {
+        sentMessages.push(JSON.parse(message));
+      },
+    };
+
+    await handleSubscribe(ws, { order_display_id: 'ORDER-123' });
+    await handleLocationPing(
+      { driverId: 'driver-owner', send: vi.fn() },
+      {
+        order_display_id: 'ORDER-123',
+        latitude: 12.9716,
+        longitude: 77.5946,
+      },
+    );
+
+    expect(sentMessages).toEqual([
+      { error: 'Forbidden: You are not authorized to subscribe to this tracking target.' },
+    ]);
+  });
+
+  it('allows a customer to subscribe to their own order tracking stream', async () => {
+    dbMock.store.orders.push({
+      order_display_id: 'ORDER-123',
+      customer_id: 'customer-owner',
+      driver_id: 'driver-owner',
+    });
+    const sentMessages = [];
+    const ws = {
+      user: { id: 'customer-owner', role: 'customer' },
+      send(message) {
+        sentMessages.push(JSON.parse(message));
+      },
+    };
+
+    await handleSubscribe(ws, { order_display_id: 'ORDER-123' });
+
+    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'ORDER-123' }]);
+  });
+
+  it('allows a driver to subscribe only to their own driver tracking stream', async () => {
+    const sentMessages = [];
+    const ws = {
+      user: { id: 'driver-owner', role: 'driver' },
+      driverId: 'driver-owner',
+      send(message) {
+        sentMessages.push(JSON.parse(message));
+      },
+    };
+
+    await handleSubscribe(ws, { driver_id: 'driver-owner' });
+
+    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'driver-owner' }]);
   });
 });


### PR DESCRIPTION
## Summary

- Resolves authenticated WebSocket users to their Supabase profile before tracking events are accepted.
- Blocks `subscribe_tracking` requests unless the socket user owns the requested order stream or driver stream.
- Adds regression coverage proving unauthorized subscribers no longer receive location updates.

## Files Changed

- `backend/api/src/sockets/tracker.js`
- `backend/api/test/unit/tracker.test.js`

## Testing Performed

```bash
npm --prefix backend/api run test:unit -- test/unit/tracker.test.js
node --check backend/api/src/sockets/tracker.js
node --check backend/api/test/unit/tracker.test.js
git diff --check
npm --prefix backend/api test
```

## Known Limitations

- The fix authorizes subscriptions at subscribe time; existing subscriptions are still removed on socket close/error as before.
- Local `BYPASS_AUTH=true` WebSocket testing may pass `user_id` and `user_role` query params; when omitted it defaults to the existing test driver identity.

## GSSoC Label Request

Please keep/add the GSSoC labels for this contribution.

## AI Assistance Disclosure

Substantial AI assistance was used to inspect the codebase, implement the fix, and prepare tests.

Closes #352
