### PR TITLE
fix(reputation): add decreaseReputation to ABI

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -25,6 +25,7 @@ import logger from '../middleware/logger.js';
 // Minimal ABI — only the subset the backend needs to call.
 const REPUTATION_ABI = [
   'function increaseReputation(address driver, uint256 points) external',
+  'function decreaseReputation(address driver, uint256 points) external',
   'function getReputation(address driver) external view returns (uint256)',
 ];
 /** @type {ethers.Contract | null} */


### PR DESCRIPTION
## Summary
The \REPUTATION_ABI\ was missing the \decreaseReputation\ function signature, even though the module comments reference it and the contract exposes it. Any code that tries to call \decreaseReputation\ on the contract through this client would fail.

## Changes
- Added \decreaseReputation\ function signature to \REPUTATION_ABI\

Closes #1208