### PR TITLE
Fix #572: Add Wallet Address Management Flow

### DIFF
--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify/widgets/menu_card.dart';
 import 'package:truxify/widgets/menu_item.dart';
 
@@ -41,6 +45,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   int _totalOrders = 0;
   num _totalSaved = 0;
   num _co2ReducedKg = 0;
+  String _walletAddress = '';
 
   @override
   void initState() {
@@ -145,6 +150,160 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final minutes = DateTime.now().difference(lastUpdated).inMinutes;
     if (minutes < 1) return 'just now';
     return minutes == 1 ? '1 min ago' : '$minutes mins ago';
+  }
+
+  Future<void> _showWalletSheet(BuildContext context) async {
+    final walletController = TextEditingController(text: _walletAddress);
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+              20, 10, 20, MediaQuery.of(context).viewInsets.bottom + 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 16),
+                decoration: BoxDecoration(
+                  color: TruxifyColors.hintText,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Text(
+                'Polygon Wallet Address',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              if (_walletAddress.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: TruxifyColors.accentLight,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.check_circle_rounded,
+                            color: TruxifyColors.success, size: 16),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            _walletAddress,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontFamily: 'monospace',
+                              color: TruxifyColors.accentDark,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              TextField(
+                controller: walletController,
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontFamily: 'monospace',
+                ),
+                decoration: InputDecoration(
+                  labelText: '0x...',
+                  hintText: '0x1234567890abcdef1234567890abcdef12345678',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () async {
+                    final address = walletController.text.trim();
+                    if (address.isEmpty) return;
+                    try {
+                      final client = Supabase.instance.client;
+                      final token = client.auth.currentSession?.accessToken;
+                      final userId = client.auth.currentUser?.id ?? '';
+                      final response = await http.put(
+                        Uri.parse('http://localhost:5000/api/profile/wallet'),
+                        headers: <String, String>{
+                          'Content-Type': 'application/json',
+                          if (token != null) 'Authorization': 'Bearer $token',
+                          'x-user-id': userId,
+                          'x-user-role': 'customer',
+                        },
+                        body: jsonEncode(<String, String>{
+                          'wallet_address': address,
+                        }),
+                      );
+                      if (response.statusCode == 200) {
+                        setState(() {
+                          _walletAddress = address;
+                        });
+                        Navigator.of(context).pop();
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Wallet address updated'),
+                              backgroundColor: TruxifyColors.success,
+                            ),
+                          );
+                        }
+                      } else {
+                        final body = jsonDecode(response.body)
+                            as Map<String, dynamic>;
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(body['error']?.toString() ??
+                                  'Failed to update wallet'),
+                              backgroundColor: TruxifyColors.errorRed,
+                            ),
+                          );
+                        }
+                      }
+                    } catch (e) {
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text('Error: $e'),
+                            backgroundColor: TruxifyColors.errorRed,
+                          ),
+                        );
+                      }
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: TruxifyColors.accent,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text('Save Wallet Address'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   void _logout(BuildContext context) {
@@ -285,6 +444,15 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     showDivider: false,
                     onTap: () => Navigator.of(context).push(AppPageRoute(
                         builder: (_) => const SavedAddressesScreen())),
+                  ),
+                  MenuItem(
+                    icon: Icons.account_balance_wallet_rounded,
+                    label: 'Wallet Address',
+                    trailing: _walletAddress.isNotEmpty
+                        ? '${_walletAddress.substring(0, 6)}...${_walletAddress.substring(_walletAddress.length - 4)}'
+                        : 'Not set',
+                    showDivider: false,
+                    onTap: () => _showWalletSheet(context),
                   ),
                 ],
               ),

--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -73,6 +73,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             'totalOrders': extra?['totalOrders']?.toString() ?? '0',
             'totalSaved': extra?['totalSaved']?.toString() ?? '0',
             'co2ReducedKg': extra?['co2ReducedKg']?.toString() ?? '0',
+            'walletAddress': profile['walletAddress']?.toString() ?? '',
           });
         }
 
@@ -86,6 +87,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
           _displayName = profile?['fullName']?.toString() ?? '';
           _displayCompany = profile?['companyName']?.toString() ?? '';
           _displayPhone = profile?['phone']?.toString() ?? '';
