### PR TITLE
fix: scope route telemetry to order

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1610,7 +1610,7 @@ router.get('/:id/route', authenticate, userLimiter, requireRole(['customer', 'dr
 
     const latestTelemetry = await mongoDb
       .collection('telemetry')
-      .find({ driver_id: order.driver_id })
+      .find({ driver_id: order.driver_id, order_id: order.id })
       .sort({ timestamp: -1 })
       .limit(1)
       .toArray();


### PR DESCRIPTION
## Summary
- scope live route telemetry lookup by both `driver_id` and `order_id`
- keep route generation aligned with the requested order, matching the driver-location endpoint behavior

Fixes #1229

## Testing
- Not run: `backend/api/src/routes/orderRoutes.js` currently fails to parse on `main` because of a pre-existing duplicate `changeDropSchema` import.