### PR TITLE
feat: add GET /api/trips/:id/events trip event history endpoint

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -186,7 +186,101 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
 });
 
 // ============================================================================
-// 🚀 ADDITIONAL TRIP ROUTES CAN BE ADDED BELOW
+// GET TRIP EVENTS (DRIVER, CUSTOMER, OR ADMIN)
 // ============================================================================
+/**
+ * GET /api/trips/:id/events
+ *
+ * Returns all telemetry/milestone events for a given trip, ordered
+ * chronologically.
+ *
+ * Access control:
+ *   - The trip's driver (trip_events.user_id === req.user.id)
+ *   - The order's customer (orders.customer_id === req.user.id)
+ *   - Any admin
+ *
+ * Optional query param: ?type=gpsUpdate  (filters by event_type)
+ */
+router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
+  const tripId = req.params.id;
+  const { type } = req.query;
+
+  try {
+    // 1. Fetch the trip to determine the driver
+    const { data: events, error: eventsErr } = await supabase
+      .from('trip_events')
+      .select('event_id, user_id, trip_id, event_type, event_timestamp, latitude, longitude, metadata, created_at')
+      .eq('trip_id', tripId)
+      .order('event_timestamp', { ascending: true });
+
+    if (eventsErr) {
+      return res.status(500).json({ error: 'Failed to fetch trip events.', details: eventsErr.message });
+    }
+
+    if (!events || events.length === 0) {
+      // Check if the trip even exists
+      const { data: existingEvent } = await supabase
+        .from('trip_events')
+        .select('trip_id')
+        .eq('trip_id', tripId)
+        .limit(1)
+        .maybeSingle();
+
+      // If no events found at all, check via orders whether this trip/order exists
+      const { data: order } = await supabase
+        .from('orders')
+        .select('id, driver_id, customer_id')
+        .eq('id', tripId)
+        .maybeSingle();
+
+      if (!order && !existingEvent) {
+        return res.status(404).json({ error: 'Trip not found.' });
+      }
+
+      // Authorisation check even for empty trips
+      if (req.user.role !== 'admin') {
+        const isDriver = order?.driver_id === req.user.id;
+        const isCustomer = order?.customer_id === req.user.id;
+        if (!isDriver && !isCustomer) {
+          return res.status(403).json({ error: 'Access Denied: You are not authorised to view events for this trip.' });
+        }
+      }
+
+      return res.json({ trip_id: tripId, events: [] });
+    }
+
+    // 2. Determine trip's driver from the first event's user_id (the driver who uploaded events)
+    const driverUserId = events[0]?.user_id;
+
+    // 3. Also look up the linked order to check customer access
+    const { data: order } = await supabase
+      .from('orders')
+      .select('id, driver_id, customer_id')
+      .eq('id', tripId)
+      .maybeSingle();
+
+    // 4. Access control
+    if (req.user.role !== 'admin') {
+      const isDriver = driverUserId === req.user.id || order?.driver_id === req.user.id;
+      const isCustomer = order?.customer_id === req.user.id;
+      if (!isDriver && !isCustomer) {
+        return res.status(403).json({ error: 'Access Denied: You are not authorised to view events for this trip.' });
+      }
+    }
+
+    // 5. Optional type filter
+    let filteredEvents = events;
+    if (type && typeof type === 'string') {
+      filteredEvents = events.filter(e => e.event_type === type);
+    }
+
+    return res.json({
+      trip_id: tripId,
+      events: filteredEvents,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal Server Error', details: err.message });
+  }
+});
 
 export default router;

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -171,10 +171,3 @@ export const updateTicketSchema = z.object({
     invalid_type_error: "Status must be one of: open, in_progress, resolved, closed",
   }).optional(),
 }).strict();
