### PR TITLE
fix: remove stack trace from driver statement error response

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -213,9 +213,6 @@ app.use((err, req, res, next) => {
 // WEBSOCKET SERVER INIT (wait for MongoDB before accepting WebSocket connections)
 // ============================================================================
 await waitForMongoDb();
-initWebSocketServer(server);
-
-await waitForMongoDb();
 initWebSocketServer(server); // Keep existing
 const io = attachLocationServer(server); // Add new one
 

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -309,7 +309,7 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
       trips: tripsList
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal Server Error', details: err.message, stack: err.stack });
+    res.status(500).json({ error: 'Internal Server Error' });
   }
 });
 


### PR DESCRIPTION
### Closes #1466

## Summary 

This PR removes sensitive error details from the `GET /driver/statement` error response in `backend/api/src/routes/profileRoutes.js`.

### Changes Made

- Removed `details` and `stack` from the `500 Internal Server Error` response.
- Kept server-side error logging with `logger.error(err)` unchanged.

### Why is this change needed?

Returning stack traces and internal error details in API responses can expose implementation details such as file paths, function names, and internal application structure. These details should remain server-side and not be returned to clients.

This change ensures that clients receive a generic error response while preserving detailed logs for debugging on the server.

### Testing

- Verified that the endpoint now returns only a generic `500 Internal Server Error` response.
- Confirmed that errors are still logged on the server using `logger.error(err)`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional real-time location service during app startup, enabling location updates to be available alongside existing live features.

* **Bug Fixes**
  * Standardized unexpected error responses in the driver statement flow to return a generic server error message, improving consistency and avoiding exposure of technical error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->