### PR TITLE
[GSSoC'26] test: seed load offer for bid acceptance

### DIFF
--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -160,6 +160,11 @@ describe('Bid Routes', () => {
       order_display_id: 'OD1',
     });
 
+    m.store.load_offers.push({
+      id: 'load-1',
+      order_display_id: 'OD1',
+    });
+
     m.store.load_bids.push({
       id: 'bid-1',
       load_id: 'load-1',


### PR DESCRIPTION
## Description

- Updated the bid-acceptance happy-path integration fixture to include the matching `load_offers` row.
- This aligns the test with the route's current ownership validation before `accept_bid_tx` is called.

## Files Changed

- `backend/api/test/integration/bids.test.js`: seeds the load offer required by the accept-bid route.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label so the contribution is scored correctly for GSSoC '26.

If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```bash
npm --prefix backend/api run test:integration -- test/integration/bids.test.js
node --check backend/api/test/integration/bids.test.js
git diff --check
npm --prefix backend/api test
```

Result:

```txt
Bid integration suite: 30 passed
Full backend suite: 67 passed
Syntax check: passed
git diff --check: clean
```

## Known Limitations

- This PR fixes the stale backend test fixture only; it does not change production route behavior.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #377
