### PR TITLE
fix: rename undefined supabaseKey to supabaseAnonKey in db.js

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -42,7 +42,7 @@ if (supabaseUrl && supabaseAnonKey) {
   );
 }
 
-if (supabaseUrl && supabaseServiceKey && supabaseServiceKey !== supabaseKey) {
+if (supabaseUrl && supabaseServiceKey && supabaseServiceKey !== supabaseAnonKey) {
   try {
     supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
       auth: {


### PR DESCRIPTION
In `backend/api/src/config/db.js` line 45, `supabaseKey` is referenced but never defined â€” only `supabaseAnonKey` and `supabaseServiceKey` are declared. This throws a `ReferenceError` at module load when both SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are configured.

Closes #1454