### PR TITLE
fix: Load price and distance filters silently accept malformed numeric strings

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -3,6 +3,7 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
+import { loadFilterQuerySchema } from '../validation/loadSchemas.js';
 
 const router = express.Router();
 
@@ -12,6 +13,18 @@ const router = express.Router();
 // ============================================================================
 router.get('/', authenticate, userLimiter, requireRole(['driver']), async (req, res) => {
   try {
+    const filterResult = loadFilterQuerySchema.safeParse(req.query);
+    if (!filterResult.success) {
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: filterResult.error.issues.map(issue => ({
+          field: issue.path.join('.') || 'query',
+          message: issue.message,
+        })),
+      });
+    }
+    const filters = filterResult.data;
+
     const pageVal = req.query.page || '1';
     const limitVal = req.query.limit || '10';
 
@@ -82,22 +95,16 @@ router.get('/', authenticate, userLimiter, requireRole(['driver']), async (req, 
     if (req.query.goods_type) {
       query = query.eq('goods_type', req.query.goods_type);
     }
-    if (req.query.min_price) {
-      const min = parseFloat(req.query.min_price);
-      if (isNaN(min) || min < 0) return res.status(400).json({ error: 'min_price must be a non-negative number' });
+    if (filters.min_price !== undefined) {
       // Map min_price (in Rupees) to freight_value (in paisa)
-      query = query.gte('freight_value', Math.round(min * 100));
+      query = query.gte('freight_value', Math.round(filters.min_price * 100));
     }
-    if (req.query.max_price) {
-      const max = parseFloat(req.query.max_price);
-      if (isNaN(max) || max < 0) return res.status(400).json({ error: 'max_price must be a non-negative number' });
+    if (filters.max_price !== undefined) {
       // Map max_price (in Rupees) to freight_value (in paisa)
-      query = query.lte('freight_value', Math.round(max * 100));
+      query = query.lte('freight_value', Math.round(filters.max_price * 100));
     }
-    if (req.query.distance) {
-      const maxDistance = parseFloat(req.query.distance);
-      if (isNaN(maxDistance) || maxDistance < 0) return res.status(400).json({ error: 'distance must be a non-negative number' });
-      query = query.lte('extra_distance_km', maxDistance);
+    if (filters.distance !== undefined) {
+      query = query.lte('extra_distance_km', filters.distance);
     }
 
     // Sorting

--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const nonNegativeDecimalString = (field) => z
+  .string({
+    error: `${field} must be a single numeric string`,
+  })
+  .regex(/^(?:\d+|\d*\.\d+)$/, {
+    message: `${field} must be a non-negative decimal number`,
+  })
+  .transform(Number)
+  .refine(Number.isFinite, {
+    message: `${field} must be a finite number`,
+  });
+
+export const loadFilterQuerySchema = z.object({
+  min_price: nonNegativeDecimalString('min_price').optional(),
+  max_price: nonNegativeDecimalString('max_price').optional(),
+  distance: nonNegativeDecimalString('distance').optional(),
+}).passthrough().superRefine((filters, ctx) => {
+  if (
+    filters.min_price !== undefined
+    && filters.max_price !== undefined
+    && filters.min_price > filters.max_price
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['min_price'],
+      message: 'min_price must be less than or equal to max_price',
+    });
+  }
+});

--- a/backend/api/test/integration/loadOffers.test.js
+++ b/backend/api/test/integration/loadOffers.test.js
@@ -147,6 +147,67 @@ describe('Load Offers Routes Integration Tests', () => {
       expect(filters).toContainEqual({ col: 'extra_distance_km', op: 'lte', val: 15 });
     });
 
+    it.each([
+      ['min_price', '100abc'],
+      ['max_price', '500rupees'],
+      ['distance', '25km'],
+      ['min_price', 'Infinity'],
+      ['max_price', '1e3'],
+      ['distance', '-1'],
+      ['distance', ''],
+    ])('rejects malformed %s filter value %s', async (field, value) => {
+      const res = await request(buildApp())
+        .get(`/api/loads?${field}=${encodeURIComponent(value)}`)
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field }),
+        ])
+      );
+      expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
+    });
+
+    it('rejects repeated numeric filters instead of accepting an array', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?min_price=100&min_price=200')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'min_price' }),
+        ])
+      );
+    });
+
+    it('rejects a minimum price greater than the maximum price', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?min_price=15000&max_price=10000')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.details).toContainEqual({
+        field: 'min_price',
+        message: 'min_price must be less than or equal to max_price',
+      });
+      expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
+    });
+
+    it('accepts complete decimal strings including zero', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?min_price=0&max_price=15000.50&distance=15.25')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      const call = m.calls.find(c => c.table === 'load_offers' && c.mode === 'select');
+      expect(call.filters).toContainEqual({ col: 'freight_value', op: 'gte', val: 0 });
+      expect(call.filters).toContainEqual({ col: 'freight_value', op: 'lte', val: 1500050 });
+      expect(call.filters).toContainEqual({ col: 'extra_distance_km', op: 'lte', val: 15.25 });
+    });
+
     it('supports status filtering (open/available maps to available)', async () => {
       m.store.load_offers.push({
         id: 'load-1',


### PR DESCRIPTION
## Summary

- Strictly validate `min_price`, `max_price`, and `distance`
- Reject malformed values, units, trailing text, exponent notation, negative numbers, and repeated parameters
- Reject requests where `min_price` exceeds `max_price`
- Preserve valid decimal and zero-value filtering
- Add integration tests covering valid and invalid inputs

## Root Cause

The load search route used `parseFloat()`, which accepts numeric prefixes and ignores trailing characters. Inputs such as `100abc` and `25km` were therefore treated as valid filters.

## Impact

Malformed filters now return `400 Bad Request` before any database query is executed. Valid prices are still converted from rupees to paisa correctly.

## Testing

- Load-route integration tests: 22 passed
- Backend syntax checks passed
- `git diff --check` passed

Fixes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter handling for load search requests with clearer validation and error responses for invalid price or distance values.
  * Ensured numeric filter inputs are interpreted consistently, including decimal values and zero.
  * Added a check to prevent inconsistent price ranges where the minimum exceeds the maximum.

* **Tests**
  * Expanded integration coverage for load filtering to verify validation errors and accepted filter formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->