### PR TITLE
[GSSoC'26] fix: never log OTP values in plaintext, even in debug mode

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -216,13 +216,9 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
   );
 
   if (process.env.TWILIO_AUTH_TOKEN) {
-    const smsOtpLog = process.env.NODE_DEBUG
-      ? `Sending SMS to customer phone containing OTP ${otp}`
-      : `Sending SMS to customer phone containing OTP ${otp.slice(0, 2)}***`;
-    logger.info(`[NotificationService] [SMS] SMS stub: ${smsOtpLog}`);
+    logger.info(`[NotificationService] [SMS] SMS stub: Sending OTP for order ${orderDisplayId} (masked)`);
   } else {
-    const logOtp = process.env.NODE_DEBUG ? otp : `${otp.slice(0, 2)}***`;
-    logger.info(`[NotificationService] [SMS] SMS stub: No SMS gateway configured. Logging OTP out-of-band: ${logOtp}`);
+    logger.info(`[NotificationService] [SMS] SMS stub: No SMS gateway configured. OTP sent out-of-band for order ${orderDisplayId} (masked)`);
   }
 
   return { success: dbSuccess || fcmResult.success, fcm: fcmResult };


### PR DESCRIPTION
## Description

- Removed all OTP values from log output in notification service
- Logs only order ID and masked metadata instead of OTP digits
- Prevents OTP interception via log access (shared infra, debug endpoints)

## Files Changed

- `backend/api/src/services/notificationService.js`: replaced OTP-logging branches with masked-only logging

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

`npm test` (backend tests)

Result: All tests pass / Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #892
