### PR TITLE
fix: address backend validation issues and query bug

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -355,7 +355,7 @@ router.get('/history', authenticate, userLimiter, requireRole(['customer']), asy
   try {
     const { data: history, error } = await supabase
       .from('orders')
-      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, driver_name, eta, created_at')
+      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, eta, created_at')
       .eq('customer_id', req.user.id)
       .order('created_at', { ascending: false });
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -34,15 +34,15 @@ const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)(:[0-5]\d)?$/; // HH:MM or HH:MM:SS
 const upiRegex = /^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z]{2,64}$/;
 
 export const createOrderSchema = z.object({
-  pickup_address: z.string().min(5, "Pickup address is too short").max(255, "Pickup address is too long").optional(),
+  pickup_address: z.string().min(5, "Pickup address is too short").max(255, "Pickup address is too long"),
   pickup_lat: latitudeSchema,
   pickup_lng: longitudeSchema,
-  drop_address: z.string().min(5, "Drop address is too short").max(255, "Drop address is too long").optional(),
+  drop_address: z.string().min(5, "Drop address is too short").max(255, "Drop address is too long"),
   drop_lat: latitudeSchema,
   drop_lng: longitudeSchema,
   pickup_date: isoDateStringSchema,
   pickup_time: z.string().regex(timeRegex, "Time must be in HH:MM format").optional(),
-  goods_type: z.string().min(2, "Goods type must be specified").optional(),
+  goods_type: z.string().min(2, "Goods type must be specified"),
   weight_tonnes: coerceNumber(z.number().positive({ message: 'Must be greater than 0' }).max(100, "Weight exceeds maximum legal limits")),
   length_ft: coerceNumber(z.number().positive().max(60)).optional(),
   width_ft: coerceNumber(z.number().positive().max(15)).optional(),
@@ -52,7 +52,7 @@ export const createOrderSchema = z.object({
   special_requirements: z.string().max(500).optional().nullable(),
   payment_method_id: z.string().optional(),
   upi_id: z.string().regex(upiRegex, "Invalid UPI ID format").optional().or(z.literal('')).nullable()
-}).passthrough();
+});
 
 export const paramIdSchema = z.object({
   id: uuidSchema.or(z.string().min(1, "ID is required"))
@@ -63,7 +63,7 @@ export const submitBidSchema = z.object({
     .number()
     .int({ message: 'Must be a positive integer' })
     .positive({ message: 'Must be greater than 0' }),
-}).passthrough();
+});
 
 export const acceptBidParamsSchema = z.object({
   id: uuidSchema.or(z.string().min(1, "Order ID is required")),
@@ -72,7 +72,7 @@ export const acceptBidParamsSchema = z.object({
 
 export const driverOnlineSchema = z.object({
   is_online: z.boolean(),
-}).passthrough();
+});
 
 export const withdrawSchema = z.object({
   amount: z
@@ -80,7 +80,7 @@ export const withdrawSchema = z.object({
     .int({ message: 'Amount must be a whole number (paisa)' })
     .positive({ message: 'Amount must be greater than 0' })
     .safe({ message: 'Amount is too large' }),
-}).passthrough();
+});
 
 export const submitRatingSchema = z.object({
   stars: z
@@ -89,7 +89,7 @@ export const submitRatingSchema = z.object({
     .min(1, { message: 'Stars must be between 1 and 5' })
     .max(5, { message: 'Stars must be between 1 and 5' }),
   comment: z.string().trim().max(1000, { message: 'Comment must be 1000 characters or fewer' }).optional().nullable(),
-}).passthrough();
+});
 export const predictDemandSchema = z.object({
   hour: z.number().min(0).max(23, { message: 'Hour must be between 0 and 23' }),
   day_of_week: z.number().min(0).max(6, { message: 'Day of week must be between 0 and 6' }),
@@ -97,7 +97,7 @@ export const predictDemandSchema = z.object({
   precipitation: z.number().nonnegative({ message: 'Precipitation must be greater than or equal to 0' }),
   historical_volume: z.number().nonnegative({ message: 'Historical volume must be greater than or equal to 0' }),
   nearby_drivers: z.number().nonnegative({ message: 'Nearby drivers must be greater than or equal to 0' }),
-}).passthrough();
+});
 
 export const updateMilestoneSchema = z.object({
   milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving', 'Delivered'], {
@@ -108,7 +108,7 @@ export const updateMilestoneSchema = z.object({
 export const verifyDeliverySchema = z.object({
   otp: z.preprocess(
     (val) => (val === undefined || val === null) ? undefined : String(val),
-    z.string().regex(/^\d{6}$/, { message: 'OTP must be 6 digits' }).optional()
+    z.string().regex(/^\d{6}$/, { message: 'OTP must be 6 digits' })
   )
 });
 
@@ -124,15 +124,15 @@ export const changeDropSchema = z.object({
       .min(-180, { message: 'Must be greater than or equal to -180' })
       .max(180, { message: 'Must be less than or equal to 180' })
   ),
-}).passthrough();
+});
 
 export const cancelOrderSchema = z.object({
   reason: z.string().max(500).optional().nullable(),
-}).passthrough();
+});
 
 export const updateWalletSchema = z.object({
   wallet_address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x-prefixed 42-character wallet address'),
-}).passthrough();
+});
 
 export const registerDeviceSchema = z.object({
   fcmToken: z.string()
@@ -141,4 +141,4 @@ export const registerDeviceSchema = z.object({
   platform: z.enum(['android', 'ios', 'web'], {
     invalid_type_error: 'platform must be one of: android, ios, web',
   }).default('android'),
-}).passthrough();
+});

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1035,7 +1035,12 @@ describe('Delivery OTP Verification and Milestones', () => {
       .send({}); // Missing OTP
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('OTP is required for verification.');
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'otp' })
+      ])
+    );
   });
 
   it('fails OTP verification if driver is not assigned', async () => {

--- a/backend/api/test/unit/requestValidation.test.js
+++ b/backend/api/test/unit/requestValidation.test.js
@@ -24,8 +24,8 @@ describe('request validation middleware', () => {
     const { res, next } = runValidation(createOrderSchema, {
       pickup_lat: 181,
       pickup_lng: 72.8777,
-      drop_lat: 28.7041,
-      drop_lng: 77.1025,
+      drop_address: 'Delhi',
+      goods_type: 'electronics',
       weight_tonnes: 10,
       pickup_date: '2026-06-10',
     });
@@ -47,8 +47,8 @@ describe('request validation middleware', () => {
     const { res, next } = runValidation(createOrderSchema, {
       pickup_lat: 120,
       pickup_lng: 72.8777,
-      drop_lat: 28.7041,
-      drop_lng: 77.1025,
+      drop_address: 'Delhi',
+      goods_type: 'electronics',
       weight_tonnes: 10,
       pickup_date: '2026-06-10',
     });
@@ -70,8 +70,8 @@ describe('request validation middleware', () => {
     const { res, next } = runValidation(createOrderSchema, {
       pickup_lat: -100,
       pickup_lng: 72.8777,
-      drop_lat: 28.7041,
-      drop_lng: 77.1025,
+      drop_address: 'Delhi',
+      goods_type: 'electronics',
       weight_tonnes: 10,
       pickup_date: '2026-06-10',
     });
@@ -93,8 +93,8 @@ describe('request validation middleware', () => {
     const { res } = runValidation(createOrderSchema, {
       pickup_lat: 19.076,
       pickup_lng: 72.8777,
-      drop_lat: 28.7041,
-      drop_lng: 77.1025,
+      drop_address: 'Delhi',
+      goods_type: 'electronics',
       weight_tonnes: 10,
       pickup_date: 'next week',
     });
@@ -150,6 +150,7 @@ describe('request validation middleware', () => {
       weight_tonnes: 10,
       pickup_date: '2026-06-10',
       pickup_address: 'Mumbai',
+      drop_address: 'Delhi',
       goods_type: 'electronics',
     });
 


### PR DESCRIPTION
This PR fixes multiple backend issues:

- Resolves #746 (remove \.passthrough()\ from all Zod mutation schemas)
- Resolves #747 (make \pickup_address\, \drop_address\, \goods_type\ required in \createOrderSchema\)
- Resolves #748 (make \otp\ required in \erifyDeliverySchema\)
- Resolves #750 (remove invalid \driver_name\ column from orders history select query)

These fixes ensure stricter data validation and prevent Supabase query crashes on the history endpoint.