### PR TITLE
fix(ml): bin_packing variable naming, bilateral_matcher function naming

### DIFF
--- a/backend/ml/app/models/bilateral_matcher.py
+++ b/backend/ml/app/models/bilateral_matcher.py
@@ -83,8 +83,8 @@ def _deadline_urgency(load: dict, distance_km: float) -> float:
     return ratio * 100.0  # scale for cost matrix
 
 
-def _destination_affinity(driver: dict, load: dict) -> float:
-    """Reward drivers whose preferred destination is close to load dest."""
+def _destination_penalty(driver: dict, load: dict) -> float:
+    """Penalize drivers whose preferred destination is far from load dest."""
     pref_lat = driver.get("preferred_dest_lat")
     pref_lng = driver.get("preferred_dest_lng")
     if pref_lat is None or pref_lng is None:
@@ -159,7 +159,7 @@ def match_bilateral(
                 + _weight_penalty(driver, load)
                 + _dimension_penalty(driver, load)
                 + _deadline_urgency(load, dist_km)
-                + _destination_affinity(driver, load)
+                + _destination_penalty(driver, load)
                 + _rating_bonus(driver)
             )
             cost[i, j] = c

--- a/backend/ml/app/models/bin_packing.py
+++ b/backend/ml/app/models/bin_packing.py
@@ -118,11 +118,11 @@ def _pack_packages(
     packed_volume = 0.0
 
     for idx, pkg in indexed:
-        pl, pw, ph = pkg["length"], pkg["width"], pkg["height"]
-        pw_ = pkg["weight"]
+        pkg_length, pkg_width, pkg_height = pkg["length"], pkg["width"], pkg["height"]
+        pkg_weight = pkg["weight"]
 
         # Weight check
-        if packed_weight + pw_ > max_weight:
+        if packed_weight + pkg_weight > max_weight:
             arrangements[idx] = {
                 "package_index": idx,
                 "position": {"x": 0.0, "y": 0.0, "z": 0.0},
@@ -134,7 +134,7 @@ def _pack_packages(
 
         placed = False
         for shelf in shelves:
-            pos = shelf.try_place(pl, pw, ph)
+            pos = shelf.try_place(pkg_length, pkg_width, pkg_height)
             if pos is not None:
                 arrangements[idx] = {
                     "package_index": idx,
@@ -142,8 +142,8 @@ def _pack_packages(
                     "rotated": pos["rotated"],
                     "fits": True,
                 }
-                packed_weight += pw_
-                packed_volume += pl * pw * ph
+                packed_weight += pkg_weight
+                packed_volume += pkg_length * pkg_width * pkg_height
                 placed = True
                 break
 
@@ -169,8 +169,8 @@ def _pack_packages(
                     "rotated": pos["rotated"],
                     "fits": True,
                 }
-                packed_weight += pw_
-                packed_volume += pl * pw * ph
+                packed_weight += pkg_weight
+                packed_volume += pkg_length * pkg_width * pkg_height
                 shelves.append(new_shelf)
             else:
                 arrangements[idx] = {


### PR DESCRIPTION
bin_packing: renamed error-prone pw/pw_/pl/ph to pkg_weight/pkg_length/
pkg_width/pkg_height to prevent maintenance mix-ups.
bilateral_matcher: renamed _destination_affinity to _destination_penalty
since it adds a positive cost (penalty) not a negative bonus.

Closes #1345, #1346
