### PR TITLE
feat(api): clean up WebSocket and DB resources on shutdown

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -116,3 +116,34 @@ if (serviceAccountJson) {
 } else {
   console.warn('⚠️ FIREBASE_SERVICE_ACCOUNT_JSON not found in .env. Firebase Auth verification disabled.');
 }
+
+export async function closeDbConnections() {
+  if (mongoClient) {
+    try {
+      await mongoClient.close();
+      mongoClient = null;
+      mongoDb = null;
+      console.log('[shutdown] MongoDB connection closed.');
+    } catch (err) {
+      console.error('[shutdown] MongoDB close error:', err.message);
+    }
+  }
+
+  if (redisClient) {
+    try {
+      if (redisClient.status !== 'end') {
+        await redisClient.quit();
+      }
+      console.log('[shutdown] Redis connection closed.');
+    } catch (err) {
+      console.error('[shutdown] Redis quit error:', err.message);
+      try {
+        redisClient.disconnect();
+      } catch (disconnectErr) {
+        console.error('[shutdown] Redis disconnect error:', disconnectErr.message);
+      }
+    } finally {
+      redisClient = null;
+    }
+  }
+}

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -5,9 +5,8 @@ import dotenv from 'dotenv';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 
-// Pre-load DB config to execute client setups
-import './config/db.js';
-import { initWebSocketServer } from './sockets/tracker.js';
+import { closeDbConnections } from './config/db.js';
+import { closeWebSocketServer, initWebSocketServer } from './sockets/tracker.js';
 
 // Load REST routes
 import orderRoutes from './routes/orderRoutes.js';
@@ -149,11 +148,12 @@ async function shutdown(signal) {
     );
     console.log('[shutdown] HTTP server closed.');
 
-    // 2. Your WebSocket server likely exposes a .close() — call it here
-    // await closeWebSocketServer();
+    // 2. Flush buffered telemetry and close WebSocket resources
+    await closeWebSocketServer();
+    console.log('[shutdown] WebSocket resources closed.');
 
-    // 3. Close DB connections, flush queues, etc.
-    // await db.end();
+    // 3. Close database/cache connections
+    await closeDbConnections();
 
     console.log('[shutdown] Clean exit.');
     process.exit(0);

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -10,12 +10,16 @@ const trackingSubscriptions = new Map();
 let telemetryWriteBuffer = [];
 const BUFFER_FLUSH_INTERVAL_MS = 20000; 
 let isSchedulerActive = false;
+let telemetryFlushInterval = null;
+let wsServer = null;
+let wsHeartbeatInterval = null;
 
 /**
  * Initialize WebSockets Server and bind event handlers
  */
 export function initWebSocketServer(server) {
   const wss = new WebSocketServer({ noServer: true });
+  wsServer = wss;
 
   server.on('upgrade', (request, socket, head) => {
     const pathname = new URL(request.url, 'http://localhost').pathname;
@@ -105,7 +109,7 @@ export function initWebSocketServer(server) {
     });
   });
 
