### PR TITLE
fix: wire Google Maps button in trip_detail_screen

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -21,15 +21,23 @@ class TripDetailScreen extends StatefulWidget {
 
 class _TripDetailScreenState extends State<TripDetailScreen> {
   final MapController _mapController = MapController();
-  _RouteResult? _cachedRoute;
+  late Future<_RouteResult?> _routeFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _routeFuture = _loadRouteForTrip(widget.trip.route);
+  }
+
   @override
   void dispose() {
     _mapController.dispose();
     super.dispose();
   }
   Future<void> _openGoogleMapsRoute() async {
-    final start = _cachedRoute?.start;
-    final end = _cachedRoute?.end;
+    final routeResult = await _routeFuture;
+    final start = routeResult?.start;
+    final end = routeResult?.end;
 
     if (start == null || end == null) {
       if (mounted) {
@@ -391,7 +399,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                     SizedBox(
                       height: 180,
                       child: FutureBuilder<_RouteResult?>(
-                        future: _loadRouteForTrip(trip.route),
+                        future: _routeFuture,
                         builder: (context, snap) {
                           if (snap.connectionState != ConnectionState.done) {
                             return Container(
@@ -799,7 +807,6 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
       }
 
       final result = _RouteResult(start: start, end: end, routePoints: routePoints);
-      if (mounted) setState(() => _cachedRoute = result);
       return result;
     } catch (_) {
       return null;

--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart' as ll;
-
+import 'package:url_launcher/url_launcher.dart';
 import '../services/geocode_service.dart';
 import '../services/route_service.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -21,13 +21,46 @@ class TripDetailScreen extends StatefulWidget {
 
 class _TripDetailScreenState extends State<TripDetailScreen> {
   final MapController _mapController = MapController();
-
+  _RouteResult? _cachedRoute;
   @override
   void dispose() {
     _mapController.dispose();
     super.dispose();
   }
+  Future<void> _openGoogleMapsRoute() async {
+    final start = _cachedRoute?.start;
+    final end = _cachedRoute?.end;
 
+    if (start == null || end == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Route coordinates not available')),
+        );
+      }
+      return;
+    }
+
+    final url = 'https://www.google.com/maps/dir/?api=1'
+        '&origin=${start.latitude},${start.longitude}'
+        '&destination=${end.latitude},${end.longitude}'
+        '&travelmode=driving';
+
+    try {
+      final uri = Uri.parse(url);
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!launched && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to open Google Maps')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to open Google Maps')),
+        );
+      }
+    }
+  }
   void _showBlockchainBottomSheet(BuildContext context) {
     showModalBottomSheet(
       context: context,
@@ -476,13 +509,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                     Padding(
                       padding: const EdgeInsets.all(12.0),
                       child: InkWell(
-                        onTap: () {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Opening route in Google Maps...'),
-                            ),
-                          );
-                        },
+                        onTap: _openGoogleMapsRoute,
                         borderRadius: BorderRadius.circular(10),
                         child: Container(
                           width: double.infinity,
@@ -771,7 +798,9 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
         ]);
       }
 
-      return _RouteResult(start: start, end: end, routePoints: routePoints);
+      final result = _RouteResult(start: start, end: end, routePoints: routePoints);
+      if (mounted) setState(() => _cachedRoute = result);
+      return result;
     } catch (_) {
       return null;
     }

--- a/apps/driver/test/trip_detail_screen_test.dart
+++ b/apps/driver/test/trip_detail_screen_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/models/app_models.dart';
+import 'package:truxify_driver/screens/trip_detail_screen.dart';
+import 'package:truxify_driver/theme/app_theme.dart';
+
+Widget _buildTestApp(Trip trip) {
+  return MaterialApp(
+    theme: TruxifyTheme.light(),
+    home: TripDetailScreen(trip: trip),
+  );
+}
+
+void main() {
+  const testTrip = Trip(
+    route: 'Surat → Jaipur',
+    date: '12 Jun 2026',
+    items: ['Textile 3t'],
+    itemCount: '1 item · 900 km',
+    distance: '900 km',
+    earnings: '₹12,000',
+    status: TripStatusType.active,
+    tripId: 'TRIP-123',
+    hash: '0x1234567890abcdef',
+    duration: '15 hrs',
+    endTime: '12 Jun, 08:00 PM',
+    paymentBreakdown: PaymentBreakdown(
+      baseFreight: '₹15,000',
+      fuelDeducted: '₹2,000',
+      tollDeducted: '₹800',
+      platformFee: '₹200',
+      netEarnings: '₹12,000',
+    ),
+    tripItems: [
+      TripItem(
+        customerName: 'Acme Corp',
+        goods: 'Textile 3t',
+        destination: 'Jaipur',
+        earnings: '₹12,000',
+        delivered: false,
+      ),
+    ],
+  );
+
+  testWidgets('TripDetailScreen renders and does not loop infinitely', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp(testTrip));
+    
+    // We expect the widget to render the detail screen.
+    expect(find.text('Trip Details'), findsOneWidget);
+    
+    // If there is an infinite loop of rebuilds, pumpAndSettle will timeout.
+    // We set a short duration or try pumpAndSettle with a short timeout.
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+  });
+}


### PR DESCRIPTION
Closes #482 

### Problem
The button only showed a misleading snackbar and never launched Maps.

### Fix
- Added `url_launcher` import (already in pubspec.yaml)
- Added `_cachedRoute` field to cache resolved coordinates from `_loadRouteForTrip()`
- Added `_openGoogleMapsRoute()` method adapted from `home_screen.dart`
- Wired `onTap` to `_openGoogleMapsRoute`
- Errors handled gracefully; existing map preview unchanged