### PR TITLE
feat(backend): implement Redis caching for user profiles in auth middleware (#401)

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -20,7 +20,7 @@ function getRedisClient() {
   } catch (err) {
     // Under Vitest testing, accessing undefined keys on namespace mock proxies throws.
     // We suppress mock proxy errors in tests, but log genuine unexpected errors in production once.
-    const isVitestMockError = process.env.NODE_ENV === 'test';
+    const isVitestMockError = process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
     if (!isVitestMockError && !hasLoggedRedisClientError) {
       console.error('Unexpected error resolving redisClient from db config:', err);
       hasLoggedRedisClientError = true;

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -4,8 +4,11 @@ const TTL_SECONDS = 900; // 15 minutes
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
 
 /**
- * Helper to safely retrieve the redisClient from the database configuration.
- * Prevents Vitest module resolution issues in tests that partially mock db.js.
+ * Safely retrieve the redisClient from the database configuration.
+ * Under standard Node.js ESM namespace imports, accessing a missing export returns undefined.
+ * However, in Vitest unit tests that mock db.js without explicitly exporting 'redisClient',
+ * Vitest's mock Proxy intercepts the property access and throws an error.
+ * The try-catch block guards against this, allowing a graceful fallback to null.
  */
 function getRedisClient() {
   try {

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -1,0 +1,70 @@
+import * as db from '../config/db.js';
+
+const TTL_SECONDS = 900; // 15 minutes
+const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
+
+/**
+ * Helper to safely retrieve the redisClient from the database configuration.
+ * Prevents Vitest module resolution issues in tests that partially mock db.js.
+ */
+function getRedisClient() {
+  try {
+    return db.redisClient;
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Retrieves a user profile from the Redis cache.
+ * Falls back to null on cache miss or Redis error.
+ * 
+ * @param {string} firebaseUid - The Firebase UID of the user.
+ * @returns {Promise<object|null>} The parsed cached profile, or null.
+ */
+export async function getCachedProfile(firebaseUid) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !firebaseUid) return null;
+  try {
+    const raw = await redisClient.get(cacheKey(firebaseUid));
+    return raw ? JSON.parse(raw) : null;
+  } catch (err) {
+    console.error('Redis getCachedProfile error:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Stores a user profile in the Redis cache.
+ * Gracefully handles Redis errors.
+ * 
+ * @param {string} firebaseUid - The Firebase UID of the user.
+ * @param {object} profile - The user profile object to cache.
+ * @returns {Promise<void>}
+ */
+export async function setCachedProfile(firebaseUid, profile) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !firebaseUid || !profile) return;
+  try {
+    await redisClient.set(cacheKey(firebaseUid), JSON.stringify(profile), 'EX', TTL_SECONDS);
+  } catch (err) {
+    console.error('Redis setCachedProfile error:', err.message);
+  }
+}
+
+/**
+ * Invalidates (deletes) a cached user profile from Redis.
+ * Gracefully handles Redis errors.
+ * 
+ * @param {string} firebaseUid - The Firebase UID of the user.
+ * @returns {Promise<void>}
+ */
+export async function invalidateCachedProfile(firebaseUid) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !firebaseUid) return;
+  try {
+    await redisClient.del(cacheKey(firebaseUid));
+  } catch (err) {
+    console.error('Redis invalidateCachedProfile error:', err.message);
+  }
+}

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -4,14 +4,6 @@ export const TTL_SECONDS = 900; // 15 minutes
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
 
-/**
- * Retrieves the redisClient from the database configuration.
- * Under Vitest, accessing a property on a mocked namespace module that is not explicitly
- * returned in the mock factory will throw an error via the mock Proxy. We wrap the access
- * in a try-catch to allow a graceful fallback to null.
- * 
- * @returns {object|null} The Redis client if configured, or null.
- */
 const LAST_LOG_TIMES = {};
 const LOG_THROTTLE_INTERVAL_MS = 60000; // 60 seconds
 
@@ -28,17 +20,20 @@ function logCacheError(operation, error) {
   }
 }
 
+/**
+ * Retrieves the redisClient from the database configuration.
+ * Under Vitest, accessing a property on a mocked namespace module that is not explicitly
+ * returned in the mock factory will throw an error via the mock Proxy. We wrap the access
+ * in a try-catch to allow a graceful fallback to null.
+ * 
+ * @returns {object|null} The Redis client if configured, or null.
+ */
 function getRedisClient() {
-  if (process.env.VITEST === 'true') {
-    // Under Vitest testing, accessing undefined keys on namespace mock proxies throws.
-    // We wrap the access in a try-catch to allow a graceful fallback to null.
-    try {
-      return db.redisClient ?? null;
-    } catch {
-      return null;
-    }
+  try {
+    return db.redisClient ?? null;
+  } catch {
+    return null;
   }
-  return db.redisClient ?? null;
 }
 
 /**

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -1,6 +1,7 @@
 import * as db from '../config/db.js';
 
 export const TTL_SECONDS = 900; // 15 minutes
+export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
 
 /**
@@ -56,11 +57,11 @@ export async function getCachedProfile(firebaseUid) {
  * @param {object} profile - The user profile object to cache.
  * @returns {Promise<void>}
  */
-export async function setCachedProfile(firebaseUid, profile) {
+export async function setCachedProfile(firebaseUid, profile, ttlSeconds = TTL_SECONDS) {
   const redisClient = getRedisClient();
   if (!redisClient || !firebaseUid || !profile) return;
   try {
-    await redisClient.set(cacheKey(firebaseUid), JSON.stringify(profile), 'EX', TTL_SECONDS);
+    await redisClient.set(cacheKey(firebaseUid), JSON.stringify(profile), 'EX', ttlSeconds);
   } catch (err) {
     console.error('Redis setCachedProfile error:', err);
   }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -12,21 +12,58 @@ const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
  * 
  * @returns {object|null} The Redis client if configured, or null.
  */
-let hasLoggedRedisClientError = false;
+const LAST_LOG_TIMES = {};
+const LOG_THROTTLE_INTERVAL_MS = 60000; // 60 seconds
+
+/**
+ * Throttles logging of cache errors on high-frequency paths to prevent flood.
+ */
+function logCacheError(operation, error) {
+  const now = Date.now();
+  const lastLog = LAST_LOG_TIMES[operation] || 0;
+  if (now - lastLog >= LOG_THROTTLE_INTERVAL_MS) {
+    LAST_LOG_TIMES[operation] = now;
+    const errorDetails = error?.stack ?? error?.message ?? String(error);
+    console.error(`Redis ${operation} error (throttled):`, errorDetails);
+  }
+}
 
 function getRedisClient() {
-  try {
-    return db.redisClient ?? null;
-  } catch (err) {
+  if (process.env.VITEST === 'true') {
     // Under Vitest testing, accessing undefined keys on namespace mock proxies throws.
-    // We suppress mock proxy errors in tests, but log genuine unexpected errors in production once.
-    const isVitestMockError = process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
-    if (!isVitestMockError && !hasLoggedRedisClientError) {
-      console.error('Unexpected error resolving redisClient from db config:', err);
-      hasLoggedRedisClientError = true;
+    // We wrap the access in a try-catch to allow a graceful fallback to null.
+    try {
+      return db.redisClient ?? null;
+    } catch {
+      return null;
     }
-    return null;
   }
+  return db.redisClient ?? null;
+}
+
+/**
+ * Validates the shape of a cached profile.
+ * 
+ * @param {string} firebaseUid - The expected Firebase UID.
+ * @param {any} cachedProfile - The cached profile to validate.
+ * @returns {boolean} True if the cached profile shape is valid, false otherwise.
+ */
+export function isValidCachedProfile(firebaseUid, cachedProfile) {
+  if (!cachedProfile || typeof cachedProfile !== 'object' || Array.isArray(cachedProfile)) {
+    return false;
+  }
+  if (typeof cachedProfile.isActive !== 'boolean') {
+    return false;
+  }
+  if (cachedProfile.isActive === false) {
+    return true; // Valid tombstone
+  }
+  return (
+    cachedProfile.isActive === true &&
+    cachedProfile.uid === firebaseUid &&
+    typeof cachedProfile.id === 'string' &&
+    typeof cachedProfile.role === 'string'
+  );
 }
 
 /**
@@ -43,7 +80,7 @@ export async function getCachedProfile(firebaseUid) {
     const raw = await redisClient.get(cacheKey(firebaseUid));
     return raw ? JSON.parse(raw) : null;
   } catch (err) {
-    console.error('Redis getCachedProfile error:', err);
+    logCacheError('getCachedProfile', err);
     // On read or parsing failure, attempt a best-effort delete of the corrupted key
     try {
       await redisClient.del(cacheKey(firebaseUid));
@@ -68,7 +105,7 @@ export async function setCachedProfile(firebaseUid, profile, ttlSeconds = TTL_SE
   try {
     await redisClient.set(cacheKey(firebaseUid), JSON.stringify(profile), 'EX', ttlSeconds);
   } catch (err) {
-    console.error('Redis setCachedProfile error:', err);
+    logCacheError('setCachedProfile', err);
   }
 }
 
@@ -85,6 +122,6 @@ export async function invalidateCachedProfile(firebaseUid) {
   try {
     await redisClient.del(cacheKey(firebaseUid));
   } catch (err) {
-    console.error('Redis invalidateCachedProfile error:', err);
+    logCacheError('invalidateCachedProfile', err);
   }
 }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -1,6 +1,6 @@
 import * as db from '../config/db.js';
 
-const TTL_SECONDS = 900; // 15 minutes
+export const TTL_SECONDS = 900; // 15 minutes
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
 
 /**
@@ -33,7 +33,7 @@ export async function getCachedProfile(firebaseUid) {
     const raw = await redisClient.get(cacheKey(firebaseUid));
     return raw ? JSON.parse(raw) : null;
   } catch (err) {
-    console.error('Redis getCachedProfile error:', err.message);
+    console.error('Redis getCachedProfile error:', err);
     return null;
   }
 }
@@ -52,7 +52,7 @@ export async function setCachedProfile(firebaseUid, profile) {
   try {
     await redisClient.set(cacheKey(firebaseUid), JSON.stringify(profile), 'EX', TTL_SECONDS);
   } catch (err) {
-    console.error('Redis setCachedProfile error:', err.message);
+    console.error('Redis setCachedProfile error:', err);
   }
 }
 
@@ -69,6 +69,6 @@ export async function invalidateCachedProfile(firebaseUid) {
   try {
     await redisClient.del(cacheKey(firebaseUid));
   } catch (err) {
-    console.error('Redis invalidateCachedProfile error:', err.message);
+    console.error('Redis invalidateCachedProfile error:', err);
   }
 }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -44,6 +44,12 @@ export async function getCachedProfile(firebaseUid) {
     return raw ? JSON.parse(raw) : null;
   } catch (err) {
     console.error('Redis getCachedProfile error:', err);
+    // On read or parsing failure, attempt a best-effort delete of the corrupted key
+    try {
+      await redisClient.del(cacheKey(firebaseUid));
+    } catch (delErr) {
+      // Ignore failures on background cleanup deletion
+    }
     return null;
   }
 }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -4,15 +4,16 @@ const TTL_SECONDS = 900; // 15 minutes
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
 
 /**
- * Safely retrieve the redisClient from the database configuration.
- * Under standard Node.js ESM namespace imports, accessing a missing export returns undefined.
- * However, in Vitest unit tests that mock db.js without explicitly exporting 'redisClient',
- * Vitest's mock Proxy intercepts the property access and throws an error.
- * The try-catch block guards against this, allowing a graceful fallback to null.
+ * Retrieves the redisClient from the database configuration.
+ * Under Vitest, accessing a property on a mocked namespace module that is not explicitly
+ * returned in the mock factory will throw an error via the mock Proxy. We wrap the access
+ * in a try-catch to allow a graceful fallback to null.
+ * 
+ * @returns {object|null} The Redis client if configured, or null.
  */
 function getRedisClient() {
   try {
-    return db.redisClient;
+    return db.redisClient ?? null;
   } catch (err) {
     return null;
   }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -11,10 +11,20 @@ const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
  * 
  * @returns {object|null} The Redis client if configured, or null.
  */
+let hasLoggedRedisClientError = false;
+
 function getRedisClient() {
   try {
     return db.redisClient ?? null;
   } catch (err) {
+    // Under Vitest testing, accessing undefined keys on namespace mock proxies throws.
+    // We suppress mock proxy errors in tests, but log genuine unexpected errors in production once.
+    const isVitestMockError = process.env.NODE_ENV === 'test' || 
+      (err.message && (err.message.includes('mock') || err.message.includes('spy')));
+    if (!isVitestMockError && !hasLoggedRedisClientError) {
+      console.error('Unexpected error resolving redisClient from db config:', err);
+      hasLoggedRedisClientError = true;
+    }
     return null;
   }
 }

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -57,7 +57,9 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
     cachedProfile.isActive === true &&
     cachedProfile.uid === firebaseUid &&
     typeof cachedProfile.id === 'string' &&
-    typeof cachedProfile.role === 'string'
+    typeof cachedProfile.role === 'string' &&
+    (cachedProfile.fullName === undefined || cachedProfile.fullName === null || typeof cachedProfile.fullName === 'string') &&
+    (cachedProfile.phone === undefined || cachedProfile.phone === null || typeof cachedProfile.phone === 'string')
   );
 }
 

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -20,8 +20,7 @@ function getRedisClient() {
   } catch (err) {
     // Under Vitest testing, accessing undefined keys on namespace mock proxies throws.
     // We suppress mock proxy errors in tests, but log genuine unexpected errors in production once.
-    const isVitestMockError = process.env.NODE_ENV === 'test' || 
-      (err.message && (err.message.includes('mock') || err.message.includes('spy')));
+    const isVitestMockError = process.env.NODE_ENV === 'test';
     if (!isVitestMockError && !hasLoggedRedisClientError) {
       console.error('Unexpected error resolving redisClient from db config:', err);
       hasLoggedRedisClientError = true;

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -140,9 +140,9 @@ export async function authenticate(req, res, next) {
       phone: userProfile.phone
     };
 
-    // Populate cache on successful DB fetch
+    // Populate cache on successful DB fetch (fire-and-forget to avoid delaying the request critical path)
     if (userProfile.firebase_uid) {
-      await setCachedProfile(userProfile.firebase_uid, req.user);
+      setCachedProfile(userProfile.firebase_uid, req.user);
     }
 
     next();

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -108,13 +108,17 @@ export async function authenticate(req, res, next) {
       // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
-        const isValidShape = cachedProfile && typeof cachedProfile === 'object' && (
-          cachedProfile.isActive === false ||
-          (cachedProfile.isActive === true &&
-           cachedProfile.uid === firebaseUid &&
-           typeof cachedProfile.id === 'string' &&
-           typeof cachedProfile.role === 'string')
-        );
+        const isValidShape = cachedProfile &&
+          typeof cachedProfile === 'object' &&
+          !Array.isArray(cachedProfile) &&
+          typeof cachedProfile.isActive === 'boolean' &&
+          (
+            cachedProfile.isActive === false ||
+            (cachedProfile.isActive === true &&
+             cachedProfile.uid === firebaseUid &&
+             typeof cachedProfile.id === 'string' &&
+             typeof cachedProfile.role === 'string')
+          );
 
         if (!isValidShape) {
           void invalidateCachedProfile(firebaseUid);

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -1,6 +1,6 @@
 import { firebaseAdmin, supabase } from '../config/db.js';
 import jwt from 'jsonwebtoken';
-import { getCachedProfile, setCachedProfile, invalidateCachedProfile, TOMBSTONE_TTL_SECONDS } from '../lib/profileCache.js';
+import { getCachedProfile, setCachedProfile, invalidateCachedProfile, TOMBSTONE_TTL_SECONDS, isValidCachedProfile } from '../lib/profileCache.js';
 
 /**
  * Authentication middleware to verify requests using Firebase ID Tokens.
@@ -108,19 +108,7 @@ export async function authenticate(req, res, next) {
       // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
-        const isValidShape = cachedProfile &&
-          typeof cachedProfile === 'object' &&
-          !Array.isArray(cachedProfile) &&
-          typeof cachedProfile.isActive === 'boolean' &&
-          (
-            cachedProfile.isActive === false ||
-            (cachedProfile.isActive === true &&
-             cachedProfile.uid === firebaseUid &&
-             typeof cachedProfile.id === 'string' &&
-             typeof cachedProfile.role === 'string')
-          );
-
-        if (!isValidShape) {
+        if (!isValidCachedProfile(firebaseUid, cachedProfile)) {
           void invalidateCachedProfile(firebaseUid);
         } else {
           if (cachedProfile.isActive === false) {

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -99,7 +99,12 @@ export async function authenticate(req, res, next) {
       const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
       const firebaseUid = decodedToken.uid;
 
-      // Check Redis cache first
+      // Check Redis cache first.
+      // NOTE: On cache hit, we attach the cached profile directly and skip the DB query entirely
+      // to reduce database load (per the Acceptance Criteria).
+      // Since all profile mutations in this API (e.g., PUT /api/profile) invalidate the cache,
+      // the cache remains consistent. Any future administrative role or status mutations
+      // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
         req.user = cachedProfile;

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -108,11 +108,13 @@ export async function authenticate(req, res, next) {
       // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
-        const isValidShape = typeof cachedProfile === 'object' &&
-          (cachedProfile.isActive === false ||
-           (typeof cachedProfile.id === 'string' &&
-            typeof cachedProfile.uid === 'string' &&
-            typeof cachedProfile.role === 'string'));
+        const isValidShape = cachedProfile && typeof cachedProfile === 'object' && (
+          cachedProfile.isActive === false ||
+          (cachedProfile.isActive === true &&
+           cachedProfile.uid === firebaseUid &&
+           typeof cachedProfile.id === 'string' &&
+           typeof cachedProfile.role === 'string')
+        );
 
         if (!isValidShape) {
           void invalidateCachedProfile(firebaseUid);

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -61,6 +61,7 @@ export async function authenticate(req, res, next) {
   try {
     let userProfile = null;
     let decoded = null;
+    let firebaseUid = null;
 
     try {
       decoded = jwt.decode(token);
@@ -97,7 +98,7 @@ export async function authenticate(req, res, next) {
         return res.status(500).json({ error: 'Firebase Auth verification is not configured on this server.' });
       }
       const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
-      const firebaseUid = decodedToken.uid;
+      firebaseUid = decodedToken.uid;
 
       // Check Redis cache first.
       // NOTE: On cache hit, we attach the cached profile directly and skip the DB query entirely
@@ -107,6 +108,12 @@ export async function authenticate(req, res, next) {
       // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
+        if (cachedProfile.isActive === false) {
+          return res.status(403).json({ 
+            error: 'User profile not found in database.', 
+            hint: 'Register user in profiles table first.' 
+          });
+        }
         req.user = cachedProfile;
         return next();
       }
@@ -130,6 +137,10 @@ export async function authenticate(req, res, next) {
     }
 
     if (!userProfile) {
+      if (firebaseUid) {
+        // Cache the inactive/not-found status as a tombstone to prevent DB load on subsequent requests
+        void setCachedProfile(firebaseUid, { isActive: false });
+      }
       return res.status(403).json({ 
         error: 'User profile not found in database.', 
         hint: 'Register user in profiles table first.' 
@@ -142,7 +153,8 @@ export async function authenticate(req, res, next) {
       uid: userProfile.firebase_uid,
       role: userProfile.role,
       fullName: userProfile.full_name,
-      phone: userProfile.phone
+      phone: userProfile.phone,
+      isActive: true
     };
 
     // Populate cache on successful DB fetch (fire-and-forget to avoid delaying the request critical path)

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -147,7 +147,7 @@ export async function authenticate(req, res, next) {
 
     // Populate cache on successful DB fetch (fire-and-forget to avoid delaying the request critical path)
     if (userProfile.firebase_uid) {
-      setCachedProfile(userProfile.firebase_uid, req.user);
+      void setCachedProfile(userProfile.firebase_uid, req.user);
     }
 
     next();

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -1,5 +1,6 @@
 import { firebaseAdmin, supabase } from '../config/db.js';
 import jwt from 'jsonwebtoken';
+import { getCachedProfile, setCachedProfile } from '../lib/profileCache.js';
 
 /**
  * Authentication middleware to verify requests using Firebase ID Tokens.
@@ -98,6 +99,13 @@ export async function authenticate(req, res, next) {
       const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
       const firebaseUid = decodedToken.uid;
 
+      // Check Redis cache first
+      const cachedProfile = await getCachedProfile(firebaseUid);
+      if (cachedProfile) {
+        req.user = cachedProfile;
+        return next();
+      }
+
       if (!supabase) {
         return res.status(500).json({ error: 'Supabase client is not configured on this server.' });
       }
@@ -131,6 +139,11 @@ export async function authenticate(req, res, next) {
       fullName: userProfile.full_name,
       phone: userProfile.phone
     };
+
+    // Populate cache on successful DB fetch
+    if (userProfile.firebase_uid) {
+      await setCachedProfile(userProfile.firebase_uid, req.user);
+    }
 
     next();
   } catch (error) {

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -1,6 +1,6 @@
 import { firebaseAdmin, supabase } from '../config/db.js';
 import jwt from 'jsonwebtoken';
-import { getCachedProfile, setCachedProfile } from '../lib/profileCache.js';
+import { getCachedProfile, setCachedProfile, invalidateCachedProfile, TOMBSTONE_TTL_SECONDS } from '../lib/profileCache.js';
 
 /**
  * Authentication middleware to verify requests using Firebase ID Tokens.
@@ -108,14 +108,24 @@ export async function authenticate(req, res, next) {
       // must explicitly call invalidateCachedProfile(firebaseUid).
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
-        if (cachedProfile.isActive === false) {
-          return res.status(403).json({ 
-            error: 'User profile not found in database.', 
-            hint: 'Register user in profiles table first.' 
-          });
+        const isValidShape = typeof cachedProfile === 'object' &&
+          (cachedProfile.isActive === false ||
+           (typeof cachedProfile.id === 'string' &&
+            typeof cachedProfile.uid === 'string' &&
+            typeof cachedProfile.role === 'string'));
+
+        if (!isValidShape) {
+          void invalidateCachedProfile(firebaseUid);
+        } else {
+          if (cachedProfile.isActive === false) {
+            return res.status(403).json({ 
+              error: 'User profile not found in database.', 
+              hint: 'Register user in profiles table first.' 
+            });
+          }
+          req.user = cachedProfile;
+          return next();
         }
-        req.user = cachedProfile;
-        return next();
       }
 
       if (!supabase) {
@@ -139,7 +149,7 @@ export async function authenticate(req, res, next) {
     if (!userProfile) {
       if (firebaseUid) {
         // Cache the inactive/not-found status as a tombstone to prevent DB load on subsequent requests
-        void setCachedProfile(firebaseUid, { isActive: false });
+        void setCachedProfile(firebaseUid, { isActive: false }, TOMBSTONE_TTL_SECONDS);
       }
       return res.status(403).json({ 
         error: 'User profile not found in database.', 

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -80,7 +80,7 @@ router.put('/', authenticate, async (req, res) => {
 
     // Invalidate the profile cache so that the next request retrieves fresh profile data
     if (req.user && req.user.uid) {
-      void invalidateCachedProfile(req.user.uid);
+      await invalidateCachedProfile(req.user.uid);
     }
 
     res.json({

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -78,9 +78,13 @@ router.put('/', authenticate, async (req, res) => {
       if (driverError) throw driverError;
     }
 
-    // Invalidate the profile cache so that the next request retrieves fresh profile data
+    // Invalidate the profile cache so that the next request retrieves fresh profile data.
+    // We intentionally do not await here (making it fire-and-forget) to avoid adding
+    // Redis network round-trip latency to the response path. Since invalidateCachedProfile
+    // catches and logs errors internally, and the client receives the updated profile in the
+    // response payload, fire-and-forget is the optimal choice.
     if (req.user && req.user.uid) {
-      await invalidateCachedProfile(req.user.uid);
+      void invalidateCachedProfile(req.user.uid);
     }
 
     res.json({

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -6,8 +6,8 @@ import {
   getDriverDetails
 } from '../services/profileService.js';
 import { supabase } from '../config/db.js';
-
 import { ProfileModel } from '../models/ProfileModel.js';
+import { invalidateCachedProfile } from '../lib/profileCache.js';
 
 const router = express.Router();
 
@@ -77,6 +77,12 @@ router.put('/', authenticate, async (req, res) => {
 
       if (driverError) throw driverError;
     }
+
+    // Invalidate the profile cache so that the next request retrieves fresh profile data
+    if (req.user && req.user.uid) {
+      await invalidateCachedProfile(req.user.uid);
+    }
+
     res.json({
       message: 'Profile updated',
       profile: data

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -80,7 +80,7 @@ router.put('/', authenticate, async (req, res) => {
 
     // Invalidate the profile cache so that the next request retrieves fresh profile data
     if (req.user && req.user.uid) {
-      await invalidateCachedProfile(req.user.uid);
+      void invalidateCachedProfile(req.user.uid);
     }
 
     res.json({

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -1,13 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
-import { invalidateCachedProfile } from '../../src/lib/profileCache.js';
 
 vi.mock('../../src/lib/profileCache.js', () => ({
   invalidateCachedProfile: vi.fn(),
   getCachedProfile: vi.fn(),
   setCachedProfile: vi.fn(),
 }));
+
+const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
 
 const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
 const m = createSupabaseMock();

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { invalidateCachedProfile } from '../../src/lib/profileCache.js';
+
+vi.mock('../../src/lib/profileCache.js', () => ({
+  invalidateCachedProfile: vi.fn(),
+  getCachedProfile: vi.fn(),
+  setCachedProfile: vi.fn(),
+}));
 
 const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
 const m = createSupabaseMock();
@@ -41,6 +48,7 @@ describe('Profile Routes', () => {
     m.store.customer_stats = [];
     m.store.driver_details = [];
     m.calls.length = 0;
+    vi.clearAllMocks();
   });
 
   describe('GET /api/profile', () => {
@@ -202,6 +210,7 @@ describe('Profile Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Profile updated');
       expect(res.body.profile).toEqual(updatedProfileRow);
+      expect(invalidateCachedProfile).toHaveBeenCalledWith('test_firebase_uid_123');
 
       const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
       expect(profileUpdateCall.payload).toEqual({
@@ -261,6 +270,7 @@ describe('Profile Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Profile updated');
       expect(res.body.profile).toEqual(updatedProfileRow);
+      expect(invalidateCachedProfile).toHaveBeenCalledWith('test_firebase_uid_123');
 
       const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
       expect(profileUpdateCall.payload).toEqual({

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -830,12 +830,13 @@ describe('authenticate middleware - Redis caching', () => {
     const next = vi.fn();
 
     // Temporarily capture and ignore console.error to avoid test noise
-    const originalConsoleError = console.error;
-    console.error = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await authenticate(req, res, next);
-
-    console.error = originalConsoleError;
+    try {
+      await authenticate(req, res, next);
+    } finally {
+      consoleSpy.mockRestore();
+    }
 
     expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:error-firebase-uid');
     expect(next).toHaveBeenCalled();

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -626,9 +626,20 @@ describe('requireRole middleware', () => {
 });
 
 describe('authenticate middleware - Redis caching', () => {
+  let originalBypassAuth;
+
   beforeEach(() => {
+    originalBypassAuth = process.env.BYPASS_AUTH;
     process.env.BYPASS_AUTH = 'false';
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalBypassAuth === undefined) {
+      delete process.env.BYPASS_AUTH;
+    } else {
+      process.env.BYPASS_AUTH = originalBypassAuth;
+    }
   });
 
   it('retrieves user profile from Redis on cache hit and skips database query', async () => {
@@ -756,7 +767,8 @@ describe('authenticate middleware - Redis caching', () => {
         uid: dbProfile.firebase_uid,
         role: dbProfile.role,
         fullName: dbProfile.full_name,
-        phone: dbProfile.phone
+        phone: dbProfile.phone,
+        isActive: true
       }),
       'EX',
       TTL_SECONDS
@@ -767,7 +779,8 @@ describe('authenticate middleware - Redis caching', () => {
       uid: dbProfile.firebase_uid,
       role: dbProfile.role,
       fullName: dbProfile.full_name,
-      phone: dbProfile.phone
+      phone: dbProfile.phone,
+      isActive: true
     });
   });
 
@@ -846,7 +859,8 @@ describe('authenticate middleware - Redis caching', () => {
       uid: dbProfile.firebase_uid,
       role: dbProfile.role,
       fullName: dbProfile.full_name,
-      phone: dbProfile.phone
+      phone: dbProfile.phone,
+      isActive: true
     });
   });
 });

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -624,3 +624,227 @@ describe('requireRole middleware', () => {
     expect(next).toHaveBeenCalled();
   });
 });
+
+describe('authenticate middleware - Redis caching', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'false';
+    vi.resetModules();
+  });
+
+  it('retrieves user profile from Redis on cache hit and skips database query', async () => {
+    const cachedUser = {
+      id: 'cached-user-123',
+      uid: 'cached-firebase-uid',
+      role: 'customer',
+      fullName: 'Cached User',
+      phone: '+1234567890'
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(cachedUser)),
+      set: vi.fn(),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'cached-firebase-uid',
+        }),
+      }),
+    };
+
+    const supabaseMock = {
+      from: vi.fn(),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        authorization: 'Bearer token123',
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:cached-firebase-uid');
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(cachedUser);
+  });
+
+  it('queries database and populates Redis on cache miss', async () => {
+    const dbProfile = {
+      id: 'db-user-123',
+      firebase_uid: 'miss-firebase-uid',
+      role: 'driver',
+      full_name: 'Database User',
+      phone: '+9876543210'
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue('OK'),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'miss-firebase-uid',
+        }),
+      }),
+    };
+
+    const supabaseMock = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: dbProfile,
+                  error: null,
+                }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        authorization: 'Bearer token123',
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:miss-firebase-uid');
+    expect(redisClientMock.set).toHaveBeenCalledWith(
+      'user:profile:miss-firebase-uid',
+      JSON.stringify({
+        id: dbProfile.id,
+        uid: dbProfile.firebase_uid,
+        role: dbProfile.role,
+        fullName: dbProfile.full_name,
+        phone: dbProfile.phone
+      }),
+      'EX',
+      900
+    );
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({
+      id: dbProfile.id,
+      uid: dbProfile.firebase_uid,
+      role: dbProfile.role,
+      fullName: dbProfile.full_name,
+      phone: dbProfile.phone
+    });
+  });
+
+  it('falls back to database query gracefully when Redis client throws error', async () => {
+    const dbProfile = {
+      id: 'db-user-456',
+      firebase_uid: 'error-firebase-uid',
+      role: 'customer',
+      full_name: 'Resilient User',
+      phone: '+1111111111'
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockRejectedValue(new Error('Redis connection lost')),
+      set: vi.fn(),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'error-firebase-uid',
+        }),
+      }),
+    };
+
+    const supabaseMock = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: dbProfile,
+                  error: null,
+                }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        authorization: 'Bearer token123',
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const next = vi.fn();
+
+    // Temporarily capture and ignore console.error to avoid test noise
+    const originalConsoleError = console.error;
+    console.error = vi.fn();
+
+    await authenticate(req, res, next);
+
+    console.error = originalConsoleError;
+
+    expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:error-firebase-uid');
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({
+      id: dbProfile.id,
+      uid: dbProfile.firebase_uid,
+      role: dbProfile.role,
+      fullName: dbProfile.full_name,
+      phone: dbProfile.phone
+    });
+  });
+});

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -730,6 +730,7 @@ describe('authenticate middleware - Redis caching', () => {
       redisClient: redisClientMock,
     }));
 
+    const { TTL_SECONDS } = await import('../../src/lib/profileCache.js');
     const { authenticate } = await import('../../src/middleware/auth.js');
 
     const req = {
@@ -758,7 +759,7 @@ describe('authenticate middleware - Redis caching', () => {
         phone: dbProfile.phone
       }),
       'EX',
-      900
+      TTL_SECONDS
     );
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual({

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -648,7 +648,8 @@ describe('authenticate middleware - Redis caching', () => {
       uid: 'cached-firebase-uid',
       role: 'customer',
       fullName: 'Cached User',
-      phone: '+1234567890'
+      phone: '+1234567890',
+      isActive: true
     };
 
     const redisClientMock = {
@@ -695,6 +696,132 @@ describe('authenticate middleware - Redis caching', () => {
     expect(supabaseMock.from).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual(cachedUser);
+  });
+
+  it('treats cached profiles with invalid shape as a cache miss and invalidates the cache key', async () => {
+    const invalidCachedUser = {
+      fullName: 'Corrupted User',
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(invalidCachedUser)),
+      set: vi.fn(),
+      del: vi.fn().mockResolvedValue(1),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'corrupted-firebase-uid',
+        }),
+      }),
+    };
+
+    const dbProfile = {
+      id: 'db-user-999',
+      firebase_uid: 'corrupted-firebase-uid',
+      role: 'customer',
+      full_name: 'Database User',
+      phone: '+9876543210'
+    };
+
+    const supabaseMock = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: dbProfile, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        authorization: 'Bearer token123',
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(redisClientMock.del).toHaveBeenCalledWith('user:profile:corrupted-firebase-uid');
+    expect(next).toHaveBeenCalled();
+    expect(req.user.id).toBe('db-user-999');
+  });
+
+  it('caches tombstone with TOMBSTONE_TTL_SECONDS when profile query returns no results', async () => {
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue('OK'),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'nonexistent-firebase-uid',
+        }),
+      }),
+    };
+
+    const supabaseMock = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: null, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { TOMBSTONE_TTL_SECONDS } = await import('../../src/lib/profileCache.js');
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        authorization: 'Bearer token123',
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(redisClientMock.set).toHaveBeenCalledWith(
+      'user:profile:nonexistent-firebase-uid',
+      JSON.stringify({ isActive: false }),
+      'EX',
+      TOMBSTONE_TTL_SECONDS
+    );
   });
 
   it('queries database and populates Redis on cache miss', async () => {

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('profileCache utility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe('getCachedProfile', () => {
+    it('returns null if redisClient is not defined in db.js', async () => {
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: null,
+      }));
+
+      const { getCachedProfile } = await import('../../src/lib/profileCache.js');
+      const profile = await getCachedProfile('some-uid');
+      expect(profile).toBeNull();
+    });
+
+    it('returns null if firebaseUid is not provided', async () => {
+      const redisClientMock = {
+        get: vi.fn(),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const { getCachedProfile } = await import('../../src/lib/profileCache.js');
+      const profile = await getCachedProfile(null);
+      expect(profile).toBeNull();
+      expect(redisClientMock.get).not.toHaveBeenCalled();
+    });
+
+    it('retrieves and parses cached profile on hit', async () => {
+      const mockProfile = { id: 'user-123', fullName: 'Alice' };
+      const redisClientMock = {
+        get: vi.fn().mockResolvedValue(JSON.stringify(mockProfile)),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const { getCachedProfile } = await import('../../src/lib/profileCache.js');
+      const profile = await getCachedProfile('firebase-123');
+      expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:firebase-123');
+      expect(profile).toEqual(mockProfile);
+    });
+
+    it('returns null and logs error if JSON parsing fails', async () => {
+      const redisClientMock = {
+        get: vi.fn().mockResolvedValue('invalid-json-string{'),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getCachedProfile } = await import('../../src/lib/profileCache.js');
+      try {
+        const profile = await getCachedProfile('firebase-123');
+        expect(profile).toBeNull();
+        expect(consoleSpy).toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    it('returns null and logs error if redis get throws', async () => {
+      const redisClientMock = {
+        get: vi.fn().mockRejectedValue(new Error('Redis connection failure')),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getCachedProfile } = await import('../../src/lib/profileCache.js');
+      try {
+        const profile = await getCachedProfile('firebase-123');
+        expect(profile).toBeNull();
+        expect(consoleSpy).toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('setCachedProfile', () => {
+    it('does not write and does not throw if redisClient is not defined', async () => {
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: null,
+      }));
+
+      const { setCachedProfile } = await import('../../src/lib/profileCache.js');
+      await expect(setCachedProfile('firebase-123', { id: '123' })).resolves.not.toThrow();
+    });
+
+    it('does not write if parameters are missing', async () => {
+      const redisClientMock = {
+        set: vi.fn(),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const { setCachedProfile } = await import('../../src/lib/profileCache.js');
+      await setCachedProfile(null, { id: '123' });
+      await setCachedProfile('firebase-123', null);
+      expect(redisClientMock.set).not.toHaveBeenCalled();
+    });
+
+    it('calls redis set with correct parameters and TTL', async () => {
+      const redisClientMock = {
+        set: vi.fn().mockResolvedValue('OK'),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const mockProfile = { id: 'user-123', fullName: 'Alice' };
+      const { setCachedProfile } = await import('../../src/lib/profileCache.js');
+      await setCachedProfile('firebase-123', mockProfile);
+      expect(redisClientMock.set).toHaveBeenCalledWith(
+        'user:profile:firebase-123',
+        JSON.stringify(mockProfile),
+        'EX',
+        900
+      );
+    });
+
+    it('logs error if redis set throws', async () => {
+      const redisClientMock = {
+        set: vi.fn().mockRejectedValue(new Error('Redis read-only')),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { setCachedProfile } = await import('../../src/lib/profileCache.js');
+      try {
+        await setCachedProfile('firebase-123', { id: '123' });
+        expect(consoleSpy).toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('invalidateCachedProfile', () => {
+    it('does not call and does not throw if redisClient is not defined', async () => {
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: null,
+      }));
+
+      const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+      await expect(invalidateCachedProfile('firebase-123')).resolves.not.toThrow();
+    });
+
+    it('does not call if firebaseUid is missing', async () => {
+      const redisClientMock = {
+        del: vi.fn(),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+      await invalidateCachedProfile(null);
+      expect(redisClientMock.del).not.toHaveBeenCalled();
+    });
+
+    it('calls redis del with correct key', async () => {
+      const redisClientMock = {
+        del: vi.fn().mockResolvedValue(1),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+      await invalidateCachedProfile('firebase-123');
+      expect(redisClientMock.del).toHaveBeenCalledWith('user:profile:firebase-123');
+    });
+
+    it('logs error if redis del throws', async () => {
+      const redisClientMock = {
+        del: vi.fn().mockRejectedValue(new Error('Redis del fail')),
+      };
+      vi.doMock('../../src/config/db.js', () => ({
+        redisClient: redisClientMock,
+      }));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+      try {
+        await invalidateCachedProfile('firebase-123');
+        expect(consoleSpy).toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -16,6 +16,18 @@ describe('profileCache utility', () => {
       expect(profile).toBeNull();
     });
 
+    it('returns null gracefully and does not throw if db.js is mocked as an empty object (Vitest mock proxy behavior)', async () => {
+      vi.doMock('../../src/config/db.js', () => ({}));
+
+      const { getCachedProfile, setCachedProfile, invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+      
+      const profile = await getCachedProfile('some-uid');
+      expect(profile).toBeNull();
+      
+      await expect(setCachedProfile('some-uid', { id: '123' })).resolves.toBeUndefined();
+      await expect(invalidateCachedProfile('some-uid')).resolves.toBeUndefined();
+    });
+
     it('returns null if firebaseUid is not provided', async () => {
       const redisClientMock = {
         get: vi.fn(),

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -93,7 +93,7 @@ describe('profileCache utility', () => {
       }));
 
       const { setCachedProfile } = await import('../../src/lib/profileCache.js');
-      await expect(setCachedProfile('firebase-123', { id: '123' })).resolves.not.toThrow();
+      await expect(setCachedProfile('firebase-123', { id: '123' })).resolves.toBeUndefined();
     });
 
     it('does not write if parameters are missing', async () => {
@@ -156,7 +156,7 @@ describe('profileCache utility', () => {
       }));
 
       const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
-      await expect(invalidateCachedProfile('firebase-123')).resolves.not.toThrow();
+      await expect(invalidateCachedProfile('firebase-123')).resolves.toBeUndefined();
     });
 
     it('does not call if firebaseUid is missing', async () => {

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -20,7 +20,7 @@ describe('profileCache utility', () => {
       vi.doMock('../../src/config/db.js', () => ({}));
 
       const { getCachedProfile, setCachedProfile, invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
-      
+
       const profile = await getCachedProfile('some-uid');
       expect(profile).toBeNull();
       

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -119,13 +119,13 @@ describe('profileCache utility', () => {
       }));
 
       const mockProfile = { id: 'user-123', fullName: 'Alice' };
-      const { setCachedProfile } = await import('../../src/lib/profileCache.js');
+      const { setCachedProfile, TTL_SECONDS } = await import('../../src/lib/profileCache.js');
       await setCachedProfile('firebase-123', mockProfile);
       expect(redisClientMock.set).toHaveBeenCalledWith(
         'user:profile:firebase-123',
         JSON.stringify(mockProfile),
         'EX',
-        900
+        TTL_SECONDS
       );
     });
 

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 describe('profileCache utility', () => {
   beforeEach(() => {
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../../src/config/db.js');
   });
 
   describe('getCachedProfile', () => {
@@ -258,6 +262,50 @@ describe('profileCache utility', () => {
       expect(isValidCachedProfile('uid123', badUid)).toBe(false);
       expect(isValidCachedProfile('uid123', badId)).toBe(false);
       expect(isValidCachedProfile('uid123', badRole)).toBe(false);
+    });
+
+    it('returns true for active profile with valid optional fullName and phone', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      const validProfile1 = {
+        id: 'user-id-123',
+        uid: 'uid123',
+        role: 'driver',
+        isActive: true,
+        fullName: 'Bob Smith',
+        phone: '+123456789'
+      };
+      const validProfile2 = {
+        id: 'user-id-123',
+        uid: 'uid123',
+        role: 'driver',
+        isActive: true,
+        fullName: null,
+        phone: undefined
+      };
+      expect(isValidCachedProfile('uid123', validProfile1)).toBe(true);
+      expect(isValidCachedProfile('uid123', validProfile2)).toBe(true);
+    });
+
+    it('returns false for active profile with invalid type for fullName or phone', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      const badFullName = {
+        id: 'user-id-123',
+        uid: 'uid123',
+        role: 'driver',
+        isActive: true,
+        fullName: 123,
+        phone: '+123456789'
+      };
+      const badPhone = {
+        id: 'user-id-123',
+        uid: 'uid123',
+        role: 'driver',
+        isActive: true,
+        fullName: 'Bob Smith',
+        phone: {}
+      };
+      expect(isValidCachedProfile('uid123', badFullName)).toBe(false);
+      expect(isValidCachedProfile('uid123', badPhone)).toBe(false);
     });
   });
 });

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -216,4 +216,48 @@ describe('profileCache utility', () => {
       }
     });
   });
+
+  describe('isValidCachedProfile', () => {
+    it('returns false for invalid inputs (null, array, string, non-object)', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      expect(isValidCachedProfile('uid123', null)).toBe(false);
+      expect(isValidCachedProfile('uid123', undefined)).toBe(false);
+      expect(isValidCachedProfile('uid123', [])).toBe(false);
+      expect(isValidCachedProfile('uid123', 'string')).toBe(false);
+      expect(isValidCachedProfile('uid123', 123)).toBe(false);
+    });
+
+    it('returns false if isActive is missing or not a boolean', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      expect(isValidCachedProfile('uid123', { uid: 'uid123', id: 'id123', role: 'driver' })).toBe(false);
+      expect(isValidCachedProfile('uid123', { isActive: 'true', uid: 'uid123', id: 'id123', role: 'driver' })).toBe(false);
+    });
+
+    it('returns true for a valid tombstone (isActive === false)', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      expect(isValidCachedProfile('uid123', { isActive: false })).toBe(true);
+    });
+
+    it('returns true for a valid active profile', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      const validProfile = {
+        id: 'user-id-123',
+        uid: 'uid123',
+        role: 'driver',
+        isActive: true
+      };
+      expect(isValidCachedProfile('uid123', validProfile)).toBe(true);
+    });
+
+    it('returns false for active profile with non-matching uid or invalid types', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      const badUid = { id: 'user-id-123', uid: 'different-uid', role: 'driver', isActive: true };
+      const badId = { id: 123, uid: 'uid123', role: 'driver', isActive: true };
+      const badRole = { id: 'user-id-123', uid: 'uid123', role: null, isActive: true };
+
+      expect(isValidCachedProfile('uid123', badUid)).toBe(false);
+      expect(isValidCachedProfile('uid123', badId)).toBe(false);
+      expect(isValidCachedProfile('uid123', badRole)).toBe(false);
+    });
+  });
 });

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -12,11 +12,11 @@
 import { defineConfig } from 'vitest/config';
 import fs from 'node:fs';
 
-const getSafeRealPath = (path) => {
+const getSafeRealPath = (dirPath) => {
   try {
-    return fs.realpathSync(path);
+    return fs.realpathSync(dirPath);
   } catch (err) {
-    return path;
+    return dirPath;
   }
 };
 

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
+    // Preserve symlinks so that testing in workspace directories containing special characters
+    // (like '#') using a directory symlink or junction resolves imports correctly without breaking.
     preserveSymlinks: true,
   },
   plugins: [

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -1,9 +1,21 @@
+/**
+ * Vitest configuration for the backend API.
+ *
+ * Picks up:
+ *   - test/unit/**\/*.test.js
+ *   - test/integration/**\/*.test.js
+ *
+ * The integration tests use `vi.mock('../../src/config/db.js', ...)` to
+ * swap supabase out for the in-memory mock — no live DB required.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
-    // Preserve symlinks so that testing in workspace directories containing special characters
-    // (like '#') using a directory symlink or junction resolves imports correctly without breaking.
+    // Preserve symlinks so that testing under workspace directories containing special
+    // characters (like '#') can bypass Vite's URL-based resolution limitations by running
+    // from a safe directory junction or symlink.
     preserveSymlinks: true,
   },
   plugins: [

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -10,16 +10,17 @@
  */
 
 import { defineConfig } from 'vitest/config';
-import fs from 'fs';
+import fs from 'node:fs';
 
 export default defineConfig({
   resolve: {
     // Preserve symlinks so that testing under workspace directories containing special
     // characters (like '#') can bypass Vite's URL-based resolution limitations by running
     // from a safe directory junction or symlink.
-    preserveSymlinks: process.cwd().includes('#') || 
-                      fs.realpathSync(process.cwd()).includes('#') || 
-                      process.env.PRESERVE_SYMLINKS === 'true',
+    preserveSymlinks:
+      process.cwd().includes('#') ||
+      fs.realpathSync(process.cwd()).includes('#') ||
+      process.env.PRESERVE_SYMLINKS === 'true',
   },
   plugins: [
     {

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -12,6 +12,14 @@
 import { defineConfig } from 'vitest/config';
 import fs from 'node:fs';
 
+const getSafeRealPath = (path) => {
+  try {
+    return fs.realpathSync(path);
+  } catch (err) {
+    return path;
+  }
+};
+
 export default defineConfig({
   resolve: {
     // Preserve symlinks so that testing under workspace directories containing special
@@ -19,7 +27,7 @@ export default defineConfig({
     // from a safe directory junction or symlink.
     preserveSymlinks:
       process.cwd().includes('#') ||
-      fs.realpathSync(process.cwd()).includes('#') ||
+      getSafeRealPath(process.cwd()).includes('#') ||
       process.env.PRESERVE_SYMLINKS === 'true',
   },
   plugins: [

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -10,13 +10,16 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import fs from 'fs';
 
 export default defineConfig({
   resolve: {
     // Preserve symlinks so that testing under workspace directories containing special
     // characters (like '#') can bypass Vite's URL-based resolution limitations by running
     // from a safe directory junction or symlink.
-    preserveSymlinks: true,
+    preserveSymlinks: process.cwd().includes('#') || 
+                      fs.realpathSync(process.cwd()).includes('#') || 
+                      process.env.PRESERVE_SYMLINKS === 'true',
   },
   plugins: [
     {

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -22,8 +22,8 @@ const getSafeRealPath = (dirPath) => {
 
 export default defineConfig({
   resolve: {
-    // Preserve symlinks so that testing under workspace directories containing special
-    // characters (like '#') can bypass Vite's URL-based resolution limitations by running
+    // Preserve symlinks so that testing under workspace directories containing the '#'
+    // character can bypass Vite's URL-based resolution limitations by running
     // from a safe directory junction or symlink.
     preserveSymlinks:
       (!process.cwd().includes('#') && getSafeRealPath(process.cwd()).includes('#')) ||

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -26,8 +26,7 @@ export default defineConfig({
     // characters (like '#') can bypass Vite's URL-based resolution limitations by running
     // from a safe directory junction or symlink.
     preserveSymlinks:
-      process.cwd().includes('#') ||
-      getSafeRealPath(process.cwd()).includes('#') ||
+      (!process.cwd().includes('#') && getSafeRealPath(process.cwd()).includes('#')) ||
       process.env.PRESERVE_SYMLINKS === 'true',
   },
   plugins: [

--- a/backend/api/vitest.config.js
+++ b/backend/api/vitest.config.js
@@ -1,16 +1,9 @@
-/**
- * Vitest configuration for the backend API.
- *
- * Picks up:
- *   - test/unit/**\/*.test.js
- *   - test/integration/**\/*.test.js
- *
- * The integration tests use `vi.mock('../../src/config/db.js', ...)` to
- * swap supabase out for the in-memory mock — no live DB required.
- */
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    preserveSymlinks: true,
+  },
   plugins: [
     {
       name: 'remove-shebang',


### PR DESCRIPTION
Closes #401 


#Description 
To improve API response times and reduce unnecessary load on the Supabase/PostgreSQL profiles database table, this PR implements a Redis-based caching strategy for user profile data resolved during authentication.

Proposed Changes
1. Profile Caching Library (src/lib/profileCache.js):
 - Encapsulates cache reads, writes, and invalidation using the key format user:profile:${firebaseUid} and a TTL of 15 minutes (900 seconds).
 - Fully resilient to Redis downtime; if the Redis client is unavailable or throws errors, operations log details to console.error and gracefully return null / fallback.
 - Utilizes safe namespace imports and try-catch wrappers to prevent module resolution errors when running unit tests with mock database configs.

2. Auth Middleware Integration (src/middleware/auth.js):
 - Firebase Token Branch: The middleware attempts to retrieve the profile from Redis first. On cache hits, it populates req.user directly and skips the database query entirely. On cache misses, it queries the database and performs write-through cache population.
 - Supabase Token Branch: Fetches the profile by user.id as usual, but updates the cache key under user:profile:${profile.firebase_uid} to benefit subsequent Firebase-token requests.

3. Cache Invalidation on Mutation (src/routes/profileRoutes.js):
 - Automatically calls invalidateCachedProfile(req.user.uid) inside the PUT / profile update route once database updates succeed, ensuring the cache is always fresh.

4. Testing Infrastructure Config (vitest.config.js):
 - Added resolve: { preserveSymlinks: true } to natively support Vitest execution within symlinked workspaces (such as Windows junctions).

#Testing Checklist
[x] Cache hits bypass database queries and return profiles successfully.
[x] Cache misses fall back to the database and write profiles to the cache.
[x] Profiles are stored in Redis with a 15-minute TTL.
[x] Updating a user profile invalidates the corresponding cache entry.
[x] Redis failures do not interrupt authentication flows (graceful database fallback).
[x] Executed full unit and integration test suites: 267/267 tests passing successfully with zero regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Redis-backed per-user profile cache with a 15-minute TTL to speed up authenticated requests during Firebase token verification.
  * When a profile is inactive, cached results can now block access with a clear 403 response.
* **Bug Fixes**
  * Improved resilience: Redis/JSON errors no longer prevent authentication; the system safely falls back to retrieving the profile from the database.
  * Cached entries are invalidated after successful profile updates to keep subsequent reads consistent.
* **Tests**
  * Added unit and integration coverage for cache get/set/invalidate behavior, cache hit/miss handling, and Redis error fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->