### PR TITLE
feat: add on-chain reputation API and driver profile display

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -13,7 +13,6 @@ import '../services/fcm_service.dart';
 import '../../core/supabase_config.dart';
 import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen;
 import 'notifications_screen.dart';
-import 'package:http/http.dart' as http;
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
@@ -40,7 +39,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
   void initState() {
     super.initState();
     _loadWalletAddress();
+    _fetchReputation();
   }
+
+  static const String _apiBaseUrl = String.fromEnvironment(
+    'TRUXIFY_API_BASE_URL',
+    defaultValue: 'http://localhost:5000',
+  );
+
+  double? _supabaseRating;
+  int? _onChainScore;
+  bool _reputationUnavailable = false;
 
   Future<void> _loadWalletAddress() async {
     try {
@@ -60,6 +69,56 @@ class _ProfileScreenState extends State<ProfileScreen> {
       }
     } catch (e) {
       debugPrint('Failed to load wallet address: $e');
+    }
+  }
+
+  Future<void> _fetchReputation() async {
+    try {
+      final client = Supabase.instance.client;
+      final userId = client.auth.currentUser?.id;
+      final token = client.auth.currentSession?.accessToken;
+      
+      if (userId == null) return;
+      
+      final response = await http.get(
+        Uri.parse(
+          '$_apiBaseUrl/api/driver/$userId/reputation',
+        ),
+        headers: {
+          if (token != null) 'Authorization': 'Bearer $token',
+          'x-user-id': userId,
+          'x-user-role': 'driver',
+        },
+      );
+      
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        
+        if (!mounted) return;
+        
+        setState(() {
+          _supabaseRating =
+            (data['supabaseRating'] as num?)?.toDouble();
+
+          _onChainScore = int.tryParse(
+            data['onChainScore']?.toString() ?? '',
+          );
+            
+          _reputationUnavailable = false;
+        });
+      } else {
+        if (!mounted) return;
+
+        setState(() {
+          _reputationUnavailable = true;
+        });
+      }
+    } catch (_) {
+      if (!mounted) return;
+      
+      setState(() {
+        _reputationUnavailable = true;
+      });
     }
   }
 
@@ -756,6 +815,56 @@ class _ProfileScreenState extends State<ProfileScreen> {
           ),
 
           const SizedBox(height: 16),
