### PR TITLE
fix(customer-app): resolve Voice AI showing hardcoded response #449

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -116,7 +116,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                       ?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 8),
               Text(
-                VoiceAiService.buildResponse(_order),
+                VoiceAiService.buildResponse(VoiceAiOrderInput.fromMap(_order)),
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: TruxifyColors.adaptiveSecondaryText(context)),
@@ -708,26 +708,23 @@ class _ActionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      enabled: onTap != null,
-      child: OutlinedButton(
-        onPressed: onTap,
-        style: OutlinedButton.styleFrom(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 14),
-          minimumSize: const Size(0, 0),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(icon, color: onTap == null ? TruxifyColors.border : color),
-            const SizedBox(height: 6),
-            Text(
-              label,
-              textAlign: TextAlign.center,
-              style: onTap == null ? const TextStyle(color: TruxifyColors.border) : null,
-            ),
-          ],
-        ),
+    return OutlinedButton(
+      onPressed: onTap,
+      style: OutlinedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 14),
+        minimumSize: const Size(0, 0),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, color: onTap == null ? TruxifyColors.border : color),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: onTap == null ? const TextStyle(color: TruxifyColors.border) : null,
+          ),
+        ],
       ),
     );
   }

--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import '../services/order_service.dart';
+import '../services/voice_ai_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
@@ -115,7 +116,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                       ?.copyWith(fontWeight: FontWeight.w800)),
               const SizedBox(height: 8),
               Text(
-                'Your truck is near Vadodara, expected by 4:30 PM today',
+                VoiceAiService.buildResponse(_order),
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: TruxifyColors.adaptiveSecondaryText(context)),
@@ -664,20 +665,20 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                             _ActionTile(
                                 icon: Icons.mic_rounded,
                                 label: 'Voice AI',
-                                onTap: _showVoiceAi),
+                                onTap: _order == null ? null : _showVoiceAi),
                             _ActionTile(
                                 icon: Icons.call_rounded,
                                 label: 'Call Driver',
-                                onTap: _showCallDriver),
+                                onTap: _order == null ? null : _showCallDriver),
                             _ActionTile(
                                 icon: Icons.edit_location_alt_rounded,
                                 label: 'Change Drop',
-                                onTap: _showChangeDrop),
+                                onTap: _order == null ? null : _showChangeDrop),
                             _ActionTile(
                                 icon: Icons.close_rounded,
                                 label: 'Cancel',
                                 color: TruxifyColors.error,
-                                onTap: _showCancel),
+                                onTap: _order == null ? null : _showCancel),
                           ],
                         ),
                       ],
@@ -697,12 +698,12 @@ class _ActionTile extends StatelessWidget {
   const _ActionTile(
       {required this.icon,
       required this.label,
-      required this.onTap,
+      this.onTap,
       this.color = TruxifyColors.accentDark});
 
   final IconData icon;
   final String label;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final Color color;
 
   @override
@@ -716,7 +717,7 @@ class _ActionTile extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(icon, color: color),
+          Icon(icon, color: onTap == null ? TruxifyColors.border : color),
           const SizedBox(height: 6),
           Text(label, textAlign: TextAlign.center),
         ],

