### PR TITLE
feat: Add custom chronological sorting order to trip events API (#1066)

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -203,7 +203,8 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
  */
 router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
   const tripId = req.params.id;
-  const { type } = req.query;
+  const { type, sort } = req.query;
+  const isAscending = sort !== 'desc';
 
   try {
     // 1. Fetch the trip to determine the driver
@@ -211,7 +212,7 @@ router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
       .from('trip_events')
       .select('event_id, user_id, trip_id, event_type, event_timestamp, latitude, longitude, metadata, created_at')
       .eq('trip_id', tripId)
-      .order('event_timestamp', { ascending: true });
+      .order('event_timestamp', { ascending: isAscending });
 
     if (eventsErr) {
       return res.status(500).json({ error: 'Failed to fetch trip events.', details: eventsErr.message });

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -437,4 +437,19 @@ describe('GET /api/trips/:id/events', () => {
     expect(res.body.events).toHaveLength(1);
     expect(res.body.events[0].event_type).toBe('gpsUpdate');
   });
+
+  it('supports custom sorting order with sort=desc', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: 'trip-sort', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+      { event_id: 'ev-2', user_id: 'driver-1', trip_id: 'trip-sort', event_type: 'milestone', event_timestamp: '2026-06-01T11:00:00Z', latitude: null, longitude: null, metadata: {}, created_at: '2026-06-01T11:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/trip-sort/events?sort=desc')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(2);
+    expect(res.body.events[0].event_id).toBe('ev-2');
+  });
 });


### PR DESCRIPTION
Resolves #1066. Exposes sort query parameter on GET /api/trips/:id/events to support chronological ordering filters.