### PR TITLE
fix: escrow deposit() records wrong customer address causing permanent fund loss

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -483,17 +483,17 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
 
     if (rpcErr) return res.status(500).json({ error: 'Failed to accept bid atomically.', details: rpcErr.message });
 
-    // Fetch driver's Polygon wallet address for escrow deposit
-    const { data: driverDetails } = await supabase
-      .from('driver_details')
-      .select('polygon_wallet_address')
-      .eq('user_id', bid.driver_id)
-      .maybeSingle();
+    // Fetch driver's and customer's Polygon wallet addresses for escrow deposit
+    const [driverDetailsResult, customerProfileResult] = await Promise.all([
+      supabase.from('driver_details').select('polygon_wallet_address').eq('user_id', bid.driver_id).maybeSingle(),
+      supabase.from('profiles').select('polygon_wallet_address').eq('id', req.user.id).maybeSingle(),
+    ]);
 
-    const driverWallet = driverDetails?.polygon_wallet_address ?? null;
-    if (driverWallet) {
+    const driverWallet = driverDetailsResult.data?.polygon_wallet_address ?? null;
+    const customerWallet = customerProfileResult.data?.polygon_wallet_address ?? null;
+    if (driverWallet && customerWallet) {
       const amountWei = ethers.parseEther((bid.bid_amount / 100).toFixed(2).toString());
-      escrowDeposit(order.order_display_id, driverWallet, amountWei).then(({ txHash }) => {
+      escrowDeposit(order.order_display_id, customerWallet, driverWallet, amountWei).then(({ txHash }) => {
         if (txHash) {
           supabase.from('orders').update({
             escrow_status: 'funded',
@@ -507,7 +507,9 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
         console.error('[escrow] Unhandled rejection in escrowDeposit:', err.message)
       );
     } else {
-      console.warn(`[escrow] Driver ${bid.driver_id} has no polygon_wallet_address — skipping escrow deposit.`);
+      console.warn(
+        `[escrow] Missing wallet address: driver=${!!driverWallet}, customer=${!!customerWallet} — skipping escrow deposit.`
+      );
     }
 
     // Update order with escrow booking reference

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -19,7 +19,7 @@
 import { ethers } from 'ethers';
 
 const ESCROW_ABI = [
-  'function deposit(bytes32 bookingId, address payable driver) external payable',
+  'function deposit(bytes32 bookingId, address payable customer, address payable driver) external payable',
   'function releaseFunds(bytes32 bookingId) external',
   'function refundFunds(bytes32 bookingId) external',
   'function escrows(bytes32 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status)',
@@ -65,15 +65,20 @@ export function getEscrowBookingId(orderDisplayId) {
  * must never block the response. The Supabase order is the source of truth.
  *
  * @param {string} orderDisplayId
- * @param {string} driverWalletAddress — 0x-prefixed Polygon address
+ * @param {string} customerWalletAddress — 0x-prefixed Polygon address of the customer
+ * @param {string} driverWalletAddress — 0x-prefixed Polygon address of the driver
  * @param {string} amountWei           — amount in wei (string or bigint)
  * @returns {Promise<{txHash: string|null, bookingId: string}>}
  */
-export async function escrowDeposit(orderDisplayId, driverWalletAddress, amountWei) {
+export async function escrowDeposit(orderDisplayId, customerWalletAddress, driverWalletAddress, amountWei) {
   const bookingId = getEscrowBookingId(orderDisplayId);
 
   if (!escrowContract) {
     console.warn('[escrow] Contract not initialised — skipping deposit.');
+    return { txHash: null, bookingId };
+  }
+  if (!ethers.isAddress(customerWalletAddress)) {
+    console.warn(`[escrow] Invalid customer wallet address "${customerWalletAddress}" — skipping deposit.`);
     return { txHash: null, bookingId };
   }
   if (!ethers.isAddress(driverWalletAddress)) {
@@ -82,7 +87,7 @@ export async function escrowDeposit(orderDisplayId, driverWalletAddress, amountW
   }
 
   try {
-    const tx = await escrowContract.deposit(bookingId, driverWalletAddress, {
+    const tx = await escrowContract.deposit(bookingId, customerWalletAddress, driverWalletAddress, {
       value: amountWei,
     });
     console.log(`[escrow] deposit tx submitted: ${tx.hash} for booking ${orderDisplayId}`);

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -12,7 +12,12 @@ vi.mock('../../src/config/db.js', () => ({
   mongoDb: null,
 }));
 
+vi.mock('../../src/services/escrow.js', () => ({
+  escrowDeposit: vi.fn(),
+}));
+
 const { default: orderRouter } = await import('../../src/routes/orderRoutes.js');
+const { escrowDeposit: mockEscrowDeposit } = await import('../../src/services/escrow.js');
 
 function buildApp() {
   const app = express();
@@ -40,6 +45,7 @@ describe('Bid Routes', () => {
     m.store.driver_details = [];
     m.store.trucks = [];
     m.calls.length = 0;
+    mockEscrowDeposit.mockReset();
   });
 
   it('POST /:id/bids rejects invalid amount', async () => {
@@ -303,6 +309,117 @@ describe('Bid Routes', () => {
 
     expect(rpc).toBeTruthy();
     expect(rpc.args.p_bid_id).toBe('bid-1');
+  });
+
+  it('POST /:id/bids/:bidId/accept triggers escrow deposit when wallet addresses present', async () => {
+    let resolveEscrow;
+    mockEscrowDeposit.mockImplementation(() => new Promise(resolve => {
+      resolveEscrow = () => resolve({ txHash: '0xescrowtest123' });
+    }));
+
+    m.store.orders.push({
+      id: 'order-escrow',
+      customer_id: 'customer-1',
+      order_display_id: 'OD-ESCROW',
+    });
+
+    m.store.load_offers.push({
+      id: 'load-escrow',
+      order_display_id: 'OD-ESCROW',
+      status: 'available',
+    });
+
+    m.store.load_bids.push({
+      id: 'bid-escrow',
+      load_id: 'load-escrow',
+      driver_id: 'driver-1',
+      bid_amount: 50000,
+      status: 'pending',
+    });
+
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One', polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' },
+      { id: 'driver-1', full_name: 'Driver One' },
+    );
+
+    m.store.driver_details.push({
+      user_id: 'driver-1',
+      rating: 4.9,
+      total_trips: 100,
+      completion_rate: 98,
+      truck_id: null,
+      polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/order-escrow/bids/bid-escrow/accept')
+      .set(CUSTOMER);
+
+    expect(res.status).toBe(200);
+
+    expect(mockEscrowDeposit).toHaveBeenCalledWith(
+      'OD-ESCROW',
+      '0x1234567890abcdef1234567890abcdef12345678',
+      '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+      expect.any(BigInt),
+    );
+
+    let order = m.store.orders.find(o => o.id === 'order-escrow');
+    expect(order.escrow_status).toBe('funding');
+
+    resolveEscrow();
+    await new Promise(r => setImmediate(r));
+
+    order = m.store.orders.find(o => o.id === 'order-escrow');
+    expect(order.escrow_status).toBe('funded');
+    expect(order.deposit_tx_hash).toBe('0xescrowtest123');
+  });
+
+  it('POST /:id/bids/:bidId/accept skips escrow when customer wallet missing', async () => {
+    m.store.orders.push({
+      id: 'order-no-cust-wallet',
+      customer_id: 'customer-1',
+      order_display_id: 'OD-NO-CUST',
+    });
+
+    m.store.load_offers.push({
+      id: 'load-no-cust',
+      order_display_id: 'OD-NO-CUST',
+      status: 'available',
+    });
+
+    m.store.load_bids.push({
+      id: 'bid-no-cust',
+      load_id: 'load-no-cust',
+      driver_id: 'driver-1',
+      bid_amount: 50000,
+      status: 'pending',
+    });
+
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One' },
+      { id: 'driver-1', full_name: 'Driver One' },
+    );
+
+    m.store.driver_details.push({
+      user_id: 'driver-1',
+      rating: 4.9,
+      total_trips: 100,
+      completion_rate: 98,
+      truck_id: null,
+      polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/order-no-cust-wallet/bids/bid-no-cust/accept')
+      .set(CUSTOMER);
+
+    expect(res.status).toBe(200);
+    expect(mockEscrowDeposit).not.toHaveBeenCalled();
   });
 
   it('POST /:id/bids/:bidId/accept rejects invalid ownership', async () => {

--- a/blockchain/contracts/Escrow.sol
+++ b/blockchain/contracts/Escrow.sol
@@ -57,20 +57,21 @@ contract Escrow {
         emit RelayerUpdated(relayer, authorized);
     }
 
-    function deposit(bytes32 bookingId, address payable driver) external payable {
+    function deposit(bytes32 bookingId, address payable customer, address payable driver) external payable {
         require(bookingId != bytes32(0), "Invalid booking");
+        require(customer != address(0), "Invalid customer");
         require(driver != address(0), "Invalid driver");
         require(msg.value > 0, "Deposit required");
         require(escrows[bookingId].status == EscrowStatus.None, "Escrow exists");
 
         escrows[bookingId] = BookingEscrow({
-            customer: payable(msg.sender),
+            customer: customer,
             driver: driver,
             amount: msg.value,
             status: EscrowStatus.Funded
         });
 
-        emit Deposited(bookingId, msg.sender, driver, msg.value);
+        emit Deposited(bookingId, customer, driver, msg.value);
     }
 
     function releaseFunds(bytes32 bookingId) external onlyRelayer nonReentrant {

--- a/blockchain/test/escrow.test.cjs
+++ b/blockchain/test/escrow.test.cjs
@@ -23,7 +23,7 @@ describe("Escrow", function () {
     const id = bookingId("booking-1");
     const amount = ethers.parseEther("1");
 
-    await escrow.connect(customer).deposit(id, driver.address, { value: amount });
+    await escrow.connect(customer).deposit(id, customer.address, driver.address, { value: amount });
     const saved = await escrow.escrows(id);
 
     assert.equal(saved.customer, customer.address);
@@ -37,7 +37,7 @@ describe("Escrow", function () {
     const { escrow, relayer, customer, driver } = await deployEscrow();
     const id = bookingId("booking-release");
     const amount = ethers.parseEther("0.25");
-    await escrow.connect(customer).deposit(id, driver.address, { value: amount });
+    await escrow.connect(customer).deposit(id, customer.address, driver.address, { value: amount });
 
     const driverBefore = await ethers.provider.getBalance(driver.address);
     await escrow.connect(relayer).releaseFunds(id);
@@ -53,7 +53,7 @@ describe("Escrow", function () {
     const { escrow, relayer, customer, driver } = await deployEscrow();
     const id = bookingId("booking-refund");
     const amount = ethers.parseEther("0.25");
-    await escrow.connect(customer).deposit(id, driver.address, { value: amount });
+    await escrow.connect(customer).deposit(id, customer.address, driver.address, { value: amount });
 
     await escrow.connect(relayer).refundFunds(id);
     const saved = await escrow.escrows(id);
@@ -68,11 +68,11 @@ describe("Escrow", function () {
     const releaseId = bookingId("double-release");
     const refundId = bookingId("double-refund");
 
-    await escrow.connect(customer).deposit(releaseId, driver.address, { value: 1000n });
+    await escrow.connect(customer).deposit(releaseId, customer.address, driver.address, { value: 1000n });
     await escrow.connect(relayer).releaseFunds(releaseId);
     await assertRejectsWith(escrow.connect(relayer).releaseFunds(releaseId), "Escrow not funded");
 
-    await escrow.connect(customer).deposit(refundId, driver.address, { value: 1000n });
+    await escrow.connect(customer).deposit(refundId, customer.address, driver.address, { value: 1000n });
     await escrow.connect(relayer).refundFunds(refundId);
     await assertRejectsWith(escrow.connect(relayer).refundFunds(refundId), "Escrow not funded");
   });
@@ -80,7 +80,7 @@ describe("Escrow", function () {
   it("rejects unauthorized release and refund attempts", async function () {
     const { escrow, customer, driver, outsider } = await deployEscrow();
     const id = bookingId("unauthorized");
-    await escrow.connect(customer).deposit(id, driver.address, { value: 1000n });
+    await escrow.connect(customer).deposit(id, customer.address, driver.address, { value: 1000n });
 
     await assertRejectsWith(escrow.connect(outsider).releaseFunds(id), "Not authorized relayer");
     await assertRejectsWith(escrow.connect(outsider).refundFunds(id), "Not authorized relayer");
@@ -91,9 +91,9 @@ describe("Escrow", function () {
     const id = bookingId("invalid-state");
 
     await assertRejectsWith(escrow.connect(relayer).releaseFunds(id), "Escrow not funded");
-    await escrow.connect(customer).deposit(id, driver.address, { value: 1000n });
+    await escrow.connect(customer).deposit(id, customer.address, driver.address, { value: 1000n });
     await assertRejectsWith(
-      escrow.connect(customer).deposit(id, driver.address, { value: 1000n }),
+      escrow.connect(customer).deposit(id, customer.address, driver.address, { value: 1000n }),
       "Escrow exists"
     );
   });
@@ -106,7 +106,7 @@ describe("Escrow", function () {
 
     const id = bookingId("reentrant-booking");
     await escrow.connect(owner).setRelayer(await attacker.getAddress(), true);
-    await escrow.connect(customer).deposit(id, await attacker.getAddress(), { value: 1000n });
+    await escrow.connect(customer).deposit(id, customer.address, await attacker.getAddress(), { value: 1000n });
 
     await assertRejectsWith(attacker.attackRelease(id), "Driver payout failed");
   });

--- a/docs/migration_add_profiles_polygon_wallet.sql
+++ b/docs/migration_add_profiles_polygon_wallet.sql
@@ -1,0 +1,9 @@
+-- Migration: Add polygon_wallet_address to profiles table
+-- This column stores the customer's Polygon (EVM) wallet address so the
+-- backend relayer can call Escrow.sol.deposit() with the correct customer
+-- address during the bid-accept escrow funding flow.
+-- Nullable — customers without a registered wallet address will simply
+-- skip the on-chain escrow deposit; the off-chain order is always saved.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS polygon_wallet_address TEXT;

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -74,6 +74,7 @@ create table if not exists profiles (
   language      text not null default 'en',
   dark_mode     boolean not null default false,
   is_active     boolean not null default true,
+  polygon_wallet_address text,                                  -- Polygon wallet address for escrow deposits
   created_at    timestamptz not null default now(),
   updated_at    timestamptz not null default now()
 );
@@ -1475,12 +1476,14 @@ $$;
 -- Passwords / auth tokens are managed by Firebase Auth, not Supabase.
 
 -- Seed Profiles (1 customer + 1 driver)
-insert into profiles (id, firebase_uid, role, full_name, phone, email, company_name, language)
+insert into profiles (id, firebase_uid, role, full_name, phone, email, company_name, language, polygon_wallet_address)
 values
   ('a1111111-1111-1111-1111-111111111111', 'firebase_customer_001', 'customer',
-   'Rajesh Kumar', '+919876543210', 'rajesh@truxify.dev', 'Kumar Logistics', 'en'),
+   'Rajesh Kumar', '+919876543210', 'rajesh@truxify.dev', 'Kumar Logistics', 'en',
+   '0x1234567890abcdef1234567890abcdef12345678'),
   ('b2222222-2222-2222-2222-222222222222', 'firebase_driver_001', 'driver',
-   'Suresh Yadav', '+919988776655', 'suresh@truxify.dev', null, 'hi')
+   'Suresh Yadav', '+919988776655', 'suresh@truxify.dev', null, 'hi',
+   null)
 on conflict (firebase_uid) do nothing;
 
 -- Seed Customer Stats
@@ -1501,11 +1504,12 @@ on conflict do nothing;
 
 -- Seed Driver Details
 insert into driver_details (user_id, truck_id, rating, total_trips, completion_rate,
-  is_online, wallet_confirmed, wallet_pending, wallet_total)
+  is_online, wallet_confirmed, wallet_pending, wallet_total, polygon_wallet_address)
 values
   ('b2222222-2222-2222-2222-222222222222',
    'c3333333-3333-3333-3333-333333333333',
-   4.72, 148, 96.50, true, 4500000, 750000, 5250000)
+   4.72, 148, 96.50, true, 4500000, 750000, 5250000,
+   '0xAbcdef1234567890Abcdef1234567890Abcdef12')
 on conflict (user_id) do nothing;
 
 -- Seed Tyre Diagnostics


### PR DESCRIPTION
## Description
The `Escrow.sol` smart contract's `deposit()` function sets `customer` to `msg.sender` — the Ethereum address that submitted the transaction. However, all deposit transactions are submitted by the **backend relayer wallet**, not the actual customer's wallet. This means `customer` is permanently recorded as the relayer address for every escrow. When `refundFunds()` is called, it sends funds to the relayer instead of the actual customer.

**Files changed:**
- `blockchain/contracts/Escrow.sol` — Added explicit `address payable customer` parameter to `deposit()`
- `backend/api/src/services/escrow.js` — Updated ABI; added `customerWalletAddress` parameter; validate both customer and driver addresses
- `backend/api/src/routes/orderRoutes.js` — Fetch customer's `polygon_wallet_address` from `profiles` table alongside driver wallet; pass both to `escrowDeposit()`

Closes #526 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escrow deposit now validates and requires both customer and driver Polygon wallet addresses before processing.
  * Profiles now support storing a Polygon wallet address for users.

* **Bug Fixes / Behavior**
  * Deposit is skipped when required wallet addresses are missing; logging now reports presence status for both parties.

* **Tests**
  * Added and updated integration and contract tests covering the updated deposit behavior.

* **Docs / Migrations**
  * Added migration and seed updates to include the new wallet column in profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->