### PR TITLE
fix(customer-app): wire change drop and cancel order actions (#450)

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -182,100 +182,173 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   }
 
   Future<void> _showChangeDrop() async {
-    final newDropController = TextEditingController(text: 'Bhiwadi, Rajasthan');
+    final newDropController = TextEditingController(text: _order?['drop_address']?.toString() ?? '');
+    final latController = TextEditingController(text: (_order?['drop_lat']?.toString() ?? ''));
+    final lngController = TextEditingController(text: (_order?['drop_lng']?.toString() ?? ''));
+
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) {
-        return Padding(
-          padding:
-              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface,
-              borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(24)),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Change Drop',
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleLarge
-                        ?.copyWith(fontWeight: FontWeight.w800)),
-                const SizedBox(height: 14),
-                TextField(
-                    controller: newDropController,
-                    decoration:
-                        const InputDecoration(labelText: 'New drop location')),
-                const SizedBox(height: 16),
-                InfoCard(
-                  child: Row(
-                    children: [
-                      const Icon(Icons.attach_money_rounded,
-                          color: TruxifyColors.accentDark),
-                      const SizedBox(width: 10),
-                      Expanded(
-                          child: Text('New estimated price: ₹7,120',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodyLarge
-                                  ?.copyWith(fontWeight: FontWeight.w700))),
-                    ],
+        bool isLoading = false;
+        String? pricingText;
+
+        return StatefulBuilder(builder: (context, setModalState) {
+          return Padding(
+            padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+            child: Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Change Drop',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
+                  const SizedBox(height: 14),
+                  TextField(
+                      controller: newDropController,
+                      decoration: const InputDecoration(labelText: 'New drop location')),
+                  const SizedBox(height: 8),
+                  Row(children: [
+                    Flexible(
+                      child: TextField(
+                        controller: latController,
+                        keyboardType: TextInputType.numberWithOptions(decimal: true),
+                        decoration: const InputDecoration(labelText: 'Latitude'),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: TextField(
+                        controller: lngController,
+                        keyboardType: TextInputType.numberWithOptions(decimal: true),
+                        decoration: const InputDecoration(labelText: 'Longitude'),
+                      ),
+                    ),
+                  ]),
+                  const SizedBox(height: 16),
+                  InfoCard(
+                    child: Row(
+                      children: [
+                        const Icon(Icons.attach_money_rounded, color: TruxifyColors.accentDark),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            pricingText != null ? pricingText : 'New estimated price: calculating...',
+                            style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                const SizedBox(height: 16),
-                PrimaryButton(
-                    label: 'Request Change',
-                    onPressed: () => Navigator.of(context).pop()),
-              ],
+                  const SizedBox(height: 16),
+                  PrimaryButton(
+                    label: isLoading ? 'Requesting...' : 'Request Change',
+                    onPressed: isLoading
+                        ? null
+                        : () async {
+                            final addr = newDropController.text.trim();
+                            final lat = double.tryParse(latController.text.trim());
+                            final lng = double.tryParse(lngController.text.trim());
+                            if (addr.isEmpty || lat == null || lng == null) {
+                              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Please enter valid address and coordinates')));
+                              return;
+                            }
+
+                            setModalState(() => isLoading = true);
+                            try {
+                              final resp = await _orderService.changeDrop(
+                                orderDisplayId: widget.orderId,
+                                dropAddress: addr,
+                                dropLat: lat,
+                                dropLng: lng,
+                              );
+
+                              final pricing = resp['pricing'];
+                              final total = pricing != null ? pricing['total_amount'] : null;
+                              setModalState(() => pricingText = total != null ? 'New estimated price: ₹${total.toString()}' : 'Price updated');
+
+                              // refresh outer order state
+                              await _loadOrder();
+
+                              if (!mounted) return;
+                              Navigator.of(context).pop();
+                              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Drop location updated successfully')));
+                            } catch (e) {
+                              setModalState(() => isLoading = false);
+                              if (!mounted) return;
+                              ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to change drop: $e')));
+                            }
+                          },
+                  ),
+                ],
+              ),
             ),
-          ),
-        );
+          );
+        });
       },
     );
+
     newDropController.dispose();
