### PR TITLE
fix : applied healthLimiter rate-limit to GET /api/health and GET /api/health/live

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
+import { healthLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
@@ -65,7 +66,7 @@ function checkPolygon() {
 const CRITICAL_UNHEALTHY = new Set(['failed', 'not_configured']);
 
 // GET /api/health — full dependency check; returns 503 when a critical service fails
-router.get('/', async (req, res) => {
+router.get('/', healthLimiter, async (req, res) => {
   const [supabaseStatus, mongoStatus, redisStatus] = await Promise.all([
     checkSupabase(),
     checkMongo(),
@@ -94,7 +95,7 @@ router.get('/', async (req, res) => {
 });
 
 // GET /api/health/live — liveness probe; always 200 as long as the process is up
-router.get('/live', (req, res) => {
+router.get('/live', healthLimiter, (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
 


### PR DESCRIPTION
Closes #828.

Summary of What Has Been Done:
Added healthLimiter rate-limit middleware (already defined in rateLimiter.js) to the public health check endpoints that actively ping Supabase, MongoDB, and Redis.

Changes Made:
- backend/api/src/routes/healthRoutes.js: imported healthLimiter, applied to GET / and GET /live routes

Impact it Made:
- Prevents DoS attacks on health endpoints that query all three database backends
- Consistent with other public-facing endpoints that use rate limiting

Note: Please assign this PR to the `tmdeveloper007` account.