### PR TITLE
Add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,12 @@ git commit -m "feat: add profit predictor model"
 git push origin feature/your-feature-name
 ```
 
+### 👥 Contributors
+
+Thanks to all contributors ❤️
+
+[![Contributors](https://contrib.rocks/image?repo=KanishJebaMathewM/Truxify)](https://github.com/KanishJebaMathewM/Truxify/graphs/contributors)
+
 ---
 
 ## 📄 License


### PR DESCRIPTION
## 📝 Description

This PR adds a Contributors section to the README using the contrib.rocks badge. It dynamically displays all contributors of the repository in a visually appealing way.

## ✨ Changes Made
- Added contributors badge using contrib.rocks
- Linked badge to the GitHub contributors page
- Improved README documentation layout
## 📌 Preview

The contributors section now shows all contributors automatically based on GitHub activity.


closes #554 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Contributors" section to the README with acknowledgment text and a contributors badge linking to the project's contributor graph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->