### PR TITLE
fix : treat empty-string env vars as unset in readRateCard

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -27,15 +27,28 @@ const DEFAULTS = Object.freeze({
   TOLL_PER_KM: 200,         // paisa per km, proxy for highway toll
 });
 
+/**
+ * Safely converts an environment variable to a finite number, falling back to
+ * the default if the variable is absent, empty, or contains a non-numeric value.
+ */
+function rateEnv(key, fallback) {
+  const raw = process.env[key];
+  if (raw === undefined || raw === null || raw.trim() === '') {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function readRateCard() {
   return {
-    ratePerTonneKm: Number(process.env.TRUXIFY_RATE_PER_TONNE_KM ?? DEFAULTS.RATE_PER_TONNE_KM),
-    fragileMultiplier: Number(process.env.TRUXIFY_FRAGILE_MULTIPLIER ?? DEFAULTS.FRAGILE_MULTIPLIER),
-    stackableDiscount: Number(process.env.TRUXIFY_STACKABLE_DISCOUNT ?? DEFAULTS.STACKABLE_DISCOUNT),
-    handlingFee: Number(process.env.TRUXIFY_HANDLING_FEE ?? DEFAULTS.HANDLING_FEE),
-    platformFeePct: Number(process.env.TRUXIFY_PLATFORM_FEE_PCT ?? DEFAULTS.PLATFORM_FEE_PCT),
-    fuelCostPct: Number(process.env.TRUXIFY_FUEL_COST_PCT ?? DEFAULTS.FUEL_COST_PCT),
-    tollPerKm: Number(process.env.TRUXIFY_TOLL_PER_KM ?? DEFAULTS.TOLL_PER_KM),
+    ratePerTonneKm: rateEnv('TRUXIFY_RATE_PER_TONNE_KM', DEFAULTS.RATE_PER_TONNE_KM),
+    fragileMultiplier: rateEnv('TRUXIFY_FRAGILE_MULTIPLIER', DEFAULTS.FRAGILE_MULTIPLIER),
+    stackableDiscount: rateEnv('TRUXIFY_STACKABLE_DISCOUNT', DEFAULTS.STACKABLE_DISCOUNT),
+    handlingFee: rateEnv('TRUXIFY_HANDLING_FEE', DEFAULTS.HANDLING_FEE),
+    platformFeePct: rateEnv('TRUXIFY_PLATFORM_FEE_PCT', DEFAULTS.PLATFORM_FEE_PCT),
+    fuelCostPct: rateEnv('TRUXIFY_FUEL_COST_PCT', DEFAULTS.FUEL_COST_PCT),
+    tollPerKm: rateEnv('TRUXIFY_TOLL_PER_KM', DEFAULTS.TOLL_PER_KM),
   };
 }
 


### PR DESCRIPTION
Closes #1109.

Summary of What Has Been Done:
Introduced a rateEnv() helper that treats absent, null, empty-string, or non-numeric environment variable values as fall-through to the hardcoded defaults. Previously, Number('') returned 0, silently producing zero pricing for any empty-string env var.

Changes Made:
- backend/api/src/lib/pricing.js: Added rateEnv() helper and updated all 7 rate card field reads to use it

Impact it Made:
- Empty-string env vars now fall back to defaults instead of producing zero
- 302 unit tests still pass