### PR TITLE
feat(api): expose FAQ and support ticket endpoints

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -12,6 +12,7 @@ import { initWebSocketServer } from './sockets/tracker.js';
 // Load REST routes
 import orderRoutes from './routes/orderRoutes.js';
 import driverRoutes from './routes/driverRoutes.js';
+import supportRoutes from './routes/supportRoutes.js';
 
 // Configuration load from root folder is handled in db.js
 
@@ -92,6 +93,7 @@ app.get('/api/health', (req, res) => {
 
 app.use('/api/orders', orderRoutes);
 app.use('/api/driver', driverRoutes);
+app.use('/api/support', supportRoutes);
 
 // Root route
 app.get('/', (req, res) => {

--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -5,7 +5,7 @@ import { authenticate } from '../middleware/auth.js';
 const router = express.Router();
 
 const FAQ_COLUMNS = 'id, question, answer, app_type, sort_order';
-const TICKET_COLUMNS = 'id, subject, category, status, created_at';
+const TICKET_COLUMNS = 'id, subject, description, category, status, created_at';
 
 function normalizeRequiredText(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -25,7 +25,7 @@ router.get('/faqs', async (req, res) => {
       .order('sort_order', { ascending: true });
 
     if (appType) {
-      query = query.eq('app_type', appType);
+      query = query.in('app_type', [appType, 'both']);
     }
 
     const { data: faqs, error } = await query;
@@ -49,6 +49,7 @@ router.get('/faqs', async (req, res) => {
 router.post('/tickets', authenticate, async (req, res) => {
   const subject = normalizeRequiredText(req.body.subject);
   const category = normalizeRequiredText(req.body.category);
+  const description = normalizeRequiredText(req.body.description) || subject;
 
   if (!subject || !category) {
     return res.status(400).json({
@@ -56,13 +57,28 @@ router.post('/tickets', authenticate, async (req, res) => {
     });
   }
 
+  // Map user-friendly/frontend categories to database-constrained values
+  const CATEGORY_MAP = {
+    billing: 'payment',
+    booking: 'order',
+    payment: 'payment',
+    order: 'order',
+    technical: 'technical',
+    general: 'general',
+    account: 'account'
+  };
+
+  const normalizedCategory = category.toLowerCase();
+  const dbCategory = CATEGORY_MAP[normalizedCategory] || 'general';
+
   try {
     const { data: ticket, error } = await supabase
       .from('support_tickets')
       .insert({
         user_id: req.user.id,
         subject,
-        category,
+        description,
+        category: dbCategory,
         status: 'open',
       })
       .select(TICKET_COLUMNS)

--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -1,0 +1,111 @@
+import express from 'express';
+import { supabase } from '../config/db.js';
+import { authenticate } from '../middleware/auth.js';
+
+const router = express.Router();
+
+const FAQ_COLUMNS = 'id, question, answer, app_type, sort_order';
+const TICKET_COLUMNS = 'id, subject, category, status, created_at';
+
+function normalizeRequiredText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+// ============================================================================
+// 1. LIST ACTIVE FAQS (PUBLIC)
+// ============================================================================
+router.get('/faqs', async (req, res) => {
+  const appType = normalizeRequiredText(req.query.app_type);
+
+  try {
+    let query = supabase
+      .from('faqs')
+      .select(FAQ_COLUMNS)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true });
+
+    if (appType) {
+      query = query.eq('app_type', appType);
+    }
+
+    const { data: faqs, error } = await query;
+
+    if (error) {
+      return res.status(500).json({
+        error: 'Failed to fetch FAQs.',
+        details: error.message,
+      });
+    }
+
+    res.json(faqs || []);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 2. CREATE SUPPORT TICKET (AUTHENTICATED USER)
+// ============================================================================
+router.post('/tickets', authenticate, async (req, res) => {
+  const subject = normalizeRequiredText(req.body.subject);
+  const category = normalizeRequiredText(req.body.category);
+
+  if (!subject || !category) {
+    return res.status(400).json({
+      error: 'subject and category are required.',
+    });
+  }
+
+  try {
+    const { data: ticket, error } = await supabase
+      .from('support_tickets')
+      .insert({
+        user_id: req.user.id,
+        subject,
+        category,
+        status: 'open',
+      })
+      .select(TICKET_COLUMNS)
+      .single();
+
+    if (error) {
+      return res.status(500).json({
+        error: 'Failed to create support ticket.',
+        details: error.message,
+      });
+    }
+
+    res.status(201).json({
+      message: 'Support ticket created successfully.',
+      ticket,
+    });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 3. LIST CURRENT USER'S SUPPORT TICKETS (AUTHENTICATED USER)
+// ============================================================================
+router.get('/tickets', authenticate, async (req, res) => {
+  try {
+    const { data: tickets, error } = await supabase
+      .from('support_tickets')
+      .select(TICKET_COLUMNS)
+      .eq('user_id', req.user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return res.status(500).json({
+        error: 'Failed to fetch support tickets.',
+        details: error.message,
+      });
+    }
+
+    res.json(tickets || []);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+export default router;

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -72,7 +72,7 @@ describe('Support Routes', () => {
     expect(faqQuery.order).toEqual({ col: 'sort_order', ascending: true });
   });
 
-  it('GET /faqs filters by app_type when provided', async () => {
+  it('GET /faqs filters by app_type and includes both-type FAQs when provided', async () => {
     m.store.faqs.push(
       {
         id: 'faq-customer',
@@ -89,14 +89,22 @@ describe('Support Routes', () => {
         app_type: 'driver',
         sort_order: 20,
         is_active: true,
+      },
+      {
+        id: 'faq-both',
+        question: 'Shared question?',
+        answer: 'Shared answer',
+        app_type: 'both',
+        sort_order: 15,
+        is_active: true,
       }
     );
 
     const res = await request(buildApp()).get('/api/support/faqs?app_type=driver');
 
     expect(res.status).toBe(200);
-    expect(res.body).toHaveLength(1);
-    expect(res.body[0].id).toBe('faq-driver');
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map(f => f.id)).toEqual(['faq-both', 'faq-driver']);
   });
 
   it('POST /tickets requires authenticated headers in auth bypass mode', async () => {
@@ -117,11 +125,15 @@ describe('Support Routes', () => {
     expect(res.body.error).toBe('subject and category are required.');
   });
 
-  it('POST /tickets creates an open ticket for the authenticated user', async () => {
+  it('POST /tickets creates an open ticket for the authenticated user with category mapping and description', async () => {
     const res = await request(buildApp())
       .post('/api/support/tickets')
       .set(CUSTOMER_HEADERS)
-      .send({ subject: '  App payment issue  ', category: ' billing ' });
+      .send({
+        subject: '  App payment issue  ',
+        category: ' billing ',
+        description: 'My custom description details'
+      });
 
     expect(res.status).toBe(201);
     expect(res.body.message).toBe('Support ticket created successfully.');
@@ -131,9 +143,21 @@ describe('Support Routes', () => {
     expect(ticketInsert.payload).toEqual({
       user_id: 'customer-1',
       subject: 'App payment issue',
-      category: 'billing',
+      description: 'My custom description details',
+      category: 'payment',
       status: 'open',
     });
+  });
+
+  it('POST /tickets defaults description to subject when omitted', async () => {
+    const res = await request(buildApp())
+      .post('/api/support/tickets')
+      .set(CUSTOMER_HEADERS)
+      .send({ subject: 'Help needed', category: 'technical' });
+
+    expect(res.status).toBe(201);
+    const ticketInsert = m.calls.find(c => c.table === 'support_tickets' && c.mode === 'insert');
+    expect(ticketInsert.payload.description).toBe('Help needed');
   });
 
   it('GET /tickets returns only tickets owned by the authenticated user', async () => {

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: m.supabase,
+  firebaseAdmin: null,
+  redisClient: null,
+  mongoDb: null,
+}));
+
+const { default: supportRouter } = await import('../../src/routes/supportRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/support', supportRouter);
+  return app;
+}
+
+const CUSTOMER_HEADERS = {
+  'x-user-id': 'customer-1',
+  'x-user-role': 'customer',
+  'x-user-name': 'Test Customer',
+};
+
+describe('Support Routes', () => {
+  beforeEach(() => {
+    m.store.faqs = [];
+    m.store.support_tickets = [];
+    m.calls.length = 0;
+  });
+
+  it('GET /faqs returns only active FAQs sorted by sort_order', async () => {
+    m.store.faqs.push(
+      {
+        id: 'faq-2',
+        question: 'Second?',
+        answer: 'Second answer',
+        app_type: 'customer',
+        sort_order: 20,
+        is_active: true,
+      },
+      {
+        id: 'faq-hidden',
+        question: 'Hidden?',
+        answer: 'Hidden answer',
+        app_type: 'customer',
+        sort_order: 5,
+        is_active: false,
+      },
+      {
+        id: 'faq-1',
+        question: 'First?',
+        answer: 'First answer',
+        app_type: 'driver',
+        sort_order: 10,
+        is_active: true,
+      }
+    );
+
+    const res = await request(buildApp()).get('/api/support/faqs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.map(faq => faq.id)).toEqual(['faq-1', 'faq-2']);
+
+    const faqQuery = m.calls.find(c => c.table === 'faqs' && c.mode === 'select');
+    expect(faqQuery.filters).toContainEqual({ col: 'is_active', op: 'eq', val: true });
+    expect(faqQuery.order).toEqual({ col: 'sort_order', ascending: true });
+  });
+
+  it('GET /faqs filters by app_type when provided', async () => {
+    m.store.faqs.push(
+      {
+        id: 'faq-customer',
+        question: 'Customer question?',
+        answer: 'Customer answer',
+        app_type: 'customer',
+        sort_order: 10,
+        is_active: true,
+      },
+      {
+        id: 'faq-driver',
+        question: 'Driver question?',
+        answer: 'Driver answer',
+        app_type: 'driver',
+        sort_order: 20,
+        is_active: true,
+      }
+    );
+
+    const res = await request(buildApp()).get('/api/support/faqs?app_type=driver');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe('faq-driver');
+  });
+
+  it('POST /tickets requires authenticated headers in auth bypass mode', async () => {
+    const res = await request(buildApp())
+      .post('/api/support/tickets')
+      .send({ subject: 'Need help', category: 'account' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /tickets validates required fields', async () => {
+    const res = await request(buildApp())
+      .post('/api/support/tickets')
+      .set(CUSTOMER_HEADERS)
+      .send({ subject: '   ', category: 'billing' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('subject and category are required.');
+  });
+
+  it('POST /tickets creates an open ticket for the authenticated user', async () => {
+    const res = await request(buildApp())
+      .post('/api/support/tickets')
+      .set(CUSTOMER_HEADERS)
+      .send({ subject: '  App payment issue  ', category: ' billing ' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Support ticket created successfully.');
+    expect(res.body.ticket.status).toBe('open');
+
+    const ticketInsert = m.calls.find(c => c.table === 'support_tickets' && c.mode === 'insert');
+    expect(ticketInsert.payload).toEqual({
+      user_id: 'customer-1',
+      subject: 'App payment issue',
+      category: 'billing',
+      status: 'open',
+    });
+  });
+
+  it('GET /tickets returns only tickets owned by the authenticated user', async () => {
+    m.store.support_tickets.push(
+      {
+        id: 'ticket-old',
+        user_id: 'customer-1',
+        subject: 'Old issue',
+        category: 'account',
+        status: 'closed',
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        id: 'ticket-other',
+        user_id: 'customer-2',
+        subject: 'Other issue',
+        category: 'billing',
+        status: 'open',
+        created_at: '2026-06-03T00:00:00.000Z',
+      },
+      {
+        id: 'ticket-new',
+        user_id: 'customer-1',
+        subject: 'New issue',
+        category: 'billing',
+        status: 'open',
+        created_at: '2026-06-02T00:00:00.000Z',
+      }
+    );
+
+    const res = await request(buildApp())
+      .get('/api/support/tickets')
+      .set(CUSTOMER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.map(ticket => ticket.id)).toEqual(['ticket-new', 'ticket-old']);
+
+    const ticketQuery = m.calls.find(c => c.table === 'support_tickets' && c.mode === 'select');
+    expect(ticketQuery.filters).toContainEqual({ col: 'user_id', op: 'eq', val: 'customer-1' });
+    expect(ticketQuery.order).toEqual({ col: 'created_at', ascending: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/support/faqs for active FAQ listing with optional app_type filtering
- add authenticated /api/support/tickets create/list endpoints scoped to the current user
- cover FAQ filtering, ticket validation, ownership scoping, and auth behavior with Vitest integration tests

Fixes #396

## Tests
- npm test -- --run test/integration/supportRoutes.test.js
- git diff --check