### PR TITLE
feat: Add name filtering to truck listing API (#1076)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -68,12 +68,19 @@ router.post('/', authenticate, requireRole(['driver']), userLimiter, validateBod
  * Returns all trucks owned by the authenticated driver.
  */
 router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, res) => {
+  const { name } = req.query;
+
   try {
-    const { data: trucks, error } = await supabase
+    let query = supabase
       .from('trucks')
       .select('id, name, number_plate, max_capacity_tons, created_at')
-      .eq('owner_id', req.user.id)
-      .order('created_at', { ascending: false });
+      .eq('owner_id', req.user.id);
+
+    if (name) {
+      query = query.ilike('name', `%${name}%`);
+    }
+
+    const { data: trucks, error } = await query.order('created_at', { ascending: false });
 
     if (error) {
       return res.status(500).json({ error: 'Failed to fetch trucks.', details: error.message });

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -125,6 +125,11 @@ class SupabaseQueryBuilder {
       case 'lte':
         res = v <= f.val;
         break;
+      case 'ilike': {
+        const valRegex = new RegExp(f.val.replace(/%/g, '.*'), 'i');
+        res = valRegex.test(v);
+        break;
+      }
       case 'in': {
         if (typeof f.val === 'string') {
           const clean = f.val.replace(/^\s*\(\s*|\s*\)\s*$/g, '');

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -163,5 +163,20 @@ describe('Truck Routes', () => {
       expect(res.body.trucks.map(t => t.id)).toContain('truck-2');
       expect(res.body.trucks.map(t => t.id)).not.toContain('truck-other');
     });
+
+    it('supports name filtering using name query param', async () => {
+      m.store.trucks.push(
+        { id: 'truck-1', name: 'Big Blue Truck', number_plate: 'MH12AB0001', max_capacity_tons: 5, owner_id: 'driver-uuid-456', created_at: '2026-06-01T00:00:00Z' },
+        { id: 'truck-2', name: 'Tiny Red Truck', number_plate: 'MH12AB0002', max_capacity_tons: 10, owner_id: 'driver-uuid-456', created_at: '2026-06-02T00:00:00Z' }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/trucks?name=blue')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trucks).toHaveLength(1);
+      expect(res.body.trucks[0].id).toBe('truck-1');
+    });
   });
 });


### PR DESCRIPTION
Resolves #1076. Adds optional name query parameter to GET /api/trucks to support case-insensitive name filtering using PostgreSQL ILIKE.