### PR TITLE
fix: honor support comment sort direction

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -447,7 +447,7 @@ router.get('/tickets/:id/comments', authenticate, userLimiter, async (req, res) 
       .from('support_ticket_comments')
       .select('id, ticket_id, user_id, user_name, message, created_at')
       .eq('ticket_id', ticketId)
-      .order('created_at', { ascending: true })
+      .order('created_at', { ascending: isAscending })
       .range(offset, offset + limit - 1);
 
     if (commentsError) {

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -528,11 +528,11 @@ describe('Support Routes', () => {
       );
 
       const res = await request(buildApp())
-        .get('/api/support/tickets/t-123/comments?limit=1&offset=1')
+        .get('/api/support/tickets/t-123/comments?sort=desc')
         .set(CUSTOMER_HEADERS);
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveLength(1);
+      expect(res.body).toHaveLength(2);
       expect(res.body[0].message).toBe('Second');
     });
   });


### PR DESCRIPTION
## Summary
- use the computed `isAscending` value when ordering support ticket comments
- update the regression test to request `sort=desc`

Fixes #1230

## Testing
- `npm test -- test/integration/supportRoutes.test.js` (blocked: `supportRoutes.js` currently fails to parse on `main` because `CATEGORY_SLA` is missing its closing brace before `CATEGORY_DESCRIPTIONS`)