### PR TITLE
fix: replace mock price lines with real pricing data in order detail (#975)

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -179,6 +179,10 @@ class HistoryOrderData {
     required this.driver,
     required this.truckNumber,
     required this.timeline,
+    this.baseFare,
+    this.distanceCharge,
+    this.tollCharge,
+    this.platformFee,
   });
 
   final String orderId;
@@ -189,6 +193,10 @@ class HistoryOrderData {
   final String driver;
   final String truckNumber;
   final List<TimelineStepData> timeline;
+  final String? baseFare;
+  final String? distanceCharge;
+  final String? tollCharge;
+  final String? platformFee;
 }
 
 class TimelineStepData {

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -3,7 +3,6 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../constants/supabase_config.dart';
 import '../controllers/app_controller.dart';
-import '../data/mock_data.dart';
 import '../models/app_models.dart';
 import '../services/order_service.dart';
 import '../theme/app_theme.dart';
@@ -132,6 +131,10 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
             driver: driverName,
             truckNumber: truckNumber,
             timeline: parsedTimeline,
+            baseFare: orderMap['base_fare'] != null ? '₹${(orderMap['base_fare'] as num / 100).toStringAsFixed(0)}' : null,
+            distanceCharge: orderMap['distance_charge'] != null ? '₹${(orderMap['distance_charge'] as num / 100).toStringAsFixed(0)}' : null,
+            tollCharge: orderMap['toll_charge'] != null ? '₹${(orderMap['toll_charge'] as num / 100).toStringAsFixed(0)}' : null,
+            platformFee: orderMap['platform_fee'] != null ? '₹${(orderMap['platform_fee'] as num / 100).toStringAsFixed(0)}' : null,
           );
 
           // Trigger rating flow if status becomes completed and rating dialog hasn't been shown yet
@@ -386,18 +389,17 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               children: [
                 Text('Price breakdown', style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
                 const SizedBox(height: 12),
-                ...mockOrderDetailPriceLines.map(
-                  (line) => Padding(
-                    padding: const EdgeInsets.only(bottom: 10),
-                    child: Row(
-                      children: [
-                        Text(line.label, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: line.isTotal ? FontWeight.w800 : FontWeight.w500)),
-                        const Spacer(),
-                        Text(line.amount, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: line.isTotal ? FontWeight.w800 : FontWeight.w600)),
-                      ],
-                    ),
-                  ),
-                ),
+                if (_currentOrder.baseFare != null || _currentOrder.distanceCharge != null || _currentOrder.tollCharge != null || _currentOrder.platformFee != null) ...[
+                  if (_currentOrder.baseFare != null)
+                    _PriceLine(label: 'Base Fare', amount: _currentOrder.baseFare!),
+                  if (_currentOrder.distanceCharge != null)
+                    _PriceLine(label: 'Distance Charge', amount: _currentOrder.distanceCharge!),
+                  if (_currentOrder.tollCharge != null)
+                    _PriceLine(label: 'Toll Charges', amount: _currentOrder.tollCharge!),
+                  if (_currentOrder.platformFee != null)
+                    _PriceLine(label: 'Platform Fee', amount: _currentOrder.platformFee!),
+                ],
+                _PriceLine(label: 'Total', amount: _currentOrder.amount, isTotal: true),
               ],
             ),
           ),
@@ -444,6 +446,28 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
             const SizedBox(height: 12),
             PrimaryButton(label: 'Submit Rating', onPressed: _submitRating),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PriceLine extends StatelessWidget {
+  const _PriceLine({required this.label, required this.amount, this.isTotal = false});
+
+  final String label;
+  final String amount;
+  final bool isTotal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: isTotal ? FontWeight.w800 : FontWeight.w500)),
+          const Spacer(),
+          Text(amount, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: isTotal ? FontWeight.w800 : FontWeight.w600)),
         ],
       ),
     );


### PR DESCRIPTION
Fixes #975 — order detail screen shows fake price breakdown. Replaced mockOrderDetailPriceLines with real pricing from API (baseFare, distanceCharge, tollCharge, platformFee). Added pricing fields to HistoryOrderData model.