### PR TITLE
Fix driver location display id lookup

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1535,15 +1535,24 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
 // ============================================================================
 // 19. GET DRIVER LOCATION (CUSTOMER OR DRIVER)
 // ============================================================================
-router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requireRole(['customer', 'driver']), validateParams(uuidParamSchema), async (req, res) => {
+router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requireRole(['customer', 'driver']), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
   try {
     // 1. Resolve order and check authentication / authorization
-    const { data: order, error: orderErr } = await supabase
+    let { data: order, error: orderErr } = await supabase
       .from('orders')
       .select('id, customer_id, driver_id, status')
       .eq('id', orderId)
       .maybeSingle();
+    if (!order && !orderErr) {
+      const result = await supabase
+        .from('orders')
+        .select('id, customer_id, driver_id, status')
+        .eq('order_display_id', orderId)
+        .maybeSingle();
+      order = result.data;
+      orderErr = result.error;
+    }
 
     if (orderErr) {
       return res.status(500).json({ error: 'Failed to fetch order details.' });


### PR DESCRIPTION
## Summary
- allow the driver-location endpoint to accept either an order UUID or an order display id
- resolve by `orders.id` first, then fall back to `order_display_id`

## Impact
Customer live tracking can use the display id already passed by the Flutter client.

Fixes #1515

## Validation
- `node --check backend/api/src/routes/orderRoutes.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver-location lookup so orders can now be found using either the internal order ID or the displayed order reference.
  * Updated request validation for this endpoint to better match accepted order identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->