### PR TITLE
[Fix]: Fixing zod schema

### DIFF
--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -1,10 +1,13 @@
 import express from 'express';
 import { registerDeviceToken } from '../controllers/deviceController.js';
 import { authenticate } from '../middleware/auth.js';
+import { validateBody } from '../middleware/validate.js';
+import { registerDeviceSchema } from '../validation/requestSchemas.js';
+import { deviceLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
 // POST /api/devices/register
-router.post('/register', authenticate, registerDeviceToken);
+router.post('/register', authenticate, deviceLimiter, validateBody(registerDeviceSchema), registerDeviceToken);
 
 export default router;

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -133,3 +133,12 @@ export const cancelOrderSchema = z.object({
 export const updateWalletSchema = z.object({
   wallet_address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x-prefixed 42-character wallet address'),
 }).passthrough();
+
+export const registerDeviceSchema = z.object({
+  fcmToken: z.string()
+    .min(4, { message: 'fcmToken must be at least 4 characters' })
+    .max(4096, { message: 'fcmToken is too long' }),
+  platform: z.enum(['android', 'ios', 'web'], {
+    invalid_type_error: 'platform must be one of: android, ios, web',
+  }).default('android'),
+}).passthrough();

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -136,7 +136,7 @@ export const updateWalletSchema = z.object({
 
 export const registerDeviceSchema = z.object({
   fcmToken: z.string()
-    .min(4, { message: 'fcmToken must be at least 4 characters' })
+    .min(10, { message: 'fcmToken must be at least 10 characters' })
     .max(4096, { message: 'fcmToken is too long' }),
   platform: z.enum(['android', 'ios', 'web'], {
     invalid_type_error: 'platform must be one of: android, ios, web',

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -84,7 +84,22 @@ describe('Device Routes Integration Tests', () => {
         .send({ platform: 'android' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe('fcmToken is required');
+      expect(res.body.error).toBe('Validation failed');
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'fcmToken' }),
+        ])
+      );
+    });
+
+    it('returns 400 if platform is not one of the allowed values', async () => {
+      const res = await request(buildApp())
+        .post('/api/devices/register')
+        .set(CUSTOMER_HEADERS)
+        .send({ fcmToken: 'token123', platform: 'smart-fridge' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
     });
 
     it('returns 500 if database upsert fails and does not expose internal error details', async () => {

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -96,7 +96,7 @@ describe('Device Routes Integration Tests', () => {
       const res = await request(buildApp())
         .post('/api/devices/register')
         .set(CUSTOMER_HEADERS)
-        .send({ fcmToken: 'token123', platform: 'smart-fridge' });
+        .send({ fcmToken: 'token1234567890', platform: 'smart-fridge' });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('Validation failed');

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -39,7 +39,7 @@ describe('Device Routes Integration Tests', () => {
     it('returns 401 if x-user-id header is missing when BYPASS_AUTH is enabled', async () => {
       const res = await request(buildApp())
         .post('/api/devices/register')
-        .send({ fcmToken: 'token123', platform: 'ios' });
+        .send({ fcmToken: 'token1234567890', platform: 'ios' });
 
       expect(res.status).toBe(401);
       expect(res.body.error).toBe('Authentication bypassed but x-user-id header is missing.');
@@ -49,7 +49,7 @@ describe('Device Routes Integration Tests', () => {
       const res = await request(buildApp())
         .post('/api/devices/register')
         .set(CUSTOMER_HEADERS)
-        .send({ fcmToken: 'token123', platform: 'ios' });
+        .send({ fcmToken: 'token1234567890', platform: 'ios' });
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
@@ -60,7 +60,7 @@ describe('Device Routes Integration Tests', () => {
       // Verify the record was stored in user_devices table
       const stored = m.store.user_devices.find(d => d.user_id === 'customer-uuid-123');
       expect(stored).toBeTruthy();
-      expect(stored.fcm_token).toBe('token123');
+      expect(stored.fcm_token).toBe('token1234567890');
       expect(stored.platform).toBe('ios');
     });
 
@@ -68,12 +68,12 @@ describe('Device Routes Integration Tests', () => {
       const res = await request(buildApp())
         .post('/api/devices/register')
         .set(CUSTOMER_HEADERS)
-        .send({ fcmToken: 'token999' });
+        .send({ fcmToken: 'token9999999999' });
 
       expect(res.status).toBe(200);
       const stored = m.store.user_devices.find(d => d.user_id === 'customer-uuid-123');
       expect(stored).toBeTruthy();
-      expect(stored.fcm_token).toBe('token999');
+      expect(stored.fcm_token).toBe('token9999999999');
       expect(stored.platform).toBe('android');
     });
 
@@ -108,7 +108,7 @@ describe('Device Routes Integration Tests', () => {
       const res = await request(buildApp())
         .post('/api/devices/register')
         .set(CUSTOMER_HEADERS)
-        .send({ fcmToken: 'token_err' });
+        .send({ fcmToken: 'token_err_database' });
 
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('Failed to register device');
@@ -126,7 +126,7 @@ describe('Device Routes Integration Tests', () => {
         const res = await request(app)
           .post('/api/devices/register')
           .set(headers)
-          .send({ fcmToken: `token-${i}` });
+          .send({ fcmToken: `token-${i}-1234567890` });
         expect(res.status).toBe(200);
       }
 
@@ -134,7 +134,7 @@ describe('Device Routes Integration Tests', () => {
       const res = await request(app)
         .post('/api/devices/register')
         .set(headers)
-        .send({ fcmToken: 'token-11' });
+        .send({ fcmToken: 'token-11-1234567890' });
 
       expect(res.status).toBe(429);
       expect(res.body.error).toBe('Rate limit exceeded');


### PR DESCRIPTION
Added a schema and wire it through validateBody, matching the pattern every other route uses. This changes the missing-fcmToken error response shape, so needed to update the tests as well.

fixes #656 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request validation for device registration: `fcmToken` is required with length constraints, and `platform` is restricted to supported values (with a default).
  * Enabled rate limiting on the device registration endpoint to reduce abuse and improve reliability under load.
* **Tests**
  * Updated device registration integration tests for validation error behavior and adjusted inputs/assertions for rate-limiting and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->