### PR TITLE
perf(auth): cache supabase profile lookups bounded by token expiry

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -4,6 +4,7 @@ import logger from '../middleware/logger.js';
 export const TTL_SECONDS = 900; // 15 minutes
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 const cacheKey = (firebaseUid) => `user:profile:${firebaseUid}`;
+const supabaseCacheKey = (userId) => `user:profile:sb:${userId}`;
 
 const LAST_LOG_TIMES = {};
 const LOG_THROTTLE_INTERVAL_MS = 60000; // 60 seconds
@@ -65,9 +66,38 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
 }
 
 /**
+ * Validates the shape of a cached Supabase profile.
+ *
+ * Supabase identities are keyed by the profile UUID (req.user.id) rather than
+ * a Firebase UID, so the identity field checked here is `id`.
+ *
+ * @param {string} userId - The expected Supabase profile UUID.
+ * @param {any} cachedProfile - The cached profile to validate.
+ * @returns {boolean} True if the cached profile shape is valid, false otherwise.
+ */
+export function isValidCachedSupabaseProfile(userId, cachedProfile) {
+  if (!cachedProfile || typeof cachedProfile !== 'object' || Array.isArray(cachedProfile)) {
+    return false;
+  }
+  if (typeof cachedProfile.isActive !== 'boolean') {
+    return false;
+  }
+  if (cachedProfile.isActive === false) {
+    return true; // Valid tombstone
+  }
+  return (
+    cachedProfile.isActive === true &&
+    cachedProfile.id === userId &&
+    typeof cachedProfile.role === 'string' &&
+    (cachedProfile.fullName === undefined || cachedProfile.fullName === null || typeof cachedProfile.fullName === 'string') &&
+    (cachedProfile.phone === undefined || cachedProfile.phone === null || typeof cachedProfile.phone === 'string')
+  );
+}
+
+/**
  * Retrieves a user profile from the Redis cache.
  * Falls back to null on cache miss or Redis error.
- * 
+ *
  * @param {string} firebaseUid - The Firebase UID of the user.
  * @returns {Promise<object|null>} The parsed cached profile, or null.
  */
@@ -121,5 +151,67 @@ export async function invalidateCachedProfile(firebaseUid) {
     await redisClient.del(cacheKey(firebaseUid));
   } catch (err) {
     logCacheError('invalidateCachedProfile', err);
+  }
+}
+
+/**
+ * Retrieves a Supabase user profile from the Redis cache.
+ * Falls back to null on cache miss or Redis error.
+ *
+ * @param {string} userId - The Supabase profile UUID.
+ * @returns {Promise<object|null>} The parsed cached profile, or null.
+ */
+export async function getCachedSupabaseProfile(userId) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !userId) return null;
+  try {
+    const raw = await redisClient.get(supabaseCacheKey(userId));
+    return raw ? JSON.parse(raw) : null;
+  } catch (err) {
+    logCacheError('getCachedSupabaseProfile', err);
+    try {
+      await redisClient.del(supabaseCacheKey(userId));
+    } catch (delErr) {
+      // Ignore failures on background cleanup deletion
+    }
+    return null;
+  }
+}
+
+/**
+ * Stores a Supabase user profile in the Redis cache.
+ * Gracefully handles Redis errors.
+ *
+ * @param {string} userId - The Supabase profile UUID.
+ * @param {object} profile - The user profile object to cache.
+ * @param {number} [ttlSeconds] - TTL in seconds; callers should clamp this to
+ *   the access token's remaining lifetime so a revoked session cannot outlive
+ *   its token.
+ * @returns {Promise<void>}
+ */
+export async function setCachedSupabaseProfile(userId, profile, ttlSeconds = TTL_SECONDS) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !userId || !profile || ttlSeconds <= 0) return;
+  try {
+    await redisClient.set(supabaseCacheKey(userId), JSON.stringify(profile), 'EX', ttlSeconds);
+  } catch (err) {
+    logCacheError('setCachedSupabaseProfile', err);
+  }
+}
+
+/**
+ * Invalidates (deletes) a cached Supabase user profile from Redis.
+ * Gracefully handles Redis errors.
+ *
+ * @param {string} userId - The Supabase profile UUID.
+ * @returns {Promise<void>}
+ */
+export async function invalidateCachedSupabaseProfile(userId) {
+  const redisClient = getRedisClient();
+  if (!redisClient || !userId) return;
+  try {
+    await redisClient.del(supabaseCacheKey(userId));
+  } catch (err) {
+    logCacheError('invalidateCachedSupabaseProfile', err);
   }
 }

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -1,6 +1,6 @@
 import { firebaseAdmin, supabase } from '../config/db.js';
 import jwt from 'jsonwebtoken';
