### PR TITLE
[GSSoC'26] fix: add upper bound to reputation contract to prevent infinite inflation

### DIFF
--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -6,6 +6,8 @@ contract Reputation {
     mapping(address => bool) public authorizedRelayers;
     mapping(address => uint256) private scores;
 
+    uint256 public constant MAX_REPUTATION = 10000;
+
     event RelayerUpdated(address indexed relayer, bool authorized);
     event ReputationIncreased(address indexed driver, uint256 points, uint256 score);
     event ReputationDecreased(address indexed driver, uint256 points, uint256 score);
@@ -36,7 +38,8 @@ contract Reputation {
 
     function increaseReputation(address driver, uint256 points) external onlyRelayer {
         require(driver != address(0), "Invalid driver");
-        scores[driver] += points;
+        uint256 newScore = scores[driver] + points;
+        scores[driver] = newScore > MAX_REPUTATION ? MAX_REPUTATION : newScore;
         emit ReputationIncreased(driver, points, scores[driver]);
     }
 


### PR DESCRIPTION
## Description

- Added `MAX_REPUTATION` constant (10,000 points) to the `Reputation` smart contract
- `increaseReputation` now caps the score at `MAX_REPUTATION` instead of allowing unlimited inflation
- Prevents compromised relayer from arbitrarily inflating driver reputations

## Files Changed

- `blockchain/contracts/Reputation.sol`: added `MAX_REPUTATION` constant; capped score in `increaseReputation`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

Solidity syntax check

Result: No errors

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #890
