### PR TITLE
fix(db): add processed_batches schema for offline sync idempotency

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -73,6 +73,7 @@ router.post('/events/batch', authenticate, validateBatchPayload(batchSyncSchema)
       .from('processed_batches')
       .select('id')
       .eq('idempotency_key', idempotencyKey)
+      .eq('user_id', userId)
       .maybeSingle();
 
     if (existingBatch) {

--- a/backend/api/test/unit/verifyDbSchema.test.js
+++ b/backend/api/test/unit/verifyDbSchema.test.js
@@ -83,4 +83,21 @@ describe('Database Schema Constraints and RPC Upsert validation in supabase_setu
     // There should be at least two such insert statements matching the upsert behavior across the RPC overloads
     expect(insertMatches.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('contains the processed_batches table required for offline sync idempotency', async () => {
+    const setupSqlPath = path.resolve(
+      __dirname,
+      '../../../../docs/supabase_setup.sql'
+    );
+
+    const sqlContent = await fs.readFile(setupSqlPath, 'utf8');
+
+    expect(
+      /create\s+table\s+if\s+not\s+exists\s+processed_batches/i.test(sqlContent)
+    ).toBe(true);
+
+    expect(
+      /idempotency_key\s+text\s+not\s+null\s+unique/i.test(sqlContent)
+    ).toBe(true);
+  });
 });

--- a/backend/api/test/unit/verifyDbSchema.test.js
+++ b/backend/api/test/unit/verifyDbSchema.test.js
@@ -84,20 +84,58 @@ describe('Database Schema Constraints and RPC Upsert validation in supabase_setu
     expect(insertMatches.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('contains the processed_batches table required for offline sync idempotency', async () => {
-    const setupSqlPath = path.resolve(
-      __dirname,
-      '../../../../docs/supabase_setup.sql'
-    );
+  it('contains the processed_batches table required for offline sync idempotency in both setup and migration SQL', async () => {
+    const setupSqlPath = path.resolve(__dirname, '../../../../docs/supabase_setup.sql');
+    const migrationSqlPath = path.resolve(__dirname, '../../../../docs/migration_add_processed_batches.sql');
 
-    const sqlContent = await fs.readFile(setupSqlPath, 'utf8');
+    const setupSql = await fs.readFile(setupSqlPath, 'utf8');
+    const migrationSql = await fs.readFile(migrationSqlPath, 'utf8');
 
-    expect(
-      /create\s+table\s+if\s+not\s+exists\s+processed_batches/i.test(sqlContent)
-    ).toBe(true);
+    for (const [name, sqlContent] of [['supabase_setup.sql', setupSql], ['migration_add_processed_batches.sql', migrationSql]]) {
+      // 1. Table creation check
+      expect(
+        /create\s+table\s+if\s+not\s+exists\s+processed_batches/i.test(sqlContent),
+        `Table creation not found in ${name}`
+      ).toBe(true);
 
-    expect(
-      /idempotency_key\s+text\s+not\s+null\s+unique/i.test(sqlContent)
-    ).toBe(true);
+      // 2. User-scoped composite unique constraint (user_id, idempotency_key)
+      expect(
+        /unique\s*\(\s*user_id\s*,\s*idempotency_key\s*\)/i.test(sqlContent),
+        `Composite unique constraint (user_id, idempotency_key) not found in ${name}`
+      ).toBe(true);
+
+      // 3. Row Level Security enablement
+      expect(
+        /alter\s+table\s+processed_batches\s+enable\s+row\s+level\s+security/i.test(sqlContent),
+        `RLS enablement not found in ${name}`
+      ).toBe(true);
+
+      // 4. Service role and authenticated user policies
+      expect(
+        /create\s+policy\s+"Service role full access on processed_batches"\s+on\s+processed_batches/i.test(sqlContent),
+        `Service role policy not found in ${name}`
+      ).toBe(true);
+
+      expect(
+        /create\s+policy\s+"Users view own processed batches"\s+on\s+processed_batches/i.test(sqlContent),
+        `Users view own processed batches policy not found in ${name}`
+      ).toBe(true);
+    }
+  });
+
+  it('verifies that database table counts and metadata are correct and in sync', async () => {
+    const setupSqlPath = path.resolve(__dirname, '../../../../docs/supabase_setup.sql');
+    const schemaMdPath = path.resolve(__dirname, '../../../../docs/schema.md');
+
+    const setupSql = await fs.readFile(setupSqlPath, 'utf8');
+    const schemaMd = await fs.readFile(schemaMdPath, 'utf8');
+
+    // supabase_setup.sql counts
+    expect(setupSql).toContain('All 27 tables');
+    expect(setupSql).toContain('PART 1: TABLE DEFINITIONS (27 tables)');
+    expect(setupSql).toContain('25 tables with indexes');
+
+    // schema.md counts
+    expect(schemaMd).toContain('27 tables · 4 RPC functions');
   });
 });

--- a/docs/migration_add_processed_batches.sql
+++ b/docs/migration_add_processed_batches.sql
@@ -1,0 +1,13 @@
+create table if not exists processed_batches (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  user_id uuid not null,
+  event_count int not null default 0,
+  processed_at timestamptz not null default now()
+);
+
+create index if not exists idx_processed_batches_user_id
+on processed_batches (user_id);
+
+create index if not exists idx_processed_batches_processed_at
+on processed_batches (processed_at);

--- a/docs/migration_add_processed_batches.sql
+++ b/docs/migration_add_processed_batches.sql
@@ -1,9 +1,10 @@
 create table if not exists processed_batches (
   id uuid primary key default gen_random_uuid(),
-  idempotency_key text not null unique,
+  idempotency_key text not null,
   user_id uuid not null,
   event_count int not null default 0,
-  processed_at timestamptz not null default now()
+  processed_at timestamptz not null default now(),
+  constraint processed_batches_user_idempotency_unique unique (user_id, idempotency_key)
 );
 
 create index if not exists idx_processed_batches_user_id
@@ -11,3 +12,18 @@ on processed_batches (user_id);
 
 create index if not exists idx_processed_batches_processed_at
 on processed_batches (processed_at);
+
+-- Enable RLS
+alter table processed_batches enable row level security;
+
+-- RLS Policies
+create policy "Service role full access on processed_batches"
+  on processed_batches for all
+  to service_role
+  using (true) with check (true);
+
+create policy "Users view own processed batches"
+  on processed_batches for select
+  to authenticated
+  using (user_id = get_profile_id());
+

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -214,6 +214,14 @@ erDiagram
         text comment
     }
 
+    processed_batches {
+        uuid id PK
+        text idempotency_key
+        uuid user_id
+        int event_count
+        timestamptz processed_at
+    }
+
     wallet_transactions {
         uuid id PK
         uuid driver_id
@@ -310,6 +318,7 @@ erDiagram
     trips ||--o{ route_map_points : "trip_display_id"
 
     profiles ||--o{ wallet_transactions : "driver_id"
+    profiles ||--o{ processed_batches : "user_id"
     profiles ||--o{ earnings_daily : "driver_id"
     profiles ||--o{ driver_milestones : "driver_id"
     milestones ||--o{ driver_milestones : "milestone_id"
@@ -357,6 +366,10 @@ graph LR
     subgraph FINANCE["💰 Finance Layer"]
         WT[wallet_transactions]
         ED[earnings_daily]
+    end
+
+    subgraph OP["⚙️ Operational Layer"]
+        PB[processed_batches]
     end
 
     subgraph ENGAGEMENT["⭐ Engagement Layer"]
@@ -448,6 +461,12 @@ graph LR
 |-------|---------|-------------|----------|
 | `wallet_transactions` | Driver earnings/withdrawals ledger | `driver_id`, `amount`, `txn_type`, `status` | `profiles.id` |
 | `earnings_daily` | Pre-aggregated daily chart data | `driver_id`, `day_date`, `amount`, `trip_count`, `hours_driven` | `profiles.id` |
+
+### ⚙️ Operational Layer (1 table)
+
+| Table | Purpose | Key Columns | Links To |
+|-------|---------|-------------|----------|
+| `processed_batches` | Offline sync / event idempotency tracking | `idempotency_key`, `user_id`, `event_count`, `processed_at` | `profiles.id` |
 
 ### ⭐ Engagement Layer (6 tables)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # 📊 Truxify — Database Schema
 
-> **26 tables · 4 RPC functions · 0 foreign keys**
+> **27 tables · 4 RPC functions · 0 foreign keys**
 > All relationships are logical (application-layer joins). No wired constraints.
 
 ---

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -543,6 +543,24 @@ create index if not exists idx_ratings_order    on ratings (order_display_id);
 
 
 -- ────────────────────────────────────────────────────────────────────────────
+-- 19A. PROCESSED BATCHES (offline sync idempotency)
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists processed_batches (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  user_id uuid not null,
+  event_count int not null default 0,
+  processed_at timestamptz not null default now()
+);
+
+create index if not exists idx_processed_batches_user_id
+on processed_batches (user_id);
+
+create index if not exists idx_processed_batches_processed_at
+on processed_batches (processed_at);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
 -- 19. WALLET TRANSACTIONS  (driver earnings / withdrawals)
 -- ────────────────────────────────────────────────────────────────────────────
 create table if not exists wallet_transactions (
@@ -676,6 +694,7 @@ alter table trip_stops              enable row level security;
 alter table route_map_points        enable row level security;
 alter table ratings                 enable row level security;
 alter table wallet_transactions     enable row level security;
+alter table processed_batches       enable row level security;
 alter table demand_routes           enable row level security;
 alter table notifications           enable row level security;
 alter table faqs                    enable row level security;
@@ -1014,6 +1033,18 @@ create policy "Drivers view own wallet transactions"
   on wallet_transactions for select
   to authenticated
   using (driver_id = get_profile_id());
+
+
+-- 19A. PROCESSED BATCHES
+create policy "Service role full access on processed_batches"
+  on processed_batches for all
+  to service_role
+  using (true) with check (true);
+
+create policy "Users view own processed batches"
+  on processed_batches for select
+  to authenticated
+  using (user_id = get_profile_id());
 
 
 -- 20. DEMAND ROUTES

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -7,7 +7,7 @@
 --   2. Go to SQL Editor → New Query
 --   3. Paste this ENTIRE file and click "Run"
 --   4. Copy your project URL + anon key into .env
---   5. You're done! All 26 tables, indexes, RLS policies, RPC functions,
+--   5. You're done! All 27 tables, indexes, RLS policies, RPC functions,
 --      and seed data are ready.
 --
 -- DESIGN PRINCIPLES:
@@ -55,7 +55,7 @@ $$;
 
 
 -- ############################################################################
--- PART 1: TABLE DEFINITIONS (26 tables)
+-- PART 1: TABLE DEFINITIONS (27 tables)
 -- ############################################################################
 
 
@@ -547,10 +547,11 @@ create index if not exists idx_ratings_order    on ratings (order_display_id);
 -- ────────────────────────────────────────────────────────────────────────────
 create table if not exists processed_batches (
   id uuid primary key default gen_random_uuid(),
-  idempotency_key text not null unique,
+  idempotency_key text not null,
   user_id uuid not null,
   event_count int not null default 0,
-  processed_at timestamptz not null default now()
+  processed_at timestamptz not null default now(),
+  constraint processed_batches_user_idempotency_unique unique (user_id, idempotency_key)
 );
 
 create index if not exists idx_processed_batches_user_id
@@ -1668,7 +1669,7 @@ on conflict do nothing;
 -- ✅ SETUP COMPLETE
 -- ============================================================================
 -- Your Supabase database now has:
---   • 24 tables with indexes
+--   • 25 tables with indexes
 --   • Row Level Security enabled + permissive policies
 --   • Auto-updating `updated_at` triggers
 --   • 4 RPC functions: accept_bid_tx, withdraw_funds_tx, complete_trip_tx, submit_rating_tx


### PR DESCRIPTION
## Description

Fixes Issue #454 by adding the missing `processed_batches` table required by the offline trip synchronization endpoint.

### Changes Made

* Added `processed_batches` table to `docs/supabase_setup.sql`
* Added indexes for efficient idempotency lookups
* Added migration file: `docs/migration_add_processed_batches.sql`
* Updated `docs/schema.md` with the new table and relationships
* Added schema verification tests in `backend/api/test/unit/verifyDbSchema.test.js`
* Added RLS enablement and policies for the new table

### Why This Fix Is Needed

The offline sync endpoint (`POST /api/v1/trips/events/batch`) uses `processed_batches` to track idempotency keys and prevent duplicate batch processing. The table was referenced by backend code but was missing from the schema and setup scripts, causing fresh deployments to fail with:

`relation "processed_batches" does not exist`

### Verification

* Confirmed backend route references `processed_batches`
* Confirmed integration tests already validate batch processing behavior
* Added schema verification tests
* Verified migration and setup scripts contain the required schema

Closes #454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced offline sync idempotency support through a new tracking table to prevent duplicate events when syncing offline changes.

* **Documentation**
  * Updated database schema documentation to include the new offline sync tracking table with its columns and relationships to other tables.

* **Tests**
  * Added unit tests to verify the presence and correctness of the offline sync tracking table in the database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->