### PR TITLE
fix: require authentication for document operations

### DIFF
--- a/apps/driver/lib/core/driver_session.dart
+++ b/apps/driver/lib/core/driver_session.dart
@@ -1,4 +1,4 @@
 class DriverSession {
-  static String driverId = const String.fromEnvironment('DRIVER_ID', defaultValue: 'demo-driver');
+  static String driverId =
+      const String.fromEnvironment('DRIVER_ID', defaultValue: '');
 }
-

--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -1,10 +1,88 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-
-import '../data/mock_data.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_driver/core/driver_session.dart';
 import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
+
+class DriverDocument {
+  const DriverDocument({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.docNumber,
+    required this.lastVerified,
+    required this.validUntil,
+    required this.statusTone,
+    required this.statusLabel,
+  });
+
+  final String id;
+  final String title;
+  final String subtitle;
+  final String docNumber;
+  final String lastVerified;
+  final String validUntil;
+  final String statusTone;
+  final String statusLabel;
+
+  factory DriverDocument.fromMap(Map<String, dynamic> map) {
+    final docType = map['doc_type'] as String? ?? '';
+    final status = map['status'] as String? ?? 'pending';
+
+    return DriverDocument(
+      id: map['id'] as String,
+      title: _docTypeLabel(docType),
+      subtitle: _docTypeSubtitle(docType),
+      docNumber: (map['id'] as String).substring(0, 8).toUpperCase(),
+      lastVerified: _formatDate(map['last_verified_at'] as String?),
+      validUntil: _formatDate(map['valid_until'] as String?),
+      statusTone: status == 'expiring_soon' ? 'warning' : 'verified',
+      statusLabel: 'Document No.',
+    );
+  }
+
+  static String _docTypeLabel(String docType) {
+    const labels = {
+      'rc_book': 'RC Book',
+      'driving_licence': 'Driving Licence',
+      'insurance': 'Insurance Policy',
+      'puc': 'Pollution Certificate',
+      'aadhar': 'Aadhaar Card',
+      'pan': 'PAN Card',
+      'business_license': 'Business License',
+      'bank_account': 'Bank Account',
+    };
+    return labels[docType] ?? docType;
+  }
+
+  static String _docTypeSubtitle(String docType) {
+    const subtitles = {
+      'rc_book': 'Vehicle Registration Certificate',
+      'driving_licence': 'Motor Vehicle Act License',
+      'insurance': 'Commercial Vehicle Policy',
+      'puc': 'Pollution Under Control Certificate',
+      'aadhar': 'Government ID Proof',
+      'pan': 'Income Tax Identity',
+      'business_license': 'Business Registration',
+      'bank_account': 'Bank Account Details',
+    };
+    return subtitles[docType] ?? '';
+  }
+
+  static String _formatDate(String? raw) {
+    if (raw == null) return '—';
+    try {
+      final dt = DateTime.parse(raw);
+      return '${dt.day.toString().padLeft(2, '0')}/'
+          '${dt.month.toString().padLeft(2, '0')}/'
+          '${dt.year}';
+    } catch (_) {
+      return raw;
+    }
+  }
+}
 
 class DocumentsScreen extends StatefulWidget {
   const DocumentsScreen({super.key});
@@ -14,9 +92,51 @@ class DocumentsScreen extends StatefulWidget {
 }
 
 class _DocumentsScreenState extends State<DocumentsScreen> {
+  final _supabase = Supabase.instance.client;
+
   String? _selectedUploadType;
+  late final Future<List<DriverDocument>> _documentsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _documentsFuture = _fetchDocuments();
+  }
+
+  Future<List<DriverDocument>> _fetchDocuments() async {
+    final driverId = DriverSession.driverId;
+
+    if (driverId.isEmpty) {
+      throw const AuthException('No authenticated user. Please log in again.');
+    }
+
+    final response = await _supabase
+        .from('documents')
+        .select()
+        .eq('user_id', driverId)
+        .order('created_at', ascending: false);
+
+    return (response as List)
+        .map((row) => DriverDocument.fromMap(row as Map<String, dynamic>))
+        .toList();
+  }
+
+  bool _requireAuth(BuildContext context) {
+    if (DriverSession.driverId.isNotEmpty) return true;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('You must be logged in to upload documents.'),
+        backgroundColor: TruxifyColors.error,
+      ),
+    );
+    return false;
+  }
+
 
   Future<void> _simulateUpload(BuildContext context, String docType) async {
+    if (!_requireAuth(context)) return;
+
     double progress = 0.0;
     String statusText = 'Reading file contents...';
     bool isDone = false;
@@ -32,7 +152,6 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       builder: (context) {
         return StatefulBuilder(
           builder: (context, setSheetState) {
-            // Start a timer to increment progress
             if (progress == 0.0) {
               Timer.periodic(const Duration(milliseconds: 300), (timer) {
                 if (!context.mounted) {
@@ -45,7 +164,6 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                     progress = 1.0;
                     statusText = 'Verifying document...';
                     timer.cancel();
-                    // Complete after verification delay
                     Future.delayed(const Duration(milliseconds: 800), () {
                       if (context.mounted) {
                         setSheetState(() {
@@ -158,6 +276,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
   }
 
   Future<void> _showUploadSheet(BuildContext context) async {
+    if (!_requireAuth(context)) return;
+
     String selectedType = _selectedUploadType ?? 'RC Book';
     await showModalBottomSheet<void>(
       context: context,
@@ -204,10 +324,14 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                             margin: const EdgeInsets.only(bottom: 8),
                             padding: const EdgeInsets.all(14),
                             decoration: BoxDecoration(
-                              color: isSelected ? TruxifyColors.accentLight : Colors.grey.shade50,
+                              color: isSelected
+                                  ? TruxifyColors.accentLight
+                                  : Colors.grey.shade50,
                               borderRadius: BorderRadius.circular(12),
                               border: Border.all(
-                                color: isSelected ? TruxifyColors.accent : Colors.grey.shade200,
+                                color: isSelected
+                                    ? TruxifyColors.accent
+                                    : Colors.grey.shade200,
                               ),
                             ),
                             child: Row(
@@ -217,12 +341,15 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                                   type,
                                   style: GoogleFonts.dmSans(
                                     fontSize: 14,
-                                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                                    fontWeight: isSelected
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
                                     color: TruxifyColors.primaryText,
                                   ),
                                 ),
                                 if (isSelected)
-                                  const Icon(Icons.check_circle_rounded, color: TruxifyColors.accent),
+                                  const Icon(Icons.check_circle_rounded,
+                                      color: TruxifyColors.accent),
                               ],
                             ),
                           ),
@@ -282,9 +409,12 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                     decoration: BoxDecoration(
-                      color: isWarning ? TruxifyColors.warningLight : TruxifyColors.successLight,
+                      color: isWarning
+                          ? TruxifyColors.warningLight
+                          : TruxifyColors.successLight,
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
@@ -292,7 +422,9 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                       style: GoogleFonts.dmSans(
                         fontSize: 10,
                         fontWeight: FontWeight.bold,
-                        color: isWarning ? TruxifyColors.warning : TruxifyColors.success,
+                        color: isWarning
+                            ? TruxifyColors.warning
+                            : TruxifyColors.success,
                       ),
                     ),
                   ),
@@ -310,37 +442,64 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                 child: Column(
                   children: [
                     Icon(
-                      isWarning ? Icons.warning_amber_rounded : Icons.verified_user_rounded,
-                      color: isWarning ? TruxifyColors.warning : TruxifyColors.success,
+                      isWarning
+                          ? Icons.warning_amber_rounded
+                          : Icons.verified_user_rounded,
+                      color: isWarning
+                          ? TruxifyColors.warning
+                          : TruxifyColors.success,
                       size: 48,
                     ),
                     const SizedBox(height: 12),
                     Text(
                       'Document Status',
-                      style: GoogleFonts.dmSans(fontSize: 13, fontWeight: FontWeight.bold, color: TruxifyColors.primaryText),
+                      style: GoogleFonts.dmSans(
+                          fontSize: 13,
+                          fontWeight: FontWeight.bold,
+                          color: TruxifyColors.primaryText),
                     ),
                     const SizedBox(height: 20),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text('Document ID:', style: GoogleFonts.dmSans(fontSize: 12, color: TruxifyColors.hintText)),
-                        Text(docNumber, style: GoogleFonts.robotoMono(fontSize: 11, fontWeight: FontWeight.bold, color: TruxifyColors.primaryText)),
+                        Text('Document ID:',
+                            style: GoogleFonts.dmSans(
+                                fontSize: 12, color: TruxifyColors.hintText)),
+                        Text(docNumber,
+                            style: GoogleFonts.robotoMono(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: TruxifyColors.primaryText)),
                       ],
                     ),
                     const Divider(height: 16, color: TruxifyColors.border),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text('Last Verified:', style: GoogleFonts.dmSans(fontSize: 12, color: TruxifyColors.hintText)),
-                        Text(lastVerified, style: GoogleFonts.dmSans(fontSize: 12, fontWeight: FontWeight.bold, color: TruxifyColors.primaryText)),
+                        Text('Last Verified:',
+                            style: GoogleFonts.dmSans(
+                                fontSize: 12, color: TruxifyColors.hintText)),
+                        Text(lastVerified,
+                            style: GoogleFonts.dmSans(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: TruxifyColors.primaryText)),
                       ],
                     ),
                     const Divider(height: 16, color: TruxifyColors.border),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text('Valid Until:', style: GoogleFonts.dmSans(fontSize: 12, color: TruxifyColors.hintText)),
-                        Text(validUntil, style: GoogleFonts.dmSans(fontSize: 12, fontWeight: FontWeight.bold, color: isWarning ? TruxifyColors.warning : TruxifyColors.primaryText)),
+                        Text('Valid Until:',
+                            style: GoogleFonts.dmSans(
+                                fontSize: 12, color: TruxifyColors.hintText)),
+                        Text(validUntil,
+                            style: GoogleFonts.dmSans(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: isWarning
+                                    ? TruxifyColors.warning
+                                    : TruxifyColors.primaryText)),
                       ],
                     ),
                   ],
@@ -354,7 +513,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                       child: OutlinedButton(
                         style: OutlinedButton.styleFrom(
                           padding: const EdgeInsets.symmetric(vertical: 14),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12)),
                           side: const BorderSide(color: TruxifyColors.accent),
                         ),
                         onPressed: () {
@@ -395,7 +555,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         backgroundColor: Colors.white,
         elevation: 0,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back_rounded, color: TruxifyColors.primaryText),
+          icon: const Icon(Icons.arrow_back_rounded,
+              color: TruxifyColors.primaryText),
           onPressed: () => Navigator.of(context).pop(),
         ),
         title: Text(
@@ -409,150 +570,270 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         shape: const Border(bottom: BorderSide(color: TruxifyColors.border)),
       ),
       body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-          children: [
-            ...documentRecords.map((document) {
-              final isWarning = document.statusTone == 'warning';
-              return Padding(
-                padding: const EdgeInsets.only(bottom: 14),
-                child: AppCard(
+        child: FutureBuilder<List<DriverDocument>>(
+          future: _documentsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.hasError) {
+              final isAuthError = snapshot.error is AuthException;
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
                   child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Expanded(
-                            child: Text(
-                              document.title,
-                              style: GoogleFonts.dmSans(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                                color: TruxifyColors.primaryText,
-                              ),
-                            ),
-                          ),
-                          Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: isWarning ? TruxifyColors.warningLight : TruxifyColors.accentLight,
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Text(
-                              isWarning ? 'Expiring Soon' : 'Verified',
-                              style: GoogleFonts.dmSans(
-                                fontSize: 10,
-                                fontWeight: FontWeight.bold,
-                                color: isWarning ? TruxifyColors.warning : TruxifyColors.accentDark,
-                              ),
-                            ),
-                          ),
-                        ],
+                      Icon(
+                        isAuthError
+                            ? Icons.lock_outline_rounded
+                            : Icons.error_outline_rounded,
+                        size: 56,
+                        color: TruxifyColors.error,
                       ),
-                      const SizedBox(height: 6),
+                      const SizedBox(height: 16),
                       Text(
-                        document.subtitle,
+                        isAuthError
+                            ? 'Session Expired'
+                            : 'Could Not Load Documents',
                         style: GoogleFonts.dmSans(
-                          fontSize: 12,
-                          color: TruxifyColors.secondaryText,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: TruxifyColors.primaryText,
                         ),
                       ),
-                      const SizedBox(height: 12),
-                      const Divider(height: 1, color: TruxifyColors.border),
-                      const SizedBox(height: 12),
-                      _DocLine(label: document.statusLabel, value: document.docNumber, isMonospace: true),
-                      _DocLine(label: 'Last verified', value: document.lastVerified),
-                      _DocLine(label: 'Valid until', value: document.validUntil, isWarning: isWarning),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: OutlinedButton(
-                              style: OutlinedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(vertical: 12),
-                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                                side: const BorderSide(color: TruxifyColors.border),
-                              ),
-                              onPressed: () => _showDocumentPreviewSheet(
-                      context,
-                      document.title,
-                      document.docNumber,
-                      document.lastVerified,
-                      document.validUntil,
-                      isWarning,
-                              ),
-                              child: Text(
-                                'View',
-                                style: GoogleFonts.dmSans(
-                                  fontWeight: FontWeight.bold,
-                                  color: TruxifyColors.secondaryText,
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: PrimaryButton(
-                              label: isWarning ? 'Renew Now' : 'Re-verify',
-                              onPressed: () {
-                                if (isWarning) {
-                                  _simulateUpload(context, document.title);
-                                } else {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text('${document.title} re-verification request sent to RTO Node.'),
-                                      backgroundColor: TruxifyColors.success,
-                                    ),
-                                  );
-                                }
-                              },
-                            ),
-                          ),
-                        ],
+                      const SizedBox(height: 8),
+                      Text(
+                        isAuthError
+                            ? 'Please log in again to view your documents.'
+                            : snapshot.error.toString(),
+                        style: GoogleFonts.dmSans(
+                          fontSize: 13,
+                          color: TruxifyColors.secondaryText,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
+                      if (isAuthError) ...[
+                        const SizedBox(height: 24),
+                        PrimaryButton(
+                          label: 'Go to Login',
+                          onPressed: () =>
+                              Navigator.of(context).pushReplacementNamed('/login'),
+                        ),
+                      ],
                     ],
                   ),
                 ),
               );
-            }),
-            GestureDetector(
-              onTap: () => _showUploadSheet(context),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: TruxifyColors.accent.withOpacity(0.3), style: BorderStyle.solid),
-                ),
+            }
+
+            if (!snapshot.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final documents = snapshot.data!;
+
+            if (documents.isEmpty) {
+              return Center(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 28, horizontal: 16),
+                  padding: const EdgeInsets.all(32),
                   child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      const Icon(Icons.cloud_upload_outlined, color: TruxifyColors.accent, size: 36),
-                      const SizedBox(height: 10),
+                      const Icon(Icons.folder_open_rounded,
+                          size: 56, color: TruxifyColors.hintText),
+                      const SizedBox(height: 16),
                       Text(
-                        'Upload New Document',
+                        'No Documents Yet',
                         style: GoogleFonts.dmSans(
-                          fontSize: 14,
+                          fontSize: 16,
                           fontWeight: FontWeight.bold,
-                          color: TruxifyColors.accentDark,
+                          color: TruxifyColors.primaryText,
                         ),
                       ),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 8),
                       Text(
-                        'RC Book, Driving Licence, Insurance, PUC Certificate',
+                        'Upload your RC Book, Driving Licence, or other documents to get started.',
                         style: GoogleFonts.dmSans(
-                          fontSize: 11,
-                          color: TruxifyColors.hintText,
+                          fontSize: 13,
+                          color: TruxifyColors.secondaryText,
                         ),
                         textAlign: TextAlign.center,
                       ),
                     ],
                   ),
                 ),
