### PR TITLE
fix(escrowRefundReconciliation): handle scalar RPC return values

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -59,7 +59,7 @@ export async function reconcilePendingEscrowRefunds() {
             p_instance_id: instanceId,
           });
 
-        if ((!claimed || claimed.length === 0) && !claimError) {
+        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0) || (!Array.isArray(claimed) && !claimError)) && !claimError) {
           logger.info(`[escrow-reconciliation] Order ${order.order_display_id} already claimed by another instance, skipping.`);
           continue;
         }


### PR DESCRIPTION
The claimed.length check assumed the RPC always returns an array.
When the RPC returns a single row (object), claimed.length is undefined
causing the skip condition to fail silently, potentially double-processing
refunds.

Closes #1275
