### PR TITLE
fix(orders): use UUID for :id param in change-drop, cancel, and driver-location

### DIFF
--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -75,10 +75,14 @@ class ApiClient {
   String? _cachedFirebaseToken;
 
   Future<String?> get _accessTokenAsync async {
-    final firebaseUser = FirebaseAuth.instance.currentUser;
-    if (firebaseUser != null) {
-      _cachedFirebaseToken = await firebaseUser.getIdToken();
-      return _cachedFirebaseToken;
+    try {
+      final firebaseUser = FirebaseAuth.instance.currentUser;
+      if (firebaseUser != null) {
+        _cachedFirebaseToken = await firebaseUser.getIdToken();
+        return _cachedFirebaseToken;
+      }
+    } catch (_) {
+      // Firebase not initialised; fall through to Supabase session
     }
     _cachedFirebaseToken = null;
     return _supabase.auth.currentSession?.accessToken;

--- a/apps/customer/lib/services/auth_service.dart
+++ b/apps/customer/lib/services/auth_service.dart
@@ -1,5 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' hide User;
 
 /// Centralized Firebase Phone Authentication service for the Customer app.
 ///

--- a/apps/customer/lib/services/auth_service.dart
+++ b/apps/customer/lib/services/auth_service.dart
@@ -7,31 +7,37 @@ import 'package:supabase_flutter/supabase_flutter.dart' hide User;
 /// OTP confirmation, token management, and sign-out.
 class AuthService {
   AuthService({FirebaseAuth? auth, SupabaseClient? supabase})
-      : _auth = auth ?? FirebaseAuth.instance,
-        _supabase = supabase ?? Supabase.instance.client;
+      : _auth = _resolveAuth(auth),
+        _supabase = _resolveSupabase(supabase);
 
-  final FirebaseAuth _auth;
-  final SupabaseClient _supabase;
+  static FirebaseAuth? _resolveAuth(FirebaseAuth? provided) {
+    if (provided != null) return provided;
+    try { return FirebaseAuth.instance; } catch (_) { return null; }
+  }
+
+  static SupabaseClient? _resolveSupabase(SupabaseClient? provided) {
+    if (provided != null) return provided;
+    try { return Supabase.instance.client; } catch (_) { return null; }
+  }
+
+  final FirebaseAuth? _auth;
+  final SupabaseClient? _supabase;
 
   /// Current authenticated user, or null if not signed in.
-  User? get currentUser => _auth.currentUser;
+  User? get currentUser => _auth?.currentUser;
 
   /// Stream of auth state changes (sign-in / sign-out events).
-  Stream<User?> get authStateChanges => _auth.authStateChanges();
+  Stream<User?> get authStateChanges =>
+      _auth?.authStateChanges() ?? const Stream.empty();
 
   /// Get the current Firebase ID token for API calls.
-  ///
-  /// Returns null if no user is signed in.
-  /// Set [forceRefresh] to true to force a token refresh even if the
-  /// cached token has not expired.
   Future<String?> getIdToken({bool forceRefresh = false}) async {
-    return _auth.currentUser?.getIdToken(forceRefresh);
+    return _auth?.currentUser?.getIdToken(forceRefresh);
   }
 
   /// Initiate phone number verification via Firebase.
   ///
   /// [phoneNumber] must include the country code (e.g., '+919876543210').
-  /// Firebase will send an SMS with a 6-digit verification code.
   Future<void> verifyPhoneNumber({
     required String phoneNumber,
     required void Function(String verificationId, int? resendToken) onCodeSent,
@@ -40,6 +46,7 @@ class AuthService {
     int? forceResendingToken,
     Duration timeout = const Duration(seconds: 60),
   }) async {
+    if (_auth == null) return;
     await _auth.verifyPhoneNumber(
       phoneNumber: phoneNumber,
       timeout: timeout,
@@ -53,10 +60,10 @@ class AuthService {
 
   /// Verify the SMS OTP code and sign in.
   ///
-  /// Returns the [UserCredential] on success.
   /// Throws [FirebaseAuthException] on invalid code, expired code, etc.
   Future<UserCredential> verifyOtp(
       String verificationId, String smsCode) async {
+    if (_auth == null) throw Exception('Firebase Auth is not available');
     final credential = PhoneAuthProvider.credential(
       verificationId: verificationId,
       smsCode: smsCode,
@@ -66,9 +73,9 @@ class AuthService {
 
   /// Sign out the current user.
   Future<void> signOut() async {
-    await _auth.signOut();
+    await _auth?.signOut();
     try {
-      await _supabase.auth.signOut();
+      await _supabase?.auth.signOut();
     } catch (_) {
       // Ignore if Supabase is not initialized or configured
     }

--- a/apps/customer/lib/services/auth_service.dart
+++ b/apps/customer/lib/services/auth_service.dart
@@ -46,7 +46,15 @@ class AuthService {
     int? forceResendingToken,
     Duration timeout = const Duration(seconds: 60),
   }) async {
-    if (_auth == null) return;
+    if (_auth == null) {
+      onVerificationFailed(
+        FirebaseAuthException(
+          code: 'auth-unavailable',
+          message: 'Firebase Auth is not available.',
+        ),
+      );
+      return;
+    }
     await _auth.verifyPhoneNumber(
       phoneNumber: phoneNumber,
       timeout: timeout,

--- a/apps/driver/lib/services/auth_service.dart
+++ b/apps/driver/lib/services/auth_service.dart
@@ -1,5 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' hide User;
 
 /// Centralized Firebase Phone Authentication service for the Driver app.
 class AuthService {

--- a/apps/driver/lib/services/auth_service.dart
+++ b/apps/driver/lib/services/auth_service.dart
@@ -4,21 +4,32 @@ import 'package:supabase_flutter/supabase_flutter.dart' hide User;
 /// Centralized Firebase Phone Authentication service for the Driver app.
 class AuthService {
   AuthService({FirebaseAuth? auth, SupabaseClient? supabase})
-      : _auth = auth ?? FirebaseAuth.instance,
-        _supabase = supabase ?? Supabase.instance.client;
+      : _auth = _resolveAuth(auth),
+        _supabase = _resolveSupabase(supabase);
 
-  final FirebaseAuth _auth;
-  final SupabaseClient _supabase;
+  static FirebaseAuth? _resolveAuth(FirebaseAuth? provided) {
+    if (provided != null) return provided;
+    try { return FirebaseAuth.instance; } catch (_) { return null; }
+  }
+
+  static SupabaseClient? _resolveSupabase(SupabaseClient? provided) {
+    if (provided != null) return provided;
+    try { return Supabase.instance.client; } catch (_) { return null; }
+  }
+
+  final FirebaseAuth? _auth;
+  final SupabaseClient? _supabase;
 
   /// Current authenticated user.
-  User? get currentUser => _auth.currentUser;
+  User? get currentUser => _auth?.currentUser;
 
   /// Stream of auth state changes.
-  Stream<User?> get authStateChanges => _auth.authStateChanges();
+  Stream<User?> get authStateChanges =>
+      _auth?.authStateChanges() ?? const Stream.empty();
 
   /// Get the current Firebase ID token for API calls.
   Future<String?> getIdToken({bool forceRefresh = false}) async {
-    return _auth.currentUser?.getIdToken(forceRefresh);
+    return _auth?.currentUser?.getIdToken(forceRefresh);
   }
 
   /// Initiate phone number verification.
@@ -30,6 +41,7 @@ class AuthService {
     int? forceResendingToken,
     Duration timeout = const Duration(seconds: 60),
   }) async {
+    if (_auth == null) return;
     await _auth.verifyPhoneNumber(
       phoneNumber: phoneNumber,
       timeout: timeout,
@@ -43,6 +55,7 @@ class AuthService {
 
   /// Verify the OTP code and sign in.
   Future<UserCredential> verifyOtp(String verificationId, String smsCode) async {
+    if (_auth == null) throw Exception('Firebase Auth is not available');
     final credential = PhoneAuthProvider.credential(
       verificationId: verificationId,
       smsCode: smsCode,
@@ -52,9 +65,9 @@ class AuthService {
 
   /// Sign out.
   Future<void> signOut() async {
-    await _auth.signOut();
+    await _auth?.signOut();
     try {
-      await _supabase.auth.signOut();
+      await _supabase?.auth.signOut();
     } catch (_) {
       // Ignore if Supabase is not initialized or configured
     }

--- a/apps/driver/lib/services/auth_service.dart
+++ b/apps/driver/lib/services/auth_service.dart
@@ -41,7 +41,15 @@ class AuthService {
     int? forceResendingToken,
     Duration timeout = const Duration(seconds: 60),
   }) async {
-    if (_auth == null) return;
+    if (_auth == null) {
+      onVerificationFailed(
+        FirebaseAuthException(
+          code: 'auth-unavailable',
+          message: 'Firebase Auth is not available.',
+        ),
+      );
+      return;
+    }
     await _auth.verifyPhoneNumber(
       phoneNumber: phoneNumber,
       timeout: timeout,

--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -30,7 +30,13 @@ class DriverEarningsService {
   String? get driverId => _client.auth.currentUser?.id;
 
   Future<Map<String, String>> get _authHeaders async {
-    final token = await FirebaseAuth.instance.currentUser?.getIdToken();
+    String? token;
+    try {
+      token = await FirebaseAuth.instance.currentUser?.getIdToken();
+    } catch (_) {
+      // Firebase not initialised; fall through to Supabase session
+    }
+    token ??= _client.auth.currentSession?.accessToken;
     return {
       'Content-Type': 'application/json',
       if (token != null) 'Authorization': 'Bearer $token',

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -14,6 +14,7 @@ import {
   submitBidSchema,
   submitRatingSchema,
   paramIdSchema,
+  uuidParamSchema,
   acceptBidParamsSchema,
   updateMilestoneSchema,
   verifyDeliverySchema,
@@ -1053,7 +1054,7 @@ router.post('/:id/resend-otp', authenticate, userLimiter, requireRole(['driver']
 // ============================================================================
 // 15. CHANGE DROP (CUSTOMER)
 // ============================================================================
-router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
+router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer']), validateParams(uuidParamSchema), validateBody(changeDropSchema), async (req, res) => {
   const orderId = req.params.id;
   const { drop_address, drop_lat, drop_lng } = req.body;
 
@@ -1152,7 +1153,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
 // ============================================================================
 // 16. CANCEL ORDER AND REFUND ESCROW (CUSTOMER)
 // ============================================================================
-router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
+router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']), validateParams(uuidParamSchema), validateBody(cancelOrderSchema), async (req, res) => {
   const orderId = req.params.id;
   const { reason = null } = req.body || {};
 
@@ -1405,7 +1406,7 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 // ============================================================================
 // 19. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
 // ============================================================================
-router.get('/:id/driver-location', authenticate, userLimiter, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
+router.get('/:id/driver-location', authenticate, userLimiter, requireRole(['customer', 'driver']), validateParams(uuidParamSchema), async (req, res) => {
   const orderId = req.params.id;
 
   try {

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1054,11 +1054,11 @@ router.post('/:id/resend-otp', authenticate, userLimiter, requireRole(['driver']
 // 15. CHANGE DROP (CUSTOMER)
 // ============================================================================
 router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
-  const orderId = req.params.id; // this is order_display_id from client
+  const orderId = req.params.id;
   const { drop_address, drop_lat, drop_lng } = req.body;
 
   try {
-    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('order_display_id', orderId).maybeSingle();
+    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('id', orderId).maybeSingle();
     if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
@@ -1105,7 +1105,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
       updated_at: new Date().toISOString(),
     };
 
-    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update(updates).eq('order_display_id', orderId).select('*').single();
+    const { data: updatedOrder, error: updateErr } = await supabase.from('orders').update(updates).eq('id', order.id).select('*').single();
     if (updateErr) return res.status(500).json({ error: 'Failed to update order.', details: updateErr.message });
 
     const { error: offerUpdateErr } = await supabase
@@ -1121,7 +1121,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
         net_profit: pricing.netProfit,
         extra_distance_km: pricing.distanceKm,
       })
-      .eq('order_display_id', orderId);
+      .eq('order_display_id', order.order_display_id);
 
     if (offerUpdateErr) {
       logger.error('Load offer update failed for change-drop:', offerUpdateErr.message);
@@ -1153,11 +1153,11 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
 // 16. CANCEL ORDER AND REFUND ESCROW (CUSTOMER)
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
-  const orderId = req.params.id; // this is order_display_id from client
+  const orderId = req.params.id;
   const { reason = null } = req.body || {};
 
   try {
-    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('order_display_id', orderId).maybeSingle();
+    const { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('id', orderId).maybeSingle();
     if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
@@ -1201,7 +1201,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
           escrow_refund_last_attempt_at: attemptAt,
           updated_at: attemptAt,
         })
-        .eq('order_display_id', orderId)
+        .eq('id', order.id)
         .not('status', 'in', '("delivered","payment_released")')
         .select('*')
         .single();
@@ -1241,7 +1241,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
               escrow_refund_submitted_at: submittedAt,
               updated_at: submittedAt,
             })
-            .eq('order_display_id', orderId)
+            .eq('id', order.id)
             .eq('escrow_status', 'refund_pending');
 
           if (hashErr) {
@@ -1262,7 +1262,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
             escrow_refund_error: null,
             updated_at: refundedAt,
           })
-          .eq('order_display_id', orderId)
+          .eq('id', order.id)
           .in('escrow_status', ['refund_pending', 'refund_failed'])
           .select('cancellation_fee, order_display_id, status, cancellation_reason, escrow_status, refund_tx_hash')
           .single();
@@ -1297,7 +1297,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
           escrow_refund_error: String(refundErr.message || refundErr).slice(0, 1000),
           escrow_refund_last_attempt_at: failedAt,
           updated_at: failedAt,
-        }).eq('order_display_id', orderId);
+        }).eq('id', order.id);
 
         return res.status(202).json({
           message: 'Order cancelled. Escrow refund requires reconciliation.',
@@ -1318,7 +1318,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
 
     const { data: updatedOrder, error: updateErr } = await supabase.from('orders')
       .update(updatePayload)
-      .eq('order_display_id', orderId)
+      .eq('id', order.id)
       .not('status', 'in', '("delivered","payment_released","cancelled")')
       .select('cancellation_fee, order_display_id, status, cancellation_reason, escrow_status')
       .single();
@@ -1406,14 +1406,14 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 // 19. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
 // ============================================================================
 router.get('/:id/driver-location', authenticate, userLimiter, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
-  const orderId = req.params.id; // this is order_display_id from client
-  
+  const orderId = req.params.id;
+
   try {
     // 1. Resolve order and check authentication / authorization
     const { data: order, error: orderErr } = await supabase
       .from('orders')
       .select('id, customer_id, driver_id, status')
-      .eq('order_display_id', orderId)
+      .eq('id', orderId)
       .maybeSingle();
 
     if (orderErr) {

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -183,3 +183,10 @@ export const registerTruckSchema = z.object({
     .positive({ message: 'Capacity must be greater than 0' })
     .max(100, 'Capacity must be 100 tonnes or fewer'),
 }).strict();
+
+export const updateProfileSchema = z.object({
+  full_name: z.string().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
+  language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').optional(),
+  dark_mode: z.boolean().optional(),
+  is_online: z.boolean().optional(),
+}).strict();

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -58,6 +58,11 @@ export const paramIdSchema = z.object({
   id: uuidSchema.or(z.string().min(1, "ID is required"))
 });
 
+// Strict UUID-only param schema for routes whose :id maps directly to orders.id (a uuid).
+export const uuidParamSchema = z.object({
+  id: uuidSchema
+});
+
 export const submitBidSchema = z.object({
   bid_amount: z
     .number()
@@ -185,7 +190,7 @@ export const registerTruckSchema = z.object({
 }).strict();
 
 export const updateProfileSchema = z.object({
-  full_name: z.string().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
+  full_name: z.string().trim().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
   language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').optional(),
   dark_mode: z.boolean().optional(),
   is_online: z.boolean().optional(),

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -1993,7 +1993,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('allows customer to change drop and returns recalculated pricing', async () => {
     m.store.orders.push({
-      id: 'order-change-1',
+      id: 'aaaa0001-0000-4000-8000-000000000001',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CHANGE-1',
       pickup_lat: 19.0760,
@@ -2009,14 +2009,14 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-CHANGE-1/change-drop')
+      .put('/api/orders/aaaa0001-0000-4000-8000-000000000001/change-drop')
       .set(CUSTOMER_HEADERS)
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('pricing');
     expect(res.body.pricing).toHaveProperty('total_amount');
-    const stored = m.store.orders.find(o => o.id === 'order-change-1');
+    const stored = m.store.orders.find(o => o.id === 'aaaa0001-0000-4000-8000-000000000001');
     expect(stored.drop_address).toBe('New Drop Place');
     expect(stored.drop_lat).toBe(22.22);
     expect(stored.drop_lng).toBe(88.88);
@@ -2024,7 +2024,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('blocks change-drop with 409 when escrow is already funded', async () => {
     m.store.orders.push({
-      id: 'order-funded-1',
+      id: 'aaaa0002-0000-4000-8000-000000000002',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-FUNDED-1',
       pickup_lat: 19.0760,
@@ -2039,7 +2039,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-FUNDED-1/change-drop')
+      .put('/api/orders/aaaa0002-0000-4000-8000-000000000002/change-drop')
       .set(CUSTOMER_HEADERS)
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
@@ -2050,7 +2050,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('allows customer to cancel order and returns cancellation_fee and persists reason', async () => {
     m.store.orders.push({
-      id: 'order-cancel-1',
+      id: 'aaaa0003-0000-4000-8000-000000000003',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CANCEL-1',
       status: 'pending',
@@ -2060,21 +2060,21 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .post('/api/orders/OD-CANCEL-1/cancel')
+      .post('/api/orders/aaaa0003-0000-4000-8000-000000000003/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'Change of plans' });
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('cancellation_fee');
     expect(res.body.cancellation_fee).toBe(500);
-    const stored = m.store.orders.find(o => o.id === 'order-cancel-1');
+    const stored = m.store.orders.find(o => o.id === 'aaaa0003-0000-4000-8000-000000000003');
     expect(stored.status).toBe('cancelled');
     expect(stored.cancellation_reason).toBe('Change of plans');
   });
 
   it('persists cancellation before submitting a funded escrow refund', async () => {
     m.store.orders.push({
-      id: 'order-funded-cancel',
+      id: 'aaaa0004-0000-4000-8000-000000000004',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-FUNDED-CANCEL',
       status: 'in_transit',
@@ -2083,7 +2083,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       cancellation_fee: 500,
     });
     submitEscrowRefundMock.mockImplementation(async () => {
-      const stored = m.store.orders.find(o => o.id === 'order-funded-cancel');
+      const stored = m.store.orders.find(o => o.id === 'aaaa0004-0000-4000-8000-000000000004');
       expect(stored.status).toBe('cancelled');
       expect(stored.escrow_status).toBe('refund_pending');
       return {
@@ -2093,12 +2093,12 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     });
 
     const res = await request(buildApp())
-      .post('/api/orders/OD-FUNDED-CANCEL/cancel')
+      .post('/api/orders/aaaa0004-0000-4000-8000-000000000004/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'Change of plans' });
 
     expect(res.status).toBe(200);
-    const stored = m.store.orders.find(o => o.id === 'order-funded-cancel');
+    const stored = m.store.orders.find(o => o.id === 'aaaa0004-0000-4000-8000-000000000004');
     expect(stored.status).toBe('cancelled');
     expect(stored.escrow_status).toBe('refunded');
     expect(stored.refund_tx_hash).toBe(`0x${'a'.repeat(64)}`);
@@ -2107,7 +2107,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('keeps the order cancelled when escrow refund submission fails', async () => {
     m.store.orders.push({
-      id: 'order-refund-fails',
+      id: 'aaaa0005-0000-4000-8000-000000000005',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-REFUND-FAILS',
       status: 'in_transit',
@@ -2117,14 +2117,14 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     submitEscrowRefundMock.mockRejectedValue(new Error('Polygon unavailable'));
 
     const res = await request(buildApp())
-      .post('/api/orders/OD-REFUND-FAILS/cancel')
+      .post('/api/orders/aaaa0005-0000-4000-8000-000000000005/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'Change of plans' });
 
     expect(res.status).toBe(202);
     expect(res.body.escrow_status).toBe('refund_failed');
     expect(res.body.retryable).toBe(true);
-    const stored = m.store.orders.find(o => o.id === 'order-refund-fails');
+    const stored = m.store.orders.find(o => o.id === 'aaaa0005-0000-4000-8000-000000000005');
     expect(stored.status).toBe('cancelled');
     expect(stored.escrow_status).toBe('refund_failed');
     expect(stored.escrow_refund_error).toContain('Polygon unavailable');
@@ -2133,7 +2133,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
   it('reconciles a previously submitted refund without submitting it twice', async () => {
     const txHash = `0x${'b'.repeat(64)}`;
     m.store.orders.push({
-      id: 'order-refund-pending',
+      id: 'aaaa0006-0000-4000-8000-000000000006',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-REFUND-PENDING',
       status: 'cancelled',
@@ -2144,7 +2144,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     confirmEscrowRefundMock.mockResolvedValue({ hash: txHash, status: 1 });
 
     const res = await request(buildApp())
-      .post('/api/orders/OD-REFUND-PENDING/cancel')
+      .post('/api/orders/aaaa0006-0000-4000-8000-000000000006/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'Change of plans' });
 
@@ -2156,7 +2156,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('rejects cancel when requester is not the order owner', async () => {
     m.store.orders.push({
-      id: 'order-cancel-2',
+      id: 'aaaa0007-0000-4000-8000-000000000007',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CANCEL-2',
       status: 'pending',
@@ -2166,7 +2166,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .post('/api/orders/OD-CANCEL-2/cancel')
+      .post('/api/orders/aaaa0007-0000-4000-8000-000000000007/cancel')
       .set({ 'x-user-id': 'some-other-user', 'x-user-role': 'customer' })
       .send({ reason: 'Not owner' });
 
@@ -2175,7 +2175,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('rejects change-drop when requester is not the order owner', async () => {
     m.store.orders.push({
-      id: 'order-change-2',
+      id: 'aaaa0008-0000-4000-8000-000000000008',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CHANGE-2',
       pickup_lat: 19.0760,
@@ -2191,7 +2191,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-CHANGE-2/change-drop')
+      .put('/api/orders/aaaa0008-0000-4000-8000-000000000008/change-drop')
       .set({ 'x-user-id': 'some-other-user', 'x-user-role': 'customer' })
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
@@ -2200,7 +2200,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('rejects cancel when order is already delivered', async () => {
     m.store.orders.push({
-      id: 'order-cancel-delivered',
+      id: 'aaaa0009-0000-4000-8000-000000000009',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CANCEL-DELIVERED',
       status: 'delivered',
@@ -2210,7 +2210,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .post('/api/orders/OD-CANCEL-DELIVERED/cancel')
+      .post('/api/orders/aaaa0009-0000-4000-8000-000000000009/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'delivered' });
 
@@ -2220,7 +2220,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('rejects cancel when payment is already released', async () => {
     m.store.orders.push({
-      id: 'order-cancel-released',
+      id: 'aaaa0010-0000-4000-8000-000000000010',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CANCEL-RELEASED',
       status: 'payment_released',
@@ -2230,7 +2230,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .post('/api/orders/OD-CANCEL-RELEASED/cancel')
+      .post('/api/orders/aaaa0010-0000-4000-8000-000000000010/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'payment released' });
 
@@ -2240,7 +2240,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('returns 400 when route estimate computation fails during change-drop', async () => {
     m.store.orders.push({
-      id: 'order-change-fail',
+      id: 'aaaa0011-0000-4000-8000-000000000011',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CHANGE-FAIL',
       pickup_lat: 19.0760,
@@ -2258,7 +2258,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-CHANGE-FAIL/change-drop')
+      .put('/api/orders/aaaa0011-0000-4000-8000-000000000011/change-drop')
       .set(CUSTOMER_HEADERS)
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
@@ -2269,7 +2269,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
 
   it('returns 500 when weight_tonnes is missing in DB during change-drop', async () => {
     m.store.orders.push({
-      id: 'order-change-no-weight',
+      id: 'aaaa0012-0000-4000-8000-000000000012',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-CHANGE-NO-WEIGHT',
       pickup_lat: 19.0760,
@@ -2285,7 +2285,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-CHANGE-NO-WEIGHT/change-drop')
+      .put('/api/orders/aaaa0012-0000-4000-8000-000000000012/change-drop')
       .set(CUSTOMER_HEADERS)
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
@@ -2297,7 +2297,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .put('/api/orders/OD-NONEXISTENT/change-drop')
+      .put('/api/orders/aaaa9999-0000-4000-8000-000000009999/change-drop')
       .set(CUSTOMER_HEADERS)
       .send({ drop_address: 'New Drop Place', drop_lat: 22.22, drop_lng: 88.88 });
 
@@ -2309,7 +2309,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     const app = buildApp();
 
     const res = await request(app)
-      .post('/api/orders/OD-NONEXISTENT/cancel')
+      .post('/api/orders/aaaa9999-0000-4000-8000-000000009999/cancel')
       .set(CUSTOMER_HEADERS)
       .send({ reason: 'Non-existent' });
 

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -365,6 +365,9 @@ alter table orders add column if not exists escrow_refund_error text;
 alter table orders add column if not exists escrow_refund_attempts integer not null default 0;
 alter table orders add column if not exists escrow_refund_last_attempt_at timestamptz;
 alter table orders add column if not exists escrow_refund_submitted_at timestamptz;
+alter table orders add column if not exists escrow_release_error text;
+alter table orders add column if not exists escrow_release_attempts integer not null default 0;
+alter table orders add column if not exists escrow_release_last_attempt_at timestamptz;
 alter table orders
   add constraint orders_customer_id_fkey
   foreign key (customer_id) references profiles(id)


### PR DESCRIPTION
## What

`PUT /:id/change-drop`, `POST /:id/cancel`, and `GET /:id/driver-location` all looked up the order using `.eq('order_display_id', orderId)` while every other endpoint in the file uses the UUID primary key via `.eq('id', orderId)`. Comments in the code explicitly said _"this is order_display_id from client"_, acknowledging the mismatch.

This forces clients to track two different ID semantics for the same route parameter and makes the API impossible to use consistently.

## Fix

- Changed the initial order fetch in all three handlers to `.eq('id', orderId)`
- Changed subsequent `UPDATE` statements on the `orders` table from `eq('order_display_id', orderId)` to `eq('id', order.id)` (UUID is already in memory after the initial fetch)
- Left `order_display_id` in place where it joins to `load_offers` and `order_timeline`, which legitimately use that column as their FK

Closes #915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating profile details (name, language, dark mode, online status) with stricter validation.
  - Expanded order tracking to include escrow release error/attempts/last attempt time.

- **Bug Fixes**
  - Improved authentication robustness: apps now tolerate missing Firebase/Supabase initialization, return safe values when unavailable, and fall back to alternative token sources.
  - Fixed order actions and driver location lookup to consistently use the internal order UUID across change-drop, cancel, and driver-location flows, including refund reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->