### PR TITLE
test : added unit tests for profileService.js

### DIFF
--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for backend/api/src/services/profileService.js
+ *
+ * Coverage:
+ *   - getProfile returns test fallback when supabase is null
+ *   - getProfile calls supabase.from('profiles').select('*').eq('id', userId).maybeSingle()
+ *   - getProfile throws when supabase query returns an error
+ *   - getCustomerStats returns zero-values fallback when supabase is null
+ *   - getCustomerStats queries customer_stats table correctly
+ *   - getDriverDetails returns fallback when supabase is null
+ *   - getDriverDetails queries driver_details table correctly
+ *
+ * Run with:  npm run test:unit -- test/unit/profileService.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// supabaseRef is an object whose .current property we mutate in beforeEach.
+// vi.mock runs once; the factory captures a live reference to supabaseRef so
+// the module always sees the current value when it reads supabase.current.
+const supabaseRef = vi.hoisted(() => ({ current: null }));
+
+vi.mock('../../src/config/db.js', () => ({
+  get supabase() { return supabaseRef.current; },
+}));
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { getProfile, getCustomerStats, getDriverDetails } from '../../src/services/profileService.js';
+
+describe('getProfile', () => {
+  beforeEach(() => {
+    supabaseRef.current = null;
+  });
+
+  it('returns a test fallback when supabase is not configured', async () => {
+    const result = await getProfile('user-123');
+    expect(result).toEqual({
+      id: 'user-123',
+      firebase_uid: 'test',
+      role: 'customer',
+      full_name: 'Test User',
+      phone: '+919999999999',
+    });
+  });
+
+  it('calls supabase.from("profiles").select("*").eq("id", userId).maybeSingle()', async () => {
+    const maybeSingleSpy = vi.fn().mockResolvedValue({ data: { id: 'user-123', role: 'driver' }, error: null });
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: maybeSingleSpy,
+    };
+    const result = await getProfile('user-123');
+    expect(supabaseRef.current.from).toHaveBeenCalledWith('profiles');
+    expect(supabaseRef.current.select).toHaveBeenCalledWith('*');
+    expect(supabaseRef.current.eq).toHaveBeenCalledWith('id', 'user-123');
+    expect(maybeSingleSpy).toHaveBeenCalled();
+    expect(result.role).toBe('driver');
+  });
+
+  it('throws when supabase query returns an error', async () => {
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    };
+    await expect(getProfile('user-123')).rejects.toThrow('DB error');
+  });
+});
+
+describe('getCustomerStats', () => {
+  beforeEach(() => {
+    supabaseRef.current = null;
+  });
+
+  it('returns zero-values fallback when supabase is not configured', async () => {
+    const result = await getCustomerStats('user-123');
+    expect(result).toEqual({ total_orders: 0, total_saved: 0, co2_reduced_kg: 0 });
+  });
+
+  it('calls supabase.from("customer_stats").select("*").eq("user_id", userId).maybeSingle()', async () => {
+    const maybeSingleSpy = vi.fn().mockResolvedValue({ data: { total_orders: 42 }, error: null });
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: maybeSingleSpy,
+    };
+    await getCustomerStats('user-456');
+    expect(supabaseRef.current.from).toHaveBeenCalledWith('customer_stats');
+    expect(supabaseRef.current.eq).toHaveBeenCalledWith('user_id', 'user-456');
+  });
+
+  it('throws when supabase returns an error', async () => {
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'Table not found' } }),
+    };
+    await expect(getCustomerStats('user-123')).rejects.toThrow('Table not found');
+  });
+});
+
+describe('getDriverDetails', () => {
+  beforeEach(() => {
+    supabaseRef.current = null;
+  });
+
+  it('returns fallback when supabase is not configured', async () => {
+    const result = await getDriverDetails('driver-789');
+    expect(result).toMatchObject({
+      truck_id: null,
+      rating: 0,
+      total_trips: 0,
+      completion_rate: 0,
+      is_online: false,
+    });
+  });
+
+  it('calls supabase.from("driver_details").select("*").eq("user_id", userId).maybeSingle()', async () => {
+    const maybeSingleSpy = vi.fn().mockResolvedValue({ data: { rating: 4.8 }, error: null });
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: maybeSingleSpy,
+    };
+    await getDriverDetails('driver-999');
+    expect(supabaseRef.current.from).toHaveBeenCalledWith('driver_details');
+    expect(supabaseRef.current.eq).toHaveBeenCalledWith('user_id', 'driver-999');
+  });
+
+  it('throws when supabase returns an error', async () => {
+    supabaseRef.current = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'Query failed' } }),
+    };
+    await expect(getDriverDetails('driver-123')).rejects.toThrow('Query failed');
+  });
+});


### PR DESCRIPTION
Closes #683.

Summary of What Has Been Done:
Added a new unit test file at backend/api/test/unit/profileService.test.js covering the three exported functions from services/profileService.js: getProfile, getCustomerStats, and getDriverDetails. Coverage includes: graceful fallback when Supabase is not configured (returns test fixture / zero-values), correct Supabase query construction for each function, and error propagation when Supabase returns an error. Uses vi.hoisted + getter pattern for supabase mocking.

Changes Made:
- backend/api/test/unit/profileService.test.js: New test file (146 lines, 9 tests)

Impact it Made:
- Fills a test coverage gap in the services layer
- Verified: npm run test:unit passes (225 tests, 12 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for profile service functionality covering configuration scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->