### PR TITLE
fix : added order_id filter to driver telemetry MongoDB query

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1209,7 +1209,7 @@ router.get('/:id/driver-location', authenticate, requireRole(['customer', 'drive
 
     const latestTelemetry = await mongoDb
       .collection('telemetry')
-      .find({ driver_id: order.driver_id })
+      .find({ driver_id: order.driver_id, order_id: order.id })
       .sort({ timestamp: -1 })
       .limit(1)
       .toArray();


### PR DESCRIPTION
Closes #787.

Summary of What Has Been Done:
Added an order_id filter to the MongoDB telemetry query in GET /orders/:id/driver-location. Previously the query returned telemetry for the driver regardless of which order it belonged to, causing stale location data to be shown when a driver has multiple active orders.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Changed the telemetry find() query from { driver_id: order.driver_id } to { driver_id: order.driver_id, order_id: order.id }.

Impact it Made:
All 239 unit tests pass. The driver location endpoint now correctly scopes telemetry to the specific order being tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver location data retrieval so the app fetches telemetry specifically for the selected order, avoiding potentially unrelated location results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->