### PR TITLE
feat: add truck registration and listing endpoints

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -1,13 +1,88 @@
 import express from 'express';
 import { supabase } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { validateBody } from '../middleware/validate.js';
+import { registerTruckSchema } from '../validation/requestSchemas.js';
 import { getRouteEstimate } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 import { predictPrice } from '../services/ml.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
+
+// ============================================================================
+// REGISTER A TRUCK (DRIVER ONLY)
+// ============================================================================
+/**
+ * POST /api/trucks
+ * Allows authenticated drivers to register a truck they own.
+ * - Validates payload with registerTruckSchema (name, number_plate, max_capacity_tons)
+ * - Returns 409 if the number plate is already registered
+ */
+router.post('/', authenticate, requireRole(['driver']), userLimiter, validateBody(registerTruckSchema), async (req, res) => {
+  const { name, number_plate, max_capacity_tons } = req.body;
+
+  try {
+    // Check for duplicate number plate
+    const { data: existing, error: checkErr } = await supabase
+      .from('trucks')
+      .select('id')
+      .eq('number_plate', number_plate)
+      .maybeSingle();
+
+    if (checkErr) {
+      return res.status(500).json({ error: 'Failed to check for existing truck.', details: checkErr.message });
+    }
+
+    if (existing) {
+      return res.status(409).json({ error: 'A truck with this number plate is already registered.' });
+    }
+
+    const { data: truck, error: insertErr } = await supabase
+      .from('trucks')
+      .insert({ name, number_plate, max_capacity_tons, owner_id: req.user.id })
+      .select('id, name, number_plate, max_capacity_tons, created_at')
+      .single();
+
+    if (insertErr) {
+      if (insertErr.code === '23505') {
+        return res.status(409).json({ error: 'A truck with this number plate is already registered.' });
+      }
+      return res.status(500).json({ error: 'Failed to register truck.', details: insertErr.message });
+    }
+
+    return res.status(201).json({ message: 'Truck registered successfully.', truck });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error', details: err.message });
+  }
+});
+
+// ============================================================================
+// LIST DRIVER'S TRUCKS
+// ============================================================================
+/**
+ * GET /api/trucks
+ * Returns all trucks owned by the authenticated driver.
+ */
+router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, res) => {
+  try {
+    const { data: trucks, error } = await supabase
+      .from('trucks')
+      .select('id, name, number_plate, max_capacity_tons, created_at')
+      .eq('owner_id', req.user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return res.status(500).json({ error: 'Failed to fetch trucks.', details: error.message });
+    }
+
+    return res.json({ trucks: trucks || [] });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error', details: err.message });
+  }
+});
+
 
 function parseBoolean(value) {
   if (typeof value === 'boolean') return value;

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -172,9 +172,21 @@ export const updateTicketSchema = z.object({
   }).optional(),
 }).strict();
 
