### PR TITLE
fix: invalidate FCM tokens on logout

### DIFF
--- a/SEC_1493.md
+++ b/SEC_1493.md
@@ -1,0 +1,1 @@
+FCM token fix


### PR DESCRIPTION
Closes #1493