### PR TITLE
fix : added correct JSDoc @param type in isValidCachedProfile()

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -41,7 +41,7 @@ function getRedisClient() {
  * Validates the shape of a cached profile.
  * 
  * @param {string} firebaseUid - The expected Firebase UID.
- * @param {any} cachedProfile - The cached profile to validate.
+ * @param {object|null} cachedProfile - The cached profile to validate.
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedProfile(firebaseUid, cachedProfile) {


### PR DESCRIPTION
Closes #678.

Summary of What Has Been Done:
Updated the JSDoc @param annotation on isValidCachedProfile() in backend/api/src/lib/profileCache.js from @param {any} to @param {object|null}, accurately reflecting the runtime behavior where the function guards against null/undefined with !cachedProfile as its first check.

Changes Made:
- backend/api/src/lib/profileCache.js: Changed @param {any} cachedProfile to @param {object|null} cachedProfile

Impact it Made:
- JSDoc now matches actual runtime behavior
- Improves developer tooling and type-checking accuracy
- Verified: npm run test:unit passes (216 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type annotations for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->