### PR TITLE
feat: add BYPASS_AUTH dev seed script and document local authenticated development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,75 @@ We welcome proposals for new features! When suggesting a feature:
 
 ---
 
+
+
+---
+
+## Local Development with BYPASS_AUTH
+
+Truxify's authentication middleware supports a `BYPASS_AUTH=true` mode for local development that skips Firebase token verification. Even in bypass mode, the middleware still looks up the user profile from the `profiles` table — so you need seeded profiles to make authenticated requests locally.
+
+### Step 1: Enable Bypass Mode
+
+Add the following to your `.env` file:
+
+```env
+BYPASS_AUTH=true
+```
+
+> **Never enable `BYPASS_AUTH` in production.** The server will return `503` if `BYPASS_AUTH=true` and `NODE_ENV=production`.
+
+### Step 2: Seed Development Profiles
+
+Run the seed script to create two predictable test profiles in your local Supabase instance:
+
+```bash
+cd backend/api
+npm run seed:dev
+```
+
+This creates:
+
+| Profile | ID | Role |
+|---------|-----|------|
+| Dev Customer | `11111111-1111-1111-1111-111111111111` | `customer` |
+| Dev Driver | `22222222-2222-2222-2222-222222222222` | `driver` |
+
+The script is **idempotent** — running it multiple times will not create duplicates.
+
+### Step 3: Make Authenticated Requests
+
+Pass the seeded profile ID in the `x-user-id` header along with `x-user-role`:
+
+**Customer request:**
+
+```bash
+curl -H "x-user-id: 11111111-1111-1111-1111-111111111111" \
+     -H "x-user-role: customer" \
+     http://localhost:3000/api/orders
+```
+
+**Driver request:**
+
+```bash
+curl -H "x-user-id: 22222222-2222-2222-2222-222222222222" \
+     -H "x-user-role: driver" \
+     http://localhost:3000/api/trips
+```
+
+### Environment Requirements
+
+The seed script requires these variables in your root `.env` file:
+
+```env
+SUPABASE_URL=http://localhost:54321
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+```
+
+Copy `.env.example` to `.env` and fill in your local Supabase credentials before running the script.
+
+---
+
 ## Community Guidelines
 
 Please be respectful and constructive when interacting with other contributors. We welcome contributors of all experience levels and encourage collaboration, learning, and knowledge sharing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ We welcome proposals for new features! When suggesting a feature:
 
 ## Local Development with BYPASS_AUTH
 
-Truxify's authentication middleware supports a `BYPASS_AUTH=true` mode for local development that skips Firebase token verification. Even in bypass mode, the middleware still looks up the user profile from the `profiles` table — so you need seeded profiles to make authenticated requests locally.
+Truxify's authentication middleware supports a `BYPASS_AUTH=true` mode for local development that skips Firebase token verification. Even in bypass mode, application endpoints still look up the user profile from the `profiles` table — so you need seeded profiles to make authenticated requests locally.
 
 ### Step 1: Enable Bypass Mode
 

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -13,7 +13,8 @@
     "test:integration": "vitest run test/integration",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "verify-db": "node scripts/verify-db-schema.js"
+    "verify-db": "node scripts/verify-db-schema.js",
+    "seed:dev": "node scripts/seed-dev-profile.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.108.2",

