### PR TITLE
fix: close res.json() response in driver statement endpoint

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -307,6 +307,7 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
         total_net_earnings: totalNetEarnings
       },
       trips: tripsList
+    });
   } catch (err) {
     logger.error(err);
     res.status(500).json({ error: 'Internal Server Error', details: err.message, stack: err.stack });


### PR DESCRIPTION
## Summary

This PR fixes a missing closing `});` in the `GET /driver/statement` endpoint.

## Changes

- Added the missing closing `});` for the `res.json()` call.
- Restored the correct syntax before the `catch` block.

## Why

Without the closing `});`, the response object remains unclosed, resulting in a syntax error and preventing the file from parsing correctly.

Closee #1461