### PR TITLE
feat: add centralised ApiClient with JWT injection and automatic 401 token refresh for customer app

### DIFF
--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -40,19 +41,28 @@ class ApiClient {
     SupabaseClient? supabaseClient,
     http.Client? httpClient,
     String? baseUrl,
-  })  : _supabase = supabaseClient ?? Supabase.instance.client,
+  })  : _providedSupabase = supabaseClient,
+        _isClientOwned = httpClient == null,
         _http = httpClient ?? http.Client(),
-        _baseUrl = _normalise(
-          baseUrl ??
-              const String.fromEnvironment(
-                'TRUXIFY_API_BASE_URL',
-                defaultValue: 'http://localhost:5000',
-              ),
-        );
+        _baseUrl = _normalise(_getBaseUrl(baseUrl));
 
-  final SupabaseClient _supabase;
+  final SupabaseClient? _providedSupabase;
+  SupabaseClient get _supabase => _providedSupabase ?? Supabase.instance.client;
   final http.Client _http;
+  final bool _isClientOwned;
   final String _baseUrl;
+
+  static String _getBaseUrl(String? overrideUrl) {
+    if (overrideUrl != null) return overrideUrl;
+    const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
+    if (envUrl.isNotEmpty) return envUrl;
+    if (kReleaseMode) {
+      throw StateError(
+        'TRUXIFY_API_BASE_URL environment variable is required in release builds.',
+      );
+    }
+    return 'http://localhost:5000';
+  }
 
   static String _normalise(String url) =>
       url.endsWith('/') ? url.substring(0, url.length - 1) : url;
