### PR TITLE
fix : correct @param type annotation from {any} to {object|null} in profileCache.js

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -72,7 +72,7 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
  * a Firebase UID, so the identity field checked here is `id`.
  *
  * @param {string} userId - The expected Supabase profile UUID.
- * @param {any} cachedProfile - The cached profile to validate.
+ * @param {object|null} cachedProfile - The cached profile to validate.
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedSupabaseProfile(userId, cachedProfile) {


### PR DESCRIPTION
fix : correct @param type annotation from {any} to {object|null} in profileCache.js

Closes #593