### PR TITLE
fix: show dynamic location label instead of hardcoded 'Surat, Gujarat' (#983)

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -104,7 +104,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   children: [
                     const Icon(Icons.place_rounded, size: 16, color: TruxifyColors.accentDark),
                     const SizedBox(width: 6),
-                    Text(_isOffline ? _locationLabel : 'Surat, Gujarat', style: const TextStyle(fontWeight: FontWeight.w700)),
+                    Text(_locationLabel, style: const TextStyle(fontWeight: FontWeight.w700)),
                   ],
                 ),
               ),


### PR DESCRIPTION
Fixes #983 — location badge always shows 'Surat, Gujarat' when online. Always displays dynamic _locationLabel from GPS/cache instead.