-
-export const updateProfileSchema = z.object({
-  full_name: z.string().max(100, 'Name must be 100 characters or fewer').optional(),
-  language: z.string().max(10, 'Language code must be 10 characters or fewer').optional(),
-  dark_mode: z.boolean().optional(),
-  is_online: z.boolean().optional(),
-}).strict();

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -328,3 +328,113 @@ describe('Trip Routes', () => {
         expect(upsertCall.payload[0].metadata.lat).toBe(19.076);
     });
 });
+
+// ============================================================================
+// GET /api/trips/:id/events - Trip Events Retrieval
+// ============================================================================
+
+const CUSTOMER_HEADERS = {
+  'x-user-id': 'customer-1',
+  'x-user-role': 'customer',
+};
+
+const ADMIN_HEADERS = {
+  'x-user-id': 'admin-1',
+  'x-user-role': 'admin',
+};
+
+function buildEventsApp() {
+  const app = express();
+  app.use(express.json());
+  // Mount on /api/trips so /:id/events resolves correctly
+  app.use('/api/trips', tripRouter);
+  return app;
+}
+
+describe('GET /api/trips/:id/events', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.trip_events = [];
+    m.store.orders = [];
+    m.calls.length = 0;
+  });
+
+  it('returns 404 when trip has no events and no matching order', async () => {
+    const res = await request(buildEventsApp())
+      .get('/api/trips/nonexistent-trip/events')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Trip not found.');
+  });
+
+  it('returns events for the driver who uploaded them', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-abc', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+      { event_id: 'ev-2', user_id: 'driver-1', trip_id: 'trip-abc', event_type: 'milestone', event_timestamp: '2026-06-01T11:00:00Z', latitude: null, longitude: null, metadata: { milestone: 'Delivered' }, created_at: '2026-06-01T11:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-abc/events')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.trip_id).toBe('trip-abc');
+    expect(res.body.events).toHaveLength(2);
+  });
+
+  it('returns 403 for a user who is neither driver, customer, nor admin', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-abc', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+    );
+    // No order => customer_id won't match
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-abc/events')
+      .set(CUSTOMER_HEADERS);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows the order customer to access trip events', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-xyz', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+    );
+    m.store.orders.push({ id: 'trip-xyz', driver_id: 'driver-1', customer_id: 'customer-1' });
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-xyz/events')
+      .set(CUSTOMER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(1);
+  });
+
+  it('allows admins to access any trip events', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-admin', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-admin/events')
+      .set(ADMIN_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(1);
+  });
+
+  it('filters events by type when ?type query param is provided', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-filter', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+      { event_id: 'ev-2', user_id: 'driver-1', trip_id: 'trip-filter', event_type: 'milestone', event_timestamp: '2026-06-01T11:00:00Z', latitude: null, longitude: null, metadata: {}, created_at: '2026-06-01T11:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-filter/events?type=gpsUpdate')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(1);
+    expect(res.body.events[0].event_type).toBe('gpsUpdate');
+  });
+});


### PR DESCRIPTION
## Summary
Enables frontends and dispatchers to retrieve the complete telemetry/milestone event history for a trip, enabling route-history plotting and delivery auditing.

Closes #868

## Changes

### `backend/api/src/routes/tripRoutes.js`
- Implement `GET /api/trips/:id/events`:
  - Fetches all events from `trip_events` for the given trip ID, ordered by `event_timestamp ASC`
  - **Access control**: trip driver (`trip_events.user_id`) or order customer (`orders.customer_id`) or admin. Returns **403** for anyone else
  - Returns **404** if no events and no matching order exist for the trip ID
  - Supports optional `?type=gpsUpdate` query param for event-type filtering (applied in-process after fetching)

### `backend/api/src/validation/requestSchemas.js`
- **Bug fix**: Remove duplicate `updateProfileSchema` export (parse error on main)

### `backend/api/test/integration/tripRoutes.test.js`
- 6 new integration tests: 404 unknown trip, driver access, 403 unauthorized, customer access via order, admin bypass, type filter

## Test Results
All 16 trip route tests pass (10 pre-existing + 6 new).