### PR TITLE
feat: Add SLA response times to support ticket categories API (#1062)

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -72,10 +72,19 @@ const CATEGORY_LABELS = {
   account: 'Account Management',
 };
 
+const CATEGORY_SLA = {
+  payment: 24,
+  order: 12,
+  technical: 4,
+  general: 48,
+  account: 24,
+};
+
 router.get('/categories', (_req, res) => {
   res.json({
     categories: VALID_CATEGORIES,
     labels: CATEGORY_LABELS,
+    sla_hours: CATEGORY_SLA,
   });
 });
 

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -536,6 +536,8 @@ describe('Support Routes', () => {
       expect(res.body.categories).toContain('account');
       expect(res.body.labels).toBeDefined();
       expect(typeof res.body.labels.payment).toBe('string');
+      expect(res.body.sla_hours).toBeDefined();
+      expect(res.body.sla_hours.payment).toBe(24);
     });
 
     it('categories array contains no duplicates', async () => {


### PR DESCRIPTION
Resolves #1062. Appends a metadata object mapping each support category to its corresponding SLA response time (in hours) on the GET /api/support/categories response.