### PR TITLE
fix: reconcile escrow refunds during cancellation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,7 @@ POLYGON_RPC_URL=https://polygon-mainnet.g.alchemy.com/v2/your-alchemy-api-key
 # Smart Contract deployment addresses
 REPUTATION_CONTRACT_ADDRESS=0x1234567890123456789012345678901234567890
 ESCROW_CONTRACT_ADDRESS=0x0987654321098765432109876543210987654321
+ESCROW_RECONCILIATION_INTERVAL_MS=60000
 
 # Wallet Private Key for signing on-chain transactions (Keep this strictly secret!)
 # Used by backend relayer for submitting gasless txs for drivers/customers

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -48,3 +48,5 @@ RELAYER_WALLET_PRIVATE_KEY=your_private_key
 ESCROW_MATIC_PER_PAISA=
 # Safety cap: reject deposits exceeding this many MATIC
 MAX_ESCROW_MATIC=5
+# Poll interval for confirmed refunds that still need a Supabase state update.
+ESCROW_RECONCILIATION_INTERVAL_MS=60000

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -24,6 +24,10 @@ import healthRoutes from './routes/healthRoutes.js';
 import logger from './middleware/logger.js';
 import { requestIdMiddleware, requestLogger } from './middleware/requestId.js';
 import { initSentry, flushSentry, sentryErrorHandler } from './middleware/sentry.js';
+import {
+  startEscrowRefundReconciliation,
+  stopEscrowRefundReconciliation,
+} from './services/escrowRefundReconciliation.js';
 
 // Configuration load from root folder is handled in db.js
 
@@ -203,6 +207,7 @@ const PORT = process.env.PORT || 5000;
 
 server.listen(PORT, () => {
   logger.info(`Truxify API listening on port ${PORT}`);
+  startEscrowRefundReconciliation();
 });
 
 // ============================================================================
