### PR TITLE
fix : added error logging in osrm.js fetch catch block

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -75,7 +75,8 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
     }
     return result;
     
-  } catch {
+  } catch (err) {
+    logger.error('[osrm] Fetch error:', err.message);
     return null;
   } finally {
     clearTimeout(timeout);

--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -5,8 +5,18 @@ const mockRedis = vi.hoisted(() => ({
   set: vi.fn(),
 }));
 
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
 vi.mock('../../src/config/db.js', () => ({
   redisClient: mockRedis,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
 }));
 
 import { getRouteEstimate, __testing } from '../../src/services/osrm.js';
@@ -182,6 +192,7 @@ describe('osrm - getRouteEstimate', () => {
     });
 
     expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith('[osrm] Fetch error:', 'AbortError');
   });
 
   it('uses OSRM_TIMEOUT_MS env variable', async () => {
@@ -255,6 +266,7 @@ describe('osrm - getRouteEstimate', () => {
 
     expect(result).toEqual({ distanceKm: 20, durationSeconds: 900 });
     expect(fetch).toHaveBeenCalledOnce();
+    expect(mockLogger.error).toHaveBeenCalledWith('[osrm] Redis get error:', 'Redis connection refused');
   });
 
   it('returns result even when Redis set throws after successful OSRM response', async () => {
@@ -269,6 +281,7 @@ describe('osrm - getRouteEstimate', () => {
     });
 
     expect(result).toEqual({ distanceKm: 10, durationSeconds: 600 });
+    expect(mockLogger.error).toHaveBeenCalledWith('[osrm] Redis set error:', 'Redis write failed');
   });
 
   it('does not cache null when OSRM returns a non-ok response', async () => {


### PR DESCRIPTION
Closes #646.

Summary of What Has Been Done:
Replaced the bare catch {} block in backend/api/src/services/osrm.js with catch (err) that calls logger.error('[osrm] Fetch error:', err.message), making OSRM fetch failures visible for debugging.

Changes Made:
- backend/api/src/services/osrm.js: Changed bare catch {} to catch (err) with logger.error call

Impact it Made:
- Operational visibility into OSRM routing API failures
- Consistent error handling pattern with other services in the codebase
- All 194 unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OSRM route estimation error handling by capturing fetch failures and logging clear error messages (while still returning no result on error). Also ensures request timeouts are handled as before.
* **Tests**
  * Expanded unit tests to mock logging and assert the correct error messages for OSRM fetch failures and Redis get/set error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->