### PR TITLE
fix(driver): remove hardcoded otp authentication bypass

### DIFF
--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -113,7 +113,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     const SizedBox(width: 12),
                     Expanded(
                       child: Text(
-                        'Mock login is enabled for the offline driver demo. OTP 1234 always works.',
+                        'OTP verification is handled by the backend. Enter the code sent to your phone to continue.',
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                               color: colorScheme.onSurface,
                             ),

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -18,7 +18,6 @@ class _OtpScreenState extends State<OtpScreen> {
   late final List<TextEditingController> _controllers =
       List.generate(4, (_) => TextEditingController());
   late final List<FocusNode> _focusNodes = List.generate(4, (_) => FocusNode());
-  bool _verifying = false;
 
   @override
   void dispose() {
@@ -92,8 +91,8 @@ class _OtpScreenState extends State<OtpScreen> {
               OtpInputRow(controllers: _controllers, focusNodes: _focusNodes),
               const SizedBox(height: 24),
               PrimaryButton(
-                label: _verifying ? 'Verifying...' : 'Verify OTP',
-                onPressed: _verifying ? null : _verifyOtp,
+                label: 'Verify OTP',
+                onPressed: _verifyOtp,
               ),
             ],
           ),

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -35,20 +35,18 @@ class _OtpScreenState extends State<OtpScreen> {
     final code = _controllers
       .map((c) => c.text.replaceAll('\u200B', ''))
       .join();
-    if (code != '1234') {
+    if (!RegExp(r'^\d{4}$').hasMatch(code)) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Enter mock OTP 1234 to continue')),
+        const SnackBar(content: Text('Enter a valid 4-digit OTP')),
       );
       return;
     }
-    setState(() => _verifying = true);
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    if (!mounted) {
-      return;
-    }
-    setState(() => _verifying = false);
-    Navigator.of(context)
-        .pushNamedAndRemoveUntil(AppRoutes.shell, (route) => false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('OTP verification is not available yet. Please try again later.'),
+      ),
+    );
+    // TODO: Integrate backend OTP verification and navigate only after a successful response.
   }
 
   @override
@@ -97,13 +95,6 @@ class _OtpScreenState extends State<OtpScreen> {
                 label: _verifying ? 'Verifying...' : 'Verify OTP',
                 onPressed: _verifying ? null : _verifyOtp,
               ),
-              const SizedBox(height: 14),
-              Text(
-                'Mock OTP: 1234',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: TruxifyColors.adaptiveSecondaryText(context),
-                    ),
-              )
             ],
           ),
         ),


### PR DESCRIPTION
## Description

Removes the hardcoded OTP authentication bypass from the Driver App.

### Changes Made

* Removed hardcoded OTP validation (`1234`)
* Removed OTP hints exposed in the UI
* Added OTP format validation for 4-digit numeric input
* Prevented authentication from succeeding without backend verification
* Added a TODO placeholder for backend OTP verification integration

### Security Impact

Previously, any user could authenticate by entering the hardcoded OTP `1234`, which was also displayed in the UI. This change removes the bypass and prevents authentication from succeeding without a future backend verification implementation.

### Verification

* No OTP-related hardcoded `1234` remains in the Driver authentication flow.
* Backend code was not modified.
* CI workflow files were not modified.

Closes #434
