### PR TITLE
fix : return safe fallback string from predictDemandLimiter keyGenerator instead of throwing

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -129,7 +129,7 @@ const predictDemandLimiter = rateLimit({
   max: process.env.NODE_ENV === 'test' ? 1000 : 10,
   keyGenerator: (req) => {
     if (!req.user || !req.user.id) {
-      throw new Error('User is not authenticated');
+      return req.ip ?? 'unknown-ip';
     }
     return req.user.id;
   },


### PR DESCRIPTION
Closes #1111.

Summary of What Has Been Done:
Changed predictDemandLimiter's keyGenerator to return req.ip (or 'unknown-ip') when req.user is absent, instead of throwing an Error. Throwing from a keyGenerator crashes the express-rate-limit middleware and returns a 500 to the client instead of a proper 429 rate-limit response.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Changed keyGenerator fallback from throw to return

Impact it Made:
- Unauthenticated requests to /predict-demand get rate-limited by IP instead of crashing
- Proper 429 responses instead of 500 crashes for unauthenticated rate abuse
- 302 unit tests still pass