### PR TITLE
feat: Add pagination (limit and offset) to support ticket comments API (#1064)

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -422,11 +422,15 @@ router.get('/tickets/:id/comments', authenticate, userLimiter, async (req, res) 
       return res.status(403).json({ error: 'Access Denied: You do not own this ticket.' });
     }
 
+    const limit = Math.max(1, Math.min(100, Number(req.query.limit) || 100));
+    const offset = Math.max(0, Number(req.query.offset) || 0);
+
     const { data: comments, error: commentsError } = await supabase
       .from('support_ticket_comments')
       .select('id, ticket_id, user_id, user_name, message, created_at')
       .eq('ticket_id', ticketId)
-      .order('created_at', { ascending: true });
+      .order('created_at', { ascending: true })
+      .range(offset, offset + limit - 1);
 
     if (commentsError) {
       return res.status(500).json({

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -520,6 +520,21 @@ describe('Support Routes', () => {
       expect(res.body).toHaveLength(1);
       expect(res.body[0].message).toBe('Hello');
     });
+
+    it('GET /tickets/:id/comments supports limit and offset pagination', async () => {
+      m.store.support_ticket_comments.push(
+        { id: 'c-1', ticket_id: 't-123', user_id: 'customer-1', message: 'First', created_at: '2026-06-01T00:00:00.000Z' },
+        { id: 'c-2', ticket_id: 't-123', user_id: 'customer-1', message: 'Second', created_at: '2026-06-02T00:00:00.000Z' }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/support/tickets/t-123/comments?limit=1&offset=1')
+        .set(CUSTOMER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].message).toBe('Second');
+    });
   });
 
   describe('GET /api/support/categories', () => {


### PR DESCRIPTION
Resolves #1064. Introduces limit and offset query parameters on the GET /api/support/tickets/:id/comments endpoint using Supabase range queries.