### PR TITLE
[GSSoC'26] fix(orders): prevent duplicate pending bids

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -265,6 +265,25 @@ router.post('/:id/bids', authenticate, requireRole(['driver']), async (req, res)
       return res.status(410).json({ error: 'Load is no longer available for bidding.' });
     }
 
+    const { data: existingBid, error: existingBidErr } = await supabase
+      .from('load_bids')
+      .select('id')
+      .eq('load_id', loadOfferId)
+      .eq('driver_id', req.user.id)
+      .eq('status', 'pending')
+      .maybeSingle();
+
+    if (existingBidErr) {
+      return res.status(500).json({
+        error: 'Failed to verify existing bids.',
+        details: existingBidErr.message
+      });
+    }
+
+    if (existingBid) {
+      return res.status(409).json({ error: 'You already have a pending bid for this load.' });
+    }
+
     // Submit bid
     const { data: bid, error: bidErr } = await supabase
       .from('load_bids')

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -49,6 +49,12 @@ const CUSTOMER_HEADERS = {
   'x-user-name': 'Test Customer',
 };
 
+const DRIVER_HEADERS = {
+  'x-user-id': '00000000-0000-0000-0000-000000000def',
+  'x-user-role': 'driver',
+  'x-user-name': 'Test Driver',
+};
+
 const validOrderBody = {
   pickup_address: '123 Pickup St, Mumbai',
   pickup_lat: 19.0760,
@@ -187,5 +193,38 @@ describe('POST /api/orders — server-side pricing contract', () => {
     expect(orderInsert.toll_estimate).not.toBe(99999);
     expect(orderInsert.platform_fee).not.toBe(99999);
     expect(orderInsert.total_amount).not.toBe(99999);
+  });
+});
+
+describe('POST /api/orders/:id/bids — duplicate bid prevention', () => {
+  beforeEach(() => {
+    m.store.load_offers = [];
+    m.store.load_bids = [];
+    m.calls.length = 0;
+  });
+
+  it('rejects a duplicate pending bid from the same driver on the same load', async () => {
+    const app = buildApp();
+    m.store.load_offers.push({
+      id: 'load-duplicate',
+      status: 'available',
+    });
+    m.store.load_bids.push({
+      id: 'existing-bid',
+      load_id: 'load-duplicate',
+      driver_id: DRIVER_HEADERS['x-user-id'],
+      bid_amount: 500000,
+      status: 'pending',
+    });
+
+    const res = await request(app)
+      .post('/api/orders/load-duplicate/bids')
+      .set(DRIVER_HEADERS)
+      .send({ bid_amount: 510000 });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: 'You already have a pending bid for this load.' });
+    const bidInserts = m.calls.filter(c => c.table === 'load_bids' && c.mode === 'insert');
+    expect(bidInserts).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Checks for an existing pending bid by the authenticated driver before inserting a new bid.
- Returns `409 Conflict` when the same driver already has a pending bid on the load.
- Adds integration coverage proving duplicate pending bids are rejected and no extra insert occurs.

## Files Changed

- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/integration/orders.test.js`

## Testing Performed

```bash
npm --prefix backend/api run test:integration -- test/integration/orders.test.js
node --check backend/api/src/routes/orderRoutes.js
node --check backend/api/test/integration/orders.test.js
git diff --check
npm --prefix backend/api test
```

## Known Limitations

- This API-level guard prevents duplicate pending bids through the route. A database partial unique index would still be a useful defense-in-depth follow-up.

## GSSoC Label Request

Please keep/add the GSSoC labels for this contribution.

## AI Assistance Disclosure

Substantial AI assistance was used to inspect the codebase, implement the fix, and prepare tests.

Closes #354
