### PR TITLE
fix : use correct env vars in db.js and enforce RLS on regular supabase client

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -14,24 +14,24 @@ dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
 //    service role key for admin operations only (bypasses RLS)
 // ============================================================================
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-if (!supabaseKey) {
-  logger.error('SUPABASE_SERVICE_ROLE_KEY is not set. Elevated operations will fail.');
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+if (!supabaseAnonKey) {
+  logger.error('SUPABASE_ANON_KEY is not set. Supabase client will not function.');
 }
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 export let supabase = null;
 export let supabaseAdmin = null;
 
-if (supabaseUrl && supabaseKey) {
+if (supabaseUrl && supabaseAnonKey) {
   try {
-    supabase = createClient(supabaseUrl, supabaseKey, {
+    supabase = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {
         persistSession: false,
         autoRefreshToken: false,
       }
     });
-    logger.info('Supabase client initialized successfully (service role key).');
+    logger.info('Supabase client initialized successfully (anon key — RLS enforced).');
   } catch (error) {
     logger.error({ err: error }, 'Failed to initialize Supabase client');
   }
@@ -206,7 +206,7 @@ export async function closeDbConnections() {
  */
 export function validateConfig() {
   const required = ['SUPABASE_URL', 'SUPABASE_ANON_KEY'];
-  const recommended = ['REDIS_URL', 'MONGODB_URI', 'FIREBASE_SERVICE_ACCOUNT_JSON'];
+  const recommended = ['REDIS_URL', 'MONGODB_URI', 'FIREBASE_SERVICE_ACCOUNT_JSON', 'SUPABASE_SERVICE_ROLE_KEY'];
   const missing = required.filter((key) => !process.env[key]);
   const missingRecommended = recommended.filter((key) => !process.env[key]);
 


### PR DESCRIPTION
Closes #1235.

Summary of What Has Been Done:
Fixed two bugs in backend/api/src/config/db.js: (1) the regular supabase client used SUPABASE_SERVICE_ROLE_KEY, bypassing RLS so any customer could read/modify other customers data. Changed to SUPABASE_ANON_KEY so RLS policies are enforced. (2) validateConfig() checked SUPABASE_ANON_KEY but the client read SERVICE_ROLE_KEY, so deployers passed validation without a working app.

Changes Made:
- backend/api/src/config/db.js: renamed supabaseKey to supabaseAnonKey and read from SUPABASE_ANON_KEY. supabase client now uses SUPABASE_ANON_KEY. Added SUPABASE_SERVICE_ROLE_KEY to recommended (not required) in validateConfig().

Impact it Made:
- Enforces RLS for all regular API operations (CRITICAL security fix)
- Fixes config validation mismatch so deployers get an accurate picture of app health
- 281/289 unit tests pass (8 pre-existing failures in ml/tracker/profileService unrelated to this change)

Note: Please assign this PR to the `tmdeveloper007` account.