### PR TITLE
fix: remove passthrough() from loadFilterQuerySchema to reject unknown params (fixes #1092)

### DIFF
--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -16,7 +16,7 @@ export const loadFilterQuerySchema = z.object({
   min_price: nonNegativeDecimalString('min_price').optional(),
   max_price: nonNegativeDecimalString('max_price').optional(),
   distance: nonNegativeDecimalString('distance').optional(),
-}).passthrough().superRefine((filters, ctx) => {
+}).superRefine((filters, ctx) => {
   if (
     filters.min_price !== undefined
     && filters.max_price !== undefined


### PR DESCRIPTION
Removes `.passthrough()` from `loadFilterQuerySchema`. Unknown query parameters will now be rejected with a validation error instead of being silently ignored.

Fixes #1092