### PR TITLE
fix(config): hardhat etherscan fallback string, .env.example matic default

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -44,8 +44,8 @@ RELAYER_WALLET_PRIVATE_KEY=your_private_key
 # ── Escrow ────────────────────────────────
 # MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
 # Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004
-# Leave unset to disable on-chain escrow deposits.
-ESCROW_MATIC_PER_PAISA=
+# Defaults to 0.01 if unset.
+ESCROW_MATIC_PER_PAISA=0.01
 # Safety cap: reject deposits exceeding this many MATIC
 MAX_ESCROW_MATIC=5
 # Poll interval for confirmed refunds that still need a Supabase state update.

--- a/blockchain/hardhat.config.cjs
+++ b/blockchain/hardhat.config.cjs
@@ -32,8 +32,8 @@ module.exports = {
   },
   etherscan: {
     apiKey: {
-      amoy: POLYGONSCAN_API_KEY,
-      polygon: POLYGONSCAN_API_KEY,
+      amoy: POLYGONSCAN_API_KEY || "",
+      polygon: POLYGONSCAN_API_KEY || "",
     },
   },
 };


### PR DESCRIPTION
Closes #1339, #1347