+          _walletAddress = profile?['walletAddress']?.toString() ?? '';
 
           String? defaultPayment;
           for (final m in methods) {
@@ -139,6 +141,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       _totalOrders = int.tryParse(cachedProfile?['totalOrders']?.toString() ?? '0') ?? 0;
       _totalSaved = num.tryParse(cachedProfile?['totalSaved']?.toString() ?? '0') ?? 0;
       _co2ReducedKg = num.tryParse(cachedProfile?['co2ReducedKg']?.toString() ?? '0') ?? 0;
+      _walletAddress = cachedProfile?['walletAddress']?.toString() ?? '';
       _lastUpdatedLabel = cachedProfile?['_cached_at']?.toString();
     });
   }

--- a/apps/customer/lib/theme/app_theme.dart
+++ b/apps/customer/lib/theme/app_theme.dart
@@ -12,8 +12,11 @@ class TruxifyColors {
   static const accentDark = Color(0xFF00695C);
   static const accentLight = Color(0xFFE0F2F1);
   static const error = Color(0xFFE53935);
+  static const errorRed = Color(0xFFE53935);
+  static const success = Color(0xFF2E7D32);
   static const warning = Color(0xFFFF6B00);
   static const border = Color(0xFFE0E0E0);
+  static const hintText = Color(0xFF999999);
 
   // Dark mode — reworked for proper contrast
   // Scaffold: #0F0F0F  →  Card: #1C1C1E  →  Elevated card: #242426

--- a/apps/customer/test/theme_toggle_test.dart
+++ b/apps/customer/test/theme_toggle_test.dart
@@ -98,6 +98,8 @@ void main() {
       matching: find.text('Dark'),
     );
     expect(darkText, findsOneWidget);
+    await tester.ensureVisible(darkText);
+    await tester.pump();
     await tester.tap(darkText);
     await tester.pump();
     await tester.pump();

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -34,6 +34,33 @@ class _ProfileScreenState extends State<ProfileScreen> {
   String _currentLanguage = 'English';
   String _walletAddress = '';
 
+  @override
+  void initState() {
+    super.initState();
+    _loadWalletAddress();
+  }
+
+  Future<void> _loadWalletAddress() async {
+    try {
+      final client = Supabase.instance.client;
+      final userId = client.auth.currentUser?.id;
+      if (userId != null) {
+        final data = await client
+            .from('profiles')
+            .select('wallet_address')
+            .eq('id', userId)
+            .maybeSingle();
+        if (data != null && mounted) {
+          setState(() {
+            _walletAddress = data['wallet_address']?.toString() ?? '';
+          });
+        }
+      }
+    } catch (e) {
+      debugPrint('Failed to load wallet address: $e');
+    }
+  }
+
   Color _borderColor(BuildContext context) {
     return Theme.of(context).brightness == Brightness.dark
         ? TruxifyColors.darkBorder

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:http/http.dart' as http;
 import '../controllers/app_controller.dart';
 import '../core/app_routes.dart';
 import '../data/mock_data.dart';
@@ -29,6 +32,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   String _driverPhone = '+91 98765 43210';
   String _driverEmail = 'kanish.jeba@truxify.com';
   String _currentLanguage = 'English';
+  String _walletAddress = '';
 
   Color _borderColor(BuildContext context) {
     return Theme.of(context).brightness == Brightness.dark
@@ -251,6 +255,152 @@ class _ProfileScreenState extends State<ProfileScreen> {
               ),
             );
           },
+        );
+      },
+    );
+  }
+
+  Future<void> _showWalletSheet(BuildContext context) async {
+    final walletController = TextEditingController(text: _walletAddress);
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+              20, 10, 20, MediaQuery.of(context).viewInsets.bottom + 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const BottomSheetHandle(),
+              const SizedBox(height: 16),
+              Text(
+                'Polygon Wallet Address',
+                style: GoogleFonts.dmSans(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (_walletAddress.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: TruxifyColors.accentLight,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.check_circle_rounded,
+                            color: TruxifyColors.success, size: 16),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            _walletAddress,
+                            style: GoogleFonts.robotoMono(
+                              fontSize: 12,
+                              color: TruxifyColors.accentDark,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              TextField(
+                controller: walletController,
+                style: GoogleFonts.robotoMono(
+                    fontSize: 13,
+                    color: Theme.of(context).colorScheme.onSurface),
+                decoration: InputDecoration(
+                  labelText: '0x...',
+                  hintText: '0x1234567890abcdef1234567890abcdef12345678',
+                  labelStyle: GoogleFonts.robotoMono(
+                      color: TruxifyColors.adaptiveSecondaryText(context)),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: _borderColor(context),
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: TruxifyColors.accent),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              PrimaryButton(
+                label: 'Save Wallet Address',
+                onPressed: () async {
+                  final address = walletController.text.trim();
+                  if (address.isEmpty) return;
+                  try {
+                    final client = Supabase.instance.client;
+                    final token = client.auth.currentSession?.accessToken;
+                    final userId = client.auth.currentUser?.id ?? '';
+                    final response = await http.put(
+                      Uri.parse('http://localhost:5000/api/profile/wallet'),
+                      headers: <String, String>{
+                        'Content-Type': 'application/json',
+                        if (token != null) 'Authorization': 'Bearer $token',
+                        'x-user-id': userId,
+                        'x-user-role': 'driver',
+                      },
+                      body: jsonEncode(<String, String>{
+                        'wallet_address': address,
+                      }),
+                    );
+                    if (response.statusCode == 200) {
+                      setState(() {
+                        _walletAddress = address;
+                      });
+                      Navigator.of(context).pop();
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content:
+                                Text('Wallet address updated successfully'),
+                            backgroundColor: TruxifyColors.success,
+                          ),
+                        );
+                      }
+                    } else {
+                      final body = jsonDecode(response.body)
+                          as Map<String, dynamic>;
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(body['error']?.toString() ??
+                                'Failed to update wallet'),
+                            backgroundColor: TruxifyColors.errorRed,
+                          ),
+                        );
+                      }
+                    }
+                  } catch (e) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Error: $e'),
+                          backgroundColor: TruxifyColors.errorRed,
+                        ),
+                      );
+                    }
+                  }
+                },
+              ),
+            ],
+          ),
         );
       },
     );
