### PR TITLE
fix(deviceController): FCM token hijack + profile sync before response

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,71 +1,3 @@
-// ===== PR (fix/issue-1334-device-token) changes =====
-import { supabase } from '../config/db.js';
-import logger from '../middleware/logger.js';
-
-/**
- * Register / update FCM token for a user device
- */
-export async function registerDeviceToken(req, res) {
-  try {
-    const userId = req.user?.id;
-    const { fcmToken, platform } = req.body;
-
-    if (!userId) {
-      return res.status(401).json({
-        error: 'User not authenticated'
-      });
-    }
-
-    if (!fcmToken) {
-      return res.status(400).json({
-        error: 'fcmToken is required'
-      });
-    }
-
-    const { error: profileSyncError } = await supabase
-      .from('profiles')
-      .update({
-        fcm_token: fcmToken,
-        fcm_token_updated_at: new Date().toISOString(),
-      })
-      .eq('id', userId);
-
-    if (profileSyncError) {
-      logger.error('[DeviceController] Failed to sync profiles.fcm_token:', profileSyncError.message);
-      return res.status(500).json({
-        error: 'Failed to register device'
-      });
-    }
-
-    const { error } = await supabase.from('user_devices').upsert(
-      {
-        user_id: userId,
-        fcm_token: fcmToken,
-        platform: platform || 'android'
-      },
-      { onConflict: 'user_id,fcm_token' }
-    );
-
-    if (error) {
-      logger.error('[DeviceController] Failed to register device token in database:', error.message);
-      return res.status(500).json({
-        error: 'Failed to register device'
-      });
-    }
-
-    return res.json({
-      success: true,
-      message: 'Device token registered'
-    });
-  } catch (err) {
-    logger.error('[DeviceController] Unexpected error in registerDeviceToken:', err.message);
-    return res.status(500).json({
-      error: 'An unexpected error occurred'
-    });
-  }
-}
-
-// ===== Base (main) changes =====
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
@@ -165,5 +97,3 @@ export async function registerDeviceToken(req, res) {
     });
   }
 }
-
-// ===== Auto-resolved: accepting both changes =====

--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,3 +1,4 @@
+// ===== PR (fix/issue-1334-device-token) changes =====
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
@@ -63,3 +64,106 @@ export async function registerDeviceToken(req, res) {
     });
   }
 }
+
+// ===== Base (main) changes =====
+import { supabase } from '../config/db.js';
+import logger from '../middleware/logger.js';
+
+/**
+ * Register / update FCM token for a user device
+ */
+export async function registerDeviceToken(req, res) {
+  try {
+    const userId = req.user?.id;
+    const { fcmToken, platform } = req.body;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: 'User not authenticated'
+      });
+    }
+
+    if (!fcmToken) {
+      return res.status(400).json({
+        error: 'fcmToken is required'
+      });
+    }
+
+    const tokenUpdatedAt = new Date().toISOString();
+    const { data: existingDevice, error: lookupError } = await supabase
+      .from('user_devices')
+      .select('user_id')
+      .eq('fcm_token', fcmToken)
+      .maybeSingle();
+
+    if (lookupError) {
+      logger.error('[DeviceController] Failed to look up existing device token owner:', lookupError.message);
+      return res.status(500).json({
+        error: 'Failed to register device'
+      });
+    }
+
+    const previousUserId = existingDevice?.user_id;
+
+    const { error } = await supabase.from('user_devices').upsert(
+      {
+        user_id: userId,
+        fcm_token: fcmToken,
+        platform: platform || 'android'
+      },
+      { onConflict: 'fcm_token' }
+    );
+
+    if (error) {
+      logger.error('[DeviceController] Failed to register device token in database:', error.message);
+      return res.status(500).json({
+        error: 'Failed to register device'
+      });
+    }
+
+    if (previousUserId && previousUserId !== userId) {
+      const { error: staleProfileError } = await supabase
+        .from('profiles')
+        .update({
+          fcm_token: null,
+          fcm_token_updated_at: tokenUpdatedAt,
+        })
+        .eq('id', previousUserId)
+        .eq('fcm_token', fcmToken);
+
+      if (staleProfileError) {
+        logger.error(
+          '[DeviceController] Device token saved but failed to clear previous profiles.fcm_token:',
+          staleProfileError.message
+        );
+      }
+    }
+
+    const { error: profileSyncError } = await supabase
+      .from('profiles')
+      .update({
+        fcm_token: fcmToken,
+        fcm_token_updated_at: tokenUpdatedAt,
+      })
+      .eq('id', userId);
+
+    if (profileSyncError) {
+      logger.error(
+        '[DeviceController] Device token saved but failed to sync profiles.fcm_token:',
+        profileSyncError.message
+      );
+    }
+
+    return res.json({
+      success: true,
+      message: 'Device token registered'
+    });
+  } catch (err) {
+    logger.error('[DeviceController] Unexpected error in registerDeviceToken:', err.message);
+    return res.status(500).json({
+      error: 'An unexpected error occurred'
+    });
+  }
+}
+
+// ===== Auto-resolved: accepting both changes =====

--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -21,22 +21,6 @@ export async function registerDeviceToken(req, res) {
       });
     }
 
-    const { error } = await supabase.from('user_devices').upsert(
-      {
-        user_id: userId,
-        fcm_token: fcmToken,
-        platform: platform || 'android'
-      },
-      { onConflict: 'fcm_token' }
-    );
-
-    if (error) {
-      logger.error('[DeviceController] Failed to register device token in database:', error.message);
-      return res.status(500).json({
-        error: 'Failed to register device'
-      });
-    }
-    
     const { error: profileSyncError } = await supabase
       .from('profiles')
       .update({
@@ -46,10 +30,26 @@ export async function registerDeviceToken(req, res) {
       .eq('id', userId);
 
     if (profileSyncError) {
-      logger.error(
-        '[DeviceController] Device token saved but failed to sync profiles.fcm_token:',
-        profileSyncError.message
-      );
+      logger.error('[DeviceController] Failed to sync profiles.fcm_token:', profileSyncError.message);
+      return res.status(500).json({
+        error: 'Failed to register device'
+      });
+    }
+
+    const { error } = await supabase.from('user_devices').upsert(
+      {
+        user_id: userId,
+        fcm_token: fcmToken,
+        platform: platform || 'android'
+      },
+      { onConflict: 'user_id,fcm_token' }
+    );
+
+    if (error) {
+      logger.error('[DeviceController] Failed to register device token in database:', error.message);
+      return res.status(500).json({
+        error: 'Failed to register device'
+      });
     }
 
     return res.json({


### PR DESCRIPTION
Two fixes:
1. Changed onConflict from 'fcm_token' to 'user_id,fcm_token' to
   prevent device token hijacking when different users share a token.
2. Moved profile sync before the response so client receives error
   if profiles.fcm_token update fails, avoiding data inconsistency.

Closes #1334, #1335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device token registration now keeps user profile token data in sync more reliably.
  * If a token is reassigned to a different account, the previous account’s saved token is cleared.
  * Failed token updates now return a clear server error instead of silently logging the issue.
  * Improved handling for duplicate device token registration so token ownership is updated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->