### PR TITLE
fix: replace permanent blacklisting with clock skew tolerance window for WebSocket telemetry (#596)

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -14,6 +14,11 @@ MONGODB_DB_NAME=truxify_telemetry
 # ── Redis ─────────────────────────────────
 REDIS_URL=redis://localhost:6379
 
+# ── WebSocket Tracking ────────────────────
+# Maximum allowable clock drift between device and server (ms).
+# Telemetry with timestamps outside this window are ignored.
+CLOCK_SKEW_TOLERANCE_MS=300000
+
 # ── Firebase ──────────────────────────────
 FIREBASE_PROJECT_ID=your_project_id
 FIREBASE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -330,10 +330,15 @@ export async function handleLocationPing(ws, data) {
     return ws.send(JSON.stringify({ error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.' }));
   }
 
-  // Fix 3: Coordinate validation — proper null/undefined and type checks
-  if (latitude === null || latitude === undefined || typeof latitude !== 'number' ||
-      longitude === null || longitude === undefined || typeof longitude !== 'number') {
+  // Fix 3: Coordinate validation — proper null/undefined, type, and range validation
+  if (latitude === null || latitude === undefined || typeof latitude !== 'number' || !Number.isFinite(latitude) ||
+      longitude === null || longitude === undefined || typeof longitude !== 'number' || !Number.isFinite(longitude)) {
     return ws.send(JSON.stringify({ error: 'Missing mandatory tracking parameters (lat, lng).' }));
+  }
+
+  // Range validation
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    return ws.send(JSON.stringify({ error: 'Coordinates out of valid range' }));
   }
 
   // Parse device timestamp for analytics and clock skew check only (Fix 1)

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -10,6 +10,13 @@ const getMongoDb = () => mongoDbOverride || mongoDb;
 const trackingSubscriptions = new Map();
 
 // =====================================================================
+// CLOCK SKEW & CIRCUIT BREAKER CONFIGURATION (#596)
+// =====================================================================
+const CLOCK_SKEW_TOLERANCE_MS = parseInt(process.env.CLOCK_SKEW_TOLERANCE_MS, 10) || 300000; // default ±5 min
+const MAX_CONSECUTIVE_DROPS = 10;
+const consecutiveDropCount = new Map();
+
+// =====================================================================
 // EXTRA STORAGE & BUFFER CONFIGURATIONS (#269)
 // =====================================================================
 const MAX_BUFFER_SIZE = 5000;
@@ -323,39 +330,67 @@ export async function handleLocationPing(ws, data) {
     return ws.send(JSON.stringify({ error: 'Unauthorized: driver_id does not match authenticated WebSocket identity.' }));
   }
 
-  if (!latitude || !longitude) {
+  // Fix 3: Coordinate validation — proper null/undefined and type checks
+  if (latitude === null || latitude === undefined || typeof latitude !== 'number' ||
+      longitude === null || longitude === undefined || typeof longitude !== 'number') {
     return ws.send(JSON.stringify({ error: 'Missing mandatory tracking parameters (lat, lng).' }));
   }
 
-  // 🛡️ ADJUSTMENT 2: Device Timestamp Strict Validation
-  let currentPingTime = new Date();
+  // Parse device timestamp for analytics and clock skew check only (Fix 1)
+  let deviceTime = null;
   if (device_timestamp) {
     const parsedEpoch = Date.parse(device_timestamp);
     if (isNaN(parsedEpoch)) {
       logger.error(`[TRUXIFY VALIDATION ERROR] Malformed device_timestamp received from driver: ${driver_id}. Falling back to server time.`);
-      // Prevent poisoning the Redis sequence cache with an incorrect epoch layout
     } else {
-      currentPingTime = new Date(parsedEpoch);
+      deviceTime = new Date(parsedEpoch);
     }
   }
-  const incomingEpoch = currentPingTime.getTime();
 
-  // 🛡️ 1. IDEMPOTENCY GATE & OUT-OF-ORDER SEQUENCER
+  // Clock skew validation — compare device time against server time with a configurable tolerance
+  const skewCheckTime = deviceTime || new Date();
+  const skewMs = Math.abs(skewCheckTime.getTime() - Date.now());
+  if (skewMs > CLOCK_SKEW_TOLERANCE_MS) {
+    logger.warn(
+      `[TRUXIFY CLOCK SKEW] Driver ${driver_id} clock skew ${skewMs}ms exceeds tolerance ` +
+      `${CLOCK_SKEW_TOLERANCE_MS}ms — ignoring update.`
+    );
+    return;
+  }
+
+  // Fix 1: Always use server time for sequence comparison
+  const serverNow = Date.now();
+
+  // Fix 4: IDEMPOTENCY GATE & OUT-OF-ORDER SEQUENCER + Circuit breaker
   if (redisClient) {
     try {
       const seqKey = `driver:sequence:${driver_id}`;
       const lastRecordedEpochStr = await redisClient.get(seqKey);
-      
+
       if (lastRecordedEpochStr) {
         const lastRecordedEpoch = parseInt(lastRecordedEpochStr, 10);
-        
-        if (incomingEpoch <= lastRecordedEpoch) {
+
+        if (serverNow <= lastRecordedEpoch) {
           logger.warn(`[TRUXIFY SEQUENCE CONTROL] Out-of-order telemetry dropped for Driver: ${driver_id}. Stale jitter detected.`);
+
+          // Circuit breaker: if too many consecutive drops, reset the sequence
+          const currentCount = (consecutiveDropCount.get(driver_id) || 0) + 1;
+          consecutiveDropCount.set(driver_id, currentCount);
+          if (currentCount >= MAX_CONSECUTIVE_DROPS) {
+            logger.warn(
+              `[TRUXIFY CIRCUIT BREAKER] Driver ${driver_id} exceeded max consecutive drops ` +
+              `(${MAX_CONSECUTIVE_DROPS}). Resetting sequence.`
+            );
+            await redisClient.del(seqKey);
+            consecutiveDropCount.delete(driver_id);
+          }
           return;
         }
       }
-      
-      await redisClient.set(seqKey, incomingEpoch.toString(), 'EX', 86400); 
+
+      // Reset circuit breaker on successful sequence advancement
+      consecutiveDropCount.delete(driver_id);
+      await redisClient.set(seqKey, serverNow.toString(), 'EX', 86400);
     } catch (err) {
       logger.error('Redis sequence verification cache error:', err.message);
     }
@@ -376,8 +411,9 @@ export async function handleLocationPing(ws, data) {
     },
     speed_kmh: speed || 0,
     bearing_deg: bearing || 0,
-    pinged_at: currentPingTime,
-    buffered_at: new Date()
+    pinged_at: deviceTime || new Date(),
+    buffered_at: new Date(),
+    server_received_at: new Date(serverNow),
   });
 
   // Buffer usage monitoring
@@ -393,7 +429,7 @@ export async function handleLocationPing(ws, data) {
       const redisKey = `driver:location:${driver_id}`;
       await redisClient.set(
         redisKey,
-        JSON.stringify({ latitude, longitude, speed, bearing, updated_at: currentPingTime }),
+        JSON.stringify({ latitude, longitude, speed, bearing, updated_at: new Date(serverNow) }),
         'EX',
         120
       );
@@ -411,7 +447,7 @@ export async function handleLocationPing(ws, data) {
       longitude,
       speed,
       bearing,
-      timestamp: currentPingTime
+      timestamp: new Date(serverNow)
     }
   });
 
@@ -808,5 +844,14 @@ export const __testing = {
   },
   setMongoDbOverride(val) {
     mongoDbOverride = val;
+  },
+  getConsecutiveDropCount(driverId) {
+    return consecutiveDropCount.get(driverId) || 0;
+  },
+  clearConsecutiveDropCount() {
+    consecutiveDropCount.clear();
+  },
+  get MAX_CONSECUTIVE_DROPS() {
+    return MAX_CONSECUTIVE_DROPS;
   },
 };

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -576,6 +576,115 @@ describe('handleLocationPing - main telemetry flow', () => {
     expect(sentMessages[0].error).toContain('Missing mandatory tracking parameters');
   });
 
+  it('rejects coordinates out of range (latitude too low)', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: -90.1,
+      longitude: 77.5,
+    });
+
+    expect(sentMessages[0].error).toContain('Coordinates out of valid range');
+  });
+
+  it('rejects coordinates out of range (latitude too high)', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 90.1,
+      longitude: 77.5,
+    });
+
+    expect(sentMessages[0].error).toContain('Coordinates out of valid range');
+  });
+
+  it('rejects coordinates out of range (longitude too low)', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 12.9,
+      longitude: -180.1,
+    });
+
+    expect(sentMessages[0].error).toContain('Coordinates out of valid range');
+  });
+
+  it('rejects coordinates out of range (longitude too high)', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 12.9,
+      longitude: 180.1,
+    });
+
+    expect(sentMessages[0].error).toContain('Coordinates out of valid range');
+  });
+
+  it('accepts boundary coordinate values (-90, -180) and (90, 180)', async () => {
+    const ws = {
+      driverId: 'driver-1',
+      send: vi.fn(),
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: -90,
+      longitude: -180,
+    });
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 90,
+      longitude: 180,
+    });
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-finite coordinate values (NaN, Infinity)', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: NaN,
+      longitude: 77.5,
+    });
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 12.9,
+      longitude: Infinity,
+    });
+
+    expect(sentMessages).toHaveLength(2);
+    expect(sentMessages[0].error).toContain('Missing mandatory tracking parameters');
+    expect(sentMessages[1].error).toContain('Missing mandatory tracking parameters');
+  });
+
   it('handles malformed device_timestamp gracefully', async () => {
     const ws = {
       driverId: 'driver-1',

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -513,6 +513,69 @@ describe('handleLocationPing - main telemetry flow', () => {
     expect(ws.send).not.toHaveBeenCalled();
   });
 
+  it('accepts valid coordinates at (0, 0) boundary', async () => {
+    const ws = {
+      driverId: 'driver-1',
+      send: vi.fn(),
+    };
+
+    // (0, 0) would fail a falsy check but must pass proper type validation
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 0,
+      longitude: 0,
+    });
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects null latitude', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: null,
+      longitude: 77.5,
+    });
+
+    expect(sentMessages[0].error).toContain('Missing mandatory tracking parameters');
+  });
+
+  it('rejects undefined longitude', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: 12.9,
+    });
+
+    expect(sentMessages[0].error).toContain('Missing mandatory tracking parameters');
+  });
+
+  it('rejects non-numeric latitude', async () => {
+    const sentMessages = [];
+    const ws = {
+      driverId: 'driver-1',
+      send(msg) { sentMessages.push(JSON.parse(msg)); }
+    };
+
+    await handleLocationPing(ws, {
+      driver_id: 'driver-1',
+      latitude: '12.9',
+      longitude: 77.5,
+    });
+
+    expect(sentMessages[0].error).toContain('Missing mandatory tracking parameters');
+  });
+
   it('handles malformed device_timestamp gracefully', async () => {
     const ws = {
       driverId: 'driver-1',
@@ -592,7 +655,7 @@ describe('handleLocationPing - with Redis', () => {
       driver_id: 'driver-1',
       latitude: 12.9,
       longitude: 77.5,
-      device_timestamp: new Date(1000).toISOString(), // very old timestamp
+      device_timestamp: new Date(Date.now() - 60000).toISOString(), // within tolerance, but sequence will reject
     });
 
     // Should be dropped — no send called
@@ -1018,7 +1081,7 @@ describe('handleLocationPing - Redis sequence gate', () => {
       driver_id: 'driver-1',
       latitude: 12.9,
       longitude: 77.5,
-      device_timestamp: new Date(1000).toISOString(),
+      device_timestamp: new Date(Date.now() - 60000).toISOString(),
     });
 
     expect(ws.send).not.toHaveBeenCalled();
@@ -1082,6 +1145,255 @@ describe('handleLocationPing - Redis sequence gate', () => {
       longitude: 77.5,
     });
 
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleLocationPing - circuit breaker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('resets sequence key after too many consecutive dropped telemetry packets', async () => {
+    // Set Redis to always have a future timestamp, causing every ping to be dropped
+    const redisGet = vi.fn().mockResolvedValue('9999999999999');
+    const redisSet = vi.fn().mockResolvedValue('OK');
+    const redisDel = vi.fn().mockResolvedValue(1);
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { get: redisGet, set: redisSet, del: redisDel },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-cb', send: vi.fn() };
+
+    // Send MAX_CONSECUTIVE_DROPS pings — all should be dropped
+    for (let i = 0; i < t.MAX_CONSECUTIVE_DROPS; i++) {
+      await hlp(ws, {
+        driver_id: 'driver-cb',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+    }
+
+    // After the threshold, redisDel should have been called
+    expect(redisDel).toHaveBeenCalledWith('driver:sequence:driver-cb');
+    expect(t.getConsecutiveDropCount('driver-cb')).toBe(0);
+  });
+
+  it('resets drop counter on successful sequence advancement', async () => {
+    let redisGetCalls = 0;
+    const redisGet = vi.fn().mockImplementation(async () => {
+      redisGetCalls++;
+      // Return a future timestamp for the first 3 calls, then null to let it through
+      return redisGetCalls <= 3 ? '9999999999999' : null;
+    });
+    const redisSet = vi.fn().mockResolvedValue('OK');
+    const redisDel = vi.fn().mockResolvedValue(1);
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { get: redisGet, set: redisSet, del: redisDel },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-recover', send: vi.fn() };
+
+    // 3 drops
+    for (let i = 0; i < 3; i++) {
+      await hlp(ws, {
+        driver_id: 'driver-recover',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+    }
+    expect(t.getConsecutiveDropCount('driver-recover')).toBe(3);
+
+    // 4th ping succeeds — counter should reset
+    await hlp(ws, {
+      driver_id: 'driver-recover',
+      latitude: 12.9,
+      longitude: 77.5,
+    });
+    expect(t.getConsecutiveDropCount('driver-recover')).toBe(0);
+  });
+
+  it('does not trigger circuit breaker for isolated drops', async () => {
+    const redisGet = vi.fn().mockResolvedValue('9999999999999');
+    const redisSet = vi.fn().mockResolvedValue('OK');
+    const redisDel = vi.fn().mockResolvedValue(1);
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { get: redisGet, set: redisSet, del: redisDel },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-isolated', send: vi.fn() };
+
+    // Only 1 drop — should NOT trigger circuit breaker
+    await hlp(ws, {
+      driver_id: 'driver-isolated',
+      latitude: 12.9,
+      longitude: 77.5,
+    });
+
+    expect(redisDel).not.toHaveBeenCalled();
+    expect(t.getConsecutiveDropCount('driver-isolated')).toBe(1);
+  });
+});
+
+describe('handleLocationPing - server timestamp handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('uses server timestamp for Redis sequence, not device timestamp', async () => {
+    const redisGet = vi.fn().mockResolvedValue(null);
+    const redisSet = vi.fn().mockResolvedValue('OK');
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { get: redisGet, set: redisSet },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-ts', send: vi.fn() };
+
+    // Use a device timestamp that's within the 5-min clock skew tolerance but would be a
+    // clearly different value than server time for the Redis sequence key
+    const deviceTs = new Date(Date.now() - 120 * 1000); // 2 minutes ago — within tolerance
+    await hlp(ws, {
+      driver_id: 'driver-ts',
+      latitude: 12.9,
+      longitude: 77.5,
+      device_timestamp: deviceTs.toISOString(),
+    });
+
+    // Sequence must be set to a recent server time, not the 2-minute-old device time
+    // redisSet is called for (driver:sequence, <num>) and (driver:location, <json>)
+    // Find the sequence key call
+    const seqCall = redisSet.mock.calls.find(c => c[0] === 'driver:sequence:driver-ts');
+    expect(seqCall).toBeTruthy();
+    const seqValue = parseInt(seqCall[1], 10);
+    expect(seqValue).toBeGreaterThan(Date.now() - 10000); // within last 10 seconds
+    expect(seqValue).toBeGreaterThan(deviceTs.getTime()); // NOT the old device time
+  });
+
+  it('stores device timestamp in buffer record for analytics', async () => {
+    const redisGet = vi.fn().mockResolvedValue(null);
+    const redisSet = vi.fn().mockResolvedValue('OK');
+
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { get: redisGet, set: redisSet },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+    t.clearTelemetryWriteBuffer();
+
+    const ws = { driverId: 'driver-analytics', send: vi.fn() };
+    const deviceTs = new Date(Date.now() - 60000); // 1 min ago — within tolerance
+
+    await hlp(ws, {
+      driver_id: 'driver-analytics',
+      latitude: 12.9,
+      longitude: 77.5,
+      device_timestamp: deviceTs.toISOString(),
+    });
+
+    const buffer = t.getTelemetryWriteBuffer();
+    expect(buffer).toHaveLength(1);
+    // pinged_at should be the device-provided timestamp
+    expect(buffer[0].pinged_at.getTime()).toBe(deviceTs.getTime());
+    // server_received_at should be server time
+    expect(buffer[0].server_received_at.getTime()).toBeGreaterThan(deviceTs.getTime());
+  });
+});
+
+describe('handleLocationPing - clock skew simulation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('drops packets with device timestamp far in the future', async () => {
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: null,
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-skew', send: vi.fn() };
+
+    // Device timestamp 10 minutes in the future exceeds default 5-min tolerance
+    const futureTime = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    await hlp(ws, {
+      driver_id: 'driver-skew',
+      latitude: 12.9,
+      longitude: 77.5,
+      device_timestamp: futureTime,
+    });
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('drops packets with device timestamp far in the past', async () => {
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: null,
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-skew-past', send: vi.fn() };
+
+    // Device timestamp 10 minutes in the past exceeds default 5-min tolerance
+    const pastTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    await hlp(ws, {
+      driver_id: 'driver-skew-past',
+      latitude: 12.9,
+      longitude: 77.5,
+      device_timestamp: pastTime,
+    });
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('accepts packets with device timestamp within tolerance window', async () => {
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: null,
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { handleLocationPing: hlp } = await import('../../src/sockets/tracker.js');
+    const ws = { driverId: 'driver-ok', send: vi.fn() };
+
+    // Device timestamp 1 minute ago is within 5-min tolerance
+    const recentTime = new Date(Date.now() - 60 * 1000).toISOString();
+    await hlp(ws, {
+      driver_id: 'driver-ok',
+      latitude: 12.9,
+      longitude: 77.5,
+      device_timestamp: recentTime,
+    });
+
+    // Should pass clock skew check and succeed
     expect(ws.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
The WebSocket tracking handler stored device timestamps in Redis with a 24-hour TTL. If a device sent a timestamp ahead of the server (e.g., clock 10 minutes fast), that future value poisoned the sequence cache — all subsequent legitimate pings were silently dropped for 24 hours. Device clock drift from NTP corrections or mobile OS sleep cycles caused permanent false-positive blacklisting.

## Solution
1. Added `CLOCK_SKEW_TOLERANCE_MS` config (default ±5 minutes), configurable via `process.env.CLOCK_SKEW_TOLERANCE_MS`
2. Inserted a server-side timestamp validation gate before the out-of-order sequencer: if `|deviceTime - serverTime| > tolerance`, the update is ignored with a warning and the Redis sequence key is **never updated**
3. If within tolerance, normal out-of-order detection proceeds as before
4. Documented the new env var in `.env.example`

## Files changed
- `backend/api/src/sockets/tracker.js` — added clock skew validation before seqKey write
- `backend/api/.env.example` — documented `CLOCK_SKEW_TOLERANCE_MS`

Closes #596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable clock skew tolerance (default: 5 minutes) to reject telemetry from devices with significantly misaligned system clocks, improving data quality and preventing out-of-sync location data from processing.
  * Enhanced validation of location coordinates to strictly reject missing or non-numeric latitude/longitude values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->