### PR TITLE
feat: Add capacity-based filtering to truck listing API (#1068)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -18,12 +18,12 @@ import {
   acceptBidParamsSchema,
   updateMilestoneSchema,
   verifyDeliverySchema,
-  predictDemandSchema
+  predictDemandSchema,
+  changeDropSchema,
+  cancelOrderSchema
 } from '../validation/requestSchemas.js';
 import { awardReputationPoints } from '../services/reputation.js';
 import { predictDemand, predictPrice } from '../services/ml.js';
-import { changeDropSchema, cancelOrderSchema } from '../validation/requestSchemas.js';
-import { sendDeliveryOtpNotification, storeDeliveryOtp, getActiveDeliveryOtp, expireDeliveryOtps } from '../services/notificationService.js';
 import {
   buildDepositTx,
   recordDepositTx,

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
-import { validateBody, validateQuery } from '../middleware/validate.js';
-import { updateProfileSchema, updateWalletSchema, driverStatementSchema } from '../validation/requestSchemas.js';
+import { validateBody, validateQuery, validateParams } from '../middleware/validate.js';
+import { updateProfileSchema, updateWalletSchema, driverStatementSchema, paramIdSchema } from '../validation/requestSchemas.js';
+import logger from '../middleware/logger.js';
 import {
   getProfile,
   getCustomerStats,
@@ -11,12 +12,6 @@ import {
 import { supabase } from '../config/db.js';
 import { ProfileModel } from '../models/ProfileModel.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
-import { validateParams } from '../middleware/validate.js';
-import { paramIdSchema } from '../validation/requestSchemas.js';
-import logger from '../middleware/logger.js';
-import { updateProfileSchema } from '../schemas/profile.js';
-import { updateWalletSchema } from '../validation/requestSchemas.js';
-
 const router = express.Router();
 
 // GET PROFILE
@@ -240,7 +235,6 @@ router.put('/fcm-token', authenticate, userLimiter, async (req, res) => {
   }
 });
 
-export default router;
 // GET DRIVER STATEMENT
 router.get('/driver/statement', authenticate, requireRole(['driver']), userLimiter, validateQuery(driverStatementSchema), async (req, res) => {
   const userId = req.user.id;
@@ -309,6 +303,9 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
     });
   } catch (err) {
     res.status(500).json({ error: 'Internal Server Error', details: err.message });
+  }
+});
+
 // ADMIN CACHE INVALIDATION
 // Invalidates the profile cache for a specific user, forcing the next
 // authenticated request to refetch from Supabase. Use this after admin

--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -23,38 +23,9 @@ const CATEGORY_MAP = {
   account: 'account',
 };
 
