### PR TITLE
fix(profileRoutes): add missing 'format' query param and close CSV if block

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -242,7 +242,7 @@ router.put('/fcm-token', authenticate, userLimiter, async (req, res) => {
 // GET DRIVER STATEMENT
 router.get('/driver/statement', authenticate, requireRole(['driver']), userLimiter, validateQuery(driverStatementSchema), async (req, res) => {
   const userId = req.user.id;
-  const { start_date, end_date, sort_by } = req.query;
+  const { start_date, end_date, sort_by, format } = req.query;
 
   try {
     let query = supabase
@@ -303,6 +303,7 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
       const csvString = csvRows.map(row => row.map(val => `"${String(val).replace(/"/g, '""')}"`).join(',')).join('\n');
       res.setHeader('Content-Type', 'text/csv');
       return res.send(csvString);
+    }
     if (sort_by === 'net_earnings') {
       tripsList.sort((a, b) => b.net_earnings - a.net_earnings);
     } else if (sort_by === 'base_freight') {


### PR DESCRIPTION
## Summary
Fixes two bugs in the GET /driver/statement endpoint:
1. \ormat\ was not destructured from \eq.query\, causing a \ReferenceError\ when the CSV branch was hit.
2. The \if (format === 'csv')\ block was missing its closing brace, causing a syntax error that prevented the module from loading.

## Changes
- Added \ormat\ to the destructured query params
- Added \}\ to close the CSV if block before the sort logic

Closes #1204