### PR TITLE
fix: add config validation and standardize env var names (#898)

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -196,3 +196,26 @@ export async function closeDbConnections() {
     }
   }
 }
+
+/**
+ * Validates that all required environment variables are present for production.
+ * Logs warnings for missing optional vars, throws for missing required vars.
+ */
+export function validateConfig() {
+  const required = ['SUPABASE_URL', 'SUPABASE_ANON_KEY'];
+  const recommended = ['REDIS_URL', 'MONGODB_URI', 'FIREBASE_SERVICE_ACCOUNT_JSON'];
+  const missing = required.filter((key) => !process.env[key]);
+  const missingRecommended = recommended.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    const msg = `Missing required env vars: ${missing.join(', ')}`;
+    logger.error(msg);
+    throw new Error(msg);
+  }
+
+  if (missingRecommended.length > 0) {
+    logger.warn(`Missing optional env vars (features disabled): ${missingRecommended.join(', ')}`);
+  }
+
+  logger.info('Config validation passed');
+}

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -8,7 +8,7 @@ import { globalLimiter, authLimiter, healthLimiter } from './middleware/rateLimi
 import tripRoutes from './routes/tripRoutes.js';
 import deviceRoutes from './routes/deviceRoutes.js';
 
-import { closeDbConnections, waitForMongoDb } from './config/db.js';
+import { closeDbConnections, waitForMongoDb, validateConfig } from './config/db.js';
 import { closeWebSocketServer, initWebSocketServer } from './sockets/tracker.js';
 
 // Load REST routes
@@ -32,6 +32,14 @@ import {
 // Configuration load from root folder is handled in db.js
 
 initSentry();
+
+// Validate required env vars at startup
+try {
+  validateConfig();
+} catch (err) {
+  logger.fatal(err.message);
+  process.exit(1);
+}
 
 // ============================================================================
 // STARTUP VALIDATION — crash fast, not at request time

--- a/blockchain/.env.example
+++ b/blockchain/.env.example
@@ -3,8 +3,9 @@
 # JSON-RPC provider URL for Polygon network (Amoy or Mainnet)
 POLYGON_RPC_URL=https://rpc-amoy.polygon.technology/
 
-# Deployer wallet private key (0x... format)
-DEPLOYER_PRIVATE_KEY=your_private_key_here
+# Relayer/Deployer wallet private key (0x... format)
+# RELAYER_PRIVATE_KEY is the preferred name; DEPLOYER_PRIVATE_KEY is accepted as fallback
+RELAYER_PRIVATE_KEY=your_private_key_here
 
 # Polygonscan API key for contract verification
 POLYGONSCAN_API_KEY=your_polygonscan_api_key_here

--- a/blockchain/hardhat.config.cjs
+++ b/blockchain/hardhat.config.cjs
@@ -2,7 +2,7 @@ require("@nomicfoundation/hardhat-ethers");
 require("@nomicfoundation/hardhat-verify");
 
 const POLYGON_RPC_URL = process.env.POLYGON_RPC_URL || "";
-const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY || "";
+const DEPLOYER_PRIVATE_KEY = process.env.RELAYER_PRIVATE_KEY || process.env.DEPLOYER_PRIVATE_KEY || "";
 const POLYGONSCAN_API_KEY = process.env.POLYGONSCAN_API_KEY || "";
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Add validateConfig() in db.js that throws on missing required env vars at startup
- Call validateConfig() in index.js before server starts (crash fast, not at request time)
- Blockchain hardhat.config.cjs: accept RELAYER_PRIVATE_KEY with DEPLOYER_PRIVATE_KEY fallback
- Update blockchain/.env.example to use RELAYER_PRIVATE_KEY as primary name

## Why
Different modules used different env var names for the same concept (RELAYER_WALLET_PRIVATE_KEY vs DEPLOYER_PRIVATE_KEY). No startup validation meant missing vars only discovered at request time.

## Changes
- validateConfig() checks: SUPABASE_URL, SUPABASE_ANON_KEY (required), REDIS_URL, MONGODB_URI, FIREBASE_SERVICE_ACCOUNT_JSON (optional with warnings)
- hardhat.config.cjs now reads RELAYER_PRIVATE_KEY first, falls back to DEPLOYER_PRIVATE_KEY

## Related
- Closes #898

## Verification
- [x] validateConfig() throws on missing required vars
- [x] validateConfig() warns on missing optional vars
- [x] Blockchain module accepts both RELAYER_PRIVATE_KEY and DEPLOYER_PRIVATE_KEY

cc @KanishJebaMathewM