### PR TITLE
fix(api): validate drivers before accepting bids

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -261,7 +261,7 @@ router.post('/:id/bids', authenticate, requireRole(['driver']), async (req, res)
     // Check if the load exists and is still available
     const { data: offer, error: offerErr } = await supabase
       .from('load_offers')
-      .select('id, status')
+      .select('id, status, customer_id')
       .eq('id', loadOfferId)
       .maybeSingle();
 
@@ -271,6 +271,48 @@ router.post('/:id/bids', authenticate, requireRole(['driver']), async (req, res)
 
     if (offer.status !== 'available') {
       return res.status(410).json({ error: 'Load is no longer available for bidding.' });
+    }
+
+    if (offer.customer_id === req.user.id) {
+      return res.status(403).json({ error: 'You cannot bid on your own load offer' });
+    }
+
+    const { data: driverDetails, error: driverDetailsErr } = await supabase
+      .from('driver_details')
+      .select('truck_id')
+      .eq('user_id', req.user.id)
+      .maybeSingle();
+
+    if (driverDetailsErr) {
+      return res.status(500).json({
+        error: 'Failed to verify driver profile.',
+        details: driverDetailsErr.message
+      });
+    }
+
+    if (!driverDetails?.truck_id) {
+      return res.status(400).json({
+        error: 'You must assign a valid truck to your profile before bidding on loads'
+      });
+    }
+
+    const { data: truck, error: truckErr } = await supabase
+      .from('trucks')
+      .select('id')
+      .eq('id', driverDetails.truck_id)
+      .maybeSingle();
+
+    if (truckErr) {
+      return res.status(500).json({
+        error: 'Failed to verify assigned truck.',
+        details: truckErr.message
+      });
+    }
+
+    if (!truck) {
+      return res.status(400).json({
+        error: 'Assigned truck record could not be found'
+      });
     }
 
     const { data: existingBid, error: existingBidErr } = await supabase

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -57,6 +57,16 @@ describe('Bid Routes', () => {
     m.store.load_offers.push({
       id: 'load-1',
       status: 'available',
+      customer_id: 'customer-1',
+    });
+
+    m.store.driver_details.push({
+      user_id: 'driver-1',
+      truck_id: 'truck-1',
+    });
+
+    m.store.trucks.push({
+      id: 'truck-1',
     });
 
     const app = buildApp();
@@ -74,6 +84,73 @@ describe('Bid Routes', () => {
 
     expect(insert).toBeTruthy();
     expect(insert.payload.bid_amount).toBe(50000);
+  });
+
+  it('POST /:id/bids blocks drivers from bidding on their own load offer', async () => {
+    m.store.load_offers.push({
+      id: 'load-1',
+      status: 'available',
+      customer_id: 'driver-1',
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/load-1/bids')
+      .set(DRIVER)
+      .send({ bid_amount: 50000 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('You cannot bid on your own load offer');
+    expect(m.calls.some(c => c.table === 'load_bids' && c.mode === 'insert')).toBe(false);
+  });
+
+  it('POST /:id/bids blocks drivers without an assigned truck', async () => {
+    m.store.load_offers.push({
+      id: 'load-1',
+      status: 'available',
+      customer_id: 'customer-1',
+    });
+
+    m.store.driver_details.push({
+      user_id: 'driver-1',
+      truck_id: null,
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/load-1/bids')
+      .set(DRIVER)
+      .send({ bid_amount: 50000 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('You must assign a valid truck to your profile before bidding on loads');
+    expect(m.calls.some(c => c.table === 'load_bids' && c.mode === 'insert')).toBe(false);
+  });
+
+  it('POST /:id/bids blocks orphaned truck assignments', async () => {
+    m.store.load_offers.push({
+      id: 'load-1',
+      status: 'available',
+      customer_id: 'customer-1',
+    });
+
+    m.store.driver_details.push({
+      user_id: 'driver-1',
+      truck_id: 'missing-truck',
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/load-1/bids')
+      .set(DRIVER)
+      .send({ bid_amount: 50000 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Assigned truck record could not be found');
+    expect(m.calls.some(c => c.table === 'load_bids' && c.mode === 'insert')).toBe(false);
   });
 
   it('POST /:id/bids returns 410 when load unavailable', async () => {

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -304,6 +304,8 @@ describe('POST /api/orders/:id/bids — duplicate bid prevention', () => {
   beforeEach(() => {
     m.store.load_offers = [];
     m.store.load_bids = [];
+    m.store.driver_details = [];
+    m.store.trucks = [];
     m.calls.length = 0;
   });
 
@@ -312,6 +314,14 @@ describe('POST /api/orders/:id/bids — duplicate bid prevention', () => {
     m.store.load_offers.push({
       id: 'load-duplicate',
       status: 'available',
+      customer_id: 'customer-1',
+    });
+    m.store.driver_details.push({
+      user_id: DRIVER_HEADERS['x-user-id'],
+      truck_id: 'truck-1',
+    });
+    m.store.trucks.push({
+      id: 'truck-1',
     });
     m.store.load_bids.push({
       id: 'existing-bid',


### PR DESCRIPTION
## Summary
- block drivers from bidding on load offers they own
- require a driver profile with an assigned truck before bid creation
- verify the assigned truck record exists before inserting a bid
- expand bid integration coverage for self-bidding, missing truck, orphaned truck, and the valid bid path

Fixes #405

## Tests
- npm test -- --run test/integration/bids.test.js
- git diff --check