### PR TITLE
feat(customer): make freight estimate range dynamic

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/common_widgets.dart';
 import 'location_picker_screen.dart';
 import 'truck_results_screen.dart';
 import 'package:truxify_shared/shimmer_widget.dart';
+import '../services/order_service.dart';
 
 class FindTrucksScreen extends StatefulWidget {
   const FindTrucksScreen({super.key});
@@ -44,6 +45,12 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
 
   String? _weightErrorText;
   bool _isLoading = false;
+
+  // Estimated price state
+  bool _estimateLoading = false;
+  String? _estimateError;
+  int? _estimateMinPrice;
+  int? _estimateMaxPrice;
 
   static const _goodsTypes = <String>[
     'Textile',
@@ -303,6 +310,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     });
 
     _formKey.currentState?.validate();
+    _estimatePrice();
   }
 
   String? _validatePickup(String? value) {
@@ -358,7 +366,13 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) setState(() => _weightErrorText = error);
+      if (mounted) {
+        setState(() => _weightErrorText = error);
+        // Trigger estimate update after validation
+        if (error == null) {
+          _estimatePrice();
+        }
+      }
     });
 
     return error;
@@ -398,6 +412,74 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
         });
       }
     });
+  }
+
+  Future<void> _estimatePrice() async {
+    // Check if we have required data for estimation
+    if (_pickupPoint == null || _dropPoint == null) {
+      setState(() {
+        _estimateError = null;
+        _estimateMinPrice = null;
+        _estimateMaxPrice = null;
+      });
+      return;
+    }
+
+    final weight = double.tryParse(_weightController.text.trim());
+    if (weight == null || weight <= 0) {
+      setState(() {
+        _estimateError = null;
+        _estimateMinPrice = null;
+        _estimateMaxPrice = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _estimateLoading = true;
+      _estimateError = null;
+    });
+
+    try {
+      final service = OrderService();
+      final result = await service.estimatePriceRange(
+        pickupLat: _pickupPoint!.latitude,
+        pickupLng: _pickupPoint!.longitude,
+        dropLat: _dropPoint!.latitude,
+        dropLng: _dropPoint!.longitude,
+        weightTonnes: weight,
+        isFragile: _fragile,
+        isStackable: _stacked,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _estimateLoading = false;
+        if (result != null) {
+          _estimateMinPrice = result['minPrice'] as int?;
+          _estimateMaxPrice = result['maxPrice'] as int?;
+          _estimateError = null;
+        } else {
+          _estimateError = 'Estimate unavailable';
+          _estimateMinPrice = null;
+          _estimateMaxPrice = null;
+        }
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _estimateLoading = false;
+          _estimateError = 'Estimate unavailable';
+          _estimateMinPrice = null;
+          _estimateMaxPrice = null;
+        });
+      }
+    }
+  }
+
+  String _formatPrice(int paise) {
+    return '₹${(paise / 100).round().toString().replaceAllMapped(RegExp(r'\B(?=(\d{3})+(?!\d))'), (m) => ',')}';
   }
 
   @override
@@ -670,7 +752,10 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             icon: Icons.layers_rounded,
                             label: 'Stackable',
                             isSelected: _stacked,
-                            onPressed: () => setState(() => _stacked = !_stacked),
+                            onPressed: () {
+                              setState(() => _stacked = !_stacked);
+                              _estimatePrice();
+                            },
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -679,7 +764,10 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             icon: Icons.warning_rounded,
                             label: 'Fragile',
                             isSelected: _fragile,
-                            onPressed: () => setState(() => _fragile = !_fragile),
+                            onPressed: () {
+                              setState(() => _fragile = !_fragile);
+                              _estimatePrice();
+                            },
                           ),
                         ),
                       ],
@@ -793,32 +881,64 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                               'Estimated Price Range',
                               style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                             ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                              decoration: BoxDecoration(
-                                color: TruxifyColors.accentLight,
-                                borderRadius: BorderRadius.circular(8),
+                            if (!_estimateLoading && _estimateError == null && _estimateMinPrice != null)
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: TruxifyColors.accentLight,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Text(
+                                  'Stable this week',
+                                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                        color: TruxifyColors.accentDark,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                ),
                               ),
-                              child: Text(
-                                'Stable this week',
-                                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                      color: TruxifyColors.accentDark,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                              ),
-                            ),
                           ],
                         ),
                         const SizedBox(height: 8),
-                        Text(
-                          '₹6,200 — ₹7,800',
-                          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                                fontWeight: FontWeight.w800,
-                                color: Theme.of(context).brightness == Brightness.dark
-                                    ? TruxifyColors.accent
-                                    : TruxifyColors.accentDark,
-                              ),
-                        ),
+                        if (_estimateLoading)
+                          Text(
+                            'Estimating price...',
+                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  color: Theme.of(context).brightness == Brightness.dark
+                                      ? TruxifyColors.accent
+                                      : TruxifyColors.accentDark,
+                                ),
+                          )
+                        else if (_estimateError != null)
+                          Text(
+                            _estimateError!,
+                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  color: Theme.of(context).brightness == Brightness.dark
+                                      ? TruxifyColors.accent
+                                      : TruxifyColors.accentDark,
+                                ),
+                          )
+                        else if (_estimateMinPrice != null && _estimateMaxPrice != null)
+                          Text(
+                            '${_formatPrice(_estimateMinPrice!)} — ${_formatPrice(_estimateMaxPrice!)}',
+                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  color: Theme.of(context).brightness == Brightness.dark
+                                      ? TruxifyColors.accent
+                                      : TruxifyColors.accentDark,
+                                ),
+                          )
+                        else
+                          Text(
+                            'Enter route details to view estimate',
+                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  color: Theme.of(context).brightness == Brightness.dark
+                                      ? TruxifyColors.accent
+                                      : TruxifyColors.accentDark,
+                                ),
+                          ),
                         const SizedBox(height: 4),
                         Text(
                           'Based on current demand + route',

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -209,6 +209,55 @@ class OrderService {
     }
   }
 