@@ -638,6 +788,34 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       builder: (_) => const NotificationsScreen(),
                     ),
                   ),
+                ),
+                Divider(
+                  height: 1,
+                  color: _borderColor(context),
+                ),
+                ListTile(
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+                  title: Text(
+                    'Wallet Address',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  subtitle: Text(
+                    _walletAddress.isNotEmpty
+                        ? '${_walletAddress.substring(0, 10)}...${_walletAddress.substring(_walletAddress.length - 6)}'
+                        : 'Not set',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12,
+                      color: TruxifyColors.adaptiveSecondaryText(context),
+                    ),
+                  ),
+                  trailing: Icon(Icons.chevron_right_rounded,
+                      color: TruxifyColors.adaptiveSecondaryText(context)),
+                  onTap: () => _showWalletSheet(context),
                 ),
                 Divider(
                   height: 1,

--- a/backend/api/src/models/ProfileModel.js
+++ b/backend/api/src/models/ProfileModel.js
@@ -11,7 +11,9 @@ export class ProfileModel {
       avatarUrl: profile.avatar_url,
       language: profile.language,
       darkMode: profile.dark_mode,
-      isActive: profile.is_active
+      isActive: profile.is_active,
+      walletAddress: profile.wallet_address,
+      polygonWalletAddress: profile.polygon_wallet_address
     };
   }
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -621,6 +621,26 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
     if (!loadOffer) return res.status(404).json({ error: 'Load offer for this order was not found.' });
     if (bid.load_id !== loadOffer.id) return res.status(403).json({ error: 'Access Denied: Bid does not belong to this order.' });
 