--- a/backend/api/scripts/seed-dev-profile.js
+++ b/backend/api/scripts/seed-dev-profile.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Development Profile Seed Script
+ *
+ * Creates (or updates) two predictable test profiles in Supabase for use
+ * with BYPASS_AUTH=true local development and integration testing.
+ *
+ * Usage:
+ *   npm run seed:dev
+ *
+ * Required environment variables:
+ *   SUPABASE_URL              — e.g. http://localhost:54321
+ *   SUPABASE_SERVICE_ROLE_KEY — service role key (bypasses RLS)
+ *
+ * The script is idempotent: running it multiple times will upsert the
+ * profiles without creating duplicates.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+// ── Colour helpers ────────────────────────────────────────────────────
+const c = {
+  green:  (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red:    (s) => `\x1b[31m${s}\x1b[0m`,
+  bold:   (s) => `\x1b[1m${s}\x1b[0m`,
+  dim:    (s) => `\x1b[2m${s}\x1b[0m`,
+  cyan:   (s) => `\x1b[36m${s}\x1b[0m`,
+};
+const TICK  = c.green('✔');
+const CROSS = c.red('✖');
+
+// ── Dev profile definitions ───────────────────────────────────────────
+const DEV_PROFILES = [
+  {
+    id:           '11111111-1111-1111-1111-111111111111',
+    firebase_uid: 'dev_firebase_uid_customer',
+    role:         'customer',
+    full_name:    'Dev Customer',
+    phone:        '+919000000001',
+    email:        'dev-customer@truxify.local',
+    is_active:    true,
+  },
+  {
+    id:           '22222222-2222-2222-2222-222222222222',
+    firebase_uid: 'dev_firebase_uid_driver',
+    role:         'driver',
+    full_name:    'Dev Driver',
+    phone:        '+919000000002',
+    email:        'dev-driver@truxify.local',
+    is_active:    true,
+  },
+];
+
+// ── Environment validation ────────────────────────────────────────────
+function validateEnv() {
+  const required = ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
+  const missing = required.filter((k) => !process.env[k]);
+
+  if (missing.length > 0) {
+    console.error();
+    console.error(c.red('  Missing required environment variables:'));
+    for (const key of missing) {
+      console.error(`    ${CROSS} ${c.bold(key)}`);
+    }
+    console.error();
+    console.error(c.dim('  Copy .env.example to .env and fill in your Supabase credentials.'));
+    console.error();
+    process.exit(1);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+async function main() {
+  console.log();
+  console.log(c.bold('  Truxify — Development Profile Seed'));
+  console.log(c.dim('  ────────────────────────────────────'));
+  console.log();
+
+  validateEnv();
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } }
+  );
+
+  // Verify connectivity with a lightweight query
+  const { error: pingError } = await supabase
+    .from('profiles')
+    .select('id')
+    .limit(1);
+
+  if (pingError) {
+    console.error(`  ${CROSS} ${c.red('Unable to connect to Supabase:')}`);
+    console.error(`      ${c.dim(pingError.message)}`);
+    console.error();
+    process.exit(1);
+  }
+
+  console.log(`  ${TICK} ${c.green('Connected to Supabase')}`);
+  console.log();
+
+  // Upsert all dev profiles
+  const { error } = await supabase
+    .from('profiles')
+    .upsert(DEV_PROFILES, { onConflict: 'id' });
+
+  if (error) {
+    console.error(`  ${CROSS} ${c.red('Failed to seed profiles:')}`);
+    console.error(`      ${c.dim(error.message)}`);
+    console.error();
+    process.exit(1);
+  }
+
+  // Success output
+  console.log(`  ${TICK} ${c.green('Development profiles ready')}`);
+  console.log();
+
+  for (const profile of DEV_PROFILES) {
+    const roleLabel = profile.role === 'customer'
+      ? c.cyan('Customer')
+      : c.yellow('Driver ');
+    console.log(`  ${roleLabel}  ${c.bold(profile.id)}`);
+    console.log(`           role: ${profile.role}  name: ${profile.full_name}`);
+    console.log();
+  }
+
+  console.log(c.dim('  ── How to use ──────────────────────────────────────────────────'));
+  console.log(c.dim('  Set BYPASS_AUTH=true in your .env, then pass the profile ID in'));
+  console.log(c.dim('  the x-user-id header with the appropriate x-user-role:'));
+  console.log();
+  console.log(c.dim('  Customer request:'));
+  console.log(c.dim('    curl -H "x-user-id: 11111111-1111-1111-1111-111111111111" \\'));
+  console.log(c.dim('         -H "x-user-role: customer" \\'));
+  console.log(c.dim('         http://localhost:3000/api/orders'));
+  console.log();
+  console.log(c.dim('  Driver request:'));
+  console.log(c.dim('    curl -H "x-user-id: 22222222-2222-2222-2222-222222222222" \\'));
+  console.log(c.dim('         -H "x-user-role: driver" \\'));
+  console.log(c.dim('         http://localhost:3000/api/trips'));
+  console.log();
+}
+
+main().catch((err) => {
+  console.error(c.red('\n  Unexpected error:'), err.message);
+  process.exit(1);
+});

--- a/backend/api/scripts/seed-dev-profile.js
+++ b/backend/api/scripts/seed-dev-profile.js
@@ -22,7 +22,12 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+const apiRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(apiRoot, '..', '..');
+
+// Load environment variables from both local api folder and root directory
+dotenv.config({ path: path.join(apiRoot, '.env') });
+dotenv.config({ path: path.join(repoRoot, '.env') });
 
 // ── Colour helpers ────────────────────────────────────────────────────
 const c = {


### PR DESCRIPTION
## Summary
Completes the `BYPASS_AUTH` local development workflow by providing a seed script that creates predictable test profiles in Supabase, and documents the full workflow in `CONTRIBUTING.md`.

---

## Changes

### `backend/api/scripts/seed-dev-profile.js` (new)
- Connects to Supabase using `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`
- Validates required environment variables before execution with clear error messages
- Verifies Supabase connectivity before attempting any writes
- Upserts two predictable dev profiles using idempotent `upsert` on `id` — safe to run repeatedly, no duplicates created:

| Profile | ID | Role |
|---------|-----|------|
| Dev Customer | `11111111-1111-1111-1111-111111111111` | `customer` |
| Dev Driver | `22222222-2222-2222-2222-222222222222` | `driver` |

- Displays seeded profile IDs and curl usage examples on success

### `backend/api/package.json` (updated)
```json
"seed:dev": "node scripts/seed-dev-profile.js"
```

### `CONTRIBUTING.md` (updated)
Added **Local Development with BYPASS_AUTH** section covering:
- Step 1: Enable `BYPASS_AUTH=true` in `.env`
- Step 2: Run `npm run seed:dev` to create test profiles
- Step 3: Make authenticated requests using `x-user-id` / `x-user-role` headers
- Environment requirements for `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`
- Security warning against enabling `BYPASS_AUTH` in production

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| `seed-dev-profile.js` created | ✅ |
| Customer development profile seeded | ✅ `11111111-1111-1111-1111-111111111111` |
| Driver development profile seeded | ✅ `22222222-2222-2222-2222-222222222222` |
| Script uses idempotent upsert operations | ✅ `upsert({ onConflict: 'id' })` |
| `npm run seed:dev` added to `package.json` | ✅ |
| Seeded profile IDs displayed after execution | ✅ |
| Script validates required environment variables | ✅ Exits with clear error on missing vars |
| `BYPASS_AUTH` workflow documented in `CONTRIBUTING.md` | ✅ |
| Requests using seeded profile IDs succeed locally | ✅ Compatible with `BYPASS_AUTH=true` middleware |
| Running script repeatedly creates no duplicates | ✅ Idempotent upsert |

Closes #585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide section for local development using an auth-bypass mode, including required environment variables, setup steps, seed execution commands, and example API requests with `x-user-id`/`x-user-role` headers.

* **Chores**
  * Added developer scripts for database schema verification and deterministic dev profile seeding to support faster local setup and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->