### PR TITLE
[GSSoC'26] fix: update load_offers when drop location changes

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1172,6 +1172,26 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
       logger.warn('Failed to update timeline for change-drop:', timelineErr.message);
     }
 
+    const loadOfferUpdates = {
+      drop_address,
+      drop_lat: Number(drop_lat),
+      drop_lng: Number(drop_lng),
+      freight_value: pricing.baseFreight,
+      fuel_cost: pricing.fuelCost,
+      toll_cost: pricing.tollEstimate,
+      net_profit: pricing.netProfit,
+      route_label: `${order.pickup_address.split(',')[0]} \u2192 ${drop_address.split(',')[0]}`,
+    };
+
+    const { error: loadOfferErr } = await supabase
+      .from('load_offers')
+      .update(loadOfferUpdates)
+      .eq('order_display_id', orderId);
+
+    if (loadOfferErr) {
+      logger.warn('Failed to update load_offers for change-drop:', loadOfferErr.message);
+    }
+
     return res.json({
       message: 'Drop location updated successfully.',
       pricing: {


### PR DESCRIPTION
## Description

- Added `load_offers` update to change-drop handler so the load board reflects the new drop location and recalculated pricing
- Updates: drop address, freight_value, fuel_cost, toll_cost, net_profit, and route_label

## Files Changed

- `backend/api/src/routes/orderRoutes.js`: Added Supabase update to `load_offers` table after orders update in change-drop endpoint

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Testing & Verification

Load board now reflects updated drop location and pricing after customer changes drop.

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a drop location now refreshes the related offer details so the displayed route and pricing stay in sync.
  * If the update cannot be applied, the system now records a warning to help surface issues sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->