### PR TITLE
fix(db): prefer SUPABASE_ANON_KEY over service role key for public cl…

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -10,12 +10,15 @@ import logger from '../middleware/logger.js';
 dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
 
 // ============================================================================
-// 1. SUPABASE CLIENT
+// 1. SUPABASE CLIENTS — anon key for public access (RLS enforced),
+//    service role key for admin operations only (bypasses RLS)
 // ============================================================================
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+const supabaseKey = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 export let supabase = null;
+export let supabaseAdmin = null;
 
 if (supabaseUrl && supabaseKey) {
   try {
@@ -25,12 +28,26 @@ if (supabaseUrl && supabaseKey) {
         autoRefreshToken: false,
       }
     });
-    logger.info('Supabase client initialized successfully.');
+    logger.info('Supabase client initialized successfully (anon key).');
   } catch (error) {
     logger.error({ err: error }, 'Failed to initialize Supabase client');
   }
 } else {
   logger.warn('SUPABASE_URL or keys not found in .env. Supabase integration disabled.');
+}
+
+if (supabaseUrl && supabaseServiceKey && supabaseServiceKey !== supabaseKey) {
+  try {
+    supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      }
+    });
+    logger.info('Supabase admin client initialized successfully (service role key).');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to initialize Supabase admin client');
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

`db.js` uses `SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY` for the public Supabase client. The service role key bypasses Row Level Security, meaning the public API has full database access even when RLS rules are configured.

## Changes

- Swapped priority to `SUPABASE_ANON_KEY || SUPABASE_SERVICE_ROLE_KEY` so the anon key is preferred
- Added a separate `supabaseAdmin` client that explicitly uses the service role key for admin operations that need RLS bypass
- `supabase` (public client) now uses only the anon key

## Testing

- Verified public client uses anon key when both env vars are set
- Verified public client falls back to service role key when anon key is unset (backward compat)
- Admin client always uses service role key

Closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved database connection initialization with enhanced error handling and logging for missing configuration
  * Optimized client creation to activate only when required environment variables are present
  * Added support for admin-level database operations with independent initialization tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->