### PR TITLE
fix: use atomic conditional UPDATE for cancel and verify-delivery (CWE-362)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -669,9 +669,14 @@ router.post('/:id/verify-delivery', authenticate, requireRole(['driver']), verif
 
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({
       otp_verified: true, status: 'payment_released', updated_at: new Date().toISOString()
-    }).eq('id', orderId).select('*').single();
+    }).eq('id', orderId).not('status', 'eq', 'cancelled').select('*').single();
 
-    if (updateErr) return res.status(500).json({ error: 'Failed to verify OTP.', details: updateErr.message });
+    if (updateErr) {
+      if (updateErr.code === 'PGRST116') {
+        return res.status(409).json({ error: 'Order was already cancelled. Cannot verify delivery.' });
+      }
+      return res.status(500).json({ error: 'Failed to verify OTP.', details: updateErr.message });
+    }
 
     await supabase.from('order_timeline').update({ completed: true, milestone_time: new Date().toISOString() }).eq('order_display_id', order.order_display_id).eq('milestone', 'Delivered');
 
@@ -683,7 +688,7 @@ router.post('/:id/verify-delivery', authenticate, requireRole(['driver']), verif
     }
 
     // Escrow: release funds to driver after successful delivery verification
-    if (order.escrow_status === 'funded') {
+    if (updatedOrder.escrow_status === 'funded') {
       escrowRelease(order.order_display_id).then(({ txHash }) => {
         if (txHash) {
           supabase.from('orders').update({
@@ -798,12 +803,18 @@ router.post('/:id/cancel', authenticate, requireRole(['customer']), validatePara
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
 
-    if (['delivered', 'payment_released'].includes(order.status)) {
-      return res.status(400).json({ error: 'Order cannot be cancelled after delivery or payment release.' });
+    const { data: updatedOrder, error: updateErr } = await supabase.from('orders')
+      .update({ status: 'cancelled', cancellation_reason: reason, updated_at: new Date().toISOString() })
+      .eq('order_display_id', orderId)
+      .not('status', 'in', '("delivered","payment_released")')
+      .select('cancellation_fee, order_display_id, status, cancellation_reason, escrow_status')
+      .single();
+    if (updateErr) {
+      if (updateErr.code === 'PGRST116') {
+        return res.status(409).json({ error: 'Order was already delivered or payment released. Cannot cancel.' });
+      }
+      return res.status(500).json({ error: 'Failed to cancel order.', details: updateErr.message });
     }
-
-    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({ status: 'cancelled', cancellation_reason: reason, updated_at: new Date().toISOString() }).eq('order_display_id', orderId).select('cancellation_fee, order_display_id, status, cancellation_reason').single();
-    if (updateErr) return res.status(500).json({ error: 'Failed to cancel order.', details: updateErr.message });
 
     const cancellationFee = updatedOrder?.cancellation_fee ?? 0;
 
@@ -811,7 +822,7 @@ router.post('/:id/cancel', authenticate, requireRole(['customer']), validatePara
       .eq('order_display_id', order.order_display_id)
       .eq('milestone', 'Order Placed');
 
-    if (order.escrow_status === 'funded') {
+    if (updatedOrder.escrow_status === 'funded') {
       escrowRefund(order.order_display_id).then(({ txHash }) => {
         if (txHash) {
           supabase.from('orders').update({

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -669,11 +669,17 @@ router.post('/:id/verify-delivery', authenticate, requireRole(['driver']), verif
 
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update({
       otp_verified: true, status: 'payment_released', updated_at: new Date().toISOString()
-    }).eq('id', orderId).not('status', 'eq', 'cancelled').select('*').single();
+    })
+      .eq('id', orderId)
+      .eq('otp_verified', false)
+      .not('status', 'eq', 'cancelled')
+      .not('status', 'eq', 'payment_released')
+      .select('*')
+      .single();
 
     if (updateErr) {
       if (updateErr.code === 'PGRST116') {
-        return res.status(409).json({ error: 'Order was already cancelled. Cannot verify delivery.' });
+        return res.status(409).json({ error: 'Order was already cancelled or payment released.' });
       }
       return res.status(500).json({ error: 'Failed to verify OTP.', details: updateErr.message });
     }
@@ -806,12 +812,12 @@ router.post('/:id/cancel', authenticate, requireRole(['customer']), validatePara
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders')
       .update({ status: 'cancelled', cancellation_reason: reason, updated_at: new Date().toISOString() })
       .eq('order_display_id', orderId)
-      .not('status', 'in', '("delivered","payment_released")')
+      .not('status', 'in', '("delivered","payment_released","cancelled")')
       .select('cancellation_fee, order_display_id, status, cancellation_reason, escrow_status')
       .single();
     if (updateErr) {
       if (updateErr.code === 'PGRST116') {
-        return res.status(409).json({ error: 'Order was already delivered or payment released. Cannot cancel.' });
+        return res.status(409).json({ error: 'Order was already cancelled, delivered, or payment released. Cannot cancel.' });
       }
       return res.status(500).json({ error: 'Failed to cancel order.', details: updateErr.message });
     }

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -77,6 +77,7 @@ class SupabaseQueryBuilder {
   like(col, p)  { this._filters.push({ col, op: 'like', val: p }); return this; }
   ilike(col, p) { this._filters.push({ col, op: 'ilike', val: p }); return this; }
   is(col, val)  { this._filters.push({ col, op: 'is', val }); return this; }
+  not(col, op, val) { this._filters.push({ col, op: `not:${op}`, val }); return this; }
   order(col, opts = {}) {
     this._order = { col, ascending: opts.ascending !== false };
     return this;
@@ -93,6 +94,54 @@ class SupabaseQueryBuilder {
     return this._exec().then(resolve, reject);
   }
   catch(reject) { return this._exec().catch(reject); }
+
+  _matches(row, f) {
+    const v = row[f.col];
+    let op = f.op;
+    let negate = false;
+    if (op.startsWith('not:')) {
+      negate = true;
+      op = op.substring(4);
+    }
+    let res = true;
+    switch (op) {
+      case 'eq':
+      case 'is':
+        res = v === f.val;
+        break;
+      case 'neq':
+        res = v !== f.val;
+        break;
+      case 'gt':
+        res = v > f.val;
+        break;
+      case 'gte':
+        res = v >= f.val;
+        break;
+      case 'lt':
+        res = v < f.val;
+        break;
+      case 'lte':
+        res = v <= f.val;
+        break;
+      case 'in': {
+        if (typeof f.val === 'string') {
+          const clean = f.val.replace(/^\s*\(\s*|\s*\)\s*$/g, '');
+          const items = clean.split(',').map(s => s.trim().replace(/^["']|["']$/g, ''));
+          res = items.includes(v);
+        } else if (Array.isArray(f.val)) {
+          res = f.val.includes(v);
+        } else {
+          res = false;
+        }
+        break;
+      }
+      default:
+        res = true;
+        break;
+    }
+    return negate ? !res : res;
+  }
 
   async _exec() {
     const callRecord = {
@@ -163,16 +212,7 @@ class SupabaseQueryBuilder {
       let updatedRows = [];
 
       for (const row of rows) {
-        const matches = this._filters.every(f => {
-          const v = row[f.col];
-
-          switch (f.op) {
-            case 'eq':
-              return v === f.val;
-            default:
-              return true;
-          }
-        });
+        const matches = this._filters.every(f => this._matches(row, f));
 
         if (matches) {
           Object.assign(row, this._payload);
@@ -181,7 +221,7 @@ class SupabaseQueryBuilder {
       }
 
       if (this._single) {
-        return { data: updatedRows[0] ?? null, error: updatedRows[0] ? null : { message: 'no rows' } };
+        return { data: updatedRows[0] ?? null, error: updatedRows[0] ? null : { code: 'PGRST116', message: 'no rows' } };
       }
       return { data: updatedRows, error: null };
     }
@@ -189,20 +229,7 @@ class SupabaseQueryBuilder {
     if (this._mode === 'select' || this._mode === null) {
       let rows = (this._store[this._table] ?? []).slice();
       for (const f of this._filters) {
-        rows = rows.filter(r => {
-          const v = r[f.col];
-          switch (f.op) {
-            case 'eq':  return v === f.val;
-            case 'neq': return v !== f.val;
-            case 'gt':  return v >  f.val;
-            case 'gte': return v >= f.val;
-            case 'lt':  return v <  f.val;
-            case 'lte': return v <= f.val;
-            case 'in':  return f.val.includes(v);
-            case 'is':  return v === f.val;
-            default:    return true;
-          }
-        });
+        rows = rows.filter(r => this._matches(r, f));
       }
       if (this._order) {
         const { col, ascending } = this._order;
@@ -214,7 +241,7 @@ class SupabaseQueryBuilder {
         rows = rows.slice(from, to + 1);
       }
       if (this._limit != null) rows = rows.slice(0, this._limit);
-      if (this._single)     return { data: rows[0] ?? null, error: rows[0] ? null : { message: 'no rows' }, count: rows[0] ? 1 : 0 };
+      if (this._single)     return { data: rows[0] ?? null, error: rows[0] ? null : { code: 'PGRST116', message: 'no rows' }, count: rows[0] ? 1 : 0 };
       if (this._maybeSingle) return { data: rows[0] ?? null, error: null, count: rows[0] ? 1 : 0 };
       return { data: rows, error: null, count: totalCount };
     }

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1817,8 +1817,8 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'delivered' });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Order cannot be cancelled after delivery or payment release.');
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('Order was already cancelled, delivered, or payment released. Cannot cancel.');
   });
 
   it('rejects cancel when payment is already released', async () => {
@@ -1837,8 +1837,8 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'payment released' });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Order cannot be cancelled after delivery or payment release.');
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('Order was already cancelled, delivered, or payment released. Cannot cancel.');
   });
 
   it('returns 400 when route estimate computation fails during change-drop', async () => {


### PR DESCRIPTION
### Race Condition Fix (CWE-362)

Closes #519

**Problem:** Cancel and verify-delivery endpoints both follow read-then-write pattern without atomicity. Concurrent requests can cause status overwrite and double escrow payout.

**Fix:**
- Cancel: UPDATE includes `.not('status', 'in', '("delivered","payment_released")')` — returns 409 if order already delivered/released
- Verify-delivery: UPDATE includes `.not('status', 'eq', 'cancelled')` — returns 409 if order already cancelled
- Both endpoints use `escrow_status` from the UPDATE response (fresh read) instead of the cached `order` object for escrow decisions

**Files changed:** `backend/api/src/routes/orderRoutes.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery verification to only mark orders as verified when OTP was not yet verified and the order is not cancelled or payment-released; adjusted responses for already-updated scenarios.
  * Updated customer cancellation to enforce cancelability via a single guarded update, returning consistent HTTP 409 conflicts when cancellation isn’t allowed.
  * Fixed escrow refund and on-chain refund eligibility to be determined from the order’s post-update state.
* **Tests**
  * Updated integration tests to expect the revised cancellation error status and message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->