### PR TITLE
[Bug]: PUT /api/profile has no Zod input validation — only mutation endpoint without validateBody()

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -9,6 +9,8 @@ import {
 import { supabase } from '../config/db.js';
 import { ProfileModel } from '../models/ProfileModel.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
+import { validateBody } from '../middleware/validate.js';
+import { updateProfileSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -120,7 +122,7 @@ router.put('/wallet', authenticate, userLimiter, async (req, res) => {
 });
 
 // UPDATE PROFILE (basic version)
-router.put('/', authenticate, userLimiter, async (req, res) => {
+router.put('/', authenticate, userLimiter, validateBody(updateProfileSchema), async (req, res) => {
   try {
     const userId = req.user.id;
     const { full_name, language, dark_mode, is_online } = req.body;

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -134,6 +134,13 @@ export const updateWalletSchema = z.object({
   wallet_address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x-prefixed 42-character wallet address'),
 }).passthrough();
 
+export const updateProfileSchema = z.object({
+  full_name: z.string().min(1, "Name is required").max(255, "Name is too long").optional(),
+  language: z.string().max(50, "Language is too long").optional(),
+  dark_mode: z.boolean().optional(),
+  is_online: z.boolean().optional(),
+}).strict();
+
 export const registerDeviceSchema = z.object({
   fcmToken: z.string()
     .min(10, { message: 'fcmToken must be at least 10 characters' })


### PR DESCRIPTION
## Fix

Added `updateProfileSchema` Zod schema and applied `validateBody()` middleware to `PUT /api/profile`, consistent with all other mutation endpoints.

### Changes

**backend/api/src/validation/requestSchemas.js** (lines 137-142)
- New `updateProfileSchema` with validated fields: `full_name`, `language`, `dark_mode`, `is_online`

**backend/api/src/routes/profileRoutes.js** (line 11, 125)
- Imported `validateBody` and `updateProfileSchema`
- Added `validateBody(updateProfileSchema)` to the PUT route middleware chain

Closes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now validate incoming data before saving changes, helping prevent invalid profile information from being accepted.
  * The update form now supports only the expected profile fields and rejects extra properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->