### PR TITLE
fix(driver): prevent OTP screen from navigating before backend verifi…

### DIFF
--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -61,7 +62,7 @@ class _OtpScreenState extends State<OtpScreen> {
           'phone': widget.phone,
           'otp': code,
         }),
-      );
+      ).timeout(const Duration(seconds: 15));
 
       if (!mounted) return;
 
@@ -76,7 +77,16 @@ class _OtpScreenState extends State<OtpScreen> {
         return;
       }
 
-      Navigator.of(context).pushNamed(AppRoutes.shell);
+      Navigator.of(context).pushReplacementNamed(AppRoutes.shell);
+    } on TimeoutException {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Verification timed out. Please check your connection and try again.',
+          ),
+        ),
+      );
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 import '../core/app_routes.dart';
 import '../theme/app_theme.dart';
@@ -15,9 +18,15 @@ class OtpScreen extends StatefulWidget {
 }
 
 class _OtpScreenState extends State<OtpScreen> {
+  static const String _apiBaseUrl = String.fromEnvironment(
+    'TRUXIFY_API_BASE_URL',
+    defaultValue: 'http://localhost:5000',
+  );
+
   late final List<TextEditingController> _controllers =
       List.generate(4, (_) => TextEditingController());
   late final List<FocusNode> _focusNodes = List.generate(4, (_) => FocusNode());
+  bool _loading = false;
 
   @override
   void dispose() {
@@ -31,6 +40,8 @@ class _OtpScreenState extends State<OtpScreen> {
   }
 
   Future<void> _verifyOtp() async {
+    if (_loading) return;
+
     final code =
         _controllers.map((c) => c.text.replaceAll('\u200B', '')).join();
     if (!RegExp(r'^\d{4}$').hasMatch(code)) {
@@ -39,17 +50,58 @@ class _OtpScreenState extends State<OtpScreen> {
       );
       return;
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-            'OTP verification is not available yet. Please try again later.'),
-      ),
-    );
-    // TODO: Integrate backend OTP verification and navigate only after a successful response.
-    // TODO: After implimenting the backend otp logic then remove the push named.
-    Navigator.of(context).pushNamed(
-      AppRoutes.shell,
-    );
+
+    setState(() => _loading = true);
+    try {
+      final uri = Uri.parse('$_apiBaseUrl/api/driver/otp/verify');
+      final response = await http.post(
+        uri,
+        headers: const {'Content-Type': 'application/json'},
+        body: jsonEncode(<String, String>{
+          'phone': widget.phone,
+          'otp': code,
+        }),
+      );
+
+      if (!mounted) return;
+
+      final success = response.statusCode >= 200 && response.statusCode < 300;
+      if (!success) {
+        final message = response.body.isNotEmpty
+            ? _extractErrorMessage(response.body)
+            : 'OTP verification failed.';
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        return;
+      }
+
+      Navigator.of(context).pushNamed(AppRoutes.shell);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not verify OTP: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  String _extractErrorMessage(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final error = decoded['error']?.toString();
+        if (error != null && error.isNotEmpty) {
+          return error;
+        }
+      }
+    } catch (_) {
+      // Fall through to generic error message.
+    }
+    return 'OTP verification failed.';
   }
 
   @override