+  /// Estimates the price range for a shipment.
+  /// Returns a map with estimated total price in paise.
+  /// Returns null if estimation fails or parameters are invalid.
+  Future<Map<String, dynamic>?> estimatePriceRange({
+    required double pickupLat,
+    required double pickupLng,
+    required double dropLat,
+    required double dropLng,
+    required double weightTonnes,
+    bool isFragile = false,
+    bool isStackable = true,
+  }) async {
+    try {
+      final results = await searchTrucks(
+        pickupLat: pickupLat,
+        pickupLng: pickupLng,
+        dropLat: dropLat,
+        dropLng: dropLng,
+        weightTonnes: weightTonnes,
+        isFragile: isFragile,
+        isStackable: isStackable,
+      );
+
+      if (results.isEmpty) return null;
+
+      // Extract price values from results and calculate min/max
+      final prices = results
+          .map((r) => r['price'] as int?)
+          .whereType<int>()
+          .toList();
+
+      if (prices.isEmpty) return null;
+
+      prices.sort();
+      final minPrice = prices.first;
+      final maxPrice = prices.last;
+
+      return {
+        'minPrice': minPrice,
+        'maxPrice': maxPrice,
+      };
+    } on StateError {
+      return null;
+    } catch (e) {
+      debugPrint('Failed to estimate price: $e');
+      return null;
+    }
+  }
+
   Future<List<Map<String, dynamic>>> fetchHistoryOrders() async {
     try {
       final body = await _apiClient.get(

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -236,8 +236,9 @@ class OrderService {
 
       // Extract price values from results and calculate min/max
       final prices = results
-          .map((r) => r['price'] as int?)
-          .whereType<int>()
+          .map((r) => r['price'] as num?)
+          .whereType<num>()
+          .map((p) => p.round())
           .toList();
 
       if (prices.isEmpty) return null;

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify/core/api_client.dart';
@@ -80,5 +80,87 @@ void main() {
         .thenThrow(const ApiException(404, 'Not Found'));
     final order404 = await orderService.fetchOrderById('ORD-404');
     expect(order404, isNull);
+  });
+
+  group('estimatePriceRange', () {
+    test('returns correct min and max when prices are integers', () async {
+      when(() => apiClient.get(
+            any(that: startsWith('/api/trucks/search')),
+            headers: any(named: 'headers'),
+          )).thenAnswer((_) async => [
+            {'price': 5000},
+            {'price': 8000},
+            {'price': 6500},
+          ]);
+
+      final result = await orderService.estimatePriceRange(
+        pickupLat: 12.3,
+        pickupLng: 45.6,
+        dropLat: 78.9,
+        dropLng: 12.3,
+        weightTonnes: 5.5,
+      );
+
+      expect(result, isNotNull);
+      expect(result!['minPrice'], equals(5000));
+      expect(result['maxPrice'], equals(8000));
+    });
+
+    test('returns correct rounded min and max when prices are doubles', () async {
+      when(() => apiClient.get(
+            any(that: startsWith('/api/trucks/search')),
+            headers: any(named: 'headers'),
+          )).thenAnswer((_) async => [
+            {'price': 5000.7},
+            {'price': 8000.2},
+            {'price': 6500.0},
+          ]);
+
+      final result = await orderService.estimatePriceRange(
+        pickupLat: 12.3,
+        pickupLng: 45.6,
+        dropLat: 78.9,
+        dropLng: 12.3,
+        weightTonnes: 5.5,
+      );
+
+      expect(result, isNotNull);
+      expect(result!['minPrice'], equals(5001)); // 5000.7 rounded
+      expect(result['maxPrice'], equals(8000)); // 8000.2 rounded
+    });
+
+    test('returns null when search results are empty', () async {
+      when(() => apiClient.get(
+            any(that: startsWith('/api/trucks/search')),
+            headers: any(named: 'headers'),
+          )).thenAnswer((_) async => []);
+
+      final result = await orderService.estimatePriceRange(
+        pickupLat: 12.3,
+        pickupLng: 45.6,
+        dropLat: 78.9,
+        dropLng: 12.3,
+        weightTonnes: 5.5,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('returns null when api client throws exception', () async {
+      when(() => apiClient.get(
+            any(that: startsWith('/api/trucks/search')),
+            headers: any(named: 'headers'),
+          )).thenThrow(const ApiException(500, 'Server Error'));
+
+      final result = await orderService.estimatePriceRange(
+        pickupLat: 12.3,
+        pickupLng: 45.6,
+        dropLat: 78.9,
+        dropLng: 12.3,
+        weightTonnes: 5.5,
+      );
+
+      expect(result, isNull);
+    });
   });
 }


### PR DESCRIPTION
Hi @KanishJebaMathewM,

I have raised a PR for this issue.

I am a GSSoC contributor, so could you please review the PR and add the appropriate GSSoC labels/level for this contribution if everything looks good?

The PR replaces the hardcoded pre-search freight estimate range with a dynamic estimate using the existing truck search/pricing flow. It also adds loading, empty, and error states for better UX.

I could not run `dart format` / `dart analyze` locally because Flutter/Dart is not available in my system PATH, but I have kept the changes limited to the relevant files.

Please review it when possible. Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live price estimation as shipment details are entered, including pickup/drop locations, weight, and goods specifications
  * Estimated price range automatically calculated and displayed once route and goods information is complete
  * Real-time feedback with loading indicators and error messages for transparent pricing discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->