### PR TITLE
fix: add runtime permission check for geolocation requests

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -34,6 +35,21 @@ class LocationService {
 
   Future<void> startTracking() async {
     if (_isTracking) return;
+
+    // Check location permission before starting tracking (fixes #1491)
+    final permission = await Permission.location.request();
+
+    if (permission.isDenied) {
+      debugPrint('[LocationService] Location permission denied');
+      throw Exception('Location permission is required to start tracking');
+    }
+
+    if (permission.isPermanentlyDenied) {
+      debugPrint('[LocationService] Location permission permanently denied');
+      openAppSettings();
+      throw Exception('Location permissions are permanently denied. Please enable in app settings.');
+    }
+
     _isTracking = true;
     debugPrint('[LocationService] Starting driver location tracking...');
     _startPositionSubscription();


### PR DESCRIPTION
## Problem

Flutter app requests geolocation without checking runtime permissions, causing `PlatformException` crash on Android 10+ and iOS 14+.

## Solution

Added runtime permission check in `LocationService.startTracking()`:
- Requests location permission using `permission_handler` package
- Throws descriptive exception if permission denied
- Guides user to app settings if permission permanently denied
- Only starts position subscription if permission granted

## Changes
- Modified `apps/driver/lib/services/location_service.dart`:
  - Import `permission_handler/permission_handler.dart`
  - Add permission check before `_startPositionSubscription()` call
  - Handle denied, temporarily denied, and permanently denied cases

## Testing
- Test with permission denied: should throw exception
- Test with permanent denial: should suggest opening app settings
- Test with granted: should start tracking normally

Closes #1491