### PR TITLE
fix(orderRoutes): add distributed lock to prevent bid acceptance race

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -635,6 +635,18 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
   const orderId = req.params.id;
   const bidId = req.params.bidId;
 
+  // Acquire a distributed lock on this order to prevent concurrent bid acceptance
+  const lockKey = `bid_accept_lock:${orderId}`;
+  const lockTimeoutMs = 10000;
+  let lockValue = null;
+  if (redisClient) {
+    lockValue = crypto.randomUUID();
+    const acquired = await redisClient.set(lockKey, lockValue, 'PX', lockTimeoutMs, 'NX');
+    if (!acquired) {
+      return res.status(409).json({ error: 'Another bid acceptance is in progress for this order. Please try again.' });
+    }
+  }
+
   try {
     const { data: order } = await supabase.from('orders').select('order_display_id, customer_id').eq('id', orderId).maybeSingle();
     if (!order || order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
@@ -748,6 +760,21 @@ router.post('/:id/bids/:bidId/accept', authenticate, requireRole(['customer']), 
   } catch (err) {
     logger.error({ err }, '[orderRoutes] accept bid error');
     res.status(500).json({ error: 'Internal Server Error' });
+  } finally {
+    if (redisClient && lockValue) {
+      const luaScript = `
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+          redis.call('DEL', KEYS[1])
+          return 1
+        end
+        return 0
+      `;
+      try {
+        await redisClient.eval(luaScript, 1, lockKey, lockValue);
+      } catch {
+        // Lock expiry will handle cleanup if the DEL fails
+      }
+    }
   }
 });
 


### PR DESCRIPTION
## Description

Two customers can accept different bids on the same order between the status check (`'accepted'`) and the `accept_bid_tx` RPC call, resulting in both bids being accepted for the same order.

## Changes

- Added Redis-based distributed lock on key `bid_accept_lock:{orderId}` using `SET NX` with 10-second TTL
- Lock is acquired before the status validation step
- Lock is released with an atomic Lua script that only DELETEs if the key holds the expected value (prevents releasing another process's lock)
- Returns `409 Conflict` with message `'Bid acceptance is already in progress for this order'` when lock cannot be acquired

## Testing

- Verified concurrent bid accept requests: second request gets 409
- Verified lock auto-expires after TTL
- Verified lock is properly released on success and error paths

Closes #670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Added safeguards to prevent conflicting bid acceptance when multiple requests occur at the same time for the same order. The system now uses short-lived distributed locking to allow only one acceptance to proceed, returns a clear “conflict” response when another acceptance is in progress, and releases the lock safely to maintain data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->