### PR TITLE
fix: remove duplicate healthLimiter import in healthRoutes.js (#977)

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -2,7 +2,6 @@ import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
 import { healthLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
-import { healthLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Fixes #977 — duplicate import statement in healthRoutes.js. Removed the redundant import on line 5.