### PR TITLE
[Bug]: createOrderSchema marks pickup_address/drop_address as optional but handler treats them as required

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -34,15 +34,15 @@ const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)(:[0-5]\d)?$/; // HH:MM or HH:MM:SS
 const upiRegex = /^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z]{2,64}$/;
 
 export const createOrderSchema = z.object({
-  pickup_address: z.string().min(5, "Pickup address is too short").max(255, "Pickup address is too long").optional(),
+  pickup_address: z.string().min(5, "Pickup address is too short").max(255, "Pickup address is too long"),
   pickup_lat: latitudeSchema,
   pickup_lng: longitudeSchema,
-  drop_address: z.string().min(5, "Drop address is too short").max(255, "Drop address is too long").optional(),
+  drop_address: z.string().min(5, "Drop address is too short").max(255, "Drop address is too long"),
   drop_lat: latitudeSchema,
   drop_lng: longitudeSchema,
   pickup_date: isoDateStringSchema,
   pickup_time: z.string().regex(timeRegex, "Time must be in HH:MM format").optional(),
-  goods_type: z.string().min(2, "Goods type must be specified").optional(),
+  goods_type: z.string().min(2, "Goods type must be specified"),
   weight_tonnes: coerceNumber(z.number().positive({ message: 'Must be greater than 0' }).max(100, "Weight exceeds maximum legal limits")),
   length_ft: coerceNumber(z.number().positive().max(60)).optional(),
   width_ft: coerceNumber(z.number().positive().max(15)).optional(),


### PR DESCRIPTION
## Fix

Removed `.optional()` from `pickup_address`, `drop_address`, and `goods_type` in `createOrderSchema` so Zod enforces their presence with consistent structured error formatting instead of relying on the handler's generic 400 check.

### Changes

**backend/api/src/validation/requestSchemas.js** (lines 37, 40, 45)
- `pickup_address` — removed `.optional()`
- `drop_address` — removed `.optional()`
- `goods_type` — removed `.optional()`

Closes #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened order submission validation by requiring pickup address, drop address, and goods type.
  * Users must now provide these details when creating an order, helping prevent incomplete requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->