### PR TITLE
fix : added Zod createTicketSchema and updateTicketSchema to support ticket endpoints

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -2,6 +2,8 @@ import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { validateBody } from '../middleware/validate.js';
+import { createTicketSchema, updateTicketSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -48,7 +50,7 @@ router.get('/faqs', async (req, res) => {
 // ============================================================================
 // 2. CREATE SUPPORT TICKET (AUTHENTICATED USER)
 // ============================================================================
-router.post('/tickets', authenticate, userLimiter, async (req, res) => {
+router.post('/tickets', authenticate, userLimiter, validateBody(createTicketSchema), async (req, res) => {
   const subject = normalizeRequiredText(req.body.subject);
   const category = normalizeRequiredText(req.body.category);
   const description = normalizeRequiredText(req.body.description) || subject;
@@ -187,7 +189,7 @@ router.get('/tickets/:id', authenticate, userLimiter, async (req, res) => {
 // ============================================================================
 // 5. UPDATE SUPPORT TICKET (AUTHENTICATED USER - OWNER OR ADMIN)
 // ============================================================================
-router.patch('/tickets/:id', authenticate, userLimiter, async (req, res) => {
+router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicketSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { subject, description, category, status } = req.body;
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -142,3 +142,31 @@ export const registerDeviceSchema = z.object({
     invalid_type_error: 'platform must be one of: android, ios, web',
   }).default('android'),
 }).passthrough();
+
+// Support ticket schemas
+const SUPPORT_CATEGORIES = ['billing', 'booking', 'payment', 'order', 'technical', 'general', 'account'];
+const TICKET_STATUSES = ['open', 'in_progress', 'resolved', 'closed'];
+
+export const createTicketSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject must be 200 characters or less'),
+  category: z.string()
+    .min(1, 'Category is required')
+    .transform(v => v.trim())
+    .refine((v) => SUPPORT_CATEGORIES.includes(v.toLowerCase()), {
+      message: `Category must be one of: ${SUPPORT_CATEGORIES.join(', ')}`,
+    }),
+  description: z.string().max(2000, 'Description must be 2000 characters or less').optional(),
+});
+
+export const updateTicketSchema = z.object({
+  subject: z.string().min(1, 'Subject cannot be empty').max(200, 'Subject must be 200 characters or less').optional(),
+  description: z.string().max(2000, 'Description must be 2000 characters or less').optional(),
+  category: z.string()
+    .transform(v => v.trim())
+    .refine((v) => SUPPORT_CATEGORIES.includes(v.toLowerCase()), {
+      message: `Category must be one of: ${SUPPORT_CATEGORIES.join(', ')}`,
+    }).optional(),
+  status: z.enum(TICKET_STATUSES, {
+    invalid_type_error: `Status must be one of: ${TICKET_STATUSES.join(', ')}`,
+  }).optional(),
+});


### PR DESCRIPTION
Closes #827.

Summary of What Has Been Done:
Defined createTicketSchema (subject required, category required, description optional) and updateTicketSchema (all fields optional, category and status validated) and applied validateBody middleware to POST /tickets and PATCH /tickets/:id routes.

Changes Made:
- backend/api/src/validation/requestSchemas.js: added createTicketSchema and updateTicketSchema
- backend/api/src/routes/supportRoutes.js: applied validateBody(createTicketSchema) and validateBody(updateTicketSchema) to the respective routes

Impact it Made:
- Strict type/size/length enforcement before Supabase persistence
- Prevents mass assignment and unexpected data type errors
- Consistent with all other mutation endpoints in the codebase

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made a minor formatting adjustment in the profile update validation schema. No user-facing behavior or validation rules changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->