### PR TITLE
fix(escrow): correct paisa-to-MATIC conversion — remove 10,000x magnitude error

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -35,3 +35,11 @@ POLYGON_RPC_URL=https://polygon-rpc.com
 REPUTATION_CONTRACT_ADDRESS=0x...
 DELIVERY_RECEIPTS_CONTRACT_ADDRESS=0x...
 RELAYER_WALLET_PRIVATE_KEY=your_private_key
+
+# ── Escrow ────────────────────────────────
+# MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
+# Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004
+# Leave unset to disable on-chain escrow deposits.
+ESCROW_MATIC_PER_PAISA=0.000004
+# Safety cap: reject deposits exceeding this many MATIC
+MAX_ESCROW_MATIC=5

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -40,6 +40,6 @@ RELAYER_WALLET_PRIVATE_KEY=your_private_key
 # MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
 # Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004
 # Leave unset to disable on-chain escrow deposits.
-ESCROW_MATIC_PER_PAISA=0.000004
+ESCROW_MATIC_PER_PAISA=
 # Safety cap: reject deposits exceeding this many MATIC
 MAX_ESCROW_MATIC=5

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -674,8 +674,12 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
         logger.warn('[escrow] ESCROW_MATIC_PER_PAISA not configured — skipping escrow deposit.');
       } else {
         const maticAmount = (bid.bid_amount * maticPerPaisa).toFixed(18);
-        const maxEscrowMatic = parseFloat(process.env.MAX_ESCROW_MATIC || '5');
-        if (parseFloat(maticAmount) > maxEscrowMatic) {
+        const maxEscrowMatic = Number.parseFloat(process.env.MAX_ESCROW_MATIC || '5');
+        if (!Number.isFinite(maxEscrowMatic) || maxEscrowMatic <= 0) {
+          logger.error('[escrow] MAX_ESCROW_MATIC is invalid — refusing deposit.');
+          return res.status(500).json({ error: 'Escrow configuration error. Please contact support.' });
+        }
+        if (Number.parseFloat(maticAmount) > maxEscrowMatic) {
           return res.status(400).json({ error: 'Computed escrow amount exceeds safety cap. Check ESCROW_MATIC_PER_PAISA configuration.' });
         }
         const amountWei = ethers.parseEther(maticAmount);

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -669,23 +669,33 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
     // Phase 1: Escrow deposit BEFORE accepting the bid
     let escrowTxHash = null;
     if (driverWallet && customerWallet) {
-      const amountWei = ethers.parseEther((bid.bid_amount / 100).toFixed(2).toString());
-      try {
-        const { txHash } = await escrowDeposit(order.order_display_id, customerWallet, driverWallet, amountWei);
-        if (txHash) {
-          escrowTxHash = txHash;
-        } else {
+      const maticPerPaisa = parseFloat(process.env.ESCROW_MATIC_PER_PAISA || '0');
+      if (!maticPerPaisa || !isFinite(maticPerPaisa) || maticPerPaisa <= 0) {
+        logger.warn('[escrow] ESCROW_MATIC_PER_PAISA not configured — skipping escrow deposit.');
+      } else {
+        const maticAmount = (bid.bid_amount * maticPerPaisa).toFixed(18);
+        const maxEscrowMatic = parseFloat(process.env.MAX_ESCROW_MATIC || '5');
+        if (parseFloat(maticAmount) > maxEscrowMatic) {
+          return res.status(400).json({ error: 'Computed escrow amount exceeds safety cap. Check ESCROW_MATIC_PER_PAISA configuration.' });
+        }
+        const amountWei = ethers.parseEther(maticAmount);
+        try {
+          const { txHash } = await escrowDeposit(order.order_display_id, customerWallet, driverWallet, amountWei);
+          if (txHash) {
+            escrowTxHash = txHash;
+          } else {
+            return res.status(500).json({
+              error: 'Escrow deposit failed. Bid was not accepted.',
+              recovery: 'Please try again or contact support if the issue persists.'
+            });
+          }
+        } catch (depositErr) {
           return res.status(500).json({
             error: 'Escrow deposit failed. Bid was not accepted.',
-            recovery: 'Please try again or contact support if the issue persists.'
+            details: depositErr.message,
+            recovery: 'Check that the customer wallet has sufficient MATIC balance for the deposit and that the Polygon RPC endpoint is reachable.'
           });
         }
-      } catch (depositErr) {
-        return res.status(500).json({
-          error: 'Escrow deposit failed. Bid was not accepted.',
-          details: depositErr.message,
-          recovery: 'Check that the customer wallet has sufficient MATIC balance for the deposit and that the Polygon RPC endpoint is reachable.'
-        });
       }
     }
 


### PR DESCRIPTION
Closes #606

## What was broken

`bid_amount` is stored in paisa (1 INR = 100 paisa, documented in `lib/pricing.js`). The accept-bid handler was doing:

```js
const amountWei = ethers.parseEther((bid.bid_amount / 100).toFixed(2).toString());
```

`bid_amount / 100` converts paisa to INR. Then `ethers.parseEther(INR_value)` treats that number as MATIC. A ₹5,000 bid (`bid_amount=500000`) would lock **5,000 MATIC** (~$2,000) on-chain for a $60 order.

## Fix

Replaced with a configurable `ESCROW_MATIC_PER_PAISA` env var that holds the explicit INR→MATIC exchange rate at the paisa granularity. If the var is not set the deposit is skipped with a warning (same existing behaviour as a missing wallet address). A `MAX_ESCROW_MATIC` cap rejects any deposit above the configured ceiling before it reaches the chain.

Both variables are documented in `.env.example`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable on-chain escrow deposit support for MATIC, including an environment-defined conversion rate and a maximum deposit cap. Leaving the conversion rate unset disables on-chain escrow deposits.

* **Bug Fixes**
  * Updated escrow deposit calculation during bid acceptance to use the configured conversion rate instead of a fixed formula.
  * Added validation for the maximum allowed MATIC amount, rejecting requests that exceed the cap and only proceeding to escrow transaction creation when inputs are valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->