### PR TITLE
fix(otpService): remove DRIVER_LOGIN_OTP universal auth bypass

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -18,7 +18,7 @@ export async function generateAndStoreOtp(phone) {
 export async function verifyOtp(phone, otp) {
   if (!redisClient) {
     logger.warn('[otp] Redis not available, cannot verify OTP.');
-    return Boolean(process.env.DRIVER_LOGIN_OTP) && otp === process.env.DRIVER_LOGIN_OTP;
+    return false;
   }
   const stored = await redisClient.get(`otp:${phone}`);
   if (!stored || stored !== otp) return false;


### PR DESCRIPTION
## Summary
Removed the \DRIVER_LOGIN_OTP\ universal bypass in \erifyOtp()\. When Redis was unavailable, the function accepted any OTP matching this env var for ANY phone number — a critical authentication bypass vulnerability.

## Changes
- When Redis is not available, \erifyOtp()\ now returns \alse\ instead of checking against \DRIVER_LOGIN_OTP\

Closes #1207