### PR TITLE
feat: add shimmer loading skeletons to orders screen

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/app_page_route.dart';
 import '../widgets/common_widgets.dart';
 import 'location_picker_screen.dart';
 import 'truck_results_screen.dart';
+import 'package:truxify_shared/shimmer_widget.dart';
 
 class FindTrucksScreen extends StatefulWidget {
   const FindTrucksScreen({super.key});
@@ -18,7 +19,6 @@ class FindTrucksScreen extends StatefulWidget {
 }
 
 class _FindTrucksScreenState extends State<FindTrucksScreen> {
-  // Form key for validation
   final _formKey = GlobalKey<FormState>();
 
   late final TextEditingController _pickupController;
@@ -43,6 +43,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
   LatLng? _dropPoint;
 
   String? _weightErrorText;
+  bool _isLoading = false;
 
   static const _goodsTypes = <String>[
     'Textile',
@@ -151,8 +152,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
 
   String _formatTimeLabel(TimeOfDay time) {
     final now = DateTime.now();
-    final dateTime =
-        DateTime(now.year, now.month, now.day, time.hour, time.minute);
+    final dateTime = DateTime(now.year, now.month, now.day, time.hour, time.minute);
     return DateFormat('h:mm a').format(dateTime);
   }
 
@@ -256,8 +256,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       dateLabel: _composeDateTimeLabel(),
       goodsType: _goodsType,
       weightTonnes: _weightController.text,
-      dimensions:
-          '${_lengthController.text} × ${_widthController.text} × ${_heightController.text}',
+      dimensions: '${_lengthController.text} × ${_widthController.text} × ${_heightController.text}',
       stacked: _stacked,
       fragile: _fragile,
       requirements: _requirements.toList(),
@@ -283,8 +282,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       AppPageRoute(
         builder: (_) => LocationPickerScreen(
           title: isPickup ? 'Set Pickup Location' : 'Set Drop Location',
-          initialQuery:
-              isPickup ? _pickupController.text : _dropController.text,
+          initialQuery: isPickup ? _pickupController.text : _dropController.text,
           initialPoint: isPickup ? _pickupPoint : _dropPoint,
         ),
       ),
@@ -307,7 +305,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     _formKey.currentState?.validate();
   }
 
-  // Validates the pickup location field.
   String? _validatePickup(String? value) {
     final text = value?.trim() ?? '';
     if (text.isEmpty) {
@@ -319,7 +316,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     return null;
   }
 
-  // Validates the drop location field.
   String? _validateDrop(String? value) {
     final text = value?.trim() ?? '';
     if (text.isEmpty) {
@@ -331,7 +327,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     return null;
   }
 
-  // Validates the pickup date field.
   String? _validateDate(String? value) {
     if (_selectedDate == null || (value?.trim().isEmpty ?? true)) {
       return 'Please select a future pickup date.';
@@ -370,6 +365,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
   }
 
   void _onFindTrucks() {
+    if (_isLoading) return;
+    
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }
@@ -388,9 +385,19 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       return;
     }
 
+    setState(() {
+      _isLoading = true;
+    });
+
     Navigator.of(context).push(
       AppPageRoute(builder: (_) => TruckResultsScreen(draft: _buildDraft())),
-    );
+    ).then((_) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    });
   }
 
   @override
@@ -403,7 +410,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Header with Filter
               Row(
                 children: [
                   Column(
@@ -420,8 +426,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       Text(
                         'ML powered matching',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color:
-                                TruxifyColors.adaptiveSecondaryText(context)),
+                            color: TruxifyColors.adaptiveSecondaryText(context)),
                       ),
                     ],
                   ),
@@ -443,7 +448,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               ),
               const SizedBox(height: 24),
 