-              ),
-            ),
-          ],
+              );
+            }
+
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+              children: [
+                ...documents.map((document) {
+                  final isWarning = document.statusTone == 'warning';
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 14),
+                    child: AppCard(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  document.title,
+                                  style: GoogleFonts.dmSans(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: TruxifyColors.primaryText,
+                                  ),
+                                ),
+                              ),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: isWarning
+                                      ? TruxifyColors.warningLight
+                                      : TruxifyColors.accentLight,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  isWarning ? 'Expiring Soon' : 'Verified',
+                                  style: GoogleFonts.dmSans(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                    color: isWarning
+                                        ? TruxifyColors.warning
+                                        : TruxifyColors.accentDark,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            document.subtitle,
+                            style: GoogleFonts.dmSans(
+                              fontSize: 12,
+                              color: TruxifyColors.secondaryText,
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          const Divider(height: 1, color: TruxifyColors.border),
+                          const SizedBox(height: 12),
+                          _DocLine(
+                              label: document.statusLabel,
+                              value: document.docNumber,
+                              isMonospace: true),
+                          _DocLine(
+                              label: 'Last verified',
+                              value: document.lastVerified),
+                          _DocLine(
+                              label: 'Valid until',
+                              value: document.validUntil,
+                              isWarning: isWarning),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: OutlinedButton(
+                                  style: OutlinedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 12),
+                                    shape: RoundedRectangleBorder(
+                                        borderRadius:
+                                            BorderRadius.circular(12)),
+                                    side: const BorderSide(
+                                        color: TruxifyColors.border),
+                                  ),
+                                  onPressed: () => _showDocumentPreviewSheet(
+                                    context,
+                                    document.title,
+                                    document.docNumber,
+                                    document.lastVerified,
+                                    document.validUntil,
+                                    isWarning,
+                                  ),
+                                  child: Text(
+                                    'View',
+                                    style: GoogleFonts.dmSans(
+                                      fontWeight: FontWeight.bold,
+                                      color: TruxifyColors.secondaryText,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: PrimaryButton(
+                                  label: isWarning ? 'Renew Now' : 'Re-verify',
+                                  onPressed: () {
+                                    if (isWarning) {
+                                      _simulateUpload(context, document.title);
+                                    } else {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                              '${document.title} re-verification request sent to RTO Node.'),
+                                          backgroundColor: TruxifyColors.success,
+                                        ),
+                                      );
+                                    }
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }),
+
+                // Upload card
+                GestureDetector(
+                  onTap: () => _showUploadSheet(context),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                          color: TruxifyColors.accent.withOpacity(0.3),
+                          style: BorderStyle.solid),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 28, horizontal: 16),
+                      child: Column(
+                        children: [
+                          const Icon(Icons.cloud_upload_outlined,
+                              color: TruxifyColors.accent, size: 36),
+                          const SizedBox(height: 10),
+                          Text(
+                            'Upload New Document',
+                            style: GoogleFonts.dmSans(
+                              fontSize: 14,
+                              fontWeight: FontWeight.bold,
+                              color: TruxifyColors.accentDark,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'RC Book, Driving Licence, Insurance, PUC Certificate',
+                            style: GoogleFonts.dmSans(
+                              fontSize: 11,
+                              color: TruxifyColors.hintText,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );
@@ -597,7 +878,9 @@ class _DocLine extends StatelessWidget {
                 : GoogleFonts.dmSans(
                     fontSize: 12,
                     fontWeight: FontWeight.w600,
-                    color: isWarning ? TruxifyColors.warning : TruxifyColors.primaryText,
+                    color: isWarning
+                        ? TruxifyColors.warning
+                        : TruxifyColors.primaryText,
                   ),
           ),
         ],

--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -109,7 +109,7 @@ class DocumentsScreen extends StatefulWidget {
 }
 
 class _DocumentsScreenState extends State<DocumentsScreen> {
-  final _supabase = Supabase.instance.client;
+  SupabaseClient get _supabase => Supabase.instance.client;
 
   String? _selectedUploadType;
   late final Future<List<DriverDocument>> _documentsFuture;

--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -32,13 +32,18 @@ class DriverDocument {
     final status = map['status'] as String? ?? 'pending';
 
     return DriverDocument(
-      id: map['id'] as String,
+      id: map['id']?.toString() ?? '',
       title: _docTypeLabel(docType),
       subtitle: _docTypeSubtitle(docType),
-      docNumber: (map['id'] as String).substring(0, 8).toUpperCase(),
+      docNumber: () {
+        final rawId = map['id']?.toString() ?? '';
+        return rawId.length >= 8
+            ? rawId.substring(0, 8).toUpperCase()
+            : rawId.toUpperCase();
+      }(),
       lastVerified: _formatDate(map['last_verified_at'] as String?),
       validUntil: _formatDate(map['valid_until'] as String?),
-      statusTone: status == 'expiring_soon' ? 'warning' : 'verified',
+      statusTone: _statusTone(status),
       statusLabel: 'Document No.',
     );
   }
@@ -82,6 +87,18 @@ class DriverDocument {
       return raw;
     }
   }
+
+  static String _statusTone(String status) {
+    switch (status) {
+      case 'expiring_soon':
+      case 'expired':
+        return 'warning';
+      case 'verified':
+        return 'verified';
+      default:
+        return 'pending';
+    }
+  }
 }
 
 class DocumentsScreen extends StatefulWidget {
@@ -107,7 +124,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
     final driverId = DriverSession.driverId;
 
     if (driverId.isEmpty) {
-      throw const AuthException('No authenticated user. Please log in again.');
+      throw AuthException('No authenticated user. Please log in again.');
     }
 
     final response = await _supabase
@@ -132,7 +149,6 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
     );
     return false;
   }
-
 
   Future<void> _simulateUpload(BuildContext context, String docType) async {
     if (!_requireAuth(context)) return;
@@ -603,7 +619,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                       Text(
                         isAuthError
                             ? 'Please log in again to view your documents.'
-                            : snapshot.error.toString(),
+                            : 'Something went wrong. Please try again later.',
                         style: GoogleFonts.dmSans(
                           fontSize: 13,
                           color: TruxifyColors.secondaryText,
@@ -614,8 +630,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                         const SizedBox(height: 24),
                         PrimaryButton(
                           label: 'Go to Login',
-                          onPressed: () =>
-                              Navigator.of(context).pushReplacementNamed('/login'),
+                          onPressed: () => Navigator.of(context)
+                              .pushReplacementNamed('/login'),
                         ),
                       ],
                     ],
@@ -775,7 +791,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                                         SnackBar(
                                           content: Text(
                                               '${document.title} re-verification request sent to RTO Node.'),
-                                          backgroundColor: TruxifyColors.success,
+                                          backgroundColor:
+                                              TruxifyColors.success,
                                         ),
                                       );
                                     }


