### PR TITLE
[GSSoC'26] fix: replace WeakMap WebSocket rate limiter with Redis-backed tracking

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -46,7 +46,6 @@ let telemetryMonitorInterval = null;
 const WS_UPGRADE_RATE_LIMIT = 5;
 const WS_UPGRADE_RATE_WINDOW_SECONDS = 60;
 const MAX_MSG_PER_SECOND = 10;
-const messageRateTracker = new WeakMap();
 
 function getClientIp(request) {
   const forwardedFor = request.headers?.['x-forwarded-for'];
@@ -272,19 +271,29 @@ export function initWebSocketServer(server) {
   logger.info('🚀 WebSocket tracking router initialized.');
 }
 
-function isMessageRateLimited(ws) {
-  const now = Date.now();
-  let state = messageRateTracker.get(ws);
-  if (!state || now - state.windowStart >= 1000) {
-    state = { count: 0, windowStart: now };
-    messageRateTracker.set(ws, state);
+async function isMessageRateLimited(ws) {
+  const key = ws.user?.id
+    ? `ws:msg:${ws.user.id}`
+    : `ws:msg:ip:${ws.driverId || 'unknown'}`;
+
+  if (!redisClient) {
+    return false;
   }
-  state.count++;
-  return state.count > MAX_MSG_PER_SECOND;
+
+  try {
+    const count = await redisClient.incr(key);
+    if (count === 1) {
+      await redisClient.expire(key, 1);
+    }
+    return count > MAX_MSG_PER_SECOND;
+  } catch (err) {
+    logger.error('[ws] Rate limit check error:', err.message);
+    return false;
+  }
 }
 
 export async function handleTrackingMessage(ws, message) {
-  if (isMessageRateLimited(ws)) {
+  if (await isMessageRateLimited(ws)) {
     return;
   }
 


### PR DESCRIPTION
## Description

- Replaced in-memory WeakMap WebSocket message rate limiter with Redis-backed tracking
- Rate limit state now persists across server restarts (keyed by user ID or driver ID)
- Falls back gracefully if Redis is unavailable

## Files Changed

- `backend/api/src/sockets/tracker.js`: removed `WeakMap` import, replaced `isMessageRateLimited` with async Redis-based implementation using `incr`/`expire`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

`npm test` (backend tests)

Result: All tests pass / Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message rate limiting for live connections to make throttling more consistent across sessions.
  * Rate limits now follow the signed-in user when available, helping prevent misuse from shared or changing network addresses.
  * If the rate-limiting service is unavailable, message handling continues instead of failing outright.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->