### PR TITLE
[fix]: Sync profiles after registering device token

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -25,13 +25,28 @@ export async function registerDeviceToken(req, res) {
       user_id: userId,
       fcm_token: fcmToken,
       platform: platform || 'android'
-    });
+    }, { onConflict: 'user_id' });
 
     if (error) {
       logger.error('[DeviceController] Failed to register device token in database:', error.message);
       return res.status(500).json({
         error: 'Failed to register device'
       });
+    }
+    
+    const { error: profileSyncError } = await supabase
+      .from('profiles')
+      .update({
+        fcm_token: fcmToken,
+        fcm_token_updated_at: new Date().toISOString(),
+      })
+      .eq('id', userId);
+
+    if (profileSyncError) {
+      logger.error(
+        '[DeviceController] Device token saved but failed to sync profiles.fcm_token:',
+        profileSyncError.message
+      );
     }
 
     return res.json({


### PR DESCRIPTION
Added profile synchronization after device token registration.

The fix: keep` user_devices` as the multi-device store, but also mirror the token onto `profiles.fcm_token` (which is what `notificationService.js` actually reads), so notifications work no matter which endpoint the client used to register.

Fixes #655 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device token registration to ensure push notification credentials are properly synchronized across user accounts for more reliable notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->