### PR TITLE
fix : added logger.warn to Redis lock release catch block in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -793,8 +793,8 @@ router.post('/:id/bids/:bidId/accept', authenticate, userLimiter, requireRole(['
       `;
       try {
         await redisClient.eval(luaScript, 1, lockKey, lockValue);
-      } catch {
-        // Lock expiry will handle cleanup if the DEL fails
+      } catch (err) {
+        logger.warn('[orderRoutes] Failed to release accept-bid lock for key %s: %s', lockKey, err.message);
       }
     }
   }


### PR DESCRIPTION
Closes #960.

Summary of What Has Been Done:
The finally block's Redis DEL Lua script for releasing the distributed accept-bid lock used a bare catch {} that silently swallowed all errors. Added logger.warn to make lock release failures observable.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Replaced bare catch {} with catch (err) { logger.warn('[orderRoutes] Failed to release accept-bid lock for key %s: %s', lockKey, err.message); }

Impact it Made:
- Lock release failures are now observable in production logs
- Consistent with error-handling patterns used in the rest of orderRoutes.js
- Local unit tests pass (15/18 test files; pre-existing failures in tracker.test.js, osrm.test.js, rateLimiter.test.js)

Note: Please assign this PR to the `tmdeveloper007` account.