### PR TITLE
fix: normalize driver OTP rate limit keys

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -19,10 +19,27 @@ const loginOtpSchema = z.object({
   otp: z.string().regex(/^\d{4}$/, { message: 'OTP must be 4 digits' }),
 });
 
+export function otpPhoneKey(phone) {
+  if (typeof phone !== 'string') {
+    return 'phone:unknown';
+  }
+
+  const digits = phone.replace(/\D/g, '');
+  if (!digits) {
+    return 'phone:unknown';
+  }
+
+  const nationalDigits = digits.length === 12 && digits.startsWith('91')
+    ? digits.slice(2)
+    : digits;
+
+  return `phone:${nationalDigits}`;
+}
+
 function perPhoneLimiter(opts) {
   return rateLimit({
     ...opts,
-    keyGenerator: (req) => `phone:${req.body.phone || 'unknown'}`,
+    keyGenerator: (req) => otpPhoneKey(req.body.phone),
   });
 }
 

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -19,11 +19,12 @@ vi.mock('../../src/services/reputation.js', () => ({
   getDriverReputation: getDriverReputationMock,
 }));
 
-// Set OTP env var before importing the router module.
-// This is required because driverRoutes.js reads DRIVER_LOGIN_OTP at module level.
-process.env.DRIVER_LOGIN_OTP = '1234';
+vi.mock('../../src/services/otpService.js', () => ({
+  generateAndStoreOtp: vi.fn().mockResolvedValue('1234'),
+  verifyOtp: vi.fn((_phone, otp) => Promise.resolve(otp === '1234')),
+}));
 
-const { default: driverRouter } = await import('../../src/routes/driverRoutes.js');
+const { default: driverRouter, otpPhoneKey } = await import('../../src/routes/driverRoutes.js');
 
 
 function buildApp() {
@@ -45,6 +46,20 @@ describe('Driver Routes', () => {
     m.store.earnings_daily = [];
     m.store.trucks = [];
     m.calls.length = 0;
+  });
+
+  describe('otpPhoneKey', () => {
+    it('normalizes equivalent phone number formats to one limiter key', () => {
+      expect(otpPhoneKey('9876543210')).toBe('phone:9876543210');
+      expect(otpPhoneKey(' 98765 43210 ')).toBe('phone:9876543210');
+      expect(otpPhoneKey('+91 98765-43210')).toBe('phone:9876543210');
+      expect(otpPhoneKey('919876543210')).toBe('phone:9876543210');
+    });
+
+    it('uses an unknown fallback for non-string or empty phone values', () => {
+      expect(otpPhoneKey(undefined)).toBe('phone:unknown');
+      expect(otpPhoneKey('---')).toBe('phone:unknown');
+    });
   });
 
   it('GET /stats returns 404 when driver profile does not exist', async () => {


### PR DESCRIPTION
## Summary
- canonicalize driver OTP phone rate-limit keys before validation
- group whitespace, punctuation, and +91/91-prefixed variants into the same limiter bucket
- add driver route coverage for equivalent phone key formats

## Testing
- npm test -- --run test/integration/driverRoutes.test.js

Fixes #1253