### PR TITLE
[Bug]: .passthrough() on 10 Zod mutation schemas silently accepts arbitrary extra fields

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -52,7 +52,7 @@ export const createOrderSchema = z.object({
   special_requirements: z.string().max(500).optional().nullable(),
   payment_method_id: z.string().optional(),
   upi_id: z.string().regex(upiRegex, "Invalid UPI ID format").optional().or(z.literal('')).nullable()
-}).passthrough();
+}).strict();
 
 export const paramIdSchema = z.object({
   id: uuidSchema.or(z.string().min(1, "ID is required"))
@@ -63,7 +63,7 @@ export const submitBidSchema = z.object({
     .number()
     .int({ message: 'Must be a positive integer' })
     .positive({ message: 'Must be greater than 0' }),
-}).passthrough();
+}).strict();
 
 export const acceptBidParamsSchema = z.object({
   id: uuidSchema.or(z.string().min(1, "Order ID is required")),
@@ -72,7 +72,7 @@ export const acceptBidParamsSchema = z.object({
 
 export const driverOnlineSchema = z.object({
   is_online: z.boolean(),
-}).passthrough();
+}).strict();
 
 export const withdrawSchema = z.object({
   amount: z
@@ -80,7 +80,7 @@ export const withdrawSchema = z.object({
     .int({ message: 'Amount must be a whole number (paisa)' })
     .positive({ message: 'Amount must be greater than 0' })
     .safe({ message: 'Amount is too large' }),
-}).passthrough();
+}).strict();
 
 export const submitRatingSchema = z.object({
   stars: z
@@ -89,7 +89,7 @@ export const submitRatingSchema = z.object({
     .min(1, { message: 'Stars must be between 1 and 5' })
     .max(5, { message: 'Stars must be between 1 and 5' }),
   comment: z.string().trim().max(1000, { message: 'Comment must be 1000 characters or fewer' }).optional().nullable(),
-}).passthrough();
+}).strict();
 export const predictDemandSchema = z.object({
   hour: z.number().min(0).max(23, { message: 'Hour must be between 0 and 23' }),
   day_of_week: z.number().min(0).max(6, { message: 'Day of week must be between 0 and 6' }),
@@ -97,7 +97,7 @@ export const predictDemandSchema = z.object({
   precipitation: z.number().nonnegative({ message: 'Precipitation must be greater than or equal to 0' }),
   historical_volume: z.number().nonnegative({ message: 'Historical volume must be greater than or equal to 0' }),
   nearby_drivers: z.number().nonnegative({ message: 'Nearby drivers must be greater than or equal to 0' }),
-}).passthrough();
+}).strict();
 
 export const updateMilestoneSchema = z.object({
   milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving', 'Delivered'], {
@@ -124,15 +124,15 @@ export const changeDropSchema = z.object({
       .min(-180, { message: 'Must be greater than or equal to -180' })
       .max(180, { message: 'Must be less than or equal to 180' })
   ),
-}).passthrough();
+}).strict();
 
 export const cancelOrderSchema = z.object({
   reason: z.string().max(500).optional().nullable(),
-}).passthrough();
+}).strict();
 
 export const updateWalletSchema = z.object({
   wallet_address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x-prefixed 42-character wallet address'),
-}).passthrough();
+}).strict();
 
 export const registerDeviceSchema = z.object({
   fcmToken: z.string()
@@ -141,4 +141,4 @@ export const registerDeviceSchema = z.object({
   platform: z.enum(['android', 'ios', 'web'], {
     invalid_type_error: 'platform must be one of: android, ios, web',
   }).default('android'),
-}).passthrough();
+}).strict();


### PR DESCRIPTION
## Fix

Replaced `.passthrough()` with `.strict()` on all 10 mutation Zod schemas so unknown fields are rejected instead of silently accepted.

### Schemas changed

1. `createOrderSchema`
2. `submitBidSchema`
3. `driverOnlineSchema`
4. `withdrawSchema`
5. `submitRatingSchema`
6. `predictDemandSchema`
7. `changeDropSchema`
8. `cancelOrderSchema`
9. `updateWalletSchema`
10. `registerDeviceSchema`

Closes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened request validation so API endpoints now reject unexpected extra fields.
  * Improved consistency by accepting only the fields explicitly required for each supported request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->