### PR TITLE
fix: prevent race condition in complete_trip_tx allowing payout for cancelled orders

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -914,6 +914,25 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['dri
       return res.status(500).json({ error: 'Failed to complete trip and release payment.', details: rpcErr.message });
     }
 
+    // Post-RPC verification: confirm the order was actually updated to payment_released
+    const { data: verifiedOrder, error: verifyErr } = await supabase
+      .from('orders')
+      .select('status')
+      .eq('id', orderId)
+      .maybeSingle();
+
+    if (verifyErr || !verifiedOrder) {
+      logger.error(`[verify-delivery] Failed to verify order status after RPC for order ${orderId}`);
+      return res.status(500).json({ error: 'Failed to verify order status after payment release.' });
+    }
+
+    if (verifiedOrder.status !== 'payment_released') {
+      logger.warn(`[verify-delivery] Order ${orderId} status changed to "${verifiedOrder.status}" — payment was not released.`);
+      return res.status(409).json({
+        error: 'Order status changed during processing. Payment was not released.',
+      });
+    }
+
     // OTP is only consumed after the RPC succeeds — if the RPC fails the driver can retry
     await verifyDeliveryOtp(orderId);
     await clearOtpState(orderId);

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -1521,8 +1521,10 @@ declare
   v_order record;
   v_trip_display_id text;
   v_active_trip_count int;
+  v_updated_count int;
 begin
-  select * into v_order from orders where id = p_order_id;
+  -- Use FOR UPDATE to lock the order row and prevent concurrent modifications
+  select * into v_order from orders where id = p_order_id for update;
 
   if not found then
     raise exception 'Order not found';
@@ -1535,6 +1537,16 @@ begin
   -- Idempotency guard: check if the order status is already payment_released
   if v_order.status = 'payment_released' then
     return;
+  end if;
+
+  -- Check if the order was cancelled
+  if v_order.status = 'cancelled' then
+    raise exception 'Order has been cancelled — cannot complete trip';
+  end if;
+
+  -- Check if the order was already delivered — prevents double-processing
+  if v_order.status = 'delivered' then
+    raise exception 'Order has already been delivered';
   end if;
 
   -- Safe lookup for the driver's active trip
@@ -1572,12 +1584,20 @@ begin
     where trip_display_id = v_trip_display_id;
   end if;
 
-  -- Update order status to payment_released
+  -- Update order status to payment_released with defensive WHERE guards
   update orders
   set otp_verified = true,
       status = 'payment_released',
       updated_at = now()
-  where id = p_order_id;
+  where id = p_order_id
+    and status != 'cancelled'
+    and status != 'payment_released';
+
+  -- Verify the update actually affected a row
+  get diagnostics v_updated_count = row_count;
+  if v_updated_count = 0 then
+    raise exception 'Order status changed during processing — possible concurrent cancellation';
+  end if;
 
   -- Update order timeline milestone 'Delivered'
   update order_timeline


### PR DESCRIPTION
## Description

The `complete_trip_tx(p_order_id UUID)` PostgreSQL RPC function did **not** use `SELECT ... FOR UPDATE` to lock the order row, and only checked for `payment_released` status, not `cancelled`. When a cancellation request and a delivery verification request executed concurrently, a driver could receive full wallet credit and on-chain escrow release for an order that was cancelled at nearly the same time.

## Changes

### `docs/supabase_setup.sql` — `complete_trip_tx` function:

1. **`FOR UPDATE` row lock**: Changed `SELECT * INTO v_order FROM orders WHERE id = p_order_id` to `SELECT ... FOR UPDATE`, acquiring an exclusive row-level lock that prevents concurrent modifications.

2. **Cancelled status check**: Added an explicit check: `IF v_order.status = 'cancelled' THEN RAISE EXCEPTION 'Order has been cancelled — cannot complete trip';`

3. **Delivered status check**: Added a check to prevent double-processing: `IF v_order.status = 'delivered' THEN RAISE EXCEPTION 'Order has already been delivered';`

4. **Defensive WHERE guards**: The final `UPDATE orders SET status = 'payment_released'` now includes `AND status != 'cancelled' AND status != 'payment_released'`.

5. **Zero-row-update detection**: Added `GET DIAGNOSTICS v_updated_count = ROW_COUNT` after the UPDATE, raising an exception if no row was affected.

### `backend/api/src/routes/orderRoutes.js` — verify-delivery handler:

6. **Post-RPC verification**: Added a status check after `complete_trip_tx` succeeds, verifying the order is actually in `payment_released` state before proceeding with escrow release. Returns HTTP 409 if the status doesn't match.

## Security

- **Race window eliminated**: `FOR UPDATE` ensures the cancel and complete operations are serialized
- **Defense in depth**: Even without the lock, WHERE guards and post-RPC verification provide multiple layers of protection
- **Drivers cannot be paid for cancelled orders**: Wallet credit, escrow release, and earnings tracking are all blocked

Closes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of payment release during delivery verification by adding validation checks to ensure orders reach the correct status. Enhanced error detection for edge cases involving concurrent order modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->