### PR TITLE
fix: import supabase from db.js instead of non-existent supabase.js in locationServer.js

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -2,6 +2,7 @@ import { Server } from "socket.io";
 import jwt from "jsonwebtoken";
 import logger from "../middleware/logger.js";
 import { GpsLog } from "../models/GpsLog.js";
+import { supabase } from "../config/db.js";
 
 /**
  * Attaches the Truxify Live Location WebSocket server to an existing
@@ -270,8 +271,7 @@ async function verifyCustomerToken(socket, next) {
  */
 async function verifyBookingOwnership(customerId, bookingId) {
   try {
-    // Import Supabase client from existing db module
-    const { supabase } = await import("../config/supabase.js");
+    // Use Supabase client from existing db module
 
     const { data, error } = await supabase
       .from("bookings")


### PR DESCRIPTION
In `backend/api/src/sockets/locationServer.js` line 274, `verifyBookingOwnership` dynamically imports Supabase from `../config/supabase.js` â€” a file that does not exist. This causes every customer `subscribe_booking` call to throw `MODULE_NOT_FOUND`, making live tracking completely non-functional.

This fix replaces the dynamic import with a static import of `supabase` from the existing `../config/db.js`. The dynamic import line is removed entirely.

Closes #1455