### PR TITLE
[GSSoC'26] fix(driver): validate earnings summary days

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -139,7 +139,14 @@ router.get('/wallet/history', authenticate, requireRole(['driver']), async (req,
 // 4. FETCH Aggregated daily/weekly earnings summaries for chart (DRIVER)
 // ============================================================================
 router.get('/earnings/summary', authenticate, requireRole(['driver']), async (req, res) => {
-  const limitDays = parseInt(req.query.days || '30', 10);
+  const daysParam = req.query.days ?? '30';
+  const limitDays = typeof daysParam === 'string' ? Number(daysParam) : NaN;
+
+  if (!Number.isInteger(limitDays) || limitDays < 1 || limitDays > 365) {
+    return res.status(400).json({
+      error: 'days must be an integer between 1 and 365'
+    });
+  }
 
   try {
     const cutoff = new Date();

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -166,6 +166,21 @@ describe('Driver Routes', () => {
     expect(Array.isArray(res.body)).toBe(true);
   });
 
+  it('GET /earnings/summary rejects invalid days values', async () => {
+    const app = buildApp();
+
+    for (const days of ['abc', '0', '-3', '1.5', '366']) {
+      const res = await request(app)
+        .get(`/api/drivers/earnings/summary?days=${days}`)
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(
+        'days must be an integer between 1 and 365'
+      );
+    }
+  });
+
   it('POST /wallet/withdraw rejects invalid amount', async () => {
     const app = buildApp();
 


### PR DESCRIPTION
## Summary
- Validate the driver earnings summary `days` query before constructing the cutoff date.
- Return a controlled `400` response for non-integer, negative, zero, or overly large values.
- Add integration coverage for invalid `days` values so malformed requests no longer regress to `500` responses.

## Files changed
- `backend/api/src/routes/driverRoutes.js`
- `backend/api/test/integration/driverRoutes.test.js`

## Testing performed
- `npm --prefix backend/api run test:integration -- test/integration/driverRoutes.test.js -t "GET /earnings/summary rejects invalid days values"`
- `node --check backend/api/src/routes/driverRoutes.js && node --check backend/api/test/integration/driverRoutes.test.js`
- `git diff --check`
- `npx vitest run test/integration/driverRoutes.test.js`

## Known limitations
- `npm --prefix backend/api test` still fails on the unrelated upstream #377 bid-acceptance fixture in `test/integration/bids.test.js` on this base branch.
- The npm `test:integration -- test/integration/driverRoutes.test.js` script also discovers the whole integration folder first, so it hits the same unrelated #377 baseline failure; `npx vitest run test/integration/driverRoutes.test.js` was used to verify only this route file.

## GSSoC
Please add the appropriate GSSoC'26 labels.

## AI assistance disclosure
This PR was prepared with AI assistance and manually verified through the commands listed above.

Closes #380