-import { getCachedProfile, setCachedProfile, invalidateCachedProfile, TOMBSTONE_TTL_SECONDS, isValidCachedProfile } from '../lib/profileCache.js';
+import { getCachedProfile, setCachedProfile, invalidateCachedProfile, TOMBSTONE_TTL_SECONDS, TTL_SECONDS, isValidCachedProfile, getCachedSupabaseProfile, setCachedSupabaseProfile, invalidateCachedSupabaseProfile, isValidCachedSupabaseProfile } from '../lib/profileCache.js';
 import logger from './logger.js';
 
 /**
@@ -63,6 +63,7 @@ export async function authenticate(req, res, next) {
     let userProfile = null;
     let decoded = null;
     let firebaseUid = null;
+    let supabaseUserId = null;
 
     try {
       decoded = jwt.decode(token);
@@ -79,6 +80,25 @@ export async function authenticate(req, res, next) {
       const { data: { user }, error: authError } = await supabase.auth.getUser(token);
       if (authError || !user) {
         return res.status(401).json({ error: 'Invalid or expired Supabase authentication token.', details: authError?.message });
+      }
+      supabaseUserId = user.id;
+
+      // Token is verified above; the cache only skips the profile lookup, keyed
+      // by the verified user id. Cache entries are bounded by the token's own
+      // expiry (see TTL calculation below) so a revoked session cannot be served.
+      const cachedProfile = await getCachedSupabaseProfile(supabaseUserId);
+      if (cachedProfile) {
+        if (!isValidCachedSupabaseProfile(supabaseUserId, cachedProfile)) {
+          void invalidateCachedSupabaseProfile(supabaseUserId);
+        } else if (cachedProfile.isActive === false) {
+          return res.status(403).json({
+            error: 'User profile not found in database.',
+            hint: 'Register user in profiles table first.'
+          });
+        } else {
+          req.user = cachedProfile;
+          return next();
+        }
       }
 
       // Fetch corresponding profile from Supabase by user.id
@@ -146,9 +166,12 @@ export async function authenticate(req, res, next) {
         // Cache the inactive/not-found status as a tombstone to prevent DB load on subsequent requests
         void setCachedProfile(firebaseUid, { isActive: false }, TOMBSTONE_TTL_SECONDS);
       }
-      return res.status(403).json({ 
-        error: 'User profile not found in database.', 
-        hint: 'Register user in profiles table first.' 
+      if (supabaseUserId) {
+        void setCachedSupabaseProfile(supabaseUserId, { isActive: false }, TOMBSTONE_TTL_SECONDS);
+      }
+      return res.status(403).json({
+        error: 'User profile not found in database.',
+        hint: 'Register user in profiles table first.'
       });
     }
 
@@ -165,6 +188,15 @@ export async function authenticate(req, res, next) {
     // Populate cache on successful DB fetch (fire-and-forget to avoid delaying the request critical path)
     if (userProfile.firebase_uid) {
       void setCachedProfile(userProfile.firebase_uid, req.user);
+    }
+    if (supabaseUserId) {
+      // Clamp the cache lifetime to the token's remaining validity so a cached
+      // profile can never outlive the access token that authorised it.
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const ttlSeconds = Number.isFinite(decoded?.exp)
+        ? Math.min(TTL_SECONDS, decoded.exp - nowSeconds)
+        : TTL_SECONDS;
+      void setCachedSupabaseProfile(supabaseUserId, req.user, ttlSeconds);
     }
 
     next();

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -7,7 +7,7 @@ import {
 } from '../services/profileService.js';
 import { supabase } from '../config/db.js';
 import { ProfileModel } from '../models/ProfileModel.js';
-import { invalidateCachedProfile } from '../lib/profileCache.js';
+import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
 
 const router = express.Router();
 
@@ -108,6 +108,9 @@ router.put('/wallet', authenticate, async (req, res) => {
     if (req.user && req.user.uid) {
       void invalidateCachedProfile(req.user.uid);
     }
+    if (req.user && req.user.id) {
+      void invalidateCachedSupabaseProfile(req.user.id);
+    }
 
     res.json({ success: true, walletAddress: normalized });
   } catch (err) {
@@ -152,6 +155,9 @@ router.put('/', authenticate, async (req, res) => {
     // response payload, fire-and-forget is the optimal choice.
     if (req.user && req.user.uid) {
       void invalidateCachedProfile(req.user.uid);
+    }
+    if (req.user && req.user.id) {
+      void invalidateCachedSupabaseProfile(req.user.id);
     }
 
     res.json({
@@ -198,6 +204,9 @@ router.put('/fcm-token', authenticate, async (req, res) => {
     // Invalidate Redis cache — next request will refetch the profile with the new token
     if (req.user.uid) {
       void invalidateCachedProfile(req.user.uid);
+    }
+    if (req.user.id) {
+      void invalidateCachedSupabaseProfile(req.user.id);
     }
 
     return res.json({ success: true, message: 'FCM token updated successfully.' });

--- a/backend/api/test/integration/fcmToken.test.js
+++ b/backend/api/test/integration/fcmToken.test.js
@@ -18,6 +18,7 @@ const supabaseUpdateMock = vi.fn();
 
 vi.mock('../../src/lib/profileCache.js', () => ({
   invalidateCachedProfile: invalidateCachedProfileMock,
+  invalidateCachedSupabaseProfile: vi.fn().mockResolvedValue(undefined),
   getCachedProfile: vi.fn().mockResolvedValue(null),
   setCachedProfile: vi.fn().mockResolvedValue(undefined),
   isValidCachedProfile: vi.fn().mockReturnValue(true),

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -4,6 +4,7 @@ import express from 'express';
 
 vi.mock('../../src/lib/profileCache.js', () => ({
   invalidateCachedProfile: vi.fn(),
+  invalidateCachedSupabaseProfile: vi.fn(),
   getCachedProfile: vi.fn(),
   setCachedProfile: vi.fn(),
 }));

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -990,4 +990,114 @@ describe('authenticate middleware - Redis caching', () => {
       isActive: true
     });
   });
+
+  it('serves a supabase profile from cache and skips the profiles query', async () => {
+    const token = jwt.sign({ iss: 'https://test.supabase.co/auth/v1' }, 'secret');
+    const cached = {
+      id: 'supabase-user-uuid',
+      uid: null,
+      role: 'customer',
+      fullName: 'Cached Supa',
+      phone: '+911111111111',
+      isActive: true,
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(cached)),
+      set: vi.fn().mockResolvedValue('OK'),
+    };
+
+    const fromSpy = vi.fn();
+    const supabaseMock = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'supabase-user-uuid' } },
+          error: null,
+        }),
+      },
+      from: fromSpy,
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: {},
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(redisClientMock.get).toHaveBeenCalledWith('user:profile:sb:supabase-user-uuid');
+    expect(fromSpy).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(cached);
+  });
+
+  it('caches a supabase profile bounded by the token expiry', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const expSeconds = nowSeconds + 120; // token expires in 2 minutes
+    const token = jwt.sign(
+      { iss: 'https://test.supabase.co/auth/v1', exp: expSeconds },
+      'secret'
+    );
+
+    const dbProfile = {
+      id: 'supabase-user-uuid',
+      firebase_uid: null,
+      role: 'customer',
+      full_name: 'Fresh Supa',
+      phone: '+912222222222',
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue('OK'),
+    };
+
+    const supabaseMock = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'supabase-user-uuid' } },
+          error: null,
+        }),
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: dbProfile, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: {},
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const setCall = redisClientMock.set.mock.calls.find(
+      ([key]) => key === 'user:profile:sb:supabase-user-uuid'
+    );
+    expect(setCall).toBeDefined();
+    const ttl = setCall[3];
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(120);
+  });
 });


### PR DESCRIPTION
Fixes #643

## What

The supabase token branch in `authenticate` did a `supabase.auth.getUser(token)` plus a `profiles` query on every request, with no caching. The firebase branch already has a Redis profile cache. The customer Flutter app authenticates with supabase sessions (`api_client.dart` sends the supabase access token), so the uncached branch is the one carrying most traffic.

## Change

Added supabase variants to `profileCache.js` (`getCachedSupabaseProfile` / `setCachedSupabaseProfile` / `invalidateCachedSupabaseProfile` / `isValidCachedSupabaseProfile`), keyed by the profile UUID under `user:profile:sb:<id>`. In `authenticate`, on a cache hit the profiles query is skipped; on a miss the profile is cached (with a tombstone for not-found).

Two things I was careful about:
- The cache is only read **after** `getUser` verifies the token. I did not skip `getUser`, because the token signature isn't verified locally (no JWT secret configured), so trusting an unverified `sub` for the cache key would be an auth bypass. This still removes the second round-trip (the profiles query) and adds negative caching.
- The cache TTL is clamped to the token's remaining lifetime (`min(TTL_SECONDS, exp - now)`) so a cached profile can't outlive the token that authorised it.

Profile mutation routes now invalidate the supabase cache entry next to the existing firebase invalidation.

Skipping `getUser` entirely via local JWT verification would need a `SUPABASE_JWT_SECRET` and is a separate change.

## Testing

- Added auth unit tests: cache hit skips the profiles query; miss caches with an exp-bounded TTL.
- Updated the two profile-route integration mocks to expose the new export.
- `npm test` -> 427 passing.

## Checklist

- [x] Code builds successfully (Node.js starts)
- [x] JavaScript formatting consistent with surrounding code
- [x] No unnecessary files included
- [ ] Documentation updated if needed (n/a)
- [x] Changes tested locally
- [x] PR linked to an active issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile cache management to ensure data consistency during authentication and after profile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->