### PR TITLE
Fix #573: Add Realtime Load Board Notifications

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -14,6 +14,7 @@ import 'package:truxify_driver/widgets/slide_to_confirm_button.dart';
 
 import '../core/app_routes.dart';
 import '../data/mock_data.dart';
+import '../models/app_models.dart';
 import '../services/geocode_service.dart';
 import '../services/marketplace_repository.dart';
 import '../services/route_service.dart';

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -77,13 +77,17 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _subscribeToNewLoads() {
-    _loadSubscription = _marketplaceRepo.subscribeToNewLoads().listen((load) {
-      if (!mounted) return;
-      setState(() {
-        _latestNewLoad = load;
-        _dismissedNewLoad = false;
+    try {
+      _loadSubscription = _marketplaceRepo.subscribeToNewLoads().listen((load) {
+        if (!mounted) return;
+        setState(() {
+          _latestNewLoad = load;
+          _dismissedNewLoad = false;
+        });
       });
-    });
+    } catch (_) {
+      // Supabase not available (e.g. in tests)
+    }
   }
 
   /// Called once on startup — fetches GPS and resolves address.

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element, unused_field
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 import 'package:geolocator/geolocator.dart';
@@ -14,6 +15,7 @@ import 'package:truxify_driver/widgets/slide_to_confirm_button.dart';
 import '../core/app_routes.dart';
 import '../data/mock_data.dart';
 import '../services/geocode_service.dart';
+import '../services/marketplace_repository.dart';
 import '../services/route_service.dart';
 import '../services/trip_service.dart';
 import '../theme/app_theme.dart';
@@ -52,18 +54,35 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isLoadingLocation = true;
   String? _locationError;
 
+  final MarketplaceRepository _marketplaceRepo = MarketplaceRepository();
+  StreamSubscription<LoadOffer>? _loadSubscription;
+  LoadOffer? _latestNewLoad;
+  bool _dismissedNewLoad = false;
+
   @override
   void initState() {
     super.initState();
     _initLocation();
+    _subscribeToNewLoads();
   }
 
   @override
   void dispose() {
+    _loadSubscription?.cancel();
     _mapController.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
+  }
+
+  void _subscribeToNewLoads() {
+    _loadSubscription = _marketplaceRepo.subscribeToNewLoads().listen((load) {
+      if (!mounted) return;
+      setState(() {
+        _latestNewLoad = load;
+        _dismissedNewLoad = false;
+      });
+    });
   }
 
   /// Called once on startup — fetches GPS and resolves address.
@@ -471,6 +490,78 @@ class _HomeScreenState extends State<HomeScreen> {
                     : _buildSearchCard(context),
               ),
             ),
+
+            // New Load Notification Banner
+            if (_latestNewLoad != null && !_dismissedNewLoad)
+              Positioned(
+                left: 12,
+                right: 12,
+                top: 96,
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() => _dismissedNewLoad = true);
+                    Navigator.of(context).pushNamed(
+                      AppRoutes.loadDetail,
+                      arguments: _latestNewLoad,
+                    );
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: TruxifyColors.accent,
+                      borderRadius: BorderRadius.circular(14),
+                      boxShadow: [
+                        BoxShadow(
+                          color: TruxifyColors.accent.withOpacity(0.25),
+                          blurRadius: 12,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.local_shipping_rounded,
+                            color: Colors.white, size: 18),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                'New Load Available!',
+                                style: GoogleFonts.dmSans(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                _latestNewLoad!.route,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: GoogleFonts.dmSans(
+                                  fontSize: 11,
+                                  color: Colors.white.withOpacity(0.85),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        GestureDetector(
+                          onTap: () {
+                            setState(() => _dismissedNewLoad = true);
+                          },
+                          child: Icon(Icons.close_rounded,
+                              color: Colors.white.withOpacity(0.7), size: 20),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
 
             // Recenter FAB — hidden until GPS is ready
             if (_currentLocation != null)

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -26,7 +26,14 @@ import 'destination_picker_screen.dart';
 import '../widgets/pulsing_location_dot.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  HomeScreen({
+    super.key,
+    MarketplaceRepository? marketplaceRepo,
+    this.mockLocationText,
+  }) : marketplaceRepo = marketplaceRepo ?? MarketplaceRepository();
+
+  final MarketplaceRepository marketplaceRepo;
+  final String? mockLocationText;
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -55,34 +62,82 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isLoadingLocation = true;
   String? _locationError;
 
-  final MarketplaceRepository _marketplaceRepo = MarketplaceRepository();
+  late final MarketplaceRepository _marketplaceRepo;
   StreamSubscription<LoadOffer>? _loadSubscription;
+  Timer? _autoHideTimer;
   LoadOffer? _latestNewLoad;
   bool _dismissedNewLoad = false;
 
   @override
   void initState() {
     super.initState();
+    _marketplaceRepo = widget.marketplaceRepo;
+    if (widget.mockLocationText != null) {
+      _currentLocationText = widget.mockLocationText;
+    }
     _initLocation();
     _subscribeToNewLoads();
   }
 
   @override
+  void didUpdateWidget(HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mockLocationText != oldWidget.mockLocationText) {
+      setState(() {
+        _currentLocationText = widget.mockLocationText;
+      });
+    }
+  }
+
+  @override
   void dispose() {
     _loadSubscription?.cancel();
+    _autoHideTimer?.cancel();
     _mapController.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
   }
 
+  bool _isLoadMatching(LoadOffer load) {
+    if (_currentLocationText != null && _currentLocationText!.isNotEmpty) {
+      final locationLower = _currentLocationText!.toLowerCase();
+      final routeLower = load.route.toLowerCase();
+      final pickupLower = load.pickup.toLowerCase();
+
+      final parts = locationLower
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.length >= 3);
+
+      for (final part in parts) {
+        if (routeLower.contains(part) || pickupLower.contains(part)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
   void _subscribeToNewLoads() {
     try {
       _loadSubscription = _marketplaceRepo.subscribeToNewLoads().listen((load) {
         if (!mounted) return;
+        if (!_isLoadMatching(load)) return;
+
+        _autoHideTimer?.cancel();
         setState(() {
           _latestNewLoad = load;
           _dismissedNewLoad = false;
+        });
+
+        _autoHideTimer = Timer(const Duration(seconds: 6), () {
+          if (mounted) {
+            setState(() {
+              _dismissedNewLoad = true;
+            });
+          }
         });
       });
     } catch (_) {
@@ -92,6 +147,14 @@ class _HomeScreenState extends State<HomeScreen> {
 
   /// Called once on startup — fetches GPS and resolves address.
   Future<void> _initLocation() async {
+    if (widget.mockLocationText != null) {
+      setState(() {
+        _currentLocationText = widget.mockLocationText;
+        _isLoadingLocation = false;
+      });
+      return;
+    }
+
     setState(() {
       _isLoadingLocation = true;
       _locationError = null;
@@ -549,18 +612,61 @@ class _HomeScreenState extends State<HomeScreen> {
                                 overflow: TextOverflow.ellipsis,
                                 style: GoogleFonts.dmSans(
                                   fontSize: 11,
+                                  fontWeight: FontWeight.w500,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(height: 1),
+                              Text(
+                                '${_latestNewLoad!.weight != '—' ? '${_latestNewLoad!.weight} ' : ''}${_latestNewLoad!.goods} • ${_latestNewLoad!.estimatedProfit}',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: GoogleFonts.dmSans(
+                                  fontSize: 10,
                                   color: Colors.white.withOpacity(0.85),
                                 ),
                               ),
                             ],
                           ),
                         ),
+                        const SizedBox(width: 10),
                         GestureDetector(
+                          key: const Key('realtime_notification_view_button'),
+                          onTap: () {
+                            setState(() => _dismissedNewLoad = true);
+                            Navigator.of(context).pushNamed(
+                              AppRoutes.loadDetail,
+                              arguments: _latestNewLoad,
+                            );
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Text(
+                              'View',
+                              style: GoogleFonts.dmSans(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: TruxifyColors.accent,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        GestureDetector(
+                          key: const Key('realtime_notification_close_button'),
                           onTap: () {
                             setState(() => _dismissedNewLoad = true);
                           },
-                          child: Icon(Icons.close_rounded,
-                              color: Colors.white.withOpacity(0.7), size: 20),
+                          child: Icon(
+                            Icons.close_rounded,
+                            color: Colors.white.withOpacity(0.7),
+                            size: 20,
+                          ),
                         ),
                       ],
                     ),

--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -14,8 +14,17 @@ import 'trip_detail_screen.dart';
 import 'trips_screen.dart';
 import 'my_truck_screen.dart';
 
+import '../services/marketplace_repository.dart';
+
 class ShellScreen extends StatefulWidget {
-  const ShellScreen({super.key});
+  const ShellScreen({
+    super.key,
+    this.marketplaceRepo,
+    this.mockLocationText,
+  });
+
+  final MarketplaceRepository? marketplaceRepo;
+  final String? mockLocationText;
 
   @override
   State<ShellScreen> createState() => _ShellScreenState();
@@ -37,7 +46,13 @@ class _ShellScreenState extends State<ShellScreen> {
   void initState() {
     super.initState();
     _tabs = [
-      _buildTabNavigator(_homeNavigatorKey, const HomeScreen()),
+      _buildTabNavigator(
+        _homeNavigatorKey,
+        HomeScreen(
+          marketplaceRepo: widget.marketplaceRepo,
+          mockLocationText: widget.mockLocationText,
+        ),
+      ),
       _buildTabNavigator(_tripsNavigatorKey, const TripsScreen()),
       _buildTabNavigator(_earningsNavigatorKey, const EarningsScreen()),
       _buildTabNavigator(

--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -160,6 +161,21 @@ class MarketplaceRepository {
       spaceAvailable: s('space_available', '—'),
       updatedTotalEarnings: s('updated_total_earnings', '—'),
     );
+  }
+
+  /// Subscribes to new available load offers via Supabase Realtime.
+  /// Returns a stream of [LoadOffer] objects as they are inserted.
+  /// Callers should cancel the [StreamSubscription] when done.
+  Stream<LoadOffer> subscribeToNewLoads() {
+    return _client
+        .from('load_offers')
+        .stream(primaryKey: ['id'])
+        .eq('status', 'available')
+        .map((rows) => rows
+            .cast<Map<String, dynamic>>()
+            .map(_mapLoadOffer)
+            .toList())
+        .expand((offers) => offers);
   }
 
   String _formatCurrency(num value) {

--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -163,19 +163,51 @@ class MarketplaceRepository {
     );
   }
 
-  /// Subscribes to new available load offers via Supabase Realtime.
+  /// Subscribes to new available load offers via Supabase Realtime postgres_changes.
   /// Returns a stream of [LoadOffer] objects as they are inserted.
   /// Callers should cancel the [StreamSubscription] when done.
   Stream<LoadOffer> subscribeToNewLoads() {
-    return _client
-        .from('load_offers')
-        .stream(primaryKey: ['id'])
-        .eq('status', 'available')
-        .map((rows) => rows
-            .cast<Map<String, dynamic>>()
-            .map(_mapLoadOffer)
-            .toList())
-        .expand((offers) => offers);
+    final controller = StreamController<LoadOffer>.broadcast();
+    RealtimeChannel? channel;
+
+    try {
+      final client = _client;
+      channel = client.channel('new_load_offers');
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'load_offers',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.eq,
+          column: 'status',
+          value: 'available',
+        ),
+        callback: (payload) {
+          try {
+            final newRecord = payload.newRecord;
+            if (newRecord != null && newRecord.isNotEmpty) {
+              final offer = _mapLoadOffer(newRecord);
+              controller.add(offer);
+            }
+          } catch (_) {
+            // Error mapping load offer
+          }
+        },
+      ).subscribe();
+    } catch (_) {
+      // Supabase/Realtime not available
+    }
+
+    controller.onCancel = () {
+      if (channel != null) {
+        try {
+          _client.removeChannel(channel);
+        } catch (_) {}
+      }
+      controller.close();
+    };
+
+    return controller.stream;
   }
 
   String _formatCurrency(num value) {

--- a/apps/driver/test/home_screen_test.dart
+++ b/apps/driver/test/home_screen_test.dart
@@ -1,19 +1,45 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truxify_driver/controllers/app_controller.dart';
 import 'package:truxify_driver/core/app_routes.dart';
+import 'package:truxify_driver/models/app_models.dart';
 import 'package:truxify_driver/screens/destination_picker_screen.dart';
 import 'package:truxify_driver/screens/shell_screen.dart';
+import 'package:truxify_driver/services/marketplace_repository.dart';
 import 'package:truxify_driver/theme/app_theme.dart';
 
-Widget _buildTestApp() {
+class FakeMarketplaceRepository extends MarketplaceRepository {
+  final _controller = StreamController<LoadOffer>.broadcast();
+
+  @override
+  Stream<LoadOffer> subscribeToNewLoads() {
+    return _controller.stream;
+  }
+
+  void emitLoad(LoadOffer load) {
+    _controller.add(load);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+Widget _buildTestApp({
+  MarketplaceRepository? marketplaceRepo,
+  String? mockLocationText,
+}) {
   final controller = TruxifyController();
 
   return TruxifyScope(
     controller: controller,
     child: MaterialApp(
       theme: TruxifyTheme.light(),
-      home: const ShellScreen(),
+      home: ShellScreen(
+        marketplaceRepo: marketplaceRepo,
+        mockLocationText: mockLocationText,
+      ),
       onGenerateRoute: (settings) {
         if (settings.name == AppRoutes.destinationPicker) {
           final args = settings.arguments as DestinationPickerArgs?;
@@ -73,5 +99,270 @@ void main() {
 
     expect(find.text('Search area, landmark, or city'), findsOneWidget);
     expect(find.text('Confirm Destination'), findsOneWidget);
+  });
+
+  testWidgets('realtime load offers inserts show notification banner and support navigate & close', (
+    WidgetTester tester,
+  ) async {
+    final fakeRepo = FakeMarketplaceRepository();
+    await tester.pumpWidget(_buildTestApp(marketplaceRepo: fakeRepo));
+    await _pumpTransition(tester);
+
+    expect(find.text('New Load Available!'), findsNothing);
+
+    const mockLoad = LoadOffer(
+      id: 'load-123',
+      route: 'Chennai → Coimbatore',
+      customer: 'Customer A',
+      company: 'Company A',
+      goods: 'Steel',
+      pickup: 'Chennai Port',
+      distanceFromDriver: '5 km',
+      estimatedProfit: '₹18,500',
+      fuelCost: '₹4,000',
+      tollCost: '₹1,500',
+      capacityUsed: 0.8,
+      truckFillLabel: 'Capacity',
+      sharingTruckWith: '—',
+      badgeLabel: 'Available',
+      badgeEmoji: '📦',
+      routeDistance: '500 km',
+      routeDuration: '9 hours',
+      weight: '12 Tons',
+      dimensions: '—',
+      stackable: '—',
+      fragile: '—',
+      specialHandling: '',
+      freightValue: '₹24,000',
+      netProfit: '₹18,500',
+      routeNote: '',
+      extraDistance: 0,
+      extraEarnings: '₹0',
+      spaceAvailable: '—',
+      updatedTotalEarnings: '—',
+    );
+
+    fakeRepo.emitLoad(mockLoad);
+    await tester.pump();
+
+    expect(find.text('New Load Available!'), findsOneWidget);
+    expect(find.text('Chennai → Coimbatore'), findsOneWidget);
+    expect(find.text('12 Tons Steel • ₹18,500'), findsOneWidget);
+
+    final viewButton = find.byKey(const Key('realtime_notification_view_button'));
+    expect(viewButton, findsOneWidget);
+    await tester.tap(viewButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('New Load Available!'), findsNothing);
+    fakeRepo.dispose();
+  });
+
+  testWidgets('notification banner dismisses when tapping close button', (
+    WidgetTester tester,
+  ) async {
+    final fakeRepo = FakeMarketplaceRepository();
+    await tester.pumpWidget(_buildTestApp(marketplaceRepo: fakeRepo));
+    await _pumpTransition(tester);
+
+    const mockLoad = LoadOffer(
+      id: 'load-123',
+      route: 'Chennai → Coimbatore',
+      customer: 'Customer A',
+      company: 'Company A',
+      goods: 'Steel',
+      pickup: 'Chennai Port',
+      distanceFromDriver: '5 km',
+      estimatedProfit: '₹18,500',
+      fuelCost: '₹4,000',
+      tollCost: '₹1,500',
+      capacityUsed: 0.8,
+      truckFillLabel: 'Capacity',
+      sharingTruckWith: '—',
+      badgeLabel: 'Available',
+      badgeEmoji: '📦',
+      routeDistance: '500 km',
+      routeDuration: '9 hours',
+      weight: '—',
+      dimensions: '—',
+      stackable: '—',
+      fragile: '—',
+      specialHandling: '',
+      freightValue: '₹24,000',
+      netProfit: '₹18,500',
+      routeNote: '',
+      extraDistance: 0,
+      extraEarnings: '₹0',
+      spaceAvailable: '—',
+      updatedTotalEarnings: '—',
+    );
+
+    fakeRepo.emitLoad(mockLoad);
+    await tester.pump();
+
+    expect(find.text('New Load Available!'), findsOneWidget);
+    expect(find.text('Steel • ₹18,500'), findsOneWidget);
+
+    final closeButton = find.byKey(const Key('realtime_notification_close_button'));
+    expect(closeButton, findsOneWidget);
+    await tester.tap(closeButton);
+    await tester.pump();
+
+    expect(find.text('New Load Available!'), findsNothing);
+    fakeRepo.dispose();
+  });
+
+  testWidgets('notification banner auto-dismisses after 6 seconds', (
+    WidgetTester tester,
+  ) async {
+    final fakeRepo = FakeMarketplaceRepository();
+    await tester.pumpWidget(_buildTestApp(marketplaceRepo: fakeRepo));
+    await _pumpTransition(tester);
+
+    const mockLoad = LoadOffer(
+      id: 'load-123',
+      route: 'Chennai → Coimbatore',
+      customer: 'Customer A',
+      company: 'Company A',
+      goods: 'Steel',
+      pickup: 'Chennai Port',
+      distanceFromDriver: '5 km',
+      estimatedProfit: '₹18,500',
+      fuelCost: '₹4,000',
+      tollCost: '₹1,500',
+      capacityUsed: 0.8,
+      truckFillLabel: 'Capacity',
+      sharingTruckWith: '—',
+      badgeLabel: 'Available',
+      badgeEmoji: '📦',
+      routeDistance: '500 km',
+      routeDuration: '9 hours',
+      weight: '—',
+      dimensions: '—',
+      stackable: '—',
+      fragile: '—',
+      specialHandling: '',
+      freightValue: '₹24,000',
+      netProfit: '₹18,500',
+      routeNote: '',
+      extraDistance: 0,
+      extraEarnings: '₹0',
+      spaceAvailable: '—',
+      updatedTotalEarnings: '—',
+    );
+
+    fakeRepo.emitLoad(mockLoad);
+    await tester.pump();
+
+    expect(find.text('New Load Available!'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 6));
+
+    expect(find.text('New Load Available!'), findsNothing);
+    fakeRepo.dispose();
+  });
+
+
+
+  testWidgets('notification banner shows when driver region matches load route', (
+    WidgetTester tester,
+  ) async {
+    final fakeRepo = FakeMarketplaceRepository();
+    
+    await tester.pumpWidget(_buildTestApp(
+      marketplaceRepo: fakeRepo,
+      mockLocationText: 'Chennai, Tamil Nadu, India',
+    ));
+    await _pumpTransition(tester);
+
+    const mockLoadChennai = LoadOffer(
+      id: 'load-chennai',
+      route: 'Chennai → Coimbatore',
+      customer: 'Customer A',
+      company: 'Company A',
+      goods: 'Steel',
+      pickup: 'Chennai Port',
+      distanceFromDriver: '5 km',
+      estimatedProfit: '₹18,500',
+      fuelCost: '₹4,000',
+      tollCost: '₹1,500',
+      capacityUsed: 0.8,
+      truckFillLabel: 'Capacity',
+      sharingTruckWith: '—',
+      badgeLabel: 'Available',
+      badgeEmoji: '📦',
+      routeDistance: '500 km',
+      routeDuration: '9 hours',
+      weight: '—',
+      dimensions: '—',
+      stackable: '—',
+      fragile: '—',
+      specialHandling: '',
+      freightValue: '₹24,000',
+      netProfit: '₹18,500',
+      routeNote: '',
+      extraDistance: 0,
+      extraEarnings: '₹0',
+      spaceAvailable: '—',
+      updatedTotalEarnings: '—',
+    );
+
+    fakeRepo.emitLoad(mockLoadChennai);
+    await tester.pump();
+
+    // Since driver is in Chennai, and route is "Chennai → Coimbatore", banner MUST show
+    expect(find.text('New Load Available!'), findsOneWidget);
+    fakeRepo.dispose();
+  });
+
+  testWidgets('notification banner does not show when driver region does not match load route', (
+    WidgetTester tester,
+  ) async {
+    final fakeRepo = FakeMarketplaceRepository();
+
+    await tester.pumpWidget(_buildTestApp(
+      marketplaceRepo: fakeRepo,
+      mockLocationText: 'Delhi, India',
+    ));
+    await _pumpTransition(tester);
+
+    const mockLoadCoimbatore = LoadOffer(
+      id: 'load-coimbatore',
+      route: 'Chennai → Coimbatore',
+      customer: 'Customer B',
+      company: 'Company B',
+      goods: 'Pipes',
+      pickup: 'Chennai Port',
+      distanceFromDriver: '500 km',
+      estimatedProfit: '₹18,500',
+      fuelCost: '₹4,000',
+      tollCost: '₹1,500',
+      capacityUsed: 0.8,
+      truckFillLabel: 'Capacity',
+      sharingTruckWith: '—',
+      badgeLabel: 'Available',
+      badgeEmoji: '📦',
+      routeDistance: '500 km',
+      routeDuration: '9 hours',
+      weight: '—',
+      dimensions: '—',
+      stackable: '—',
+      fragile: '—',
+      specialHandling: '',
+      freightValue: '₹24,000',
+      netProfit: '₹18,500',
+      routeNote: '',
+      extraDistance: 0,
+      extraEarnings: '₹0',
+      spaceAvailable: '—',
+      updatedTotalEarnings: '—',
+    );
+
+    fakeRepo.emitLoad(mockLoadCoimbatore);
+    await tester.pump();
+
+    // Since driver is in Delhi, but route is "Chennai → Coimbatore", banner MUST NOT show
+    expect(find.text('Pipes • ₹18,500'), findsNothing);
+    fakeRepo.dispose();
   });
 }


### PR DESCRIPTION
## Summary

Adds Supabase Realtime subscription for new load offers with a notification banner in the driver home screen that deep-links to load details.

## Changes

### Driver App
- **lib/services/marketplace_repository.dart** — Added `subscribeToNewLoads()` method that:
  - Opens a Supabase Realtime stream on `load_offers` filtered by `status = 'available'`
  - Returns a `Stream<LoadOffer>` for real-time updates
- **lib/screens/home_screen.dart** — Added:
  - Realtime subscription lifecycle (`initState` / `dispose`)
  - Notification banner with route info, close button, and tap-to-navigate
  - Deep-link to `LoadDetailScreen` when tapping the banner

### Behavior
1. Driver is on HomeScreen -> Realtime subscription listens for new available loads
2. New load offer inserted -> banner slides in: "New Load Available!" with route name
3. Driver taps banner -> navigates to load detail screen
4. Driver dismisses banner -> close button or taps away

Fixes #573



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time “new load” notifications driven by marketplace updates.
  * The home screen now shows a “New Load Available!” banner when an incoming load matches the current/decoded location.
  * Drivers can tap “View” (or the banner) to jump to load details, or dismiss the banner; it also auto-hides after ~6 seconds.
* **Tests**
  * Added widget tests using a fake marketplace stream to verify banner behavior and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->