### PR TITLE
fix: remove OTP from notification metadata and redact in logs (CWE-312/532)

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -23,7 +23,6 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         notif_type: 'order_update',
         metadata: {
           order_display_id: orderDisplayId,
-          otp,
         },
       });
 
@@ -71,12 +70,14 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
 
   // 3. SMS Gateway (e.g. Twilio) Stub
   if (process.env.TWILIO_AUTH_TOKEN) {
-    console.log(
-      `[NotificationService] [SMS] SMS stub: Sending SMS to customer phone containing OTP ${otp}`
-    );
+    const smsOtpLog = process.env.NODE_DEBUG
+      ? `Sending SMS to customer phone containing OTP ${otp}`
+      : `Sending SMS to customer phone containing OTP ${otp.slice(0, 2)}***`;
+    console.log(`[NotificationService] [SMS] SMS stub: ${smsOtpLog}`);
   } else {
+    const logOtp = process.env.NODE_DEBUG ? otp : `${otp.slice(0, 2)}***`;
     console.log(
-      `[NotificationService] [SMS] SMS stub: No SMS gateway configured. Logging OTP out-of-band: ${otp}`
+      `[NotificationService] [SMS] SMS stub: No SMS gateway configured. Logging OTP out-of-band: ${logOtp}`
     );
   }
 }


### PR DESCRIPTION
### Security Fix (CWE-312 / CWE-532)

Closes #517

**Changes in `notificationService.js`:**

1. **CWE-312 — Cleartext Storage:** Removed `otp` from `metadata` in the notification insert. The OTP is still delivered through the notification `body` text and is available during the delivery window — it no longer persists indefinitely in the `notifications` table metadata.

2. **CWE-532 — Sensitive Info in Logs:** Redacted OTP in SMS gateway console logs (shows only first 2 digits: `***`). Full OTP only logged when `NODE_DEBUG` environment variable is set.

**Files changed:** `backend/api/src/services/notificationService.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced OTP protection by masking sensitive values in logs when debug mode is disabled. OTP data handling has been updated to improve privacy and reduce exposure of sensitive authentication codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->