### PR TITLE
fix: stop logging FCM registration tokens

### DIFF
--- a/apps/customer/lib/services/fcm_service.dart
+++ b/apps/customer/lib/services/fcm_service.dart
@@ -74,7 +74,7 @@ class FcmService {
     );
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
-      debugPrint('[FCM] Token updated successfully on backend: $token');
+      debugPrint('[FCM] Token updated successfully on backend.');
     } else {
       debugPrint('[FCM] Failed to update token on backend: ${response.body}');
     }

--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -75,7 +75,7 @@ class FcmService {
     );
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
-      debugPrint('[FCM] Token updated successfully on backend: $token');
+      debugPrint('[FCM] Token updated successfully on backend.');
     } else {
       debugPrint('[FCM] Failed to update token on backend: ${response.body}');
     }


### PR DESCRIPTION
## Summary
- remove raw FCM registration token output from customer token update success logs
- remove raw FCM registration token output from driver token update success logs

## Testing
- rg -n -F 'Token updated successfully on backend: $token' apps/customer/lib/services/fcm_service.dart apps/driver/lib/services/fcm_service.dart
- Flutter tooling unavailable in this environment

Fixes #1249