### PR TITLE
Show delivery OTP in customer notification

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -181,7 +181,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
   logger.info(`[NotificationService] Delivering OTP for Order ${orderDisplayId} to Customer ${customerId}`);
 
   const title = 'Delivery Verification OTP';
-  const body = `Your delivery OTP for order ${orderDisplayId} is ready. Share this with the driver only after verifying your cargo has arrived safely.`;
+  const body = `Your delivery OTP for order ${orderDisplayId} is ${otp}. Share this with the driver only after verifying your cargo has arrived safely.`;
   const otpHash = crypto.createHash('sha256').update(String(otp)).digest('hex');
 
   let dbSuccess = false;
@@ -208,8 +208,8 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
 
   let fcmResult;
   try { fcmResult = await sendFcmNotification(
-    customerId,
-    { title: 'Delivery Verification OTP', body: `A delivery OTP has been generated for order ${orderDisplayId}. Open the app to view the code.` },
+      customerId,
+    { title: 'Delivery Verification OTP', body },
     { orderDisplayId, notifType: 'delivery_otp' }
   ); } catch (_) { /* logged internally by sendFcmNotification */ }
 


### PR DESCRIPTION
## Summary
- include the generated delivery OTP in the customer notification body
- reuse the same body for database and FCM notification delivery
- keep notification metadata limited to the existing OTP hash

## Impact
Customers can see the six-digit delivery code they need to share after verifying the cargo.

Fixes #1521

## Validation
- `node --check backend/api/src/services/notificationService.js`
