### PR TITLE
Refactor hardcoded colors to use AppTheme variables

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1359,7 +1359,7 @@ class _HomeScreenState extends State<HomeScreen> {
       decoration: BoxDecoration(
         color: Theme.of(context).brightness == Brightness.dark
             ? Theme.of(context).colorScheme.surfaceContainerHighest
-            : const Color(0xFFF9F7F7),
+            : TruxifyColors.background,
         border: Border.all(color: TruxifyColors.border),
         borderRadius: BorderRadius.circular(12),
       ),
@@ -1391,7 +1391,7 @@ class _HomeScreenState extends State<HomeScreen> {
       decoration: BoxDecoration(
         color: Theme.of(context).brightness == Brightness.dark
             ? Theme.of(context).colorScheme.surfaceContainerHighest
-            : const Color(0xFFF9F7F7),
+            : TruxifyColors.background,
         border: Border.all(color: TruxifyColors.border),
         borderRadius: BorderRadius.circular(12),
       ),
@@ -1497,7 +1497,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
                   color: _isTripStarted
-                      ? const Color(0xFFEAFCEE)
+                      ? TruxifyColors.successLight
                       : TruxifyColors.accentLight,
                   borderRadius: BorderRadius.circular(6),
                 ),

--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -109,7 +109,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                 decoration: BoxDecoration(
                   color: Theme.of(context).brightness == Brightness.dark
                       ? TruxifyColors.darkSecondaryBackground
-                      : const Color(0xFFF5F5F5),
+                      : TruxifyColors.secondaryBackground,
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Column(
@@ -287,7 +287,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
               padding: const EdgeInsets.all(20),
               decoration: const BoxDecoration(
                 gradient: LinearGradient(
-                  colors: [TruxifyColors.accent, Color(0xFF5E0B0B)],
+                  colors: [TruxifyColors.accent, TruxifyColors.accentDark],
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,
                 ),
@@ -423,7 +423,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                         builder: (context, snap) {
                           if (snap.connectionState != ConnectionState.done) {
                             return Container(
-                              color: const Color(0xFFF0E8E8),
+                              color: TruxifyColors.subtleBorder,
                               child: const Center(
                                   child: CircularProgressIndicator()),
                             );
@@ -433,7 +433,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                           if (result == null ||
                               (result.start == null && result.end == null)) {
                             return Container(
-                              color: const Color(0xFFF0E8E8),
+                              color: TruxifyColors.subtleBorder,
                               child: Stack(
                                 children: [
                                   Positioned(
@@ -811,7 +811,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
                       Icons.chevron_right,
                       color: Theme.of(context).brightness == Brightness.dark
                           ? TruxifyColors.darkSecondaryText
-                          : const Color(0xFFCCBBBB),
+                          : TruxifyColors.navInactive,
                       size: 22,
                     ),
                   ],

--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -851,7 +851,7 @@ class _TripsScreenState extends State<TripsScreen> {
         break;
       case TripStatusType.completed:
         statusColor = TruxifyColors.success;
-        statusBgColor = const Color(0xFFE8F5E9);
+        statusBgColor = TruxifyColors.successLight;
         statusLabel = 'Completed';
         break;
       case TripStatusType.cancelled:
@@ -968,7 +968,7 @@ class _TripsScreenState extends State<TripsScreen> {
                                       color: Theme.of(context).brightness ==
                                               Brightness.dark
                                           ? TruxifyColors.darkAccentLight
-                                          : const Color(0xFFFDEAEA),
+                                          : TruxifyColors.accentLight,
                                       border: Border.all(
                                           color: TruxifyColors.border),
                                       borderRadius: BorderRadius.circular(20),
@@ -1026,7 +1026,7 @@ class _TripsScreenState extends State<TripsScreen> {
     if (routePoints.isEmpty) {
       return Container(
         decoration: BoxDecoration(
-          color: const Color(0xFFF0E8E8),
+          color: TruxifyColors.subtleBorder,
           borderRadius: BorderRadius.circular(8),
         ),
         child: const Center(

--- a/apps/driver/lib/widgets/earnings_shimmer.dart
+++ b/apps/driver/lib/widgets/earnings_shimmer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../theme/app_theme.dart';
 
 /// A wrapper that applies a consistent, theme-aware shimmer effect.
 class EarningsShimmerWrapper extends StatelessWidget {
@@ -13,12 +14,12 @@ class EarningsShimmerWrapper extends StatelessWidget {
 
     // Adaptive color system matching the Truxify maroon/grey palette
     final Color baseColor = isDark
-        ? const Color(0xFF2B2B2D) // Dark border/card adjacent
-        : const Color(0xFFECE4E4); // Maroon/grey border adjacent
+        ? TruxifyColors.darkBorder
+        : TruxifyColors.border;
 
     final Color highlightColor = isDark
-        ? const Color(0xFF38383C)
-        : const Color(0xFFF7F2F2);
+        ? TruxifyColors.darkSecondaryBackground
+        : TruxifyColors.subtleBorder;
 
     return Shimmer.fromColors(
       baseColor: baseColor,


### PR DESCRIPTION
Closes #1434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated several driver app screens to use shared theme colors for better consistency across light and dark modes.
  * Refreshed backgrounds and status badges in home, trip detail, and trips views to match the app’s visual system.
  * Aligned shimmer/loading placeholders with the same theme-based color palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->