### PR TITLE
fix : correct JSDoc @param type for isValidCachedSupabaseProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -72,7 +72,7 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
  * a Firebase UID, so the identity field checked here is `id`.
  *
  * @param {string} userId - The expected Supabase profile UUID.
- * @param {any} cachedProfile - The cached profile to validate.
+ * @param {object|null|undefined} cachedProfile - The cached profile to validate.
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedSupabaseProfile(userId, cachedProfile) {


### PR DESCRIPTION
Closes #1113.

Summary of What Has Been Done:
Changed the JSDoc @param annotation for the cachedProfile parameter in isValidCachedSupabaseProfile() from @param {any} to @param {object|null|undefined}. The function validates that cachedProfile must be a non-null, non-array object with an isActive boolean field — 'any' was inconsistent with this actual behaviour.

Changes Made:
- backend/api/src/lib/profileCache.js: Corrected @param type annotation on isValidCachedSupabaseProfile

Impact it Made:
- IDEs and type-aware editors will now correctly infer the parameter type
- Developers will immediately understand valid input types from JSDoc
- 302 unit tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented type for a profile cache parameter, making the accepted value more explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->