+    latController.dispose();
+    lngController.dispose();
   }
 
   Future<void> _showCancel() async {
+    bool isLoading = false;
+    String? feeText = _order?['cancellation_fee'] != null ? 'Cancellation fee ₹${_order!['cancellation_fee']}' : null;
+
     await showModalBottomSheet<void>(
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) {
-        return Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.warning_amber_rounded,
-                  color: TruxifyColors.warning, size: 42),
-              const SizedBox(height: 10),
-              Text('Cancellation fee ₹680',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.w800)),
-              const SizedBox(height: 6),
-              Text('This fee is charged for cancelling after assignment.',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: TruxifyColors.adaptiveSecondaryText(context))),
-              const SizedBox(height: 18),
-              PrimaryButton(
-                  label: 'Confirm Cancel',
+        return StatefulBuilder(builder: (context, setModalState) {
+          return Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.warning_amber_rounded, color: TruxifyColors.warning, size: 42),
+                const SizedBox(height: 10),
+                Text(feeText ?? 'Cancellation fee calculating...',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800)),
+                const SizedBox(height: 6),
+                Text('This fee is charged for cancelling after assignment.', textAlign: TextAlign.center, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
+                const SizedBox(height: 18),
+                PrimaryButton(
+                  label: isLoading ? 'Cancelling...' : 'Confirm Cancel',
                   backgroundColor: TruxifyColors.error,
-                  onPressed: () => Navigator.of(context).pop()),
-            ],
-          ),
-        );
+                  onPressed: isLoading
+                      ? null
+                      : () async {
+                          setModalState(() => isLoading = true);
+                          try {
+                            final resp = await _orderService.cancelOrder(orderDisplayId: widget.orderId);
+                            final fee = resp['cancellation_fee'];
+                            await _loadOrder();
+                            if (!mounted) return;
+                            Navigator.of(context).pop();
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Order cancelled. Fee: ₹${fee ?? 0}')));
+                          } catch (e) {
+                            setModalState(() => isLoading = false);
+                            if (!mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to cancel order: $e')));
+                          }
+                        },
+                ),
+              ],
+            ),
+          );
+        });
       },
     );
   }

--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -239,7 +239,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                         const SizedBox(width: 10),
                         Expanded(
                           child: Text(
-                            pricingText != null ? pricingText : 'New estimated price: calculating...',
+                            (pricingText ?? 'New estimated price: calculating...'),
                             style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w700),
                           ),
                         ),

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -85,6 +85,72 @@ class OrderService {
     return body['order']?['order_display_id']?.toString() ?? '';
   }
 
