### PR TITLE
fix: remove duplicate healthLimiter import in healthRoutes.js

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -2,7 +2,6 @@ import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
 import { healthLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
-import { healthLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary

Removes the duplicate `healthLimiter` import from `backend/api/src/routes/healthRoutes.js`.

Closes #1460

## Problem

The file imported `healthLimiter` twice using the same binding name, which can result in a module loading error in ES module environments.

## Solution

- Removed the duplicate import statement.
- Left a single valid import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up an unnecessary import in the health route configuration.
  * No user-facing behavior, routing, or service responses were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->