### PR TITLE
feat(tracking): persist websocket subscription metadata (#463)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -183,6 +183,7 @@ export function initWebSocketServer(server) {
           role: profile.role,
         };
         ws.driverId = profile.id;
+        await restoreSubscriptions(ws);
         console.log(`✅ WS Authenticated user: ${ws.user.id}`);
       } catch (e) {
         console.error('WS Auth failed:', e.message);
@@ -514,8 +515,7 @@ export async function handleSubscribe(ws, data) {
     try {
       const subscriberId = ws.user?.id || ws.driverId;
       if (subscriberId) {
-        await redisClient.sadd(`tracking:subscriptions:${targetId}`, subscriberId);
-        await redisClient.expire(`tracking:subscriptions:${targetId}`, 3600);
+        await redisClient.sadd(`user:subscriptions:${subscriberId}`, targetId);
       }
     } catch (err) {
       console.error('Redis subscription persistence error:', err.message);
@@ -575,7 +575,7 @@ async function handleUnsubscribe(ws, data) {
       const subscriberId = ws.user?.id || ws.driverId;
       try {
         if (subscriberId) {
-          await redisClient.srem(`tracking:subscriptions:${targetId}`, subscriberId);
+          await redisClient.srem(`user:subscriptions:${subscriberId}`, targetId);
         }
       } catch (err) {
         console.error('Redis subscription cleanup error:', err.message);
@@ -588,19 +588,6 @@ async function handleUnsubscribe(ws, data) {
 }
 
 async function removeClientFromAllSubscriptions(ws) {
-  if (redisClient && ws.subscriptionTargets?.size) {
-    const subscriberId = ws.user?.id || ws.driverId;
-    if (subscriberId) {
-      for (const targetId of ws.subscriptionTargets) {
-        try {
-          await redisClient.srem(`tracking:subscriptions:${targetId}`, subscriberId);
-        } catch (err) {
-          console.error('Redis subscription cleanup error:', err.message);
-        }
-      }
-    }
-  }
-
   trackingSubscriptions.forEach((clients, key) => {
     if (clients.has(ws)) {
       clients.delete(ws);
@@ -612,9 +599,36 @@ async function removeClientFromAllSubscriptions(ws) {
   });
 }
 
+async function restoreSubscriptions(ws) {
+  if (!redisClient || !ws.user?.id) return;
+
+  try {
+    const targets = await redisClient.smembers(`user:subscriptions:${ws.user.id}`);
+
+    ws.subscriptionTargets ??= new Set();
+
+    for (const targetId of targets) {
+      if (!trackingSubscriptions.has(targetId)) {
+        trackingSubscriptions.set(targetId, new Set());
+      }
+
+      trackingSubscriptions.get(targetId).add(ws);
+      ws.subscriptionTargets.add(targetId);
+    }
+  } catch (err) {
+    console.error('Subscription restoration error:', err.message);
+  }
+}
+
 export const __testing = {
   resetTrackingSubscriptions() {
     trackingSubscriptions.clear();
+  },
+  async restoreSubscriptions(ws) {
+    await restoreSubscriptions(ws);
+  },
+  getTrackingSubscriptions() {
+    return trackingSubscriptions;
   },
   flushTelemetryBuffer,
   removeClientFromAllSubscriptions,

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -600,14 +600,27 @@ async function removeClientFromAllSubscriptions(ws) {
 }
 
 async function restoreSubscriptions(ws) {
-  if (!redisClient || !ws.user?.id) return;
+  const subscriberId = ws.user?.id || ws.driverId;
+  if (!redisClient || !subscriberId) return;
 
   try {
-    const targets = await redisClient.smembers(`user:subscriptions:${ws.user.id}`);
+    const targets = await redisClient.smembers(`user:subscriptions:${subscriberId}`);
 
     ws.subscriptionTargets ??= new Set();
 
     for (const targetId of targets) {
+      const allowed = await canSubscribe(
+        ws,
+        targetId.startsWith('ORDER-')
+          ? { order_display_id: targetId }
+          : { driver_id: targetId }
+      );
+
+      if (!allowed) {
+        await redisClient.srem(`user:subscriptions:${subscriberId}`, targetId);
+        continue;
+      }
+
       if (!trackingSubscriptions.has(targetId)) {
         trackingSubscriptions.set(targetId, new Set());
       }

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -516,6 +516,7 @@ export async function handleSubscribe(ws, data) {
       const subscriberId = ws.user?.id || ws.driverId;
       if (subscriberId) {
         await redisClient.sadd(`user:subscriptions:${subscriberId}`, targetId);
+        await redisClient.persist(`user:subscriptions:${subscriberId}`);
       }
     } catch (err) {
       console.error('Redis subscription persistence error:', err.message);
@@ -597,6 +598,31 @@ async function removeClientFromAllSubscriptions(ws) {
       trackingSubscriptions.delete(key);
     }
   });
+
+  if (redisClient) {
+    const subscriberId = ws.user?.id || ws.driverId;
+    if (subscriberId) {
+      let hasOtherSockets = false;
+      if (wsServer && wsServer.clients) {
+        for (const client of wsServer.clients) {
+          if (client !== ws && client.readyState === 1) {
+            const clientUserId = client.user?.id || client.driverId;
+            if (clientUserId === subscriberId) {
+              hasOtherSockets = true;
+              break;
+            }
+          }
+        }
+      }
+      if (!hasOtherSockets) {
+        try {
+          await redisClient.expire(`user:subscriptions:${subscriberId}`, 3600);
+        } catch (err) {
+          console.error('Redis subscription expire error on disconnect:', err.message);
+        }
+      }
+    }
+  }
 }
 
 async function restoreSubscriptions(ws) {
@@ -607,6 +633,10 @@ async function restoreSubscriptions(ws) {
     const targets = await redisClient.smembers(`user:subscriptions:${subscriberId}`);
 
     ws.subscriptionTargets ??= new Set();
+
+    if (targets.length > 0) {
+      await redisClient.persist(`user:subscriptions:${subscriberId}`);
+    }
 
     for (const targetId of targets) {
       const allowed = await canSubscribe(

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -204,12 +204,16 @@ export function initWebSocketServer(server) {
 
     ws.on('close', () => {
       console.log('🔌 WebSocket connection closed.');
-      removeClientFromAllSubscriptions(ws);
+      void (async () => {
+        await removeClientFromAllSubscriptions(ws);
+      })();
     });
 
     ws.on('error', (err) => {
       console.error('🔌 WebSocket client error:', err.message);
-      removeClientFromAllSubscriptions(ws);
+      void (async () => {
+        await removeClientFromAllSubscriptions(ws);
+      })();
     });
   });
 
@@ -264,7 +268,7 @@ export async function handleTrackingMessage(ws, message) {
         break;
 
       case 'unsubscribe_tracking':
-        handleUnsubscribe(ws, data);
+        await handleUnsubscribe(ws, data);
         break;
 
       default:
@@ -503,8 +507,23 @@ export async function handleSubscribe(ws, data) {
   }
 
   trackingSubscriptions.get(targetId).add(ws);
+  ws.subscriptionTargets ??= new Set();
+  ws.subscriptionTargets.add(targetId);
+
+  if (redisClient) {
+    try {
+      const subscriberId = ws.user?.id || ws.driverId;
+      if (subscriberId) {
+        await redisClient.sadd(`tracking:subscriptions:${targetId}`, subscriberId);
+        await redisClient.expire(`tracking:subscriptions:${targetId}`, 3600);
+      }
+    } catch (err) {
+      console.error('Redis subscription persistence error:', err.message);
+    }
+  }
+
   console.log(`🔌 Client subscribed to telemetry updates for: "${targetId}"`);
-  ws.send(JSON.stringify({ status: 'subscribed', target: targetId }));
+  ws.send(JSON.stringify({ status: 'subscribed', target: targetId, reconnect_supported: true }));
 }
 
 async function canSubscribe(ws, { order_display_id, driver_id }) {
@@ -544,18 +563,44 @@ async function canSubscribe(ws, { order_display_id, driver_id }) {
   return order.customer_id === userId || order.driver_id === userId;
 }
 
-function handleUnsubscribe(ws, data) {
+async function handleUnsubscribe(ws, data) {
   const { order_display_id, driver_id } = data;
   const targetId = order_display_id || driver_id;
 
   if (targetId && trackingSubscriptions.has(targetId)) {
     trackingSubscriptions.get(targetId).delete(ws);
+    ws.subscriptionTargets?.delete(targetId);
+
+    if (redisClient) {
+      const subscriberId = ws.user?.id || ws.driverId;
+      try {
+        if (subscriberId) {
+          await redisClient.srem(`tracking:subscriptions:${targetId}`, subscriberId);
+        }
+      } catch (err) {
+        console.error('Redis subscription cleanup error:', err.message);
+      }
+    }
+
     console.log(`🔌 Client unsubscribed from updates for: "${targetId}"`);
     ws.send(JSON.stringify({ status: 'unsubscribed', target: targetId }));
   }
 }
 
-function removeClientFromAllSubscriptions(ws) {
+async function removeClientFromAllSubscriptions(ws) {
+  if (redisClient && ws.subscriptionTargets?.size) {
+    const subscriberId = ws.user?.id || ws.driverId;
+    if (subscriberId) {
+      for (const targetId of ws.subscriptionTargets) {
+        try {
+          await redisClient.srem(`tracking:subscriptions:${targetId}`, subscriberId);
+        } catch (err) {
+          console.error('Redis subscription cleanup error:', err.message);
+        }
+      }
+    }
+  }
+
   trackingSubscriptions.forEach((clients, key) => {
     if (clients.has(ws)) {
       clients.delete(ws);

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -747,12 +747,11 @@ describe('removeClientFromAllSubscriptions', () => {
 describe('tracker Redis subscription metadata', () => {
   it('persists subscriptions in Redis when available', async () => {
     const sadd = vi.fn().mockResolvedValue(1);
-    const expire = vi.fn().mockResolvedValue(1);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd, expire, srem: vi.fn() },
+      redisClient: { sadd, smembers: vi.fn().mockResolvedValue([]), srem: vi.fn() },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -767,8 +766,7 @@ describe('tracker Redis subscription metadata', () => {
 
     await subscribeWithRedis(ws, { driver_id: 'driver-redis' });
 
-    expect(sadd).toHaveBeenCalledWith('tracking:subscriptions:driver-redis', 'driver-redis');
-    expect(expire).toHaveBeenCalledWith('tracking:subscriptions:driver-redis', 3600);
+    expect(sadd).toHaveBeenCalledWith('user:subscriptions:driver-redis', 'driver-redis');
     expect(sentMessages[0]).toEqual({
       status: 'subscribed',
       target: 'driver-redis',
@@ -778,13 +776,13 @@ describe('tracker Redis subscription metadata', () => {
 
   it('cleans up Redis subscription metadata on disconnect and supports re-subscription after reconnect', async () => {
     const sadd = vi.fn().mockResolvedValue(1);
-    const expire = vi.fn().mockResolvedValue(1);
     const srem = vi.fn().mockResolvedValue(1);
+    const smembers = vi.fn().mockResolvedValue([]);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd, expire, srem },
+      redisClient: { sadd, srem, smembers },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -801,7 +799,7 @@ describe('tracker Redis subscription metadata', () => {
     await redisTesting.removeClientFromAllSubscriptions(ws);
     await subscribeWithRedis(ws, { driver_id: 'driver-reconnect' });
 
-    expect(srem).toHaveBeenCalledWith('tracking:subscriptions:driver-reconnect', 'driver-reconnect');
+    expect(srem).not.toHaveBeenCalled();
     expect(ws.send).toHaveBeenLastCalledWith(
       JSON.stringify({
         status: 'subscribed',
@@ -809,6 +807,54 @@ describe('tracker Redis subscription metadata', () => {
         reconnect_supported: true,
       })
     );
+  });
+
+  it('restores subscriptions from Redis on reconnect', async () => {
+    const smembers = vi.fn().mockResolvedValue(['driver-1']);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { sadd: vi.fn(), smembers, srem: vi.fn() },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { __testing: redisTesting } = await import('../../src/sockets/tracker.js');
+    const ws = {
+      user: { id: 'driver-redis', role: 'driver' },
+      driverId: 'driver-redis',
+      send: vi.fn(),
+    };
+
+    await redisTesting.restoreSubscriptions(ws);
+
+    expect(smembers).toHaveBeenCalledWith('user:subscriptions:driver-redis');
+    expect(redisTesting.getTrackingSubscriptions().get('driver-1')?.has(ws)).toBe(true);
+    expect(ws.subscriptionTargets.has('driver-1')).toBe(true);
+  });
+
+  it('restores subscriptions from Redis on reconnect after a fresh socket is authenticated', async () => {
+    const smembers = vi.fn().mockResolvedValue(['driver-1']);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { sadd: vi.fn(), smembers, srem: vi.fn() },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { __testing: redisTesting } = await import('../../src/sockets/tracker.js');
+    const restoredWs = {
+      user: { id: 'driver-redis', role: 'driver' },
+      driverId: 'driver-redis',
+      send: vi.fn(),
+    };
+
+    await redisTesting.restoreSubscriptions(restoredWs);
+
+    expect(redisTesting.getTrackingSubscriptions().get('driver-1')?.has(restoredWs)).toBe(true);
   });
 });
 

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -834,27 +834,42 @@ describe('tracker Redis subscription metadata', () => {
     expect(ws.subscriptionTargets.has('driver-1')).toBe(true);
   });
 
-  it('restores subscriptions from Redis on reconnect after a fresh socket is authenticated', async () => {
-    const smembers = vi.fn().mockResolvedValue(['driver-1']);
+  it('does not restore unauthorized subscriptions and prunes stale Redis entries', async () => {
+    const smembers = vi.fn().mockResolvedValue(['ORDER-1']);
+    const srem = vi.fn().mockResolvedValue(1);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd: vi.fn(), smembers, srem: vi.fn() },
+      redisClient: { sadd: vi.fn(), smembers, srem },
       firebaseAdmin: null,
-      supabase: null,
+      supabase: {
+        from() {
+          return {
+            select() {
+              return this;
+            },
+            eq() {
+              return this;
+            },
+            async maybeSingle() {
+              return { data: null, error: null };
+            },
+          };
+        },
+      },
     }));
 
     const { __testing: redisTesting } = await import('../../src/sockets/tracker.js');
-    const restoredWs = {
-      user: { id: 'driver-redis', role: 'driver' },
-      driverId: 'driver-redis',
+    const ws = {
+      user: { id: 'customer-1', role: 'customer' },
       send: vi.fn(),
     };
 
-    await redisTesting.restoreSubscriptions(restoredWs);
+    await redisTesting.restoreSubscriptions(ws);
 
-    expect(redisTesting.getTrackingSubscriptions().get('driver-1')?.has(restoredWs)).toBe(true);
+    expect(redisTesting.getTrackingSubscriptions().has('ORDER-1')).toBe(false);
+    expect(srem).toHaveBeenCalledWith('user:subscriptions:customer-1', 'ORDER-1');
   });
 });
 

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -747,11 +747,18 @@ describe('removeClientFromAllSubscriptions', () => {
 describe('tracker Redis subscription metadata', () => {
   it('persists subscriptions in Redis when available', async () => {
     const sadd = vi.fn().mockResolvedValue(1);
+    const persist = vi.fn().mockResolvedValue(1);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd, smembers: vi.fn().mockResolvedValue([]), srem: vi.fn() },
+      redisClient: {
+        sadd,
+        smembers: vi.fn().mockResolvedValue([]),
+        srem: vi.fn(),
+        persist,
+        expire: vi.fn().mockResolvedValue(1),
+      },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -767,6 +774,7 @@ describe('tracker Redis subscription metadata', () => {
     await subscribeWithRedis(ws, { driver_id: 'driver-redis' });
 
     expect(sadd).toHaveBeenCalledWith('user:subscriptions:driver-redis', 'driver-redis');
+    expect(persist).toHaveBeenCalledWith('user:subscriptions:driver-redis');
     expect(sentMessages[0]).toEqual({
       status: 'subscribed',
       target: 'driver-redis',
@@ -778,11 +786,13 @@ describe('tracker Redis subscription metadata', () => {
     const sadd = vi.fn().mockResolvedValue(1);
     const srem = vi.fn().mockResolvedValue(1);
     const smembers = vi.fn().mockResolvedValue([]);
+    const expire = vi.fn().mockResolvedValue(1);
+    const persist = vi.fn().mockResolvedValue(1);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd, srem, smembers },
+      redisClient: { sadd, srem, smembers, expire, persist },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -797,6 +807,8 @@ describe('tracker Redis subscription metadata', () => {
 
     await subscribeWithRedis(ws, { driver_id: 'driver-reconnect' });
     await redisTesting.removeClientFromAllSubscriptions(ws);
+    expect(expire).toHaveBeenCalledWith('user:subscriptions:driver-reconnect', 3600);
+
     await subscribeWithRedis(ws, { driver_id: 'driver-reconnect' });
 
     expect(srem).not.toHaveBeenCalled();
@@ -810,12 +822,19 @@ describe('tracker Redis subscription metadata', () => {
   });
 
   it('restores subscriptions from Redis on reconnect', async () => {
-    const smembers = vi.fn().mockResolvedValue(['driver-1']);
+    const smembers = vi.fn().mockResolvedValue(['driver-redis']);
+    const persist = vi.fn().mockResolvedValue(1);
 
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd: vi.fn(), smembers, srem: vi.fn() },
+      redisClient: {
+        sadd: vi.fn(),
+        smembers,
+        srem: vi.fn(),
+        persist,
+        expire: vi.fn().mockResolvedValue(1),
+      },
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -830,8 +849,9 @@ describe('tracker Redis subscription metadata', () => {
     await redisTesting.restoreSubscriptions(ws);
 
     expect(smembers).toHaveBeenCalledWith('user:subscriptions:driver-redis');
-    expect(redisTesting.getTrackingSubscriptions().get('driver-1')?.has(ws)).toBe(true);
-    expect(ws.subscriptionTargets.has('driver-1')).toBe(true);
+    expect(persist).toHaveBeenCalledWith('user:subscriptions:driver-redis');
+    expect(redisTesting.getTrackingSubscriptions().get('driver-redis')?.has(ws)).toBe(true);
+    expect(ws.subscriptionTargets.has('driver-redis')).toBe(true);
   });
 
   it('does not restore unauthorized subscriptions and prunes stale Redis entries', async () => {
@@ -841,7 +861,13 @@ describe('tracker Redis subscription metadata', () => {
     vi.resetModules();
     vi.doMock('../../src/config/db.js', () => ({
       mongoDb: null,
-      redisClient: { sadd: vi.fn(), smembers, srem },
+      redisClient: {
+        sadd: vi.fn(),
+        smembers,
+        srem,
+        persist: vi.fn().mockResolvedValue(1),
+        expire: vi.fn().mockResolvedValue(1),
+      },
       firebaseAdmin: null,
       supabase: {
         from() {

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -121,7 +121,7 @@ describe('tracker WebSocket telemetry authorization', () => {
 
     await handleSubscribe(ws, { order_display_id: 'ORDER-123' });
 
-    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'ORDER-123' }]);
+    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'ORDER-123', reconnect_supported: true }]);
   });
 
   it('allows a driver to subscribe only to their own driver tracking stream', async () => {
@@ -136,7 +136,7 @@ describe('tracker WebSocket telemetry authorization', () => {
 
     await handleSubscribe(ws, { driver_id: 'driver-owner' });
 
-    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'driver-owner' }]);
+    expect(sentMessages).toEqual([{ status: 'subscribed', target: 'driver-owner', reconnect_supported: true }]);
   });
 });
 
@@ -715,7 +715,7 @@ describe('removeClientFromAllSubscriptions', () => {
 
     await handleSubscribe(ws, { driver_id: 'driver-1' });
 
-    __testing.removeClientFromAllSubscriptions(ws);
+    await __testing.removeClientFromAllSubscriptions(ws);
 
     // Subscription should be cleaned up — no error thrown
     expect(true).toBe(true);
@@ -729,7 +729,7 @@ describe('removeClientFromAllSubscriptions', () => {
     };
 
     await handleSubscribe(ws, { driver_id: 'driver-2' });
-    __testing.removeClientFromAllSubscriptions(ws);
+    await __testing.removeClientFromAllSubscriptions(ws);
 
     // Subscribe again to verify map was cleaned (no duplicate sets)
     const ws2 = {
@@ -739,7 +739,75 @@ describe('removeClientFromAllSubscriptions', () => {
     };
     await handleSubscribe(ws2, { driver_id: 'driver-2' });
     expect(ws2.send).toHaveBeenCalledWith(
-      JSON.stringify({ status: 'subscribed', target: 'driver-2' })
+      JSON.stringify({ status: 'subscribed', target: 'driver-2', reconnect_supported: true })
+    );
+  });
+});
+
+describe('tracker Redis subscription metadata', () => {
+  it('persists subscriptions in Redis when available', async () => {
+    const sadd = vi.fn().mockResolvedValue(1);
+    const expire = vi.fn().mockResolvedValue(1);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { sadd, expire, srem: vi.fn() },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleSubscribe: subscribeWithRedis } = await import('../../src/sockets/tracker.js');
+    const sentMessages = [];
+    const ws = {
+      user: { id: 'driver-redis', role: 'driver' },
+      driverId: 'driver-redis',
+      send(msg) { sentMessages.push(JSON.parse(msg)); },
+    };
+
+    await subscribeWithRedis(ws, { driver_id: 'driver-redis' });
+
+    expect(sadd).toHaveBeenCalledWith('tracking:subscriptions:driver-redis', 'driver-redis');
+    expect(expire).toHaveBeenCalledWith('tracking:subscriptions:driver-redis', 3600);
+    expect(sentMessages[0]).toEqual({
+      status: 'subscribed',
+      target: 'driver-redis',
+      reconnect_supported: true,
+    });
+  });
+
+  it('cleans up Redis subscription metadata on disconnect and supports re-subscription after reconnect', async () => {
+    const sadd = vi.fn().mockResolvedValue(1);
+    const expire = vi.fn().mockResolvedValue(1);
+    const srem = vi.fn().mockResolvedValue(1);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { sadd, expire, srem },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleSubscribe: subscribeWithRedis, __testing: redisTesting } = await import('../../src/sockets/tracker.js');
+    const ws = {
+      user: { id: 'driver-reconnect', role: 'driver' },
+      driverId: 'driver-reconnect',
+      subscriptionTargets: new Set(),
+      send: vi.fn(),
+    };
+
+    await subscribeWithRedis(ws, { driver_id: 'driver-reconnect' });
+    await redisTesting.removeClientFromAllSubscriptions(ws);
+    await subscribeWithRedis(ws, { driver_id: 'driver-reconnect' });
+
+    expect(srem).toHaveBeenCalledWith('tracking:subscriptions:driver-reconnect', 'driver-reconnect');
+    expect(ws.send).toHaveBeenLastCalledWith(
+      JSON.stringify({
+        status: 'subscribed',
+        target: 'driver-reconnect',
+        reconnect_supported: true,
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes #463 by improving WebSocket tracking subscription resilience.

### Changes Made

#### Tracking Subscription Persistence

* Added Redis-backed persistence for tracking subscription metadata.
* Stores active subscriber identifiers using Redis sets keyed by tracking target.
* Added TTL support to prevent stale metadata accumulation.

#### Subscription Lifecycle

* Persist subscription metadata on subscribe.
* Remove metadata on unsubscribe.
* Clean up all tracked subscriptions when a WebSocket disconnects or errors.

#### Reconnect Support

* Added `reconnect_supported: true` to subscription acknowledgements.
* Enables clients to detect reconnect-capable tracking sessions while preserving backward compatibility.

#### Tests

* Added coverage for Redis persistence during subscribe.
* Added coverage for Redis cleanup during unsubscribe and disconnect.
* Updated subscription acknowledgement assertions.

### Notes

This implementation persists subscription metadata and improves reconnect handling. It does not restore active WebSocket subscriptions after a server restart, as live socket state cannot be reconstructed from Redis alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subscription confirmation messages now include `reconnect_supported: true` to support client reconnect flows.
  * Subscription membership is now persisted and restored after WebSocket authentication to maintain tracking continuity.

* **Bug Fixes**
  * Improved WebSocket cleanup for `close`/`error` and unsubscribe handling to ensure subscription state is reliably removed.

* **Tests**
  * Expanded unit tests to verify reconnect support fields, Redis-backed persistence and cleanup, and restoration behavior including pruning stale or unauthorized entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->