### PR TITLE
[GSSoC'26] fix(customer): create orders through backend API

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -31,10 +31,6 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   late final AnimationController _controller;
   late final OrderService _orderService;
 
-  String _generateOrderId() {
-    return '#ORD${DateTime.now().millisecondsSinceEpoch}';
-  }
-
   @override
   void initState() {
     super.initState();
@@ -51,11 +47,8 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   }
 
   Future<void> _pay() async {
-    final orderId = _generateOrderId();
-
     try {
-      await _orderService.createOrder(
-        orderDisplayId: orderId,
+      final orderId = await _orderService.createOrder(
         pickupAddress: widget.draft.pickup,
         dropAddress: widget.draft.drop,
         pickupLat: widget.draft.pickupLat ?? _pickupLat,
@@ -65,9 +58,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
         pickupTime: widget.draft.dateLabel,
         goodsType: widget.draft.goodsType,
         weightTonnes: double.tryParse(widget.draft.weightTonnes) ?? 0,
-        truckId: mockDefaultTruckNumber,
-        driverId: widget.truck.driver,
-        totalAmount: 7000,
+        upiId: _upiController.text.trim(),
       );
 
       _createdOrderId = orderId;

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -1,16 +1,35 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'supabase_service.dart';
 
 class OrderService {
-  OrderService({SupabaseClient? client}) : _providedClient = client;
+  OrderService({
+    SupabaseClient? client,
+    http.Client? httpClient,
+    String? apiBaseUrl,
+  })  : _providedClient = client,
+        _httpClient = httpClient ?? http.Client(),
+        _apiBaseUrl = _normalizeBaseUrl(apiBaseUrl ?? defaultApiBaseUrl);
+
+  static const String defaultApiBaseUrl = String.fromEnvironment(
+    'TRUXIFY_API_BASE_URL',
+    defaultValue: 'http://localhost:5000',
+  );
 
   final SupabaseClient? _providedClient;
+  final http.Client _httpClient;
+  final String _apiBaseUrl;
 
   SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
 
-  Future<void> createOrder({
-    required String orderDisplayId,
+  static String _normalizeBaseUrl(String value) {
+    return value.endsWith('/') ? value.substring(0, value.length - 1) : value;
+  }
+
+  Future<String> createOrder({
     required String pickupAddress,
     required String dropAddress,
     required double pickupLat,
@@ -20,29 +39,50 @@ class OrderService {
     required String pickupTime,
     required String goodsType,
     required double weightTonnes,
-    required String truckId,
-    required String driverId,
-    required double totalAmount,
+    String? paymentMethodId,
+    String? upiId,
   }) async {
-    await _client.from('orders').insert({
-      'order_display_id': orderDisplayId,
-      'customer_id': SupabaseService.requireUserId(),
-      'driver_id': driverId,
-      'truck_id': truckId,
-      'status': 'pending',
-      'pickup_address': pickupAddress,
-      'pickup_lat': pickupLat,
-      'pickup_lng': pickupLng,
-      'drop_address': dropAddress,
-      'drop_lat': dropLat,
-      'drop_lng': dropLng,
-      'pickup_date': DateTime.now().toIso8601String(),
-      'pickup_time': pickupTime,
-      'goods_type': goodsType,
-      'weight_tonnes': weightTonnes,
-      'total_amount': (totalAmount * 100).toInt(),
-      'eta': 'TBD',
-    });
+    final user = SupabaseService.currentUser;
+    final userId = SupabaseService.requireUserId();
+    final token = _client.auth.currentSession?.accessToken;
+    final fullName = user?.userMetadata?['full_name']?.toString();
+
+    final response = await _httpClient.post(
+      Uri.parse('$_apiBaseUrl/api/orders'),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+        'x-user-id': userId,
+        'x-user-role': 'customer',
+        if (fullName != null && fullName.isNotEmpty) 'x-user-name': fullName,
+      },
+      body: jsonEncode(<String, dynamic>{
+        'pickup_address': pickupAddress,
+        'pickup_lat': pickupLat,
+        'pickup_lng': pickupLng,
+        'drop_address': dropAddress,
+        'drop_lat': dropLat,
+        'drop_lng': dropLng,
+        'pickup_date': DateTime.now().toIso8601String(),
+        'pickup_time': pickupTime,
+        'goods_type': goodsType,
+        'weight_tonnes': weightTonnes,
+        'payment_method_id': paymentMethodId,
+        'upi_id': upiId,
+      }),
+    );
+
+    final body = response.body.isNotEmpty
+        ? jsonDecode(response.body) as Map<String, dynamic>
+        : <String, dynamic>{};
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+        body['error']?.toString() ?? 'Failed to create order via backend API.',
+      );
+    }
+
+    return body['order']?['order_display_id']?.toString() ?? '';
   }
 
   Future<Map<String, dynamic>?> fetchOrderById(String orderDisplayId) async {


### PR DESCRIPTION
## Description

- Reworked customer booking creation to call the backend `POST /api/orders` endpoint.
- Removed client-side persistence of `order_display_id`, `driver_id`, `truck_id`, and `total_amount` from the booking creation path so pricing, assignment, timeline, and load-offer creation stay backend-owned.

## Files Changed

- `apps/customer/lib/services/order_service.dart`: posts booking data to the backend API and returns the backend-generated order display id.
- `apps/customer/lib/screens/booking_confirmation_screen.dart`: uses the backend-generated order id and stops passing client assignment/pricing values.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label so the contribution is scored correctly for GSSoC '26.

If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```bash
rg -n "from\('orders'\)\.insert|total_amount|driver_id|truck_id|required String orderDisplayId|required String driverId|required String truckId|required double totalAmount" apps/customer/lib/services/order_service.dart apps/customer/lib/screens/booking_confirmation_screen.dart || true
git diff --check
flutter --version
dart --version
npm install && npm test  # from backend/api
```

Result:

```txt
Static direct-write check: no matches
git diff --check: clean
flutter --version: command not found
dart --version: command not found
backend npm test: failed on existing upstream #377 fixture issue in test/integration/bids.test.js (expected 404 to be 200)
```

## Known Limitations

- Flutter/Dart tests could not be run in this environment because neither `flutter` nor `dart` is installed.
- The backend suite is red on current upstream because of the stale bid-acceptance fixture tracked in #377; this PR does not include that separate test-fixture fix.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #378
