### PR TITLE
[GSSoC'26] fix: add configurable retry logic with exponential backoff to OSRM route estimation

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -3,9 +3,9 @@ import logger from '../middleware/logger.js';
 
 const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
 const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 500;
 const CACHE_TTL_SECONDS = 86400;
-const MAX_RETRIES = 1;
-const RETRY_DELAYS_MS = [500, 1000]; // exponential backoff
 
 function parsePositiveNumber(value, fallback) {
   const parsed = Number(value);
@@ -48,9 +48,10 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
   }
 
   const timeoutMs = parsePositiveNumber(process.env.OSRM_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+  const maxRetries = parsePositiveNumber(process.env.OSRM_MAX_RETRIES, DEFAULT_MAX_RETRIES);
+  const baseDelayMs = parsePositiveNumber(process.env.OSRM_RETRY_BASE_DELAY_MS, DEFAULT_RETRY_BASE_DELAY_MS);
 
-  // Retry loop for transient network/fetch errors
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -60,8 +61,12 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
       });
 
       if (!response.ok) {
-        // Non-ok HTTP responses are data errors, not transient — do not retry
         clearTimeout(timeout);
+        if (response.status >= 500 && attempt < maxRetries - 1) {
+          logger.warn('[osrm] Server error %d (attempt %d/%d). Retrying...', response.status, attempt + 1, maxRetries);
+          await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
+          continue;
+        }
         return null;
       }
 
@@ -90,11 +95,12 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
 
     } catch (err) {
       clearTimeout(timeout);
-      if (attempt < MAX_RETRIES) {
-        logger.warn(`[osrm] Fetch error (attempt ${attempt + 1}/${MAX_RETRIES + 1}): ${err.message}. Retrying in ${RETRY_DELAYS_MS[attempt]}ms.`);
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS_MS[attempt]));
+      if (attempt < maxRetries - 1) {
+        const delayMs = baseDelayMs * Math.pow(2, attempt);
+        logger.warn('[osrm] Fetch error (attempt %d/%d): %s. Retrying in %d ms...', attempt + 1, maxRetries, err.message, delayMs);
+        await new Promise(r => setTimeout(r, delayMs));
       } else {
-        logger.error('[osrm] Fetch error after all retries:', err.message);
+        logger.error('[osrm] Fetch error after all %d retries: %s', maxRetries, err.message);
         return null;
       }
     }


### PR DESCRIPTION
## Description

- Added configurable retry logic with exponential backoff to OSRM route estimation
- Retries on both transient network errors and 5xx server responses (previously only network errors were retried with a fixed stub)
- Configuration via `OSRM_MAX_RETRIES` (default: 3) and `OSRM_RETRY_BASE_DELAY_MS` (default: 500) environment variables
- 4xx client errors are not retried (return null immediately)

## Files Changed

- `backend/api/src/services/osrm.js`: replaced hardcoded `MAX_RETRIES`/`RETRY_DELAYS_MS` with env-var-driven exponential backoff; added 5xx retry

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

`npm test` (backend tests)

Result: All tests pass / Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #887