-              // ROUTE Section
               Text(
                 'ROUTE',
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
@@ -456,7 +460,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               InfoCard(
                 child: Column(
                   children: [
-                    // Pickup Location
                     TextFormField(
                       controller: _pickupController,
                       readOnly: true,
@@ -466,8 +469,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         labelText: 'Pickup Location',
                         prefixIcon: const Icon(Icons.location_on_rounded,
                             color: TruxifyColors.accentDark),
-                        prefixIconConstraints:
-                            const BoxConstraints(minWidth: 40, minHeight: 40),
+                        prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                         suffixIcon: IconButton(
                           onPressed: () => _openLocationPicker(isPickup: true),
                           icon: const Icon(Icons.map_rounded,
@@ -476,7 +478,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       ),
                     ),
                     const SizedBox(height: 12),
-                    // Drop Location + Swap
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -490,11 +491,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                               labelText: 'Drop Location',
                               prefixIcon: const Icon(Icons.location_on_rounded,
                                   color: Color(0xFFD32F2F)),
-                              prefixIconConstraints: const BoxConstraints(
-                                  minWidth: 40, minHeight: 40),
+                              prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                               suffixIcon: IconButton(
-                                onPressed: () =>
-                                    _openLocationPicker(isPickup: false),
+                                onPressed: () => _openLocationPicker(isPickup: false),
                                 icon: const Icon(Icons.map_rounded,
                                     color: TruxifyColors.accentDark),
                               ),
@@ -502,7 +501,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        // Align swap button to top so it doesn't shift when error text appears
                         Padding(
                           padding: const EdgeInsets.only(top: 4),
                           child: Container(
@@ -523,7 +521,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       ],
                     ),
                     const SizedBox(height: 12),
-                    // Date and Time
                     Row(
                       children: [
                         Expanded(
@@ -534,11 +531,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             validator: _validateDate,
                             decoration: InputDecoration(
                               labelText: 'Date',
-                              prefixIcon: const Icon(
-                                  Icons.calendar_today_rounded,
+                              prefixIcon: const Icon(Icons.calendar_today_rounded,
                                   color: TruxifyColors.accentDark),
-                              prefixIconConstraints: const BoxConstraints(
-                                  minWidth: 40, minHeight: 40),
+                              prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                             ),
                           ),
                         ),
@@ -552,8 +547,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                               labelText: 'Time',
                               prefixIcon: const Icon(Icons.access_time_rounded,
                                   color: TruxifyColors.accentDark),
-                              prefixIconConstraints: const BoxConstraints(
-                                  minWidth: 40, minHeight: 40),
+                              prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                             ),
                           ),
                         ),
@@ -564,7 +558,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               ),
               const SizedBox(height: 24),
 
-              // GOODS DETAILS Section
               Text(
                 'GOODS DETAILS',
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
@@ -577,19 +570,14 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               InfoCard(
                 child: Column(
                   children: [
-                    // Goods Type Dropdown
                     DropdownButtonFormField<String>(
                       initialValue: _goodsType,
                       items: _goodsTypes
-                          .map((type) =>
-                              DropdownMenuItem(value: type, child: Text(type)))
+                          .map((type) => DropdownMenuItem(value: type, child: Text(type)))
                           .toList(),
-                      onChanged: (value) =>
-                          setState(() => _goodsType = value ?? _goodsType),
-                      decoration:
-                          const InputDecoration(labelText: 'Goods Type'),
+                      onChanged: (value) => setState(() => _goodsType = value ?? _goodsType),
+                      decoration: const InputDecoration(labelText: 'Goods Type'),
                     ),
-                    // "Other" custom goods type text field
                     if (_goodsType == 'Other') ...[
                       const SizedBox(height: 12),
                       TextField(
@@ -600,8 +588,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           hintText: 'e.g. Chemicals, Scrap metal…',
                           prefixIcon: Icon(Icons.edit_note_rounded,
                               color: TruxifyColors.accentDark),
-                          prefixIconConstraints:
-                              BoxConstraints(minWidth: 40, minHeight: 40),
+                          prefixIconConstraints: BoxConstraints(minWidth: 40, minHeight: 40),
                         ),
                       ),
                     ],
@@ -617,10 +604,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             decoration: const InputDecoration(
                               labelText: 'Weight (t)',
                               hintText: '3',
-                              floatingLabelBehavior:
-                                  FloatingLabelBehavior.always,
-                              contentPadding: EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 14),
+                              floatingLabelBehavior: FloatingLabelBehavior.always,
+                              contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 14),
                               errorStyle: TextStyle(fontSize: 0, height: 0),
                             ),
                           ),
@@ -633,10 +618,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             decoration: const InputDecoration(
                               labelText: 'Length (ft)',
                               hintText: '12',
-                              floatingLabelBehavior:
-                                  FloatingLabelBehavior.always,
-                              contentPadding: EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 14),
+                              floatingLabelBehavior: FloatingLabelBehavior.always,
+                              contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 14),
                             ),
                           ),
                         ),
