### PR TITLE
fix: add missing logger import in profileRoutes.js (#971)

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -12,6 +12,7 @@ import { ProfileModel } from '../models/ProfileModel.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
 import { validateParams } from '../middleware/validate.js';
 import { paramIdSchema } from '../validation/requestSchemas.js';
+import logger from '../middleware/logger.js';
 import { updateProfileSchema, updateWalletSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();


### PR DESCRIPTION
Fixes #971 — server crashes with ReferenceError when cache invalidation fails because logger is never imported. Added `import logger from '../middleware/logger.js'`.