### PR TITLE
fix : removed duplicate confirmEscrowRefund function in escrow.js

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -57,24 +57,6 @@ if (rpcUrl && contractAddress && relayerPrivateKey) {
 }
 
 /**
- * Confirm a previously submitted refund transaction during a retry.
- */
-export async function confirmEscrowRefund(txHash) {
-  if (!escrowContract) {
-    throw new Error('Escrow contract is not initialised.');
-  }
-  if (!ethers.isHexString(txHash, 32)) {
-    throw new Error('Invalid escrow refund transaction hash.');
-  }
-
-  const receipt = await escrowContract.runner.provider.waitForTransaction(txHash, 1);
-  if (!receipt || receipt.status === 0) {
-    throw new Error('Escrow refund transaction reverted or was not found.');
-  }
-  return receipt;
-}
-
-/**
  * Derive a deterministic booking ID from an order's display ID.
  * @param {string} orderDisplayId — e.g. "#FF20260521"
  * @returns {string} bytes32 hex string


### PR DESCRIPTION
Closes #1399.

Summary of What Has Been Done:
Removed the duplicate function declaration of confirmEscrowRefund from backend/api/src/services/escrow.js. The function was declared twice (at line 62 and line 265), causing a JavaScript SyntaxError at parse time.

Changes Made:
- backend/api/src/services/escrow.js: Removed the first duplicate declaration (18 lines deleted), keeping only the canonical definition.

Impact it Made:
- All 18 backend unit test files now pass (320 tests).
- npm ci and npm run test:unit succeed without parse errors.

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized refund confirmation logic within the service for clearer code flow. Behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->