### PR TITLE
feat(backend): connect earnings screen to backend wallet & earnings APIs

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -34,6 +34,12 @@ class _EarningsScreenState extends State<EarningsScreen> {
     _loadAllData();
   }
 
+  @override
+  void dispose() {
+    _earningsService.dispose();
+    super.dispose();
+  }
+
   Future<void> _loadAllData() async {
     await Future.wait([
       _loadMonthlyEarnings(),

--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -4,10 +4,14 @@ import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class DriverEarningsService {
-  DriverEarningsService({SupabaseClient? client, http.Client? httpClient, String? apiBaseUrl,})
-      : _providedClient = client,
-      _httpClient = httpClient ?? http.Client(),
-      _apiBaseUrl = (apiBaseUrl ?? defaultApiBaseUrl).replaceFirst(RegExp(r'/$'), '',);
+  DriverEarningsService({
+    SupabaseClient? client,
+    http.Client? httpClient,
+    String? apiBaseUrl,
+  })  : _providedClient = client,
+        _isClientOwned = httpClient == null,
+        _httpClient = httpClient ?? http.Client(),
+        _apiBaseUrl = (apiBaseUrl ?? defaultApiBaseUrl).replaceFirst(RegExp(r'/$'), '',);
 
   static const String defaultApiBaseUrl = String.fromEnvironment(
     'TRUXIFY_API_BASE_URL',
@@ -17,6 +21,7 @@ class DriverEarningsService {
   final SupabaseClient? _providedClient;
   SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
   final http.Client _httpClient;
+  final bool _isClientOwned;
   final String _apiBaseUrl;
 
   String? get driverId => _client.auth.currentUser?.id;
@@ -39,18 +44,40 @@ class DriverEarningsService {
       queryParameters: {'page': '$page', 'limit': '$limit'},
     );
 
-    final response = await _httpClient.get(uri, headers: _authHeaders);
-    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw Exception(
-        decoded['error']?.toString() ?? 'Failed to load wallet history.',
-      );
+    final http.Response response;
+    try {
+      response = await _httpClient.get(uri, headers: _authHeaders);
+    } catch (e) {
+      throw Exception('Network error: Failed to fetch wallet history.');
     }
 
-    final transactions = decoded['transactions'] as List<dynamic>? ?? [];
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } catch (_) {
+      throw Exception('Failed to parse wallet history response.');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final errorMsg = (decoded is Map) ? decoded['error']?.toString() : null;
+      throw Exception(errorMsg ?? 'Failed to load wallet history.');
+    }
+
+    if (decoded is! Map) {
+      throw Exception('Invalid wallet history response format.');
+    }
+
+    final transactions = decoded['transactions'];
+    if (transactions is! List) {
+      return [];
+    }
+
     return transactions
-        .map((t) => Map<String, dynamic>.from(t as Map))
+        .map((t) {
+          if (t is! Map) return null;
+          return Map<String, dynamic>.from(t);
+        })
+        .whereType<Map<String, dynamic>>()
         .toList();
   }
 
@@ -64,27 +91,64 @@ class DriverEarningsService {
     final today = DateTime.now();
 
     final daysSinceMonthStart = today.difference(start).inDays + 1;
+
+    // Fallback: If we query a historical month > 365 days ago,
+    // the backend API will reject it or return incomplete data.
+    // We fetch directly from the Supabase client for these older months.
+    if (daysSinceMonthStart > 365) {
+      final response = await _client
+          .from('earnings_daily')
+          .select()
+          .eq('driver_id', driverId!)
+          .gte('day_date', start.toIso8601String().split('T').first)
+          .lt('day_date', end.toIso8601String().split('T').first)
+          .order('day_date');
+      return List<Map<String, dynamic>>.from(response);
+    }
+
     final days = daysSinceMonthStart.clamp(1, 365);
 
     final uri = Uri.parse('$_apiBaseUrl/api/driver/earnings/summary').replace(
       queryParameters: {'days': '$days'},
     );
 
-    final response = await _httpClient.get(uri, headers: _authHeaders);
-    final decoded = jsonDecode(response.body);
+    final http.Response response;
+    try {
+      response = await _httpClient.get(uri, headers: _authHeaders);
+    } catch (e) {
+      throw Exception('Network error: Failed to fetch earnings summary.');
+    }
+
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } catch (_) {
+      throw Exception('Failed to parse earnings summary response.');
+    }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final error = decoded is Map ? decoded['error']?.toString() : null;
       throw Exception(error ?? 'Failed to load earnings summary.');
     }
 
-    return (decoded as List<dynamic>)
-        .map((e) => Map<String, dynamic>.from(e as Map))
+    if (decoded is! List) {
+      throw Exception('Invalid earnings summary response format.');
+    }
+
+    return decoded
+        .map((e) {
+          if (e is! Map) return null;
+          return Map<String, dynamic>.from(e);
+        })
+        .whereType<Map<String, dynamic>>()
         .where((e) {
-      final date = DateTime.tryParse(e['day_date'].toString());
-      if (date == null) return false;
-      return !date.isBefore(start) && date.isBefore(end);
-    }).toList();
+          final dateStr = e['day_date'];
+          if (dateStr == null) return false;
+          final date = DateTime.tryParse(dateStr.toString());
+          if (date == null) return false;
+          return !date.isBefore(start) && date.isBefore(end);
+        })
+        .toList();
   }
 
   Future<List<Map<String, dynamic>>> fetchCompletedTripsForDay({
@@ -103,5 +167,11 @@ class DriverEarningsService {
         .order('created_at', ascending: false);
 
     return List<Map<String, dynamic>>.from(response);
+  }
+
+  void dispose() {
+    if (_isClientOwned) {
+      _httpClient.close();
+    }
   }
 }

--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -1,24 +1,57 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class DriverEarningsService {
-  DriverEarningsService({SupabaseClient? client})
-      : _providedClient = client;
+  DriverEarningsService({SupabaseClient? client, http.Client? httpClient, String? apiBaseUrl,})
+      : _providedClient = client,
+      _httpClient = httpClient ?? http.Client(),
+      _apiBaseUrl = (apiBaseUrl ?? defaultApiBaseUrl).replaceFirst(RegExp(r'/$'), '',);
+
+  static const String defaultApiBaseUrl = String.fromEnvironment(
+    'TRUXIFY_API_BASE_URL',
+    defaultValue: 'http://localhost:5000',
+  );
 
   final SupabaseClient? _providedClient;
   SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
+  final http.Client _httpClient;
+  final String _apiBaseUrl;
 
   String? get driverId => _client.auth.currentUser?.id;
 
-  Future<List<Map<String, dynamic>>> fetchWalletTransactions() async {
+  Map<String, String> get _authHeaders {
+    final token = _client.auth.currentSession?.accessToken;
+    return {
+      'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  Future<List<Map<String, dynamic>>> fetchWalletTransactions({
+    int page = 1,
+    int limit = 50,
+  }) async {
     if (driverId == null) return [];
 
-    final response = await _client
-        .from('wallet_transactions')
-        .select()
-        .eq('driver_id', driverId!)
-        .order('created_at', ascending: false);
+    final uri = Uri.parse('$_apiBaseUrl/api/driver/wallet/history').replace(
+      queryParameters: {'page': '$page', 'limit': '$limit'},
+    );
 
-    return List<Map<String, dynamic>>.from(response);
+    final response = await _httpClient.get(uri, headers: _authHeaders);
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        decoded['error']?.toString() ?? 'Failed to load wallet history.',
+      );
+    }
+
+    final transactions = decoded['transactions'] as List<dynamic>? ?? [];
+    return transactions
+        .map((t) => Map<String, dynamic>.from(t as Map))
+        .toList();
   }
 
   Future<List<Map<String, dynamic>>> fetchMonthlyEarnings({
@@ -28,16 +61,30 @@ class DriverEarningsService {
 
     final start = DateTime(month.year, month.month, 1);
     final end = DateTime(month.year, month.month + 1, 1);
+    final today = DateTime.now();
 
-    final response = await _client
-        .from('earnings_daily')
-        .select()
-        .eq('driver_id', driverId!)
-        .gte('day_date', start.toIso8601String().split('T').first)
-        .lt('day_date', end.toIso8601String().split('T').first)
-        .order('day_date');
+    final daysSinceMonthStart = today.difference(start).inDays + 1;
+    final days = daysSinceMonthStart.clamp(1, 365);
 
-    return List<Map<String, dynamic>>.from(response);
+    final uri = Uri.parse('$_apiBaseUrl/api/driver/earnings/summary').replace(
+      queryParameters: {'days': '$days'},
+    );
+
+    final response = await _httpClient.get(uri, headers: _authHeaders);
+    final decoded = jsonDecode(response.body);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final error = decoded is Map ? decoded['error']?.toString() : null;
+      throw Exception(error ?? 'Failed to load earnings summary.');
+    }
+
+    return (decoded as List<dynamic>)
+        .map((e) => Map<String, dynamic>.from(e as Map))
+        .where((e) {
+      final date = DateTime.tryParse(e['day_date'].toString());
+      if (date == null) return false;
+      return !date.isBefore(start) && date.isBefore(end);
+    }).toList();
   }
 
   Future<List<Map<String, dynamic>>> fetchCompletedTripsForDay({

--- a/apps/driver/test/driver_earnings_service_test.dart
+++ b/apps/driver/test/driver_earnings_service_test.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_driver/services/driver_earnings_service.dart';
+
+class MockGoTrueClient implements GoTrueClient {
+  final User? mockUser;
+  final Session? mockSession;
+  MockGoTrueClient({this.mockUser, this.mockSession});
+  
+  @override
+  User? get currentUser => mockUser;
+  
+  @override
+  Session? get currentSession => mockSession;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeUser implements User {
+  final String _id;
+  FakeUser(this._id);
+  @override
+  String get id => _id;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeSession implements Session {
+  final String _token;
+  FakeSession(this._token);
+  @override
+  String get accessToken => _token;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakePostgrestFilterBuilder<T> implements PostgrestFilterBuilder<T> {
+  final Future<dynamic> _futureValue;
+  FakePostgrestFilterBuilder(this._futureValue);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #then) {
+      final Function onValue = invocation.positionalArguments[0] as Function;
+      final Function? onError = invocation.namedArguments[#onError] as Function?;
+      return _futureValue.then((val) => onValue(val), onError: onError);
+    }
+    return this;
+  }
+}
+
+class FakeSupabaseQueryBuilder implements SupabaseQueryBuilder {
+  final Future<dynamic> _futureValue;
+  FakeSupabaseQueryBuilder(this._futureValue);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #select) {
+      return FakePostgrestFilterBuilder<List<Map<String, dynamic>>>(_futureValue);
+    }
+    return this;
+  }
+}
+
+class FakeSupabaseClient implements SupabaseClient {
+  final GoTrueClient _auth;
+  final Function(String relation)? onFrom;
+  final Future<dynamic> Function(String relation)? queryResult;
+  
+  FakeSupabaseClient({
+    required GoTrueClient auth,
+    this.onFrom,
+    this.queryResult,
+  }) : _auth = auth;
+
+  @override
+  GoTrueClient get auth => _auth;
+
+  @override
+  SupabaseQueryBuilder from(String relation) {
+    onFrom?.call(relation);
+    final resultFuture = queryResult?.call(relation) ?? Future.value(<Map<String, dynamic>>[]);
+    return FakeSupabaseQueryBuilder(resultFuture);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class MockHttpClient extends http.BaseClient {
+  final Future<http.Response> Function(http.BaseRequest request) mockHandler;
+  MockHttpClient(this.mockHandler);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await mockHandler(request);
+    return http.StreamedResponse(
+      Stream.value(response.bodyBytes),
+      response.statusCode,
+      headers: response.headers,
+      request: request,
+    );
+  }
+}
+
+void main() {
+  group('DriverEarningsService Tests', () {
+    const driverId = 'driver-123';
+    final mockUser = FakeUser(driverId);
+    final mockSession = FakeSession('mock-token');
+    final mockAuth = MockGoTrueClient(mockUser: mockUser, mockSession: mockSession);
+
+    test('fetchWalletTransactions returns parsed transactions on success', () async {
+      final mockResponse = {
+        'transactions': [
+          {'id': 'txn-1', 'amount': 1000, 'status': 'completed', 'description': 'Trip pay'},
+          {'id': 'txn-2', 'amount': 500, 'status': 'pending', 'description': 'Ref pay'},
+        ]
+      };
+
+      final httpClient = MockHttpClient((request) async {
+        expect(request.url.path, equals('/api/driver/wallet/history'));
+        expect(request.url.queryParameters['page'], equals('1'));
+        expect(request.url.queryParameters['limit'], equals('10'));
+        expect(request.headers['Authorization'], equals('Bearer mock-token'));
+        return http.Response(jsonEncode(mockResponse), 200);
+      });
+
+      final supabaseClient = FakeSupabaseClient(auth: mockAuth);
+      final service = DriverEarningsService(
+        client: supabaseClient,
+        httpClient: httpClient,
+      );
+
+      final result = await service.fetchWalletTransactions(page: 1, limit: 10);
+      expect(result.length, equals(2));
+      expect(result[0]['id'], equals('txn-1'));
+      expect(result[1]['status'], equals('pending'));
+      
+      service.dispose();
+    });
+
+    test('fetchWalletTransactions throws exception on API error', () async {
+      final httpClient = MockHttpClient((request) async {
+        return http.Response(jsonEncode({'error': 'Unauthorized access'}), 401);
+      });
+
+      final supabaseClient = FakeSupabaseClient(auth: mockAuth);
+      final service = DriverEarningsService(
+        client: supabaseClient,
+        httpClient: httpClient,
+      );
+
+      expect(
+        () => service.fetchWalletTransactions(),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Unauthorized access'))),
+      );
+      
+      service.dispose();
+    });
+
+    test('fetchMonthlyEarnings returns filtered earnings for current month', () async {
+      final mockResponse = [
+        {'day_date': '2026-06-01', 'amount': 2000, 'trip_count': 1, 'hours_driven': 2.5},
+        {'day_date': '2026-06-15', 'amount': 4500, 'trip_count': 2, 'hours_driven': 5.0},
+        {'day_date': '2026-05-31', 'amount': 1000, 'trip_count': 1, 'hours_driven': 1.0}, // outside requested month
+      ];
+
+      final httpClient = MockHttpClient((request) async {
+        expect(request.url.path, equals('/api/driver/earnings/summary'));
+        return http.Response(jsonEncode(mockResponse), 200);
+      });
+
+      final supabaseClient = FakeSupabaseClient(auth: mockAuth);
+      final service = DriverEarningsService(
+        client: supabaseClient,
+        httpClient: httpClient,
+      );
+
+      // Querying June 2026
+      final result = await service.fetchMonthlyEarnings(month: DateTime(2026, 6));
+      expect(result.length, equals(2));
+      expect(result[0]['day_date'], equals('2026-06-01'));
+      expect(result[1]['day_date'], equals('2026-06-15'));
+      
+      service.dispose();
+    });
+
+    test('fetchMonthlyEarnings falls back to database for dates > 365 days ago', () async {
+      bool databaseCalled = false;
+      final supabaseClient = FakeSupabaseClient(
+        auth: mockAuth,
+        onFrom: (relation) {
+          expect(relation, equals('earnings_daily'));
+          databaseCalled = true;
+        },
+        queryResult: (relation) {
+          return Future.value([
+            {'day_date': '2020-01-15', 'amount': 3000, 'trip_count': 2, 'hours_driven': 4.0}
+          ]);
+        },
+      );
+
+      final httpClient = MockHttpClient((request) async {
+        fail('HTTP client should not be called for historical months older than 365 days');
+      });
+
+      final service = DriverEarningsService(
+        client: supabaseClient,
+        httpClient: httpClient,
+      );
+
+      // Querying January 2020 (way older than 365 days)
+      final result = await service.fetchMonthlyEarnings(month: DateTime(2020, 1));
+      expect(databaseCalled, isTrue);
+      expect(result.length, equals(1));
+      expect(result[0]['amount'], equals(3000));
+      
+      service.dispose();
+    });
+
+    test('fetchCompletedTripsForDay queries trips table via supabase client', () async {
+      bool databaseCalled = false;
+      final supabaseClient = FakeSupabaseClient(
+        auth: mockAuth,
+        onFrom: (relation) {
+          expect(relation, equals('trips'));
+          databaseCalled = true;
+        },
+        queryResult: (relation) {
+          return Future.value([
+            {'id': 'trip-1', 'status': 'completed', 'trip_date': '2026-06-15'}
+          ]);
+        },
+      );
+
+      final service = DriverEarningsService(client: supabaseClient);
+      final result = await service.fetchCompletedTripsForDay(date: DateTime(2026, 6, 15));
+      expect(databaseCalled, isTrue);
+      expect(result.length, equals(1));
+      expect(result[0]['id'], equals('trip-1'));
+      
+      service.dispose();
+    });
+  });
+}

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -156,7 +156,7 @@ router.get('/earnings/summary', authenticate, requireRole(['driver']), async (re
 
     const { data: summary, error } = await supabase
       .from('earnings_daily')
-      .select('day_date, amount, trip_count')
+      .select('day_date, amount, trip_count, hours_driven')
       .eq('driver_id', req.user.id)
       .gte('day_date', cutoff.toISOString().split('T')[0])
       .order('day_date', { ascending: true });


### PR DESCRIPTION
## Summary

- DriverEarnings Service now calls `GET /api/driver/earnings/summary?days=N` instead of querying the earnings_daily table directly, filtering the trailing-N-day response down to the requested month.
- fetchWalletTransactions now calls `GET /api/driver/wallet/history?page=&limit=` instead of querying `wallet_transactions` directly.
- Backend: `/api/driver/earnings/summary` now also selects `hours_driven` so the existing "HOURS" stat on the daily detail card continues to work.

##fixes
fixes: #468 

## Test plan
- [x] `dart analyze` passes on `driver_earnings_service.dart` and
      `earnings_screen.dart`
- [x] Run driver app against local backend (`BYPASS_AUTH` or real
      Supabase session) and verify:
  - [x] Heatmap and Today/Week/Month totals populate from `/earnings/summary`
  - [x] Daily detail card shows correct hours for a day with trips
  - [x] Pending Payments card still lists pending wallet transactions
  - [x] Prev/next month navigation still works for the current and recent months


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
* Wallet transaction history now supports pagination (page and limit) to efficiently browse large records.
* Driver earnings summaries now include daily “hours driven” alongside earnings data for more complete performance insights.

**Bug Fixes**
* Ensures earnings and transaction data are fetched reliably with authenticated HTTP calls, validating responses and surfacing meaningful errors when requests fail.

**Chores**
* Added automated test coverage for driver earnings and wallet transactions flows, including HTTP and fallback behaviors.

**Refactor**
* Added proper cleanup of the earnings service when leaving the earnings screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->