### PR TITLE
[GSSoC'26] fix: add maxPayload limit to WebSocket server to prevent DoS

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -46,6 +46,7 @@ let telemetryMonitorInterval = null;
 const WS_UPGRADE_RATE_LIMIT = 5;
 const WS_UPGRADE_RATE_WINDOW_SECONDS = 60;
 const MAX_MSG_PER_SECOND = 10;
+const MAX_WS_PAYLOAD_BYTES = 64 * 1024; // 64KB for telemetry payloads
 const messageRateTracker = new WeakMap();
 
 function getClientIp(request) {
@@ -98,7 +99,10 @@ export function rejectWebSocketUpgrade(socket) {
  * Initialize WebSockets Server and bind event handlers
  */
 export function initWebSocketServer(server) {
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: MAX_WS_PAYLOAD_BYTES,
+  });
   wsServer = wss;
 
   server.on('upgrade', async (request, socket, head) => {
@@ -289,6 +293,11 @@ export async function handleTrackingMessage(ws, message) {
   }
 
   const messageText = message.toString();
+
+  if (Buffer.byteLength(messageText, 'utf8') > MAX_WS_PAYLOAD_BYTES) {
+    ws.close(1009, 'Message too large');
+    return;
+  }
 
   if (messageText === 'ping') {
     ws.isAlive = true;


### PR DESCRIPTION
## Description

- Added 64KB `maxPayload` limit to WebSocketServer to reject oversized messages before they consume memory
- Added explicit `Buffer.byteLength` check in `handleTrackingMessage` as defense-in-depth before `JSON.parse`
- Prevents DoS via large payloads that could crash the server

## Files Changed

- `backend/api/src/sockets/tracker.js`: added `MAX_WS_PAYLOAD_BYTES` constant, `maxPayload` option to WebSocketServer, size check in message handler

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

`npm test` (backend tests)

Result: All tests pass / Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #891