--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -708,19 +708,26 @@ class _ActionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OutlinedButton(
-      onPressed: onTap,
-      style: OutlinedButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 14),
-        minimumSize: const Size(0, 0),
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon, color: onTap == null ? TruxifyColors.border : color),
-          const SizedBox(height: 6),
-          Text(label, textAlign: TextAlign.center),
-        ],
+    return Semantics(
+      enabled: onTap != null,
+      child: OutlinedButton(
+        onPressed: onTap,
+        style: OutlinedButton.styleFrom(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 14),
+          minimumSize: const Size(0, 0),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: onTap == null ? TruxifyColors.border : color),
+            const SizedBox(height: 6),
+            Text(
+              label,
+              textAlign: TextAlign.center,
+              style: onTap == null ? const TextStyle(color: TruxifyColors.border) : null,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/customer/lib/services/voice_ai_service.dart
+++ b/apps/customer/lib/services/voice_ai_service.dart
@@ -1,0 +1,40 @@
+class VoiceAiService {
+  static String formatStatus(String status) {
+    switch (status) {
+      case 'driver_assigned':
+        return 'driver assigned';
+      case 'in_transit':
+        return 'in transit';
+      case 'payment_released':
+        return 'payment released';
+      case 'completed':
+      case 'delivered':
+        return 'delivered';
+      case 'cancelled':
+        return 'cancelled';
+      case 'pending':
+        return 'pending';
+      default:
+        return status.replaceAll('_', ' ');
+    }
+  }
+
+  static String buildResponse(Map<String, dynamic>? order) {
+    if (order == null) {
+      return 'Loading your shipment details…';
+    }
+
+    final eta = order['eta']?.toString();
+    final rawStatus = order['status']?.toString() ?? 'in_transit';
+    final status = formatStatus(rawStatus);
+    final dropAddress = order['drop_address']?.toString() ?? 'your destination';
+
+    if (eta != null && eta.isNotEmpty) {
+      return 'Your shipment is currently $status and expected to reach '
+             '$dropAddress by $eta.';
+    }
+
+    return 'Your shipment is currently $status. '
+           'ETA information is not yet available.';
+  }
+}

--- a/apps/customer/lib/services/voice_ai_service.dart
+++ b/apps/customer/lib/services/voice_ai_service.dart
@@ -1,5 +1,30 @@
+class VoiceAiOrderInput {
+  final String? status;
+  final String? eta;
+  final String? dropAddress;
+
+  const VoiceAiOrderInput({
+    this.status,
+    this.eta,
+    this.dropAddress,
+  });
+
+  static VoiceAiOrderInput? fromMap(Map<String, dynamic>? map) {
+    if (map == null) return null;
+    return VoiceAiOrderInput(
+      status: map['status']?.toString(),
+      eta: map['eta']?.toString(),
+      dropAddress: map['drop_address']?.toString(),
+    );
+  }
+}
+
 class VoiceAiService {
-  static String formatStatus(String status) {
+  static String formatStatus(String? rawStatus) {
+    final status = rawStatus?.trim().toLowerCase() ?? '';
+    if (status.isEmpty) {
+      return 'pending';
+    }
     switch (status) {
       case 'driver_assigned':
         return 'driver assigned';
@@ -19,18 +44,18 @@ class VoiceAiService {
     }
   }
 
-  static String buildResponse(Map<String, dynamic>? order) {
+  static String buildResponse(VoiceAiOrderInput? order) {
     if (order == null) {
       return 'Loading your shipment details…';
     }
 
-    final rawEta = order['eta']?.toString().trim();
+    final rawEta = order.eta?.trim();
     final eta = (rawEta != null && rawEta.isNotEmpty) ? rawEta : null;
 
-    final rawStatus = order['status']?.toString().trim() ?? '';
+    final rawStatus = order.status?.trim() ?? '';
     final status = formatStatus(rawStatus.isNotEmpty ? rawStatus : 'pending');
 
-    final rawDropAddress = order['drop_address']?.toString().trim();
+    final rawDropAddress = order.dropAddress?.trim();
     final dropAddress = (rawDropAddress != null && rawDropAddress.isNotEmpty)
         ? rawDropAddress
         : 'your destination';

--- a/apps/customer/lib/services/voice_ai_service.dart
+++ b/apps/customer/lib/services/voice_ai_service.dart
@@ -24,12 +24,18 @@ class VoiceAiService {
       return 'Loading your shipment details…';
     }
 
-    final eta = order['eta']?.toString();
-    final rawStatus = order['status']?.toString() ?? 'in_transit';
-    final status = formatStatus(rawStatus);
-    final dropAddress = order['drop_address']?.toString() ?? 'your destination';
+    final rawEta = order['eta']?.toString().trim();
+    final eta = (rawEta != null && rawEta.isNotEmpty) ? rawEta : null;
 
-    if (eta != null && eta.isNotEmpty) {
+    final rawStatus = order['status']?.toString().trim() ?? '';
+    final status = formatStatus(rawStatus.isNotEmpty ? rawStatus : 'pending');
+
+    final rawDropAddress = order['drop_address']?.toString().trim();
+    final dropAddress = (rawDropAddress != null && rawDropAddress.isNotEmpty)
+        ? rawDropAddress
+        : 'your destination';
+
+    if (eta != null) {
       return 'Your shipment is currently $status and expected to reach '
              '$dropAddress by $eta.';
     }

--- a/apps/customer/test/voice_ai_service_test.dart
+++ b/apps/customer/test/voice_ai_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify/services/voice_ai_service.dart';
+
+void main() {
+  group('VoiceAiService Tests', () {
+    test('buildResponse with null order returns loading message', () {
+      final response = VoiceAiService.buildResponse(null);
+      expect(response, equals('Loading your shipment details…'));
+    });
+
+    test('buildResponse with complete order data maps correctly', () {
+      final order = {
+        'status': 'in_transit',
+        'drop_address': 'Vadodara',
+        'eta': 'Today 4:30 PM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently in transit and expected to reach Vadodara by Today 4:30 PM.'),
+      );
+    });
+
+    test('buildResponse with missing ETA uses fallback message', () {
+      final order = {
+        'status': 'pending',
+        'drop_address': 'Vadodara',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently pending. ETA information is not yet available.'),
+      );
+    });
+
+    test('buildResponse with driver_assigned status formats status correctly', () {
+      final order = {
+        'status': 'driver_assigned',
+        'drop_address': 'Mumbai',
+        'eta': 'Today 5:00 PM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently driver assigned and expected to reach Mumbai by Today 5:00 PM.'),
+      );
+    });
+
+    test('buildResponse fallback for unknown status formatted properly', () {
+      final order = {
+        'status': 'custom_status_value',
+        'drop_address': 'Jaipur',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently custom status value. ETA information is not yet available.'),
+      );
+    });
+  });
+}

--- a/apps/customer/test/voice_ai_service_test.dart
+++ b/apps/customer/test/voice_ai_service_test.dart
@@ -2,18 +2,64 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:truxify/services/voice_ai_service.dart';
 
 void main() {
-  group('VoiceAiService Tests', () {
-    test('buildResponse with null order returns loading message', () {
+  group('VoiceAiOrderInput Tests', () {
+    test('fromMap with null input returns null', () {
+      expect(VoiceAiOrderInput.fromMap(null), isNull);
+    });
+
+    test('fromMap with valid map constructs DTO correctly', () {
+      final map = <String, dynamic>{
+        'status': 'in_transit',
+        'eta': 'Today 4:30 PM',
+        'drop_address': 'Vadodara',
+      };
+      final input = VoiceAiOrderInput.fromMap(map);
+      expect(input, isNotNull);
+      expect(input!.status, equals('in_transit'));
+      expect(input.eta, equals('Today 4:30 PM'));
+      expect(input.dropAddress, equals('Vadodara'));
+    });
+  });
+
+  group('VoiceAiService.formatStatus Tests', () {
+    test('formats standard database statuses correctly', () {
+      expect(VoiceAiService.formatStatus('driver_assigned'), equals('driver assigned'));
+      expect(VoiceAiService.formatStatus('in_transit'), equals('in transit'));
+      expect(VoiceAiService.formatStatus('payment_released'), equals('payment released'));
+      expect(VoiceAiService.formatStatus('completed'), equals('delivered'));
+      expect(VoiceAiService.formatStatus('delivered'), equals('delivered'));
+      expect(VoiceAiService.formatStatus('cancelled'), equals('cancelled'));
+      expect(VoiceAiService.formatStatus('pending'), equals('pending'));
+    });
+
+    test('normalizes casing and trims whitespace', () {
+      expect(VoiceAiService.formatStatus('  IN_TRANSIT  '), equals('in transit'));
+      expect(VoiceAiService.formatStatus('  Driver_Assigned  '), equals('driver assigned'));
+    });
+
+    test('defaults to pending on null, empty, or whitespace-only inputs', () {
+      expect(VoiceAiService.formatStatus(null), equals('pending'));
+      expect(VoiceAiService.formatStatus(''), equals('pending'));
+      expect(VoiceAiService.formatStatus('   '), equals('pending'));
+    });
+
+    test('replaces underscores for unknown custom statuses', () {
+      expect(VoiceAiService.formatStatus('custom_state_here'), equals('custom state here'));
+    });
+  });
+
+  group('VoiceAiService.buildResponse Tests', () {
+    test('buildResponse with null DTO returns loading message', () {
       final response = VoiceAiService.buildResponse(null);
       expect(response, equals('Loading your shipment details…'));
     });
 
-    test('buildResponse with complete order data maps correctly', () {
-      final order = <String, dynamic>{
-        'status': 'in_transit',
-        'drop_address': 'Vadodara',
-        'eta': 'Today 4:30 PM',
-      };
+    test('buildResponse with complete DTO maps correctly', () {
+      const order = VoiceAiOrderInput(
+        status: 'in_transit',
+        dropAddress: 'Vadodara',
+        eta: 'Today 4:30 PM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -22,10 +68,10 @@ void main() {
     });
 
     test('buildResponse with missing ETA uses fallback message', () {
-      final order = <String, dynamic>{
-        'status': 'pending',
-        'drop_address': 'Vadodara',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'pending',
+        dropAddress: 'Vadodara',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -34,11 +80,11 @@ void main() {
     });
 
     test('buildResponse with driver_assigned status formats status correctly', () {
-      final order = <String, dynamic>{
-        'status': 'driver_assigned',
-        'drop_address': 'Mumbai',
-        'eta': 'Today 5:00 PM',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'driver_assigned',
+        dropAddress: 'Mumbai',
+        eta: 'Today 5:00 PM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -47,10 +93,10 @@ void main() {
     });
 
     test('buildResponse fallback for unknown status formatted properly', () {
-      final order = <String, dynamic>{
-        'status': 'custom_status_value',
-        'drop_address': 'Jaipur',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'custom_status_value',
+        dropAddress: 'Jaipur',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -59,10 +105,10 @@ void main() {
     });
 
     test('buildResponse handles missing status (defaults to pending)', () {
-      final order = <String, dynamic>{
-        'drop_address': 'Delhi',
-        'eta': 'Tomorrow 10:00 AM',
-      };
+      const order = VoiceAiOrderInput(
+        dropAddress: 'Delhi',
+        eta: 'Tomorrow 10:00 AM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -71,11 +117,11 @@ void main() {
     });
 
     test('buildResponse handles blank/whitespace status (defaults to pending)', () {
-      final order = <String, dynamic>{
-        'status': '   ',
-        'drop_address': 'Delhi',
-        'eta': 'Tomorrow 10:00 AM',
-      };
+      const order = VoiceAiOrderInput(
+        status: '   ',
+        dropAddress: 'Delhi',
+        eta: 'Tomorrow 10:00 AM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -84,10 +130,10 @@ void main() {
     });
 
     test('buildResponse handles missing drop address (defaults to your destination)', () {
-      final order = <String, dynamic>{
-        'status': 'in_transit',
-        'eta': 'Today 8:00 PM',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'in_transit',
+        eta: 'Today 8:00 PM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -96,11 +142,11 @@ void main() {
     });
 
     test('buildResponse handles blank/whitespace drop address (defaults to your destination)', () {
-      final order = <String, dynamic>{
-        'status': 'in_transit',
-        'drop_address': '   ',
-        'eta': 'Today 8:00 PM',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'in_transit',
+        dropAddress: '   ',
+        eta: 'Today 8:00 PM',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,
@@ -109,11 +155,11 @@ void main() {
     });
 
     test('buildResponse treats blank/whitespace ETA as missing', () {
-      final order = <String, dynamic>{
-        'status': 'in_transit',
-        'drop_address': 'Chennai',
-        'eta': '   ',
-      };
+      const order = VoiceAiOrderInput(
+        status: 'in_transit',
+        dropAddress: 'Chennai',
+        eta: '   ',
+      );
       final response = VoiceAiService.buildResponse(order);
       expect(
         response,

--- a/apps/customer/test/voice_ai_service_test.dart
+++ b/apps/customer/test/voice_ai_service_test.dart
@@ -9,7 +9,7 @@ void main() {
     });
 
     test('buildResponse with complete order data maps correctly', () {
-      final order = {
+      final order = <String, dynamic>{
         'status': 'in_transit',
         'drop_address': 'Vadodara',
         'eta': 'Today 4:30 PM',
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('buildResponse with missing ETA uses fallback message', () {
-      final order = {
+      final order = <String, dynamic>{
         'status': 'pending',
         'drop_address': 'Vadodara',
       };
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('buildResponse with driver_assigned status formats status correctly', () {
-      final order = {
+      final order = <String, dynamic>{
         'status': 'driver_assigned',
         'drop_address': 'Mumbai',
         'eta': 'Today 5:00 PM',
@@ -47,7 +47,7 @@ void main() {
     });
 
     test('buildResponse fallback for unknown status formatted properly', () {
-      final order = {
+      final order = <String, dynamic>{
         'status': 'custom_status_value',
         'drop_address': 'Jaipur',
       };
@@ -55,6 +55,69 @@ void main() {
       expect(
         response,
         equals('Your shipment is currently custom status value. ETA information is not yet available.'),
+      );
+    });
+
+    test('buildResponse handles missing status (defaults to pending)', () {
+      final order = <String, dynamic>{
+        'drop_address': 'Delhi',
+        'eta': 'Tomorrow 10:00 AM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently pending and expected to reach Delhi by Tomorrow 10:00 AM.'),
+      );
+    });
+
+    test('buildResponse handles blank/whitespace status (defaults to pending)', () {
+      final order = <String, dynamic>{
+        'status': '   ',
+        'drop_address': 'Delhi',
+        'eta': 'Tomorrow 10:00 AM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently pending and expected to reach Delhi by Tomorrow 10:00 AM.'),
+      );
+    });
+
+    test('buildResponse handles missing drop address (defaults to your destination)', () {
+      final order = <String, dynamic>{
+        'status': 'in_transit',
+        'eta': 'Today 8:00 PM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently in transit and expected to reach your destination by Today 8:00 PM.'),
+      );
+    });
+
+    test('buildResponse handles blank/whitespace drop address (defaults to your destination)', () {
+      final order = <String, dynamic>{
+        'status': 'in_transit',
+        'drop_address': '   ',
+        'eta': 'Today 8:00 PM',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently in transit and expected to reach your destination by Today 8:00 PM.'),
+      );
+    });
+
+    test('buildResponse treats blank/whitespace ETA as missing', () {
+      final order = <String, dynamic>{
+        'status': 'in_transit',
+        'drop_address': 'Chennai',
+        'eta': '   ',
+      };
+      final response = VoiceAiService.buildResponse(order);
+      expect(
+        response,
+        equals('Your shipment is currently in transit. ETA information is not yet available.'),
       );
     });
   });


### PR DESCRIPTION
Closes #449 


## Description
Replaced the hardcoded Voice AI response text in the customer app with dynamic, shipment-specific status and ETA updates.

## Proposed Changes

### ⚙️ Service Layer
- **[NEW] `voice_ai_service.dart`**:
  - Created `VoiceAiService` to build dynamic voice feedback based on the order's status, ETA, and destination.
  - Added status mapping utility to convert database statuses (e.g. `in_transit`, `driver_assigned`) into user-friendly lowercase strings (e.g. `in transit`, `driver assigned`).

### 📦 UI Layer
- **[MODIFY] `live_tracking_screen.dart`**:
  - Integrated `VoiceAiService.buildResponse(_order)` into the Voice AI bottom sheet.
  - Updated the action grid (`Voice AI`, `Call Driver`, `Change Drop`, `Cancel`) to disable interactions when `_order` is still loading/null.
  - Added visual styling to `_ActionTile` to dim the icon using `TruxifyColors.border` when disabled.

### 🧪 Tests
- **[NEW] `voice_ai_service_test.dart`**:
  - Added unit tests covering multiple scenarios: null/loading data, complete order tracking data, missing ETA fallback, status formatting, and fallback case for unknown statuses.

## Verification
- verified code changes via `git diff`.
- Ensured all actions are visually disabled and safe against null pointers when the order data hasn't finished loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice AI integrated into live tracking to generate dynamic, human‑readable shipment status and ETA messages.
  * Added a Voice AI input model and response builder to produce context-aware messages.

* **Bug Fixes / UX**
  * Action tiles (Voice AI, Call Driver, Change Drop, Cancel) auto-disable when no active order and show a clear disabled visual state.

* **Tests**
  * Added comprehensive unit tests covering Voice AI input parsing, status formatting, and response outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->