### PR TITLE
[Bug]: Driver location endpoint returns stale/off-order telemetry due to missing order_id filter in MongoDB query

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1170,7 +1170,7 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 });
 
 // ============================================================================
-// 17. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
+// 19. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
 // ============================================================================
 router.get('/:id/driver-location', authenticate, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id; // this is order_display_id from client
@@ -1209,7 +1209,7 @@ router.get('/:id/driver-location', authenticate, requireRole(['customer', 'drive
 
     const latestTelemetry = await mongoDb
       .collection('telemetry')
-      .find({ driver_id: order.driver_id })
+      .find({ driver_id: order.driver_id, order_id: order.id })
       .sort({ timestamp: -1 })
       .limit(1)
       .toArray();


### PR DESCRIPTION
## Fix

Added `order_id: order.id` to the MongoDB telemetry filter so the driver location endpoint returns GPS data from the correct order, not a stale or unrelated trip.

### Changes

**backend/api/src/routes/orderRoutes.js** (line 1231)
- Added `order_id: order.id` to the MongoDB `.find()` filter alongside existing `driver_id` filter

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver location lookups so the app now matches telemetry by both driver and order, helping return the correct live location for each order.
  * Updated endpoint labeling in the route documentation to stay aligned with the current flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->