### PR TITLE
fix: validate vehicle type query filter

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -48,14 +48,20 @@ router.get('/', authenticate, userLimiter, requireRole(['driver']), async (req, 
 
     // Handle vehicle_type filtering in JS to avoid database column errors.
     // Default mapped vehicle_type is 'Truck'. If they filter by something else, return empty.
-    if (req.query.vehicle_type && (typeof req.query.vehicle_type !== 'string' || req.query.vehicle_type.toLowerCase() !== 'truck')) {
-      return res.json({
-        page,
-        limit,
-        total: 0,
-        totalPages: 0,
-        loads: []
-      });
+    if (req.query.vehicle_type) {
+      if (typeof req.query.vehicle_type !== 'string') {
+        return res.status(400).json({ error: 'vehicle_type must be a single string' });
+      }
+
+      if (req.query.vehicle_type.toLowerCase() !== 'truck') {
+        return res.json({
+          page,
+          limit,
+          total: 0,
+          totalPages: 0,
+          loads: []
+        });
+      }
     }
 
     const from = (page - 1) * limit;

--- a/backend/api/test/integration/loadOffers.test.js
+++ b/backend/api/test/integration/loadOffers.test.js
@@ -238,6 +238,31 @@ describe('Load Offers Routes Integration Tests', () => {
       expect(res.body.total).toBe(0);
     });
 
+    it('accepts truck vehicle_type filter case-insensitively', async () => {
+      m.store.load_offers.push({
+        id: 'load-1',
+        status: 'available',
+      });
+
+      const res = await request(buildApp())
+        .get('/api/loads?vehicle_type=truck')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.loads).toHaveLength(1);
+      expect(res.body.loads[0].vehicle_type).toBe('Truck');
+    });
+
+    it('rejects repeated vehicle_type filters instead of treating them as an array', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?vehicle_type=Truck&vehicle_type=Van')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('vehicle_type must be a single string');
+      expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
+    });
+
     it('maps sort_by parameters correctly', async () => {
       // Sort by estimated_price -> maps to freight_value
       await request(buildApp())


### PR DESCRIPTION
## Summary
- return a 400 response when vehicle_type is submitted multiple times
- keep case-insensitive truck filtering supported
- preserve empty results for unsupported single vehicle_type values

## Testing
- npm test -- --run test/integration/loadOffers.test.js

Fixes #1254