### PR TITLE
fix : wrapped blockchain calls in try-catch inside awardReputationPoints in reputation.js

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -84,10 +84,14 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
     logger.warn(`[reputation] Invalid driver wallet address "${driverWalletAddress}" — skipping.`);
     return;
   }
-  const tx = await reputationContract.increaseReputation(driverWalletAddress, stars);
-  logger.info(`[reputation] increaseReputation tx submitted: ${tx.hash}`);
-  await tx.wait(1); // wait for 1 confirmation
-  logger.info(`[reputation] increaseReputation confirmed for driver ${driverWalletAddress} (+${stars} pts).`);
+  try {
+    const tx = await reputationContract.increaseReputation(driverWalletAddress, stars);
+    logger.info(`[reputation] increaseReputation tx submitted: ${tx.hash}`);
+    await tx.wait(1); // wait for 1 confirmation
+    logger.info(`[reputation] increaseReputation confirmed for driver ${driverWalletAddress} (+${stars} pts).`);
+  } catch (err) {
+    logger.error(`[reputation] Blockchain error in awardReputationPoints for ${driverWalletAddress}: ${err.message}`);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1052.

Summary of What Has Been Done:
Wrapped the reputationContract.increaseReputation() and tx.wait() calls inside awardReputationPoints() with a try-catch block. The function is documented as fire-and-forget, but unhandled blockchain exceptions could still propagate to callers and crash route handlers.

Changes Made:
- backend/api/src/services/reputation.js: Added try-catch around blockchain calls with logger.error for failures, matching the fire-and-forget design intent.

Impact it Made:
- Prevents blockchain RPC errors from crashing HTTP route handlers.
- Makes the fire-and-forget guarantee explicit and reliable.

Note: Please assign this PR to the `tmdeveloper007` account.