### PR TITLE
fix: separate latitude and longitude validation schemas

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-const coordinateSchema = z
+const latitudeSchema = z
+  .number()
+  .min(-90, { message: 'Must be greater than or equal to -90' })
+  .max(90, { message: 'Must be less than or equal to 90' });
+
+const longitudeSchema = z
   .number()
   .min(-180, { message: 'Must be greater than or equal to -180' })
   .max(180, { message: 'Must be less than or equal to 180' });
@@ -12,10 +17,10 @@ const isoDateStringSchema = z
   });
 
 export const createOrderSchema = z.object({
-  pickup_lat: coordinateSchema,
-  pickup_lng: coordinateSchema,
-  drop_lat: coordinateSchema,
-  drop_lng: coordinateSchema,
+  pickup_lat: latitudeSchema,
+  pickup_lng: longitudeSchema,
+  drop_lat: latitudeSchema,
+  drop_lng: longitudeSchema,
   weight_tonnes: z.number().positive({ message: 'Must be greater than 0' }),
   pickup_date: isoDateStringSchema,
 }).passthrough();

--- a/backend/api/test/unit/requestValidation.test.js
+++ b/backend/api/test/unit/requestValidation.test.js
@@ -36,7 +36,53 @@ describe('request validation middleware', () => {
       details: expect.arrayContaining([
         expect.objectContaining({
           field: 'pickup_lat',
-          message: 'Must be less than or equal to 180',
+          message: 'Must be less than or equal to 90',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects latitude values outside -90 to 90 range', () => {
+    const { res, next } = runValidation(createOrderSchema, {
+      pickup_lat: 120,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 10,
+      pickup_date: '2026-06-10',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'pickup_lat',
+          message: 'Must be less than or equal to 90',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects negative latitude values outside -90 to 90 range', () => {
+    const { res, next } = runValidation(createOrderSchema, {
+      pickup_lat: -100,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 10,
+      pickup_date: '2026-06-10',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'pickup_lat',
+          message: 'Must be greater than or equal to -90',
         }),
       ]),
     });


### PR DESCRIPTION
## Summary

- Separates latitude and longitude validation into distinct schemas
- Latitude fields now correctly reject values outside -90 to 90
- Longitude fields keep the existing -180 to 180 range

## Problem

The `coordinateSchema` was used for both latitude and longitude, allowing values from -180 to 180. This meant latitude values like `120` passed validation, creating unusable orders with impossible coordinates.

## Changes

- `backend/api/src/validation/requestSchemas.js`: Replaced `coordinateSchema` with `latitudeSchema` (-90 to 90) and `longitudeSchema` (-180 to 180)
- `backend/api/test/unit/requestValidation.test.js`: Added 2 tests for out-of-range latitude values (positive and negative)

## Files Changed

- `backend/api/src/validation/requestSchemas.js` (+10, -6)
- `backend/api/test/unit/requestValidation.test.js` (+51, -1)

## Testing Performed

- All 7 validation tests pass
- Tests verify `pickup_lat: 120` → 400 error "Must be less than or equal to 90"
- Tests verify `pickup_lat: -100` → 400 error "Must be greater than or equal to -90"

Closes #425
