### PR TITLE
fix : removed silent service role key fallback from Supabase client init in db.js

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -14,7 +14,7 @@ dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
 //    service role key for admin operations only (bypasses RLS)
 // ============================================================================
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 export let supabase = null;


### PR DESCRIPTION
Closes #1050.

Summary of What Has Been Done:
Changed supabaseKey initialization to use only SUPABASE_ANON_KEY instead of falling back to SUPABASE_SERVICE_ROLE_KEY when the anon key is absent. This prevents the Supabase client from silently initializing with service role privileges when the anon key is misconfigured.

Changes Made:
- backend/api/src/config/db.js: Changed const supabaseKey = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY to const supabaseKey = process.env.SUPABASE_ANON_KEY.

Impact it Made:
- Makes configuration errors explicit — missing SUPABASE_ANON_KEY will now prevent client initialization instead of silently using elevated privileges.
- Prevents a potential RLS bypass if the anon key is absent.

Note: Please assign this PR to the `tmdeveloper007` account.