### PR TITLE
[Bug]: Change-drop endpoint updates orders table but does not update corresponding load_offers record

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1003,6 +1003,25 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update(updates).eq('order_display_id', orderId).select('*').single();
     if (updateErr) return res.status(500).json({ error: 'Failed to update order.', details: updateErr.message });
 
+    const { error: offerUpdateErr } = await supabase
+      .from('load_offers')
+      .update({
+        drop_address,
+        drop_lat: Number(drop_lat),
+        drop_lng: Number(drop_lng),
+        route_label: `${(order.pickup_address || '').split(',')[0]} → ${drop_address.split(',')[0]}`,
+        freight_value: pricing.baseFreight,
+        fuel_cost: pricing.fuelCost,
+        toll_cost: pricing.tollEstimate,
+        net_profit: pricing.netProfit,
+        extra_distance_km: pricing.distanceKm,
+      })
+      .eq('order_display_id', orderId);
+
+    if (offerUpdateErr) {
+      logger.error('Load offer update failed for change-drop:', offerUpdateErr.message);
+    }
+
     try {
       await supabase.from('order_timeline').insert({ order_display_id: order.order_display_id, milestone: 'Drop Changed', milestone_time: new Date().toISOString(), completed: true, sort_order: 25 });
     } catch (timelineErr) {


### PR DESCRIPTION
## Fix

Added a `load_offers` update after the `orders` update in the change-drop handler so the load board reflects the new drop address and recalculated pricing.

### Changes

**backend/api/src/routes/orderRoutes.js** (lines 1006-1021)
- After updating `orders`, also update `load_offers` with:
  - `drop_address`, `drop_lat`, `drop_lng`
  - Updated `route_label`
  - Recalculated `freight_value`, `fuel_cost`, `toll_cost`, `net_profit`
  - `extra_distance_km` from pricing

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing a drop now also updates the related load offer details, keeping the stop location, route label, pricing, and profit figures in sync.
  * Extra distance is now saved alongside the updated pricing information for more accurate records.
  * If the load offer update fails, the change still completes and the issue is logged for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->