### PR TITLE
fix : added structured logger in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -205,7 +205,7 @@ router.post('/', authenticate, requireRole(['customer']), validateBody(createOrd
     }
     estimatedPrice = Math.round(mlResult.estimated_price * 100);
   } catch (mlErr) {
-    console.warn('[ML] Price prediction unavailable, falling back to base pricing:', mlErr.message);
+    logger.warn({ err: mlErr.message }, 'Price prediction unavailable, falling back to base pricing');
   }
 
   const orderDisplayId = generateOrderDisplayId();


### PR DESCRIPTION
Closes #717.

Summary of What Has Been Done:
Replaced `console.warn` with `logger.warn()` in `backend/api/src/routes/orderRoutes.js` for the ML price prediction fallback path. The logger was already imported in this file.

Changes Made:
- backend/api/src/routes/orderRoutes.js: replaced `console.warn('[ML] Price prediction unavailable, falling back to base pricing:', mlErr.message)` with `logger.warn({ err: mlErr.message }, 'Price prediction unavailable, falling back to base pricing')`

Impact it Made:
- Consistent structured pino logging in order routes; all 216 unit tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging for order creation fallback when price prediction is unavailable, switching to structured warning logs to better capture error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->