@@ -95,8 +147,8 @@ class _OtpScreenState extends State<OtpScreen> {
               OtpInputRow(controllers: _controllers, focusNodes: _focusNodes),
               const SizedBox(height: 24),
               PrimaryButton(
-                label: 'Verify OTP',
-                onPressed: _verifyOtp,
+                label: _loading ? 'Verifying...' : 'Verify OTP',
+                onPressed: _loading ? null : _verifyOtp,
               ),
             ],
           ),

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -15,7 +15,7 @@ const loginOtpSchema = z.object({
 
 const verifyLoginOtpLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 20,
+  max: 5,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many OTP verification attempts. Please try again later.' },

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -3,8 +3,47 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
 import { driverOnlineSchema, withdrawSchema } from '../validation/requestSchemas.js';
+import rateLimit from 'express-rate-limit';
+import { z } from 'zod';
 
 const router = express.Router();
+
+const loginOtpSchema = z.object({
+  phone: z.string().trim().min(10).max(20),
+  otp: z.string().regex(/^\d{4}$/, { message: 'OTP must be 4 digits' }),
+});
+
+const verifyLoginOtpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many OTP verification attempts. Please try again later.' },
+});
+
+router.post('/otp/verify', verifyLoginOtpLimiter, validateBody(loginOtpSchema), async (req, res) => {
+  const { phone, otp } = req.body;
+  const expectedOtp = (process.env.DRIVER_LOGIN_OTP || '1234').trim();
+
+  if (process.env.NODE_ENV === 'production' && !process.env.DRIVER_LOGIN_OTP) {
+    return res.status(503).json({
+      error: 'Driver login OTP verification is not configured on this server.',
+    });
+  }
+
+  if (process.env.DRIVER_LOGIN_PHONE && phone !== process.env.DRIVER_LOGIN_PHONE.trim()) {
+    return res.status(400).json({ error: 'Invalid phone number for OTP verification.' });
+  }
+
+  if (otp !== expectedOtp) {
+    return res.status(400).json({ error: 'Invalid OTP. Please try again.' });
+  }
+
+  return res.json({
+    message: 'OTP verified successfully.',
+    verified: true,
+  });
+});
 
 // ============================================================================
 // 1. GET DRIVER STATS (DRIVER)

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -72,6 +72,29 @@ describe('Driver Routes', () => {
     expect(res.body.truck).toBe(null);
   });
 
+  it('POST /otp/verify accepts the default driver login OTP', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/drivers/otp/verify')
+      .send({ phone: '9876543210', otp: '1234' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.verified).toBe(true);
+    expect(res.body.message).toBe('OTP verified successfully.');
+  });
+
+  it('POST /otp/verify rejects invalid OTP', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/drivers/otp/verify')
+      .send({ phone: '9876543210', otp: '0000' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid OTP. Please try again.');
+  });
+
   it('GET /stats returns truck details when truck assigned', async () => {
     m.store.driver_details.push({
       user_id: 'driver-1',


### PR DESCRIPTION
## Summary

This PR addresses issue #543 by replacing the temporary OTP flow in the driver app with a real backend verification step, so the app only navigates forward after the OTP has been confirmed.

## What was happening before

In the previous flow, the driver OTP screen only checked that the entered code was 4 digits long. After that, it still navigated to `AppRoutes.shell` even though verification was not actually completed. That meant the OTP step was effectively just a client-side placeholder.

## What changed

### Driver app
- Added a backend OTP verification call in `apps/driver/lib/screens/otp_screen.dart`
- Kept the existing 4-digit format validation
- Added a loading state while verification is in progress
- Prevented navigation until the backend returns success
- Showed backend error messages when verification fails

### Backend API
- Added a small OTP verification endpoint for the driver login flow in `backend/api/src/routes/driverRoutes.js`
- Added rate limiting for repeated OTP attempts
- Allowed the OTP to be configured through environment variables for local development
- Kept the default local test OTP as `1234`

### Tests
- Added integration coverage in `backend/api/test/integration/driverRoutes.test.js`
- Verified both the success and failure cases for OTP validation

## Files changed

- `apps/driver/lib/screens/otp_screen.dart`
- `backend/api/src/routes/driverRoutes.js`
- `backend/api/test/integration/driverRoutes.test.js`

## Why this is needed

The previous implementation let users proceed without a real backend check, which made the OTP screen misleading and incomplete. This change makes the flow behave more like a proper verification gate and keeps the navigation aligned with the verification result.

## Testing

- Ran backend integration tests for the driver routes
- Confirmed the new OTP verification route passes the test suite

Closes #543

## Checklist

- [x] I have tested the backend OTP verification flow
- [x] I have added or updated tests for the new behavior
- [x] I have kept the change scoped to the driver OTP flow
- [x] I have confirmed the app no longer navigates before backend verification
- [x] I have reviewed the changes for unintended side effects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Driver OTP verification is now backed by the backend, replacing the placeholder flow.
  * Users receive clearer error feedback on failed verification attempts.
  * The verification button shows a “Verifying...” state and disables duplicate submissions while processing.
  * Added backend protection for OTP attempts via rate limiting and stricter OTP input validation.
* **Tests**
  * Added integration coverage for successful verification and invalid-OTP error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->