+    // Fetch wallet addresses BEFORE any state change to validate escrow readiness
+    const [driverDetailsResult, customerProfileResult] = await Promise.all([
+      supabase.from('driver_details').select('polygon_wallet_address').eq('user_id', bid.driver_id).maybeSingle(),
+      supabase.from('profiles').select('polygon_wallet_address').eq('id', req.user.id).maybeSingle(),
+    ]);
+
+    const driverWallet = driverDetailsResult.data?.polygon_wallet_address ?? null;
+    const customerWallet = customerProfileResult.data?.polygon_wallet_address ?? null;
+
+    if (!driverWallet || !customerWallet) {
+      return res.status(400).json({
+        error: 'Escrow deposit prerequisites not met.',
+        details: {
+          driver_wallet_set: !!driverWallet,
+          customer_wallet_set: !!customerWallet,
+        },
+        recovery: 'Please ensure both you and the driver have valid Polygon wallet addresses configured in your profiles, then try again.'
+      });
+    }
+
     const { data: profile } = await supabase.from('profiles').select('full_name').eq('id', bid.driver_id).maybeSingle();
     const { data: details } = await supabase.from('driver_details').select('rating, truck_id').eq('user_id', bid.driver_id).maybeSingle();
 
@@ -631,6 +651,28 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
       truckInfo = data;
     }
 
+    // Phase 1: Escrow deposit BEFORE accepting the bid
+    const amountWei = ethers.parseEther((bid.bid_amount / 100).toFixed(2).toString());
+    let escrowTxHash = null;
+    try {
+      const { txHash } = await escrowDeposit(order.order_display_id, customerWallet, driverWallet, amountWei);
+      if (txHash) {
+        escrowTxHash = txHash;
+      } else {
+        return res.status(500).json({
+          error: 'Escrow deposit failed. Bid was not accepted.',
+          recovery: 'Please try again or contact support if the issue persists.'
+        });
+      }
+    } catch (depositErr) {
+      return res.status(500).json({
+        error: 'Escrow deposit failed. Bid was not accepted.',
+        details: depositErr.message,
+        recovery: 'Check that the customer wallet has sufficient MATIC balance for the deposit and that the Polygon RPC endpoint is reachable.'
+      });
+    }
+
+    // Phase 2: Atomically accept the bid
     const { error: rpcErr } = await supabase.rpc('accept_bid_tx', {
       p_bid_id: bidId, p_order_id: orderId, p_load_id: bid.load_id, p_driver_id: bid.driver_id,
       p_truck_id: truckInfo?.id || null, p_driver_name: profile?.full_name || 'Assigned Driver',
@@ -638,49 +680,40 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
       p_bid_amount: bid.bid_amount, p_order_display_id: order.order_display_id
     });
 
