### PR TITLE
fix: resolve admin cache invalidation identity

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -335,12 +335,37 @@ router.delete('/admin/cache/:userId', authenticate, requireRole(['admin']), asyn
       return res.status(400).json({ error: 'userId path parameter is required.' });
     }
 
+    let { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('id, firebase_uid')
+      .eq('id', targetUserId)
+      .maybeSingle();
+
+    if (!profile && !profileError) {
+      const firebaseLookup = await supabase
+        .from('profiles')
+        .select('id, firebase_uid')
+        .eq('firebase_uid', targetUserId)
+        .maybeSingle();
+
+      profile = firebaseLookup.data;
+      profileError = firebaseLookup.error;
+    }
+
+    if (profileError) {
+      return res.status(500).json({ error: 'Failed to resolve profile cache identity.', details: profileError.message });
+    }
+
+    if (!profile) {
+      return res.status(404).json({ error: 'Profile not found.' });
+    }
+
     await Promise.all([
-      invalidateCachedProfile(targetUserId),
-      invalidateCachedSupabaseProfile(targetUserId),
+      profile.firebase_uid ? invalidateCachedProfile(profile.firebase_uid) : Promise.resolve(),
+      invalidateCachedSupabaseProfile(profile.id),
     ]);
 
-    return res.json({ success: true, message: `Cache invalidated for user ${targetUserId}.` });
+    return res.json({ success: true, message: `Cache invalidated for user ${profile.id}.` });
   } catch (err) {
     return res.status(500).json({ error: 'Failed to invalidate profile cache.', details: err.message });
   }

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -9,7 +9,7 @@ vi.mock('../../src/lib/profileCache.js', () => ({
   setCachedProfile: vi.fn(),
 }));
 
-const { invalidateCachedProfile } = await import('../../src/lib/profileCache.js');
+const { invalidateCachedProfile, invalidateCachedSupabaseProfile } = await import('../../src/lib/profileCache.js');
 
 const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
 const m = createSupabaseMock();
@@ -40,6 +40,12 @@ const DRIVER_HEADERS = {
   'x-user-id': 'driver-uuid-456',
   'x-user-role': 'driver',
   'x-user-name': 'Test Driver',
+};
+
+const ADMIN_HEADERS = {
+  'x-user-id': 'admin-uuid-789',
+  'x-user-role': 'admin',
+  'x-user-name': 'Test Admin',
 };
 
 describe('Profile Routes', () => {
@@ -512,6 +518,45 @@ describe('Profile Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.trips).toHaveLength(2);
       expect(res.body.trips[0].id).toBe('order-high-earn');
+    });
+  });
+
+  describe('DELETE /api/profile/admin/cache/:userId', () => {
+    it('invalidates Firebase and Supabase profile caches when passed a profile id', async () => {
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+      });
+
+      const res = await request(buildApp())
+        .delete('/api/profile/admin/cache/customer-uuid-123')
+        .set(ADMIN_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: 'Cache invalidated for user customer-uuid-123.',
+      });
+      expect(invalidateCachedProfile).toHaveBeenCalledWith('firebase-cust-uid');
+      expect(invalidateCachedSupabaseProfile).toHaveBeenCalledWith('customer-uuid-123');
+    });
+
+    it('resolves Firebase uid input before invalidating both profile caches', async () => {
+      m.store.profiles.push({
+        id: 'driver-uuid-456',
+        firebase_uid: 'firebase-driver-uid',
+        role: 'driver',
+      });
+
+      const res = await request(buildApp())
+        .delete('/api/profile/admin/cache/firebase-driver-uid')
+        .set(ADMIN_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Cache invalidated for user driver-uuid-456.');
+      expect(invalidateCachedProfile).toHaveBeenCalledWith('firebase-driver-uid');
+      expect(invalidateCachedSupabaseProfile).toHaveBeenCalledWith('driver-uuid-456');
     });
   });
 });


### PR DESCRIPTION
## Summary
- resolve admin cache invalidation input against profiles.id first, then profiles.firebase_uid
- invalidate Firebase and Supabase profile cache keys with their correct identifiers
- add integration coverage for both id and Firebase uid inputs

## Testing
- npm test -- --run test/integration/profileRoutes.test.js

Fixes #1250