### PR TITLE
fix : added logger.warn for Sentry flush failure in flushSentry

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -13,8 +13,8 @@ export async function flushSentry(timeoutMs = 2000) {
   if (!process.env.SENTRY_DSN) return;
   try {
     await Sentry.flush(timeoutMs);
-  } catch {
-    // ignore flush errors during process teardown
+  } catch (err) {
+    logger.warn('[sentry] Sentry.flush failed during teardown: %s', err.message);
   }
 }
 


### PR DESCRIPTION
Closes #962.

Summary of What Has Been Done:
Replaced the bare catch {} in flushSentry with catch (err) { logger.warn(...) } so Sentry flush failures during process teardown are observable in production logs.

Changes Made:
- backend/api/src/middleware/sentry.js: Added logger.warn for Sentry.flush failure in flushSentry

Impact it Made:
- Sentry flush failures are now observable in production logs without blocking teardown
- Consistent with logging patterns used elsewhere in the middleware layer
- Local unit tests pass (15/18 test files; pre-existing failures in tracker.test.js, osrm.test.js, rateLimiter.test.js)

Note: Please assign this PR to the `tmdeveloper007` account.