### PR TITLE
feat: Add CSV export format support to driver statement API (#1060)

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -238,7 +238,7 @@ router.put('/fcm-token', authenticate, userLimiter, async (req, res) => {
 // GET DRIVER STATEMENT
 router.get('/driver/statement', authenticate, requireRole(['driver']), userLimiter, validateQuery(driverStatementSchema), async (req, res) => {
   const userId = req.user.id;
-  const { start_date, end_date } = req.query;
+  const { start_date, end_date, format } = req.query;
 
   try {
     let query = supabase
@@ -290,6 +290,16 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
         status: trip.status
       };
     });
+
+    if (format === 'csv') {
+      const csvRows = [
+        ['ID', 'Order Display ID', 'Pickup Address', 'Drop Address', 'Pickup Date', 'Base Freight', 'Platform Fee', 'Toll Estimate', 'Net Earnings', 'Status'],
+        ...tripsList.map(t => [t.id, t.order_display_id, t.pickup_address, t.drop_address, t.pickup_date, t.base_freight, t.platform_fee, t.toll_estimate, t.net_earnings, t.status])
+      ];
+      const csvString = csvRows.map(row => row.map(val => `"${String(val).replace(/"/g, '""')}"`).join(',')).join('\n');
+      res.setHeader('Content-Type', 'text/csv');
+      return res.send(csvString);
+    }
 
     res.json({
       summary: {

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -188,6 +188,7 @@ export const driverStatementSchema = z.object({
   end_date: z.string().refine(value => !Number.isNaN(Date.parse(value)), {
     message: 'Must be a valid date string',
   }).optional(),
+  format: z.enum(['json', 'csv']).optional(),
 }).strict();
 
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -455,5 +455,28 @@ describe('Profile Routes', () => {
       expect(res.body.trips).toHaveLength(1);
       expect(res.body.trips[0].id).toBe('order-2');
     });
+
+    it('returns CSV formatting when format=csv is passed', async () => {
+      m.store.orders.push({
+        id: 'order-1',
+        driver_id: 'driver-uuid-456',
+        status: 'delivered',
+        pickup_address: 'A',
+        drop_address: 'B',
+        pickup_date: '2026-06-01',
+        base_freight: 10000,
+        platform_fee: 500,
+        toll_estimate: 1500
+      });
+
+      const res = await request(buildApp())
+        .get('/api/profile/driver/statement?format=csv')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/csv');
+      expect(res.text).toContain('"order-1"');
+      expect(res.text).toContain('"10000"');
+    });
   });
 });


### PR DESCRIPTION
Resolves #1060. Adds optional format=csv parameter to the driver statement endpoint to export trip and earnings report data in CSV format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driver statements can now be downloaded as CSV by choosing the CSV format.
  * Support categories now return a cleaner structured response for apps to display labels and category lists.
  * Orders can now progress to a new **Delivered** status.

* **Bug Fixes**
  * Improved request validation for several endpoints to better accept valid IDs and statement options.
  * Fixed support route test structure and expanded coverage for CSV statement output.

* **Chores**
  * Updated route imports and test setup to keep the API and automated checks aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->