-    if (rpcErr) return res.status(500).json({ error: 'Failed to accept bid atomically.', details: rpcErr.message });
-
-    // Record escrow booking reference immediately
-    const { error: escrowBookingErr } = await supabase
-      .from('orders')
-      .update({
-        escrow_booking_id: `escrow:${order.order_display_id}`,
-        escrow_status: 'funding',
-      })
-      .eq('id', orderId);
-
-    if (escrowBookingErr) {
-      console.warn('[escrow] Failed to update escrow_booking_id:', escrowBookingErr.message);
+    if (rpcErr) {
+      // Compensating transaction: escrow deposit succeeded but DB update failed
+      if (escrowTxHash) {
+        try {
+          await escrowRefund(order.order_display_id);
+          console.warn(`[escrow] Compensating refund issued for order ${order.order_display_id} after RPC failure.`);
+        } catch (refundErr) {
+          console.error(`[escrow] CRITICAL: Escrow refund also failed for order ${order.order_display_id}:`, refundErr.message);
+        }
+      }
+      return res.status(500).json({
+        error: 'Failed to accept bid atomically.',
+        details: rpcErr.message,
+        recovery: 'The escrow deposit has been refunded. Please try again.'
+      });
     }
 
-    // Fetch driver's and customer's Polygon wallet addresses for escrow deposit
-    const [driverDetailsResult, customerProfileResult] = await Promise.all([
-      supabase.from('driver_details').select('polygon_wallet_address').eq('user_id', bid.driver_id).maybeSingle(),
-      supabase.from('profiles').select('polygon_wallet_address').eq('id', req.user.id).maybeSingle(),
-    ]);
+    // Record escrow booking reference and deposit info
+    const escrowUpdate = {
+      escrow_booking_id: `escrow:${order.order_display_id}`,
+      escrow_status: escrowTxHash ? 'funded' : 'pending',
+    };
+    if (escrowTxHash) {
+      escrowUpdate.deposit_tx_hash = escrowTxHash;
+      escrowUpdate.escrow_deposited_at = new Date().toISOString();
+    }
 
-    const driverWallet = driverDetailsResult.data?.polygon_wallet_address ?? null;
-    const customerWallet = customerProfileResult.data?.polygon_wallet_address ?? null;
+    const { error: escrowUpdateErr } = await supabase
+      .from('orders')
+      .update(escrowUpdate)
+      .eq('id', orderId);
 
-    if (driverWallet && customerWallet) {
-      const amountWei = ethers.parseEther((bid.bid_amount / 100).toFixed(2).toString());
-      try {
-        const { txHash } = await escrowDeposit(order.order_display_id, customerWallet, driverWallet, amountWei);
-        if (txHash) {
-          await supabase.from('orders').update({
-            escrow_status: 'funded',
-            deposit_tx_hash: txHash,
-            escrow_deposited_at: new Date().toISOString(),
-          }).eq('id', orderId);
-        }
-      } catch (depositErr) {
-        console.error('[escrow] Deposit failed for order', orderId, ':', depositErr.message);
-        await supabase.from('orders').update({
-          escrow_status: 'fund_failed',
-        }).eq('id', orderId);
-      }
-    } else {
-      console.warn(`[escrow] Missing wallet address: driver=${!!driverWallet}, customer=${!!customerWallet} — skipping escrow deposit.`);
+    if (escrowUpdateErr) {
+      console.warn('[escrow] Failed to update escrow booking reference:', escrowUpdateErr.message);
     }
 
     res.json({ message: 'Bid accepted. Driver and truck assigned.' });

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -631,7 +631,10 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
     const customerWallet = customerProfileResult.data?.polygon_wallet_address ?? null;
 
     if (!driverWallet || !customerWallet) {
-      console.warn(`[escrow] Missing wallet address: driver=${!!driverWallet}, customer=${!!customerWallet} — skipping escrow deposit.`);
+      console.warn(`[escrow] Missing wallet address: driver=${!!driverWallet}, customer=${!!customerWallet} — rejecting bid acceptance.`);
+      return res.status(422).json({
+        error: 'Both customer and driver must connect a wallet before escrow can be initiated.'
+      });
     }
 
     const { data: profile } = await supabase.from('profiles').select('full_name').eq('id', bid.driver_id).maybeSingle();

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -72,12 +72,12 @@ router.put('/wallet', authenticate, async (req, res) => {
   const { wallet_address } = req.body;
 
   if (!wallet_address || typeof wallet_address !== 'string') {
-    return res.status(400).json({ error: 'wallet_address is required and must be a string.' });
+    return res.status(400).json({ error: 'Invalid wallet address' });
   }
 
   const normalized = wallet_address.trim();
   if (!/^0x[a-fA-F0-9]{40}$/.test(normalized)) {
-    return res.status(400).json({ error: 'Invalid wallet address format. Must be a 0x-prefixed 42-character address.' });
+    return res.status(400).json({ error: 'Invalid wallet address' });
   }
 
   try {
@@ -105,7 +105,11 @@ router.put('/wallet', authenticate, async (req, res) => {
       return res.status(500).json({ error: 'Failed to update wallet address.', details: updateErr.message });
     }
 
-    res.json({ message: 'Wallet address updated successfully.', wallet_address: normalized });
+    if (req.user && req.user.uid) {
+      void invalidateCachedProfile(req.user.uid);
+    }
+
+    res.json({ success: true, walletAddress: normalized });
   } catch (err) {
     res.status(500).json({ error: 'Internal Server Error.' });
   }

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -66,6 +66,51 @@ router.get('/:id/name', authenticate, async (req, res) => {
   }
 });
 
+// UPDATE WALLET ADDRESS
+router.put('/wallet', authenticate, async (req, res) => {
+  const userId = req.user.id;
+  const { wallet_address } = req.body;
+
+  if (!wallet_address || typeof wallet_address !== 'string') {
+    return res.status(400).json({ error: 'wallet_address is required and must be a string.' });
+  }
+
+  const normalized = wallet_address.trim();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(normalized)) {
+    return res.status(400).json({ error: 'Invalid wallet address format. Must be a 0x-prefixed 42-character address.' });
+  }
+
+  try {
+    const { data: existing, error: checkErr } = await supabase
+      .from('profiles')
+      .select('wallet_address, polygon_wallet_address')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (checkErr) return res.status(500).json({ error: 'Failed to fetch profile.', details: checkErr.message });
+    if (!existing) return res.status(404).json({ error: 'Profile not found.' });
+
+    const { error: updateErr } = await supabase
+      .from('profiles')
+      .update({
+        wallet_address: normalized,
+        polygon_wallet_address: normalized,
+      })
+      .eq('id', userId);
+
+    if (updateErr) {
+      if (updateErr.code === '23505') {
+        return res.status(409).json({ error: 'This wallet address is already registered to another account.' });
+      }
+      return res.status(500).json({ error: 'Failed to update wallet address.', details: updateErr.message });
+    }
+
+    res.json({ message: 'Wallet address updated successfully.', wallet_address: normalized });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error.' });
+  }
+});
+
 // UPDATE PROFILE (basic version)
 router.put('/', authenticate, async (req, res) => {
   try {

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -129,3 +129,7 @@ export const changeDropSchema = z.object({
 export const cancelOrderSchema = z.object({
   reason: z.string().max(500).optional().nullable(),
 }).passthrough();
+
+export const updateWalletSchema = z.object({
+  wallet_address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x-prefixed 42-character wallet address'),
+}).passthrough();

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -268,6 +268,8 @@ describe('Bid Routes', () => {
   });
 
   it('POST /:id/bids/:bidId/accept executes RPC', async () => {
+    mockEscrowDeposit.mockResolvedValue({ txHash: '0xescrowtest123' });
+
     m.store.orders.push({
       id: 'order-1',
       customer_id: 'customer-1',
@@ -288,15 +290,16 @@ describe('Bid Routes', () => {
       status: 'pending',
     });
 
-    m.store.profiles.push({
-      id: 'driver-1',
-      full_name: 'Driver One',
-    });
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One', polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' },
+      { id: 'driver-1', full_name: 'Driver One' },
+    );
 
     m.store.driver_details.push({
       user_id: 'driver-1',
       rating: 4.9,
       truck_id: null,
+      polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
     });
 
     const app = buildApp();
@@ -490,7 +493,7 @@ describe('Bid Routes', () => {
     m.supabase.rpc = originalRpc;
   });
 
-  it('POST /:id/bids/:bidId/accept skips escrow when customer wallet missing', async () => {
+  it('POST /:id/bids/:bidId/accept rejects with 422 when customer wallet missing', async () => {
     m.store.orders.push({
       id: 'order-no-cust-wallet',
       customer_id: 'customer-1',
@@ -531,7 +534,54 @@ describe('Bid Routes', () => {
       .post('/api/orders/order-no-cust-wallet/bids/bid-no-cust/accept')
       .set(CUSTOMER);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Both customer and driver must connect a wallet before escrow can be initiated.');
+    expect(mockEscrowDeposit).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/bids/:bidId/accept rejects with 422 when driver wallet missing', async () => {
+    m.store.orders.push({
+      id: 'order-no-driver-wallet',
+      customer_id: 'customer-1',
+      order_display_id: 'OD-NO-DRIV',
+    });
+
+    m.store.load_offers.push({
+      id: 'load-no-driv',
+      order_display_id: 'OD-NO-DRIV',
+      status: 'available',
+    });
+
+    m.store.load_bids.push({
+      id: 'bid-no-driv',
+      load_id: 'load-no-driv',
+      driver_id: 'driver-2',
+      bid_amount: 50000,
+      status: 'pending',
+    });
+
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One', polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' },
+      { id: 'driver-2', full_name: 'Driver Two' },
+    );
+
+    m.store.driver_details.push({
+      user_id: 'driver-2',
+      rating: 4.9,
+      total_trips: 100,
+      completion_rate: 98,
+      truck_id: null,
+      polygon_wallet_address: null,
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/orders/order-no-driver-wallet/bids/bid-no-driv/accept')
+      .set(CUSTOMER);
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Both customer and driver must connect a wallet before escrow can be initiated.');
     expect(mockEscrowDeposit).not.toHaveBeenCalled();
   });
 

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -287,4 +287,90 @@ describe('Profile Routes', () => {
       expect(driverUpdateCall.filters).toContainEqual({ col: 'user_id', op: 'eq', val: 'driver-uuid-456' });
     });
   });
+
+  describe('PUT /api/profile/wallet', () => {
+    it('successfully updates user wallet addresses and invalidates cache', async () => {
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+      });
+
+      const res = await request(buildApp())
+        .put('/api/profile/wallet')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      });
+      expect(invalidateCachedProfile).toHaveBeenCalledWith('test_firebase_uid_123');
+
+      const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
+      expect(profileUpdateCall.payload).toEqual({
+        wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+        polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+      });
+    });
+
+    it('rejects invalid wallet addresses with 400', async () => {
+      const res = await request(buildApp())
+        .put('/api/profile/wallet')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          wallet_address: 'invalid-address',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({
+        error: 'Invalid wallet address',
+      });
+    });
+
+    it('returns 409 conflict when wallet address is already taken', async () => {
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+      });
+
+      const originalFrom = m.supabase.from;
+      m.supabase.from = (table) => {
+        if (table === 'profiles') {
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: () => Promise.resolve({
+                  data: { id: 'customer-uuid-123', wallet_address: null, polygon_wallet_address: null },
+                  error: null
+                })
+              })
+            }),
+            update: () => ({
+              eq: () => Promise.resolve({
+                error: { code: '23505', message: 'duplicate key value violates unique constraint' }
+              })
+            })
+          };
+        }
+        return originalFrom(table);
+      };
+
+      const res = await request(buildApp())
+        .put('/api/profile/wallet')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+        });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('This wallet address is already registered to another account.');
+
+      m.supabase.from = originalFrom;
+    });
+  });
 });

