### PR TITLE
ci: add ML engine test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,26 @@ jobs:
       - name: Test
         working-directory: apps/driver
         run: flutter test
+
+  ml:
+    name: ML engine tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/ml/requirements.txt
+
+      - name: Install dependencies
+        working-directory: backend/ml
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        working-directory: backend/ml
+        run: python -m pytest tests/ -v


### PR DESCRIPTION
## Summary
Added a dedicated CI job for the ML engine (backend/ml/) which was missing from the pipeline. The ML tests were never being run in CI.

## Changes
- Added \ml\ job with Python 3.11 setup, dependency installation, and pytest

Closes #1209