### PR TITLE
[fix]: Fix return value for inactive cached profiles

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -52,7 +52,7 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
     return false;
   }
   if (cachedProfile.isActive === false) {
-    return true; // Valid tombstone
+    return false;
   }
   return (
     cachedProfile.isActive === true &&


### PR DESCRIPTION
**File changed:** `backend/api/src/lib/profileCache.js`

`isValidCachedProfile` returned `true` for tombstone entries (`{ isActive: false }`), causing `auth.js` to short-circuit and return 403 for the full 30-second tombstone TTL without re-querying the DB — blocking legitimately active users hit by a transient miss. Fixed by returning `false` for tombstones so the caller falls through to a live DB query.

fixes #697 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected profile cache validation to properly handle inactive profile entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->