### PR TITLE
fix: use fresh tripData from RPC instead of stale order for wallet update (fixes #1108)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -983,7 +983,7 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['dri
     }
 
     // Call complete_trip_tx RPC to atomically update trip, driver stats, wallet, earnings, order status, and timeline.
-    const { error: rpcErr } = await supabase.rpc('complete_trip_tx', {
+    const { data: tripData, error: rpcErr } = await supabase.rpc('complete_trip_tx', {
       p_order_id: orderId,
       p_otp_id: otpRecord.id,
     });
@@ -1060,15 +1060,17 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['dri
           });
         }
 
-        if (order.driver_id) {
+        const driverId = tripData?.driver_id || order.driver_id;
+        const displayId = tripData?.order_display_id || order.order_display_id;
+        if (driverId) {
           const { error: walletErr } = await supabase
             .from('wallet_transactions')
             .update({
               tx_hash: txHash,
-              description: `Escrow payout for ${order.order_display_id}`,
+              description: `Escrow payout for ${displayId}`,
             })
-            .eq('driver_id', order.driver_id)
-            .eq('order_display_id', order.order_display_id)
+            .eq('driver_id', driverId)
+            .eq('order_display_id', displayId)
             .eq('txn_type', 'credit');
 
           if (walletErr) {


### PR DESCRIPTION
Uses `tripData` from the `complete_trip_tx` RPC return value instead of the stale pre-RPC `order` object for `driver_id` in the wallet transaction update, eliminating a latent race condition.

Fixes #1108