### PR TITLE
feat: implement profile service endpoints

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -12,6 +12,7 @@ import { closeWebSocketServer, initWebSocketServer } from './sockets/tracker.js'
 import orderRoutes from './routes/orderRoutes.js';
 import driverRoutes from './routes/driverRoutes.js';
 import supportRoutes from './routes/supportRoutes.js';
+import profileRoutes from './routes/profileRoutes.js';
 
 // Configuration load from root folder is handled in db.js
 
@@ -93,7 +94,7 @@ app.get('/api/health', (req, res) => {
 app.use('/api/orders', orderRoutes);
 app.use('/api/driver', driverRoutes);
 app.use('/api/support', supportRoutes);
-
+app.use('/api/profile', profileRoutes);
 // Root route
 app.get('/', (req, res) => {
   res.send('<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://localhost:5000/ws/tracking</code></p>');

--- a/backend/api/src/models/ProfileModel.js
+++ b/backend/api/src/models/ProfileModel.js
@@ -1,0 +1,42 @@
+export class ProfileModel {
+  static fromProfile(profile) {
+    return {
+      id: profile.id,
+      firebaseUid: profile.firebase_uid,
+      role: profile.role,
+      fullName: profile.full_name,
+      phone: profile.phone,
+      email: profile.email,
+      companyName: profile.company_name,
+      avatarUrl: profile.avatar_url,
+      language: profile.language,
+      darkMode: profile.dark_mode,
+      isActive: profile.is_active
+    };
+  }
+
+  static fromCustomerStats(stats) {
+    if (!stats) return null;
+
+    return {
+      totalOrders: stats.total_orders,
+      totalSaved: stats.total_saved,
+      co2ReducedKg: stats.co2_reduced_kg
+    };
+  }
+
+  static fromDriverDetails(details) {
+    if (!details) return null;
+
+    return {
+      truckId: details.truck_id,
+      rating: details.rating,
+      totalTrips: details.total_trips,
+      completionRate: details.completion_rate,
+      isOnline: details.is_online,
+      walletConfirmed: details.wallet_confirmed,
+      walletPending: details.wallet_pending,
+      walletTotal: details.wallet_total
+    };
+  }
+}

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -1,6 +1,12 @@
 import express from 'express';
 import { authenticate } from '../middleware/auth.js';
-import { supabase } from '../config/db.js';
+import {
+  getProfile,
+  getCustomerStats,
+  getDriverDetails
+} from '../services/profileService.js';
+
+import { ProfileModel } from '../models/ProfileModel.js';
 
 const router = express.Router();
 
@@ -11,13 +17,7 @@ router.get('/', authenticate, async (req, res) => {
     const role = req.user.role;
 
     // 1. base profile
-    const { data: profile, error: profileErr } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .maybeSingle();
-
-    if (profileErr) throw profileErr;
+    const profile = await getProfile(userId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
@@ -26,30 +26,19 @@ router.get('/', authenticate, async (req, res) => {
 
     // 2. role-based fetch
     if (role === 'customer') {
-      const { data } = await supabase
-        .from('customer_stats')
-        .select('*')
-        .eq('user_id', userId)
-        .maybeSingle();
-
-      extra = data;
+      const stats = await getCustomerStats(userId);
+      extra = ProfileModel.fromCustomerStats(stats);
     }
 
     if (role === 'driver') {
-      const { data } = await supabase
-        .from('driver_details')
-        .select('*')
-        .eq('user_id', userId)
-        .maybeSingle();
-
-      extra = data;
+      const details = await getDriverDetails(userId);
+      extra = ProfileModel.fromDriverDetails(details);
     }
 
     return res.json({
-      profile,
+      profile: ProfileModel.fromProfile(profile),
       extra
     });
-
   } catch (err) {
     return res.status(500).json({
       error: 'Failed to fetch profile',
@@ -62,7 +51,7 @@ router.get('/', authenticate, async (req, res) => {
 router.put('/', authenticate, async (req, res) => {
   try {
     const userId = req.user.id;
-    const { full_name, language, dark_mode } = req.body;
+    const { full_name, language, dark_mode, is_online } = req.body;
 
     const { data, error } = await supabase
       .from('profiles')
@@ -76,6 +65,18 @@ router.put('/', authenticate, async (req, res) => {
       .single();
 
     if (error) throw error;
+
+    // role-specific update (driver only)
+    if (req.user.role === 'driver' && typeof is_online !== 'undefined') {
+      const { error: driverError } = await supabase
+        .from('driver_details')
+        .update({
+          is_online
+        })
+        .eq('user_id', userId);
+
+      if (driverError) throw driverError;
+    }
 
     res.json({
       message: 'Profile updated',

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -5,6 +5,7 @@ import {
   getCustomerStats,
   getDriverDetails
 } from '../services/profileService.js';
+import { supabase } from '../config/db.js';
 
 import { ProfileModel } from '../models/ProfileModel.js';
 
@@ -52,6 +53,7 @@ router.put('/', authenticate, async (req, res) => {
   try {
     const userId = req.user.id;
     const { full_name, language, dark_mode, is_online } = req.body;
+    const role = req.user.role;
 
     const { data, error } = await supabase
       .from('profiles')
@@ -65,19 +67,16 @@ router.put('/', authenticate, async (req, res) => {
       .single();
 
     if (error) throw error;
-
-    // role-specific update (driver only)
-    if (req.user.role === 'driver' && typeof is_online !== 'undefined') {
+    if (role === 'driver' && typeof is_online === 'boolean') {
       const { error: driverError } = await supabase
-        .from('driver_details')
-        .update({
-          is_online
-        })
-        .eq('user_id', userId);
+      .from('driver_details')
+      .update({
+        is_online
+      })
+      .eq('user_id', userId);
 
       if (driverError) throw driverError;
     }
-
     res.json({
       message: 'Profile updated',
       profile: data

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -1,0 +1,93 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.js';
+import { supabase } from '../config/db.js';
+
+const router = express.Router();
+
+// GET PROFILE
+router.get('/', authenticate, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const role = req.user.role;
+
+    // 1. base profile
+    const { data: profile, error: profileErr } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (profileErr) throw profileErr;
+    if (!profile) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    let extra = null;
+
+    // 2. role-based fetch
+    if (role === 'customer') {
+      const { data } = await supabase
+        .from('customer_stats')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      extra = data;
+    }
+
+    if (role === 'driver') {
+      const { data } = await supabase
+        .from('driver_details')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      extra = data;
+    }
+
+    return res.json({
+      profile,
+      extra
+    });
+
+  } catch (err) {
+    return res.status(500).json({
+      error: 'Failed to fetch profile',
+      details: err.message
+    });
+  }
+});
+
+// UPDATE PROFILE (basic version)
+router.put('/', authenticate, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { full_name, language, dark_mode } = req.body;
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .update({
+        full_name,
+        language,
+        dark_mode
+      })
+      .eq('id', userId)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    res.json({
+      message: 'Profile updated',
+      profile: data
+    });
+
+  } catch (err) {
+    res.status(500).json({
+      error: 'Failed to update profile',
+      details: err.message
+    });
+  }
+});
+
+export default router;

--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -1,0 +1,59 @@
+import { supabase } from '../config/db.js';
+
+export async function getProfile(userId) {
+  if (!supabase) {
+    return {
+      id: userId,
+      firebase_uid: 'test',
+      role: 'customer',
+      full_name: 'Test User',
+      phone: '+919999999999'
+    };
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')   // ✅ FIXED HERE
+    .select('*')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getCustomerStats(userId) {
+  if (!supabase) return { total_orders: 0, total_saved: 0, co2_reduced_kg: 0 };
+
+  const { data, error } = await supabase
+    .from('customer_stats')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getDriverDetails(userId) {
+  if (!supabase) {
+    return {
+      truck_id: null,
+      rating: 0,
+      total_trips: 0,
+      completion_rate: 0,
+      is_online: false,
+      wallet_confirmed: 0,
+      wallet_pending: 0,
+      wallet_total: 0
+    };
+  }
+
+  const { data, error } = await supabase
+    .from('driver_details')
+    .select('*')
+    .eq('user_id', userId)   // ✅ FIXED LINE
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: m.supabase,
+  firebaseAdmin: null,
+  redisClient: null,
+  mongoDb: null,
+}));
+
+const { default: profileRouter } = await import('../../src/routes/profileRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/profile', profileRouter);
+  return app;
+}
+
+const CUSTOMER_HEADERS = {
+  'x-user-id': 'customer-uuid-123',
+  'x-user-role': 'customer',
+  'x-user-name': 'Test Customer',
+};
+
+const DRIVER_HEADERS = {
+  'x-user-id': 'driver-uuid-456',
+  'x-user-role': 'driver',
+  'x-user-name': 'Test Driver',
+};
+
+describe('Profile Routes', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.profiles = [];
+    m.store.customer_stats = [];
+    m.store.driver_details = [];
+    m.calls.length = 0;
+  });
+
+  describe('GET /api/profile', () => {
+    it('returns 404 if profile not found', async () => {
+      const res = await request(buildApp())
+        .get('/api/profile')
+        .set(CUSTOMER_HEADERS);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Profile not found');
+    });
+
+    it('returns customer profile and statistics for customer role', async () => {
+      // Seed data
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+        full_name: 'Jane Doe',
+        phone: '+919876543210',
+        email: 'jane@example.com',
+        company_name: 'Acme Corp',
+        avatar_url: 'https://r2.com/avatar.jpg',
+        language: 'en',
+        dark_mode: false,
+        is_active: true,
+      });
+
+      m.store.customer_stats.push({
+        id: 'stats-1',
+        user_id: 'customer-uuid-123',
+        total_orders: 42,
+        total_saved: 12500, // paisa
+        co2_reduced_kg: 15.6,
+      });
+
+      const res = await request(buildApp())
+        .get('/api/profile')
+        .set(CUSTOMER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.profile).toEqual({
+        id: 'customer-uuid-123',
+        firebaseUid: 'firebase-cust-uid',
+        role: 'customer',
+        fullName: 'Jane Doe',
+        phone: '+919876543210',
+        email: 'jane@example.com',
+        companyName: 'Acme Corp',
+        avatarUrl: 'https://r2.com/avatar.jpg',
+        language: 'en',
+        darkMode: false,
+        isActive: true,
+      });
+
+      expect(res.body.extra).toEqual({
+        totalOrders: 42,
+        totalSaved: 12500,
+        co2ReducedKg: 15.6,
+      });
+    });
+
+    it('returns driver profile and details for driver role', async () => {
+      // Seed data
+      m.store.profiles.push({
+        id: 'driver-uuid-456',
+        firebase_uid: 'firebase-driver-uid',
+        role: 'driver',
+        full_name: 'John Driver',
+        phone: '+919999999999',
+        email: 'john@example.com',
+        company_name: null,
+        avatar_url: 'https://r2.com/driver.jpg',
+        language: 'hi',
+        dark_mode: true,
+        is_active: true,
+      });
+
+      m.store.driver_details.push({
+        id: 'details-1',
+        user_id: 'driver-uuid-456',
+        truck_id: 'truck-123',
+        rating: 4.85,
+        total_trips: 150,
+        completion_rate: 98.5,
+        is_online: true,
+        wallet_confirmed: 50000,
+        wallet_pending: 12000,
+        wallet_total: 62000,
+      });
+
+      const res = await request(buildApp())
+        .get('/api/profile')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.profile).toEqual({
+        id: 'driver-uuid-456',
+        firebaseUid: 'firebase-driver-uid',
+        role: 'driver',
+        fullName: 'John Driver',
+        phone: '+919999999999',
+        email: 'john@example.com',
+        companyName: null,
+        avatarUrl: 'https://r2.com/driver.jpg',
+        language: 'hi',
+        darkMode: true,
+        isActive: true,
+      });
+
+      expect(res.body.extra).toEqual({
+        truckId: 'truck-123',
+        rating: 4.85,
+        totalTrips: 150,
+        completionRate: 98.5,
+        isOnline: true,
+        walletConfirmed: 50000,
+        walletPending: 12000,
+        walletTotal: 62000,
+      });
+    });
+  });
+
+  describe('PUT /api/profile', () => {
+    it('updates profiles fields for customer role', async () => {
+      // Seed profile
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+        full_name: 'Old Name',
+        phone: '+919876543210',
+        email: 'jane@example.com',
+        company_name: 'Acme Corp',
+        avatar_url: 'https://r2.com/avatar.jpg',
+        language: 'en',
+        dark_mode: false,
+        is_active: true,
+      });
+
+      // Mock update response (Supabase single() on update)
+      const updatedProfileRow = {
+        id: 'customer-uuid-123',
+        full_name: 'New Name',
+        language: 'hi',
+        dark_mode: true,
+      };
+      m.programData(updatedProfileRow);
+
+      const res = await request(buildApp())
+        .put('/api/profile')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          full_name: 'New Name',
+          language: 'hi',
+          dark_mode: true,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Profile updated');
+      expect(res.body.profile).toEqual(updatedProfileRow);
+
+      const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
+      expect(profileUpdateCall.payload).toEqual({
+        full_name: 'New Name',
+        language: 'hi',
+        dark_mode: true,
+      });
+    });
+
+    it('updates profiles fields and driver online status for driver role', async () => {
+      // Seed profile and driver details
+      m.store.profiles.push({
+        id: 'driver-uuid-456',
+        firebase_uid: 'firebase-driver-uid',
+        role: 'driver',
+        full_name: 'Old Driver Name',
+        phone: '+919999999999',
+        email: 'john@example.com',
+        company_name: null,
+        avatar_url: 'https://r2.com/driver.jpg',
+        language: 'en',
+        dark_mode: false,
+        is_active: true,
+      });
+
+      m.store.driver_details.push({
+        id: 'details-1',
+        user_id: 'driver-uuid-456',
+        truck_id: 'truck-123',
+        rating: 4.85,
+        total_trips: 150,
+        completion_rate: 98.5,
+        is_online: false,
+        wallet_confirmed: 50000,
+        wallet_pending: 12000,
+        wallet_total: 62000,
+      });
+
+      const updatedProfileRow = {
+        id: 'driver-uuid-456',
+        full_name: 'New Driver Name',
+        language: 'hi',
+        dark_mode: true,
+      };
+      m.programData(updatedProfileRow);
+
+      const res = await request(buildApp())
+        .put('/api/profile')
+        .set(DRIVER_HEADERS)
+        .send({
+          full_name: 'New Driver Name',
+          language: 'hi',
+          dark_mode: true,
+          is_online: true,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Profile updated');
+      expect(res.body.profile).toEqual(updatedProfileRow);
+
+      const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
+      expect(profileUpdateCall.payload).toEqual({
+        full_name: 'New Driver Name',
+        language: 'hi',
+        dark_mode: true,
+      });
+
+      const driverUpdateCall = m.calls.find(c => c.table === 'driver_details' && c.mode === 'update');
+      expect(driverUpdateCall.payload).toEqual({
+        is_online: true,
+      });
+      expect(driverUpdateCall.filters).toContainEqual({ col: 'user_id', op: 'eq', val: 'driver-uuid-456' });
+    });
+  });
+});


### PR DESCRIPTION

Closes #283

## Summary

Implemented authenticated profile service endpoints and profile data mapping.

### Changes Made

* Added `GET /api/profile` endpoint protected by the existing authentication middleware
* Added `PUT /api/profile` endpoint for updating profile preferences
* Added profile service layer for data retrieval
* Added `ProfileModel` DTO for snake_case → camelCase response mapping
* Added customer statistics retrieval from `customer_stats`
* Added driver details retrieval from `driver_details`
* Added role-based profile enrichment using `req.user.id` and `req.user.role`
* Registered profile routes under `/api/profile`

### Testing

* Created a local Supabase instance using the repository schema
* Verified profile retrieval from `profiles`
* Verified customer statistics retrieval from `customer_stats`
* Verified driver details retrieval from `driver_details`
* Tested profile updates through `PUT /api/profile`
* Tested authenticated access using `BYPASS_AUTH=true`

### Notes

* Authentication relies on the existing `authenticate` middleware.
* No Firebase UID is accepted through request parameters.
* Profile data is resolved from the authenticated user context (`req.user`).
