### PR TITLE
fix: add bounds guard to prevent index out of bounds crash on home screen (#984)

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -143,9 +143,11 @@ class _HomeScreenState extends State<HomeScreen> {
                   return ShipmentCard(
                     shipment: shipment,
                     onTap: () {
-                      Navigator.of(context).push(
-                        AppPageRoute(builder: (_) => LiveTrackingScreen(orderId: mockActiveOrders[index].orderId)),
-                      );
+                      if (index < mockActiveOrders.length) {
+                        Navigator.of(context).push(
+                          AppPageRoute(builder: (_) => LiveTrackingScreen(orderId: mockActiveOrders[index].orderId)),
+                        );
+                      }
                     },
                   );
                 },


### PR DESCRIPTION
Fixes #984 — tapping shipment card crashes if mockActiveShipments and mockActiveOrders have different lengths. Added bounds check before indexing mockActiveOrders.