### PR TITLE
fix(ml): report actual model status in /health endpoint

### DIFF
--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -21,6 +21,9 @@ from .models.collaborative_filter import collaborative_filter
 from .models.trust_scorer import trust_scorer
 from .models.deadhead_eliminator import find_return_loads
 from .models.mid_trip_reoptimiser import find_mid_trip_loads
+from .models.base import model_exists
+from .models.demand_forecast import MODEL_NAME as DEMAND_MODEL_NAME
+from .models.price_prediction import MODEL_NAME as PRICE_MODEL_NAME
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -349,7 +352,18 @@ async def root(_auth=Depends(verify_api_key)):
 @app.get("/health")
 async def health():
     """Health check endpoint for Docker container orchestration."""
-    return {"status": "healthy", "service": "ml-engine"}
+    models = {
+        "eta_predictor": eta_predictor.model is not None,
+        "demand_forecast": model_exists(DEMAND_MODEL_NAME),
+        "price_forecast": model_exists(PRICE_MODEL_NAME),
+        "driver_profit": model_exists("driver_profit"),
+    }
+    all_ready = all(models.values())
+    return {
+        "status": "healthy" if all_ready else "degraded",
+        "service": "ml-engine",
+        "models": models,
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The \/health\ endpoint always returned \{'status': 'healthy'}\ irrespective of whether ML models were loaded/trained. For container orchestration with liveness/readiness probes, the endpoint should reflect actual model availability.

## Changes
- \/health\ now returns per-model readiness status
- Returns \'degraded'\ overall status when models are missing, \'healthy'\ when all are ready

Closes #1211