### PR TITLE
fix(driver): fully clear session state on logout

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../controllers/app_controller.dart';
+import '../core/app_routes.dart';
 import '../data/mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:truxify_driver/screens/login_screen.dart';
 import '../../core/supabase_config.dart';
 import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen;
 import 'notifications_screen.dart';
@@ -729,15 +729,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   await Supabase.instance.client.auth.signOut();
                 }
 
-                if (context.mounted) {
-                  Navigator.pushAndRemoveUntil(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const LoginScreen(),
-                    ),
-                    (route) => false,
-                  );
+                if (!context.mounted) {
+                  return;
                 }
+
+                // Logout lives inside the profile tab's nested navigator, so we
+                // must clear the root stack to remove the authenticated shell.
+                Navigator.of(context, rootNavigator: true)
+                    .pushNamedAndRemoveUntil(
+                  AppRoutes.login,
+                  (route) => false,
+                );
               } catch (e) {
                 if (context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/apps/driver/test/profile_logout_test.dart
+++ b/apps/driver/test/profile_logout_test.dart
@@ -54,7 +54,11 @@ void main() {
     await _pumpTransition(tester);
     expect(find.text('My Documents'), findsOneWidget);
 
-    await tester.pageBack();
+    await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+    await _pumpTransition(tester);
+
+    // Scroll down to bring Logout tile into view
+    await tester.drag(find.byType(ListView), const Offset(0, -500));
     await _pumpTransition(tester);
 
     expect(find.text('Logout'), findsOneWidget);

--- a/apps/driver/test/profile_logout_test.dart
+++ b/apps/driver/test/profile_logout_test.dart
@@ -54,8 +54,10 @@ void main() {
     await _pumpTransition(tester);
     expect(find.text('My Documents'), findsOneWidget);
 
-    await tester.tap(find.text('Profile'));
+    await tester.pageBack();
     await _pumpTransition(tester);
+
+    expect(find.text('Logout'), findsOneWidget);
 
     await tester.tap(find.text('Logout'));
     await _pumpTransition(tester);

--- a/apps/driver/test/profile_logout_test.dart
+++ b/apps/driver/test/profile_logout_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/controllers/app_controller.dart';
+import 'package:truxify_driver/core/app_routes.dart';
+import 'package:truxify_driver/screens/login_screen.dart';
+import 'package:truxify_driver/screens/shell_screen.dart';
+import 'package:truxify_driver/theme/app_theme.dart';
+
+Widget _buildTestApp() {
+  final controller = TruxifyController();
+
+  return TruxifyScope(
+    controller: controller,
+    child: MaterialApp(
+      theme: TruxifyTheme.light(),
+      initialRoute: AppRoutes.shell,
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case AppRoutes.shell:
+            return MaterialPageRoute<void>(
+              builder: (_) => const ShellScreen(),
+            );
+          case AppRoutes.login:
+            return MaterialPageRoute<void>(
+              builder: (_) => const LoginScreen(),
+            );
+          default:
+            return MaterialPageRoute<void>(
+              builder: (_) => const Scaffold(body: SizedBox.shrink()),
+            );
+        }
+      },
+    ),
+  );
+}
+
+Future<void> _pumpTransition(WidgetTester tester) async {
+  for (int i = 0; i < 15; i++) {
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+void main() {
+  testWidgets('logout clears the shell stack and returns to login', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp());
+    await _pumpTransition(tester);
+
+    await tester.tap(find.text('Profile'));
+    await _pumpTransition(tester);
+
+    await tester.tap(find.text('Documents'));
+    await _pumpTransition(tester);
+    expect(find.text('My Documents'), findsOneWidget);
+
+    await tester.tap(find.text('Profile'));
+    await _pumpTransition(tester);
+
+    await tester.tap(find.text('Logout'));
+    await _pumpTransition(tester);
+
+    expect(find.text('Welcome, Driver'), findsOneWidget);
+    expect(find.text('Logout'), findsNothing);
+    expect(find.text('My Documents'), findsNothing);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Welcome, Driver'), findsOneWidget);
+    expect(find.text('Logout'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Description

Fixes the Driver App logout flow where authenticated screens remained accessible until application restart.

### Changes Made

* Reset logout navigation using the root navigator.
* Fully clear the authenticated shell route stack.
* Redirect users to the login screen immediately after logout.
* Added a regression test covering logout behavior and back-navigation protection.

### Root Cause

Logout was being triggered from within the Profile tab's nested navigator. The previous implementation cleared only the nested navigation stack while leaving the authenticated `ShellScreen` route active underneath. As a result, protected screens could still be reached through navigation history until the app restarted.

### Verification

* Logout removes the authenticated shell from the navigation stack.
* Protected screens are no longer accessible after logout.
* Back navigation cannot return to authenticated routes.
* Added widget test for logout flow.

Closes #438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logout functionality to properly terminate the authentication session and reset the app's navigation stack, ensuring users are completely signed out.

* **Tests**
  * Added comprehensive test coverage for the logout flow to verify users are correctly returned to the login screen and authenticated data is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->