### PR TITLE
docs(readme): add backend and docker setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,91 @@ editing `.env` away from production-style values.
 
 ---
 
+## 🧩 Backend Development Setup
+
+The backend lives in [`backend/api`](backend/api). Use the following steps to
+set it up locally:
+
+```bash
+cd backend/api
+npm install
+cp .env.example .env
+npm run dev
+```
+
+### Available Commands
+
+```bash
+npm run dev
+npm start
+npm test
+```
+
+- `npm run dev` starts the backend in development mode with auto-reload.
+- `npm start` starts the production server.
+- `npm test` runs the backend test suite.
+
+---
+
+## 🔧 Environment Configuration
+
+The backend uses [`backend/api/.env.example`](backend/api/.env.example) as the
+template for local configuration. Copy it to `.env` before running the service
+and fill in the required values for your environment.
+
+This project may require configuration for Supabase, PostgreSQL, MongoDB,
+Redis, Firebase, Polygon, and routing services. Keep sensitive values such as
+API keys, private keys, and service account JSON out of version control.
+
+Do not commit secrets to the repository. Treat `.env` as a local-only file and
+update `.env.example` when new configuration values are needed for onboarding.
+
+---
+
+## 🐳 Docker Compose Setup
+
+Run the full local stack with:
+
+```bash
+docker compose up --build
+```
+
+This starts the following services:
+
+| Service | Description |
+|---|---|
+| `api` | Backend API running from `backend/api` on port `5000` |
+| `db` | PostgreSQL/PostGIS database on port `5432` |
+| `mongo` | MongoDB event/log storage on port `27017` |
+| `redis` | Redis cache on port `6379` |
+
+The `api` container is configured to use the local `db`, `mongo`, and `redis`
+services so you can work with a complete development environment without
+connecting to external infrastructure.
+
+---
+
+## 🌐 Local Service Access
+
+Once the stack is running, you can reach the local services here:
+
+- API: `http://localhost:5000`
+- PostgreSQL: `localhost:5432`
+- MongoDB: `localhost:27017`
+- Redis: `localhost:6379`
+
+---
+
+## 🤝 Contributor Notes
+
+- Verify that `backend/api/.env` exists before starting the backend or Docker
+  Compose services.
+- Run `npm test` before opening a pull request to catch regressions early.
+- Prefer Docker Compose when you want the full local development environment
+  with API, PostgreSQL/PostGIS, MongoDB, and Redis together.
+
+---
+
 ## 📊 Impact Metrics (Projected)
 
 | Metric | With Brokers | With Truxify |


### PR DESCRIPTION
## Description

Adds backend development and Docker setup documentation to the root README to improve onboarding for new contributors.

### Changes Made

* Added Backend Development Setup instructions for `backend/api`
* Added Environment Configuration guidance using `.env.example`
* Added Docker Compose workflow documentation
* Documented local service access endpoints and ports
* Added contributor notes and setup recommendations

### Documentation Added

#### Backend Development

* Navigate to `backend/api`
* Install dependencies
* Configure `.env`
* Run development and production servers
* Execute tests

#### Docker Compose

* Build and start all services using:

```bash
docker compose up --build
```

* Documented services:

  * API
  * PostgreSQL/PostGIS
  * MongoDB
  * Redis

#### Local Access

* API: `http://localhost:5000`
* PostgreSQL: `localhost:5432`
* MongoDB: `localhost:27017`
* Redis: `localhost:6379`

### Checklist

* [x] Backend setup documented
* [x] Docker workflow documented
* [x] Environment variables explained
* [x] Local service access documented
* [x] Commands verified
* [x] README structure preserved

Closes #340