@@ -212,6 +217,7 @@ const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 async function shutdown(signal) {
   logger.info(`${signal} received — draining connections...`);
+  stopEscrowRefundReconciliation();
 
   const forceExit = setTimeout(() => {
     logger.error('[shutdown] Timeout exceeded — forcing exit.');

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -22,7 +22,14 @@ import {
 import { awardReputationPoints } from '../services/reputation.js';
 import { predictDemand, predictPrice } from '../services/ml.js';
 import { changeDropSchema, cancelOrderSchema } from '../validation/requestSchemas.js';
-import { buildDepositTx, recordDepositTx, escrowRelease, escrowRefund, ESCROW_MATIC_PER_PAISA } from '../services/escrow.js';
+import {
+  buildDepositTx,
+  recordDepositTx,
+  escrowRelease,
+  submitEscrowRefund,
+  confirmEscrowRefund,
+  ESCROW_MATIC_PER_PAISA,
+} from '../services/escrow.js';
 import { sendDeliveryOtpNotification, storeDeliveryOtp, getActiveDeliveryOtp, verifyDeliveryOtp, expireDeliveryOtps } from '../services/notificationService.js';
 import logger from '../middleware/logger.js';
 
@@ -1115,42 +1122,146 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
       return res.status(409).json({ error: 'Cannot cancel: delivery OTP has already been verified.' });
     }
 
-    let refundTxHash = null;
-    // Phase 1: Process escrow refund BEFORE changing order status
-    if (order.escrow_status === 'funded') {
-      try {
-        const { txHash } = await escrowRefund(order.order_display_id);
-        refundTxHash = txHash;
-      } catch (refundErr) {
-        logger.error('[escrow] Refund failed for order', orderId, ':', refundErr.message);
-        return res.status(502).json({
-          error: 'Escrow refund failed. Order was not cancelled.',
-          details: 'The blockchain transaction could not be completed. Please try again or contact support.',
+    if (order.status === 'cancelled' && order.escrow_status === 'refunded') {
+      return res.json({
+        message: 'Order was already cancelled and refunded.',
+        cancellation_fee: order.cancellation_fee ?? 0,
+        order,
+      });
+    }
+
+    const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(order.escrow_status);
+    let workingOrder = order;
+
+    // Persist cancellation before touching the blockchain. A failed or delayed
+    // refund must never leave the order available for continued work.
+    if (requiresRefund && (order.status !== 'cancelled' || order.escrow_status !== 'refund_pending')) {
+      const attemptAt = new Date().toISOString();
+      const { data: pendingOrder, error: pendingErr } = await supabase
+        .from('orders')
+        .update({
+          status: 'cancelled',
+          cancellation_reason: reason ?? order.cancellation_reason,
+          escrow_status: 'refund_pending',
+          escrow_refund_error: null,
+          escrow_refund_attempts: (order.escrow_refund_attempts ?? 0) + 1,
+          escrow_refund_last_attempt_at: attemptAt,
+          updated_at: attemptAt,
+        })
+        .eq('order_display_id', orderId)
+        .not('status', 'in', '("delivered","payment_released")')
+        .select('*')
+        .single();
+
+      if (pendingErr) {
+        if (pendingErr.code === 'PGRST116') {
+          return res.status(409).json({ error: 'Order was already delivered or payment released. Cannot cancel.' });
+        }
+        return res.status(500).json({
+          error: 'Failed to place the order into refund reconciliation.',
+          details: pendingErr.message,
         });
       }
+      workingOrder = pendingOrder;
+    }
 
-      if (!refundTxHash) {
-        logger.error('[escrow] Refund returned null txHash for order', orderId);
-        return res.status(502).json({
-          error: 'Escrow refund could not be processed. Order was not cancelled.',
+    if (requiresRefund) {
+      let refundTxHash = workingOrder.refund_tx_hash ?? null;
+
+      try {
+        let receipt;
+
+        if (refundTxHash) {
+          receipt = await confirmEscrowRefund(refundTxHash);
+        } else {
+          const submitted = await submitEscrowRefund(order.order_display_id);
+          refundTxHash = submitted.txHash;
+          if (!refundTxHash || !submitted.waitForConfirmation) {
+            throw new Error('Escrow refund transaction was not submitted.');
+          }
+
+          const submittedAt = new Date().toISOString();
+          const { error: hashErr } = await supabase
+            .from('orders')
+            .update({
+              refund_tx_hash: refundTxHash,
+              escrow_refund_submitted_at: submittedAt,
+              updated_at: submittedAt,
+            })
+            .eq('order_display_id', orderId)
+            .eq('escrow_status', 'refund_pending');
+
+          if (hashErr) {
+            logger.error('[escrow] Failed to persist refund tx hash for order', orderId, ':', hashErr.message);
+          }
+          receipt = await submitted.waitForConfirmation();
+        }
+
+        const refundedAt = new Date().toISOString();
+        const { data: updatedOrder, error: updateErr } = await supabase
+          .from('orders')
+          .update({
+            status: 'cancelled',
+            cancellation_reason: reason ?? workingOrder.cancellation_reason,
+            escrow_status: 'refunded',
+            refund_tx_hash: receipt.hash ?? refundTxHash,
+            escrow_refunded_at: refundedAt,
+            escrow_refund_error: null,
+            updated_at: refundedAt,
+          })
+          .eq('order_display_id', orderId)
+          .in('escrow_status', ['refund_pending', 'refund_failed'])
+          .select('cancellation_fee, order_display_id, status, cancellation_reason, escrow_status, refund_tx_hash')
+          .single();
+
+        if (updateErr) {
+          logger.error('[escrow] Refund confirmed but final order update failed for', orderId, ':', updateErr.message);
+          return res.status(202).json({
+            message: 'Order cancelled and escrow refund confirmed. Database reconciliation is pending.',
+            refund_tx_hash: receipt.hash ?? refundTxHash,
+            escrow_status: 'refund_pending',
+            reconciliation_required: true,
+          });
+        }
+
+        await supabase.from('order_timeline').update({ completed: true, milestone_time: refundedAt })
+          .eq('order_display_id', order.order_display_id)
+          .eq('milestone', 'Order Placed');
+
+        return res.json({
+          message: 'Order cancelled and escrow refunded successfully.',
+          cancellation_fee: updatedOrder?.cancellation_fee ?? 0,
+          order: updatedOrder,
+        });
+      } catch (refundErr) {
+        logger.error('[escrow] Refund failed for order', orderId, ':', refundErr.message);
+        const failedAt = new Date().toISOString();
+        const nextEscrowStatus = refundTxHash ? 'refund_pending' : 'refund_failed';
+        await supabase.from('orders').update({
+          status: 'cancelled',
+          escrow_status: nextEscrowStatus,
+          refund_tx_hash: refundTxHash,
+          escrow_refund_error: String(refundErr.message || refundErr).slice(0, 1000),
+          escrow_refund_last_attempt_at: failedAt,
+          updated_at: failedAt,
+        }).eq('order_display_id', orderId);
+
+        return res.status(202).json({
+          message: 'Order cancelled. Escrow refund requires reconciliation.',
+          escrow_status: nextEscrowStatus,
+          refund_tx_hash: refundTxHash,
+          retryable: true,
         });
       }
     } else if (order.escrow_booking_id) {
       logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain refund.`);
     }
 
-    // Phase 2: Change order status to cancelled and update escrow record atomically
     const updatePayload = {
       status: 'cancelled',
       cancellation_reason: reason,
       updated_at: new Date().toISOString(),
     };
-
-    if (order.escrow_status === 'funded') {
-      updatePayload.escrow_status = 'refunded';
-      updatePayload.refund_tx_hash = refundTxHash;
-      updatePayload.escrow_refunded_at = new Date().toISOString();
-    }
 
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders')
       .update(updatePayload)

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -178,6 +178,18 @@ export async function escrowRelease(orderDisplayId) {
  * @returns {Promise<{txHash: string|null, bookingId: string}>}
  */
 export async function escrowRefund(orderDisplayId) {
+  const submitted = await submitEscrowRefund(orderDisplayId);
+  if (!submitted.txHash) return submitted;
+
+  const receipt = await submitted.waitForConfirmation();
+  return { txHash: receipt.hash, bookingId: submitted.bookingId };
+}
+
+/**
+ * Submit an escrow refund and return its hash before confirmation.
+ * Callers can persist the hash before waiting on the network.
+ */
+export async function submitEscrowRefund(orderDisplayId) {
   const bookingId = getEscrowBookingId(orderDisplayId);
 
   if (!escrowContract) {
@@ -187,7 +199,34 @@ export async function escrowRefund(orderDisplayId) {
 
   const tx = await escrowContract.refundFunds(bookingId);
   logger.info(`[escrow] refundFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
-  const receipt = await tx.wait(1);
-  logger.info(`[escrow] refundFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
-  return { txHash: receipt.hash, bookingId };
+  return {
+    txHash: tx.hash,
+    bookingId,
+    waitForConfirmation: async () => {
+      const receipt = await tx.wait(1);
+      if (!receipt || receipt.status === 0) {
+        throw new Error('Escrow refund transaction reverted or was not found.');
+      }
+      logger.info(`[escrow] refundFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
+      return receipt;
+    },
+  };
+}
+
+/**
+ * Confirm a previously submitted refund transaction during a retry.
+ */
+export async function confirmEscrowRefund(txHash) {
+  if (!escrowContract) {
+    throw new Error('Escrow contract is not initialised.');
+  }
+  if (!ethers.isHexString(txHash, 32)) {
+    throw new Error('Invalid escrow refund transaction hash.');
+  }
+
+  const receipt = await escrowContract.runner.provider.waitForTransaction(txHash, 1);
+  if (!receipt || receipt.status === 0) {
+    throw new Error('Escrow refund transaction reverted or was not found.');
+  }
+  return receipt;
 }

--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -1,0 +1,79 @@
+import { supabase } from '../config/db.js';
+import logger from '../middleware/logger.js';
+import { confirmEscrowRefund } from './escrow.js';
+
+const DEFAULT_INTERVAL_MS = 60_000;
+let reconciliationTimer = null;
+let reconciliationRunning = false;
+
+export async function reconcilePendingEscrowRefunds() {
+  if (reconciliationRunning) return;
+  reconciliationRunning = true;
+
+  try {
+    const { data: pendingOrders, error } = await supabase
+      .from('orders')
+      .select('id, order_display_id, refund_tx_hash')
+      .eq('escrow_status', 'refund_pending')
+      .not('refund_tx_hash', 'is', null)
+      .limit(50);
+
+    if (error) {
+      logger.error('[escrow-reconciliation] Failed to load pending refunds:', error.message);
+      return;
+    }
+
+    for (const order of pendingOrders ?? []) {
+      try {
+        const receipt = await confirmEscrowRefund(order.refund_tx_hash);
+        const refundedAt = new Date().toISOString();
+        const { error: updateError } = await supabase
+          .from('orders')
+          .update({
+            status: 'cancelled',
+            escrow_status: 'refunded',
+            refund_tx_hash: receipt.hash ?? order.refund_tx_hash,
+            escrow_refunded_at: refundedAt,
+            escrow_refund_error: null,
+            updated_at: refundedAt,
+          })
+          .eq('id', order.id)
+          .eq('escrow_status', 'refund_pending');
+
+        if (updateError) {
+          logger.error(
+            `[escrow-reconciliation] Failed to finalize refund for ${order.order_display_id}:`,
+            updateError.message
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          `[escrow-reconciliation] Refund for ${order.order_display_id} is not confirmed yet:`,
+          err.message
+        );
+      }
+    }
+  } finally {
+    reconciliationRunning = false;
+  }
+}
+
+export function startEscrowRefundReconciliation() {
+  if (reconciliationTimer) return;
+
+  const configuredInterval = Number(process.env.ESCROW_RECONCILIATION_INTERVAL_MS);
+  const intervalMs = Number.isFinite(configuredInterval) && configuredInterval > 0
+    ? configuredInterval
+    : DEFAULT_INTERVAL_MS;
+
+  reconciliationTimer = setInterval(() => {
+    void reconcilePendingEscrowRefunds();
+  }, intervalMs);
+  reconciliationTimer.unref?.();
+}
+
+export function stopEscrowRefundReconciliation() {
+  if (!reconciliationTimer) return;
+  clearInterval(reconciliationTimer);
+  reconciliationTimer = null;
+}

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -70,11 +70,15 @@ vi.mock('../../src/services/reputation.js', () => ({
 }));
 
 const escrowReleaseMock = vi.fn();
+const submitEscrowRefundMock = vi.fn();
+const confirmEscrowRefundMock = vi.fn();
 vi.mock('../../src/services/escrow.js', async () => {
   const actual = await vi.importActual('../../src/services/escrow.js');
   return {
     ...actual,
     escrowRelease: escrowReleaseMock,
+    submitEscrowRefund: submitEscrowRefundMock,
+    confirmEscrowRefund: confirmEscrowRefundMock,
   };
 });
 
@@ -1895,6 +1899,8 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     m.calls.length = 0;
     routeEstimateMock.mockReset();
     routeEstimateMock.mockResolvedValue({ distanceKm: 100 });
+    submitEscrowRefundMock.mockReset();
+    confirmEscrowRefundMock.mockReset();
   });
 
   it('allows customer to change drop and returns recalculated pricing', async () => {
@@ -1976,6 +1982,88 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const stored = m.store.orders.find(o => o.id === 'order-cancel-1');
     expect(stored.status).toBe('cancelled');
     expect(stored.cancellation_reason).toBe('Change of plans');
+  });
+
+  it('persists cancellation before submitting a funded escrow refund', async () => {
+    m.store.orders.push({
+      id: 'order-funded-cancel',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-FUNDED-CANCEL',
+      status: 'in_transit',
+      escrow_status: 'funded',
+      escrow_refund_attempts: 0,
+      cancellation_fee: 500,
+    });
+    submitEscrowRefundMock.mockImplementation(async () => {
+      const stored = m.store.orders.find(o => o.id === 'order-funded-cancel');
+      expect(stored.status).toBe('cancelled');
+      expect(stored.escrow_status).toBe('refund_pending');
+      return {
+        txHash: `0x${'a'.repeat(64)}`,
+        waitForConfirmation: vi.fn().mockResolvedValue({ hash: `0x${'a'.repeat(64)}`, status: 1 }),
+      };
+    });
+
+    const res = await request(buildApp())
+      .post('/api/orders/OD-FUNDED-CANCEL/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'Change of plans' });
+
+    expect(res.status).toBe(200);
+    const stored = m.store.orders.find(o => o.id === 'order-funded-cancel');
+    expect(stored.status).toBe('cancelled');
+    expect(stored.escrow_status).toBe('refunded');
+    expect(stored.refund_tx_hash).toBe(`0x${'a'.repeat(64)}`);
+    expect(stored.escrow_refund_attempts).toBe(1);
+  });
+
+  it('keeps the order cancelled when escrow refund submission fails', async () => {
+    m.store.orders.push({
+      id: 'order-refund-fails',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-REFUND-FAILS',
+      status: 'in_transit',
+      escrow_status: 'funded',
+      cancellation_fee: 500,
+    });
+    submitEscrowRefundMock.mockRejectedValue(new Error('Polygon unavailable'));
+
+    const res = await request(buildApp())
+      .post('/api/orders/OD-REFUND-FAILS/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'Change of plans' });
+
+    expect(res.status).toBe(202);
+    expect(res.body.escrow_status).toBe('refund_failed');
+    expect(res.body.retryable).toBe(true);
+    const stored = m.store.orders.find(o => o.id === 'order-refund-fails');
+    expect(stored.status).toBe('cancelled');
+    expect(stored.escrow_status).toBe('refund_failed');
+    expect(stored.escrow_refund_error).toContain('Polygon unavailable');
+  });
+
+  it('reconciles a previously submitted refund without submitting it twice', async () => {
+    const txHash = `0x${'b'.repeat(64)}`;
+    m.store.orders.push({
+      id: 'order-refund-pending',
+      customer_id: CUSTOMER_HEADERS['x-user-id'],
+      order_display_id: 'OD-REFUND-PENDING',
+      status: 'cancelled',
+      escrow_status: 'refund_pending',
+      refund_tx_hash: txHash,
+      cancellation_fee: 500,
+    });
+    confirmEscrowRefundMock.mockResolvedValue({ hash: txHash, status: 1 });
+
+    const res = await request(buildApp())
+      .post('/api/orders/OD-REFUND-PENDING/cancel')
+      .set(CUSTOMER_HEADERS)
+      .send({ reason: 'Change of plans' });
+
+    expect(res.status).toBe(200);
+    expect(confirmEscrowRefundMock).toHaveBeenCalledWith(txHash);
+    expect(submitEscrowRefundMock).not.toHaveBeenCalled();
+    expect(m.store.orders[0].escrow_status).toBe('refunded');
   });
 
   it('rejects cancel when requester is not the order owner', async () => {

--- a/backend/api/test/unit/verifyDbSchema.test.js
+++ b/backend/api/test/unit/verifyDbSchema.test.js
@@ -63,6 +63,22 @@ erDiagram
 });
 
 describe('Database Schema Constraints and RPC Upsert validation in supabase_setup.sql', () => {
+  it('includes durable escrow refund reconciliation fields', async () => {
+    const setupSqlPath = path.resolve(__dirname, '../../../../docs/supabase_setup.sql');
+    const migrationSqlPath = path.resolve(
+      __dirname,
+      '../../../../supabase/migrations/20260624233000_track_escrow_refund_reconciliation.sql'
+    );
+
+    for (const sqlPath of [setupSqlPath, migrationSqlPath]) {
+      const sqlContent = await fs.readFile(sqlPath, 'utf8');
+      expect(sqlContent).toMatch(/escrow_refund_error\s+text/i);
+      expect(sqlContent).toMatch(/escrow_refund_attempts\s+integer\s+not\s+null\s+default\s+0/i);
+      expect(sqlContent).toMatch(/escrow_refund_last_attempt_at\s+timestamptz/i);
+      expect(sqlContent).toMatch(/escrow_refund_submitted_at\s+timestamptz/i);
+    }
+  });
+
   it('includes the referential integrity migration file', async () => {
     const migrationSqlPath = path.resolve(__dirname, '../../../../docs/migration_add_referential_integrity.sql');
     await expect(fs.stat(migrationSqlPath)).resolves.toBeDefined();

--- a/docs/migration_add_escrow.sql
+++ b/docs/migration_add_escrow.sql
@@ -10,7 +10,7 @@
 -- Escrow booking identifier (e.g. "escrow:#FF202605211234")
 ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_booking_id TEXT;
 
--- Escrow status: null | 'funding' | 'funded' | 'released' | 'refunded'
+-- Escrow status also uses refund_pending/refund_failed while cancellation is reconciled.
 ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_status TEXT;
 
 -- Deposit transaction hash from Escrow.sol.deposit()
@@ -26,3 +26,9 @@ ALTER TABLE orders ADD COLUMN IF NOT EXISTS refund_tx_hash TEXT;
 ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_deposited_at TIMESTAMPTZ;
 ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_released_at TIMESTAMPTZ;
 ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refunded_at TIMESTAMPTZ;
+
+-- Durable refund reconciliation state
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_error TEXT;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_last_attempt_at TIMESTAMPTZ;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_submitted_at TIMESTAMPTZ;

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -361,6 +361,10 @@ create index if not exists idx_orders_driver       on orders (driver_id);
 create index if not exists idx_orders_status       on orders (status);
 create index if not exists idx_orders_pickup_date  on orders (pickup_date);
 create index if not exists idx_orders_display_id   on orders (order_display_id);
+alter table orders add column if not exists escrow_refund_error text;
+alter table orders add column if not exists escrow_refund_attempts integer not null default 0;
+alter table orders add column if not exists escrow_refund_last_attempt_at timestamptz;
+alter table orders add column if not exists escrow_refund_submitted_at timestamptz;
 alter table orders
   add constraint orders_customer_id_fkey
   foreign key (customer_id) references profiles(id)

--- a/supabase/migrations/20260624233000_track_escrow_refund_reconciliation.sql
+++ b/supabase/migrations/20260624233000_track_escrow_refund_reconciliation.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_error TEXT;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_last_attempt_at TIMESTAMPTZ;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_refund_submitted_at TIMESTAMPTZ;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Persist cancellation before submitting a funded escrow refund
- Track refunds through `refund_pending`, `refund_failed`, and `refunded`
- Store transaction hashes before waiting for confirmation
- Resume submitted refunds without creating duplicate transactions
- Reconcile pending refunds through a background worker
- Add database migration and regression tests

## Root Cause

The cancellation route processed the blockchain refund before updating Supabase. If the refund succeeded but the database update failed, the refunded order remained active and a retry could attempt another refund.

## Impact

Cancelled orders now become inactive before the blockchain operation starts. Failed or delayed refunds retain enough information to be retried and reconciled safely.

## Testing

- Cancellation integration tests: 14 passed
- Escrow service tests: 16 passed
- Database schema tests: 11 passed
- Backend syntax checks passed
- `git diff --check` passed

## Notes

The focused order tests were run with the separate #855 compile fix applied temporarily because upstream `main` currently contains a duplicate schema export. That unrelated fix is not included in this branch.

Fixes #860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry and reconciliation for pending escrow refunds.
  * Cancellation now better handles orders tied to escrow refund processing.

* **Bug Fixes**
  * Improved cancellation flow so refund-confirmed orders are updated more reliably.
  * Added clearer handling for failed or incomplete refund processing, with safer retry behavior.

* **Chores**
  * Updated environment configuration and database schema to support refund tracking and background reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->