### PR TITLE
fix: use bytes32 bookingId from buildDepositTx instead of raw string

### DIFF
--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -724,6 +724,7 @@ describe('Bid Routes', () => {
         id: 'order-1',
         customer_id: 'customer-1',
         order_display_id: 'OD1',
+        escrow_booking_id: 'escrow:OD1',
         escrow_status: 'funding',
       });
 
@@ -745,6 +746,7 @@ describe('Bid Routes', () => {
         id: 'order-1',
         customer_id: 'customer-1',
         order_display_id: 'OD1',
+        escrow_booking_id: 'escrow:OD1',
         escrow_status: 'funding',
       });
 


### PR DESCRIPTION
## Description

The escrow deposit confirmation flow used two different representations of the "booking ID" without conversion. The `getEscrowBookingId()` function generates a `bytes32` Keccak256 hash, but `orderRoutes.js` stored and passed a raw `escrow:#FF...` string instead. This caused every `confirm-deposit` call to fail with "Transaction booking ID does not match".

## Changes

**Fix 1 — `backend/api/src/routes/orderRoutes.js:692`**: Captured the returned `bookingId` from `buildDepositTx()` (was previously discarded — only `txData` was destructured).

**Fix 2 — `backend/api/src/routes/orderRoutes.js:714`**: Stored the bytes32 hash (`bookingId`) instead of the raw string `escrow:${order.order_display_id}` in the `escrow_booking_id` column.

**Fix 3 — `backend/api/src/routes/orderRoutes.js:1085`**: Used the stored `order.escrow_booking_id` from the database instead of reconstructing the raw string `escrow:${order.order_display_id}` when calling `recordDepositTx()`.

## Testing

- `confirm-deposit` endpoint no longer fails on booking ID comparison
- Escrow lifecycle can progress: `funding` → `funded` → `released`
- Orders are no longer stuck in `funding` state forever

Closes #801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in booking identifier handling during bid acceptance and escrow deposit confirmation flows. The escrow deposit reference is now stored and used consistently across the deposit creation and confirmation steps for more accurate tracking.
* **Tests**
  * Updated bid and escrow integration tests to reflect the corrected escrow booking identifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->