### PR TITLE
fix: require order owner for deposit confirmation

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1453,11 +1453,14 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
   try {
     const { data: order, error: fetchErr } = await supabase
       .from('orders')
-      .select('id, order_display_id, escrow_booking_id, escrow_status')
+      .select('id, customer_id, order_display_id, escrow_booking_id, escrow_status')
       .eq('id', orderId)
       .maybeSingle();
 
     if (fetchErr || !order) return res.status(404).json({ error: 'Order not found' });
+    if (order.customer_id !== req.user.id) {
+      return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
+    }
     if (order.escrow_status !== 'funding') {
       return res.status(400).json({ error: 'Order is not in funding state' });
     }


### PR DESCRIPTION
## Summary
- fetch `customer_id` in the confirm-deposit order lookup
- reject deposit confirmation when the authenticated customer does not own the order

Fixes #1228

## Testing
- Not run: `backend/api/src/routes/orderRoutes.js` currently fails to parse on `main` because of a pre-existing duplicate `changeDropSchema` import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit confirmation access control so only the correct customer can confirm an order.
  * The app now returns a clear `403 Forbidden` response when the signed-in user does not match the order’s customer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->