### PR TITLE
fix: replace compile-time DRIVER_ID with Supabase auth session

### DIFF
--- a/apps/driver/lib/core/driver_session.dart
+++ b/apps/driver/lib/core/driver_session.dart
@@ -1,4 +1,12 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 class DriverSession {
-  static String driverId =
-      const String.fromEnvironment('DRIVER_ID', defaultValue: '');
+  static String get driverId {
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user == null) {
+      const devOverride = String.fromEnvironment('DRIVER_ID', defaultValue: '');
+      return devOverride;
+    }
+    return user.id;
+  }
 }

--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-import '../core/driver_session.dart';
 
 class LocationService {
   LocationService._privateConstructor();
@@ -61,8 +60,8 @@ class LocationService {
 
   Future<void> _sendLocationPing(Position position) async {
     try {
-      final driverId = DriverSession.driverId;
-      if (driverId.isEmpty) return;
+      final driverId = Supabase.instance.client.auth.currentUser?.id;
+      if (driverId == null || driverId.isEmpty) return;
 
       // 1. Resolve active order if not cached
       if (_activeOrderId == null) {
@@ -125,7 +124,7 @@ class LocationService {
 
     final session = Supabase.instance.client.auth.currentSession;
     final token = session?.accessToken ?? '';
-    final driverId = DriverSession.driverId;
+    final driverId = Supabase.instance.client.auth.currentUser?.id ?? '';
 
     final baseUri = Uri.parse(defaultApiBaseUrl);
     final wsScheme = baseUri.scheme == 'https' ? 'wss' : 'ws';

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -4,7 +4,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
-import '../core/driver_session.dart';
 
 class TripService {
   TripService({
@@ -27,9 +26,9 @@ class TripService {
   SupabaseClient get _client => _providedClient ?? Supabase.instance.client;
 
   String get _driverId {
-    final id = DriverSession.driverId;
-    if (id.isEmpty) throw Exception('Driver session not initialised');
-    return id;
+    final user = _client.auth.currentUser;
+    if (user == null) throw Exception('Driver not authenticated');
+    return user.id;
   }
 
   static String _normalizeBaseUrl(String value) {
@@ -38,10 +37,11 @@ class TripService {
 
   Future<Map<String, String>> _authHeaders() async {
     final accessToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+    final userId = _client.auth.currentUser?.id ?? '';
     return <String, String>{
       'Content-Type': 'application/json',
       if (accessToken != null) 'Authorization': 'Bearer $accessToken',
-      'x-user-id': _driverId,
+      'x-user-id': userId,
       'x-user-role': 'driver',
     };
   }

--- a/apps/driver/test/trip_service_test.dart
+++ b/apps/driver/test/trip_service_test.dart
@@ -1,10 +1,33 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:truxify_driver/core/driver_session.dart';
 import 'package:truxify_driver/services/trip_service.dart';
 
 http.Client createUnusedHttpClient() => http.Client();
+
+class MockGoTrueClient implements GoTrueClient {
+  final User? mockUser;
+  final Session? mockSession;
+  MockGoTrueClient({this.mockUser, this.mockSession});
+
+  @override
+  User? get currentUser => mockUser;
+
+  @override
+  Session? get currentSession => mockSession;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeUser implements User {
+  final String _id;
+  FakeUser(this._id);
+  @override
+  String get id => _id;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class FakePostgrestTransformBuilder<T> implements PostgrestTransformBuilder<T> {
   final Future<dynamic> _futureValue;
@@ -102,8 +125,13 @@ class FakeSupabaseQueryBuilder implements SupabaseQueryBuilder {
 
 class FakeSupabaseClient implements SupabaseClient {
   final FakeSupabaseQueryBuilder Function(String relation) onFrom;
+  final GoTrueClient _auth;
 
-  FakeSupabaseClient({required this.onFrom});
+  FakeSupabaseClient({required this.onFrom, GoTrueClient? auth})
+      : _auth = auth ?? MockGoTrueClient();
+
+  @override
+  GoTrueClient get auth => _auth;
 
   @override
   SupabaseQueryBuilder from(String relation) {
@@ -121,9 +149,8 @@ void main() {
   const tripDisplayId = 'trip-display-456';
   const stopId = 'stop-789';
 
-  setUp(() {
-    DriverSession.driverId = driverId;
-  });
+  final mockUser = FakeUser(driverId);
+  final mockAuth = MockGoTrueClient(mockUser: mockUser);
 
   group('TripService.markStopCompleted Tests', () {
     test('Successfully completes stop and sets next stop as current', () async {
@@ -133,6 +160,7 @@ void main() {
       int tripStopsCallCount = 0;
 
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             return FakeSupabaseQueryBuilder(
@@ -186,6 +214,7 @@ void main() {
       int tripStopsCallCount = 0;
 
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             return FakeSupabaseQueryBuilder(
@@ -230,6 +259,7 @@ void main() {
       bool tripsQueryChecked = false;
 
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             tripsQueryChecked = true;
@@ -267,6 +297,7 @@ void main() {
 
     test('Throws exception if driver does not own the trip', () async {
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             // Return null for ownership check
@@ -292,6 +323,7 @@ void main() {
       final eqParams = <String, dynamic>{};
 
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'driver_details') {
             return FakeSupabaseQueryBuilder(
@@ -314,6 +346,7 @@ void main() {
 
     test('Throws exception if driver_details update returns null', () async {
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'driver_details') {
             return FakeSupabaseQueryBuilder(
@@ -339,6 +372,7 @@ void main() {
       int tripStopsCallCount = 0;
 
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             return FakeSupabaseQueryBuilder(
@@ -375,6 +409,7 @@ void main() {
 
     test('Throws exception if startTrip finds no active stops', () async {
       final client = FakeSupabaseClient(
+        auth: mockAuth,
         onFrom: (relation) {
           if (relation == 'trips') {
             return FakeSupabaseQueryBuilder(


### PR DESCRIPTION
## Description

The Flutter driver app used a **compile-time constant** (`DriverSession.driverId`) set via `--dart-define=DRIVER_ID=xxx` for ALL direct Supabase queries. Every build was hardcoded to a single driver's UUID, making distribution to multiple drivers impossible. Direct Supabase queries (trip verification, stop updates, online status) all filtered by this hardcoded constant, causing "Unauthorized access" errors for any driver whose UUID didn't match the build-time value.

## Changes

**Fix 1 — `apps/driver/lib/services/trip_service.dart`**: Replaced the compile-time `_driverId` getter (`DriverSession.driverId`) with the authenticated Supabase session's user ID (`_client.auth.currentUser.id`). Also updated `_authHeaders()` to pass the session-based userId in the `x-user-id` header.

**Fix 2 — `apps/driver/lib/services/location_service.dart`**: Replaced all `DriverSession.driverId` references (lines 64, 128) with `Supabase.instance.client.auth.currentUser?.id` for location pings and WebSocket connections.

**Fix 3 — `apps/driver/lib/core/driver_session.dart`**: Made `DriverSession.driverId` derive from the Supabase auth session as the primary source, with the compile-time `DRIVER_ID` as a fallback for local development only.

## Testing

- Multiple drivers can now use the same build — identity comes from the authenticated Supabase session
- Trip ownership verification correctly uses the authenticated user's ID
- Online status and location updates affect the correct driver's records
- Existing screens that reference `DriverSession.driverId` continue to work

Closes #802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated driver identification system to use live authenticated user sessions instead of static compile-time values across location and trip services for improved session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->