### PR TITLE
fix(flutter): api_client cast, websocket race, ticket id, notification userId

### DIFF
--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -240,9 +240,12 @@ class ApiClient {
 
     String message;
     try {
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
-      message = (json['error'] ?? json['message'] ?? response.reasonPhrase)
-          .toString();
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        message = (decoded['error'] ?? decoded['message'] ?? response.reasonPhrase ?? 'Unknown error').toString();
+      } else {
+        message = response.reasonPhrase ?? 'Unknown error';
+      }
     } catch (_) {
       message = response.reasonPhrase ?? 'Unknown error';
     }

--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -55,12 +55,13 @@ class ResilientWebSocket {
   }
 
   void send(dynamic message) {
-    if (_channel == null) {
+    final channel = _channel;
+    if (channel == null) {
       return;
     }
 
     final payload = message is String ? message : jsonEncode(message);
-    _channel!.sink.add(payload);
+    channel.sink.add(payload);
   }
 
   void _scheduleReconnect() {
@@ -81,8 +82,9 @@ class ResilientWebSocket {
   void _startHeartbeat() {
     _heartbeatTimer?.cancel();
     _heartbeatTimer = Timer.periodic(const Duration(seconds: 15), (_) {
-      if (_channel != null) {
-        _channel!.sink.add('ping');
+      final channel = _channel;
+      if (channel != null) {
+        channel.sink.add('ping');
       }
     });
   }

--- a/packages/truxify_shared/lib/src/models/notification_item.dart
+++ b/packages/truxify_shared/lib/src/models/notification_item.dart
@@ -1,7 +1,7 @@
 class NotificationItem {
   const NotificationItem({
     required this.id,
-    required this.userId,
+    this.userId,
     required this.title,
     required this.body,
     required this.notifType,

--- a/packages/truxify_shared/lib/src/models/support_ticket.dart
+++ b/packages/truxify_shared/lib/src/models/support_ticket.dart
@@ -1,6 +1,6 @@
 class SupportTicket {
   const SupportTicket({
-    required this.id,
+    this.id = '',
     required this.userId,
     required this.subject,
     required this.description,


### PR DESCRIPTION
4 fixes:
- api_client: jsonDecode cast outside try/catch, null reasonPhrase
- resilient_websocket: TOCTOU race in heartbeat and send
- support_ticket: made id optional with default empty string
- notification_item: removed required from nullable userId

Closes #1340, #1341, #1342, #1343, #1344
