### PR TITLE
[GSSoC'26] fix(orders): verify accepted bid belongs to order

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -432,7 +432,29 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
       return res.status(404).json({ error: 'Bid is not active or not found.' });
     }
 
-    // 6.3 Fetch driver details & truck details for denormalized snapshot storage
+    // 6.3 Verify the bid belongs to this order's load offer
+    const { data: loadOffer, error: loadOfferErr } = await supabase
+      .from('load_offers')
+      .select('id')
+      .eq('order_display_id', order.order_display_id)
+      .maybeSingle();
+
+    if (loadOfferErr) {
+      return res.status(500).json({
+        error: 'Failed to verify bid ownership.',
+        details: loadOfferErr.message
+      });
+    }
+
+    if (!loadOffer) {
+      return res.status(404).json({ error: 'Load offer for this order was not found.' });
+    }
+
+    if (bid.load_id !== loadOffer.id) {
+      return res.status(403).json({ error: 'Access Denied: Bid does not belong to this order.' });
+    }
+
+    // 6.4 Fetch driver details & truck details for denormalized snapshot storage
     const { data: profile } = await supabase
       .from('profiles')
       .select('full_name')
@@ -465,7 +487,7 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
       truckInfo = data;
     }
 
-    // 6.4 Execute atomically via Supabase RPC
+    // 6.5 Execute atomically via Supabase RPC
     const { error: rpcErr } = await supabase.rpc('accept_bid_tx', {
       p_bid_id:           bidId,
       p_order_id:         orderId,

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -189,3 +189,45 @@ describe('POST /api/orders — server-side pricing contract', () => {
     expect(orderInsert.total_amount).not.toBe(99999);
   });
 });
+
+describe('POST /api/orders/:id/bids/:bidId/accept — bid ownership', () => {
+  beforeEach(() => {
+    m.store.orders = [];
+    m.store.load_offers = [];
+    m.store.load_bids = [];
+    m.store.profiles = [];
+    m.store.driver_details = [];
+    m.store.trucks = [];
+    m.calls.length = 0;
+  });
+
+  it('rejects a pending bid when it belongs to a different order load offer', async () => {
+    const app = buildApp();
+    m.store.orders.push({
+      id: 'order-owned',
+      order_display_id: 'ORDER-OWNED',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+    });
+    m.store.load_offers.push({
+      id: 'load-owned',
+      order_display_id: 'ORDER-OWNED',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+    });
+    m.store.load_bids.push({
+      id: 'bid-from-other-load',
+      load_id: 'load-other',
+      driver_id: 'driver-other',
+      bid_amount: 42000,
+      status: 'pending',
+    });
+
+    const res = await request(app)
+      .post('/api/orders/order-owned/bids/bid-from-other-load/accept')
+      .set(CUSTOMER_HEADERS)
+      .send();
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Access Denied: Bid does not belong to this order.' });
+    expect(m.calls.some(c => c.rpc === 'accept_bid_tx')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Verifies that the bid being accepted belongs to the load offer for the authenticated customer’s order.
- Rejects cross-order bid acceptance before driver lookup or `accept_bid_tx` execution.
- Adds an integration regression test covering the cross-order bid acceptance vulnerability.

## Files Changed

- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/integration/orders.test.js`

## Testing Performed

```bash
npm --prefix backend/api run test:integration -- test/integration/orders.test.js
node --check backend/api/src/routes/orderRoutes.js
node --check backend/api/test/integration/orders.test.js
git diff --check
npm --prefix backend/api test
```

## Known Limitations

- The endpoint returns `404` when the owned order has no load offer and `403` when the bid exists but belongs to a different load.

## GSSoC Label Request

Please keep/add the GSSoC labels for this contribution.

## AI Assistance Disclosure

Substantial AI assistance was used to inspect the codebase, implement the fix, and prepare tests.

Closes #353
