### PR TITLE
feat: add GET /api/support/categories public configuration endpoint

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -11,9 +11,50 @@ const FAQ_COLUMNS = 'id, question, answer, app_type, sort_order';
 const TICKET_COLUMNS = 'id, subject, description, category, status, created_at, updated_at';
 const TICKET_DETAIL_COLUMNS = 'id, user_id, subject, description, category, status, created_at, updated_at';
 
+// Canonical map of all accepted category aliases -> database values.
+// Shared by ticket creation, ticket update, and the categories endpoint.
+const CATEGORY_MAP = {
+  billing: 'payment',
+  booking: 'order',
+  payment: 'payment',
+  order: 'order',
+  technical: 'technical',
+  general: 'general',
+  account: 'account',
+};
+
+// The unique set of valid DB-level category values.
+const VALID_CATEGORIES = [...new Set(Object.values(CATEGORY_MAP))];
+
+// Human-readable labels for each DB-level category value.
+const CATEGORY_LABELS = {
+  payment: 'Payment & Billing',
+  order: 'Order & Booking',
+  technical: 'Technical Issue',
+  general: 'General Enquiry',
+  account: 'Account Management',
+};
+
 function normalizeRequiredText(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
+
+// ============================================================================
+// 0. GET SUPPORT TICKET CATEGORIES (PUBLIC - no auth required)
+// ============================================================================
+/**
+ * GET /api/support/categories
+ *
+ * Returns the list of valid accepted support ticket category values.
+ * Public so onboarding screens / mobile apps can populate dropdowns
+ * without needing a user session.
+ */
+router.get('/categories', (_req, res) => {
+  res.json({
+    categories: VALID_CATEGORIES,
+    labels: CATEGORY_LABELS,
+  });
+});
 
 // ============================================================================
 // 1. LIST ACTIVE FAQS (PUBLIC)
@@ -54,17 +95,6 @@ router.post('/tickets', authenticate, userLimiter, validateBody(createTicketSche
   const subject = normalizeRequiredText(req.body.subject);
   const category = normalizeRequiredText(req.body.category);
   const description = normalizeRequiredText(req.body.description) || subject;
-
-  // Map user-friendly/frontend categories to database-constrained values
-  const CATEGORY_MAP = {
-    billing: 'payment',
-    booking: 'order',
-    payment: 'payment',
-    order: 'order',
-    technical: 'technical',
-    general: 'general',
-    account: 'account'
-  };
 
   const normalizedCategory = category.toLowerCase();
   const dbCategory = CATEGORY_MAP[normalizedCategory] || 'general';
@@ -212,11 +242,6 @@ router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicke
     if (ticket.status === 'closed') {
       return res.status(400).json({ error: 'Cannot update a closed ticket.' });
     }
-
-    const CATEGORY_MAP = {
-      billing: 'payment', booking: 'order', payment: 'payment',
-      order: 'order', technical: 'technical', general: 'general', account: 'account',
-    };
 
     const updates = { updated_at: new Date().toISOString() };
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -172,9 +172,3 @@ export const updateTicketSchema = z.object({
   }).optional(),
 }).strict();
 
-export const updateProfileSchema = z.object({
-  full_name: z.string().max(100, 'Name must be 100 characters or fewer').optional(),
-  language: z.string().max(10, 'Language code must be 10 characters or fewer').optional(),
-  dark_mode: z.boolean().optional(),
-  is_online: z.boolean().optional(),
-}).strict();

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -461,4 +461,40 @@ describe('Support Routes', () => {
       expect(res.body.tickets[0].id).toBe('t1');
     });
   });
+
+  describe('GET /api/support/categories', () => {
+    it('returns 200 with categories array and labels map - no auth required', async () => {
+      const res = await request(buildApp())
+        .get('/api/support/categories');
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.categories)).toBe(true);
+      expect(res.body.categories).toContain('payment');
+      expect(res.body.categories).toContain('order');
+      expect(res.body.categories).toContain('technical');
+      expect(res.body.categories).toContain('general');
+      expect(res.body.categories).toContain('account');
+      expect(res.body.labels).toBeDefined();
+      expect(typeof res.body.labels.payment).toBe('string');
+    });
+
+    it('categories array contains no duplicates', async () => {
+      const res = await request(buildApp())
+        .get('/api/support/categories');
+
+      expect(res.status).toBe(200);
+      const unique = [...new Set(res.body.categories)];
+      expect(res.body.categories).toHaveLength(unique.length);
+    });
+
+    it('each category in the array has a corresponding label', async () => {
+      const res = await request(buildApp())
+        .get('/api/support/categories');
+
+      expect(res.status).toBe(200);
+      for (const cat of res.body.categories) {
+        expect(res.body.labels[cat]).toBeDefined();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Exposes `GET /api/support/categories` as a public, unauthenticated endpoint so frontend apps and mobile clients can populate ticket-category dropdowns without needing a user session.

Closes #869

## Changes

### `backend/api/src/routes/supportRoutes.js`
- Extract a shared `CATEGORY_MAP` constant (previously duplicated inside the POST and PATCH ticket handlers) — single source of truth
- Derive `VALID_CATEGORIES` (unique DB-level values) and `CATEGORY_LABELS` (human-readable names) from the map
- Implement `GET /api/support/categories` — synchronous, no DB query, no auth required
- Refactor ticket creation and update handlers to use the shared `CATEGORY_MAP`

### `backend/api/src/validation/requestSchemas.js`
- **Bug fix**: Remove duplicate `updateProfileSchema` export that prevented rolldown from parsing the module

### `backend/api/test/integration/supportRoutes.test.js`
- 3 new integration tests: response shape validation, no-duplicates assertion, label-completeness assertion

## Test Results
All 24 support route tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public support categories endpoint so client apps can retrieve available ticket categories and their display labels.
* **Bug Fixes**
  * Improved support ticket category handling to keep category values consistent across ticket creation and updates.
  * Expanded profile validation to allow longer full names and language values, reducing unnecessary input rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->