### PR TITLE
Skip order telemetry without active order

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -141,6 +141,10 @@ class LocationService {
 
       final orderId = _activeOrderId;
       final orderDisplayId = _activeOrderDisplayId;
+      if (orderId == null || orderDisplayId == null) {
+        debugPrint('[LocationService] No active order found; skipping order telemetry ping');
+        return;
+      }
 
       // 2. Ensure WebSocket is connected
       if (_channel == null) {


### PR DESCRIPTION
## Summary
- skip order telemetry pings when the driver app cannot resolve an active order
- avoid opening the tracking WebSocket for null order identifiers

## Impact
Telemetry records are not written with null `order_id` or `order_display_id` when a driver has no active shipment.

Fixes #1517

## Validation
- `dart` is not installed in this environment, so Flutter/Dart checks could not be run
