### PR TITLE
fix: validate withdrawal amount as positive integer

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
-import { driverOnlineSchema } from '../validation/requestSchemas.js';
+import { driverOnlineSchema, withdrawSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -175,12 +175,8 @@ router.get('/earnings/summary', authenticate, requireRole(['driver']), async (re
 // ============================================================================
 // 5. WITHDRAW FUNDS FROM WALLET (DRIVER)
 // ============================================================================
-router.post('/wallet/withdraw', authenticate, requireRole(['driver']), async (req, res) => {
+router.post('/wallet/withdraw', authenticate, requireRole(['driver']), validateBody(withdrawSchema), async (req, res) => {
   const { amount } = req.body; // in paisa
-
-  if (!amount || amount <= 0) {
-    return res.status(400).json({ error: 'Invalid withdrawal amount specified.' });
-  }
 
   try {
     // 5.1 Fetch driver confirmed balance

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -30,3 +30,11 @@ export const submitBidSchema = z.object({
 export const driverOnlineSchema = z.object({
   is_online: z.boolean(),
 }).passthrough();
+
+export const withdrawSchema = z.object({
+  amount: z
+    .number()
+    .int({ message: 'Amount must be a whole number (paisa)' })
+    .positive({ message: 'Amount must be greater than 0' })
+    .safe({ message: 'Amount is too large' }),
+}).passthrough();

--- a/backend/api/test/unit/requestValidation.test.js
+++ b/backend/api/test/unit/requestValidation.test.js
@@ -4,6 +4,7 @@ import {
   createOrderSchema,
   driverOnlineSchema,
   submitBidSchema,
+  withdrawSchema,
 } from '../../src/validation/requestSchemas.js';
 
 function runValidation(schema, body) {
@@ -110,5 +111,77 @@ describe('request validation middleware', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(req.body.pickup_address).toBe('Mumbai');
     expect(req.body.goods_type).toBe('electronics');
+  });
+
+  it('rejects decimal withdrawal amounts', () => {
+    const { res, next } = runValidation(withdrawSchema, { amount: 1.5 });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'amount',
+          message: 'Amount must be a whole number (paisa)',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects string withdrawal amounts', () => {
+    const { res, next } = runValidation(withdrawSchema, { amount: '1000' });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'amount',
+          message: expect.stringContaining('number'),
+        }),
+      ]),
+    });
+  });
+
+  it('rejects zero withdrawal amounts', () => {
+    const { res, next } = runValidation(withdrawSchema, { amount: 0 });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'amount',
+          message: 'Amount must be greater than 0',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects negative withdrawal amounts', () => {
+    const { res, next } = runValidation(withdrawSchema, { amount: -100 });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: expect.arrayContaining([
+        expect.objectContaining({
+          field: 'amount',
+          message: 'Amount must be greater than 0',
+        }),
+      ]),
+    });
+  });
+
+  it('accepts valid integer withdrawal amounts', () => {
+    const { req, res, next } = runValidation(withdrawSchema, { amount: 1000 });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.body.amount).toBe(1000);
   });
 });


### PR DESCRIPTION
## Summary

- Adds Zod schema validation for wallet withdrawal amounts
- Rejects decimal values, strings, zero, and negative amounts
- Ensures only positive integers (paisa) reach the withdrawal RPC

## Problem

The withdrawal endpoint only checked `!amount || amount <= 0`, allowing decimal values (`1.5`) and numeric strings (`"1000"`) to pass validation due to JavaScript coercion. This could cause inconsistent wallet transaction data or RPC errors.

## Changes

- `backend/api/src/validation/requestSchemas.js`: Added `withdrawSchema` with `z.number().int().positive().safe()`
- `backend/api/src/routes/driverRoutes.js`: Applied `validateBody(withdrawSchema)` middleware to withdrawal route
- `backend/api/test/unit/requestValidation.test.js`: Added 5 tests for withdrawal validation

## Files Changed

- `backend/api/src/validation/requestSchemas.js` (+9, -0)
- `backend/api/src/routes/driverRoutes.js` (+1, -4)
- `backend/api/test/unit/requestValidation.test.js` (+74, -2)

## Testing Performed

- All 10 validation tests pass
- Tests verify: decimal → rejected, string → rejected, zero → rejected, negative → rejected, valid integer → accepted

Closes #426
