### PR TITLE
fix: add API key authentication to ML engine microservice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ POSTGRES_DB=truxify
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# 1.5 ML ENGINE (API Key for ML Microservice Authentication)
+# ──────────────────────────────────────────────────────────────────────────────
+# Shared secret used by the API service to authenticate requests to the ML engine.
+# Generate a secure random key and set the same value in both services.
+ML_API_KEY=<generate-a-secure-random-key>
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # 2. MONGODB ATLAS (High-Volume Live GPS Pings, Activity logs, ML Training Data)
 # ──────────────────────────────────────────────────────────────────────────────
 # Full MongoDB connection URI

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -13,25 +13,40 @@ const DEFAULT_ML_SERVICE_URL = 'http://localhost:8001';
  * @param {number} features.nearby_drivers
  * @returns {Promise<object>} response from the ML engine
  */
+function getHeaders() {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (process.env.ML_API_KEY) {
+    headers['X-API-Key'] = process.env.ML_API_KEY;
+  }
+  return headers;
+}
+
+async function handleResponse(response) {
+  if (response.status === 401 || response.status === 403) {
+    const text = await response.text();
+    throw new Error(`ML Engine authentication failed: ${response.status} — check ML_API_KEY configuration`);
+  }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`ML Engine request failed: ${response.statusText} (${text})`);
+  }
+  return response.json();
+}
+
 export async function predictDemand(features) {
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/predict/demand`;
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getHeaders(),
     body: JSON.stringify(features),
     signal: AbortSignal.timeout(5000),
   });
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`ML Engine prediction request failed: ${response.statusText} (${text})`);
-  }
-
-  return response.json();
+  return handleResponse(response);
 }
 
 /**
@@ -51,9 +66,7 @@ export async function predictPrice({ distanceKm, cargoWeightKg, truckType, route
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getHeaders(),
     body: JSON.stringify({
       distance_km: distanceKm,
       cargo_weight_kg: cargoWeightKg,
@@ -64,10 +77,5 @@ export async function predictPrice({ distanceKm, cargoWeightKg, truckType, route
     signal: AbortSignal.timeout(5000),
   });
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`ML Engine price prediction failed: ${response.statusText} (${text})`);
-  }
-
-  return response.json();
+  return handleResponse(response);
 }

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -623,9 +623,13 @@ describe('Bid Routes', () => {
       status: 'pending',
     });
 
-    m.store.profiles.push({ id: 'driver-1', full_name: 'Driver One' });
-    m.store.driver_details.push({ user_id: 'driver-1', rating: 4.9, truck_id: null });
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One', polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' },
+      { id: 'driver-1', full_name: 'Driver One', polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12' },
+    );
+    m.store.driver_details.push({ user_id: 'driver-1', rating: 4.9, truck_id: null, polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12' });
 
+    mockEscrowDeposit.mockResolvedValue({ txHash: '0xescrowtest123' });
     m.programRpcError('Load offer is no longer available');
 
     const app = buildApp();
@@ -660,9 +664,13 @@ describe('Bid Routes', () => {
       status: 'pending',
     });
 
-    m.store.profiles.push({ id: 'driver-1', full_name: 'Driver One' });
-    m.store.driver_details.push({ user_id: 'driver-1', rating: 4.9, truck_id: null });
+    m.store.profiles.push(
+      { id: 'customer-1', full_name: 'Customer One', polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' },
+      { id: 'driver-1', full_name: 'Driver One', polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12' },
+    );
+    m.store.driver_details.push({ user_id: 'driver-1', rating: 4.9, truck_id: null, polygon_wallet_address: '0xAbcdef1234567890Abcdef1234567890Abcdef12' });
 
+    mockEscrowDeposit.mockResolvedValue({ txHash: '0xescrowtest123' });
     m.programRpcError('Order is no longer pending');
 
     const app = buildApp();

--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import os
 from fastapi import FastAPI, HTTPException, Header, Depends
@@ -18,7 +19,7 @@ async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
     ml_api_key = os.environ.get("ML_API_KEY")
     if not ml_api_key:
         return
-    if not x_api_key or x_api_key != ml_api_key:
+    if not x_api_key or not hmac.compare_digest(x_api_key, ml_api_key):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 app = FastAPI(

--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -1,5 +1,6 @@
 import logging
-from fastapi import FastAPI, HTTPException
+import os
+from fastapi import FastAPI, HTTPException, Header, Depends
 from pydantic import BaseModel, Field
 from typing import List, Optional
 
@@ -12,6 +13,13 @@ from .models.price_prediction import predict_price
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
+    ml_api_key = os.environ.get("ML_API_KEY")
+    if not ml_api_key:
+        return
+    if not x_api_key or x_api_key != ml_api_key:
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 app = FastAPI(
     title="Truxify ML Engine",
@@ -54,7 +62,7 @@ class TrainResponse(BaseModel):
 
 
 @app.get("/")
-async def root():
+async def root(_auth=Depends(verify_api_key)):
     return {"message": "Truxify ML Engine is running"}
 
 
@@ -64,7 +72,7 @@ async def health():
 
 
 @app.post("/predict/demand", response_model=DemandForecastOutput)
-async def predict_demand_endpoint(input: DemandForecastInput):
+async def predict_demand_endpoint(input: DemandForecastInput, _auth=Depends(verify_api_key)):
     features = [
         input.hour,
         input.day_of_week,
@@ -85,7 +93,7 @@ async def predict_demand_endpoint(input: DemandForecastInput):
 
 
 @app.post("/predict", response_model=PricePredictOutput)
-async def predict_price_endpoint(input: PricePredictInput):
+async def predict_price_endpoint(input: PricePredictInput, _auth=Depends(verify_api_key)):
     try:
         price = predict_price(
             distance_km=input.distance_km,
@@ -103,7 +111,7 @@ async def predict_price_endpoint(input: PricePredictInput):
 
 
 @app.post("/train/demand", response_model=TrainResponse)
-async def train_demand_endpoint():
+async def train_demand_endpoint(_auth=Depends(verify_api_key)):
     try:
         metrics = train_demand_forecast_model()
         return TrainResponse(status="success", metrics=metrics)
@@ -113,7 +121,7 @@ async def train_demand_endpoint():
 
 
 @app.get("/models")
-async def list_models():
+async def list_models(_auth=Depends(verify_api_key)):
     from .models.base import MODEL_STORAGE_DIR
     import os, json
     models = []

--- a/backend/ml/tests/test_endpoints.py
+++ b/backend/ml/tests/test_endpoints.py
@@ -40,17 +40,25 @@ def test_auth_missing_key(monkeypatch):
     monkeypatch.setenv("ML_API_KEY", "test-secret-key")
     response = client.post("/predict/demand", json=_auth_payload())
     assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
 
 
 def test_auth_invalid_key(monkeypatch):
     monkeypatch.setenv("ML_API_KEY", "test-secret-key")
     response = client.post("/predict/demand", json=_auth_payload(), headers={"X-API-Key": "wrong-key"})
     assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
 
 
 def test_auth_valid_key(monkeypatch):
     monkeypatch.setenv("ML_API_KEY", "test-secret-key")
     response = client.post("/predict/demand", json=_auth_payload(), headers={"X-API-Key": "test-secret-key"})
+    assert response.status_code == 200
+
+
+def test_auth_dev_mode_bypass(monkeypatch):
+    monkeypatch.delenv("ML_API_KEY", raising=False)
+    response = client.post("/predict/demand", json=_auth_payload())
     assert response.status_code == 200
 
 

--- a/backend/ml/tests/test_endpoints.py
+++ b/backend/ml/tests/test_endpoints.py
@@ -25,6 +25,42 @@ def test_health():
     assert response.json() == {"status": "healthy"}
 
 
+def _auth_payload():
+    return {
+        "hour": 15.5,
+        "day_of_week": 4.0,
+        "temperature": 28.0,
+        "precipitation": 0.0,
+        "historical_volume": 35.0,
+        "nearby_drivers": 10.0
+    }
+
+
+def test_auth_missing_key(monkeypatch):
+    monkeypatch.setenv("ML_API_KEY", "test-secret-key")
+    response = client.post("/predict/demand", json=_auth_payload())
+    assert response.status_code == 401
+
+
+def test_auth_invalid_key(monkeypatch):
+    monkeypatch.setenv("ML_API_KEY", "test-secret-key")
+    response = client.post("/predict/demand", json=_auth_payload(), headers={"X-API-Key": "wrong-key"})
+    assert response.status_code == 401
+
+
+def test_auth_valid_key(monkeypatch):
+    monkeypatch.setenv("ML_API_KEY", "test-secret-key")
+    response = client.post("/predict/demand", json=_auth_payload(), headers={"X-API-Key": "test-secret-key"})
+    assert response.status_code == 200
+
+
+def test_health_no_auth_required(monkeypatch):
+    monkeypatch.setenv("ML_API_KEY", "test-secret-key")
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
 def test_train_demand():
     response = client.post("/train/demand")
     assert response.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MONGODB_URI: mongodb://mongo:27017
       MONGODB_DB_NAME: truxify_telemetry
       REDIS_URL: redis://redis:6379
-      ML_API_KEY: ${ML_API_KEY}
+      ML_API_KEY: ${ML_API_KEY:?ML_API_KEY is required}
     volumes:
       - ./backend/api:/app
       - /app/node_modules
@@ -33,7 +33,7 @@ services:
     ports:
       - "8001:8000"
     environment:
-      ML_API_KEY: ${ML_API_KEY}
+      ML_API_KEY: ${ML_API_KEY:?ML_API_KEY is required}
     volumes:
       - ./backend/ml:/app
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       MONGODB_URI: mongodb://mongo:27017
       MONGODB_DB_NAME: truxify_telemetry
       REDIS_URL: redis://redis:6379
+      ML_API_KEY: ${ML_API_KEY}
     volumes:
       - ./backend/api:/app
       - /app/node_modules
@@ -31,6 +32,8 @@ services:
     container_name: truxify-ml-engine
     ports:
       - "8001:8000"
+    environment:
+      ML_API_KEY: ${ML_API_KEY}
     volumes:
       - ./backend/ml:/app
   db:


### PR DESCRIPTION
## Summary

Adds API key authentication to the ML Engine microservice and updates the companion API client to send credentials.

### Changes

#### `backend/ml/app/main.py`
- Added `verify_api_key` FastAPI dependency that reads `ML_API_KEY` from environment and validates `X-API-Key` header
- Applied `Depends(verify_api_key)` to all endpoints: `GET /`, `POST /predict/demand`, `POST /predict`, `POST /train/demand`, `GET /models`
- Kept `GET /health` unauthenticated for Docker health checks
- Returns HTTP 401 with generic "Unauthorized" message (no key format leakage)
- When `ML_API_KEY` is not set, auth is disabled (backward compatible for dev)

#### `backend/api/src/services/ml.js`
- Added `getHeaders()` helper that includes `X-API-Key: <ML_API_KEY>` when the env var is set
- Added `handleResponse()` helper that throws a descriptive error for 401/403 responses
- Both `predictDemand()` and `predictPrice()` use the shared helpers

#### `.env.example`
- Added `ML_API_KEY=<generate-a-secure-random-key>` section

#### `docker-compose.yml`
- Added `ML_API_KEY: ${ML_API_KEY}` to both `api` and `ml-engine` services

#### Tests (`backend/ml/tests/test_endpoints.py`)
- `test_auth_missing_key` — no header returns 401
- `test_auth_invalid_key` — wrong key returns 401
- `test_auth_valid_key` — correct key returns 200
- `test_health_no_auth_required` — health endpoint bypasses auth

Closes #628



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API-key authentication for the ML service’s prediction, training, and model listing endpoints using `X-API-Key` (when `ML_API_KEY` is set). `/health` remains open.
* **Chores**
  * Updated the example environment and container setup to configure `ML_API_KEY` for both the API and ML engine.
* **Bug Fixes**
  * Standardized ML request headers and centralized response/error handling for clearer authentication and non-success failures.
* **Tests**
  * Added authentication and `/health` endpoint coverage; updated bid acceptance integration tests to seed required wallet/escrow prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->