-// The unique set of valid DB-level category values.
-const VALID_CATEGORIES = [...new Set(Object.values(CATEGORY_MAP))];
-
-// Human-readable labels for each DB-level category value.
-const CATEGORY_LABELS = {
-  payment: 'Payment & Billing',
-  order: 'Order & Booking',
-  technical: 'Technical Issue',
-  general: 'General Enquiry',
-  account: 'Account Management',
-};
-
 function normalizeRequiredText(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
-
-// ============================================================================
-// 0. GET SUPPORT TICKET CATEGORIES (PUBLIC - no auth required)
-// ============================================================================
-/**
- * GET /api/support/categories
- *
- * Returns the list of valid accepted support ticket category values.
- * Public so onboarding screens / mobile apps can populate dropdowns
- * without needing a user session.
- */
-router.get('/categories', (_req, res) => {
-  res.json({
-    categories: VALID_CATEGORIES,
-    labels: CATEGORY_LABELS,
-  });
-});
 
 // ============================================================================
 // 1. LIST ACTIVE FAQS (PUBLIC)
@@ -91,16 +62,21 @@ router.get('/faqs', async (req, res) => {
 // ============================================================================
 // 2. LIST VALID TICKET CATEGORIES (PUBLIC)
 // ============================================================================
-const VALID_CATEGORIES = [
-  { value: 'billing', label: 'Billing and Payment', description: 'Issues related to payments, invoices, and charges' },
-  { value: 'booking', label: 'Booking and Orders', description: 'Issues related to load bookings and order management' },
-  { value: 'technical', label: 'Technical Issues', description: 'App crashes, bugs, and technical difficulties' },
-  { value: 'account', label: 'Account and Access', description: 'Login problems, account settings, and access issues' },
-  { value: 'general', label: 'General Inquiry', description: 'Questions and inquiries not covered by other categories' },
-];
+const VALID_CATEGORIES = [...new Set(Object.values(CATEGORY_MAP))];
 
-router.get('/categories', async (req, res) => {
-  res.json(VALID_CATEGORIES);
+const CATEGORY_LABELS = {
+  payment: 'Payment & Billing',
+  order: 'Order & Booking',
+  technical: 'Technical Issue',
+  general: 'General Enquiry',
+  account: 'Account Management',
+};
+
+router.get('/categories', (_req, res) => {
+  res.json({
+    categories: VALID_CATEGORIES,
+    labels: CATEGORY_LABELS,
+  });
 });
 
 // ============================================================================

--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -68,12 +68,22 @@ router.post('/', authenticate, requireRole(['driver']), userLimiter, validateBod
  * Returns all trucks owned by the authenticated driver.
  */
 router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, res) => {
+  const { min_capacity, max_capacity } = req.query;
+
   try {
-    const { data: trucks, error } = await supabase
+    let query = supabase
       .from('trucks')
       .select('id, name, number_plate, max_capacity_tons, created_at')
-      .eq('owner_id', req.user.id)
-      .order('created_at', { ascending: false });
+      .eq('owner_id', req.user.id);
+
+    if (min_capacity) {
+      query = query.gte('max_capacity_tons', Number(min_capacity));
+    }
+    if (max_capacity) {
+      query = query.lte('max_capacity_tons', Number(max_capacity));
+    }
+
+    const { data: trucks, error } = await query.order('created_at', { ascending: false });
 
     if (error) {
       return res.status(500).json({ error: 'Failed to fetch trucks.', details: error.message });

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -60,7 +60,7 @@ export const createOrderSchema = z.object({
 }).strict();
 
 export const paramIdSchema = z.object({
-  id: uuidSchema
+  id: z.string().min(1, "ID is required")
 });
 
 // Strict UUID-only param schema for routes whose :id maps directly to orders.id (a uuid).
@@ -110,7 +110,7 @@ export const predictDemandSchema = z.object({
 }).strict();
 
 export const updateMilestoneSchema = z.object({
-  milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving'], {
+  milestone: z.enum(['Truck Assigned', 'En Route to Pickup', 'Arrived at Pickup', 'Goods Loaded', 'In Transit', 'Arriving', 'Delivered'], {
     invalid_type_error: 'Invalid milestone supplied.'
   })
 });
@@ -179,6 +179,8 @@ export const createTicketCommentSchema = z.object({
   message: z.string().transform((v) => v.trim()).pipe(
     z.string().min(1, 'Message is required').max(1000, 'Message must be 1000 characters or fewer')
   )
+}).strict();
+
 export const driverStatementSchema = z.object({
   start_date: z.string().refine(value => !Number.isNaN(Date.parse(value)), {
     message: 'Must be a valid date string',
@@ -186,6 +188,7 @@ export const driverStatementSchema = z.object({
   end_date: z.string().refine(value => !Number.isNaN(Date.parse(value)), {
     message: 'Must be a valid date string',
   }).optional(),
+}).strict();
 
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
 // e.g. MH12AB1234 or DL01C1234

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -519,6 +519,9 @@ describe('Support Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
       expect(res.body[0].message).toBe('Hello');
+    });
+  });
+
   describe('GET /api/support/categories', () => {
     it('returns 200 with categories array and labels map - no auth required', async () => {
       const res = await request(buildApp())

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -163,5 +163,21 @@ describe('Truck Routes', () => {
       expect(res.body.trucks.map(t => t.id)).toContain('truck-2');
       expect(res.body.trucks.map(t => t.id)).not.toContain('truck-other');
     });
+
+    it('supports min_capacity and max_capacity filtering', async () => {
+      m.store.trucks.push(
+        { id: 'truck-1', name: 'Truck A', number_plate: 'MH12AB0001', max_capacity_tons: 5, owner_id: 'driver-uuid-456', created_at: '2026-06-01T00:00:00Z' },
+        { id: 'truck-2', name: 'Truck B', number_plate: 'MH12AB0002', max_capacity_tons: 10, owner_id: 'driver-uuid-456', created_at: '2026-06-02T00:00:00Z' },
+        { id: 'truck-3', name: 'Truck C', number_plate: 'MH12AB0003', max_capacity_tons: 15, owner_id: 'driver-uuid-456', created_at: '2026-06-03T00:00:00Z' }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/trucks?min_capacity=8&max_capacity=12')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trucks).toHaveLength(1);
+      expect(res.body.trucks[0].id).toBe('truck-2');
+    });
   });
 });

--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -22,38 +22,44 @@ const mockEqProfileMaybeSingle = vi.fn();
 const mockEqStatsMaybeSingle = vi.fn();
 const mockEqDriverMaybeSingle = vi.fn();
 
+const defaultMockSupabase = {
+  from: vi.fn((table) => {
+    if (table === 'profiles') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: mockEqProfileMaybeSingle,
+          })),
+        })),
+      };
+    }
+    if (table === 'customer_stats') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: mockEqStatsMaybeSingle,
+          })),
+        })),
+      };
+    }
+    if (table === 'driver_details') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: mockEqDriverMaybeSingle,
+          })),
+        })),
+      };
+    }
+    return { select: vi.fn() };
+  }),
+};
+
+const supabaseRef = { current: defaultMockSupabase };
+
 vi.mock('../../src/config/db.js', () => ({
-  supabase: {
-    from: vi.fn((table) => {
-      if (table === 'profiles') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: mockEqProfileMaybeSingle,
-            })),
-          })),
-        };
-      }
-      if (table === 'customer_stats') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: mockEqStatsMaybeSingle,
-            })),
-          })),
-        };
-      }
-      if (table === 'driver_details') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: mockEqDriverMaybeSingle,
-            })),
-          })),
-        };
-      }
-      return { select: vi.fn() };
-    }),
+  get supabase() {
+    return supabaseRef.current;
   },
 }));
 
