### PR TITLE
fix : add CORS middleware to FastAPI ML engine

### DIFF
--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -2,6 +2,7 @@ import hmac
 import logging
 import os
 from fastapi import FastAPI, HTTPException, Header, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
 
@@ -26,6 +27,20 @@ app = FastAPI(
     title="Truxify ML Engine",
     description="Machine Learning microservice for Truxify",
     version="1.0.0",
+)
+
+# CORS: restrict to known origins — no wildcard "*" to prevent unauthorized cross-origin access
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:5000",   # Node.js API development
+        "http://127.0.0.1:5000",
+        "http://localhost:8000",   # FastAPI itself (browser testing)
+        "http://127.0.0.1:8000",
+    ],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["X-API-Key", "Content-Type"],
 )
 
 


### PR DESCRIPTION
Closes #946.

Summary of What Has Been Done:
Added CORSMiddleware to backend/ml/app/main.py restricting cross-origin access to known localhost ports (5000 for Node.js API, 8000 for the ML service itself). No wildcard origins are used.

Changes Made:
- backend/ml/app/main.py: imported CORSMiddleware and added app.add_middleware() call restricting origins to localhost:5000 and localhost:8000, with allow_credentials=True and allow_methods restricted to GET/POST/OPTIONS

Impact it Made:
- Prevents unauthorized cross-origin requests to the ML inference endpoint
- Fixes browser preflight failures during local development testing
- Aligns ML service with the security posture of the Node.js API