### PR TITLE
[Bug]: Order history query selects driver_name column that does not exist in orders table

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -355,11 +355,19 @@ router.get('/history', authenticate, userLimiter, requireRole(['customer']), asy
   try {
     const { data: history, error } = await supabase
       .from('orders')
-      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, driver_name, eta, created_at')
+      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, driver_id, eta, created_at')
       .eq('customer_id', req.user.id)
       .order('created_at', { ascending: false });
 
     if (error) return res.status(500).json({ error: 'Failed to fetch history.', details: error.message });
+
+    const driverIds = [...new Set((history || []).filter(o => o.driver_id).map(o => o.driver_id))];
+    if (driverIds.length > 0) {
+      const { data: profiles } = await supabase.from('profiles').select('id, full_name').in('id', driverIds);
+      const driverMap = Object.fromEntries((profiles || []).map(p => [p.id, p.full_name]));
+      (history || []).forEach(o => { o.driver_name = driverMap[o.driver_id] || 'Driver Assigned'; });
+    }
+
     res.json(history);
   } catch (err) {
     res.status(500).json({ error: 'Internal Server Error' });


### PR DESCRIPTION
## Fix

Replaced the nonexistent `driver_name` column in the history query select with `driver_id`, then resolved driver names from the `profiles` table post-query (same pattern as `/my/active` endpoint at line 302-306).

### Changes

**backend/api/src/routes/orderRoutes.js** (lines 358, 364-369)
- Changed `driver_name` → `driver_id` in the Supabase select
- Added profile lookup for all non-null `driver_id` values
- Attached `driver_name` dynamically after the query

Closes #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order history results so driver names are shown reliably for each past order.
  * Updated history responses to fill in missing driver names using associated profile information when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->