### PR TITLE
fix: use paramIdSchema for driver-location to fix live tracking (fixes #1103)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -43,6 +43,7 @@ const OTP_MAX_FAILED_ATTEMPTS = parseInt(process.env.OTP_MAX_FAILED_ATTEMPTS || 
 const OTP_LOCKOUT_MINUTES = parseInt(process.env.OTP_LOCKOUT_MINUTES || '30', 10);
 const IN_MEMORY_OTP_MAP_MAX_SIZE = parseInt(process.env.IN_MEMORY_OTP_MAP_MAX_SIZE || '10000', 10);
 const DELIVERY_OTP_READY_STATUSES = new Set(['arriving']);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const inMemoryOtpFailedAttempts = new Map();
 
@@ -1589,13 +1590,17 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 // ============================================================================
 router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
+  const isUuid = UUID_RE.test(orderId);
   try {
     // 1. Resolve order and check authentication / authorization
-    let { data: order, error: orderErr } = await supabase
-      .from('orders')
-      .select('id, customer_id, driver_id, status')
-      .eq('id', orderId)
-      .maybeSingle();
+    let { data: order, error: orderErr } = isUuid
+      ? await supabase
+          .from('orders')
+          .select('id, customer_id, driver_id, status')
+          .eq('id', orderId)
+          .maybeSingle()
+      : { data: null, error: null };
+
     if (!order && !orderErr) {
       const result = await supabase
         .from('orders')

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -14,7 +14,6 @@ import {
   submitBidSchema,
   submitRatingSchema,
   paramIdSchema,
-  uuidParamSchema,
   acceptBidParamsSchema,
   updateMilestoneSchema,
   verifyDeliverySchema,


### PR DESCRIPTION
Changes `uuidParamSchema` to `paramIdSchema` on the driver-location endpoint so it accepts display IDs sent by the Flutter client, with `order_display_id` fallback lookup. Fixes live tracking on the customer map.

Fixes #1103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the driver-location endpoint so it can now find orders using either the internal order ID or the display order ID.
  * Updated request validation for this endpoint to accept the correct route parameter format.
  * Kept existing authorization, tracking, and response behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->