### PR TITLE
fix(tripRoutes): remove const type redeclaration

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -203,9 +203,8 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
  */
 router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
   const tripId = req.params.id;
-  const { type, sort } = req.query;
+  const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
   const isAscending = sort !== 'desc';
-  const { type, min_lat, max_lat, min_lng, max_lng } = req.query;
 
   try {
     // 1. Fetch the trip to determine the driver


### PR DESCRIPTION
## Summary
The \	ype\ variable was declared twice with \const\ in the same function scope (route handler for GET /:id/events), causing a SyntaxError that prevents the module from loading.

## Changes
- Merged the two separate destructuring assignments into a single \const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;\

Closes #1206