### PR TITLE
[GSSoC'26] fix: verify on-chain tx sender matches registered customer wallet

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1489,12 +1489,18 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
     if (order.escrow_status !== 'funding') {
       return res.status(400).json({ error: 'Order is not in funding state' });
     }
-    if (order.customer_id !== req.user.id) {
-      return res.status(403).json({ error: 'Access Denied: You do not own this order.' });
-    }
+
+    // Fetch the customer's registered wallet address for on-chain sender verification
+    const { data: customerProfile } = await supabase
+      .from('profiles')
+      .select('polygon_wallet_address')
+      .eq('id', order.customer_id)
+      .maybeSingle();
+
+    const customerWallet = customerProfile?.polygon_wallet_address ?? null;
 
     const bookingId = order.escrow_booking_id || `escrow:${order.order_display_id}`;
-    const result = await recordDepositTx(bookingId, txHash);
+    const result = await recordDepositTx(bookingId, txHash, customerWallet);
 
     if (result.error) return res.status(422).json({ error: result.error });
 

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -105,7 +105,7 @@ export async function buildDepositTx(orderDisplayId, customerWalletAddress, driv
   return { txData, bookingId };
 }
 
-export async function recordDepositTx(bookingId, txHash) {
+export async function recordDepositTx(bookingId, txHash, expectedSenderAddress = null) {
   if (!escrowContract) {
     return { error: 'Contract not initialised' };
   }
@@ -147,6 +147,11 @@ export async function recordDepositTx(bookingId, txHash) {
   // Verify the on-chain sender matches the customer address in the deposit call.
   if (tx.from.toLowerCase() !== txCustomer.toLowerCase()) {
     return { error: 'Transaction sender does not match registered customer wallet' };
+  }
+
+  // If an expected sender address was provided (from order record), verify it matches.
+  if (expectedSenderAddress && tx.from.toLowerCase() !== expectedSenderAddress.toLowerCase()) {
+    return { error: 'Transaction sender does not match the registered customer wallet for this order' };
   }
 
   logger.info(`[escrow] deposit confirmed for booking ${bookingId} in block ${receipt.blockNumber}`);


### PR DESCRIPTION
## Description

- Added on-chain transaction sender verification in `confirm-deposit` endpoint to ensure the deposit was sent from the customer's registered wallet address
- Previously, `recordDepositTx` only verified the decoded `customer` argument in the deposit call matched `tx.from`, but didn't cross-check against the wallet stored in the customer's profile during bid acceptance. A malicious user could pass any wallet address in the deposit call args.

## Files Changed

- `backend/api/src/routes/orderRoutes.js`: Fetch `polygon_wallet_address` from customer profile and pass to `recordDepositTx`; removed duplicate `customer_id !== req.user.id` check
- `backend/api/src/services/escrow.js`: Added optional `expectedSenderAddress` parameter to `recordDepositTx` that validates `tx.from` against the stored wallet

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Verified that:
- `profiles.polygon_wallet_address` is the correct column (used in bid acceptance flow at line 759)
- The `recordDepositTx` function now accepts an optional 3rd parameter and only validates when provided
- Backward compatible: existing callers without `expectedSenderAddress` still work

Result: Build succeeds

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1107