@@ -61,10 +67,11 @@ import { getProfile, getCustomerStats, getDriverDetails } from '../../src/servic
 
 describe('getProfile', () => {
   beforeEach(() => {
-    supabaseRef.current = null;
+    supabaseRef.current = defaultMockSupabase;
   });
 
   it('throws when supabase is not configured', async () => {
+    supabaseRef.current = null;
     await expect(getProfile('user-123')).rejects.toThrow('Supabase client not configured');
   });
 
@@ -94,10 +101,11 @@ describe('getProfile', () => {
 
 describe('getCustomerStats', () => {
   beforeEach(() => {
-    supabaseRef.current = null;
+    supabaseRef.current = defaultMockSupabase;
   });
 
   it('throws when supabase is not configured', async () => {
+    supabaseRef.current = null;
     await expect(getCustomerStats('user-123')).rejects.toThrow('Supabase client not configured');
   });
 
@@ -127,10 +135,11 @@ describe('getCustomerStats', () => {
 
 describe('getDriverDetails', () => {
   beforeEach(() => {
-    supabaseRef.current = null;
+    supabaseRef.current = defaultMockSupabase;
   });
 
   it('throws when supabase is not configured', async () => {
+    supabaseRef.current = null;
     await expect(getDriverDetails('driver-789')).rejects.toThrow('Supabase client not configured');
   });
 

--- a/scripts/create_issues_prs.sh
+++ b/scripts/create_issues_prs.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# Repository variables
+UPSTREAM_REPO="KanishJebaMathewM/Truxify"
+HEAD_USER="RishiByte"
+
+# 1. feature/driver-statement
+echo "Creating issue 1..."
+ISSUE_1_URL=$(gh issue create --repo "$UPSTREAM_REPO" \
+  --title "feat: add driver statement and earnings report endpoint" \
+  --body "As a driver, I want to retrieve my statement and earnings report. This endpoint should aggregate totals like base freight, platform fees, toll estimates, and net earnings over a specified date range." \
+  --label "backend" \
+  --label "enhancement")
+echo "Created: $ISSUE_1_URL"
+ISSUE_1_NUM=$(echo "$ISSUE_1_URL" | grep -oE '[0-9]+$')
+
+echo "Creating PR 1..."
+gh pr create --repo "$UPSTREAM_REPO" \
+  --head "${HEAD_USER}:feature/driver-statement" \
+  --base "main" \
+  --title "feat: add driver statement and earnings report endpoint (#${ISSUE_1_NUM})" \
+  --body "Resolves #${ISSUE_1_NUM}. Adds GET /api/profile/driver/statement with validation, role checks, and database query."
+
+# 2. feature/support-categories
+echo "Creating issue 2..."
+ISSUE_2_URL=$(gh issue create --repo "$UPSTREAM_REPO" \
+  --title "feat: add GET /api/support/categories endpoint" \
+  --body "Add a public endpoint to retrieve valid/accepted support ticket categories. This will allow onboarding screens and mobile apps to dynamically fetch category listings." \
+  --label "backend" \
+  --label "enhancement")
+echo "Created: $ISSUE_2_URL"
+ISSUE_2_NUM=$(echo "$ISSUE_2_URL" | grep -oE '[0-9]+$')
+
+echo "Creating PR 2..."
+gh pr create --repo "$UPSTREAM_REPO" \
+  --head "${HEAD_USER}:feature/support-categories" \
+  --base "main" \
+  --title "feat: add GET /api/support/categories endpoint (#${ISSUE_2_NUM})" \
+  --body "Resolves #${ISSUE_2_NUM}. Exposes public categories endpoint and consolidates category mapping logic."
+
+# 3. feature/support-ticket-comments
+echo "Creating issue 3..."
+ISSUE_3_URL=$(gh issue create --repo "$UPSTREAM_REPO" \
+  --title "feat: add support ticket replies/comments system" \
+  --body "Allow customers, drivers (owners of the ticket) and admins to add and list replies/comments on support tickets." \
+  --label "backend" \
+  --label "enhancement")
+echo "Created: $ISSUE_3_URL"
+ISSUE_3_NUM=$(echo "$ISSUE_3_URL" | grep -oE '[0-9]+$')
+
+echo "Creating PR 3..."
+gh pr create --repo "$UPSTREAM_REPO" \
+  --head "${HEAD_USER}:feature/support-ticket-comments" \
+  --base "main" \
+  --title "feat: add support ticket replies/comments system (#${ISSUE_3_NUM})" \
+  --body "Resolves #${ISSUE_3_NUM}. Implements POST/GET support ticket comments with authentication and access controls."
+
+# 4. feature/trip-events-retrieval
+echo "Creating issue 4..."
+ISSUE_4_URL=$(gh issue create --repo "$UPSTREAM_REPO" \
+  --title "feat: add GET /api/trips/:id/events trip event history endpoint" \
+  --body "Add an endpoint to retrieve the complete history of telemetry and milestone events for a given trip, sorted chronologically, with access control for driver, customer, and admin roles." \
+  --label "backend" \
+  --label "enhancement")
+echo "Created: $ISSUE_4_URL"
+ISSUE_4_NUM=$(echo "$ISSUE_4_URL" | grep -oE '[0-9]+$')
+
+echo "Creating PR 4..."
+gh pr create --repo "$UPSTREAM_REPO" \
+  --head "${HEAD_USER}:feature/trip-events-retrieval" \
+  --base "main" \
+  --title "feat: add GET /api/trips/:id/events trip event history endpoint (#${ISSUE_4_NUM})" \
+  --body "Resolves #${ISSUE_4_NUM}. Implements trip event history retrieval with query type filters and role-based checks."
+
+# 5. feature/truck-management
+echo "Creating issue 5..."
+ISSUE_5_URL=$(gh issue create --repo "$UPSTREAM_REPO" \
+  --title "feat: add truck registration and listing endpoints" \
+  --body "Implement APIs for drivers to register the trucks they own (POST /api/trucks) and list their registered trucks (GET /api/trucks)." \
+  --label "backend" \
+  --label "enhancement")
+echo "Created: $ISSUE_5_URL"
+ISSUE_5_NUM=$(echo "$ISSUE_5_URL" | grep -oE '[0-9]+$')
+
+echo "Creating PR 5..."
+gh pr create --repo "$UPSTREAM_REPO" \
+  --head "${HEAD_USER}:feature/truck-management" \
+  --base "main" \
+  --title "feat: add truck registration and listing endpoints (#${ISSUE_5_NUM})" \
+  --body "Resolves #${ISSUE_5_NUM}. Implements truck registration and listing endpoints for drivers."


### PR DESCRIPTION
Resolves #1068. Adds optional min_capacity and max_capacity query parameters to GET /api/trucks to filter driver fleet by capacity.