### PR TITLE
fix: reject comments on closed support tickets

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -78,6 +78,8 @@ const CATEGORY_SLA = {
   technical: 4,
   general: 48,
   account: 24,
+};
+
 const CATEGORY_DESCRIPTIONS = {
   payment: 'Issues related to payments, invoices, billing, and refunds.',
   order: 'Issues related to load bookings, orders, and shipment tracking.',
@@ -363,7 +365,7 @@ router.post('/tickets/:id/comments', authenticate, userLimiter, validateBody(cre
   try {
     const { data: ticket, error: fetchError } = await supabase
       .from('support_tickets')
-      .select('id, user_id')
+      .select('id, user_id, status')
       .eq('id', ticketId)
       .maybeSingle();
 
@@ -380,6 +382,10 @@ router.post('/tickets/:id/comments', authenticate, userLimiter, validateBody(cre
 
     if (ticket.user_id !== req.user.id && req.user.role !== 'admin') {
       return res.status(403).json({ error: 'Access Denied: You do not own this ticket.' });
+    }
+
+    if (ticket.status === 'closed') {
+      return res.status(409).json({ error: 'Cannot comment on a closed ticket.' });
     }
 
     const { data: comment, error: insertError } = await supabase

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -503,6 +503,62 @@ describe('Support Routes', () => {
       expect(res.status).toBe(403);
     });
 
+    it('POST /tickets/:id/comments returns 409 when ticket is closed (owner)', async () => {
+      m.store.support_tickets[0].status = 'closed';
+
+      const res = await request(buildApp())
+        .post('/api/support/tickets/t-123/comments')
+        .set(CUSTOMER_HEADERS)
+        .send({ message: 'New comment after closure' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Cannot comment on a closed ticket.');
+
+      const commentInsert = m.calls.find(c => c.table === 'support_ticket_comments' && c.mode === 'insert');
+      expect(commentInsert).toBeUndefined();
+    });
+
+    it('POST /tickets/:id/comments returns 409 when ticket is closed (admin)', async () => {
+      m.store.support_tickets[0].status = 'closed';
+
+      const res = await request(buildApp())
+        .post('/api/support/tickets/t-123/comments')
+        .set({
+          'x-user-id': 'admin-1',
+          'x-user-role': 'admin',
+          'x-user-name': 'Test Admin',
+        })
+        .send({ message: 'Admin note on closed ticket' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Cannot comment on a closed ticket.');
+
+      const commentInsert = m.calls.find(c => c.table === 'support_ticket_comments' && c.mode === 'insert');
+      expect(commentInsert).toBeUndefined();
+    });
+
+    it('POST /tickets/:id/comments still accepts comments on open tickets', async () => {
+      const res = await request(buildApp())
+        .post('/api/support/tickets/t-123/comments')
+        .set(CUSTOMER_HEADERS)
+        .send({ message: 'Still open, commenting fine' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.comment.message).toBe('Still open, commenting fine');
+    });
+
+    it('POST /tickets/:id/comments still accepts comments on in_progress tickets', async () => {
+      m.store.support_tickets[0].status = 'in_progress';
+
+      const res = await request(buildApp())
+        .post('/api/support/tickets/t-123/comments')
+        .set(CUSTOMER_HEADERS)
+        .send({ message: 'In progress comment' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.comment.message).toBe('In progress comment');
+    });
+
     it('GET /tickets/:id/comments retrieves comments for ticket owner', async () => {
       m.store.support_ticket_comments.push({
         id: 'c-1',


### PR DESCRIPTION
## Summary

Closes #1244

The `POST /api/support/tickets/:id/comments` route was selecting only
`id, user_id` from `support_tickets`, so it had no visibility into ticket
status. This allowed new comments to be added to closed tickets, creating
inconsistent state — the `PATCH` route already correctly blocks all updates
on closed tickets with HTTP 400, but the comments route had no such guard.

## Changes

**`backend/api/src/routes/supportRoutes.js`**
- Extended the select in the comments route from `'id, user_id'` to
  `'id, user_id, status'`
- Added a status check immediately after the ownership check: returns
  HTTP 409 with `'Cannot comment on a closed ticket.'` when the ticket
  is closed
- Fixed a pre-existing syntax error: `CATEGORY_SLA` was missing its
  closing `};`, which prevented the entire file from parsing

**`backend/api/test/integration/supportRoutes.test.js`**
- 409 returned when ticket owner posts to a closed ticket (no DB insert made)
- 409 returned when admin posts to a closed ticket
- 201 still returned for open tickets
- 201 still returned for in_progress tickets

## Test Results

Test Files  1 passed (1)
      Tests  32 passed (32)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented comments from being added to closed support tickets, returning a clear error message instead.
  * Confirmed comments still work for open and in-progress tickets, with the expected response details.
* **Tests**
  * Expanded support ticket comment coverage to validate closed-ticket rejection and successful comment creation in supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->