### PR TITLE
feat: implement filter functionality for Find Trucks screen (fixes #1100)

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -40,6 +40,12 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     'Temperature control',
     'Loading help needed'
   };
+
+  String _filterTruckType = 'Any';
+  double _filterMinCapacity = 0;
+  double _filterMaxCapacity = 25;
+  String _filterMaterialType = 'Any';
+  bool _hasActiveFilters = false;
   LatLng? _pickupPoint;
   LatLng? _dropPoint;
 
@@ -414,6 +420,153 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     });
   }
 
+  void _showFilterSheet() {
+    final truckTypes = ['Any', 'Open Body', 'Closed Body', 'Container', 'Refrigerated'];
+    final materialTypes = ['Any', 'Textile', 'Electronics', 'Food', 'Machinery', 'Furniture'];
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return Padding(
+              padding: EdgeInsets.fromLTRB(
+                  20, 10, 20, MediaQuery.of(context).viewInsets.bottom + 20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 40,
+                      height: 4,
+                      margin: const EdgeInsets.only(bottom: 20),
+                      decoration: BoxDecoration(
+                        color: TruxifyColors.hintText,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  Text(
+                    'Filter Trucks',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 20),
+                  Text('Truck Type',
+                      style: Theme.of(context).textTheme.labelMedium),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<String>(
+                    value: _filterTruckType,
+                    items: truckTypes
+                        .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                        .toList(),
+                    onChanged: (v) => setSheetState(() => _filterTruckType = v ?? 'Any'),
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8)),
+                      contentPadding:
+                          const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text('Capacity (tonnes)',
+                      style: Theme.of(context).textTheme.labelMedium),
+                  const SizedBox(height: 8),
+                  RangeSlider(
+                    values: RangeValues(_filterMinCapacity, _filterMaxCapacity),
+                    min: 0,
+                    max: 25,
+                    divisions: 25,
+                    labels: RangeLabels(
+                      '${_filterMinCapacity.toInt()}t',
+                      '${_filterMaxCapacity.toInt()}t',
+                    ),
+                    onChanged: (v) => setSheetState(() {
+                      _filterMinCapacity = v.start;
+                      _filterMaxCapacity = v.end;
+                    }),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text('${_filterMinCapacity.toInt()} tonnes',
+                          style: Theme.of(context).textTheme.bodySmall),
+                      Text('${_filterMaxCapacity.toInt()} tonnes',
+                          style: Theme.of(context).textTheme.bodySmall),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Text('Material Type',
+                      style: Theme.of(context).textTheme.labelMedium),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<String>(
+                    value: _filterMaterialType,
+                    items: materialTypes
+                        .map((m) => DropdownMenuItem(value: m, child: Text(m)))
+                        .toList(),
+                    onChanged: (v) => setSheetState(() => _filterMaterialType = v ?? 'Any'),
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8)),
+                      contentPadding:
+                          const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () {
+                            setSheetState(() {
+                              _filterTruckType = 'Any';
+                              _filterMinCapacity = 0;
+                              _filterMaxCapacity = 25;
+                              _filterMaterialType = 'Any';
+                            });
+                          },
+                          child: const Text('Reset'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () {
+                            setState(() {
+                              _hasActiveFilters =
+                                  _filterTruckType != 'Any' ||
+                                  _filterMaterialType != 'Any' ||
+                                  _filterMinCapacity > 0 ||
+                                  _filterMaxCapacity < 25;
+                            });
+                            Navigator.of(context).pop();
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: TruxifyColors.accent,
+                            foregroundColor: Colors.white,
+                          ),
+                          child: const Text('Apply'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
   Future<void> _estimatePrice() async {
     // Check if we have required data for estimation
     if (_pickupPoint == null || _dropPoint == null) {
@@ -521,9 +674,12 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: IconButton(
-                      onPressed: () {},
-                      icon: const Icon(Icons.filter_list_rounded,
-                          color: TruxifyColors.accentDark),
+                      onPressed: _showFilterSheet,
+                      icon: Badge(
+                        isLabelVisible: _hasActiveFilters,
+                        child: const Icon(Icons.filter_list_rounded,
+                            color: TruxifyColors.accentDark),
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
Implements a filter bottom sheet with truck type dropdown, capacity range slider, material type dropdown, and badge indicator on the filter icon.

Fixes #1100