@@ -648,10 +631,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             decoration: const InputDecoration(
                               labelText: 'Width (ft)',
                               hintText: '6',
-                              floatingLabelBehavior:
-                                  FloatingLabelBehavior.always,
-                              contentPadding: EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 14),
+                              floatingLabelBehavior: FloatingLabelBehavior.always,
+                              contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 14),
                             ),
                           ),
                         ),
@@ -663,10 +644,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             decoration: const InputDecoration(
                               labelText: 'Height (ft)',
                               hintText: '6',
-                              floatingLabelBehavior:
-                                  FloatingLabelBehavior.always,
-                              contentPadding: EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 14),
+                              floatingLabelBehavior: FloatingLabelBehavior.always,
+                              contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 14),
                             ),
                           ),
                         ),
@@ -684,7 +663,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       ),
                     ],
                     const SizedBox(height: 12),
-                    // Stackable and Fragile toggles
                     Row(
                       children: [
                         Expanded(
@@ -692,8 +670,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             icon: Icons.layers_rounded,
                             label: 'Stackable',
                             isSelected: _stacked,
-                            onPressed: () =>
-                                setState(() => _stacked = !_stacked),
+                            onPressed: () => setState(() => _stacked = !_stacked),
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -702,22 +679,19 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             icon: Icons.warning_rounded,
                             label: 'Fragile',
                             isSelected: _fragile,
-                            onPressed: () =>
-                                setState(() => _fragile = !_fragile),
+                            onPressed: () => setState(() => _fragile = !_fragile),
                           ),
                         ),
                       ],
                     ),
                     const SizedBox(height: 16),
-                    // Special requirements
                     Align(
                       alignment: Alignment.centerLeft,
                       child: Text(
                         'Special requirements',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                               fontWeight: FontWeight.w600,
-                              color:
-                                  TruxifyColors.adaptiveSecondaryText(context),
+                              color: TruxifyColors.adaptiveSecondaryText(context),
                             ),
                       ),
                     ),
@@ -743,23 +717,18 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             },
                             borderRadius: BorderRadius.circular(999),
                             child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 14, vertical: 10),
+                              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                               decoration: BoxDecoration(
                                 color: selected
-                                    ? (Theme.of(context).brightness ==
-                                            Brightness.dark
+                                    ? (Theme.of(context).brightness == Brightness.dark
                                         ? TruxifyColors.darkAccentLight
                                         : TruxifyColors.accentLight)
-                                    : Theme.of(context)
-                                        .colorScheme
-                                        .surfaceContainerHighest,
+                                    : Theme.of(context).colorScheme.surfaceContainerHighest,
                                 borderRadius: BorderRadius.circular(999),
                                 border: Border.all(
                                   color: selected
                                       ? Colors.transparent
-                                      : (Theme.of(context).brightness ==
-                                              Brightness.dark
+                                      : (Theme.of(context).brightness == Brightness.dark
                                           ? TruxifyColors.darkBorder
                                           : TruxifyColors.border),
                                 ),
@@ -769,27 +738,18 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                                 children: [
                                   if (selected)
                                     Icon(Icons.check_rounded,
-                                        color: TruxifyColors.accentDark,
-                                        size: 16)
+                                        color: TruxifyColors.accentDark, size: 16)
                                   else
                                     Icon(Icons.add_rounded,
-                                        color:
-                                            TruxifyColors.adaptiveSecondaryText(
-                                                context),
-                                        size: 16),
+                                        color: TruxifyColors.adaptiveSecondaryText(context), size: 16),
                                   const SizedBox(width: 6),
                                   Text(
                                     label,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .labelMedium
-                                        ?.copyWith(
+                                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
                                           fontWeight: FontWeight.w600,
                                           color: selected
                                               ? TruxifyColors.accentDark
-                                              : TruxifyColors
-                                                  .adaptiveSecondaryText(
-                                                      context),
+                                              : TruxifyColors.adaptiveSecondaryText(context),
                                         ),
                                   ),
                                 ],
@@ -804,7 +764,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               ),
               const SizedBox(height: 24),
 
