### PR TITLE
test : added unit tests for escrow.js getEscrowBookingId and buildDepositTx

### DIFF
--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -8,7 +8,7 @@
  *
  * Run with:  npm test -- test/unit/escrow.test.js
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getEscrowBookingId, buildDepositTx, ESCROW_MATIC_PER_PAISA } from '../../src/services/escrow.js';
 
 describe('escrow service — getEscrowBookingId', () => {
@@ -37,8 +37,39 @@ describe('escrow service — getEscrowBookingId', () => {
     expect(getEscrowBookingId(id1)).not.toBe(getEscrowBookingId(id2));
   });
 
-  it('ESCROW_MATIC_PER_PAISA defaults to 0.01 when env var is absent', () => {
+  it('ESCROW_MATIC_PER_PAISA parses the configured env var correctly', () => {
+    // process.env.ESCROW_MATIC_PER_PAISA is set to '0.01' in setup.js
     expect(ESCROW_MATIC_PER_PAISA).toBe(0.01);
+  });
+
+  it('ESCROW_MATIC_PER_PAISA defaults to 0.01 when env var is absent', async () => {
+    const originalEnv = process.env.ESCROW_MATIC_PER_PAISA;
+    delete process.env.ESCROW_MATIC_PER_PAISA;
+    
+    vi.resetModules();
+    const { ESCROW_MATIC_PER_PAISA: defaultVal } = await import('../../src/services/escrow.js');
+    expect(defaultVal).toBe(0.01);
+
+    if (originalEnv !== undefined) {
+      process.env.ESCROW_MATIC_PER_PAISA = originalEnv;
+    }
+    vi.resetModules();
+  });
+
+  it('ESCROW_MATIC_PER_PAISA parses a custom value correctly', async () => {
+    const originalEnv = process.env.ESCROW_MATIC_PER_PAISA;
+    process.env.ESCROW_MATIC_PER_PAISA = '0.05';
+
+    vi.resetModules();
+    const { ESCROW_MATIC_PER_PAISA: customVal } = await import('../../src/services/escrow.js');
+    expect(customVal).toBe(0.05);
+
+    if (originalEnv !== undefined) {
+      process.env.ESCROW_MATIC_PER_PAISA = originalEnv;
+    } else {
+      delete process.env.ESCROW_MATIC_PER_PAISA;
+    }
+    vi.resetModules();
   });
 });
 

--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for backend/api/src/services/escrow.js
+ *
+ * Coverage:
+ *   - getEscrowBookingId: output shape, determinism, prefix, uniqueness
+ *   - buildDepositTx: graceful fallback when contract is unconfigured,
+ *     invalid address validation, invalid amount validation
+ *
+ * Run with:  npm test -- test/unit/escrow.test.js
+ */
+import { describe, it, expect } from 'vitest';
+import { getEscrowBookingId, buildDepositTx, ESCROW_MATIC_PER_PAISA } from '../../src/services/escrow.js';
+
+describe('escrow service — getEscrowBookingId', () => {
+  it('returns a hex string prefixed with 0x', () => {
+    const result = getEscrowBookingId('#FF20260521');
+    expect(typeof result).toBe('string');
+    expect(result.startsWith('0x')).toBe(true);
+  });
+
+  it('returns a 66-character hex string (bytes32)', () => {
+    const result = getEscrowBookingId('#FF20260521');
+    expect(result.length).toBe(66);
+    expect(/^0x[0-9a-f]{64}$/.test(result)).toBe(true);
+  });
+
+  it('is deterministic for the same input', () => {
+    const id = '#FF20260521';
+    const first = getEscrowBookingId(id);
+    const second = getEscrowBookingId(id);
+    expect(first).toBe(second);
+  });
+
+  it('produces different outputs for different inputs', () => {
+    const id1 = '#FF20260521';
+    const id2 = '#FF20260522';
+    expect(getEscrowBookingId(id1)).not.toBe(getEscrowBookingId(id2));
+  });
+
+  it('ESCROW_MATIC_PER_PAISA defaults to 0.01 when env var is absent', () => {
+    expect(ESCROW_MATIC_PER_PAISA).toBe(0.01);
+  });
+});
+
+describe('escrow service — buildDepositTx (contract unconfigured)', () => {
+  // escrowContract is null when POLYGON_RPC_URL / ESCROW_CONTRACT_ADDRESS /
+  // RELAYER_WALLET_PRIVATE_KEY are not set (CI / dev environments).
+  // In that state buildDepositTx must return { txData: null, bookingId }.
+
+  it('returns txData: null when escrowContract is not initialised', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260521',
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      '1000000000000000000'
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+
+  it('returns txData: null and a valid bookingId for an invalid customer wallet address', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260522',
+      'not-an-address',
+      '0x0000000000000000000000000000000000000002',
+      '1000000000000000000'
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+
+  it('returns txData: null for an invalid driver wallet address', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260523',
+      '0x0000000000000000000000000000000000000001',
+      'invalid-driver',
+      '1000000000000000000'
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+
+  it('returns txData: null when amountWei is zero', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260524',
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      '0'
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+
+  it('returns txData: null when amountWei is falsy', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260525',
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      null
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+
+  it('returns txData: null when amountWei is negative (BigInt)', async () => {
+    const { txData, bookingId } = await buildDepositTx(
+      '#FF20260526',
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      '-1000000000000000000'
+    );
+    expect(txData).toBeNull();
+    expect(typeof bookingId).toBe('string');
+    expect(bookingId.startsWith('0x')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #719.

Summary of What Has Been Done:
Created `backend/api/test/unit/escrow.test.js` with 11 unit tests covering:
- `getEscrowBookingId`: output shape (bytes32 hex), determinism, uniqueness, ESCROW_MATIC_PER_PAISA default
- `buildDepositTx`: graceful `{ txData: null, bookingId }` fallback when contract is unconfigured; invalid address validation; zero/falsy/negative amountWei validation

Changes Made:
- backend/api/test/unit/escrow.test.js: new file with 11 vitest unit tests

Impact it Made:
- Improved test coverage for the escrow service; all 227 unit tests pass locally (12 test files)

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for escrow service functionality, validating data integrity and behavior under various input conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->