### PR TITLE
docs : remove duplicate Docker Local Development section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -510,52 +510,6 @@ SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 Copy `.env.example` to `.env` and fill in your local Supabase credentials before running the script.
 
 ---
-
-## Local Development Environment
-
-### Prerequisites
-
-- Docker Desktop
-- Git
-
-### Setup
-
-1. Copy the environment file:
-
-```bash
-cp .env.example .env
-```
-
-2. Create the local Docker override:
-
-```bash
-cp docker-compose.override.yml.example docker-compose.override.yml
-```
-
-3. Start the stack:
-
-```bash
-docker compose up
-```
-
-4. Verify containers:
-
-```bash
-docker ps
-```
-
-Expected services:
-
-- api
-- ml-engine
-- PostgreSQL/PostGIS
-- MongoDB
-- Redis
-
-All services communicate through the Docker network and no external cloud credentials are required for basic local development.
-
----
-
 ## Health Verification
 
 After starting the stack, verify that the backend is healthy:


### PR DESCRIPTION
Closes #943.

Summary of What Has Been Done:
Removed the duplicate Local Development Environment section from CONTRIBUTING.md. The file had a full Docker setup guide at line 334 and a shorter duplicate at line 514.

Changes Made:
- CONTRIBUTING.md: removed lines 513-558 (the duplicate section and its trailing separator)

Impact it Made:
- Cleaner documentation with no redundant sections
- Easier navigation for contributors setting up Docker environment