### PR TITLE
fix(orders): block change-drop when escrow is already funded

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -917,6 +917,12 @@ router.put('/:id/change-drop', authenticate, requireRole(['customer']), validate
     if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
+    if (order.escrow_status === 'funded') {
+      return res.status(409).json({
+        error: 'Drop location cannot be changed after escrow has been funded.',
+        recovery: 'Cancel this order to receive a refund, then rebook with the correct destination.',
+      });
+    }
     if (order.weight_tonnes == null) return res.status(500).json({ error: 'Data inconsistency: Order is missing weight_tonnes.' });
 
     let pricing;

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1808,6 +1808,32 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     expect(stored.drop_lng).toBe(88.88);
   });
 
+  it('blocks change-drop with 409 when escrow is already funded', async () => {
+    m.store.orders.push({
+      id: 'order-funded-1',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-FUNDED-1',
+      pickup_lat: 19.0760,
+      pickup_lng: 72.8777,
+      drop_lat: 28.7041,
+      drop_lng: 77.1025,
+      weight_tonnes: 3,
+      status: 'accepted',
+      escrow_status: 'funded',
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .put('/api/orders/OD-FUNDED-1/change-drop')
+      .set(CUSTOMER_HEADERS)
+      .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).toHaveProperty('recovery');
+  });
+
   it('allows customer to cancel order and returns cancellation_fee and persists reason', async () => {
     m.store.orders.push({
       id: 'order-cancel-1',


### PR DESCRIPTION
Closes #607

The change-drop handler was recalculating and persisting a new `total_amount` without checking whether escrow was already funded. Once `escrowRelease` fires on delivery it releases the original on-chain amount, not the updated total, so the driver payout diverges from the Supabase record.

The `Escrow.sol` contract itself reverts on a second `deposit()` for the same `bookingId` (`"Escrow exists"`), so there's no path to adjust the on-chain amount after funding anyway. The handler now returns 409 early if `escrow_status === 'funded'`, surfacing the constraint explicitly with a recovery hint to cancel and rebook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented changing an order’s drop location after the escrow is marked as funded. Requests are now rejected with an HTTP 409 response, including clear error messaging and recovery guidance.
* **Tests**
  * Added an integration test to confirm `/api/orders/:id/change-drop` is blocked when escrow is already funded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->