--- a/docs/migration_add_wallet_address.sql
+++ b/docs/migration_add_wallet_address.sql
@@ -1,0 +1,12 @@
+-- Migration: Add wallet_address to profiles table
+-- Stores the user's Polygon (EVM) wallet address for escrow deposits and
+-- on-chain reputation updates.
+-- Add unique constraint to prevent duplicate wallet registration.
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS wallet_address TEXT;
+
+ALTER TABLE profiles
+  DROP CONSTRAINT IF EXISTS profiles_wallet_address_key;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_wallet_address_key UNIQUE (wallet_address);


### PR DESCRIPTION
## Summary

Implements a complete wallet address management flow: migration, API endpoint, escrow enforcement, and Flutter UI for both apps.

## Changes

### Database
- **docs/migration_add_wallet_address.sql** — Adds \wallet_address\ column to profiles table with unique constraint

### Backend API
- **src/routes/profileRoutes.js** — Added \PUT /api/profile/wallet\ endpoint that:
  - Validates Ethereum/Polygon address format (0x-prefixed 42 chars)
  - Writes to both \wallet_address\ and \polygon_wallet_address\ columns for backward compat
  - Returns 409 on duplicate wallet address
- **src/routes/orderRoutes.js** — Refactored bid acceptance flow:
  - Wallet addresses are now fetched **before** any state changes
  - Returns 400 with clear error if either party lacks a wallet
  - Escrow deposit happens before bid acceptance (compensating refund on failure)
- **src/validation/requestSchemas.js** — Added \updateWalletSchema\

### Flutter Apps
- **apps/driver/lib/screens/profile_screen.dart** — Added Wallet Address tile in Settings with edit bottom sheet
- **apps/customer/lib/screens/profile_screen.dart** — Added Wallet Address tile in Account section with edit bottom sheet

Fixes #572



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customers and drivers can view, add, and edit Polygon wallet addresses in profile settings (including offline restoration) via a wallet prompt/sheet.
  * Added an authenticated wallet update API to save wallet addresses with normalized formatting.
* **Bug Fixes**
  * Improved bid acceptance escrow flow: both parties’ wallet connections are required up front; missing wallets now return HTTP 422.
  * More reliable deposit failure/refund messaging and clearer recovery text.
* **UI/Styles**
  * Added success/error and hint text color tokens for improved feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->