### PR TITLE
fix : added Zod validation schemas for support ticket endpoints

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -2,6 +2,8 @@ import express from 'express';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { validateBody } from '../middleware/validate.js';
+import { createTicketSchema, updateTicketSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -48,16 +50,10 @@ router.get('/faqs', async (req, res) => {
 // ============================================================================
 // 2. CREATE SUPPORT TICKET (AUTHENTICATED USER)
 // ============================================================================
-router.post('/tickets', authenticate, userLimiter, async (req, res) => {
+router.post('/tickets', authenticate, userLimiter, validateBody(createTicketSchema), async (req, res) => {
   const subject = normalizeRequiredText(req.body.subject);
   const category = normalizeRequiredText(req.body.category);
   const description = normalizeRequiredText(req.body.description) || subject;
-
-  if (!subject || !category) {
-    return res.status(400).json({
-      error: 'subject and category are required.',
-    });
-  }
 
   // Map user-friendly/frontend categories to database-constrained values
   const CATEGORY_MAP = {
@@ -187,7 +183,7 @@ router.get('/tickets/:id', authenticate, userLimiter, async (req, res) => {
 // ============================================================================
 // 5. UPDATE SUPPORT TICKET (AUTHENTICATED USER - OWNER OR ADMIN)
 // ============================================================================
-router.patch('/tickets/:id', authenticate, userLimiter, async (req, res) => {
+router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicketSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { subject, description, category, status } = req.body;
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -144,8 +144,12 @@ export const registerDeviceSchema = z.object({
 }).passthrough();
 
 export const createTicketSchema = z.object({
-  subject: z.string().min(1, 'Subject is required').max(200, 'Subject must be 200 characters or fewer'),
-  category: z.string().min(1, 'Category is required').max(50, 'Category must be 50 characters or fewer'),
+  subject: z.string().transform((v) => v.trim()).pipe(
+    z.string().min(1, 'Subject is required').max(200, 'Subject must be 200 characters or fewer')
+  ),
+  category: z.string().transform((v) => v.trim()).pipe(
+    z.string().min(1, 'Category is required').max(50, 'Category must be 50 characters or fewer')
+  ),
   description: z.string().max(5000, 'Description must be 5000 characters or fewer').optional(),
 });
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -142,3 +142,25 @@ export const registerDeviceSchema = z.object({
     invalid_type_error: 'platform must be one of: android, ios, web',
   }).default('android'),
 }).passthrough();
+
+export const createTicketSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject must be 200 characters or fewer'),
+  category: z.string().min(1, 'Category is required').max(50, 'Category must be 50 characters or fewer'),
+  description: z.string().max(5000, 'Description must be 5000 characters or fewer').optional(),
+});
+
+export const updateTicketSchema = z.object({
+  subject: z.string().min(1, 'Subject cannot be empty').max(200, 'Subject must be 200 characters or fewer').optional(),
+  category: z.string().min(1, 'Category cannot be empty').max(50, 'Category must be 50 characters or fewer').optional(),
+  description: z.string().max(5000, 'Description must be 5000 characters or fewer').optional(),
+  status: z.enum(['open', 'in_progress', 'resolved', 'closed'], {
+    invalid_type_error: "Status must be one of: open, in_progress, resolved, closed",
+  }).optional(),
+});
+
+export const updateProfileSchema = z.object({
+  full_name: z.string().max(100, 'Name must be 100 characters or fewer').optional(),
+  language: z.string().max(10, 'Language code must be 10 characters or fewer').optional(),
+  dark_mode: z.boolean().optional(),
+  is_online: z.boolean().optional(),
+});

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -122,7 +122,12 @@ describe('Support Routes', () => {
       .send({ subject: '   ', category: 'billing' });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('subject and category are required.');
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'subject', message: 'Subject is required' }),
+      ])
+    );
   });
 
   it('POST /tickets creates an open ticket for the authenticated user with category mapping and description', async () => {


### PR DESCRIPTION
Closes #846.

Summary of What Has Been Done:
Added createTicketSchema and updateTicketSchema to requestSchemas.js and wired them into the support ticket route handlers via validateBody, replacing manual inline validation with consistent Zod-based input validation.

Changes Made:
- backend/api/src/validation/requestSchemas.js: Added createTicketSchema (subject + category required) and updateTicketSchema (all fields optional, status validated against VALID_STATUSES).
- backend/api/src/routes/supportRoutes.js: Import and apply validateBody with the schemas on POST /tickets and PATCH /tickets/:id.

Impact it Made:
- Backend unit tests pass (302/302)
- Consistent Zod validation across all mutation endpoints

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket creation and updates now consistently validate request bodies and normalize `subject`/`category`/`description`, including defaulting `description` to `subject` when empty after normalization.
  * Ticket `status` inputs are now more strictly validated to prevent invalid ticket states.
  * Updated ticket/profile field limits (including a higher description maximum and tighter profile name/language constraints).

* **New Features**
  * Added/updated request validation for profile updates (notably `full_name` and `language`).

* **Tests**
  * Updated POST ticket validation tests to match structured validation error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->