### PR TITLE
fix(security): prevent IDOR in driver trip queries

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -112,9 +112,28 @@ class OrderService {
     return List<Map<String, dynamic>>.from(response);
   }
 
+  Future<void> _verifyOrderOwnership(
+    String orderDisplayId,
+    String customerId,
+  ) async {
+    final orderCheck = await _client
+        .from('orders')
+        .select('id')
+        .eq('order_display_id', orderDisplayId)
+        .eq('customer_id', customerId)
+        .maybeSingle();
+
+    if (orderCheck == null) {
+      throw Exception('Unauthorized access to order data');
+    }
+  }
+
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
     String orderDisplayId,
   ) async {
+    final customerId = SupabaseService.requireUserId();
+    await _verifyOrderOwnership(orderDisplayId, customerId);
+
     final response = await _client
         .from('order_timeline')
         .select()

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -106,10 +106,15 @@ class TripService {
     String stopId,
     String tripDisplayId,
   ) async {
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
+    await _verifyTripOwnership(tripDisplayId, driverId);
+
     await _client.from('trip_stops').update({
       'is_completed': true,
       'is_current': false,
-    }).eq('id', stopId);
+    }).eq('id', stopId).eq('trip_display_id', tripDisplayId);
 
     final nextStops = await _client
         .from('trip_stops')
@@ -122,11 +127,15 @@ class TripService {
     if (nextStops.isNotEmpty) {
       await _client
           .from('trip_stops')
-          .update({'is_current': true}).eq('id', nextStops.first['id']);
+          .update({'is_current': true})
+          .eq('id', nextStops.first['id'])
+          .eq('trip_display_id', tripDisplayId);
     } else {
       await _client
           .from('trips')
-          .update({'status': 'completed'}).eq('trip_display_id', tripDisplayId);
+          .update({'status': 'completed'})
+          .eq('trip_display_id', tripDisplayId)
+          .eq('driver_id', driverId);
     }
   }
 }

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -8,9 +8,31 @@ class TripService {
 
   SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
 
+  Future<void> _verifyTripOwnership(
+    String tripDisplayId,
+    String driverId,
+  ) async {
+    final tripCheck = await _client
+        .from('trips')
+        .select('id')
+        .eq('trip_display_id', tripDisplayId)
+        .eq('driver_id', driverId)
+        .maybeSingle();
+
+    if (tripCheck == null) {
+      throw Exception('Unauthorized access to trip data');
+    }
+  }
+
   Future<List<Map<String, dynamic>>> fetchActiveTrips() async {
-    final response =
-        await _client.from('trips').select().eq('status', 'active');
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
+    final response = await _client
+        .from('trips')
+        .select()
+        .eq('status', 'active')
+        .eq('driver_id', driverId);
 
     debugPrint('Trips response: $response');
 
@@ -20,6 +42,11 @@ class TripService {
   Future<List<Map<String, dynamic>>> fetchTripItems(
     String tripDisplayId,
   ) async {
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
+    await _verifyTripOwnership(tripDisplayId, driverId);
+
     final response = await _client
         .from('trip_items')
         .select()
@@ -31,6 +58,11 @@ class TripService {
   Future<List<Map<String, dynamic>>> fetchTripStops(
     String tripDisplayId,
   ) async {
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
+    await _verifyTripOwnership(tripDisplayId, driverId);
+
     final response = await _client
         .from('trip_stops')
         .select()
@@ -43,6 +75,11 @@ class TripService {
   Future<List<Map<String, dynamic>>> fetchRouteMapPoints(
     String tripDisplayId,
   ) async {
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
+    await _verifyTripOwnership(tripDisplayId, driverId);
+
     final response = await _client
         .from('route_map_points')
         .select()
@@ -53,9 +90,13 @@ class TripService {
   }
 
   Future<List<Map<String, dynamic>>> fetchTrips() async {
+    final driverId = _client.auth.currentUser?.id;
+    if (driverId == null) throw Exception('User not authenticated');
+
     final response = await _client
         .from('trips')
         .select()
+        .eq('driver_id', driverId)
         .order('trip_date', ascending: false);
 
     return List<Map<String, dynamic>>.from(response);


### PR DESCRIPTION
## Related Issue

Closes #357

## Summary

This PR fixes an IDOR (Insecure Direct Object Reference) vulnerability in the driver application by enforcing ownership validation on trip-related queries.

## Changes Made

### Driver App

Updated the following methods in `apps/driver/lib/services/trip_service.dart`:

* `fetchActiveTrips()`
* `fetchTrips()`
* `fetchTripItems()`
* `fetchTripStops()`
* `fetchRouteMapPoints()`

### Security Fix

* Added `driver_id` filtering to trip queries that directly access the `trips` table.
* Implemented a private `_verifyTripOwnership()` helper to validate that a requested `trip_display_id` belongs to the authenticated driver before fetching related records.
* Prevented unauthorized access to:

  * Trip history
  * Trip items
  * Trip stops
  * Route map points

## Implementation Notes

The database schema stores relationships through `trip_display_id` and does not use foreign-key constraints. Child tables (`trip_items`, `trip_stops`, and `route_map_points`) do not contain a `driver_id` column.

To enforce authorization without modifying the schema, ownership verification is performed against the parent `trips` table before retrieving child records.

## Security Impact

* Eliminates cross-driver data exposure.
* Ensures drivers can only access records associated with their own trips.
* Prevents unauthorized retrieval of delivery and route information.

## Testing

* Verified ownership filtering on trip queries.
* Verified authorized trip access continues to work.
* Verified unauthorized trip access is blocked through ownership validation.

## Checklist

* [x] Issue reproduced and analyzed
* [x] Security fix implemented
* [x] No database schema changes
* [x] No UI changes
* [x] Existing functionality preserved