@@ -61,11 +71,12 @@ class ApiClient {
 
   String? get _accessToken => _supabase.auth.currentSession?.accessToken;
 
-  Map<String, String> _headers({String? token}) {
+  Map<String, String> _headers({String? token, Map<String, String>? additionalHeaders}) {
     final t = token ?? _accessToken;
     return <String, String>{
       'Content-Type': 'application/json',
       if (t != null && t.isNotEmpty) 'Authorization': 'Bearer $t',
+      ...?additionalHeaders,
     };
   }
 
@@ -74,7 +85,9 @@ class ApiClient {
       final res = await _supabase.auth.refreshSession();
       return res.session?.accessToken;
     } catch (e) {
-      developer.log('[ApiClient] Token refresh failed: $e', name: 'ApiClient');
+      if (kDebugMode) {
+        developer.log('[ApiClient] Token refresh failed: $e', name: 'ApiClient');
+      }
       return null;
     }
   }
@@ -83,15 +96,18 @@ class ApiClient {
 
   Future<http.Response> _execute(
     Future<http.Response> Function(Map<String, String> headers) fn, {
+    Map<String, String>? additionalHeaders,
     bool isRetry = false,
   }) async {
-    final response = await fn(_headers());
+    final response = await fn(_headers(additionalHeaders: additionalHeaders));
 
     if (response.statusCode == 401 && !isRetry) {
-      developer.log(
-        '[ApiClient] 401 received — attempting token refresh',
-        name: 'ApiClient',
-      );
+      if (kDebugMode) {
+        developer.log(
+          '[ApiClient] 401 received — attempting token refresh',
+          name: 'ApiClient',
+        );
+      }
 
       final newToken = await _refreshedToken();
       if (newToken == null) {
@@ -100,7 +116,7 @@ class ApiClient {
         );
       }
 
-      final retryResponse = await fn(_headers(token: newToken));
+      final retryResponse = await fn(_headers(token: newToken, additionalHeaders: additionalHeaders));
       if (retryResponse.statusCode == 401) {
         throw const ApiAuthException(
           'Authentication failed after token refresh. Please log in again.',
@@ -112,45 +128,67 @@ class ApiClient {
     return response;
   }
 
+  // ── URI building and path normalization ───────────────────────────
+
+  Uri _buildUri(String path) {
+    final cleanPath = path.startsWith('/') ? path : '/$path';
+    return Uri.parse('$_baseUrl$cleanPath');
+  }
+
   // ── HTTP methods ──────────────────────────────────────────────────
 
-  Future<dynamic> get(String path) async {
-    final uri = Uri.parse('$_baseUrl$path');
-    final response = await _execute((h) => _http.get(uri, headers: h));
+  Future<dynamic> get(String path, {Map<String, String>? headers}) async {
+    final uri = _buildUri(path);
+    final response = await _execute(
+      (h) => _http.get(uri, headers: h),
+      additionalHeaders: headers,
+    );
     return _decode(response);
   }
 
-  Future<dynamic> post(String path, {Object? body}) async {
-    final uri = Uri.parse('$_baseUrl$path');
+  Future<dynamic> post(String path, {Object? body, Map<String, String>? headers}) async {
+    final uri = _buildUri(path);
     final encoded = body != null ? jsonEncode(body) : null;
     final response = await _execute(
       (h) => _http.post(uri, headers: h, body: encoded),
+      additionalHeaders: headers,
     );
     return _decode(response);
   }
 
-  Future<dynamic> put(String path, {Object? body}) async {
-    final uri = Uri.parse('$_baseUrl$path');
+  Future<dynamic> put(String path, {Object? body, Map<String, String>? headers}) async {
+    final uri = _buildUri(path);
     final encoded = body != null ? jsonEncode(body) : null;
     final response = await _execute(
       (h) => _http.put(uri, headers: h, body: encoded),
+      additionalHeaders: headers,
     );
     return _decode(response);
   }
 
-  Future<dynamic> patch(String path, {Object? body}) async {
-    final uri = Uri.parse('$_baseUrl$path');
+  Future<dynamic> patch(String path, {Object? body, Map<String, String>? headers}) async {
+    final uri = _buildUri(path);
     final encoded = body != null ? jsonEncode(body) : null;
     final response = await _execute(
       (h) => _http.patch(uri, headers: h, body: encoded),
+      additionalHeaders: headers,
     );
     return _decode(response);
   }
 
-  Future<dynamic> delete(String path) async {
-    final uri = Uri.parse('$_baseUrl$path');
-    final response = await _execute((h) => _http.delete(uri, headers: h));
+  Future<dynamic> delete(String path, {Map<String, String>? headers}) async {
+    final uri = _buildUri(path);
+    final response = await _execute(
+      (h) => _http.delete(uri, headers: h),
+      additionalHeaders: headers,
+    );
     return _decode(response);
+  }
+
+  void dispose() {
+    if (_isClientOwned) {
+      _http.close();
+    }
   }
 
   // ── Response decoding ─────────────────────────────────────────────
@@ -161,10 +199,12 @@ class ApiClient {
       return jsonDecode(response.body);
     }
 
-    developer.log(
-      '[ApiClient] Request failed: ${response.statusCode} ${response.body}',
-      name: 'ApiClient',
-    );
+    if (kDebugMode) {
+      developer.log(
+        '[ApiClient] Request failed: ${response.statusCode} ${response.body}',
+        name: 'ApiClient',
+      );
+    }
 
     String message;
     try {

--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Exception thrown when an API request fails after token refresh.
+class ApiAuthException implements Exception {
+  const ApiAuthException(this.message);
+  final String message;
+  @override
+  String toString() => 'ApiAuthException: $message';
+}
+
+/// Exception thrown when an API request returns a non-2xx response.
+class ApiException implements Exception {
+  const ApiException(this.statusCode, this.message, {this.body});
+  final int statusCode;
+  final String message;
+  final String? body;
+  @override
+  String toString() => 'ApiException($statusCode): $message';
+}
+
+/// Centralised API client for all Truxify backend requests.
+///
+/// Responsibilities:
+///   - Reads the current Supabase session access token.
+///   - Injects `Authorization: Bearer <accessToken>` into every request.
+///   - On HTTP 401, attempts `supabase.auth.refreshSession()` once and retries.
+///   - If the retry still returns 401, throws [ApiAuthException].
+///   - Logs failures in debug mode via `dart:developer`.
+///
+/// Usage:
+/// ```dart
+/// final client = ApiClient();
+/// final data = await client.get('/api/orders');
+/// ```
+class ApiClient {
+  ApiClient({
+    SupabaseClient? supabaseClient,
+    http.Client? httpClient,
+    String? baseUrl,
+  })  : _supabase = supabaseClient ?? Supabase.instance.client,
+        _http = httpClient ?? http.Client(),
+        _baseUrl = _normalise(
+          baseUrl ??
+              const String.fromEnvironment(
+                'TRUXIFY_API_BASE_URL',
+                defaultValue: 'http://localhost:5000',
+              ),
+        );
+
+  final SupabaseClient _supabase;
+  final http.Client _http;
+  final String _baseUrl;
+
+  static String _normalise(String url) =>
+      url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+
+  // ── Token helpers ─────────────────────────────────────────────────
+
+  String? get _accessToken => _supabase.auth.currentSession?.accessToken;
+
+  Map<String, String> _headers({String? token}) {
+    final t = token ?? _accessToken;
+    return <String, String>{
+      'Content-Type': 'application/json',
+      if (t != null && t.isNotEmpty) 'Authorization': 'Bearer $t',
+    };
+  }
+
+  Future<String?> _refreshedToken() async {
+    try {
+      final res = await _supabase.auth.refreshSession();
+      return res.session?.accessToken;
+    } catch (e) {
+      developer.log('[ApiClient] Token refresh failed: $e', name: 'ApiClient');
+      return null;
+    }
+  }
+
+  // ── Core request execution ────────────────────────────────────────
+
+  Future<http.Response> _execute(
+    Future<http.Response> Function(Map<String, String> headers) fn, {
+    bool isRetry = false,
+  }) async {
+    final response = await fn(_headers());
+
+    if (response.statusCode == 401 && !isRetry) {
+      developer.log(
+        '[ApiClient] 401 received — attempting token refresh',
+        name: 'ApiClient',
+      );
+
+      final newToken = await _refreshedToken();
+      if (newToken == null) {
+        throw const ApiAuthException(
+          'Session expired and token refresh failed. Please log in again.',
+        );
+      }
+
+      final retryResponse = await fn(_headers(token: newToken));
+      if (retryResponse.statusCode == 401) {
+        throw const ApiAuthException(
+          'Authentication failed after token refresh. Please log in again.',
+        );
+      }
+      return retryResponse;
+    }
+
+    return response;
+  }
+
+  // ── HTTP methods ──────────────────────────────────────────────────
+
+  Future<dynamic> get(String path) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final response = await _execute((h) => _http.get(uri, headers: h));
+    return _decode(response);
+  }
+
+  Future<dynamic> post(String path, {Object? body}) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final encoded = body != null ? jsonEncode(body) : null;
+    final response = await _execute(
+      (h) => _http.post(uri, headers: h, body: encoded),
+    );
+    return _decode(response);
+  }
+
+  Future<dynamic> put(String path, {Object? body}) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final encoded = body != null ? jsonEncode(body) : null;
+    final response = await _execute(
+      (h) => _http.put(uri, headers: h, body: encoded),
+    );
+    return _decode(response);
+  }
+
+  Future<dynamic> patch(String path, {Object? body}) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final encoded = body != null ? jsonEncode(body) : null;
+    final response = await _execute(
+      (h) => _http.patch(uri, headers: h, body: encoded),
+    );
+    return _decode(response);
+  }
+
+  Future<dynamic> delete(String path) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final response = await _execute((h) => _http.delete(uri, headers: h));
+    return _decode(response);
+  }
+
+  // ── Response decoding ─────────────────────────────────────────────
+
+  dynamic _decode(http.Response response) {
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (response.body.isEmpty) return null;
+      return jsonDecode(response.body);
+    }
+
+    developer.log(
+      '[ApiClient] Request failed: ${response.statusCode} ${response.body}',
+      name: 'ApiClient',
+    );
+
+    String message;
+    try {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      message = (json['error'] ?? json['message'] ?? response.reasonPhrase)
+          .toString();
+    } catch (_) {
+      message = response.reasonPhrase ?? 'Unknown error';
+    }
+
+    throw ApiException(response.statusCode, message, body: response.body);
+  }
+}

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -1,32 +1,26 @@
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:supabase_flutter/supabase_flutter.dart';
+import '../core/api_client.dart';
 import 'supabase_service.dart';
 
 class OrderService {
   OrderService({
-    SupabaseClient? client,
-    http.Client? httpClient,
-    String? apiBaseUrl,
-  })  : _providedClient = client,
-        _httpClient = httpClient ?? http.Client(),
-        _apiBaseUrl = _normalizeBaseUrl(apiBaseUrl ?? defaultApiBaseUrl);
+    ApiClient? apiClient,
+  }) : _apiClient = apiClient ?? ApiClient();
 
   static const String defaultApiBaseUrl = String.fromEnvironment(
     'TRUXIFY_API_BASE_URL',
     defaultValue: 'http://localhost:5000',
   );
 
-  final SupabaseClient? _providedClient;
-  final http.Client _httpClient;
-  final String _apiBaseUrl;
+  final ApiClient _apiClient;
 
-  SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
-
-  static String _normalizeBaseUrl(String value) {
-    return value.endsWith('/') ? value.substring(0, value.length - 1) : value;
+  Map<String, String> _customHeaders() {
+    final userId = SupabaseService.requireUserId();
+    return <String, String>{
+      'x-user-id': userId,
+      'x-user-role': 'customer',
+    };
   }
 
   Future<String> createOrder({
@@ -43,46 +37,38 @@ class OrderService {
     String? upiId,
   }) async {
     final user = SupabaseService.currentUser;
-    final userId = SupabaseService.requireUserId();
-    final token = _client.auth.currentSession?.accessToken;
     final fullName = user?.userMetadata?['full_name']?.toString();
-
-    final response = await _httpClient.post(
-      Uri.parse('$_apiBaseUrl/api/orders'),
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-        'x-user-id': userId,
-        'x-user-role': 'customer',
-        if (fullName != null && fullName.isNotEmpty) 'x-user-name': fullName,
-      },
-      body: jsonEncode(<String, dynamic>{
-        'pickup_address': pickupAddress,
-        'pickup_lat': pickupLat,
-        'pickup_lng': pickupLng,
-        'drop_address': dropAddress,
-        'drop_lat': dropLat,
-        'drop_lng': dropLng,
-        'pickup_date': DateTime.now().toIso8601String(),
-        'pickup_time': pickupTime,
-        'goods_type': goodsType,
-        'weight_tonnes': weightTonnes,
-        'payment_method_id': paymentMethodId,
-        'upi_id': upiId,
-      }),
-    );
-
-    final body = response.body.isNotEmpty
-        ? jsonDecode(response.body) as Map<String, dynamic>
-        : <String, dynamic>{};
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(
-        body['error']?.toString() ?? 'Failed to create order via backend API.',
-      );
+    final headers = _customHeaders();
+    if (fullName != null && fullName.isNotEmpty) {
+      headers['x-user-name'] = fullName;
     }
 
-    return body['order']?['order_display_id']?.toString() ?? '';
+    try {
+      final body = await _apiClient.post(
+        '/api/orders',
+        headers: headers,
+        body: <String, dynamic>{
+          'pickup_address': pickupAddress,
+          'pickup_lat': pickupLat,
+          'pickup_lng': pickupLng,
+          'drop_address': dropAddress,
+          'drop_lat': dropLat,
+          'drop_lng': dropLng,
+          'pickup_date': DateTime.now().toIso8601String(),
+          'pickup_time': pickupTime,
+          'goods_type': goodsType,
+          'weight_tonnes': weightTonnes,
+          'payment_method_id': paymentMethodId,
+          'upi_id': upiId,
+        },
+      ) as Map<String, dynamic>?;
+
+      return body?['order']?['order_display_id']?.toString() ?? '';
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to create order via backend API: $e');
+    }
   }
 
   Future<Map<String, dynamic>> changeDrop({
@@ -91,126 +77,101 @@ class OrderService {
     required double dropLat,
     required double dropLng,
   }) async {
-    final token = _client.auth.currentSession?.accessToken;
-    final userId = SupabaseService.requireUserId();
-
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId/change-drop');
-
-    final response = await _httpClient.put(
-      uri,
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-        'x-user-id': userId,
-        'x-user-role': 'customer',
-      },
-      body: jsonEncode(<String, dynamic>{
-        'drop_address': dropAddress,
-        'drop_lat': dropLat,
-        'drop_lng': dropLng,
-      }),
-    );
-
-    final body = response.body.isNotEmpty ? jsonDecode(response.body) as Map<String, dynamic> : <String, dynamic>{};
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(body['error']?.toString() ?? 'Failed to change drop via backend API.');
+    try {
+      final body = await _apiClient.put(
+        '/api/orders/$orderDisplayId/change-drop',
+        headers: _customHeaders(),
+        body: <String, dynamic>{
+          'drop_address': dropAddress,
+          'drop_lat': dropLat,
+          'drop_lng': dropLng,
+        },
+      );
+      return body is Map<String, dynamic> ? body : <String, dynamic>{};
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to change drop via backend API: $e');
     }
-
-    return body;
   }
 
   Future<Map<String, dynamic>> cancelOrder({
     required String orderDisplayId,
     String? reason,
   }) async {
-    final token = _client.auth.currentSession?.accessToken;
-    final userId = SupabaseService.requireUserId();
-
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId/cancel');
-
-    final response = await _httpClient.post(
-      uri,
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-        'x-user-id': userId,
-        'x-user-role': 'customer',
-      },
-      body: jsonEncode(<String, dynamic>{
-        if (reason != null) 'reason': reason,
-      }),
-    );
-
-    final body = response.body.isNotEmpty ? jsonDecode(response.body) as Map<String, dynamic> : <String, dynamic>{};
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(body['error']?.toString() ?? 'Failed to cancel order via backend API.');
+    try {
+      final body = await _apiClient.post(
+        '/api/orders/$orderDisplayId/cancel',
+        headers: _customHeaders(),
+        body: <String, dynamic>{
+          if (reason != null) 'reason': reason,
+        },
+      );
+      return body is Map<String, dynamic> ? body : <String, dynamic>{};
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to cancel order via backend API: $e');
     }
-
-    return body;
-  }
-
-  Map<String, String> _authHeaders() {
-    final token = _client.auth.currentSession?.accessToken;
-    final userId = SupabaseService.requireUserId();
-    return <String, String>{
-      'Content-Type': 'application/json',
-      if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-      'x-user-id': userId,
-      'x-user-role': 'customer',
-    };
   }
 
   Future<Map<String, dynamic>?> fetchOrderById(String orderDisplayId) async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId');
-    final response = await _httpClient.get(uri, headers: _authHeaders());
-
-    if (response.statusCode == 404) return null;
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('Failed to fetch order');
+    try {
+      final body = await _apiClient.get(
+        '/api/orders/$orderDisplayId',
+        headers: _customHeaders(),
+      ) as Map<String, dynamic>?;
+      return body?['order'] as Map<String, dynamic>?;
+    } on ApiException catch (e) {
+      if (e.statusCode == 404) return null;
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to fetch order: $e');
     }
-
-    final body = jsonDecode(response.body) as Map<String, dynamic>;
-    return body['order'] as Map<String, dynamic>?;
   }
 
   Future<List<Map<String, dynamic>>> fetchOrders() async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/history');
-    final response = await _httpClient.get(uri, headers: _authHeaders());
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('Failed to fetch orders');
+    try {
+      final body = await _apiClient.get(
+        '/api/orders/history',
+        headers: _customHeaders(),
+      );
+      return List<Map<String, dynamic>>.from(body as List);
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to fetch orders: $e');
     }
-
-    final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
   }
 
   Future<List<Map<String, dynamic>>> fetchOrderTimeline(
     String orderDisplayId,
   ) async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/$orderDisplayId/timeline');
-    final response = await _httpClient.get(uri, headers: _authHeaders());
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('Failed to fetch order timeline');
+    try {
+      final body = await _apiClient.get(
+        '/api/orders/$orderDisplayId/timeline',
+        headers: _customHeaders(),
+      );
+      return List<Map<String, dynamic>>.from(body as List);
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to fetch order timeline: $e');
     }
-
-    final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
   }
 
   Future<List<Map<String, dynamic>>> fetchActiveOrders() async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/my/active');
-    final response = await _httpClient.get(uri, headers: _authHeaders());
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('Failed to fetch active orders');
+    try {
+      final body = await _apiClient.get(
+        '/api/orders/my/active',
+        headers: _customHeaders(),
+      );
+      return List<Map<String, dynamic>>.from(body as List);
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to fetch active orders: $e');
     }
-
-    final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
   }
 
   Future<List<Map<String, dynamic>>> searchTrucks({
@@ -222,9 +183,6 @@ class OrderService {
     bool isFragile = false,
     bool isStackable = true,
   }) async {
-    final token = _client.auth.currentSession?.accessToken;
-    final userId = SupabaseService.requireUserId();
-
     final params = <String, String>{
       'pickup_lat': pickupLat.toString(),
       'pickup_lng': pickupLng.toString(),
@@ -235,55 +193,44 @@ class OrderService {
       'is_stackable': isStackable.toString(),
     };
 
-    final uri = Uri.parse('$_apiBaseUrl/api/trucks/search').replace(queryParameters: params);
-    final response = await _httpClient.get(
-      uri,
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-        'x-user-id': userId,
-        'x-user-role': 'customer',
-      },
-    );
+    final path = Uri(path: '/api/trucks/search', queryParameters: params).toString();
 
-    final body = response.body.isNotEmpty
-        ? jsonDecode(response.body)
-        : null;
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final message = body is Map<String, dynamic>
-          ? (body['error']?.toString() ?? 'Failed to search trucks')
-          : 'Failed to search trucks';
-      throw StateError(message);
+    try {
+      final body = await _apiClient.get(
+        path,
+        headers: _customHeaders(),
+      );
+      final List<dynamic> listBody = body is List<dynamic> ? body : <dynamic>[];
+      return listBody.cast<Map<String, dynamic>>();
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to search trucks: $e');
     }
-
-    final List<dynamic> listBody = body is List<dynamic> ? body : <dynamic>[];
-
-    return listBody.cast<Map<String, dynamic>>();
   }
 
   Future<List<Map<String, dynamic>>> fetchHistoryOrders() async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/history');
-    final response = await _httpClient.get(uri, headers: _authHeaders());
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('Failed to fetch history orders');
+    try {
+      final body = await _apiClient.get(
+        '/api/orders/history',
+        headers: _customHeaders(),
+      );
+      return List<Map<String, dynamic>>.from(body as List);
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } catch (e) {
+      throw StateError('Failed to fetch history orders: $e');
     }
-
-    final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
   }
 
   Future<String?> fetchDriverName(String driverId) async {
     try {
-      final uri = Uri.parse('$_apiBaseUrl/api/profile/$driverId/name');
-      final response = await _httpClient.get(uri, headers: _authHeaders());
-      if (response.statusCode == 200) {
-        final body = jsonDecode(response.body) as Map<String, dynamic>;
-        final fullName = body['full_name']?.toString().trim();
-        return (fullName != null && fullName.isNotEmpty) ? fullName : null;
-      }
-      return null;
+      final body = await _apiClient.get(
+        '/api/profile/$driverId/name',
+        headers: _customHeaders(),
+      ) as Map<String, dynamic>?;
+      final fullName = body?['full_name']?.toString().trim();
+      return (fullName != null && fullName.isNotEmpty) ? fullName : null;
     } catch (e, st) {
       debugPrint('Error fetching driver name: $e\n$st');
       return null;
@@ -292,14 +239,12 @@ class OrderService {
 
   Future<String?> fetchTruckNumber(String truckId) async {
     try {
-      final uri = Uri.parse('$_apiBaseUrl/api/trucks/$truckId/number');
-      final response = await _httpClient.get(uri, headers: _authHeaders());
-      if (response.statusCode == 200) {
-        final body = jsonDecode(response.body) as Map<String, dynamic>;
-        final numberPlate = body['number_plate']?.toString().trim();
-        return (numberPlate != null && numberPlate.isNotEmpty) ? numberPlate : null;
-      }
-      return null;
+      final body = await _apiClient.get(
+        '/api/trucks/$truckId/number',
+        headers: _customHeaders(),
+      ) as Map<String, dynamic>?;
+      final numberPlate = body?['number_plate']?.toString().trim();
+      return (numberPlate != null && numberPlate.isNotEmpty) ? numberPlate : null;
     } catch (e, st) {
       debugPrint('Error fetching truck number: $e\n$st');
       return null;

--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -1,65 +1,36 @@
 import 'dart:convert';
-
-import 'package:http/http.dart' as http;
-import 'package:supabase_flutter/supabase_flutter.dart';
-
+import '../core/api_client.dart';
 import 'supabase_service.dart';
 
 class ProfileService {
   ProfileService({
-    SupabaseClient? client,
-    http.Client? httpClient,
-    String? apiBaseUrl,
-  })  : _providedClient = client,
-        _httpClient = httpClient ?? http.Client(),
-        _apiBaseUrl = _normalizeBaseUrl(apiBaseUrl ?? defaultApiBaseUrl);
+    ApiClient? apiClient,
+  }) : _apiClient = apiClient ?? ApiClient();
 
-  static const String defaultApiBaseUrl = String.fromEnvironment(
-    'TRUXIFY_API_BASE_URL',
-    defaultValue: 'http://localhost:5000',
-  );
-
-  final SupabaseClient? _providedClient;
-  final http.Client _httpClient;
-  final String _apiBaseUrl;
-
-  SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
-
-  static String _normalizeBaseUrl(String value) {
-    return value.endsWith('/') ? value.substring(0, value.length - 1) : value;
-  }
+  final ApiClient _apiClient;
 
   Future<Map<String, dynamic>> fetchProfile() async {
     final userId = SupabaseService.requireUserId();
-    final token = _client.auth.currentSession?.accessToken;
     final fullName = SupabaseService.currentUser?.userMetadata?['full_name']?.toString();
 
-    final response = await _httpClient.get(
-      Uri.parse('$_apiBaseUrl/api/profile'),
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
-        'x-user-id': userId,
-        'x-user-role': 'customer',
-        if (fullName != null && fullName.isNotEmpty) 'x-user-name': fullName,
-      },
-    );
+    final headers = <String, String>{
+      'x-user-id': userId,
+      'x-user-role': 'customer',
+      if (fullName != null && fullName.isNotEmpty) 'x-user-name': fullName,
+    };
 
-    Map<String, dynamic> body;
     try {
-      body = response.body.isNotEmpty
-          ? jsonDecode(response.body) as Map<String, dynamic>
-          : <String, dynamic>{};
-    } catch (_) {
+      final result = await _apiClient.get('/api/profile', headers: headers);
+      if (result is Map<String, dynamic>) {
+        return result;
+      }
+      return <String, dynamic>{};
+    } on ApiException catch (e) {
+      throw StateError(e.message);
+    } on FormatException {
       throw const FormatException('Invalid JSON response from server.');
+    } catch (e) {
+      throw StateError('Failed to fetch profile via backend API: $e');
     }
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(
-        body['error']?.toString() ?? 'Failed to fetch profile via backend API.',
-      );
-    }
-
-    return body;
   }
 }

--- a/apps/customer/lib/services/supabase_service.dart
+++ b/apps/customer/lib/services/supabase_service.dart
@@ -3,7 +3,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class SupabaseService {
   SupabaseService._();
 
-  static SupabaseClient get client => Supabase.instance.client;
+  static SupabaseClient? mockClient;
+
+  static SupabaseClient get client => mockClient ?? Supabase.instance.client;
 
   static User? get currentUser => client.auth.currentUser;
 

--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -33,6 +33,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/apps/customer/test/core/api_client_test.dart
+++ b/apps/customer/test/core/api_client_test.dart
@@ -11,6 +11,7 @@ class MockHttpClient extends Mock implements http.Client {}
 class MockSupabaseClient extends Mock implements SupabaseClient {}
 class MockGoTrueClient extends Mock implements GoTrueClient {}
 class MockSession extends Mock implements Session {}
+class MockUser extends Mock implements User {}
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -145,7 +146,7 @@ void main() {
       });
 
       when(() => authClient.refreshSession()).thenAnswer((_) async =>
-          AuthResponse(session: refreshedSession, user: null));
+          AuthResponse(session: refreshedSession, user: MockUser()));
 
       final client = buildClient(
           httpClient: httpClient, supabaseClient: supabaseClient);
@@ -189,7 +190,7 @@ void main() {
               http.Response('{"error":"Unauthorized"}', 401));
 
       when(() => authClient.refreshSession()).thenAnswer((_) async =>
-          AuthResponse(session: refreshedSession, user: null));
+          AuthResponse(session: refreshedSession, user: MockUser()));
 
       final client = buildClient(
           httpClient: httpClient, supabaseClient: supabaseClient);
