### PR TITLE
fix: handle websocket heartbeat pings

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -64,35 +64,8 @@ export function initWebSocketServer(server) {
       ws.isAlive = true;
     });
 
-    ws.on('message', async (message) => {
-      try {
-        const payload = JSON.parse(message.toString());
-        const { event, data } = payload;
-
-        if (!event || !data) {
-          return ws.send(JSON.stringify({ error: 'Invalid payload format. Must include "event" and "data" keys.' }));
-        }
-
-        switch (event) {
-          case 'location_ping':
-            await handleLocationPing(ws, data);
-            break;
-
-          case 'subscribe_tracking':
-            handleSubscribe(ws, data);
-            break;
-
-          case 'unsubscribe_tracking':
-            handleUnsubscribe(ws, data);
-            break;
-
-          default:
-            ws.send(JSON.stringify({ warning: `Unknown event type: ${event}` }));
-        }
-      } catch (err) {
-        console.error('WS Message parsing error:', err.message);
-        ws.send(JSON.stringify({ error: 'Invalid JSON payload structure.' }));
-      }
+    ws.on('message', (message) => {
+      handleTrackingMessage(ws, message);
     });
 
     ws.on('close', () => {
@@ -126,6 +99,44 @@ export function initWebSocketServer(server) {
   }
 
   console.log('🚀 WebSocket tracking router initialized.');
+}
+
+export async function handleTrackingMessage(ws, message) {
+  const messageText = message.toString();
+
+  if (messageText === 'ping') {
+    ws.isAlive = true;
+    return ws.send('pong');
+  }
+
+  try {
+    const payload = JSON.parse(messageText);
+    const { event, data } = payload;
+
+    if (!event || !data) {
+      return ws.send(JSON.stringify({ error: 'Invalid payload format. Must include "event" and "data" keys.' }));
+    }
+
+    switch (event) {
+      case 'location_ping':
+        await handleLocationPing(ws, data);
+        break;
+
+      case 'subscribe_tracking':
+        handleSubscribe(ws, data);
+        break;
+
+      case 'unsubscribe_tracking':
+        handleUnsubscribe(ws, data);
+        break;
+
+      default:
+        ws.send(JSON.stringify({ warning: `Unknown event type: ${event}` }));
+    }
+  } catch (err) {
+    console.error('WS Message parsing error:', err.message);
+    ws.send(JSON.stringify({ error: 'Invalid JSON payload structure.' }));
+  }
 }
 
 /**

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -6,7 +6,7 @@ vi.mock('../../src/config/db.js', () => ({
   firebaseAdmin: null,
 }));
 
-const { handleLocationPing } = await import('../../src/sockets/tracker.js');
+const { handleLocationPing, handleTrackingMessage } = await import('../../src/sockets/tracker.js');
 
 describe('tracker WebSocket telemetry authorization', () => {
   it('rejects a driver_id that does not match the authenticated socket', async () => {
@@ -32,5 +32,47 @@ describe('tracker WebSocket telemetry authorization', () => {
         error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.',
       },
     ]);
+  });
+});
+
+describe('tracker WebSocket heartbeat messages', () => {
+  it('responds to raw client ping messages without attempting JSON parsing', async () => {
+    const sentMessages = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ws = {
+      isAlive: false,
+      send(message) {
+        sentMessages.push(message);
+      },
+    };
+
+    await handleTrackingMessage(ws, 'ping');
+
+    expect(ws.isAlive).toBe(true);
+    expect(sentMessages).toEqual(['pong']);
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('keeps returning a JSON error for malformed non-heartbeat messages', async () => {
+    const sentMessages = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ws = {
+      send(message) {
+        sentMessages.push(JSON.parse(message));
+      },
+    };
+
+    await handleTrackingMessage(ws, 'not-json');
+
+    expect(sentMessages).toEqual([
+      {
+        error: 'Invalid JSON payload structure.',
+      },
+    ]);
+    expect(errorSpy).toHaveBeenCalledWith('WS Message parsing error:', expect.any(String));
+
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- handle raw WebSocket `ping` heartbeat messages before JSON parsing
- reply with `pong` and keep the socket marked alive
- add regression coverage for heartbeat and malformed non-heartbeat messages

Fixes #359

## Tests
- `npm test -- --run test/unit/tracker.test.js`