### PR TITLE
fix : added null guard for supabase client in removeClientFromAllSubscriptions in tracker.js

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -958,7 +958,9 @@ async function removeClientFromAllSubscriptions(ws) {
       if (locationChannels.has(key)) {
         const { channel } = locationChannels.get(key);
         channel.unsubscribe();
-        supabase.removeChannel(channel);
+        if (supabase) {
+          supabase.removeChannel(channel);
+        }
         locationChannels.delete(key);
         logger.info(`Removed Supabase Realtime channel for order "${key}" on last subscriber disconnect.`);
       }


### PR DESCRIPTION
Closes #1051.

Summary of What Has Been Done:
Added a null guard around the supabase.removeChannel() call inside removeClientFromAllSubscriptions(). When Supabase is not configured (supabase is null), the call was throwing a TypeError and preventing clean WebSocket disconnect handling.

Changes Made:
- backend/api/src/sockets/tracker.js: Wrapped supabase.removeChannel(channel) with if (supabase) { ... } guard.

Impact it Made:
- Prevents TypeError crash when Supabase is unconfigured.
- Allows clean WebSocket disconnect handling in all environments.

Note: Please assign this PR to the `tmdeveloper007` account.