### PR TITLE
fix : added healthLimiter to health check routes

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
+import { healthLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
@@ -65,7 +66,7 @@ function checkPolygon() {
 const CRITICAL_UNHEALTHY = new Set(['failed', 'not_configured']);
 
 // GET /api/health — full dependency check; returns 503 when a critical service fails
-router.get('/', async (req, res) => {
+router.get('/', healthLimiter, async (req, res) => {
   const [supabaseStatus, mongoStatus, redisStatus] = await Promise.all([
     checkSupabase(),
     checkMongo(),
@@ -94,7 +95,7 @@ router.get('/', async (req, res) => {
 });
 
 // GET /api/health/live — liveness probe; always 200 as long as the process is up
-router.get('/live', (req, res) => {
+router.get('/live', healthLimiter, (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
 


### PR DESCRIPTION
Closes #845.

Summary of What Has Been Done:
Imported healthLimiter from rateLimiter.js and applied it to both GET /api/health and GET /api/health/live routes in healthRoutes.js. Public health endpoints are frequently polled by load balancers and monitoring tools — unthrottled they can exhaust DB connections.

Changes Made:
- backend/api/src/routes/healthRoutes.js: Import healthLimiter and add to both health route handlers.

Impact it Made:
- Backend unit tests pass (302/302)
- Aligns health endpoints with the DoS protection strategy applied across the API

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added rate limiting to the main health check and liveness endpoints to help protect them from excessive requests.
  * Health check responses, status codes, and dependency evaluation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->