### PR TITLE
fix : removed duplicate confirmEscrowRefund export in escrow.js

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -57,24 +57,6 @@ if (rpcUrl && contractAddress && relayerPrivateKey) {
 }
 
 /**
- * Confirm a previously submitted refund transaction during a retry.
- */
-export async function confirmEscrowRefund(txHash) {
-  if (!escrowContract) {
-    throw new Error('Escrow contract is not initialised.');
-  }
-  if (!ethers.isHexString(txHash, 32)) {
-    throw new Error('Invalid escrow refund transaction hash.');
-  }
-
-  const receipt = await escrowContract.runner.provider.waitForTransaction(txHash, 1);
-  if (!receipt || receipt.status === 0) {
-    throw new Error('Escrow refund transaction reverted or was not found.');
-  }
-  return receipt;
-}
-
-/**
  * Derive a deterministic booking ID from an order's display ID.
  * @param {string} orderDisplayId — e.g. "#FF20260521"
  * @returns {string} bytes32 hex string


### PR DESCRIPTION
Closes #1419.

Summary of What Has Been Done:
Removed the duplicate export of confirmEscrowRefund from backend/api/src/services/escrow.js. The automated merge commit 0ce93ee left a stale copy of the function at lines 62-73 alongside the correctly-placed occurrence at lines 265-277. JavaScript parse error prevented all backend unit tests from running.

Changes Made:
- backend/api/src/services/escrow.js: Removed 18 lines (the duplicate function definition at lines 58-75)

Impact it Made:
- All 320 backend unit tests now pass
- Unblocks backend CI for all 16 open PRs
- Fixes the parse error introduced by automated merge conflict resolution

Note: Please assign this PR to the tmdeveloper007 account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal code organization with no change to user-facing escrow refund behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->