### PR TITLE
Fix #1449: Change-Drop After Bid Acceptance Overwrites total_amount, Creating On-Chain/Off-Chain Financial Desync

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1177,9 +1177,12 @@ router.put('/:id/change-drop', authenticate, userLimiter, requireRole(['customer
     if (orderErr) return res.status(500).json({ error: 'Failed to fetch order.', details: orderErr.message });
     if (!order) return res.status(404).json({ error: 'Order not found.' });
     if (order.customer_id !== req.user.id) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
-    if (order.escrow_status === 'funded') {
+    if (order.escrow_status === 'funded' || order.status !== 'pending') {
+      const reason = order.escrow_status === 'funded'
+        ? 'after escrow has been funded'
+        : `after order status is '${order.status}'`;
       return res.status(409).json({
-        error: 'Drop location cannot be changed after escrow has been funded.',
+        error: `Drop location cannot be changed ${reason}.`,
         recovery: 'Cancel this order to receive a refund, then rebook with the correct destination.',
       });
     }

--- a/supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql
+++ b/supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql
@@ -87,10 +87,11 @@ BEGIN
   WHERE order_display_id = v_order.order_display_id
     AND milestone = 'Delivered';
 
+  -- Use COALESCE to prefer bid_amount (immutable) over total_amount (mutable)
   UPDATE driver_details
   SET total_trips = total_trips + 1,
-      wallet_confirmed = wallet_confirmed + v_order.total_amount,
-      wallet_total = wallet_total + v_order.total_amount,
+      wallet_confirmed = wallet_confirmed + COALESCE(v_order.bid_amount, v_order.total_amount),
+      wallet_total = wallet_total + COALESCE(v_order.bid_amount, v_order.total_amount),
       updated_at = NOW()
   WHERE user_id = v_order.driver_id;
 
@@ -104,14 +105,14 @@ BEGIN
   ) VALUES (
     v_order.driver_id,
     v_order.order_display_id,
-    v_order.total_amount,
+    COALESCE(v_order.bid_amount, v_order.total_amount),
     'credit',
     'confirmed',
     'Payout for Order ' || v_order.order_display_id
   );
 
   INSERT INTO earnings_daily (driver_id, day_date, amount, trip_count)
-  VALUES (v_order.driver_id, CURRENT_DATE, v_order.total_amount, 1)
+  VALUES (v_order.driver_id, CURRENT_DATE, COALESCE(v_order.bid_amount, v_order.total_amount), 1)
   ON CONFLICT (driver_id, day_date)
   DO UPDATE SET
     amount = earnings_daily.amount + EXCLUDED.amount,

--- a/supabase/migrations/20260628000000_add_rpc_functions.sql
+++ b/supabase/migrations/20260628000000_add_rpc_functions.sql
@@ -64,6 +64,7 @@ begin
         driver_rating    = p_driver_rating,
         truck_number     = p_truck_number,
         total_amount     = p_bid_amount,
+        bid_amount       = p_bid_amount,
         escrow_booking_id = coalesce(p_escrow_booking_id, escrow_booking_id),
         updated_at       = now()
     where id = p_order_id;

--- a/supabase/migrations/20260701000000_add_bid_amount_column.sql
+++ b/supabase/migrations/20260701000000_add_bid_amount_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS bid_amount INT;


### PR DESCRIPTION
## Description

Fixes the "change drop" feature where accepting a new bid would overwrite `total_amount`, causing the original order total to be lost.

**Root cause**: When a bid was accepted, `accept_bid_tx` set `total_amount` directly, and the change-drop guard only checked `escrow === 'funded'`. This allowed bid acceptance to overwrite the original amount after escrow was funded.

**Fix**:
- Tightened the change-drop guard to also block when `order.status !== 'pending'`
- Added a `bid_amount` column to orders, set alongside `total_amount` during bid acceptance
- `complete_trip_tx` now uses `COALESCE(bid_amount, total_amount)` for the wallet credit amount

### Changes
- `backend/api/src/routes/orderRoutes.js` — Strengthen change-drop guard
- `supabase/migrations/20260628000000_add_rpc_functions.sql` — Updated `accept_bid_tx` to set `bid_amount`
- `supabase/migrations/20260701000000_add_bid_amount_column.sql` — New migration adding `bid_amount` column
- `supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql` — Updated `complete_trip_tx` to use `COALESCE(bid_amount, total_amount)`

Closes #1449