### PR TITLE
fix : add order ownership check to confirm-deposit endpoint

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1453,13 +1453,16 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
   try {
     const { data: order, error: fetchErr } = await supabase
       .from('orders')
-      .select('id, order_display_id, escrow_booking_id, escrow_status')
+      .select('id, order_display_id, customer_id, escrow_booking_id, escrow_status')
       .eq('id', orderId)
       .maybeSingle();
 
     if (fetchErr || !order) return res.status(404).json({ error: 'Order not found' });
     if (order.escrow_status !== 'funding') {
       return res.status(400).json({ error: 'Order is not in funding state' });
+    }
+    if (order.customer_id !== req.user.id) {
+      return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
     }
 
     const bookingId = order.escrow_booking_id || `escrow:${order.order_display_id}`;


### PR DESCRIPTION
Closes #1236.

Summary of What Has Been Done:
Added customer_id to the order fetch in the confirm-deposit handler and returned a 403 response if the fetched customer_id does not match the authenticated user's id. This closes the authorization gap where any authenticated customer could confirm deposits for another customer's order.

Changes Made:
- backend/api/src/routes/orderRoutes.js: added customer_id to the Supabase select for the confirm-deposit handler. Added ownership check: if (order.customer_id !== req.user.id) return res.status(403).json(...).

Impact it Made:
- Closes authorization bypass on confirm-deposit endpoint
- Prevents one customer from confirming deposit transactions for another customer's orders
- 281/289 unit tests pass (8 pre-existing failures unrelated to this change)

Note: Please assign this PR to the `tmdeveloper007` account.