+  Future<Map<String, dynamic>> changeDrop({
+    required String orderDisplayId,
+    required String dropAddress,
+    required double dropLat,
+    required double dropLng,
+  }) async {
+    final token = _client.auth.currentSession?.accessToken;
+    final userId = SupabaseService.requireUserId();
+
+    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId/change-drop');
+
+    final response = await _httpClient.put(
+      uri,
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+        'x-user-id': userId,
+        'x-user-role': 'customer',
+      },
+      body: jsonEncode(<String, dynamic>{
+        'drop_address': dropAddress,
+        'drop_lat': dropLat,
+        'drop_lng': dropLng,
+      }),
+    );
+
+    final body = response.body.isNotEmpty ? jsonDecode(response.body) as Map<String, dynamic> : <String, dynamic>{};
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(body['error']?.toString() ?? 'Failed to change drop via backend API.');
+    }
+
+    return body;
+  }
+
+  Future<Map<String, dynamic>> cancelOrder({
+    required String orderDisplayId,
+    String? reason,
+  }) async {
+    final token = _client.auth.currentSession?.accessToken;
+    final userId = SupabaseService.requireUserId();
+
+    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId/cancel');
+
+    final response = await _httpClient.post(
+      uri,
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+        'x-user-id': userId,
+        'x-user-role': 'customer',
+      },
+      body: jsonEncode(<String, dynamic>{
+        if (reason != null) 'reason': reason,
+      }),
+    );
+
+    final body = response.body.isNotEmpty ? jsonDecode(response.body) as Map<String, dynamic> : <String, dynamic>{};
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(body['error']?.toString() ?? 'Failed to cancel order via backend API.');
+    }
+
+    return body;
+  }
+
   Future<Map<String, dynamic>?> fetchOrderById(String orderDisplayId) async {
     final userId = SupabaseService.requireUserId();
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -625,6 +625,7 @@ router.put('/:id/change-drop', authenticate, requireRole(['customer']), validate
     if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
+    if (order.weight_tonnes == null) return res.status(500).json({ error: 'Data inconsistency: Order is missing weight_tonnes.' });
 
     // Recalculate pricing based on new drop location
     let pricing;
@@ -641,7 +642,7 @@ router.put('/:id/change-drop', authenticate, requireRole(['customer']), validate
         pickupLng:  Number(order.pickup_lng),
         dropLat:    Number(drop_lat),
         dropLng:    Number(drop_lng),
-        weightTonnes: Number(order.weight_tonnes || 0),
+        weightTonnes: Number(order.weight_tonnes),
         roadDistanceKm: routeEstimate?.distanceKm,
         isFragile:   Boolean(order.is_fragile),
         isStackable: Boolean(order.is_stackable),
@@ -705,7 +706,7 @@ router.post('/:id/cancel', authenticate, requireRole(['customer']), validatePara
       return res.status(400).json({ error: 'Order cannot be cancelled after delivery or payment release.' });
     }
 
-    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({ status: 'cancelled', updated_at: new Date().toISOString() }).eq('order_display_id', orderId).select('cancellation_fee, order_display_id, status').single();
+    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({ status: 'cancelled', cancellation_reason: reason, updated_at: new Date().toISOString() }).eq('order_display_id', orderId).select('cancellation_fee, order_display_id, status, cancellation_reason').single();
     if (updateErr) return res.status(500).json({ error: 'Failed to cancel order.', details: updateErr.message });
 
     const cancellationFee = updatedOrder?.cancellation_fee ?? 0;

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -14,6 +14,7 @@ import {
   verifyDeliverySchema,
   predictDemandSchema
 } from '../validation/requestSchemas.js';
+import { changeDropSchema, cancelOrderSchema } from '../validation/requestSchemas.js';
 import { awardReputationPoints } from '../services/reputation.js';
 import { sendDeliveryOtpNotification } from '../services/notificationService.js';
 import { predictDemand } from '../services/ml.js';
@@ -609,6 +610,110 @@ router.post('/:id/verify-delivery', authenticate, requireRole(['driver']), verif
     res.json({ message: 'Delivery verified successfully! Payment released to driver.', order: responseOrder });
   } catch (err) {
     res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 10. CHANGE DROP (CUSTOMER)
+// ============================================================================
+router.put('/:id/change-drop', authenticate, requireRole(['customer']), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
+  const orderId = req.params.id; // this is order_display_id from client
+  const { drop_address, drop_lat, drop_lng } = req.body;
+
+  try {
+    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('order_display_id', orderId).maybeSingle();
+    if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
+    if (!order) return res.status(404).json({ error: 'Order not found.' });
+    if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
+
+    // Recalculate pricing based on new drop location
+    let pricing;
+    try {
+      const routeEstimate = await getRouteEstimate({
+        pickupLat: Number(order.pickup_lat),
+        pickupLng: Number(order.pickup_lng),
+        dropLat: Number(drop_lat),
+        dropLng: Number(drop_lng),
+      });
+
+      pricing = computeOrderPricing({
+        pickupLat:  Number(order.pickup_lat),
+        pickupLng:  Number(order.pickup_lng),
+        dropLat:    Number(drop_lat),
+        dropLng:    Number(drop_lng),
+        weightTonnes: Number(order.weight_tonnes || 0),
+        roadDistanceKm: routeEstimate?.distanceKm,
+        isFragile:   Boolean(order.is_fragile),
+        isStackable: Boolean(order.is_stackable),
+      });
+    } catch (pricingErr) {
+      console.error('Pricing computation error for change-drop:', pricingErr.message);
+      return res.status(400).json({ error: 'Unable to compute new pricing for the requested drop.', details: pricingErr.message });
+    }
+
+    const updates = {
+      drop_address,
+      drop_lat: Number(drop_lat),
+      drop_lng: Number(drop_lng),
+      base_freight: pricing.baseFreight,
+      toll_estimate: pricing.tollEstimate,
+      platform_fee: pricing.platformFee,
+      total_amount: pricing.totalAmount,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update(updates).eq('order_display_id', orderId).select('*').single();
+    if (updateErr) return res.status(500).json({ error: 'Failed to update order.', details: updateErr.message });
+
+    // Update timeline entry for change-drop if present (best-effort)
+    try {
+      await supabase.from('order_timeline').insert({ order_display_id: order.order_display_id, milestone: 'Drop Changed', milestone_time: new Date().toISOString(), completed: true, sort_order: 25 });
+    } catch (timelineErr) {
+      console.warn('Failed to update timeline for change-drop:', timelineErr.message);
+    }
+
+    return res.json({
+      message: 'Drop location updated successfully.',
+      pricing: {
+        base_freight: pricing.baseFreight,
+        toll_estimate: pricing.tollEstimate,
+        platform_fee: pricing.platformFee,
+        total_amount: pricing.totalAmount,
+      },
+      order: updatedOrder,
+    });
+  } catch (err) {
+    console.error('Change drop exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 11. CANCEL ORDER (CUSTOMER)
+// ============================================================================
+router.post('/:id/cancel', authenticate, requireRole(['customer']), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
+  const orderId = req.params.id; // this is order_display_id from client
+  const { reason = null } = req.body || {};
+
+  try {
+    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('order_display_id', orderId).maybeSingle();
+    if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
+    if (!order) return res.status(404).json({ error: 'Order not found.' });
+    if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
+
+    if (['delivered', 'payment_released'].includes(order.status)) {
+      return res.status(400).json({ error: 'Order cannot be cancelled after delivery or payment release.' });
+    }
+
+    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({ status: 'cancelled', updated_at: new Date().toISOString() }).eq('order_display_id', orderId).select('cancellation_fee, order_display_id, status').single();
+    if (updateErr) return res.status(500).json({ error: 'Failed to cancel order.', details: updateErr.message });
+
+    const cancellationFee = updatedOrder?.cancellation_fee ?? 0;
+
+    return res.json({ message: 'Order cancelled successfully.', cancellation_fee: cancellationFee });
+  } catch (err) {
+    console.error('Cancel order exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
 });
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -113,9 +113,17 @@ export const verifyDeliverySchema = z.object({
 });
 
 export const changeDropSchema = z.object({
-  drop_address: z.string().min(3, 'Drop address is required'),
-  drop_lat: coerceNumber(z.number({ invalid_type_error: 'Latitude must be a number' }).min(-90).max(90)),
-  drop_lng: coerceNumber(z.number({ invalid_type_error: 'Longitude must be a number' }).min(-180).max(180)),
+  drop_address: z.string().min(3, 'Drop address must be at least 3 characters'),
+  drop_lat: coerceNumber(
+    z.number({ invalid_type_error: 'Latitude must be a number' })
+      .min(-90, { message: 'Must be greater than or equal to -90' })
+      .max(90, { message: 'Must be less than or equal to 90' })
+  ),
+  drop_lng: coerceNumber(
+    z.number({ invalid_type_error: 'Longitude must be a number' })
+      .min(-180, { message: 'Must be greater than or equal to -180' })
+      .max(180, { message: 'Must be less than or equal to 180' })
+  ),
 }).passthrough();
 
 export const cancelOrderSchema = z.object({

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -111,3 +111,13 @@ export const verifyDeliverySchema = z.object({
     z.string().regex(/^\d{6}$/, { message: 'OTP must be 6 digits' }).optional()
   )
 });
+
+export const changeDropSchema = z.object({
+  drop_address: z.string().min(3, 'Drop address is required'),
+  drop_lat: coerceNumber(z.number({ invalid_type_error: 'Latitude must be a number' }).min(-90).max(90)),
+  drop_lng: coerceNumber(z.number({ invalid_type_error: 'Longitude must be a number' }).min(-180).max(180)),
+}).passthrough();
+
+export const cancelOrderSchema = z.object({
+  reason: z.string().max(500).optional().nullable(),
+}).passthrough();

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1584,7 +1584,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     expect(stored.drop_lng).toBe(88.88);
   });
 
-  it('allows customer to cancel order and returns cancellation_fee', async () => {
+  it('allows customer to cancel order and returns cancellation_fee and persists reason', async () => {
     m.store.orders.push({
       id: 'order-cancel-1',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
@@ -1605,6 +1605,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     expect(res.body.cancellation_fee).toBe(500);
     const stored = m.store.orders.find(o => o.id === 'order-cancel-1');
     expect(stored.status).toBe('cancelled');
+    expect(stored.cancellation_reason).toBe('Change of plans');
   });
 
   it('rejects cancel when requester is not the order owner', async () => {
@@ -1624,5 +1625,149 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       .send({ reason: 'Not owner' });
 
     expect(res.status).toBe(403);
+  });
+
+  it('rejects change-drop when requester is not the order owner', async () => {
+    m.store.orders.push({
+      id: 'order-change-2',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CHANGE-2',
+      pickup_lat: 19.0760,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 3,
+      is_fragile: false,
+      is_stackable: true,
+      status: 'pending'
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-CHANGE-2/change-drop')
+      .set({ 'x-user-id': 'some-other-user', 'x-user-role': 'customer' })
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects cancel when order is already delivered', async () => {
+    m.store.orders.push({
+      id: 'order-cancel-delivered',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CANCEL-DELIVERED',
+      status: 'delivered',
+      cancellation_fee: 500
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/OD-CANCEL-DELIVERED/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'delivered' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Order cannot be cancelled after delivery or payment release.');
+  });
+
+  it('rejects cancel when payment is already released', async () => {
+    m.store.orders.push({
+      id: 'order-cancel-released',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CANCEL-RELEASED',
+      status: 'payment_released',
+      cancellation_fee: 500
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/OD-CANCEL-RELEASED/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'payment released' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Order cannot be cancelled after delivery or payment release.');
+  });
+
+  it('returns 400 when route estimate computation fails during change-drop', async () => {
+    m.store.orders.push({
+      id: 'order-change-fail',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CHANGE-FAIL',
+      pickup_lat: 19.0760,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 3,
+      is_fragile: false,
+      is_stackable: true,
+      status: 'pending'
+    });
+
+    routeEstimateMock.mockRejectedValue(new Error('OSRM service down'));
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-CHANGE-FAIL/change-drop')
+      .set(CUSTOMER_HEADERS)
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Unable to compute new pricing for the requested drop.');
+    expect(res.body.details).toBe('OSRM service down');
+  });
+
+  it('returns 500 when weight_tonnes is missing in DB during change-drop', async () => {
+    m.store.orders.push({
+      id: 'order-change-no-weight',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CHANGE-NO-WEIGHT',
+      pickup_lat: 19.0760,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: null,
+      is_fragile: false,
+      is_stackable: true,
+      status: 'pending'
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-CHANGE-NO-WEIGHT/change-drop')
+      .set(CUSTOMER_HEADERS)
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Data inconsistency: Order is missing weight_tonnes.');
+  });
+
+  it('returns 404 for change-drop with non-existent order_display_id', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-NONEXISTENT/change-drop')
+      .set(CUSTOMER_HEADERS)
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Order not found.');
+  });
+
+  it('returns 404 for cancel with non-existent order_display_id', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/OD-NONEXISTENT/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'Non-existent' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Order not found.');
   });
 });

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1542,3 +1542,87 @@ describe('POST /api/orders/predict-demand — ML demand prediction', () => {
     expect(res.body.details).toBe('ML service unavailable');
   });
 });
+
+describe('Customer actions: change-drop and cancel endpoints', () => {
+  beforeEach(() => {
+    // reset store and calls
+    m.store.orders = [];
+    m.store.order_timeline = [];
+    m.calls.length = 0;
+    routeEstimateMock.mockReset();
+    routeEstimateMock.mockResolvedValue({ distanceKm: 100 });
+  });
+
+  it('allows customer to change drop and returns recalculated pricing', async () => {
+    m.store.orders.push({
+      id: 'order-change-1',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CHANGE-1',
+      pickup_lat: 19.0760,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 3,
+      is_fragile: false,
+      is_stackable: true,
+      status: 'pending'
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-CHANGE-1/change-drop')
+      .set(CUSTOMER_HEADERS)
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('pricing');
+    expect(res.body.pricing).toHaveProperty('total_amount');
+    const stored = m.store.orders.find(o => o.id === 'order-change-1');
+    expect(stored.drop_address).toBe('New Drop Place');
+    expect(stored.drop_lat).toBe(22.22);
+    expect(stored.drop_lng).toBe(88.88);
+  });
+
+  it('allows customer to cancel order and returns cancellation_fee', async () => {
+    m.store.orders.push({
+      id: 'order-cancel-1',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CANCEL-1',
+      status: 'pending',
+      cancellation_fee: 500
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/OD-CANCEL-1/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'Change of plans' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('cancellation_fee');
+    expect(res.body.cancellation_fee).toBe(500);
+    const stored = m.store.orders.find(o => o.id === 'order-cancel-1');
+    expect(stored.status).toBe('cancelled');
+  });
+
+  it('rejects cancel when requester is not the order owner', async () => {
+    m.store.orders.push({
+      id: 'order-cancel-2',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-CANCEL-2',
+      status: 'pending',
+      cancellation_fee: 300
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/OD-CANCEL-2/cancel')
+      .set({ 'x-user-id': 'some-other-user', 'x-user-role': 'customer' })
+      .send({ reason: 'Not owner' });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/docs/migration_add_cancellation_reason.sql
+++ b/docs/migration_add_cancellation_reason.sql
@@ -1,0 +1,3 @@
+-- Migration: Add cancellation_reason to orders table
+
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS cancellation_reason TEXT;

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -126,6 +126,7 @@ erDiagram
         text goods_type
         numeric weight_tonnes
         int total_amount
+        text cancellation_reason
         text driver_name
         text eta
     }
@@ -433,7 +434,7 @@ graph LR
 
 | Table | Purpose | Key Columns | Links To |
 |-------|---------|-------------|----------|
-| `orders` | Core booking record | `order_display_id`, `customer_id`, `driver_id`, `status` | `profiles.id`, `trucks.id` |
+| `orders` | Core booking record | `order_display_id`, `customer_id`, `driver_id`, `status`, `cancellation_reason` | `profiles.id`, `trucks.id` |
 | `order_timeline` | Milestone events per order | `order_display_id`, `milestone`, `completed` | `orders.order_display_id` |
 | `saved_addresses` | Customer saved locations | `user_id`, `label`, `lat/lng` | `profiles.id` |
 | `payment_methods` | Customer payment options | `user_id`, `method_type`, `display_label` | `profiles.id` |

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -288,6 +288,7 @@ create table if not exists orders (
   platform_fee         int not null default 0,
   total_amount         int not null default 0,
   cancellation_fee     int not null default 0,
+  cancellation_reason  text,
 
   -- Payment
   payment_method_id    uuid,                                  -- payment_methods.id


### PR DESCRIPTION
## Summary

Fixes #450 by wiring the Customer App's **Change Drop** and **Cancel Order** actions to backend APIs.

### Changes Made

#### Backend

* Added `changeDropSchema` validation schema.
* Added `cancelOrderSchema` validation schema.
* Added `PUT /api/orders/:id/change-drop` endpoint.
* Added `POST /api/orders/:id/cancel` endpoint.
* Recalculated pricing when drop location changes.
* Updated order status to `cancelled` when cancellation is confirmed.
* Added ownership and authorization checks.

#### Customer App

* Added `changeDrop()` API integration in `OrderService`.
* Added `cancelOrder()` API integration in `OrderService`.
* Wired Change Drop modal to backend endpoint.
* Wired Cancel Order modal to backend endpoint.
* Added loading, success, and error handling.
* Refreshed order data after successful operations.
* Removed hardcoded action behavior that only closed modals.

#### Tests

* Added integration tests covering:

  * Successful drop location update
  * Successful order cancellation
  * Unauthorized cancellation attempts

### Validation

* `orders.test.js` passes successfully, including the new integration tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modify drop location on pending orders with latitude/longitude inputs; pricing recalculates and updates instantly.
  * Cancel orders from the app with dynamic cancellation-fee display and confirmation flow.
* **UX Improvements**
  * Loading/disabled states, input validation, and immediate success/error notifications for both flows.
* **Tests**
  * Integration tests added to verify change-drop and cancel behaviors, error cases, and authorization checks.
* **Documentation & Migration**
  * Schema docs and DB migration added to record a cancellation_reason field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->