### PR TITLE
fix(flutter): gracefully handle Firebase init failure instead of rethrowing

### DIFF
--- a/apps/customer/lib/main.dart
+++ b/apps/customer/lib/main.dart
@@ -37,7 +37,6 @@ void main() async {
     }
   } catch (e) {
     debugPrint('Firebase initialization failed: $e');
-    rethrow;
   }
 
   // Initialize Supabase if keys are provided.

--- a/apps/driver/lib/main.dart
+++ b/apps/driver/lib/main.dart
@@ -36,7 +36,6 @@ Future<void> main() async {
     }
   } catch (e) {
     debugPrint('Firebase initialization failed: $e');
-    rethrow;
   }
 
   // Initialize Supabase if keys are provided.


### PR DESCRIPTION
Both apps used rethrow after Firebase initialization failure, causing
unrecoverable crashes. Changed to match Supabase's graceful error handling
so a Firebase misconfiguration doesn't crash the app.

Closes #1271
