### PR TITLE
fix: add rate limit, role restriction, and fetch timeout to predict-demand (CWE-400)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -110,6 +110,15 @@ const verifyDeliveryLimiter = rateLimit({
   message: { error: 'Too many delivery verification attempts. Please try again later.' },
 });
 
+// Rate limiter for the predict-demand endpoint
+const predictDemandLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many demand prediction requests. Please try again later.' },
+});
+
 /**
  * Helper to generate order display IDs like #FF20260521
  */
@@ -837,7 +846,7 @@ router.post('/:id/cancel', authenticate, requireRole(['customer']), validatePara
 // ============================================================================
 // 12. PREDICT RIDE DEMAND (CUSTOMER OR DRIVER)
 // ============================================================================
-router.post('/predict-demand', authenticate, validateBody(predictDemandSchema), async (req, res) => {
+router.post('/predict-demand', authenticate, requireRole(['customer', 'driver']), predictDemandLimiter, validateBody(predictDemandSchema), async (req, res) => {
   try {
     const prediction = await predictDemand(req.body);
     return res.json(prediction);

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -114,6 +114,12 @@ const verifyDeliveryLimiter = rateLimit({
 const predictDemandLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: process.env.NODE_ENV === 'test' ? 1000 : 10,
+  keyGenerator: (req) => {
+    if (!req.user || !req.user.id) {
+      throw new Error('User is not authenticated');
+    }
+    return req.user.id;
+  },
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many demand prediction requests. Please try again later.' },

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -16,18 +16,26 @@ export async function predictDemand(features) {
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/predict/demand`;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(features),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(features),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
+    }
+
+    return response.json();
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return response.json();
 }

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -16,26 +16,19 @@ export async function predictDemand(features) {
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/predict/demand`;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(features),
+    signal: AbortSignal.timeout(5000),
+  });
 
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(features),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
-    }
-
-    return response.json();
-  } finally {
-    clearTimeout(timeoutId);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
   }
+
+  return response.json();
 }

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1690,6 +1690,61 @@ describe('POST /api/orders/predict-demand — ML demand prediction', () => {
     expect(res.body.error).toBe('Failed to fetch demand prediction from ML engine.');
     expect(res.body.details).toBe('ML service unavailable');
   });
+
+  it('restricts role to customer or driver (returns 403 for admin)', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/orders/predict-demand')
+      .set({
+        'x-user-id': '00000000-0000-0000-0000-000000000xyz',
+        'x-user-role': 'admin',
+        'x-user-name': 'Test Admin',
+      })
+      .send({
+        hour: 14.5,
+        day_of_week: 3,
+        temperature: 25,
+        precipitation: 0,
+        historical_volume: 50,
+        nearby_drivers: 15,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Forbidden: Insufficient privileges.');
+  });
+
+  it('predictDemandLimiter uses user-based rate limiting key generator', async () => {
+    const route = orderRouter.stack.find(s => s.route && s.route.path === '/predict-demand');
+    expect(route).toBeDefined();
+
+    const rateLimitLayer = route.route.stack.find(
+      layer => layer.name === 'rateLimit' || (layer.handle && typeof layer.handle.resetKey === 'function')
+    );
+    expect(rateLimitLayer).toBeDefined();
+
+    const limiter = rateLimitLayer.handle;
+    expect(limiter.getKey).toBeDefined();
+
+    const mockUserVal = 'test-user-rate-limit-123';
+    const mockReq = {
+      user: { id: mockUserVal },
+      ip: '127.0.0.1',
+    };
+    const mockRes = {
+      headersSent: false,
+      setHeader: () => {},
+      getHeader: () => {},
+    };
+    let nextCalled = false;
+    const next = () => { nextCalled = true; };
+
+    await limiter(mockReq, mockRes, next);
+    expect(nextCalled).toBe(true);
+
+    const info = await limiter.getKey(mockUserVal);
+    expect(info).toBeDefined();
+    expect(info.totalHits).toBe(1);
+  });
 });
 
 describe('Customer actions: change-drop and cancel endpoints', () => {


### PR DESCRIPTION
### DoS Amplifier Fix (CWE-400)

Closes #520

**Problem:** Predict-demand endpoint had no rate limiter, no role restriction, and no fetch timeout — a single user could exhaust the Node.js connection pool.

**Fix:**
- Added `predictDemandLimiter` (10 req / 60s per user) matching verify-delivery pattern
- Added `requireRole(['customer', 'driver'])` — was unrestricted
- Added 5s AbortSignal timeout to ML engine fetch in `ml.js`

**Files changed:** `backend/api/src/routes/orderRoutes.js`, `backend/api/src/services/ml.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Security**
  * Added stricter access control to the demand prediction endpoint so only customers and drivers can use it.
  * Added validation to reject unauthorized roles with a clear 403 response.

* **Performance & Reliability**
  * Introduced rate limiting for demand prediction requests to reduce abuse and excessive load.
  * Added a timeout to the machine learning request to prevent long-running calls.

* **Tests**
  * Expanded integration coverage for authorization and rate-limiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->