### PR TITLE
fix(#1031): add column-level RLS protection for load_offers pricing fields

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -299,6 +299,18 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), validateB
       logger.error('Load Offer Insertion Error:', offerErr.message);
     }
 
+    // Verify pricing was stored correctly (integrity check)
+    const { data: verifyOffer } = await supabase
+      .from('load_offers')
+      .select('freight_value, net_profit, fuel_cost, toll_cost, extra_distance_km')
+      .eq('order_display_id', orderDisplayId)
+      .single();
+
+    if (verifyOffer && verifyOffer.freight_value !== pricing.baseFreight) {
+      logger.error(`[SECURITY] Load offer pricing mismatch for ${orderDisplayId}: ` +
+        `expected ${pricing.baseFreight}, got ${verifyOffer.freight_value}`);
+    }
+
     res.status(201).json({ message: 'Order created successfully and broadcasted to loads board.', order });
   } catch (err) {
     logger.error('Order creation exception:', err.message);

--- a/docs/supabase/migrations/002_rls_policies.sql
+++ b/docs/supabase/migrations/002_rls_policies.sql
@@ -148,6 +148,13 @@ CREATE POLICY "Customers update own load offers"
   USING  (customer_id = get_profile_id())
   WITH CHECK (customer_id = get_profile_id());
 
+-- Trigger-based column-level protection: only service_role can modify pricing columns
+DROP TRIGGER IF EXISTS trg_load_offer_pricing_protect ON load_offers;
+CREATE TRIGGER trg_load_offer_pricing_protect
+  BEFORE UPDATE ON load_offers
+  FOR EACH ROW
+  EXECUTE FUNCTION check_load_offer_update_allowed();
+
 
 -- ────────────────────────────────────────────────────────────────────────────
 -- 6. LOAD BIDS
@@ -260,5 +267,24 @@ DROP POLICY IF EXISTS "Drivers view ratings about themselves" ON ratings;
 CREATE POLICY "Drivers view ratings about themselves"
   ON ratings FOR SELECT TO authenticated
   USING (driver_id = get_profile_id());
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Helper: Trigger function to prevent non-service-role users from modifying
+-- pricing columns on load_offers table (Issue #1031)
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION check_load_offer_update_allowed()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF (OLD.freight_value IS DISTINCT FROM NEW.freight_value
+   OR OLD.net_profit IS DISTINCT FROM NEW.net_profit
+   OR OLD.fuel_cost IS DISTINCT FROM NEW.fuel_cost
+   OR OLD.toll_cost IS DISTINCT FROM NEW.toll_cost
+   OR OLD.extra_distance_km IS DISTINCT FROM NEW.extra_distance_km)
+  AND current_role <> 'service_role' THEN
+    RAISE EXCEPTION 'Pricing columns cannot be modified by non-service-role users';
+  END IF;
+  RETURN NEW;
+END;
+$$;
 
 COMMIT;


### PR DESCRIPTION
## Description
Fixes #1031 — `load_offers` UPDATE RLS had no column restrictions, allowing customers to arbitrarily set pricing fields.

### Changes Made

1. **`docs/supabase/migrations/002_rls_policies.sql`**
   - Added `check_load_offer_update_allowed()` trigger function that rejects UPDATEs to pricing columns (`freight_value`, `net_profit`, `fuel_cost`, `toll_cost`, `extra_distance_km`) from non-`service_role` users
   - Added `trg_load_offer_pricing_protect` BEFORE UPDATE trigger on `load_offers`

2. **`backend/api/src/routes/orderRoutes.js`**
   - Added server-side pricing integrity verification after `load_offers` INSERT to log mismatches between stored and computed pricing

### Root Cause
The existing RLS policy at `002_rls_policies.sql:145-149` only verified `customer_id = get_profile_id()` — it did not restrict which columns the customer could modify. A customer could call the Supabase REST API directly to inflate `freight_value`, `net_profit`, etc., and drivers would see the manipulated prices via Realtime subscriptions.

### Column Protection
The trigger compares OLD and NEW values for each pricing column. If any pricing column changed and `current_role <> 'service_role'`, the UPDATE is rejected with: `Pricing columns cannot be modified by non-service-role users`.