### PR TITLE
[fix]:Refactor OTP verification logic in driverRoutes

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -27,13 +27,13 @@ const verifyLoginOtpLimiter = rateLimit({
 
 router.post('/otp/verify', verifyLoginOtpLimiter, validateBody(loginOtpSchema), async (req, res) => {
   const { phone, otp } = req.body;
-  const expectedOtp = (process.env.DRIVER_LOGIN_OTP || '1234').trim();
-
-  if (process.env.NODE_ENV === 'production' && !process.env.DRIVER_LOGIN_OTP) {
+  if (!process.env.DRIVER_LOGIN_OTP) {
     return res.status(503).json({
       error: 'Driver login OTP verification is not configured on this server.',
     });
   }
+
+  const expectedOtp = process.env.DRIVER_LOGIN_OTP.trim();
 
   if (process.env.DRIVER_LOGIN_PHONE && phone !== process.env.DRIVER_LOGIN_PHONE.trim()) {
     return res.status(400).json({ error: 'Invalid phone number for OTP verification.' });
@@ -443,4 +443,3 @@ router.get('/:driverId/reputation', authenticate, requireRole(['driver']), async
 });
 
 export default router;
-

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -27,13 +27,12 @@ const verifyLoginOtpLimiter = rateLimit({
 
 router.post('/otp/verify', verifyLoginOtpLimiter, validateBody(loginOtpSchema), async (req, res) => {
   const { phone, otp } = req.body;
-  if (!process.env.DRIVER_LOGIN_OTP) {
+  const expectedOtp = process.env.DRIVER_LOGIN_OTP?.trim();
+  if (!expectedOtp) {
     return res.status(503).json({
       error: 'Driver login OTP verification is not configured on this server.',
     });
   }
-
-  const expectedOtp = process.env.DRIVER_LOGIN_OTP.trim();
 
   if (process.env.DRIVER_LOGIN_PHONE && phone !== process.env.DRIVER_LOGIN_PHONE.trim()) {
     return res.status(400).json({ error: 'Invalid phone number for OTP verification.' });


### PR DESCRIPTION
**File changed:** `backend/api/src/routes/driverRoutes.js`

The OTP verify endpoint defaulted to `"1234"` when `DRIVER_LOGIN_OTP` was unset, and only failed closed in `NODE_ENV === 'production'` — any other environment (or a misconfigured prod) silently accepted `1234` for all drivers. Fixed by removing the default entirely and failing closed unconditionally when the env var is missing.

fixes #699 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated driver login OTP verification to rely solely on the configured server OTP value.
  * If the required OTP configuration is missing or empty, verification now fails with a clear “service unavailable” configuration error response.
  * This prevents unintended verification behavior caused by fallback or production-only handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->