### PR TITLE
[GSSoC'26] fix: add timeout to ML training endpoint to prevent indefinite hangs

### DIFF
--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import hmac
 import logging
 import os
@@ -113,9 +114,16 @@ async def predict_price_endpoint(input: PricePredictInput, _auth=Depends(verify_
 
 @app.post("/train/demand", response_model=TrainResponse)
 async def train_demand_endpoint(_auth=Depends(verify_api_key)):
+    timeout = int(os.environ.get("ML_TRAINING_TIMEOUT_SECONDS", 300))
     try:
-        metrics = train_demand_forecast_model()
+        metrics = await asyncio.wait_for(
+            asyncio.to_thread(train_demand_forecast_model),
+            timeout=timeout,
+        )
         return TrainResponse(status="success", metrics=metrics)
+    except asyncio.TimeoutError:
+        logger.error("Demand model training timed out after %d seconds", timeout)
+        raise HTTPException(status_code=504, detail="Training timed out")
     except Exception as e:
         logger.error("Demand model training failed: %s", e)
         raise HTTPException(status_code=500, detail="Training failed")


### PR DESCRIPTION
## Description

- Added timeout to ML training endpoint to prevent indefinite hangs
- Wraps `train_demand_forecast_model()` in `asyncio.wait_for` with configurable `ML_TRAINING_TIMEOUT_SECONDS` (default: 300s / 5 minutes)
- Returns HTTP 504 on timeout instead of hanging indefinitely
- Training now runs in thread pool via `asyncio.to_thread` to avoid blocking the event loop

## Files Changed

- `backend/ml/app/main.py`: added `asyncio` import, wrapped training call with `asyncio.wait_for`/`asyncio.to_thread`, added timeout error handler

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

Python syntax check on `backend/ml/app/main.py`

Result: No syntax errors

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #888
