### PR TITLE
[Bug]: extra_distance_km column referenced in loadRoutes.js distance filter and sort is never populated

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -269,6 +269,7 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), validateB
         fuel_cost: pricing.fuelCost,
         toll_cost: pricing.tollEstimate,
         net_profit: pricing.netProfit,
+        extra_distance_km: pricing.distanceKm,
         status: 'available'
       });
 


### PR DESCRIPTION
## Fix

Added `extra_distance_km` to the `load_offers` insert in the order creation handler. The value comes from `pricing.distanceKm` which is already computed by `computeOrderPricing()` (either from OSRM road distance or haversine fallback).

### Changes

**backend/api/src/routes/orderRoutes.js** (line 272)
- Insert `extra_distance_km: pricing.distanceKm` alongside existing `freight_value`, `fuel_cost`, `toll_cost`, `net_profit`
- The `GET /api/loads` endpoint already filters by `.lte("extra_distance_km", maxDistance)` and sorts by `extra_distance_km` — these will now work correctly

Closes #739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order creation now includes an additional distance-related value in the backend broadcast, helping ensure offer data is more complete and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->