### PR TITLE
[Fix]: Fixes rate limiting

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -59,3 +59,17 @@ export const bidLimiter = rateLimit({
   store: buildStore('rl:bid:'),
   message: { error: 'Rate limit exceeded', retryAfter: 60 },
 });
+
+export const deviceLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    if (req.user?.id) return `user:${req.user.id}`;
+    if (req.user?.uid) return `uid:${req.user.uid}`;
+    return ipKeyGenerator(req);
+  },
+  store: buildStore('rl:device:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 600 },
+});

--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import { registerDeviceToken } from '../controllers/deviceController.js';
 import { authenticate } from '../middleware/auth.js';
+import { deviceLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
 // POST /api/devices/register
-router.post('/register', authenticate, registerDeviceToken);
+router.post('/register', authenticate, deviceLimiter, registerDeviceToken);
 
 export default router;

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -98,5 +98,32 @@ describe('Device Routes Integration Tests', () => {
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('Failed to register device');
     });
+
+    it('enforces rate limits after 10 requests within the window', async () => {
+      const app = buildApp();
+      const headers = {
+        ...CUSTOMER_HEADERS,
+        'x-user-id': 'rate-limited-user-uuid',
+      };
+
+      // Make 10 successful requests
+      for (let i = 0; i < 10; i++) {
+        const res = await request(app)
+          .post('/api/devices/register')
+          .set(headers)
+          .send({ fcmToken: `token-${i}` });
+        expect(res.status).toBe(200);
+      }
+
+      // The 11th request should exceed the limit and return 429
+      const res = await request(app)
+        .post('/api/devices/register')
+        .set(headers)
+        .send({ fcmToken: 'token-11' });
+
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe('Rate limit exceeded');
+      expect(res.body.retryAfter).toBe(600);
+    });
   });
 });


### PR DESCRIPTION
Added the device rate limiter with custom key generator

Fixes #657 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to device registration requests to cap activity at 10 requests per 10-minute window per device/user.
  * When the limit is exceeded, requests now return **HTTP 429** with a **“Rate limit exceeded”** message and **retry-after** set to **600 seconds**.
* **Tests**
  * Added an integration test to verify the rate-limiting behavior for `POST /api/devices/register`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->