### PR TITLE
fix: make awardReputationPoints truly fire-and-forget (fixes #1104)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -599,11 +599,9 @@ router.post('/:id/ratings', authenticate, userLimiter, requireRole(['customer'])
     const polygonAddress = driverDetails?.polygon_wallet_address ?? null;
 
     if (polygonAddress) {
-      try {
-        await awardReputationPoints(polygonAddress, stars);
-      } catch (repErr) {
+      awardReputationPoints(polygonAddress, stars).catch((repErr) => {
         logger.error('[reputation] On-chain reputation update failed:', repErr.message);
-      }
+      });
     } else {
       logger.warn(
         `[reputation] Driver ${order.driver_id} has no polygon_wallet_address — skipping on-chain update.`


### PR DESCRIPTION
Changes `await awardReputationPoints(...)` to `.catch()` fire-and-forget pattern to match the documented design contract, preventing blockchain confirmation time from blocking HTTP response.

Fixes #1104