### PR TITLE
fix(api): rate limit WebSocket upgrades

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -40,6 +40,11 @@ export async function isWebSocketUpgradeAllowed(request) {
 
     if (attempts === 1) {
       await redisClient.expire(key, WS_UPGRADE_RATE_WINDOW_SECONDS);
+    } else {
+      const ttl = await redisClient.ttl(key);
+      if (ttl === -1) {
+        await redisClient.expire(key, WS_UPGRADE_RATE_WINDOW_SECONDS);
+      }
     }
 
     return attempts <= WS_UPGRADE_RATE_LIMIT;

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -14,6 +14,50 @@ let telemetryFlushInterval = null;
 let wsServer = null;
 let wsHeartbeatInterval = null;
 
+const WS_UPGRADE_RATE_LIMIT = 5;
+const WS_UPGRADE_RATE_WINDOW_SECONDS = 60;
+
+function getClientIp(request) {
+  const forwardedFor = request.headers?.['x-forwarded-for'];
+
+  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  return request.socket?.remoteAddress || request.connection?.remoteAddress || 'unknown';
+}
+
+export async function isWebSocketUpgradeAllowed(request) {
+  if (!redisClient) {
+    return true;
+  }
+
+  const ipAddress = getClientIp(request);
+  const key = `ws:upgrade:${ipAddress}`;
+
+  try {
+    const attempts = await redisClient.incr(key);
+
+    if (attempts === 1) {
+      await redisClient.expire(key, WS_UPGRADE_RATE_WINDOW_SECONDS);
+    }
+
+    return attempts <= WS_UPGRADE_RATE_LIMIT;
+  } catch (err) {
+    console.error('Redis WebSocket upgrade rate limit error:', err.message);
+    return true;
+  }
+}
+
+export function rejectWebSocketUpgrade(socket) {
+  socket.write(
+    'HTTP/1.1 429 Too Many Requests\r\n' +
+    'Connection: close\r\n' +
+    '\r\n'
+  );
+  socket.destroy();
+}
+
 /**
  * Initialize WebSockets Server and bind event handlers
  */
@@ -21,10 +65,17 @@ export function initWebSocketServer(server) {
   const wss = new WebSocketServer({ noServer: true });
   wsServer = wss;
 
-  server.on('upgrade', (request, socket, head) => {
+  server.on('upgrade', async (request, socket, head) => {
     const pathname = new URL(request.url, 'http://localhost').pathname;
 
     if (pathname === '/ws/tracking') {
+      const allowed = await isWebSocketUpgradeAllowed(request);
+
+      if (!allowed) {
+        rejectWebSocketUpgrade(socket);
+        return;
+      }
+
       wss.handleUpgrade(request, socket, head, (ws) => {
         wss.emit('connection', ws, request);
       });

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -34,7 +34,14 @@ vi.mock('../../src/config/db.js', () => ({
   },
 }));
 
-const { closeWebSocketServer, handleLocationPing, handleTrackingMessage, handleSubscribe, __testing } = await import('../../src/sockets/tracker.js');
+const {
+  closeWebSocketServer,
+  handleLocationPing,
+  handleTrackingMessage,
+  handleSubscribe,
+  rejectWebSocketUpgrade,
+  __testing,
+} = await import('../../src/sockets/tracker.js');
 
 describe('tracker WebSocket telemetry authorization', () => {
   beforeEach(() => {
@@ -175,6 +182,7 @@ describe('tracker WebSocket heartbeat messages', () => {
   });
 });
 
+<<<<<<< HEAD
 describe('tracker graceful shutdown', () => {
   afterEach(async () => {
     __testing.setShutdownState();
@@ -231,6 +239,121 @@ describe('tracker graceful shutdown', () => {
     });
 
     errorSpy.mockRestore();
+  });
+});
+
+describe('tracker WebSocket upgrade rate limiting', () => {
+  it('allows requests within the Redis-backed per-IP limit', async () => {
+    const incr = vi.fn().mockResolvedValue(1);
+    const expire = vi.fn().mockResolvedValue(1);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { incr, expire },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const allowed = await isWebSocketUpgradeAllowed({
+      headers: { 'x-forwarded-for': '203.0.113.10, 10.0.0.2' },
+      socket: { remoteAddress: '10.0.0.2' },
+    });
+
+    expect(allowed).toBe(true);
+    expect(incr).toHaveBeenCalledWith('ws:upgrade:203.0.113.10');
+    expect(expire).toHaveBeenCalledWith('ws:upgrade:203.0.113.10', 60);
+  });
+
+  it('blocks the sixth upgrade attempt for the same IP', async () => {
+    const incr = vi.fn().mockResolvedValue(6);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { incr, expire: vi.fn() },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const allowed = await isWebSocketUpgradeAllowed({
+      headers: {},
+      socket: { remoteAddress: '198.51.100.7' },
+    });
+
+    expect(allowed).toBe(false);
+  });
+
+  it('tracks separate IP addresses independently', async () => {
+    const counts = new Map();
+    const incr = vi.fn(async (key) => {
+      const next = (counts.get(key) || 0) + 1;
+      counts.set(key, next);
+      return next;
+    });
+    const expire = vi.fn().mockResolvedValue(1);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { incr, expire },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const firstIpRequest = { headers: {}, socket: { remoteAddress: '203.0.113.20' } };
+    const secondIpRequest = { headers: {}, socket: { remoteAddress: '203.0.113.21' } };
+
+    await isWebSocketUpgradeAllowed(firstIpRequest);
+    await isWebSocketUpgradeAllowed(firstIpRequest);
+    await isWebSocketUpgradeAllowed(firstIpRequest);
+    await isWebSocketUpgradeAllowed(firstIpRequest);
+    await isWebSocketUpgradeAllowed(firstIpRequest);
+
+    expect(await isWebSocketUpgradeAllowed(firstIpRequest)).toBe(false);
+    expect(await isWebSocketUpgradeAllowed(secondIpRequest)).toBe(true);
+  });
+
+  it('allows upgrades and logs when Redis rate limiting fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: {
+        incr: vi.fn().mockRejectedValue(new Error('redis down')),
+        expire: vi.fn(),
+      },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const allowed = await isWebSocketUpgradeAllowed({
+      headers: {},
+      socket: { remoteAddress: '203.0.113.30' },
+    });
+
+    expect(allowed).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith('Redis WebSocket upgrade rate limit error:', 'redis down');
+
+    errorSpy.mockRestore();
+  });
+
+  it('rejects excessive upgrades with an HTTP 429 response', () => {
+    const socket = {
+      write: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    rejectWebSocketUpgrade(socket);
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 429 Too Many Requests'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Connection: close'));
+    expect(socket.destroy).toHaveBeenCalled();
   });
 });
 

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -182,7 +182,6 @@ describe('tracker WebSocket heartbeat messages', () => {
   });
 });
 
-<<<<<<< HEAD
 describe('tracker graceful shutdown', () => {
   afterEach(async () => {
     __testing.setShutdownState();
@@ -246,11 +245,12 @@ describe('tracker WebSocket upgrade rate limiting', () => {
   it('allows requests within the Redis-backed per-IP limit', async () => {
     const incr = vi.fn().mockResolvedValue(1);
     const expire = vi.fn().mockResolvedValue(1);
+    const ttl = vi.fn().mockResolvedValue(60);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { incr, expire },
+      redisClient: { incr, expire, ttl },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -268,11 +268,13 @@ describe('tracker WebSocket upgrade rate limiting', () => {
 
   it('blocks the sixth upgrade attempt for the same IP', async () => {
     const incr = vi.fn().mockResolvedValue(6);
+    const expire = vi.fn().mockResolvedValue(1);
+    const ttl = vi.fn().mockResolvedValue(60);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { incr, expire: vi.fn() },
+      redisClient: { incr, expire, ttl },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -284,6 +286,8 @@ describe('tracker WebSocket upgrade rate limiting', () => {
     });
 
     expect(allowed).toBe(false);
+    expect(ttl).toHaveBeenCalledWith('ws:upgrade:198.51.100.7');
+    expect(expire).not.toHaveBeenCalled();
   });
 
   it('tracks separate IP addresses independently', async () => {
@@ -294,11 +298,12 @@ describe('tracker WebSocket upgrade rate limiting', () => {
       return next;
     });
     const expire = vi.fn().mockResolvedValue(1);
+    const ttl = vi.fn().mockResolvedValue(60);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { incr, expire },
+      redisClient: { incr, expire, ttl },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -317,6 +322,30 @@ describe('tracker WebSocket upgrade rate limiting', () => {
     expect(await isWebSocketUpgradeAllowed(secondIpRequest)).toBe(true);
   });
 
+  it('sets expiration using fallback TTL check when attempts > 1 and TTL is missing (-1)', async () => {
+    const incr = vi.fn().mockResolvedValue(3);
+    const ttl = vi.fn().mockResolvedValue(-1); // no TTL exists
+    const expire = vi.fn().mockResolvedValue(1);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { incr, expire, ttl },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const allowed = await isWebSocketUpgradeAllowed({
+      headers: {},
+      socket: { remoteAddress: '198.51.100.12' },
+    });
+
+    expect(allowed).toBe(true);
+    expect(ttl).toHaveBeenCalledWith('ws:upgrade:198.51.100.12');
+    expect(expire).toHaveBeenCalledWith('ws:upgrade:198.51.100.12', 60);
+  });
+
   it('allows upgrades and logs when Redis rate limiting fails', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -326,6 +355,7 @@ describe('tracker WebSocket upgrade rate limiting', () => {
       redisClient: {
         incr: vi.fn().mockRejectedValue(new Error('redis down')),
         expire: vi.fn(),
+        ttl: vi.fn(),
       },
       firebaseAdmin: null,
       supabase: null,
@@ -484,6 +514,7 @@ describe('handleLocationPing - with Redis', () => {
     const redisSet = vi.fn().mockResolvedValue('OK');
     const redisClient = { get: redisGet, set: redisSet };
 
+    vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
       redisClient,


### PR DESCRIPTION
## Summary
- add Redis-backed per-IP rate limiting before `/ws/tracking` WebSocket handshakes
- reject the sixth upgrade attempt in a one-minute window with HTTP 429 and close the socket
- keep upgrades available if Redis is unavailable, while logging the limiter failure
- add unit coverage for allowed, blocked, independent-IP, Redis-failure, and 429 rejection behavior

Fixes #403

## Validation
- `npm test -- --run test/unit/tracker.test.js`
- `node --check src/sockets/tracker.js`
- `git diff --check`
