### PR TITLE
feat(api): add Zod request validation

### DIFF
--- a/backend/api/package-lock.json
+++ b/backend/api/package-lock.json
@@ -17,7 +17,8 @@
         "firebase-admin": "^13.10.0",
         "ioredis": "^5.11.0",
         "mongodb": "^7.2.0",
-        "ws": "^8.21.0"
+        "ws": "^8.21.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.8",
@@ -5156,6 +5157,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -22,7 +22,8 @@
     "firebase-admin": "^13.10.0",
     "ioredis": "^5.11.0",
     "mongodb": "^7.2.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.8",

--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -1,0 +1,22 @@
+function formatValidationIssues(error) {
+  return error.issues.map(issue => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : 'body',
+    message: issue.message,
+  }));
+}
+
+export function validateBody(schema) {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.body);
+
+    if (!result.success) {
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: formatValidationIssues(result.error),
+      });
+    }
+
+    req.body = result.data;
+    return next();
+  };
+}

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
+import { validateBody } from '../middleware/validate.js';
+import { driverOnlineSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -47,7 +49,7 @@ router.get('/stats', authenticate, requireRole(['driver']), async (req, res) => 
 // ============================================================================
 // 2. TOGGLE ONLINE / OFFLINE STATUS (DRIVER)
 // ============================================================================
-router.put('/online', authenticate, requireRole(['driver']), async (req, res) => {
+router.put('/online', authenticate, requireRole(['driver']), validateBody(driverOnlineSchema), async (req, res) => {
   const { is_online } = req.body;
 
   if (typeof is_online !== 'boolean') {

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
+import { validateBody } from '../middleware/validate.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 import { getRouteEstimate } from '../services/osrm.js';
+import { createOrderSchema, submitBidSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -20,7 +22,7 @@ function generateOrderDisplayId() {
 // ============================================================================
 // 1. CREATE AN ORDER (CUSTOMER)
 // ============================================================================
-router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
+router.post('/', authenticate, requireRole(['customer']), validateBody(createOrderSchema), async (req, res) => {
   const {
     pickup_address, pickup_lat, pickup_lng,
     drop_address, drop_lat, drop_lng,
@@ -31,7 +33,7 @@ router.post('/', authenticate, requireRole(['customer']), async (req, res) => {
   } = req.body;
 
   // Basic validations
-  if (!pickup_address || !pickup_lat || !pickup_lng || !drop_address || !drop_lat || !drop_lng || !goods_type || !weight_tonnes) {
+  if (!pickup_address || pickup_lat == null || pickup_lng == null || !drop_address || drop_lat == null || drop_lng == null || !goods_type || weight_tonnes == null) {
     return res.status(400).json({ error: 'Missing required routing or cargo specification fields.' });
   }
 
@@ -249,7 +251,7 @@ router.get('/:id', authenticate, async (req, res) => {
 // ============================================================================
 // 4. SUBMIT BID FOR LOAD OFFER (DRIVER)
 // ============================================================================
-router.post('/:id/bids', authenticate, requireRole(['driver']), async (req, res) => {
+router.post('/:id/bids', authenticate, requireRole(['driver']), validateBody(submitBidSchema), async (req, res) => {
   const loadOfferId = req.params.id; // load_offers.id
   const { bid_amount } = req.body; // in paisa
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+const coordinateSchema = z
+  .number()
+  .min(-180, { message: 'Must be greater than or equal to -180' })
+  .max(180, { message: 'Must be less than or equal to 180' });
+
+const isoDateStringSchema = z
+  .string()
+  .refine(value => /^\d{4}-\d{2}-\d{2}(?:T.*Z?)?$/.test(value) && !Number.isNaN(Date.parse(value)), {
+    message: 'Must be a valid ISO date string',
+  });
+
+export const createOrderSchema = z.object({
+  pickup_lat: coordinateSchema,
+  pickup_lng: coordinateSchema,
+  drop_lat: coordinateSchema,
+  drop_lng: coordinateSchema,
+  weight_tonnes: z.number().positive({ message: 'Must be greater than 0' }),
+  pickup_date: isoDateStringSchema,
+}).passthrough();
+
+export const submitBidSchema = z.object({
+  bid_amount: z
+    .number()
+    .int({ message: 'Must be a positive integer' })
+    .positive({ message: 'Must be greater than 0' }),
+}).passthrough();
+
+export const driverOnlineSchema = z.object({
+  is_online: z.boolean(),
+}).passthrough();

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -51,6 +51,35 @@ describe('Bid Routes', () => {
       .send({ bid_amount: 0 });
 
     expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'bid_amount',
+          message: 'Must be greater than 0',
+        }),
+      ])
+    );
+  });
+
+  it('POST /:id/bids rejects non-integer bid amounts', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/load-1/bids')
+      .set(DRIVER)
+      .send({ bid_amount: 100.5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'bid_amount',
+          message: 'Must be a positive integer',
+        }),
+      ])
+    );
   });
 
   it('POST /:id/bids creates bid', async () => {

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -109,6 +109,15 @@ describe('Driver Routes', () => {
       .send({ is_online: 'yes' });
 
     expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'is_online',
+          message: expect.any(String),
+        }),
+      ])
+    );
   });
 
   it('GET /wallet/history rejects invalid page', async () => {

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -183,14 +183,51 @@ describe('POST /api/orders — server-side pricing contract', () => {
     expect(orderInsert.toll_estimate).toBe(Math.round(200 * 1423.456));
   });
 
-  it('bad coordinates: NaN drop_lat → 400 with a clear pricing error', async () => {
+  it('accepts zero-valued coordinates when they are in range', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/orders')
+      .set(CUSTOMER_HEADERS)
+      .send({ ...validOrderBody, pickup_lat: 0, pickup_lng: 0 });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('bad coordinates: NaN drop_lat → 400 with structured validation details', async () => {
     const app = buildApp();
     const res = await request(app)
       .post('/api/orders')
       .set(CUSTOMER_HEADERS)
       .send({ ...validOrderBody, drop_lat: 'not-a-number' });
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'drop_lat',
+          message: expect.any(String),
+        }),
+      ])
+    );
+  });
+
+  it('invalid pickup_date format → 400 with field-level validation details', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/orders')
+      .set(CUSTOMER_HEADERS)
+      .send({ ...validOrderBody, pickup_date: 'tomorrow' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'pickup_date',
+          message: 'Must be a valid ISO date string',
+        }),
+      ])
+    );
   });
 
   it('zero weight → 400', async () => {
@@ -200,6 +237,15 @@ describe('POST /api/orders — server-side pricing contract', () => {
       .set(CUSTOMER_HEADERS)
       .send({ ...validOrderBody, weight_tonnes: 0 });
     expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'weight_tonnes',
+          message: 'Must be greater than 0',
+        }),
+      ])
+    );
   });
 
   it('regression: NO `const { base_freight } = pricing` destructure in route handler', async () => {
@@ -558,7 +604,17 @@ describe('POST /api/orders — missing required fields', () => {
       .send({ pickup_address: '123 St' }); // missing most required fields
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Missing required');
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'pickup_lat' }),
+        expect.objectContaining({ field: 'pickup_lng' }),
+        expect.objectContaining({ field: 'drop_lat' }),
+        expect.objectContaining({ field: 'drop_lng' }),
+        expect.objectContaining({ field: 'weight_tonnes' }),
+        expect.objectContaining({ field: 'pickup_date' }),
+      ])
+    );
   });
 });
 