### PR DESCRIPTION
## Summary

This PR removes the hardcoded document user fallback and enforces authentication for all document-related operations in the Driver app.

## Changes Made

* Removed the hardcoded seed/demo user fallback from document operations.
* Updated `DriverSession` to use an empty default value instead of `demo-driver`.
* Added authentication checks before fetching documents.
* Added authentication guards for upload actions.
* Prevented unauthenticated users from accessing or modifying documents.
* Added error handling for expired or missing sessions.
* Added user-facing feedback through SnackBars and an authentication error screen.
* Redirects users to the login screen when authentication is unavailable.

## Security Improvements

This change prevents:

* Unauthorized access to seed/demo account documents.
* Incorrect document ownership assignment.
* Uploading documents under the wrong account.
* Silent authentication failures.

## Acceptance Criteria

* [x] Hardcoded seed UUID fallback removed.
* [x] Document operations require authentication.
* [x] Unauthenticated users cannot read documents.
* [x] Unauthenticated users cannot upload documents.
* [x] Proper error handling implemented.
* [x] Existing authenticated document workflows continue to function correctly.

## Files Modified

* `apps/driver/lib/core/driver_session.dart`
* `apps/driver/lib/screens/documents_screen.dart`

Closes https://github.com/KanishJebaMathewM/Truxify/issues/480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents now load from your account data instead of sample data.
  * Added document renewal and re-verification flows, including updated preview and action behavior.
* **Bug Fixes**
  * Improved authentication handling with clear error states and upload gating when no valid session/ID is available.
  * Verification dates, expiration info, and status-based labeling/styling are now derived consistently.
* **Chore**
  * Removed the demo driver fallback so document operations require an explicit driver ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->