### PR TITLE
[Bug]: Delivery OTP cannot be regenerated after expiry — milestone already past 'In Transit', no resend endpoint

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -946,7 +946,43 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['dri
 });
 
 // ============================================================================
-// 14. CHANGE DROP (CUSTOMER)
+// 14. RESEND DELIVERY OTP (DRIVER)
+// ============================================================================
+router.post('/:id/resend-otp', authenticate, userLimiter, requireRole(['driver']), validateParams(paramIdSchema), async (req, res) => {
+  const orderId = req.params.id;
+
+  try {
+    const { data: order, error: orderErr } = await supabase.from('orders').select('id, order_display_id, driver_id, customer_id, status').eq('id', orderId).maybeSingle();
+    if (orderErr || !order) return res.status(404).json({ error: 'Order not found.' });
+    if (order.driver_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You are not assigned to this order.' });
+
+    const terminalStatuses = ['delivered', 'cancelled', 'payment_released'];
+    if (terminalStatuses.includes(order.status)) {
+      return res.status(400).json({ error: 'Cannot resend OTP for a completed or cancelled order.' });
+    }
+
+    const otp = crypto.randomInt(100000, 1000000).toString();
+    const stored = await storeDeliveryOtp(orderId, otp, OTP_TTL_MINUTES);
+    if (!stored) {
+      return res.status(500).json({ error: 'Failed to generate delivery OTP.' });
+    }
+
+    await clearOtpState(orderId);
+
+    const notifResult = await sendDeliveryOtpNotification(order.customer_id, order.order_display_id, otp);
+    if (!notifResult.success) {
+      logger.warn(`[OrderRoutes] Resend OTP notification failed for order ${order.order_display_id} — FCM error: ${notifResult.fcm?.error || 'unknown'}`);
+    }
+
+    res.json({ message: 'New delivery OTP sent.', expiresInMinutes: OTP_TTL_MINUTES });
+  } catch (err) {
+    logger.error('[OrderRoutes] Resend OTP error:', err.message);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 15. CHANGE DROP (CUSTOMER)
 // ============================================================================
 router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
   const orderId = req.params.id; // this is order_display_id from client
@@ -1026,7 +1062,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
 });
 
 // ============================================================================
-// 15. CANCEL ORDER AND REFUND ESCROW (CUSTOMER)
+// 16. CANCEL ORDER AND REFUND ESCROW (CUSTOMER)
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
   const orderId = req.params.id; // this is order_display_id from client
@@ -1115,7 +1151,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
 });
 
 // ============================================================================
-// 16. CONFIRM ESCROW DEPOSIT (CUSTOMER)
+// 17. CONFIRM ESCROW DEPOSIT (CUSTOMER)
 // ============================================================================
 router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(
   z.object({ txHash: z.string().regex(/^0x([A-Fa-f0-9]{64})$/, 'Invalid transaction hash') }),
@@ -1154,7 +1190,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
 });
 
 // ============================================================================
-// 17. PREDICT RIDE DEMAND (CUSTOMER OR DRIVER)
+// 18. PREDICT RIDE DEMAND (CUSTOMER OR DRIVER)
 // ============================================================================
 router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer', 'driver']), predictDemandLimiter, validateBody(predictDemandSchema), async (req, res) => {
   try {
@@ -1170,7 +1206,7 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 });
 
 // ============================================================================
-// 17. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
+// 19. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
 // ============================================================================
 router.get('/:id/driver-location', authenticate, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id; // this is order_display_id from client


### PR DESCRIPTION
## Fix

Added `POST /api/orders/:id/resend-otp` endpoint so drivers can request a new delivery OTP when it expires.

### Changes

**backend/api/src/routes/orderRoutes.js** (lines 949-981)
- New `POST /:id/resend-otp` route for assigned drivers
- Validates driver assignment and order status (rejects completed/cancelled orders)
- Generates a fresh 6-digit OTP with the configured TTL
- Stores it via existing `storeDeliveryOtp()` and clears failure state via `clearOtpState()`
- Sends notification via existing `sendDeliveryOtpNotification()`
- Updated section numbering (14→19) for clarity

Closes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drivers can now resend a delivery OTP for eligible orders from the app.
  * The response includes the OTP expiration time in minutes.

* **Bug Fixes**
  * Resending is blocked for completed, cancelled, or payment-released orders.
  * Previous OTP state is cleared before generating a new code, helping avoid lockout issues.
  * If OTP delivery fails, the system now logs a warning and continues gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->