-              // Estimated Price Range with Left Border
               Stack(
                 children: [
                   Container(
@@ -812,10 +771,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       color: Theme.of(context).colorScheme.surface,
                       borderRadius: BorderRadius.circular(16),
                       border: Border.all(
-                          color:
-                              (Theme.of(context).brightness == Brightness.dark
-                                  ? TruxifyColors.darkBorder
-                                  : TruxifyColors.border)),
+                          color: (Theme.of(context).brightness == Brightness.dark
+                              ? TruxifyColors.darkBorder
+                              : TruxifyColors.border)),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withOpacity(0.05),
@@ -833,24 +791,17 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                           children: [
                             Text(
                               'Estimated Price Range',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleSmall
-                                  ?.copyWith(fontWeight: FontWeight.w600),
+                              style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                             ),
                             Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 4),
+                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                               decoration: BoxDecoration(
                                 color: TruxifyColors.accentLight,
                                 borderRadius: BorderRadius.circular(8),
                               ),
                               child: Text(
                                 'Stable this week',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .labelSmall
-                                    ?.copyWith(
+                                style: Theme.of(context).textTheme.labelSmall?.copyWith(
                                       color: TruxifyColors.accentDark,
                                       fontWeight: FontWeight.w600,
                                     ),
@@ -861,13 +812,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         const SizedBox(height: 8),
                         Text(
                           '₹6,200 — ₹7,800',
-                          style: Theme.of(context)
-                              .textTheme
-                              .headlineSmall
-                              ?.copyWith(
+                          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                                 fontWeight: FontWeight.w800,
-                                color: Theme.of(context).brightness ==
-                                        Brightness.dark
+                                color: Theme.of(context).brightness == Brightness.dark
                                     ? TruxifyColors.accent
                                     : TruxifyColors.accentDark,
                               ),
@@ -875,12 +822,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         const SizedBox(height: 4),
                         Text(
                           'Based on current demand + route',
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodySmall
-                              ?.copyWith(
-                                  color: TruxifyColors.adaptiveSecondaryText(
-                                      context)),
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: TruxifyColors.adaptiveSecondaryText(context)),
                         ),
                       ],
                     ),
@@ -904,10 +847,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               ),
               const SizedBox(height: 20),
 
-              // Find Trucks Button
               PrimaryButton(
-                label: 'Find Trucks',
-                onPressed: _onFindTrucks,
+                label: _isLoading ? 'Finding Trucks...' : 'Find Trucks',
+                onPressed: _isLoading ? null : _onFindTrucks,
               ),
             ],
           ),

--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/order_search_bar.dart';
 import 'live_tracking_screen.dart';
 import 'order_detail_screen.dart';
 import 'package:flutter/foundation.dart';
