### PR TITLE
fix: replace mock truck number with real truck data in booking confirmation (#973)

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -90,6 +90,7 @@ class TruckResultData {
     this.baseFreight,
     this.tollEstimate,
     this.platformFee,
+    this.truckNumber,
     this.isAiEstimate = false,
   });
 
@@ -132,6 +133,7 @@ class TruckResultData {
       baseFreight: baseFreightStr,
       tollEstimate: tollEstimateStr,
       platformFee: platformFeeStr,
+      truckNumber: json['truckNumber'] as String? ?? json['number_plate'] as String?,
       isAiEstimate: json['isAiEstimate'] as bool? ?? false,
     );
   }
@@ -148,6 +150,7 @@ class TruckResultData {
   final String? baseFreight;
   final String? tollEstimate;
   final String? platformFee;
+  final String? truckNumber;
   final bool isAiEstimate;
 }
 

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/order_service.dart';
 import '../controllers/app_controller.dart';
-import '../data/mock_data.dart';
 import '../models/app_models.dart';
 import '../models/payment_method.dart';
 import '../models/saved_address.dart';
@@ -184,7 +183,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                     label: 'Driver',
                     value:
                         '${widget.truck.driver} ⭐ ${widget.truck.rating.toStringAsFixed(1)}'),
-                _SummaryRow(label: 'Truck', value: mockDefaultTruckNumber),
+                _SummaryRow(label: 'Truck', value: widget.truck.truckNumber ?? widget.truck.truck),
               ],
             ),
           ),
@@ -350,7 +349,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   }
 }
 
-const mockDefaultTruckNumber = 'TN 45 AB 1234';
+const widget.truck.truckNumber ?? widget.truck.truck = 'TN 45 AB 1234';
 
 class _SummaryRow extends StatelessWidget {
   const _SummaryRow({required this.label, required this.value});


### PR DESCRIPTION
Fixes #973 — booking confirmation shows fake truck number. Replaced mockDefaultTruckNumber with widget.truck.truckNumber. Added truckNumber field to TruckResultData model.