### PR TITLE
fix: clear stale FCM token when reassigned

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -21,6 +21,22 @@ export async function registerDeviceToken(req, res) {
       });
     }
 
+    const tokenUpdatedAt = new Date().toISOString();
+    const { data: existingDevice, error: lookupError } = await supabase
+      .from('user_devices')
+      .select('user_id')
+      .eq('fcm_token', fcmToken)
+      .maybeSingle();
+
+    if (lookupError) {
+      logger.error('[DeviceController] Failed to look up existing device token owner:', lookupError.message);
+      return res.status(500).json({
+        error: 'Failed to register device'
+      });
+    }
+
+    const previousUserId = existingDevice?.user_id;
+
     const { error } = await supabase.from('user_devices').upsert(
       {
         user_id: userId,
@@ -36,12 +52,30 @@ export async function registerDeviceToken(req, res) {
         error: 'Failed to register device'
       });
     }
-    
+
+    if (previousUserId && previousUserId !== userId) {
+      const { error: staleProfileError } = await supabase
+        .from('profiles')
+        .update({
+          fcm_token: null,
+          fcm_token_updated_at: tokenUpdatedAt,
+        })
+        .eq('id', previousUserId)
+        .eq('fcm_token', fcmToken);
+
+      if (staleProfileError) {
+        logger.error(
+          '[DeviceController] Device token saved but failed to clear previous profiles.fcm_token:',
+          staleProfileError.message
+        );
+      }
+    }
+
     const { error: profileSyncError } = await supabase
       .from('profiles')
       .update({
         fcm_token: fcmToken,
-        fcm_token_updated_at: new Date().toISOString(),
+        fcm_token_updated_at: tokenUpdatedAt,
       })
       .eq('id', userId);
 

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -32,6 +32,7 @@ describe('Device Routes Integration Tests', () => {
     process.env.BYPASS_AUTH = 'true';
     process.env.NODE_ENV = 'test';
     m.store.user_devices = [];
+    m.store.profiles = [];
     m.calls.length = 0;
   });
 
@@ -62,6 +63,42 @@ describe('Device Routes Integration Tests', () => {
       expect(stored).toBeTruthy();
       expect(stored.fcm_token).toBe('token1234567890');
       expect(stored.platform).toBe('ios');
+    });
+
+    it('clears a reassigned token from the previous user profile', async () => {
+      m.store.user_devices.push({
+        user_id: 'previous-user-uuid',
+        fcm_token: 'shared-token-123456',
+        platform: 'android',
+      });
+      m.store.profiles.push(
+        {
+          id: 'previous-user-uuid',
+          fcm_token: 'shared-token-123456',
+          fcm_token_updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'customer-uuid-123',
+          fcm_token: null,
+          fcm_token_updated_at: null,
+        }
+      );
+
+      const res = await request(buildApp())
+        .post('/api/devices/register')
+        .set(CUSTOMER_HEADERS)
+        .send({ fcmToken: 'shared-token-123456', platform: 'ios' });
+
+      expect(res.status).toBe(200);
+
+      const previousProfile = m.store.profiles.find(p => p.id === 'previous-user-uuid');
+      const currentProfile = m.store.profiles.find(p => p.id === 'customer-uuid-123');
+      const device = m.store.user_devices.find(d => d.fcm_token === 'shared-token-123456');
+
+      expect(previousProfile.fcm_token).toBeNull();
+      expect(currentProfile.fcm_token).toBe('shared-token-123456');
+      expect(device.user_id).toBe('customer-uuid-123');
+      expect(device.platform).toBe('ios');
     });
 
     it('uses default platform android if platform is not provided', async () => {
@@ -102,7 +139,7 @@ describe('Device Routes Integration Tests', () => {
       expect(res.body.error).toBe('Validation failed');
     });
 
-    it('returns 500 if database upsert fails and does not expose internal error details', async () => {
+    it('returns 500 if database registration fails and does not expose internal error details', async () => {
       m.programError('Database connection lost');
 
       const res = await request(buildApp())


### PR DESCRIPTION
## Summary
- look up the existing device-token owner before registration upsert
- clear the previous profile's fcm_token when the same token moves to another user
- add a device registration regression test for reassigned tokens

## Testing
- npm test -- --run test/integration/devices.test.js

Fixes #1248