@@ -877,4 +933,3 @@ describe('Delivery OTP Verification and Milestones', () => {
     expect(rpcCall.args).toEqual({ p_order_id: 'order-1' });
   });
 });
-

--- a/backend/api/test/unit/requestValidation.test.js
+++ b/backend/api/test/unit/requestValidation.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { validateBody } from '../../src/middleware/validate.js';
+import {
+  createOrderSchema,
+  driverOnlineSchema,
+  submitBidSchema,
+} from '../../src/validation/requestSchemas.js';
+
+function runValidation(schema, body) {
+  const req = { body };
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  };
+  const next = vi.fn();
+
+  validateBody(schema)(req, res, next);
+  return { req, res, next };
+}
+
+describe('request validation middleware', () => {
+  it('rejects invalid coordinates with field-level details', () => {
+    const { res, next } = runValidation(createOrderSchema, {
+      pickup_lat: 181,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 10,
+      pickup_date: '2026-06-10',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'pickup_lat',
+          message: 'Must be less than or equal to 180',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects invalid ISO date strings', () => {
+    const { res } = runValidation(createOrderSchema, {
+      pickup_lat: 19.076,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 10,
+      pickup_date: 'next week',
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'pickup_date',
+          message: 'Must be a valid ISO date string',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects negative bid amounts', () => {
+    const { res } = runValidation(submitBidSchema, { bid_amount: -1 });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'bid_amount',
+          message: 'Must be greater than 0',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects invalid boolean values for driver online state', () => {
+    const { res } = runValidation(driverOnlineSchema, { is_online: 'true' });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'is_online',
+          message: expect.any(String),
+        }),
+      ]),
+    });
+  });
+
+  it('passes through valid payloads without stripping unrelated route fields', () => {
+    const { req, res, next } = runValidation(createOrderSchema, {
+      pickup_lat: 19.076,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 10,
+      pickup_date: '2026-06-10',
+      pickup_address: 'Mumbai',
+      goods_type: 'electronics',
+    });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.body.pickup_address).toBe('Mumbai');
+    expect(req.body.goods_type).toBe('electronics');
+  });
+});


### PR DESCRIPTION
## Summary
- adds reusable Zod body validation middleware with structured field-level errors
- validates order creation, bid submission, and driver online-status payloads
- adds focused unit and route coverage for invalid coordinates, dates, bid amounts, and boolean status values

## Testing
- npm test -- --run test/unit/requestValidation.test.js test/integration/orders.test.js test/integration/bids.test.js test/integration/driverRoutes.test.js -t "request validation|accepts zero|bad coordinates|invalid pickup_date|zero weight|missing required|POST /:id/bids rejects|PUT /online rejects"
- npm test -- --run test/unit/requestValidation.test.js test/integration/bids.test.js test/integration/driverRoutes.test.js
- node --check src/middleware/validate.js
- node --check src/validation/requestSchemas.js
- git diff --check

Fixes #393
