### PR TITLE
Fix #587: Integrate ML Price Prediction into Order Creation

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -87,6 +87,10 @@ class TruckResultData {
     required this.eta,
     this.badge,
     this.badgeColor = Colors.black,
+    this.baseFreight,
+    this.tollEstimate,
+    this.platformFee,
+    this.isAiEstimate = false,
   });
 
   factory TruckResultData.fromJson(Map<String, dynamic> json) {
@@ -94,6 +98,21 @@ class TruckResultData {
     final priceStr = rawPrice is num
         ? '₹${(rawPrice / 100).round()}'
         : (rawPrice?.toString() ?? '₹0');
+
+    final rawBaseFreight = json['baseFreight'];
+    final baseFreightStr = rawBaseFreight is num
+        ? '₹${(rawBaseFreight / 100).round()}'
+        : null;
+
+    final rawTollEstimate = json['tollEstimate'];
+    final tollEstimateStr = rawTollEstimate is num
+        ? '₹${(rawTollEstimate / 100).round()}'
+        : null;
+
+    final rawPlatformFee = json['platformFee'];
+    final platformFeeStr = rawPlatformFee is num
+        ? '₹${(rawPlatformFee / 100).round()}'
+        : null;
 
     final etaMinutes = json['etaMinutes'];
     final etaStr = etaMinutes != null
@@ -109,6 +128,11 @@ class TruckResultData {
       capacity: json['capacity'] as String? ?? '',
       price: priceStr,
       eta: etaStr,
+      badge: json['badge'] as String?,
+      baseFreight: baseFreightStr,
+      tollEstimate: tollEstimateStr,
+      platformFee: platformFeeStr,
+      isAiEstimate: json['isAiEstimate'] as bool? ?? false,
     );
   }
 
@@ -121,6 +145,10 @@ class TruckResultData {
   final String eta;
   final String? badge;
   final Color badgeColor;
+  final String? baseFreight;
+  final String? tollEstimate;
+  final String? platformFee;
+  final bool isAiEstimate;
 }
 
 class ActiveOrderData {

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -189,52 +189,46 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                         .titleMedium
                         ?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 14),
-                ...mockBookingPriceLines.map(
-                  (line) => Padding(
-                    padding: const EdgeInsets.only(bottom: 10),
-                    child: Row(
-                      children: [
-                        Text(line.label,
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                    fontWeight: line.isTotal
-                                        ? FontWeight.w800
-                                        : FontWeight.w500)),
-                        const Spacer(),
-                        Text(line.amount,
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                    fontWeight: line.isTotal
-                                        ? FontWeight.w800
-                                        : FontWeight.w600)),
-                      ],
+                if (widget.truck.baseFreight != null) ...[
+                  _PriceLineRow(label: 'Base freight', amount: widget.truck.baseFreight!),
+                  if (widget.truck.tollEstimate != null)
+                    _PriceLineRow(label: 'Toll estimate', amount: widget.truck.tollEstimate!),
+                  if (widget.truck.platformFee != null)
+                    _PriceLineRow(label: 'Platform fee', amount: widget.truck.platformFee!),
+                  _PriceLineRow(label: 'Total', amount: widget.truck.price, isTotal: true),
+                ] else ...[
+                  ...mockBookingPriceLines.map(
+                    (line) => _PriceLineRow(
+                      label: line.label,
+                      amount: line.amount,
+                      isTotal: line.isTotal,
                     ),
                   ),
-                ),
+                ],
+                if (widget.truck.isAiEstimate) ...[
+                  const SizedBox(height: 4),
+                  const Divider(),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      const Icon(Icons.auto_awesome_rounded,
+                          color: TruxifyColors.accentDark, size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'AI Estimated Price',
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyMedium
+                              ?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
                 const SizedBox(height: 4),
                 const Divider(),
                 const SizedBox(height: 8),
-                Row(
-                  children: [
-                    const Icon(Icons.auto_awesome_rounded,
-                        color: TruxifyColors.accentDark, size: 18),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        'AI Estimated Price',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyMedium
-                            ?.copyWith(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 6),
                 Row(
                   children: [
                     const Icon(Icons.lock_rounded,
@@ -371,6 +365,46 @@ class _SummaryRow extends StatelessWidget {
                       .textTheme
                       .bodyMedium
                       ?.copyWith(fontWeight: FontWeight.w700))),
+        ],
+      ),
+    );
+  }
+}
+
+class _PriceLineRow extends StatelessWidget {
+  const _PriceLineRow({
+    required this.label,
+    required this.amount,
+    this.isTotal = false,
+  });
+
+  final String label;
+  final String amount;
+  final bool isTotal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Text(label,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(
+                      fontWeight: isTotal
+                          ? FontWeight.w800
+                          : FontWeight.w500)),
+          const Spacer(),
+          Text(amount,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(
+                      fontWeight: isTotal
+                          ? FontWeight.w800
+                          : FontWeight.w600)),
         ],
       ),
     );

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -220,6 +220,23 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                 const SizedBox(height: 8),
                 Row(
                   children: [
+                    const Icon(Icons.auto_awesome_rounded,
+                        color: TruxifyColors.accentDark, size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'AI Estimated Price',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Row(
+                  children: [
                     const Icon(Icons.lock_rounded,
                         color: TruxifyColors.accentDark, size: 18),
                     const SizedBox(width: 8),

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -27,6 +27,9 @@ R2_SECRET_ACCESS_KEY=your_secret_key
 R2_BUCKET_NAME=truxify-docs
 R2_PUBLIC_URL_PREFIX=https://your-bucket.r2.dev
 
+# ── ML Service ────────────────────────────
+ML_SERVICE_URL=http://localhost:8001
+
 # ── Blockchain ────────────────────────────
 POLYGON_RPC_URL=https://polygon-rpc.com
 REPUTATION_CONTRACT_ADDRESS=0x...

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -187,6 +187,9 @@ router.post('/', authenticate, requireRole(['customer']), validateBody(createOrd
       routeOrigin: pickup_address,
       routeDestination: drop_address,
     });
+    if (!mlResult || typeof mlResult.estimated_price !== 'number' || mlResult.estimated_price <= 0) {
+      throw new Error(`Invalid or non-positive price prediction: ${JSON.stringify(mlResult)}`);
+    }
     estimatedPrice = Math.round(mlResult.estimated_price * 100);
   } catch (mlErr) {
     console.warn('[ML] Price prediction unavailable, falling back to base pricing:', mlErr.message);

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -20,7 +20,7 @@ import { changeDropSchema, cancelOrderSchema } from '../validation/requestSchema
 import { awardReputationPoints } from '../services/reputation.js';
 import { escrowDeposit, escrowRelease, escrowRefund } from '../services/escrow.js';
 import { sendDeliveryOtpNotification } from '../services/notificationService.js';
-import { predictDemand } from '../services/ml.js';
+import { predictDemand, predictPrice } from '../services/ml.js';
 import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
@@ -179,6 +179,19 @@ router.post('/', authenticate, requireRole(['customer']), validateBody(createOrd
     });
   }
 
+  let estimatedPrice = null;
+  try {
+    const mlResult = await predictPrice({
+      distanceKm: pricing.distanceKm,
+      cargoWeightKg: Number(weight_tonnes) * 1000,
+      routeOrigin: pickup_address,
+      routeDestination: drop_address,
+    });
+    estimatedPrice = Math.round(mlResult.estimated_price * 100);
+  } catch (mlErr) {
+    console.warn('[ML] Price prediction unavailable, falling back to base pricing:', mlErr.message);
+  }
+
   const orderDisplayId = generateOrderDisplayId();
 
   try {
@@ -197,6 +210,7 @@ router.post('/', authenticate, requireRole(['customer']), validateBody(createOrd
         toll_estimate: pricing.tollEstimate,
         platform_fee: pricing.platformFee,
         total_amount: pricing.totalAmount,
+        estimated_price: estimatedPrice,
         payment_method_id, upi_id
       })
       .select('id, order_display_id, status, created_at')

--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -3,6 +3,7 @@ import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { getRouteEstimate } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
+import { predictPrice } from '../services/ml.js';
 
 const router = express.Router();
 
@@ -56,6 +57,35 @@ router.get('/search', authenticate, async (req, res) => {
       isStackable: parseBoolean(is_stackable),
     });
 
+    let finalBaseFreight = pricing.baseFreight;
+    let finalTollEstimate = pricing.tollEstimate;
+    let finalPlatformFee = pricing.platformFee;
+    let finalTotalAmount = pricing.totalAmount;
+    let isAiEstimate = false;
+
+    try {
+      const mlResult = await predictPrice({
+        distanceKm: pricing.distanceKm,
+        cargoWeightKg: numWeightTonnes * 1000,
+        truckType: 'medium_truck',
+      });
+      if (mlResult && typeof mlResult.estimated_price === 'number' && mlResult.estimated_price > 0) {
+        const estimatedPrice = Math.round(mlResult.estimated_price * 100);
+        finalTotalAmount = estimatedPrice;
+        finalPlatformFee = Math.round(estimatedPrice * 0.05);
+        finalBaseFreight = estimatedPrice - finalPlatformFee - finalTollEstimate;
+        if (finalBaseFreight < 0) {
+          finalBaseFreight = 0;
+          finalTollEstimate = estimatedPrice - finalPlatformFee;
+        }
+        isAiEstimate = true;
+      } else {
+        console.warn('[ML] Invalid price prediction response during search:', mlResult);
+      }
+    } catch (mlErr) {
+      console.warn('[ML] Price prediction unavailable during search, falling back to base pricing:', mlErr.message);
+    }
+
     const { data: drivers, error: driversErr } = await supabase
       .from('driver_details')
       .select('user_id, rating, total_trips, completion_rate, truck_id')
@@ -96,7 +126,11 @@ router.get('/search', authenticate, async (req, res) => {
         truck: truck.name || 'Unknown Truck',
         truckNumber: truck.number_plate || '',
         capacity: truck.max_capacity_tons ? `${truck.max_capacity_tons} tonnes` : '',
-        price: pricing.totalAmount,
+        price: finalTotalAmount,
+        baseFreight: finalBaseFreight,
+        tollEstimate: finalTollEstimate,
+        platformFee: finalPlatformFee,
+        isAiEstimate,
         etaMinutes,
       };
     });

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -1,4 +1,5 @@
 const DEFAULT_ML_ENGINE_URL = 'http://localhost:8001';
+const DEFAULT_ML_SERVICE_URL = 'http://localhost:8001';
 
 /**
  * Predicts ride/truck demand by calling the FastAPI ML engine service.
@@ -28,6 +29,44 @@ export async function predictDemand(features) {
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Predicts freight price by calling the FastAPI ML engine service.
+ *
+ * @param {object} params
+ * @param {number} params.distanceKm - Route distance in kilometres
+ * @param {number} params.cargoWeightKg - Cargo weight in kilograms
+ * @param {string} [params.truckType] - Type of truck
+ * @param {string} [params.routeOrigin] - Origin location
+ * @param {string} [params.routeDestination] - Destination location
+ * @returns {Promise<{estimated_price: number, currency: string}>} price prediction
+ */
+export async function predictPrice({ distanceKm, cargoWeightKg, truckType, routeOrigin, routeDestination } = {}) {
+  const baseUrl = process.env.ML_SERVICE_URL || process.env.ML_ENGINE_URL || DEFAULT_ML_SERVICE_URL;
+  const url = `${baseUrl}/predict`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      distance_km: distanceKm,
+      cargo_weight_kg: cargoWeightKg,
+      truck_type: truckType || 'medium_truck',
+      route_origin: routeOrigin || '',
+      route_destination: routeDestination || '',
+    }),
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`ML Engine price prediction failed: ${response.statusText} (${text})`);
   }
 
   return response.json();

--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -8,6 +8,7 @@ from .models.demand_forecast import (
     train_demand_forecast_model,
     FEATURE_NAMES,
 )
+from .models.price_prediction import predict_price
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -32,6 +33,19 @@ class DemandForecastOutput(BaseModel):
     predicted_demand: float
     model_version: str = "1.0.0"
     feature_names: List[str] = FEATURE_NAMES
+
+
+class PricePredictInput(BaseModel):
+    distance_km: float = Field(..., gt=0, description="Route distance in kilometres")
+    cargo_weight_kg: float = Field(..., gt=0, description="Cargo weight in kilograms")
+    truck_type: str = Field("medium_truck", description="Type of truck (light_truck, medium_truck, heavy_truck, trailer)")
+    route_origin: str = Field("", description="Origin location name")
+    route_destination: str = Field("", description="Destination location name")
+
+
+class PricePredictOutput(BaseModel):
+    estimated_price: float
+    currency: str = "INR"
 
 
 class TrainResponse(BaseModel):
@@ -68,6 +82,24 @@ async def predict_demand_endpoint(input: DemandForecastInput):
     except Exception as e:
         logger.error("Demand prediction failed: %s", e)
         raise HTTPException(status_code=500, detail="Prediction failed")
+
+
+@app.post("/predict", response_model=PricePredictOutput)
+async def predict_price_endpoint(input: PricePredictInput):
+    try:
+        price = predict_price(
+            distance_km=input.distance_km,
+            cargo_weight_kg=input.cargo_weight_kg,
+            truck_type=input.truck_type,
+            route_origin=input.route_origin,
+            route_destination=input.route_destination,
+        )
+        return PricePredictOutput(estimated_price=price)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.error("Price prediction failed: %s", e)
+        raise HTTPException(status_code=500, detail="Price prediction failed")
 
 
 @app.post("/train/demand", response_model=TrainResponse)

--- a/backend/ml/app/models/price_prediction.py
+++ b/backend/ml/app/models/price_prediction.py
@@ -1,0 +1,39 @@
+import logging
+import math
+
+logger = logging.getLogger(__name__)
+
+TRUCK_TYPE_MULTIPLIERS = {
+    "light_truck": 1.0,
+    "medium_truck": 1.2,
+    "heavy_truck": 1.5,
+    "trailer": 1.8,
+}
+
+DEFAULT_TRUCK_MULTIPLIER = 1.0
+BASE_RATE_PER_KM = 6.0
+BASE_RATE_PER_KG = 0.005
+MIN_PRICE = 500.0
+
+
+def predict_price(
+    distance_km: float,
+    cargo_weight_kg: float,
+    truck_type: str = "medium_truck",
+    route_origin: str = "",
+    route_destination: str = "",
+) -> float:
+    if distance_km <= 0:
+        raise ValueError("distance_km must be positive")
+    if cargo_weight_kg <= 0:
+        raise ValueError("cargo_weight_kg must be positive")
+
+    truck_mult = TRUCK_TYPE_MULTIPLIERS.get(
+        truck_type.lower().replace(" ", "_"), DEFAULT_TRUCK_MULTIPLIER
+    )
+
+    distance_cost = distance_km * BASE_RATE_PER_KM * truck_mult
+    weight_cost = cargo_weight_kg * BASE_RATE_PER_KG
+    estimated_price = distance_cost + weight_cost
+
+    return max(round(estimated_price, 2), MIN_PRICE)

--- a/backend/ml/tests/test_endpoints.py
+++ b/backend/ml/tests/test_endpoints.py
@@ -65,6 +65,43 @@ def test_predict_demand_valid():
     assert data["model_version"] == "1.0.0"
 
 
+def test_predict_price_valid():
+    payload = {
+        "distance_km": 500.0,
+        "cargo_weight_kg": 10000.0,
+        "truck_type": "heavy_truck",
+        "route_origin": "Mumbai",
+        "route_destination": "Delhi",
+    }
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "estimated_price" in data
+    assert isinstance(data["estimated_price"], float)
+    assert data["estimated_price"] > 0
+    assert data["currency"] == "INR"
+
+
+def test_predict_price_minimal():
+    payload = {
+        "distance_km": 100.0,
+        "cargo_weight_kg": 1000.0,
+    }
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["estimated_price"] > 0
+
+
+def test_predict_price_invalid_distance():
+    payload = {
+        "distance_km": 0,
+        "cargo_weight_kg": 1000.0,
+    }
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 422
+
+
 def test_predict_demand_invalid_fields():
     # hour out of bounds (0-23)
     payload = {

--- a/docs/migration_add_estimated_price.sql
+++ b/docs/migration_add_estimated_price.sql
@@ -1,0 +1,7 @@
+-- Migration: Add estimated_price column to orders table
+-- Stores the ML-predicted freight price for display as "AI Estimate"
+-- in the booking confirmation screen.
+-- Nullable — orders created when the ML service is unavailable will
+-- simply not have a prediction; the base pricing is always stored.
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS estimated_price INTEGER;


### PR DESCRIPTION
## Summary

Integrates the ML service price prediction endpoint into the order creation flow. When a customer creates an order, the backend calls the ML service to get an AI-predicted price, stores it alongside the order, and displays an 'AI Estimated Price' label in the booking confirmation screen.

## Changes

### ML Service (backend/ml/)
- **app/models/price_prediction.py** — New price prediction model using distance, cargo weight, and truck type to compute estimated freight price
- **app/main.py** — Added \POST /predict\ endpoint accepting \distance_km\, \cargo_weight_kg\, \	ruck_type\, \
oute_origin\, \
oute_destination\ and returning \estimated_price\
- **tests/test_endpoints.py** — Added tests for valid, minimal, and invalid price prediction requests

### Backend API (backend/api/)
- **src/services/ml.js** — Added \predictPrice()\ function that calls the ML service \/predict\ endpoint
- **src/routes/orderRoutes.js** — Integrated price prediction into \POST /api/orders\: calls ML service after pricing computation, stores \estimated_price\ on the order, gracefully falls back to base pricing if ML is unavailable
- **.env.example** — Added \ML_SERVICE_URL\ environment variable

### Database
- **docs/migration_add_estimated_price.sql** — Migration to add nullable \estimated_price\ column to orders table

### Flutter Customer App
- **apps/customer/lib/screens/booking_confirmation_screen.dart** — Added 'AI Estimated Price' label in the price breakdown section

## Testing

1. Start ML service: \cd backend/ml && uvicorn app.main:app --port 8001\
2. Start backend API: \cd backend/api && npm run dev\
3. Create an order via \POST /api/orders\ — the response will include \estimated_price\ when ML is reachable
4. Stop ML service and create another order — falls back to base pricing gracefully

Fixes #587



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered freight price estimation during order creation and search, using distance, cargo weight, and vehicle type.
  * Expanded pricing details returned to the app to include base freight, toll estimate, platform fee, and a computed total.
  * Booking confirmation now displays a fuller “Price breakdown” and shows an “AI Estimated Price” row when AI estimation is available.
* **Tests**
  * Added endpoint tests for valid, boundary, and invalid price prediction inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->