+
+          const SizedBox(height: 16),
+
+AppCard(
+  padding: const EdgeInsets.all(16),
+  child: Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        'Reputation',
+        style: GoogleFonts.dmSans(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+      ),
+      const SizedBox(height: 12),
+
+      if (_reputationUnavailable)
+        Text(
+          'Unable to fetch reputation.',
+          style: GoogleFonts.dmSans(
+            color: TruxifyColors.errorRed,
+          ),
+        )
+      else
+        Row(
+          children: [
+            Expanded(
+              child: _MetricColumn(
+                label: 'Supabase Rating',
+                value: _supabaseRating?.toStringAsFixed(1) ?? '--',
+              ),
+            ),
+            Container(
+              width: 1,
+              height: 32,
+              color: _borderColor(context),
+            ),
+            Expanded(
+              child: _MetricColumn(
+                label: 'On-chain Score',
+                value: _onChainScore?.toString() ?? '--',
+              ),
+            ),
+          ],
+        ),
+    ],
+  ),
+),
 
           const SectionLabel(label: 'SETTINGS'),
           AppCard(

--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:http/http.dart' as http;
+
 import '../controllers/app_controller.dart';
 import '../core/app_routes.dart';
 import '../data/mock_data.dart';
@@ -35,21 +35,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
   String _currentLanguage = 'English';
   String _walletAddress = '';
 
+  bool _isLoadingReputation = true;
+  double? _platformRating;
+  int? _onChainScore;
+  bool _reputationUnavailable = false;
+
   @override
   void initState() {
     super.initState();
     _loadWalletAddress();
     _fetchReputation();
   }
-
-  static const String _apiBaseUrl = String.fromEnvironment(
-    'TRUXIFY_API_BASE_URL',
-    defaultValue: 'http://localhost:5000',
-  );
-
-  double? _supabaseRating;
-  int? _onChainScore;
-  bool _reputationUnavailable = false;
 
   Future<void> _loadWalletAddress() async {
     try {
@@ -58,12 +54,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
       if (userId != null) {
         final data = await client
             .from('profiles')
-            .select('wallet_address')
+            .select('polygon_wallet_address')
             .eq('id', userId)
             .maybeSingle();
         if (data != null && mounted) {
           setState(() {
-            _walletAddress = data['wallet_address']?.toString() ?? '';
+            _walletAddress = data['polygon_wallet_address']?.toString() ?? '';
           });
         }
       }
@@ -73,56 +69,73 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   Future<void> _fetchReputation() async {
+    if (!mounted) return;
+    setState(() {
+      _isLoadingReputation = true;
+      _reputationUnavailable = false;
+    });
+
     try {
       final client = Supabase.instance.client;
-      final userId = client.auth.currentUser?.id;
-      final token = client.auth.currentSession?.accessToken;
-      
-      if (userId == null) return;
-      
-      final response = await http.get(
-        Uri.parse(
-          '$_apiBaseUrl/api/driver/$userId/reputation',
-        ),
-        headers: {
-          if (token != null) 'Authorization': 'Bearer $token',
-          'x-user-id': userId,
-          'x-user-role': 'driver',
-        },
+      final driverId = client.auth.currentUser?.id;
+      if (driverId == null) {
+        if (mounted) {
+          setState(() {
+            _isLoadingReputation = false;
+          });
+        }
+        return;
+      }
+
+      const apiBaseUrl = String.fromEnvironment(
+        'TRUXIFY_API_BASE_URL',
+        defaultValue: 'http://localhost:5000',
       );
-      
+
+      final uri = Uri.parse('$apiBaseUrl/api/driver/$driverId/reputation');
+      final token = client.auth.currentSession?.accessToken;
+      final response = await http.get(
+        uri,
+        headers: {
+          'Content-Type': 'application/json',
+          if (token != null) 'Authorization': 'Bearer $token',
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (!mounted) return;
+
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
-        
-        if (!mounted) return;
-        
         setState(() {
-          _supabaseRating =
-            (data['supabaseRating'] as num?)?.toDouble();
-
-          _onChainScore = int.tryParse(
-            data['onChainScore']?.toString() ?? '',
-          );
-            
-          _reputationUnavailable = false;
+          _platformRating = data['supabaseRating'] != null
+              ? (data['supabaseRating'] as num).toDouble()
+              : null;
+          _onChainScore = data['onChainScore'] != null
+              ? (data['onChainScore'] as num).toInt()
+              : null;
+          _walletAddress = data['walletAddress']?.toString() ?? '';
+          _isLoadingReputation = false;
         });
       } else {
-        if (!mounted) return;
-
         setState(() {
           _reputationUnavailable = true;
+          _isLoadingReputation = false;
         });
       }
-    } catch (_) {
-      if (!mounted) return;
-      
-      setState(() {
-        _reputationUnavailable = true;
-      });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _reputationUnavailable = true;
+          _isLoadingReputation = false;
+        });
+      }
     }
   }
 
+
   Color _borderColor(BuildContext context) {
+
+
     return Theme.of(context).brightness == Brightness.dark
         ? TruxifyColors.darkBorder
         : TruxifyColors.border;
@@ -814,59 +827,85 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           ),
 
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
-          const SizedBox(height: 16),
-
-AppCard(
-  padding: const EdgeInsets.all(16),
-  child: Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: [
-      Text(
-        'Reputation',
-        style: GoogleFonts.dmSans(
-          fontSize: 16,
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-      ),
-      const SizedBox(height: 12),
-
-      if (_reputationUnavailable)
-        Text(
-          'Unable to fetch reputation.',
-          style: GoogleFonts.dmSans(
-            color: TruxifyColors.errorRed,
+          // Reputation Card
+          AppCard(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    children: [
+                      const Icon(Icons.star_rounded, color: Colors.amber, size: 24),
+                      const SizedBox(height: 8),
+                      Text(
+                        _isLoadingReputation
+                            ? '...'
+                            : _platformRating != null
+                                ? '${_platformRating!.toStringAsFixed(1)} / 5.0'
+                                : '0.0 / 5.0',
+                        style: GoogleFonts.dmSans(
+                          fontSize: 16,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Platform Rating',
+                        textAlign: TextAlign.center,
+                        style: GoogleFonts.dmSans(
+                          fontSize: 11,
+                          color: TruxifyColors.adaptiveSecondaryText(context),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  width: 1,
+                  height: 48,
+                  color: _borderColor(context),
+                ),
+                Expanded(
+                  child: Column(
+                    children: [
+                      const Icon(Icons.link_rounded, color: TruxifyColors.accent, size: 24),
+                      const SizedBox(height: 8),
+                      Text(
+                        _isLoadingReputation
+                            ? '...'
+                            : (_reputationUnavailable || (_walletAddress.isNotEmpty && _onChainScore == null))
+                                ? 'Unavailable'
+                                : _walletAddress.isEmpty
+                                    ? 'Wallet Not Connected'
+                                    : '$_onChainScore / 100',
+                        textAlign: TextAlign.center,
+                        style: GoogleFonts.dmSans(
+                          fontSize: (_walletAddress.isEmpty || _reputationUnavailable || (_walletAddress.isNotEmpty && _onChainScore == null)) && !_isLoadingReputation ? 12 : 16,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'On-Chain Reputation',
+                        textAlign: TextAlign.center,
+                        style: GoogleFonts.dmSans(
+                          fontSize: 11,
+                          color: TruxifyColors.adaptiveSecondaryText(context),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           ),
-        )
-      else
-        Row(
-          children: [
-            Expanded(
-              child: _MetricColumn(
-                label: 'Supabase Rating',
-                value: _supabaseRating?.toStringAsFixed(1) ?? '--',
-              ),
-            ),
-            Container(
-              width: 1,
-              height: 32,
-              color: _borderColor(context),
-            ),
-            Expanded(
-              child: _MetricColumn(
-                label: 'On-chain Score',
-                value: _onChainScore?.toString() ?? '--',
-              ),
-            ),
-          ],
-        ),
-    ],
-  ),
-),
 
-          const SectionLabel(label: 'SETTINGS'),
+          const SizedBox(height: 16),
+
           AppCard(
             child: Column(
               children: [

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -6,6 +6,7 @@ import { driverOnlineSchema, withdrawSchema } from '../validation/requestSchemas
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';
+import { getDriverReputation } from '../services/reputation.js';
 
 const router = express.Router();
 
@@ -313,7 +314,81 @@ router.get('/bids', authenticate, requireRole(['driver']), async (req, res) => {
 });
 
 // ============================================================================
-// 10. WITHDRAW FUNDS FROM WALLET (DRIVER)
+// 10. FETCH DRIVER ON-CHAIN REPUTATION
+// ============================================================================
+router.get(
+  '/:driverId/reputation',
+  authenticate,
+  requireRole(['driver']),
+  async (req, res) => {
+    const { driverId } = req.params;
+
+    if (driverId !== req.user.id) {
+      return res.status(403).json({
+        error: 'Forbidden'
+      });
+    }
+
+    if (!supabase) {
+      return res.status(200).json({
+        driverId,
+        walletAddress: null,
+        onChainScore: null,
+        supabaseRating: null
+      });
+    }
+    
+    try {
+      const { data: details, error } = await supabase
+      .from('driver_details')
+      .select('rating, polygon_wallet_address')
+      .eq('user_id', driverId)
+      .maybeSingle();
+
+    if (error) {
+      return res.status(500).json({
+        error: 'Failed to fetch driver reputation.',
+        details: error.message
+      });
+    }
+
+    if (!details) {
+      return res.status(404).json({
+        error: 'Driver not found.'
+      });
+    }
+
+    const walletAddress = details.polygon_wallet_address ?? null;
+
+    let onChainScore = null;
+
+    if (walletAddress) {
+      try {
+        onChainScore = await getDriverReputation(walletAddress);
+      } catch (err) {
+        logger.error(
+          `[reputation] Failed to fetch on-chain reputation for ${driverId}: ${err.message}`
+        );
+      }
+    }
+
+    return res.status(200).json({
+      driverId,
+      walletAddress,
+      onChainScore,
+      supabaseRating: details.rating
+    });
+  } catch (err) {
+    logger.error(err);
+
+    return res.status(500).json({
+      error: 'Internal Server Error'
+    });
+  }
+});
+
+// ============================================================================
+// 11. WITHDRAW FUNDS FROM WALLET (DRIVER)
 // ============================================================================
 router.post('/wallet/withdraw', authenticate, requireRole(['driver']), validateBody(withdrawSchema), async (req, res) => {
   const { amount } = req.body; // in paisa

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1,14 +1,16 @@
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { supabase, redisClient } from '../config/db.js';
+import { getDriverReputation } from '../services/reputation.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
+
 import { validateBody } from '../middleware/validate.js';
 import { driverOnlineSchema, withdrawSchema } from '../validation/requestSchemas.js';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';
-import { getDriverReputation } from '../services/reputation.js';
 
 const router = express.Router();
+
 
 const loginOtpSchema = z.object({
   phone: z.string().trim().min(10).max(20),
@@ -314,81 +316,7 @@ router.get('/bids', authenticate, requireRole(['driver']), async (req, res) => {
 });
 
 // ============================================================================
-// 10. FETCH DRIVER ON-CHAIN REPUTATION
-// ============================================================================
-router.get(
-  '/:driverId/reputation',
-  authenticate,
-  requireRole(['driver']),
-  async (req, res) => {
-    const { driverId } = req.params;
-
-    if (driverId !== req.user.id) {
-      return res.status(403).json({
-        error: 'Forbidden'
-      });
-    }
-
-    if (!supabase) {
-      return res.status(200).json({
-        driverId,
-        walletAddress: null,
-        onChainScore: null,
-        supabaseRating: null
-      });
-    }
-    
-    try {
-      const { data: details, error } = await supabase
-      .from('driver_details')
-      .select('rating, polygon_wallet_address')
-      .eq('user_id', driverId)
-      .maybeSingle();
-
-    if (error) {
-      return res.status(500).json({
-        error: 'Failed to fetch driver reputation.',
-        details: error.message
-      });
-    }
-
-    if (!details) {
-      return res.status(404).json({
-        error: 'Driver not found.'
-      });
-    }
-
-    const walletAddress = details.polygon_wallet_address ?? null;
-
-    let onChainScore = null;
-
-    if (walletAddress) {
-      try {
-        onChainScore = await getDriverReputation(walletAddress);
-      } catch (err) {
-        logger.error(
-          `[reputation] Failed to fetch on-chain reputation for ${driverId}: ${err.message}`
-        );
-      }
-    }
-
-    return res.status(200).json({
-      driverId,
-      walletAddress,
-      onChainScore,
-      supabaseRating: details.rating
-    });
-  } catch (err) {
-    logger.error(err);
-
-    return res.status(500).json({
-      error: 'Internal Server Error'
-    });
-  }
-});
-
-// ============================================================================
-// 11. WITHDRAW FUNDS FROM WALLET (DRIVER)
+// 10. WITHDRAW FUNDS FROM WALLET (DRIVER)
 // ============================================================================
 router.post('/wallet/withdraw', authenticate, requireRole(['driver']), validateBody(withdrawSchema), async (req, res) => {
   const { amount } = req.body; // in paisa
@@ -437,4 +365,82 @@ router.post('/wallet/withdraw', authenticate, requireRole(['driver']), validateB
   }
 });
 
+// ============================================================================
+// 11. GET DRIVER REPUTATION (DRIVER)
+// ============================================================================
+router.get('/:driverId/reputation', authenticate, requireRole(['driver']), async (req, res) => {
+  const { driverId } = req.params;
+
+  if (driverId !== req.user.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+
+    // Check cache in Redis first if client exists
+    if (redisClient) {
+      try {
+        const cached = await redisClient.get(`driver-reputation:${driverId}`);
+        if (cached) {
+          logger.info(`[reputation] Cache hit for driver ${driverId}`);
+          return res.status(200).json(JSON.parse(cached));
+        }
+      } catch (cacheErr) {
+        logger.error(`[reputation] Redis read error for driver ${driverId}: ${cacheErr.message}`);
+      }
+    }
+
+    // Fetch details from Supabase
+    const { data: details, error } = await supabase
+      .from('driver_details')
+      .select('rating, polygon_wallet_address')
+      .eq('user_id', driverId)
+      .maybeSingle();
+
+    if (error) {
+      logger.error(`[reputation] Supabase query error for driver ${driverId}: ${error.message}`);
+      return res.status(500).json({ error: 'Failed to fetch driver details.', details: error.message });
+    }
+
+    if (!details) {
+      return res.status(404).json({ error: 'Driver not found.' });
+    }
+
+    const walletAddress = details.polygon_wallet_address ?? null;
+    let onChainScore = null;
+
+    if (walletAddress) {
+      onChainScore = await getDriverReputation(walletAddress);
+    }
+
+    const responseData = {
+      driverId,
+      walletAddress,
+      onChainScore,
+      supabaseRating: details.rating
+    };
+
+    // Cache the response in Redis for 30 seconds
+    if (redisClient) {
+      try {
+        await redisClient.set(
+          `driver-reputation:${driverId}`,
+          JSON.stringify(responseData),
+          'EX',
+          30
+        );
+      } catch (cacheErr) {
+        logger.error(`[reputation] Redis write error for driver ${driverId}: ${cacheErr.message}`);
+      }
+    }
+
+    return res.status(200).json(responseData);
+
+  } catch (err) {
+    logger.error(`[reputation] Unexpected error retrieving reputation for driver ${driverId}: ${err.message}`);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
 export default router;
+

--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -79,3 +79,29 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
   await tx.wait(1); // wait for 1 confirmation
   logger.info(`[reputation] increaseReputation confirmed for driver ${driverWalletAddress} (+${stars} pts).`);
 }
+
+export async function getDriverReputation(walletAddress) {
+  if (!reputationContract) {
+    return null;
+  }
+
+  if (!walletAddress || !ethers.isAddress(walletAddress)) {
+    return null;
+  }
+
+  try {
+    const score = await Promise.race([
+      reputationContract.getReputation(walletAddress),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('RPC timeout')), 5000)
+      ),
+    ]);
+    
+    return score.toString();
+  } catch (err) {
+    logger.error(
+      `[reputation] Failed to fetch on-chain reputation: ${err.message}`
+    );
+    return null;
+  }
+}

--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -80,15 +80,21 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
   logger.info(`[reputation] increaseReputation confirmed for driver ${driverWalletAddress} (+${stars} pts).`);
 }
 
+/**
+ * Fetch the on-chain reputation score for a driver.
+ *
+ * @param {string} walletAddress — 0x-prefixed Polygon address of the driver
+ * @returns {Promise<number|null>}
+ */
 export async function getDriverReputation(walletAddress) {
   if (!reputationContract) {
+    logger.warn('[reputation] Contract not initialised — skipping on-chain retrieval.');
     return null;
   }
-
-  if (!walletAddress || !ethers.isAddress(walletAddress)) {
+  if (!ethers.isAddress(walletAddress)) {
+    logger.warn(`[reputation] Invalid wallet address "${walletAddress}" — skipping.`);
     return null;
   }
-
   try {
     const score = await Promise.race([
       reputationContract.getReputation(walletAddress),
@@ -96,12 +102,10 @@ export async function getDriverReputation(walletAddress) {
         setTimeout(() => reject(new Error('RPC timeout')), 5000)
       ),
     ]);
-    
-    return score.toString();
+    return Number(score);
   } catch (err) {
-    logger.error(
-      `[reputation] Failed to fetch on-chain reputation: ${err.message}`
-    );
+    logger.error(`[reputation] Failed to fetch on-chain reputation for ${walletAddress}: ${err.message}`);
     return null;
   }
 }
+

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -12,7 +12,15 @@ vi.mock('../../src/config/db.js', () => ({
   mongoDb: null,
 }));
 
+const getDriverReputationMock = vi.fn().mockResolvedValue(92);
+vi.mock('../../src/services/reputation.js', () => ({
+  reputationContract: {},
+  awardReputationPoints: vi.fn(),
+  getDriverReputation: getDriverReputationMock,
+}));
+
 const { default: driverRouter } = await import('../../src/routes/driverRoutes.js');
+
 
 function buildApp() {
   const app = express();
@@ -397,4 +405,90 @@ describe('Driver Routes', () => {
 
     expect(res.status).toBe(400);
   });
+
+  describe('GET /:driverId/reputation', () => {
+    beforeEach(() => {
+      getDriverReputationMock.mockReset();
+    });
+
+    it('returns both platform rating and on-chain score when wallet exists and blockchain responds', async () => {
+      m.store.driver_details.push({
+        user_id: 'driver-1',
+        rating: 4.8,
+        polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+      });
+
+      getDriverReputationMock.mockResolvedValue(92);
+
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/drivers/driver-1/reputation')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        driverId: 'driver-1',
+        walletAddress: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+        onChainScore: 92,
+        supabaseRating: 4.8,
+      });
+      expect(getDriverReputationMock).toHaveBeenCalledWith('0xAbcdef1234567890Abcdef1234567890Abcdef12');
+    });
+
+    it('returns onChainScore null and walletAddress null when driver has no wallet', async () => {
+      m.store.driver_details.push({
+        user_id: 'driver-1',
+        rating: 4.8,
+        polygon_wallet_address: null,
+      });
+
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/drivers/driver-1/reputation')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        driverId: 'driver-1',
+        walletAddress: null,
+        onChainScore: null,
+        supabaseRating: 4.8,
+      });
+      expect(getDriverReputationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns onChainScore null and supabase rating when blockchain/contract fails', async () => {
+      m.store.driver_details.push({
+        user_id: 'driver-1',
+        rating: 4.8,
+        polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+      });
+
+      getDriverReputationMock.mockResolvedValue(null);
+
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/drivers/driver-1/reputation')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        driverId: 'driver-1',
+        walletAddress: '0xAbcdef1234567890Abcdef1234567890Abcdef12',
+        onChainScore: null,
+        supabaseRating: 4.8,
+      });
+      expect(getDriverReputationMock).toHaveBeenCalledWith('0xAbcdef1234567890Abcdef1234567890Abcdef12');
+    });
+
+    it('returns 404 if driver profile is not found', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/drivers/driver-1/reputation')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(404);
+    });
+  });
 });
+


### PR DESCRIPTION
## Summary

Completes the driver reputation integration by exposing on-chain reputation data through an API endpoint and displaying both blockchain and platform ratings in the driver profile.

---

## Changes

### `backend/api/src/services/reputation.js` (updated)

Added `getDriverReputation()`:

- Returns `null` when the reputation contract is unavailable.
- Validates wallet addresses before contract calls.
- Queries `reputationContract.getReputation(walletAddress)`.
- Handles blockchain failures gracefully.
- Logs errors without breaking the request flow.

### `backend/api/src/routes/driverRoutes.js` (updated)

Added:

```http
GET /api/drivers/:driverId/reputation
```

Features:

- Protected by authentication and driver role checks.
- Reads `rating` and `polygon_wallet_address` from Supabase.
- Retrieves on-chain reputation score when a wallet exists.
- Aggregates blockchain and Supabase reputation into a single response.
- Returns HTTP 200 even when blockchain data is unavailable.
- Logs blockchain failures without affecting platform rating.

### `apps/driver/lib/screens/profile_screen.dart` (updated)

Added reputation UI and API integration:

- Fetch reputation on profile initialization.
- Store platform rating and on-chain score separately.
- Display a new Reputation card.
- Show both Supabase Rating and On-chain Score.
- Display unavailable state when reputation retrieval fails.

---

## Acceptance Criteria

| Criterion | Status |
|------------|--------|
| Reputation API endpoint implemented | ✅ `GET /api/drivers/:driverId/reputation` |
| On-chain reputation service added | ✅ `getDriverReputation()` |
| Supabase and blockchain scores aggregated | ✅ Single response |
| Missing wallet addresses handled gracefully | ✅ Returns `onChainScore: null` |
| Blockchain failures do not break endpoint | ✅ Error logged |
| Driver profile displays reputation card | ✅ `profile_screen.dart` |
| Platform rating continues to work | ✅ Existing rating preserved |
| On-chain score displayed separately | ✅ Reputation card |
| Unavailable state shown correctly | ✅ UI fallback |

---

## Test Results

### Normal Case
- Wallet exists.
- Contract returns reputation score.
- Both Supabase rating and on-chain score are returned.

### Missing Wallet
- Endpoint returns HTTP 200.
- `onChainScore` remains `null`.

### Blockchain Failure
- Endpoint still responds successfully.
- Platform rating remains available.
- Errors are logged appropriately.

### Flutter UI
- Reputation card renders correctly.
- On-chain score displays properly.
- Unavailable state is shown when fetching fails.

---

Closes #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Driver profile now includes a **Reputation** card showing both **platform rating** and **on-chain reputation score**.
  * Reputation data is available via an authenticated backend endpoint for the logged-in driver.
* **Bug Fixes**
  * Reputation loading and error states are now handled more clearly (e.g., **“Unavailable”**, **“Wallet Not Connected”**, and loading placeholders) so the metrics area no longer stays blank when lookups fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->