@@ -234,6 +235,48 @@ void main() {
           isA<ApiException>().having((e) => e.statusCode, 'statusCode', 500),
         ),
       );
+    });
+  });
+
+  // ── Core enhancements ──────────────────────────────────────────────
+
+  group('ApiClient Core Enhancements', () {
+    test('normalises paths with and without leading slash', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => jsonResponse({'ok': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      // Path without leading slash
+      await client.get('api/orders');
+      verify(() => httpClient.get(Uri.parse('http://localhost:5000/api/orders'), headers: any(named: 'headers'))).called(1);
+
+      // Path with leading slash
+      await client.get('/api/orders');
+      verify(() => httpClient.get(Uri.parse('http://localhost:5000/api/orders'), headers: any(named: 'headers'))).called(1);
+    });
+
+    test('accepts custom headers and merges them', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => jsonResponse({'ok': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await client.get('/api/orders', headers: {'custom-key': 'custom-val'});
+
+      final captured = verify(
+        () => httpClient.get(any(), headers: captureAny(named: 'headers')),
+      ).captured;
+      final headers = captured.first as Map<String, String>;
+      expect(headers['Authorization'], equals('Bearer $kMockToken'));
+      expect(headers['custom-key'], equals('custom-val'));
+    });
+
+    test('dispose closes http client if owned', () {
+      final client = ApiClient(supabaseClient: supabaseClient);
+      client.dispose();
     });
   });
 }

--- a/apps/customer/test/core/api_client_test.dart
+++ b/apps/customer/test/core/api_client_test.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify/core/api_client.dart';
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+class MockHttpClient extends Mock implements http.Client {}
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+class MockGoTrueClient extends Mock implements GoTrueClient {}
+class MockSession extends Mock implements Session {}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+http.Response jsonResponse(Object body, {int status = 200}) => http.Response(
+      jsonEncode(body),
+      status,
+      headers: {'content-type': 'application/json'},
+    );
+
+const String kBaseUrl = 'http://localhost:5000';
+const String kMockToken = 'mock_access_token';
+const String kRefreshedToken = 'refreshed_access_token';
+
+ApiClient buildClient({
+  required MockHttpClient httpClient,
+  required MockSupabaseClient supabaseClient,
+}) =>
+    ApiClient(
+      supabaseClient: supabaseClient,
+      httpClient: httpClient,
+      baseUrl: kBaseUrl,
+    );
+
+void main() {
+  late MockHttpClient httpClient;
+  late MockSupabaseClient supabaseClient;
+  late MockGoTrueClient authClient;
+  late MockSession session;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+    registerFallbackValue(<String, String>{});
+  });
+
+  setUp(() {
+    httpClient = MockHttpClient();
+    supabaseClient = MockSupabaseClient();
+    authClient = MockGoTrueClient();
+    session = MockSession();
+
+    when(() => supabaseClient.auth).thenReturn(authClient);
+    when(() => authClient.currentSession).thenReturn(session);
+    when(() => session.accessToken).thenReturn(kMockToken);
+  });
+
+  // ── Header injection ───────────────────────────────────────────────
+
+  group('Authorization header injection', () {
+    test('GET attaches Bearer token from current session', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => jsonResponse({'ok': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+      await client.get('/api/orders');
+
+      final captured = verify(
+        () => httpClient.get(any(), headers: captureAny(named: 'headers')),
+      ).captured;
+      final headers = captured.first as Map<String, String>;
+      expect(headers['Authorization'], equals('Bearer $kMockToken'));
+    });
+
+    test('POST attaches Bearer token', () async {
+      when(() => httpClient.post(any(),
+              headers: any(named: 'headers'), body: any(named: 'body')))
+          .thenAnswer((_) async => jsonResponse({'id': '123'}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+      await client.post('/api/orders', body: {'key': 'value'});
+
+      final captured = verify(
+        () => httpClient.post(any(),
+            headers: captureAny(named: 'headers'),
+            body: any(named: 'body')),
+      ).captured;
+      final headers = captured.first as Map<String, String>;
+      expect(headers['Authorization'], equals('Bearer $kMockToken'));
+    });
+
+    test('PUT attaches Bearer token', () async {
+      when(() => httpClient.put(any(),
+              headers: any(named: 'headers'), body: any(named: 'body')))
+          .thenAnswer((_) async => jsonResponse({'updated': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+      await client.put('/api/profile', body: {'full_name': 'Test'});
+
+      final captured = verify(
+        () => httpClient.put(any(),
+            headers: captureAny(named: 'headers'),
+            body: any(named: 'body')),
+      ).captured;
+      final headers = captured.first as Map<String, String>;
+      expect(headers['Authorization'], equals('Bearer $kMockToken'));
+    });
+
+    test('omits Authorization header when no session exists', () async {
+      when(() => authClient.currentSession).thenReturn(null);
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => jsonResponse({'ok': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+      await client.get('/api/health');
+
+      final captured = verify(
+        () => httpClient.get(any(), headers: captureAny(named: 'headers')),
+      ).captured;
+      final headers = captured.first as Map<String, String>;
+      expect(headers.containsKey('Authorization'), isFalse);
+    });
+  });
+
+  // ── Token refresh and retry ────────────────────────────────────────
+
+  group('Token refresh on 401', () {
+    test('retries with refreshed token after 401', () async {
+      final refreshedSession = MockSession();
+      when(() => refreshedSession.accessToken).thenReturn(kRefreshedToken);
+
+      var callCount = 0;
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response('{"error":"Unauthorized"}', 401);
+        }
+        return jsonResponse({'orders': []});
+      });
+
+      when(() => authClient.refreshSession()).thenAnswer((_) async =>
+          AuthResponse(session: refreshedSession, user: null));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+      final result = await client.get('/api/orders');
+
+      expect(result, isA<Map>());
+      expect(callCount, equals(2));
+
+      final captured = verify(
+        () => httpClient.get(any(), headers: captureAny(named: 'headers')),
+      ).captured;
+      // Second call should use the refreshed token
+      final retryHeaders = captured.last as Map<String, String>;
+      expect(retryHeaders['Authorization'], equals('Bearer $kRefreshedToken'));
+    });
+
+    test('throws ApiAuthException when refresh fails', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async =>
+              http.Response('{"error":"Unauthorized"}', 401));
+
+      when(() => authClient.refreshSession())
+          .thenThrow(Exception('refresh failed'));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await expectLater(
+        () => client.get('/api/orders'),
+        throwsA(isA<ApiAuthException>()),
+      );
+    });
+
+    test('throws ApiAuthException when retry after refresh still returns 401',
+        () async {
+      final refreshedSession = MockSession();
+      when(() => refreshedSession.accessToken).thenReturn(kRefreshedToken);
+
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async =>
+              http.Response('{"error":"Unauthorized"}', 401));
+
+      when(() => authClient.refreshSession()).thenAnswer((_) async =>
+          AuthResponse(session: refreshedSession, user: null));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await expectLater(
+        () => client.get('/api/orders'),
+        throwsA(isA<ApiAuthException>()),
+      );
+    });
+
+    test('does not retry on non-401 errors', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async =>
+              http.Response('{"error":"Not Found"}', 404));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await expectLater(
+        () => client.get('/api/orders/nonexistent'),
+        throwsA(isA<ApiException>()),
+      );
+
+      verifyNever(() => authClient.refreshSession());
+    });
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────
+
+  group('ApiException on non-2xx responses', () {
+    test('throws ApiException with status code on 500', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async =>
+              http.Response('{"error":"Internal Server Error"}', 500));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await expectLater(
+        () => client.get('/api/orders'),
+        throwsA(
+          isA<ApiException>().having((e) => e.statusCode, 'statusCode', 500),
+        ),
+      );
+    });
+  });
+}

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -1,0 +1,84 @@
+﻿import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify/core/api_client.dart';
+import 'package:truxify/services/order_service.dart';
+import 'package:truxify/services/supabase_service.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+class MockGoTrueClient extends Mock implements GoTrueClient {}
+class MockUser extends Mock implements User {}
+
+void main() {
+  late MockApiClient apiClient;
+  late MockSupabaseClient supabaseClient;
+  late MockGoTrueClient authClient;
+  late MockUser user;
+  late OrderService orderService;
+
+  setUp(() {
+    apiClient = MockApiClient();
+    supabaseClient = MockSupabaseClient();
+    authClient = MockGoTrueClient();
+    user = MockUser();
+
+    SupabaseService.mockClient = supabaseClient;
+
+    when(() => supabaseClient.auth).thenReturn(authClient);
+    when(() => authClient.currentUser).thenReturn(user);
+    when(() => user.id).thenReturn('user_123');
+    when(() => user.userMetadata).thenReturn({'full_name': 'John Doe'});
+
+    orderService = OrderService(apiClient: apiClient);
+  });
+
+  tearDown(() {
+    SupabaseService.mockClient = null;
+  });
+
+  test('createOrder delegates post to ApiClient', () async {
+    when(() => apiClient.post(any(), body: any(named: 'body'), headers: any(named: 'headers')))
+        .thenAnswer((_) async => {'order': {'order_display_id': 'ORD-123'}});
+
+    final orderId = await orderService.createOrder(
+      pickupAddress: 'Pickup Loc',
+      dropAddress: 'Drop Loc',
+      pickupLat: 12.3,
+      pickupLng: 45.6,
+      dropLat: 78.9,
+      dropLng: 12.3,
+      pickupTime: '10:00 AM',
+      goodsType: 'Timber',
+      weightTonnes: 5.5,
+    );
+
+    expect(orderId, equals('ORD-123'));
+
+    final captured = verify(
+      () => apiClient.post(
+        '/api/orders',
+        headers: captureAny(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).captured;
+    final headers = captured.first as Map<String, String>;
+    expect(headers['x-user-id'], equals('user_123'));
+    expect(headers['x-user-role'], equals('customer'));
+    expect(headers['x-user-name'], equals('John Doe'));
+  });
+
+  test('fetchOrderById handles success and 404', () async {
+    when(() => apiClient.get('/api/orders/ORD-123', headers: any(named: 'headers')))
+        .thenAnswer((_) async => {'order': {'id': 'ORD-123', 'status': 'pending'}});
+
+    final order = await orderService.fetchOrderById('ORD-123');
+    expect(order?['id'], equals('ORD-123'));
+
+    // 404 error case
+    when(() => apiClient.get('/api/orders/ORD-404', headers: any(named: 'headers')))
+        .thenThrow(const ApiException(404, 'Not Found'));
+    final order404 = await orderService.fetchOrderById('ORD-404');
+    expect(order404, isNull);
+  });
+}

--- a/apps/customer/test/services/profile_service_test.dart
+++ b/apps/customer/test/services/profile_service_test.dart
@@ -1,0 +1,67 @@
+﻿import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify/core/api_client.dart';
+import 'package:truxify/services/profile_service.dart';
+import 'package:truxify/services/supabase_service.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+class MockGoTrueClient extends Mock implements GoTrueClient {}
+class MockUser extends Mock implements User {}
+
+void main() {
+  late MockApiClient apiClient;
+  late MockSupabaseClient supabaseClient;
+  late MockGoTrueClient authClient;
+  late MockUser user;
+  late ProfileService profileService;
+
+  setUp(() {
+    apiClient = MockApiClient();
+    supabaseClient = MockSupabaseClient();
+    authClient = MockGoTrueClient();
+    user = MockUser();
+
+    SupabaseService.mockClient = supabaseClient;
+
+    when(() => supabaseClient.auth).thenReturn(authClient);
+    when(() => authClient.currentUser).thenReturn(user);
+    when(() => user.id).thenReturn('user_123');
+    when(() => user.userMetadata).thenReturn({'full_name': 'John Doe'});
+
+    profileService = ProfileService(apiClient: apiClient);
+  });
+
+  tearDown(() {
+    SupabaseService.mockClient = null;
+  });
+
+  test('fetchProfile calls ApiClient get and returns data', () async {
+    when(() => apiClient.get('/api/profile', headers: any(named: 'headers')))
+        .thenAnswer((_) async => {'id': 'user_123', 'email': 'john@example.com'});
+
+    final profile = await profileService.fetchProfile();
+
+    expect(profile['id'], equals('user_123'));
+    expect(profile['email'], equals('john@example.com'));
+
+    final captured = verify(
+      () => apiClient.get('/api/profile', headers: captureAny(named: 'headers')),
+    ).captured;
+    final headers = captured.first as Map<String, String>;
+    expect(headers['x-user-id'], equals('user_123'));
+    expect(headers['x-user-role'], equals('customer'));
+    expect(headers['x-user-name'], equals('John Doe'));
+  });
+
+  test('fetchProfile translates ApiException to StateError', () async {
+    when(() => apiClient.get('/api/profile', headers: any(named: 'headers')))
+        .thenThrow(const ApiException(400, 'Bad Request'));
+
+    expect(
+      () => profileService.fetchProfile(),
+      throwsA(isA<StateError>().having((e) => e.message, 'message', 'Bad Request')),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Adds a centralised `ApiClient` class to the customer Flutter app that injects the Supabase JWT into every backend request and automatically retries on 401 with a refreshed token — eliminating duplicated auth logic across services.

---

## Changes

### `apps/customer/lib/core/api_client.dart` (new)
- `ApiClient` class reads `supabase.auth.currentSession?.accessToken` and injects `Authorization: Bearer <token>` into every request
- Supports `GET`, `POST`, `PUT`, `PATCH`, `DELETE`
- On HTTP `401`: calls `supabase.auth.refreshSession()` once and retries with the new token
- If retry still returns `401` → throws `ApiAuthException`
- If refresh itself fails → throws `ApiAuthException`
- Non-2xx responses throw `ApiException` with `statusCode` and parsed error message
- Base URL from `TRUXIFY_API_BASE_URL` compile-time env var with `http://localhost:5000` fallback
- `ApiAuthException` and `ApiException` as typed error classes for structured error handling

### `apps/customer/test/core/api_client_test.dart` (new)
8 unit tests using `mocktail`:
- `GET`/`POST`/`PUT` attach `Authorization: Bearer mock_access_token`
- Omits `Authorization` when no session exists
- Retries with refreshed token after `401`
- Throws `ApiAuthException` when refresh fails
- Throws `ApiAuthException` when retry after refresh still returns `401`
- Does not call `refreshSession` on non-401 errors
- Throws `ApiException` with correct `statusCode` on `500`

### `apps/customer/pubspec.yaml`
- Added `mocktail: ^1.0.4` to `dev_dependencies`

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Every backend request includes `Authorization: Bearer <token>` | ✅ |
| Auth logic in single reusable `ApiClient` | ✅ `api_client.dart` |
| HTTP 401 triggers automatic token refresh | ✅ `_execute()` with `refreshSession()` |
| Failed requests retried exactly once after refresh | ✅ `isRetry` flag prevents infinite retry |
| Unit tests verify JWT header injection | ✅ 3 header injection tests |
| Unit tests verify token refresh and retry | ✅ 3 refresh/retry tests |
| No infinite retry loop | ✅ `isRetry: true` on second call |

---

## Notes
The existing services (`order_service.dart`, `profile_service.dart`, `location_service.dart`, `voice_ai_service.dart`) can be migrated to use `ApiClient` as a follow-up — the client is designed as a drop-in replacement for their current `http.Client` + inline token logic.

Closes #568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized API client with automatic authorization header injection, token refresh on authentication failures, and JSON request/response handling for backend calls.
* **Refactor**
  * Updated order and profile data services to use the centralized API client for consistent request headers, responses, and error handling.
* **Tests**
  * Added unit tests for the API client, order service, and profile service.
* **Chores**
  * Enabled easier Supabase client mocking in tests and added `mocktail` to dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->