### PR TITLE
fix(tracking): use removeChannel() in LiveTrackingScreen dispose to prevent channel leaks

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -9,6 +9,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../core/offline/websocket/resilient_websocket.dart';
 import '../theme/app_theme.dart';
+import '../constants/supabase_config.dart';
 import '../widgets/common_widgets.dart';
 import '../widgets/timeline_connector.dart';
 import '../widgets/timeline_milestone.dart';
@@ -56,14 +57,16 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
 
     _loadOrder();
     _loadTimeline();
-    _subscribeToOrderUpdates();
-    _subscribeToTracking();
+    if (SupabaseConfig.isConfigured) {
+      _subscribeToOrderUpdates();
+      _subscribeToTracking();
+    }
   }
 
   @override
   void dispose() {
     _movementController.dispose();
-    if (_ordersChannel != null) {
+    if (SupabaseConfig.isConfigured && _ordersChannel != null) {
       Supabase.instance.client.removeChannel(_ordersChannel!);
     }
     _trackingSubscription?.cancel();

--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -63,7 +63,9 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   @override
   void dispose() {
     _movementController.dispose();
-    _ordersChannel?.unsubscribe();
+    if (_ordersChannel != null) {
+      Supabase.instance.client.removeChannel(_ordersChannel!);
+    }
     _trackingSubscription?.cancel();
     _trackingWebSocket?.close();
     super.dispose();


### PR DESCRIPTION
Closes #608

`dispose()` was calling `_ordersChannel?.unsubscribe()`, which sends the unsubscribe frame but leaves the channel object in the `SupabaseClient`'s internal channel list. Channels were never removed from the registry, so visiting multiple order tracking screens in one session would accumulate dead channels that continued receiving Postgres Change events and firing `_loadOrder()`/`_loadTimeline()` on stale orders.

Replaced with `Supabase.instance.client.removeChannel(_ordersChannel!)`, which both unsubscribes and removes the channel from the client registry. Same pattern already used in `apps/driver/lib/screens/trips_screen.dart:302-308`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live tracking resource cleanup by only starting and stopping realtime subscriptions when Supabase is properly configured, and by removing realtime channels from the client during disposal to prevent lingering updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->