### PR TITLE
fix: only cache default Surat location when no cached location exists (#982)

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -37,7 +37,10 @@ class _HomeScreenState extends State<HomeScreen> {
     final connectivity = await Connectivity().checkConnectivity();
     final hasNetwork = connectivity.isNotEmpty && !connectivity.contains(ConnectivityResult.none);
     await _cacheManager.open();
-    await _cacheManager.cacheLastLocation(21.1702, 72.8311);
+    final existingLocation = await _cacheManager.getLastLocation();
+    if (existingLocation == null) {
+      await _cacheManager.cacheLastLocation(21.1702, 72.8311);
+    }
     final cachedLocation = await _cacheManager.getLastLocation();
     if (!mounted) return;
 


### PR DESCRIPTION
Fixes #982 — home screen caches hardcoded Surat GPS on every launch, overriding real location. Changed to only cache default when no location exists yet.