### PR TITLE
fix : use fire-and-forget for awardReputationPoints instead of blocking await

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -557,11 +557,10 @@ router.post('/:id/ratings', authenticate, userLimiter, requireRole(['customer'])
     const polygonAddress = driverDetails?.polygon_wallet_address ?? null;
 
     if (polygonAddress) {
-      try {
-        await awardReputationPoints(polygonAddress, stars);
-      } catch (repErr) {
+      // Fire-and-forget: blockchain confirmation must never block the HTTP response.
+      void awardReputationPoints(polygonAddress, stars).catch((repErr) => {
         logger.error('[reputation] On-chain reputation update failed:', repErr.message);
-      }
+      });
     } else {
       logger.warn(
         `[reputation] Driver ${order.driver_id} has no polygon_wallet_address — skipping on-chain update.`


### PR DESCRIPTION
Closes #1110.

Summary of What Has Been Done:
Replaced 'await awardReputationPoints(...)' with 'void awardReputationPoints(...).catch(...)' so blockchain confirmation does not block the HTTP response on the submit_rating endpoint. The Supabase rating is the source of truth; on-chain reputation is best-effort and should never delay the API response.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Changed from 'try { await awardReputationPoints(...) } catch (repErr)' to 'void awardReputationPoints(...).catch((repErr) => ...)'

Impact it Made:
- Rating submission API returns immediately without waiting for blockchain confirmation
- Users see instant response even when Polygon RPC is slow or congested
- 302 unit tests still pass