### PR TITLE
fix : removed redundant healthLimiter import and route-level usage from healthRoutes.js

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
-import { healthLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
@@ -66,7 +65,7 @@ function checkPolygon() {
 const CRITICAL_UNHEALTHY = new Set(['failed', 'not_configured']);
 
 // GET /api/health — full dependency check; returns 503 when a critical service fails
-router.get('/', healthLimiter, async (req, res) => {
+router.get('/', async (req, res) => {
   const [supabaseStatus, mongoStatus, redisStatus] = await Promise.all([
     checkSupabase(),
     checkMongo(),
@@ -95,7 +94,7 @@ router.get('/', healthLimiter, async (req, res) => {
 });
 
 // GET /api/health/live — liveness probe; always 200 as long as the process is up
-router.get('/live', healthLimiter, (req, res) => {
+router.get('/live', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
 


### PR DESCRIPTION
Closes #1053.

Summary of What Has Been Done:
Removed the healthLimiter import and its usage from individual routes in healthRoutes.js. The middleware is already applied at the /api/health mount point in index.js via app.use('/api/health', healthLimiter), so the route-level usage was redundant and caused double rate-limiting per health check request.

Changes Made:
- backend/api/src/routes/healthRoutes.js: Removed import of healthLimiter.
- backend/api/src/routes/healthRoutes.js: Removed healthLimiter from GET / and GET /live route definitions.

Impact it Made:
- Eliminates redundant rate-limit middleware application per health check request.
- Reduces unnecessary middleware overhead on health check endpoints.

Note: Please assign this PR to the `tmdeveloper007` account.