### PR TITLE
fix : added 401 response for requireRole missing req.user

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -181,7 +181,7 @@ export async function authenticate(req, res, next) {
 export function requireRole(allowedRoles) {
   return (req, res, next) => {
     if (!req.user) {
-      return res.status(501).json({ error: 'Security middleware configuration error.' });
+      return res.status(401).json({ error: 'Security middleware configuration error.' });
     }
 
     if (!allowedRoles.includes(req.user.role)) {

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -537,7 +537,7 @@ describe('requireRole middleware', () => {
     vi.resetModules();
   });
 
-  it('returns 501 when req.user is not set', async () => {
+  it('returns 401 when req.user is not set', async () => {
     vi.doMock('../../src/config/db.js', () => ({
       firebaseAdmin: null,
       supabase: null,
@@ -554,7 +554,7 @@ describe('requireRole middleware', () => {
 
     middleware(req, res, vi.fn());
 
-    expect(res.status).toHaveBeenCalledWith(501);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it('returns 403 when user role is not in allowedRoles', async () => {


### PR DESCRIPTION
Closes #645.

Summary of What Has Been Done:
Fixed the requireRole() middleware in backend/api/src/middleware/auth.js to return HTTP 401 (Unauthorized) instead of 501 (Not Implemented) when req.user is missing. Updated the existing unit test that was asserting the incorrect 501 status to now assert 401.

Changes Made:
- backend/api/src/middleware/auth.js: Changed status 501 to 401 in requireRole guard
- backend/api/test/unit/auth.test.js: Updated test title and expected status from 501 to 401

Impact it Made:
- Correct HTTP semantics — clients receive 401 when unauthenticated, consistent with the authenticate middleware
- All 194 unit tests pass
- No breaking changes to other functionality

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication middleware to return the correct HTTP 401 (Unauthorized) status code instead of 501 (Server Error) when user authentication information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->