### PR TITLE
[fix]: Refactor deposit transaction population method

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -82,12 +82,10 @@ export function getEscrowBookingId(orderDisplayId) {
  */
 export async function buildDepositTx(orderDisplayId, customerWalletAddress, driverWalletAddress, amountWei) {
   const bookingId = getEscrowBookingId(orderDisplayId);
-  // Graceful fallback when contract is not configured (CI / dev environments)
   if (!escrowContract) {
     return { txData: null, bookingId };
   }
 
-  // Validate inputs; for robustness return a null txData rather than throwing
   if (!ethers.isAddress(customerWalletAddress) || !ethers.isAddress(driverWalletAddress)) {
     return { txData: null, bookingId };
   }
@@ -95,7 +93,7 @@ export async function buildDepositTx(orderDisplayId, customerWalletAddress, driv
     return { txData: null, bookingId };
   }
 
-  const txData = await escrowContract.populateTransaction.deposit(
+  const txData = await escrowContract.deposit.populateTransaction(
     bookingId,
     customerWalletAddress,
     driverWalletAddress,


### PR DESCRIPTION
**File changed:** `backend/api/src/services/escrow.js`

`escrowContract.populateTransaction.deposit()` is an ethers v5 API that does not exist in ethers v6.16.0 (used in this project), causing a `TypeError` crash on every bid acceptance. Fixed by changing the call to the v6-correct `escrowContract.deposit.populateTransaction()`.

fixes #698 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit transaction validation to properly handle invalid addresses and amounts, preventing transaction errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->