### PR TITLE
fix: align supabase_flutter version across apps (#897)

### DIFF
--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   truxify_shared:
     path: ../../packages/truxify_shared
-  supabase_flutter: ^2.8.4
+  supabase_flutter: ^2.9.1
   flutter_map: ^8.3.0
   flutter_map_cancellable_tile_provider: ^3.0.0
   google_fonts: ^8.1.0


### PR DESCRIPTION
## Summary
- Align supabase_flutter version between customer and driver apps
- Customer: ^2.8.4 -> ^2.9.1
- Driver: already ^2.9.1

## Why
Different supabase_flutter versions can produce different generated types in the supabase/ directory, causing shared code in packages/truxify_shared to fail type-checking. Aligning versions ensures type compatibility.

## Related
- Closes #897

## Verification
- [x] Version strings match: both apps now ^2.9.1
- [x] No other dependency changes

cc @KanishJebaMathewM