-  const interval = setInterval(() => {
+  wsHeartbeatInterval = setInterval(() => {
     wss.clients.forEach((ws) => {
       if (ws.isAlive === false) {
         console.log('🔌 Terminating unresponsive WebSocket client.');
@@ -117,7 +121,10 @@ export function initWebSocketServer(server) {
   }, 30000);
 
   wss.on('close', () => {
-    clearInterval(interval);
+    if (wsHeartbeatInterval) {
+      clearInterval(wsHeartbeatInterval);
+      wsHeartbeatInterval = null;
+    }
   });
 
   if (!isSchedulerActive) {
@@ -320,9 +327,52 @@ async function flushTelemetryBuffer() {
 
 function initTelemetryScheduler() {
   isSchedulerActive = true;
-  setInterval(async () => {
+  telemetryFlushInterval = setInterval(async () => {
     await flushTelemetryBuffer();
   }, BUFFER_FLUSH_INTERVAL_MS);
+}
+
+export async function closeWebSocketServer() {
+  if (telemetryFlushInterval) {
+    clearInterval(telemetryFlushInterval);
+    telemetryFlushInterval = null;
+    isSchedulerActive = false;
+  }
+
+  if (wsHeartbeatInterval) {
+    clearInterval(wsHeartbeatInterval);
+    wsHeartbeatInterval = null;
+  }
+
+  try {
+    await flushTelemetryBuffer();
+  } catch (err) {
+    console.error('[shutdown] Failed to flush telemetry buffer:', err.message);
+  }
+
+  if (!wsServer) {
+    return;
+  }
+
+  const serverToClose = wsServer;
+  wsServer = null;
+
+  await new Promise((resolve) => {
+    serverToClose.clients?.forEach((client) => {
+      try {
+        client.close(1001, 'Server shutting down');
+      } catch (err) {
+        console.error('[shutdown] Failed to close WebSocket client:', err.message);
+      }
+    });
+
+    serverToClose.close((err) => {
+      if (err) {
+        console.error('[shutdown] WebSocket server close error:', err.message);
+      }
+      resolve();
+    });
+  });
 }
 
 export async function handleSubscribe(ws, data) {
@@ -417,7 +467,24 @@ export const __testing = {
   getTelemetryWriteBuffer() {
     return telemetryWriteBuffer;
   },
+  setTelemetryWriteBuffer(records) {
+    telemetryWriteBuffer = records;
+  },
   clearTelemetryWriteBuffer() {
     telemetryWriteBuffer = [];
+  },
+  getShutdownState() {
+    return {
+      isSchedulerActive,
+      hasTelemetryFlushInterval: Boolean(telemetryFlushInterval),
+      hasWebSocketServer: Boolean(wsServer),
+      hasWsHeartbeatInterval: Boolean(wsHeartbeatInterval),
+    };
+  },
+  setShutdownState({ telemetryInterval = null, heartbeatInterval = null, server = null } = {}) {
+    telemetryFlushInterval = telemetryInterval;
+    wsHeartbeatInterval = heartbeatInterval;
+    wsServer = server;
+    isSchedulerActive = Boolean(telemetryInterval);
   },
 };

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -34,7 +34,7 @@ vi.mock('../../src/config/db.js', () => ({
   },
 }));
 
-const { handleLocationPing, handleTrackingMessage, handleSubscribe, __testing } = await import('../../src/sockets/tracker.js');
+const { closeWebSocketServer, handleLocationPing, handleTrackingMessage, handleSubscribe, __testing } = await import('../../src/sockets/tracker.js');
 
 describe('tracker WebSocket telemetry authorization', () => {
   beforeEach(() => {
@@ -170,6 +170,65 @@ describe('tracker WebSocket heartbeat messages', () => {
       },
     ]);
     expect(errorSpy).toHaveBeenCalledWith('WS Message parsing error:', expect.any(String));
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe('tracker graceful shutdown', () => {
+  afterEach(async () => {
+    __testing.setShutdownState();
+    __testing.clearTelemetryWriteBuffer();
+    await closeWebSocketServer();
+  });
+
+  it('flushes telemetry without dropping buffered records when MongoDB is unavailable', async () => {
+    const telemetryInterval = setInterval(() => {}, 1000);
+    const heartbeatInterval = setInterval(() => {}, 1000);
+    const client = { close: vi.fn() };
+    const server = {
+      clients: new Set([client]),
+      close: vi.fn((callback) => callback()),
+    };
+    const clearSpy = vi.spyOn(global, 'clearInterval');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    __testing.setTelemetryWriteBuffer([{ driver_id: 'driver-1' }]);
+    __testing.setShutdownState({
+      telemetryInterval,
+      heartbeatInterval,
+      server,
+    });
+
+    await closeWebSocketServer();
+
+    expect(clearSpy).toHaveBeenCalledWith(telemetryInterval);
+    expect(clearSpy).toHaveBeenCalledWith(heartbeatInterval);
+    expect(client.close).toHaveBeenCalledWith(1001, 'Server shutting down');
+    expect(server.close).toHaveBeenCalled();
+    expect(__testing.getTelemetryWriteBuffer()).toHaveLength(1);
+    expect(__testing.getShutdownState()).toEqual({
+      isSchedulerActive: false,
+      hasTelemetryFlushInterval: false,
+      hasWebSocketServer: false,
+      hasWsHeartbeatInterval: false,
+    });
+
+    clearSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('is safe to call when no WebSocket server has been initialized', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await closeWebSocketServer();
+
+    expect(__testing.getShutdownState()).toEqual({
+      isSchedulerActive: false,
+      hasTelemetryFlushInterval: false,
+      hasWebSocketServer: false,
+      hasWsHeartbeatInterval: false,
+    });
 
     errorSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- export closeWebSocketServer() to stop telemetry flush scheduling, flush buffered telemetry, close heartbeat monitoring, and close active WebSocket resources
- export closeDbConnections() to release MongoDB and Redis clients during app shutdown
- wire both helpers into the existing shutdown flow after HTTP server drain
- add tracker unit coverage for graceful shutdown behavior and telemetry retention when MongoDB is unavailable

Fixes #400

## Tests
- npm test -- --run test/unit/tracker.test.js
- node --check src/index.js
- node --check src/sockets/tracker.js
- node --check src/config/db.js
- git diff --check