### PR TITLE
[Bug]: Driver polygon wallet written to profiles table but escrow read from driver_details — wallet never propagates

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -106,6 +106,14 @@ router.put('/wallet', authenticate, userLimiter, async (req, res) => {
       return res.status(500).json({ error: 'Failed to update wallet address.', details: updateErr.message });
     }
 
+    const { error: driverDetailsErr } = await supabase
+      .from('driver_details')
+      .upsert({ user_id: userId, polygon_wallet_address: normalized }, { onConflict: 'user_id' });
+
+    if (driverDetailsErr) {
+      return res.status(500).json({ error: 'Failed to sync wallet to driver details.', details: driverDetailsErr.message });
+    }
+
     if (req.user && req.user.uid) {
       void invalidateCachedProfile(req.user.uid);
     }


### PR DESCRIPTION
## Fix

Added an upsert into `driver_details` after writing to `profiles` in the wallet update handler so both tables stay in sync.

### Changes

**backend/api/src/routes/profileRoutes.js** (lines 108-114)
- After updating `profiles.polygon_wallet_address`, upsert the same address into `driver_details.polygon_wallet_address`
- Uses Supabase upsert with `onConflict: user_id` so it works for both existing and new driver detail rows
- Read paths in `orderRoutes.js` and `escrow.js` already query `driver_details` — they will now see the wallet

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet updates now also stay in sync with driver details, helping keep account information consistent across the app.
  * If wallet syncing fails, the app now returns a clearer error instead of silently continuing, making issues easier to detect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->