### PR TITLE
[GSSoC'26] fix: return straight-line route instead of 404 when no driver assigned

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1630,7 +1630,23 @@ router.get('/:id/route', authenticate, userLimiter, telemetryLimiter, requireRol
     }
 
     if (!order.driver_id) {
-      return res.status(404).json({ error: 'No driver assigned to this order.' });
+      // No driver assigned yet — return a straight-line pickup-to-drop route
+      // so the tracking screen shows a route before driver assignment.
+      const originLat = Number(order.pickup_lat);
+      const originLng = Number(order.pickup_lng);
+      const destLat = Number(order.drop_lat);
+      const destLng = Number(order.drop_lng);
+
+      if (!Number.isFinite(originLat) || !Number.isFinite(originLng) ||
+          !Number.isFinite(destLat) || !Number.isFinite(destLng)) {
+        return res.status(500).json({ error: 'Order has invalid coordinates.' });
+      }
+
+      const feature = buildStraightLineGeometry({ originLat, originLng, destLat, destLng });
+      if (!feature) {
+        return res.status(500).json({ error: 'Failed to compute route.' });
+      }
+      return res.json({ ...feature, fallback: true });
     }
 
     // 2. Query MongoDB telemetry collection for the driver's latest position


### PR DESCRIPTION
## Description

- Fixed `GET /:id/route` returning 404 when no driver is assigned by returning a straight-line pickup-to-drop route instead
- The customer live tracking screen calls `fetchOrderRoute` immediately in `initState`, before any driver is assigned. The 404 left the tracking map with no route polyline until driver assignment.

## Files Changed

- `backend/api/src/routes/orderRoutes.js`: Replaced 404 response with `buildStraightLineGeometry` fallback when `driver_id` is null

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Verified that `buildStraightLineGeometry` is already imported and used in the same handler for OSRM fallback. The coordinates (`pickup_lat`, `pickup_lng`, `drop_lat`, `drop_lng`) are validated as non-null before this point.

Result: Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1105
