### PR TITLE
fix: correct earnings summary days filter to include only N calendar days

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -152,7 +152,7 @@ router.get('/earnings/summary', authenticate, requireRole(['driver']), async (re
 
   try {
     const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - limitDays);
+    cutoff.setDate(cutoff.getDate() - (limitDays - 1));
 
     const { data: summary, error } = await supabase
       .from('earnings_daily')

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -175,6 +175,55 @@ describe('Driver Routes', () => {
     expect(Array.isArray(res.body)).toBe(true);
   });
 
+  it('GET /earnings/summary with days=1 returns only today', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+    m.store.earnings_daily.push(
+      { driver_id: 'driver-1', day_date: yesterday, amount: 1000, trip_count: 1 },
+      { driver_id: 'driver-1', day_date: today, amount: 2000, trip_count: 2 }
+    );
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/drivers/earnings/summary?days=1')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].day_date).toBe(today);
+  });
+
+  it('GET /earnings/summary with days=7 returns at most 7 calendar dates', async () => {
+    const today = new Date();
+    const dates = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - i);
+      dates.push(d.toISOString().split('T')[0]);
+    }
+    const oldDate = new Date(today);
+    oldDate.setDate(oldDate.getDate() - 10);
+    const oldDateStr = oldDate.toISOString().split('T')[0];
+
+    m.store.earnings_daily.push(
+      { driver_id: 'driver-1', day_date: oldDateStr, amount: 500, trip_count: 1 },
+      ...dates.map((d, i) => ({ driver_id: 'driver-1', day_date: d, amount: (i + 1) * 100, trip_count: i + 1 }))
+    );
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/drivers/earnings/summary?days=7')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(7);
+    expect(res.body[0].day_date).toBe(dates[0]);
+    expect(res.body[6].day_date).toBe(dates[6]);
+  });
+
   it('GET /earnings/summary rejects invalid days values', async () => {
     const app = buildApp();
 


### PR DESCRIPTION
## Summary

- Fixes earnings summary days filter to return exactly N calendar days
- Changes cutoff calculation from `limitDays` to `limitDays - 1`
- Adds tests verifying days=1 and days=7 behavior

## Problem

The earnings summary endpoint subtracted `limitDays` from today and used an inclusive `gte` query. For `days=1`, this returned yesterday and today (2 days). For `days=7`, it returned 8 days.

## Changes

- `backend/api/src/routes/driverRoutes.js`: Changed `cutoff.setDate(cutoff.getDate() - limitDays)` to `cutoff.setDate(cutoff.getDate() - (limitDays - 1))`
- `backend/api/test/integration/driverRoutes.test.js`: Added 2 tests for days=1 and days=7

## Files Changed

- `backend/api/src/routes/driverRoutes.js` (+1, -1)
- `backend/api/test/integration/driverRoutes.test.js` (+49, -0)

## Testing Performed

- All 20 driver routes tests pass
- `days=1` returns only today's row
- `days=7` returns exactly 7 calendar dates

Closes #427