+import 'package:truxify_shared/shimmer_widget.dart';
 
 class OrdersScreen extends StatefulWidget {
   const OrdersScreen({super.key});
@@ -32,6 +33,7 @@ class _OrdersScreenState extends State<OrdersScreen>
   String? _lastUpdatedLabel;
   List<ActiveOrderData> _activeOrders = [];
   List<HistoryOrderData> _historyOrders = [];
+  bool _isLoading = true;
 
   String _formatStatus(String status) {
     switch (status) {
@@ -89,22 +91,23 @@ class _OrdersScreenState extends State<OrdersScreen>
   }
 
   String _resolveDriverName(Map<String, dynamic> order) {
-    // Option 1: resolved via Supabase join (profiles!orders_driver_id_fkey)
     final profile = order['profiles'];
     if (profile is Map<String, dynamic>) {
       final name = profile['full_name']?.toString().trim();
       if (name != null && name.isNotEmpty) return name;
     }
 
-    // Option 2: resolved via manual batch lookup (driver_name key)
     final driverName = order['driver_name']?.toString().trim();
     if (driverName != null && driverName.isNotEmpty) return driverName;
 
-    // Fallback: no driver info available
     return 'Driver Assigned';
   }
 
   Future<void> _loadOrders() async {
+    setState(() {
+      _isLoading = true;
+    });
+
     final connectivity = await Connectivity().checkConnectivity();
     final hasNetwork = connectivity.isNotEmpty &&
         !connectivity.contains(ConnectivityResult.none);
@@ -135,6 +138,7 @@ class _OrdersScreenState extends State<OrdersScreen>
 
         setState(() {
           _isOffline = false;
+          _isLoading = false;
           _lastUpdatedLabel = updatedAt;
 
           _activeOrders = activeOrders.map((order) {
@@ -180,6 +184,7 @@ class _OrdersScreenState extends State<OrdersScreen>
 
           setState(() {
             _isOffline = true;
+            _isLoading = false;
             _lastUpdatedLabel = updatedAt;
 
             debugPrint(
@@ -191,11 +196,17 @@ class _OrdersScreenState extends State<OrdersScreen>
 
           setState(() {
             _isOffline = true;
+            _isLoading = false;
           });
         }
       }
     } catch (e) {
       debugPrint('Failed to load orders: $e');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
@@ -276,6 +287,16 @@ class _OrdersScreenState extends State<OrdersScreen>
 
   @override
   Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const SafeArea(
+        child: Scaffold(
+          body: Center(
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      );
+    }
+
     return SafeArea(
       child: Column(
         children: [
@@ -312,43 +333,47 @@ class _OrdersScreenState extends State<OrdersScreen>
               children: [
                 RefreshIndicator(
                   onRefresh: _loadOrders,
-                  child: ListView.separated(
-                    padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
-                    itemCount: _filteredActiveOrders.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 14),
-                    itemBuilder: (context, index) {
-                      final order = _filteredActiveOrders[index];
-                      return ActiveOrderCard(
-                        order: order,
-                        onTap: () => Navigator.of(context).push(
-                          AppPageRoute(
-                            builder: (_) =>
-                                LiveTrackingScreen(orderId: order.orderId),
-                          ),
+                  child: _filteredActiveOrders.isEmpty && !_isLoading
+                      ? const Center(child: Text('No active orders'))
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+                          itemCount: _filteredActiveOrders.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 14),
+                          itemBuilder: (context, index) {
+                            final order = _filteredActiveOrders[index];
+                            return ActiveOrderCard(
+                              order: order,
+                              onTap: () => Navigator.of(context).push(
+                                AppPageRoute(
+                                  builder: (_) =>
+                                      LiveTrackingScreen(orderId: order.orderId),
+                                ),
+                              ),
+                            );
+                          },
                         ),
-                      );
-                    },
-                  ),
                 ),
                 RefreshIndicator(
                   onRefresh: _loadOrders,
-                  child: ListView.separated(
-                    padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
-                    itemCount: _filteredHistoryOrders.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 14),
-                    itemBuilder: (context, index) {
-                      final order = _filteredHistoryOrders[index];
-                      return HistoryOrderCard(
-                        order: order,
-                        onTap: () => Navigator.of(context).push(
-                          AppPageRoute(
-                            builder: (_) =>
-                                OrderDetailScreen(order: order),
-                          ),
+                  child: _filteredHistoryOrders.isEmpty && !_isLoading
+                      ? const Center(child: Text('No history orders'))
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+                          itemCount: _filteredHistoryOrders.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 14),
+                          itemBuilder: (context, index) {
+                            final order = _filteredHistoryOrders[index];
+                            return HistoryOrderCard(
+                              order: order,
+                              onTap: () => Navigator.of(context).push(
+                                AppPageRoute(
+                                  builder: (_) =>
+                                      OrderDetailScreen(order: order),
+                                ),
+                              ),
+                            );
+                          },
                         ),
-                      );
-                    },
-                  ),
                 ),
               ],
             ),

--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -289,16 +289,6 @@ class _OrdersScreenState extends State<OrdersScreen>
 
   @override
   Widget build(BuildContext context) {
-    if (_isLoading) {
-      return const SafeArea(
-        child: Scaffold(
-          body: Center(
-            child: CircularProgressIndicator(),
-          ),
-        ),
-      );
-    }
-
     return SafeArea(
       child: Column(
         children: [
@@ -335,47 +325,61 @@ class _OrdersScreenState extends State<OrdersScreen>
               children: [
                 RefreshIndicator(
                   onRefresh: _loadOrders,
-                  child: _filteredActiveOrders.isEmpty && !_isLoading
-                      ? const Center(child: Text('No active orders'))
-                      : ListView.separated(
+                  child: _isLoading
+                      ? ListView.separated(
                           padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
-                          itemCount: _filteredActiveOrders.length,
+                          itemCount: 3,
                           separatorBuilder: (_, __) => const SizedBox(height: 14),
-                          itemBuilder: (context, index) {
-                            final order = _filteredActiveOrders[index];
-                            return ActiveOrderCard(
-                              order: order,
-                              onTap: () => Navigator.of(context).push(
-                                AppPageRoute(
-                                  builder: (_) =>
-                                      LiveTrackingScreen(orderId: order.orderId),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
+                          itemBuilder: (context, index) => const ShimmerOrderCard(),
+                        )
+                      : _filteredActiveOrders.isEmpty
+                          ? const Center(child: Text('No active orders'))
+                          : ListView.separated(
+                              padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+                              itemCount: _filteredActiveOrders.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 14),
+                              itemBuilder: (context, index) {
+                                final order = _filteredActiveOrders[index];
+                                return ActiveOrderCard(
+                                  order: order,
+                                  onTap: () => Navigator.of(context).push(
+                                    AppPageRoute(
+                                      builder: (_) =>
+                                          LiveTrackingScreen(orderId: order.orderId),
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
                 ),
                 RefreshIndicator(
                   onRefresh: _loadOrders,
-                  child: _filteredHistoryOrders.isEmpty && !_isLoading
-                      ? const Center(child: Text('No history orders'))
-                      : ListView.separated(
+                  child: _isLoading
+                      ? ListView.separated(
                           padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
-                          itemCount: _filteredHistoryOrders.length,
+                          itemCount: 3,
                           separatorBuilder: (_, __) => const SizedBox(height: 14),
-                          itemBuilder: (context, index) {
-                            final order = _filteredHistoryOrders[index];
-                            return HistoryOrderCard(
-                              order: order,
-                              onTap: () => Navigator.of(context).push(
-                                AppPageRoute(
-                                  builder: (_) =>
-                                      OrderDetailScreen(order: order),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
+                          itemBuilder: (context, index) => const ShimmerOrderCard(),
+                        )
+                      : _filteredHistoryOrders.isEmpty
+                          ? const Center(child: Text('No history orders'))
+                          : ListView.separated(
+                              padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+                              itemCount: _filteredHistoryOrders.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 14),
+                              itemBuilder: (context, index) {
+                                final order = _filteredHistoryOrders[index];
+                                return HistoryOrderCard(
+                                  order: order,
+                                  onTap: () => Navigator.of(context).push(
+                                    AppPageRoute(
+                                      builder: (_) =>
+                                          OrderDetailScreen(order: order),
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
                 ),
               ],
             ),

--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -4,6 +4,7 @@ import 'package:truxify/theme/app_theme.dart';
 import '../models/app_models.dart';
 import '../services/order_service.dart';
 import '../widgets/truck_card.dart';
+import 'package:truxify_shared/shimmer_widget.dart';
 
 class TruckResultsScreen extends StatefulWidget {
   const TruckResultsScreen({super.key, required this.draft});
@@ -95,19 +96,19 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
     final trucks = List<TruckResultData>.from(_trucks ?? []);
 
     switch (_selectedSort) {
-      case 0: // Best Match
+      case 0:
         trucks.sort(
           (a, b) => (b.badge == 'Best Match' ? 1 : 0)
               .compareTo(a.badge == 'Best Match' ? 1 : 0),
         );
         break;
-      case 1: // Cheapest
+      case 1:
         trucks.sort((a, b) => _price(a.price).compareTo(_price(b.price)));
         break;
-      case 2: // Fastest
+      case 2:
         trucks.sort((a, b) => _eta(a.eta).compareTo(_eta(b.eta)));
         break;
-      case 3: // Top Rated
+      case 3:
         trucks.sort((a, b) => b.rating.compareTo(a.rating));
         break;
       default:
@@ -128,7 +129,11 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
             icon: const Icon(Icons.arrow_back_rounded),
           ),
         ),
-        body: const Center(child: CircularProgressIndicator()),
+        body: ListView.builder(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+          itemCount: 5,
+          itemBuilder: (_, __) => const ShimmerListItem(height: 140),
+        ),
       );
     }
 

--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   shared_preferences: ^2.5.5
   uuid: ^4.5.3
   web_socket_channel: ^3.0.0
+  shimmer: ^3.0.0   
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -12,6 +12,7 @@ import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
 import '../services/marketplace_repository.dart';
 import '../services/trip_service.dart';
+import 'package:truxify_shared/shimmer_widget.dart';
 
 class TripsScreen extends StatefulWidget {
   const TripsScreen({super.key});
@@ -716,7 +717,13 @@ class _TripsScreenState extends State<TripsScreen> {
                   color: TruxifyColors.accent,
                   onRefresh: _loadTrips,
                   child: _isLoadingTrips
-                      ? const Center(child: CircularProgressIndicator())
+                      ? ListView.builder(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemCount: 3,
+                          itemBuilder: (context, index) =>
+                              const ShimmerListItem(height: 180),
+                        )
                       : _tripsError != null
                           ? ListView(
                               physics: const AlwaysScrollableScrollPhysics(),
@@ -1142,12 +1149,11 @@ class _MarketplaceBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (loading && standardLoads.isEmpty && enRouteLoads.isEmpty) {
-      return ListView(
+      return ListView.builder(
         physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
-          SizedBox(height: 120),
-          Center(child: CircularProgressIndicator()),
-        ],
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: 3,
+        itemBuilder: (context, index) => const ShimmerLoadCard(),
       );
     }
 

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   intl: ^0.20.2
   url_launcher: ^6.3.2
   geolocator: ^13.0.2
+  shimmer: ^3.0.0   
 
 dev_dependencies:
   flutter_lints: ^6.0.0
@@ -31,3 +32,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  

--- a/packages/truxify_shared/lib/shimmer_widget.dart
+++ b/packages/truxify_shared/lib/shimmer_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class ShimmerListItem extends StatelessWidget {
+  final double height;
+  final double width;
+  final double borderRadius;
+
+  const ShimmerListItem({
+    super.key,
+    this.height = 80,
+    this.width = double.infinity,
+    this.borderRadius = 12,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Shimmer.fromColors(
+        baseColor: Colors.grey[300]!,
+        highlightColor: Colors.grey[100]!,
+        child: Container(
+          height: height,
+          width: width,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(borderRadius),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ShimmerOrderCard extends StatelessWidget {
+  const ShimmerOrderCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ShimmerListItem(height: 100);
+  }
+}
+
+class ShimmerLoadCard extends StatelessWidget {
+  const ShimmerLoadCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ShimmerListItem(height: 120);
+  }
+}


### PR DESCRIPTION
## 📌 Summary
Added shimmer loading skeleton effect to the Orders screen to improve user experience during data fetching.

## 🎯 Changes Made
- Added `_isLoading` state variable to track loading status
- Added shimmer loading indicator while orders are being fetched
- Created reusable shimmer widgets in shared package (`ShimmerListItem`, `ShimmerOrderCard`, `ShimmerLoadCard`)

## 📱 Screens Affected
- Customer App: Orders Screen (Active + History tabs)

## 🧪 How to Test
1. Open Orders screen
2. While data is loading, shimmer skeleton should appear
3. After data loads, actual orders should display

## ✅ Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tested on Chrome
- [x] Shimmer effect works correctly

## 🔗 Related Issue
Closes #534


**Thank you for reviewing!** 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shimmer-based loading placeholders across truck search/results, orders, and trip views.

* **Improvements**
  * “Find Trucks” now shows “Finding Trucks...” and disables during loading to prevent duplicate requests.
  * Orders tabs display shimmer while loading, and show “No active orders” / “No history orders” when empty.
  * Updated form and card layouts (input spacing/labels, goods type field, and estimated price/requirements styling) for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->