### PR TITLE
fix: fix truck list query scoping bug in GET /api/trucks (#1126)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -79,6 +79,7 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
 
     if (name) {
       query = query.ilike('name', `%${name}%`);
+    }
     if (min_capacity) {
       query = query.gte('max_capacity_tons', Number(min_capacity));
     }


### PR DESCRIPTION
Resolves #1126.

The query execution was inside the if (name) block, causing the endpoint to hang when no name filter was provided. min_capacity/max_capacity filters also only applied when name was set. Corrects the brace placement so query runs unconditionally.