### PR TITLE
feat(osrm): added  Redis caching to route estimates with graceful fallback

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -1,5 +1,8 @@
+import {redisClient} from '../config/db.js';
+
 const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
 const DEFAULT_TIMEOUT_MS = 1500;
+const CACHE_TTL_SECONDS = 86400;
 
 function parsePositiveNumber(value, fallback) {
   const parsed = Number(value);
@@ -16,12 +19,29 @@ function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
   return url;
 }
 
+function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng}){
+  const r = (n) => Number(n.toFixed(4));
+  return `osrm:route:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
+}
+
 export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng } = {}) {
   if (
     !Number.isFinite(pickupLat) || !Number.isFinite(pickupLng) ||
     !Number.isFinite(dropLat) || !Number.isFinite(dropLng)
   ) {
     return null;
+  }
+
+  const cacheKey = buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng });
+
+  if(redisClient){
+    try {
+      const cached = await redisClient.get(cacheKey);
+      if (cached) return JSON.parse(cached);
+
+    } catch(err){
+      console.error('[osrm] Redis get error:', err.message);
+    }
   }
 
   const timeoutMs = parsePositiveNumber(process.env.OSRM_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
@@ -40,10 +60,20 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
       return null;
     }
 
-    return {
+    const result = {
       distanceKm: route.distance / 1000,
       durationSeconds: Number.isFinite(route.duration) ? route.duration : null,
     };
+
+    if (redisClient){
+      try{
+        await redisClient.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS);
+      } catch(err){
+        console.error('[osrm] Redis set error:', err.message);
+      }
+    }
+    return result;
+    
   } catch {
     return null;
   } finally {
@@ -51,4 +81,4 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
   }
 }
 
-export const __testing = { buildRouteUrl, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS };
+export const __testing = { buildRouteUrl, buildCacheKey, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS };

--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -1,7 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockRedis = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  redisClient: mockRedis,
+}));
+
 import { getRouteEstimate, __testing } from '../../src/services/osrm.js';
 
-const { buildRouteUrl, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS } = __testing;
+const { buildRouteUrl, buildCacheKey, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS } = __testing;
+
 
 describe('osrm - buildRouteUrl', () => {
   it('builds correct URL with coordinates', () => {
@@ -41,13 +52,40 @@ describe('osrm - buildRouteUrl', () => {
   });
 });
 
+describe('osrm - buildCacheKey', ()=> {
+  it('rounds coordinates to 4 decimanl places', () => {
+    const key = buildCacheKey({
+      pickupLat: 12.9715987,
+      pickupLng: 77.5945627,
+      dropLat: 13.0827,
+      dropLng: 80.2707,
+    });
+    expect(key).toBe('osrm:route:12.9716:77.5946:13.0827:80.2707');
+  });
+
+  it('produces same key for coordinates that round to same values', () => {
+    const key1 = buildCacheKey({ pickupLat: 12.97161, pickupLng: 77.5, dropLat:13.0, dropLng: 80.0});
+    const key2 = buildCacheKey({ pickupLat: 12.97164, pickupLng: 77.5, dropLat:13.0, dropLng:80.0});
+    expect(key1).toBe(key2);
+  });
+
+  it('produces different keys for different coordinates', () => {
+    const key1 = buildCacheKey({ pickupLat: 12.97161, pickupLng: 77.5, dropLat:13.0, dropLng: 80.0});
+    const key2 = buildCacheKey({ pickupLat: 12.97174, pickupLng: 77.5, dropLat:13.0, dropLng:80.0});
+    expect(key1).not.toBe(key2);
+  });
+})
+
 describe('osrm - getRouteEstimate', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
+    mockRedis.get.mockResolvedValue(null);
+    mockRedis.set.mockResolvedValue('OK');
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
   it('returns null when coordinates are missing', async () => {
@@ -161,5 +199,98 @@ describe('osrm - getRouteEstimate', () => {
     expect(result).not.toBeNull();
 
     delete process.env.OSRM_TIMEOUT_MS;
+  });
+
+  it('returns cached result without calling fetch on cache hit', async () => {
+    mockRedis.get.mockResolvedValue(JSON.stringify({ distanceKm: 45, durationSeconds: 3600 }));
+
+    const result = await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(result).toEqual({ distanceKm: 45, durationSeconds: 3600 });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('queries Redis with the correct cache key', async () => {
+    mockRedis.get.mockResolvedValue(JSON.stringify({ distanceKm: 10, durationSeconds: 600 }));
+
+    await getRouteEstimate({
+      pickupLat: 12.9715987, pickupLng: 77.5945627, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(mockRedis.get).toHaveBeenCalledWith('osrm:route:12.9716:77.5946:13.0827:80.2707');
+  });
+
+  it('calls OSRM and stores result in Redis on cache miss', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ routes: [{ distance: 45000, duration: 3600 }] }),
+    });
+
+    const result = await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(result).toEqual({ distanceKm: 45, durationSeconds: 3600 });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'osrm:route:12.9716:77.5946:13.0827:80.2707',
+      JSON.stringify(result),
+      'EX',
+      86400
+    );
+  });
+
+  it('falls back to OSRM when Redis get throws', async () => {
+    mockRedis.get.mockRejectedValue(new Error('Redis connection refused'));
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ routes: [{ distance: 20000, duration: 900 }] }),
+    });
+
+    const result = await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(result).toEqual({ distanceKm: 20, durationSeconds: 900 });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('returns result even when Redis set throws after successful OSRM response', async () => {
+    mockRedis.set.mockRejectedValue(new Error('Redis write failed'));
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ routes: [{ distance: 10000, duration: 600 }] }),
+    });
+
+    const result = await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(result).toEqual({ distanceKm: 10, durationSeconds: 600 });
+  });
+
+  it('does not cache null when OSRM returns a non-ok response', async () => {
+    fetch.mockResolvedValue({ ok: false });
+
+    await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('does not cache null when OSRM returns an invalid route', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ routes: [] }),
+    });
+
+    await getRouteEstimate({
+      pickupLat: 12.9716, pickupLng: 77.5946, dropLat: 13.0827, dropLng: 80.2707,
+    });
+
+    expect(mockRedis.set).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Caches `getRouteEstimate` responses in Redis using deterministic keys (`osrm:route:{lat}:{lng}:{lat}:{lng}` rounded to 4 decimal places).
- Cache hits skip the external OSRM HTTP call entirely; cache misses store the result with a 24-hour TTL (86400).
- Redis failures (both read and write) are caught and logged; the function falls through to the normal OSRM request, so order creation is never blocked.
- All existing routing tests pass unchanged; 8 new unit tests cover cache hit, cache miss.

##Fixes
fixes: #402 

## Test plan

- [x] `npm test` in `backend/api` — all osrm unit tests pass
- [x] Set `REDIS_URL` and create an order twice for the same route — second request should skip the OSRM call (verify via logs or Redis `GET` on the key)
- [x] Take Redis offline and confirm order creation still succeeds (fallback path)
- [x] Confirm pricing and distance values are unchanged from before this PR
