### PR TITLE
Potential fix for code scanning alert no. 14: Permissive CORS configuration

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -39,6 +39,13 @@ app.use(cors({
     // Allow non-browser/same-origin requests with no Origin header
     if (!origin) return callback(null, true);
     if (allowedOrigins.includes(origin)) return callback(null, true);
+
+    // In development/testing, allow localhost or loopback origins
+    if (process.env.NODE_ENV !== 'production') {
+      const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+      if (isLocalhost) return callback(null, true);
+    }
+
     return callback(null, false);
   },
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -20,13 +20,27 @@ const app = express();
 const server = http.createServer(app);
 app.set('trust proxy', 1); // ← add this
 
-// Enable CORS for frontend clients (Flutter Web, mobile, etc.)
-const corsOrigins = process.env.NODE_ENV === 'production'
-  ? (process.env.ALLOWED_ORIGINS || '').split(',').filter(Boolean)
-  : '*';
+// Enable CORS only for explicitly allowed frontend origins
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => {
+    if (!origin) return false;
+    try {
+      const parsed = new URL(origin);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  });
 
 app.use(cors({
-  origin: corsOrigins,
+  origin: (origin, callback) => {
+    // Allow non-browser/same-origin requests with no Origin header
+    if (!origin) return callback(null, true);
+    if (allowedOrigins.includes(origin)) return callback(null, true);
+    return callback(null, false);
+  },
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'x-user-id', 'x-user-role', 'x-user-name']
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/KanishJebaMathewM/Truxify/security/code-scanning/14](https://github.com/KanishJebaMathewM/Truxify/security/code-scanning/14)

Use a deny-by-default CORS policy and validate configured origins against a strict format before allowing them.  
Best fix here: remove the `'*'` fallback entirely, parse `ALLOWED_ORIGINS` in all environments, keep only valid `http/https` origins, and pass a function to `cors.origin` that allows only configured origins (or same-origin/no-origin requests), returning `false` otherwise.

In `backend/api/src/index.js` (around lines 23–32), replace the current `corsOrigins` assignment and `app.use(cors({ ... }))` block with:
- `allowedOrigins` derived from `process.env.ALLOWED_ORIGINS` (comma-separated).
- Validation via `new URL(...)` and protocol check (`http:`/`https:`).
- CORS `origin` callback that allows only origins in `allowedOrigins`; rejects everything else.
- Keep existing methods/headers unchanged.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
