### PR TITLE
fix: expire delivery OTPs on drop location change (fixes #1084)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1270,7 +1270,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
       logger.warn('Failed to update timeline for change-drop:', timelineErr.message);
     }
 
-    await expireDeliveryOtps(order.order_display_id);
+    await expireDeliveryOtps(order.id);
 
     return res.json({
       message: 'Drop location updated successfully.',
@@ -1425,7 +1425,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
           .eq('order_display_id', order.order_display_id)
           .eq('milestone', 'Order Placed');
 
-        await expireDeliveryOtps(order.order_display_id);
+        await expireDeliveryOtps(order.id);
 
         return res.json({
           message: 'Order cancelled and escrow refunded successfully.',
@@ -1481,7 +1481,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
       .eq('order_display_id', order.order_display_id)
       .eq('milestone', 'Order Placed');
 
-    await expireDeliveryOtps(order.order_display_id);
+    await expireDeliveryOtps(order.id);
 
     return res.json({ message: 'Order cancelled successfully.', cancellation_fee: cancellationFee, order: updatedOrder });
   } catch (err) {
@@ -1599,16 +1599,6 @@ router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, 
       .select('id, customer_id, driver_id, status')
       .eq('id', orderId)
       .maybeSingle();
-    if (!order && !orderErr) {
-      const result = await supabase
-        .from('orders')
-        .select('id, customer_id, driver_id, status')
-        .eq('order_display_id', orderId)
-        .maybeSingle();
-      order = result.data;
-      orderErr = result.error;
-    }
-
     if (!order && !orderErr) {
       const result = await supabase
         .from('orders')

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1270,6 +1270,8 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
       logger.warn('Failed to update timeline for change-drop:', timelineErr.message);
     }
 
+    await expireDeliveryOtps(order.order_display_id);
+
     return res.json({
       message: 'Drop location updated successfully.',
       pricing: {
@@ -1597,6 +1599,16 @@ router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, 
       .select('id, customer_id, driver_id, status')
       .eq('id', orderId)
       .maybeSingle();
+    if (!order && !orderErr) {
+      const result = await supabase
+        .from('orders')
+        .select('id, customer_id, driver_id, status')
+        .eq('order_display_id', orderId)
+        .maybeSingle();
+      order = result.data;
+      orderErr = result.error;
+    }
+
     if (!order && !orderErr) {
       const result = await supabase
         .from('orders')


### PR DESCRIPTION
Adds `await expireDeliveryOtps(order.order_display_id)` to the change-drop handler so old OTPs are cleaned up when the drop location changes.

Fixes #1084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delivery OTPs are now cleared after a destination change, even if the order timeline update runs into an issue.
  * Improved driver location retrieval fallback so orders are more reliably found when the primary lookup doesn’t return a result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->