### PR TITLE
fix: resolve 5 Flutter mock data bugs — truck number, blockchain hash, price lines, edit profile

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -90,6 +90,7 @@ class TruckResultData {
     this.baseFreight,
     this.tollEstimate,
     this.platformFee,
+    this.truckNumber,
     this.isAiEstimate = false,
   });
 
@@ -132,6 +133,7 @@ class TruckResultData {
       baseFreight: baseFreightStr,
       tollEstimate: tollEstimateStr,
       platformFee: platformFeeStr,
+      truckNumber: json['truckNumber'] as String? ?? json['number_plate'] as String?,
       isAiEstimate: json['isAiEstimate'] as bool? ?? false,
     );
   }
@@ -148,6 +150,7 @@ class TruckResultData {
   final String? baseFreight;
   final String? tollEstimate;
   final String? platformFee;
+  final String? truckNumber;
   final bool isAiEstimate;
 }
 
@@ -179,6 +182,11 @@ class HistoryOrderData {
     required this.driver,
     required this.truckNumber,
     required this.timeline,
+    this.blockchainTxHash,
+    this.baseFare,
+    this.distanceCharge,
+    this.tollCharge,
+    this.platformFee,
   });
 
   final String orderId;
@@ -189,6 +197,11 @@ class HistoryOrderData {
   final String driver;
   final String truckNumber;
   final List<TimelineStepData> timeline;
+  final String? blockchainTxHash;
+  final String? baseFare;
+  final String? distanceCharge;
+  final String? tollCharge;
+  final String? platformFee;
 }
 
 class TimelineStepData {

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/order_service.dart';
 import '../controllers/app_controller.dart';
-import '../data/mock_data.dart';
 import '../models/app_models.dart';
 import '../models/payment_method.dart';
 import '../models/saved_address.dart';
@@ -184,7 +183,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                     label: 'Driver',
                     value:
                         '${widget.truck.driver} ⭐ ${widget.truck.rating.toStringAsFixed(1)}'),
-                _SummaryRow(label: 'Truck', value: mockDefaultTruckNumber),
+                _SummaryRow(label: 'Truck', value: widget.truck.truckNumber ?? widget.truck.truck),
               ],
             ),
           ),
@@ -206,15 +205,8 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                   if (widget.truck.platformFee != null)
                     _PriceLineRow(label: 'Platform fee', amount: widget.truck.platformFee!),
                   _PriceLineRow(label: 'Total', amount: widget.truck.price, isTotal: true),
-                ] else ...[
-                  ...mockBookingPriceLines.map(
-                    (line) => _PriceLineRow(
-                      label: line.label,
-                      amount: line.amount,
-                      isTotal: line.isTotal,
-                    ),
-                  ),
-                ],
+                ] else
+                  _PriceLineRow(label: 'Total', amount: widget.truck.price, isTotal: true),
                 if (widget.truck.isAiEstimate) ...[
                   const SizedBox(height: 4),
                   const Divider(),
@@ -349,8 +341,6 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     );
   }
 }
-
-const mockDefaultTruckNumber = 'TN 45 AB 1234';
 
 class _SummaryRow extends StatelessWidget {
   const _SummaryRow({required this.label, required this.value});

--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -18,9 +18,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(text: 'Karthik Murugan');
-    _companyController = TextEditingController(text: 'Sri Murugan Textiles');
-    _phoneController = TextEditingController(text: '+91 98765 43210');
+    _nameController = TextEditingController();
+    _companyController = TextEditingController();
+    _phoneController = TextEditingController();
   }
 
   @override

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -3,7 +3,6 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../constants/supabase_config.dart';
 import '../controllers/app_controller.dart';
-import '../data/mock_data.dart';
 import '../models/app_models.dart';
 import '../services/order_service.dart';
 import '../theme/app_theme.dart';
@@ -132,6 +131,11 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
             driver: driverName,
             truckNumber: truckNumber,
             timeline: parsedTimeline,
