### PR TITLE
fix: remove 'Delivered' from milestone schema enum (#972)

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -105,7 +105,7 @@ export const predictDemandSchema = z.object({
 }).strict();
 
 export const updateMilestoneSchema = z.object({
-  milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving', 'Delivered'], {
+  milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving'], {
     invalid_type_error: 'Invalid milestone supplied.'
   })
 });


### PR DESCRIPTION
Fixes #972 — updateMilestoneSchema allows 'Delivered' but route handler rejects it with 400. Removed 'Delivered' from Zod enum to match handler expectations.