### PR TITLE
fix: initialize edit profile with empty values instead of hardcoded mocks (#980)

### DIFF
--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -18,9 +18,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(text: 'Karthik Murugan');
-    _companyController = TextEditingController(text: 'Sri Murugan Textiles');
-    _phoneController = TextEditingController(text: '+91 98765 43210');
+    _nameController = TextEditingController();
+    _companyController = TextEditingController();
+    _phoneController = TextEditingController();
   }
 
   @override


### PR DESCRIPTION
Fixes #980 — edit profile screen pre-filled with 'Karthik Murugan', 'Sri Murugan Textiles', '+91 98765 43210'. Initialized text controllers with empty strings instead.