-export const updateProfileSchema = z.object({
-  full_name: z.string().max(100, 'Name must be 100 characters or fewer').optional(),
-  language: z.string().max(10, 'Language code must be 10 characters or fewer').optional(),
-  dark_mode: z.boolean().optional(),
-  is_online: z.boolean().optional(),
+
+// Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
+// e.g. MH12AB1234 or DL01C1234
+const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;
+
+export const registerTruckSchema = z.object({
+  name: z.string()
+    .min(2, 'Truck name must be at least 2 characters')
+    .max(100, 'Truck name must be 100 characters or fewer'),
+  number_plate: z.string()
+    .transform((v) => v.trim().toUpperCase())
+    .pipe(
+      z.string().regex(numberPlateRegex, 'Invalid number plate format (e.g. MH12AB1234)')
+    ),
+  max_capacity_tons: z.number()
+    .positive({ message: 'Capacity must be greater than 0' })
+    .max(100, 'Capacity must be 100 tonnes or fewer'),
 }).strict();

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: m.supabase,
+  firebaseAdmin: null,
+  redisClient: null,
+  mongoDb: null,
+}));
+
+// Stub out external service calls so the /search route doesn't fail
+vi.mock('../../src/services/osrm.js', () => ({ getRouteEstimate: vi.fn().mockResolvedValue({ distanceKm: 10, durationSeconds: 1200 }) }));
+vi.mock('../../src/lib/pricing.js', () => ({ computeOrderPricing: vi.fn().mockReturnValue({ baseFreight: 1000, tollEstimate: 100, platformFee: 50, totalAmount: 1150, distanceKm: 10 }) }));
+vi.mock('../../src/services/ml.js', () => ({ predictPrice: vi.fn().mockResolvedValue({ estimated_price: 0 }) }));
+
+const { default: truckRouter } = await import('../../src/routes/truckRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/trucks', truckRouter);
+  return app;
+}
+
+const DRIVER_HEADERS = {
+  'x-user-id': 'driver-uuid-456',
+  'x-user-role': 'driver',
+  'x-user-name': 'Test Driver',
+};
+
+const CUSTOMER_HEADERS = {
+  'x-user-id': 'customer-uuid-123',
+  'x-user-role': 'customer',
+  'x-user-name': 'Test Customer',
+};
+
+describe('Truck Routes', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.trucks = [];
+    m.calls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  describe('POST /api/trucks', () => {
+    it('returns 403 for non-driver role', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(CUSTOMER_HEADERS)
+        .send({ name: 'My Truck', number_plate: 'MH12AB1234', max_capacity_tons: 5 });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('registers a truck for an authenticated driver', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Big Blue', number_plate: 'MH12AB1234', max_capacity_tons: 10 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.message).toBe('Truck registered successfully.');
+      expect(res.body.truck).toBeDefined();
+      expect(res.body.truck.number_plate).toBe('MH12AB1234');
+
+      // Verify truck was inserted into store
+      const insertCall = m.calls.find(c => c.table === 'trucks' && c.mode === 'insert');
+      expect(insertCall).toBeDefined();
+      expect(insertCall.payload.owner_id).toBe('driver-uuid-456');
+      expect(insertCall.payload.max_capacity_tons).toBe(10);
+    });
+
+    it('normalises number plate to uppercase', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Red Rig', number_plate: 'mh12ab5678', max_capacity_tons: 8 });
+
+      expect(res.status).toBe(201);
+      const insertCall = m.calls.find(c => c.table === 'trucks' && c.mode === 'insert');
+      expect(insertCall.payload.number_plate).toBe('MH12AB5678');
+    });
+
+    it('returns 400 for missing required fields', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Missing plate' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+    });
+
+    it('returns 400 for invalid number plate format', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Bad Plate', number_plate: 'INVALID-PLATE', max_capacity_tons: 5 });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for zero or negative capacity', async () => {
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Tiny', number_plate: 'MH12AB9999', max_capacity_tons: 0 });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 409 when number plate is already registered', async () => {
+      // Pre-seed the plate as already existing
+      m.store.trucks.push({ id: 'truck-existing', number_plate: 'MH12AB1234', owner_id: 'other-driver' });
+
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Duplicate', number_plate: 'MH12AB1234', max_capacity_tons: 5 });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toContain('already registered');
+    });
+  });
+
+  describe('GET /api/trucks', () => {
+    it('returns 403 for non-driver role', async () => {
+      const res = await request(buildApp())
+        .get('/api/trucks')
+        .set(CUSTOMER_HEADERS);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns empty list when driver has no trucks', async () => {
+      const res = await request(buildApp())
+        .get('/api/trucks')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trucks).toEqual([]);
+    });
+
+    it('returns only trucks belonging to the authenticated driver', async () => {
+      m.store.trucks.push(
+        { id: 'truck-1', name: 'Truck A', number_plate: 'MH12AB0001', max_capacity_tons: 5, owner_id: 'driver-uuid-456', created_at: '2026-06-01T00:00:00Z' },
+        { id: 'truck-2', name: 'Truck B', number_plate: 'MH12AB0002', max_capacity_tons: 10, owner_id: 'driver-uuid-456', created_at: '2026-06-02T00:00:00Z' },
+        { id: 'truck-other', name: 'Other Driver Truck', number_plate: 'DL01C9999', max_capacity_tons: 15, owner_id: 'another-driver', created_at: '2026-06-01T00:00:00Z' },
+      );
+
+      const res = await request(buildApp())
+        .get('/api/trucks')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trucks).toHaveLength(2);
+      expect(res.body.trucks.map(t => t.id)).toContain('truck-1');
+      expect(res.body.trucks.map(t => t.id)).toContain('truck-2');
+      expect(res.body.trucks.map(t => t.id)).not.toContain('truck-other');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Drivers can now register trucks they own and list them through the API, enabling multi-truck management.

Closes #867

## Changes

### `backend/api/src/validation/requestSchemas.js`
- Add `registerTruckSchema` — validates `name` (2-100 chars), `number_plate` (Indian format regex, auto-uppercased), `max_capacity_tons` (positive, ≤100)
- **Bug fix**: Remove duplicate `updateProfileSchema` export (parse error on main)

### `backend/api/src/routes/truckRoutes.js`
- **`POST /api/trucks`**: Driver-only endpoint to register a truck
  - Validates body with `registerTruckSchema`
  - Checks for duplicate number plates before insert → 409 Conflict
  - Stores `owner_id = req.user.id` to associate truck with driver
- **`GET /api/trucks`**: Driver-only endpoint to list owned trucks
  - Filters by `owner_id`, ordered by `created_at DESC`

### `backend/api/test/integration/truckRoutes.test.js` [NEW]
- 10 integration tests: role guard, happy-path register, uppercase normalisation, validation rejections (missing fields, bad plate format, zero capacity), duplicate plate 409, empty listing, owner-filtered listing

## Test Results
All 10 truck route tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drivers can register a truck and retrieve a list of trucks they own.
  * Truck registration validates vehicle details (including standardized plate formatting) and enforces capacity limits.
* **Bug Fixes**
  * Improved handling for incomplete/invalid submissions and prevention of duplicate truck registrations.
  * Ensures truck results are restricted to the signed-in driver’s own trucks.
* **Tests**
  * Added integration coverage for role access, validation, normalization, duplication, and ownership filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->