+            blockchainTxHash: orderMap['blockchain_tx_hash']?.toString(),
+            baseFare: orderMap['base_fare'] != null ? '₹${(orderMap['base_fare'] as num / 100).toStringAsFixed(0)}' : null,
+            distanceCharge: orderMap['distance_charge'] != null ? '₹${(orderMap['distance_charge'] as num / 100).toStringAsFixed(0)}' : null,
+            tollCharge: orderMap['toll_charge'] != null ? '₹${(orderMap['toll_charge'] as num / 100).toStringAsFixed(0)}' : null,
+            platformFee: orderMap['platform_fee'] != null ? '₹${(orderMap['platform_fee'] as num / 100).toStringAsFixed(0)}' : null,
           );
 
           // Trigger rating flow if status becomes completed and rating dialog hasn't been shown yet
@@ -303,7 +307,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               const SizedBox(height: 10),
               const Text('Transaction hash'),
               const SizedBox(height: 6),
-              SelectableText('0x8ab9f2c7e9f5d41a3d0b7f4d2c0e91f9c7d48abca7712c4f2c1d8b7f9a1c0e55'),
+              SelectableText(_currentOrder.blockchainTxHash ?? 'Blockchain data pending'),
               const SizedBox(height: 16),
               PrimaryButton(label: 'Close', onPressed: () => Navigator.of(context).pop()),
             ],
@@ -386,18 +390,17 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               children: [
                 Text('Price breakdown', style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 12),
-                ...mockOrderDetailPriceLines.map(
-                  (line) => Padding(
-                    padding: const EdgeInsets.only(bottom: 10),
-                    child: Row(
-                      children: [
-                        Text(line.label, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: line.isTotal ? FontWeight.w800 : FontWeight.w500)),
-                        const Spacer(),
-                        Text(line.amount, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: line.isTotal ? FontWeight.w800 : FontWeight.w600)),
-                      ],
-                    ),
-                  ),
-                ),
+                if (_currentOrder.baseFare != null || _currentOrder.distanceCharge != null || _currentOrder.tollCharge != null || _currentOrder.platformFee != null) ...[
+                  if (_currentOrder.baseFare != null)
+                    _PriceLine(label: 'Base Fare', amount: _currentOrder.baseFare!),
+                  if (_currentOrder.distanceCharge != null)
+                    _PriceLine(label: 'Distance Charge', amount: _currentOrder.distanceCharge!),
+                  if (_currentOrder.tollCharge != null)
+                    _PriceLine(label: 'Toll Charges', amount: _currentOrder.tollCharge!),
+                  if (_currentOrder.platformFee != null)
+                    _PriceLine(label: 'Platform Fee', amount: _currentOrder.platformFee!),
+                ],
+                _PriceLine(label: 'Total', amount: _currentOrder.amount, isTotal: true),
               ],
             ),
           ),
@@ -444,6 +447,28 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
             const SizedBox(height: 12),
             PrimaryButton(label: 'Submit Rating', onPressed: _submitRating),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PriceLine extends StatelessWidget {
+  const _PriceLine({required this.label, required this.amount, this.isTotal = false});
+
+  final String label;
+  final String amount;
+  final bool isTotal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: isTotal ? FontWeight.w800 : FontWeight.w500)),
+          const Spacer(),
+          Text(amount, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: isTotal ? FontWeight.w800 : FontWeight.w600)),
         ],
       ),
     );


### PR DESCRIPTION
Batch 2 — fixes 5 Flutter mock data bugs across 4 files.

## Changes

### #973 — Booking confirmation uses fake truck number
Replaced `mockDefaultTruckNumber` with `widget.truck.truckNumber` (added `truckNumber` field to `TruckResultData` model).

### #974 — Order detail receipt shows hardcoded fake blockchain hash
Replaced hardcoded hash with `_currentOrder.blockchainTxHash` field populated from API data.

### #975 — Order detail screen uses mock price lines
Replaced `mockOrderDetailPriceLines` with real pricing fields (`baseFare`, `distanceCharge`, `tollCharge`, `platformFee`) from order API.

### #976 — Booking confirmation screen shows mock price lines
Removed `mockBookingPriceLines` fallback; shows real truck pricing or falls through to total only.

### #980 — Edit profile screen pre-filled with hardcoded mock values
Initialized text controllers with empty strings instead of hardcoded 'Karthik Murugan' / 'Sri Murugan Textiles' / '+91 98765 43210'.