### PR TITLE
Encode order display ids in API paths

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -14,6 +14,8 @@ class OrderService {
 
   final ApiClient _apiClient;
 
+  String _encodePathSegment(String value) => Uri.encodeComponent(value);
+
   List<Map<String, dynamic>> _historyFromResponse(dynamic body) {
     if (body is Map<String, dynamic>) {
       return List<Map<String, dynamic>>.from(body['history'] as List? ?? []);
@@ -70,7 +72,7 @@ class OrderService {
   }) async {
     try {
       final body = await _apiClient.put(
-        '/api/orders/$orderDisplayId/change-drop',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}/change-drop',
         body: <String, dynamic>{
           'drop_address': dropAddress,
           'drop_lat': dropLat,
@@ -91,7 +93,7 @@ class OrderService {
   }) async {
     try {
       final body = await _apiClient.post(
-        '/api/orders/$orderDisplayId/cancel',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}/cancel',
         body: <String, dynamic>{
           if (reason != null) 'reason': reason,
         },
@@ -107,7 +109,7 @@ class OrderService {
   Future<Map<String, dynamic>?> fetchOrderById(String orderDisplayId) async {
     try {
       final body = await _apiClient.get(
-        '/api/orders/$orderDisplayId',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}',
       ) as Map<String, dynamic>?;
       return body?['order'] as Map<String, dynamic>?;
     } on ApiException catch (e) {
@@ -136,7 +138,7 @@ class OrderService {
   ) async {
     try {
       final body = await _apiClient.get(
-        '/api/orders/$orderDisplayId/timeline',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}/timeline',
       );
       return List<Map<String, dynamic>>.from(body as List);
     } on ApiException catch (e) {
@@ -285,7 +287,7 @@ class OrderService {
   Future<Map<String, dynamic>> fetchDriverLocation(String orderDisplayId) async {
     try {
       final body = await _apiClient.get(
-        '/api/orders/$orderDisplayId/driver-location',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}/driver-location',
       );
       return body is Map<String, dynamic> ? body : <String, dynamic>{};
     } on ApiException catch (e) {
@@ -298,7 +300,7 @@ class OrderService {
   Future<Map<String, dynamic>> fetchOrderRoute(String orderDisplayId) async {
     try {
       final body = await _apiClient.get(
-        '/api/orders/$orderDisplayId/route',
+        '/api/orders/${_encodePathSegment(orderDisplayId)}/route',
       );
       return body is Map<String, dynamic> ? body : <String, dynamic>{};
     } on ApiException catch (e) {


### PR DESCRIPTION
## Summary
- encode order display ids before using them as API path segments
- cover order detail, timeline, change-drop, cancel, driver-location, and route calls

## Impact
Display ids with reserved URL characters such as `#` no longer truncate the request path.

Fixes #1516

## Validation
- `dart format apps/customer/lib/services/order_service.dart` could not run because `dart` is not installed in this environment
