### PR TITLE
fix: add per-connection WebSocket message rate limiting (CWE-770)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -23,6 +23,8 @@ let telemetryMonitorInterval = null;
 
 const WS_UPGRADE_RATE_LIMIT = 5;
 const WS_UPGRADE_RATE_WINDOW_SECONDS = 60;
+const MAX_MSG_PER_SECOND = 10;
+const messageRateTracker = new WeakMap();
 
 function getClientIp(request) {
   const forwardedFor = request.headers?.['x-forwarded-for'];
@@ -248,7 +250,22 @@ export function initWebSocketServer(server) {
   console.log('🚀 WebSocket tracking router initialized.');
 }
 
+function isMessageRateLimited(ws) {
+  const now = Date.now();
+  let state = messageRateTracker.get(ws);
+  if (!state || now - state.windowStart >= 1000) {
+    state = { count: 0, windowStart: now };
+    messageRateTracker.set(ws, state);
+  }
+  state.count++;
+  return state.count > MAX_MSG_PER_SECOND;
+}
+
 export async function handleTrackingMessage(ws, message) {
+  if (isMessageRateLimited(ws)) {
+    return;
+  }
+
   const messageText = message.toString();
 
   if (messageText === 'ping') {

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1087,6 +1087,46 @@ describe('flushTelemetryBuffer - with MongoDB', () => {
     expect(buffer[1].driver_id).toBe('new-driver');
   });
 
+  it('caps retry re-queue depth to prevent geometric growth on persistent failures', async () => {
+    const insertMany = vi.fn().mockImplementation(async () => {
+      // Simulate new pings arriving to almost fill the buffer while DB write is active
+      const { __testing: t } = await import('../../src/sockets/tracker.js');
+      const mockNewRecords = Array.from({ length: 4995 }, (_, i) => ({ driver_id: `new-driver-${i}` }));
+      t.setTelemetryWriteBuffer(mockNewRecords);
+      throw new Error('transient write failure');
+    });
+    const collection = vi.fn().mockReturnValue({ insertMany });
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: { collection },
+      redisClient: null,
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { __testing: t } = await import('../../src/sockets/tracker.js');
+    const mockOldRecords = Array.from({ length: 10 }, (_, i) => ({ driver_id: `old-driver-${i}` }));
+    t.setTelemetryWriteBuffer(mockOldRecords);
+
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await t.flushTelemetryBuffer();
+
+    const buffer = t.getTelemetryWriteBuffer();
+    // 5000 is MAX_BUFFER_SIZE. 4995 new records + 5 kept old records = 5000 records.
+    expect(buffer).toHaveLength(5000);
+    // The first 5 old records (indices 0 to 4) should be dropped, keeping only indices 5 to 9.
+    expect(buffer[0].driver_id).toBe('old-driver-5');
+    expect(buffer[4].driver_id).toBe('old-driver-9');
+    expect(buffer[5].driver_id).toBe('new-driver-0');
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[TRUXIFY BUFFER DROP] Buffer full: dropped 5 oldest records from retry batch.')
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
   it('discards buffer on MongoDB validation error (code 121)', async () => {
     const validationError = new Error('Document failed validation');
     validationError.code = 121;

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1214,4 +1214,38 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
       consoleWarnSpy.mockRestore();
     });
   });
+
+  describe('per-connection message rate limiting (CWE-770)', () => {
+    beforeEach(() => {
+      __testing.clearTelemetryWriteBuffer();
+    });
+
+    it('allows messages within the per-second limit', async () => {
+      const ws = { driverId: 'driver-rate', send: vi.fn() };
+
+      for (let i = 0; i < 5; i++) {
+        await handleTrackingMessage(ws, JSON.stringify({
+          event: 'location_ping',
+          data: { latitude: 12.97, longitude: 77.59 },
+        }));
+      }
+
+      const buffer = __testing.getTelemetryWriteBuffer();
+      expect(buffer.length).toBe(5);
+    });
+
+    it('drops messages that exceed the per-second limit', async () => {
+      const ws = { driverId: 'driver-rate-limit', send: vi.fn() };
+
+      for (let i = 0; i < 15; i++) {
+        await handleTrackingMessage(ws, JSON.stringify({
+          event: 'location_ping',
+          data: { latitude: 12.97, longitude: 77.59 },
+        }));
+      }
+
+      const buffer = __testing.getTelemetryWriteBuffer();
+      expect(buffer.length).toBe(10);
+    });
+  });
 });


### PR DESCRIPTION
### Security Fix (CWE-770)

Closes #518

**Changes:**

1. **Per-connection message rate limiting** — Added `MAX_MSG_PER_SECOND = 10` with a `WeakMap`-based rate tracker. `handleTrackingMessage` silently drops messages that exceed 10/sec per WebSocket connection. The rate window resets each second.

2. **Tests added** — Verifies messages within limit pass through, messages over limit are dropped (15 msg/s → 10 accepted).

**Existing protections (not changed):**
- `MAX_BUFFER_SIZE = 5000` with oldest-10% drop on overflow
- Capacity-aware re-queue on flush failure (`MAX_BUFFER_SIZE - telemetryWriteBuffer.length`)

**Files changed:** `backend/api/src/sockets/tracker.js`, `backend/api/test/unit/tracker.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-connection message rate limiting to drop excessive `location_ping` traffic, protecting system stability.
  * Improved telemetry buffer retry handling during transient write failures by capping retry re-queue growth and emitting a buffer-drop warning when limits are reached.

* **Tests**
  * Added unit tests to verify rate limiting accepts messages within the allowance and drops excess while keeping buffer sizing bounded.
  * Added tests covering telemetry buffer retry behavior, ensuring capped retry depth, correct ordering, and warning output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->