### PR TITLE
fix: replace hardcoded fake blockchain hash with real transaction data (#974)

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -179,6 +179,7 @@ class HistoryOrderData {
     required this.driver,
     required this.truckNumber,
     required this.timeline,
+    this.blockchainTxHash,
   });
 
   final String orderId;
@@ -189,6 +190,7 @@ class HistoryOrderData {
   final String driver;
   final String truckNumber;
   final List<TimelineStepData> timeline;
+  final String? blockchainTxHash;
 }
 
 class TimelineStepData {

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -132,6 +132,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
             driver: driverName,
             truckNumber: truckNumber,
             timeline: parsedTimeline,
+            blockchainTxHash: orderMap['blockchain_tx_hash']?.toString(),
           );
 
           // Trigger rating flow if status becomes completed and rating dialog hasn't been shown yet
@@ -303,7 +304,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               const SizedBox(height: 10),
               const Text('Transaction hash'),
               const SizedBox(height: 6),
-              SelectableText('0x8ab9f2c7e9f5d41a3d0b7f4d2c0e91f9c7d48abca7712c4f2c1d8b7f9a1c0e55'),
+              SelectableText(_currentOrder.blockchainTxHash ?? 'Blockchain data pending'),
               const SizedBox(height: 16),
               PrimaryButton(label: 'Close', onPressed: () => Navigator.of(context).pop()),
             ],


### PR DESCRIPTION
Fixes #974 — order detail receipt shows hardcoded fake blockchain hash for every order. Replaced with real blockchainTxHash from API data. Added blockchainTxHash field to HistoryOrderData model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order details now show the blockchain transaction hash when it’s available.
  * The blockchain receipt view now displays a pending message when transaction data isn’t ready yet.

* **Bug Fixes**
  * Replaced the previously hardcoded transaction hash display with the actual value from the order, improving accuracy in order details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->