### PR TITLE
fix: remove duplicate dead-code auth check in confirm-deposit endpoint

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1489,9 +1489,6 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
     if (order.escrow_status !== 'funding') {
       return res.status(400).json({ error: 'Order is not in funding state' });
     }
-    if (order.customer_id !== req.user.id) {
-      return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
-    }
 
     const bookingId = order.escrow_booking_id || `escrow:${order.order_display_id}`;
     const result = await recordDepositTx(bookingId, txHash);


### PR DESCRIPTION
In `backend/api/src/routes/orderRoutes.js` lines 1492-1494, the exact same `order.customer_id !== req.user.id` authorization check appears as dead code â€” the identical check at line 1486 already `return`s early on failure. The second block can never be reached.

Removing it keeps the codebase DRY and removes misleading dead code.

Closes #1456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified deposit confirmation so successful payments are recorded and marked funded without an extra wallet lookup step.
  * Improved reliability of escrow booking identification during deposit confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->