### PR TITLE
fix: escrow race conditions and missing atomicity in order lifecycle (fix #1558)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -829,10 +829,6 @@ router.post('/:id/bids/:bidId/accept', authenticate, userLimiter, requireRole(['
           } else {
             depositTxData = txData;
           }
-          await supabase.from('orders').update({
-            escrow_booking_id: bookingId,
-            escrow_status: 'funding',
-          }).eq('id', orderId);
         }
       }
     }
@@ -846,16 +842,19 @@ router.post('/:id/bids/:bidId/accept', authenticate, userLimiter, requireRole(['
     });
 
     if (rpcErr) {
-      // Rollback the pre-update so the order is not left in an impossible state
-      await supabase
-        .from('orders')
-        .update({ escrow_status: 'pending', escrow_booking_id: null })
-        .eq('id', orderId);
       return res.status(500).json({
         error: 'Failed to accept bid atomically.',
         details: rpcErr.message,
-        recovery: 'The pending escrow deposit has been voided. Please try again.'
       });
+    }
+
+    // Phase 3: Only after bid is accepted, write escrow pre-update to DB
+    if (depositTxData) {
+      const bookingId = bookingIdFromUuid(order.order_display_id);
+      await supabase.from('orders').update({
+        escrow_booking_id: bookingId,
+        escrow_status: 'funding',
+      }).eq('id', orderId);
     }
 
     res.json({
@@ -1496,6 +1495,17 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
   const orderId = req.params.id;
   const { txHash } = req.body;
 
+  const lockKey = `deposit_lock:${orderId}`;
+  const lockTimeoutMs = 10000;
+  let lockValue = null;
+  if (redisClient) {
+    lockValue = crypto.randomUUID();
+    const acquired = await redisClient.set(lockKey, lockValue, 'PX', lockTimeoutMs, 'NX');
+    if (!acquired) {
+      return res.status(409).json({ error: 'Another deposit confirmation is in progress for this order. Please try again.' });
+    }
+  }
+
   try {
     const { data: order, error: fetchErr } = await supabase
       .from('orders')
@@ -1511,6 +1521,14 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
       return res.status(400).json({ error: 'Order is not in funding state' });
     }
 
+    const { data: customerProfile } = await supabase
+      .from('profiles')
+      .select('polygon_wallet_address')
+      .eq('id', req.user.id)
+      .maybeSingle();
+
+    const customerWallet = customerProfile?.polygon_wallet_address ?? null;
+
     const bookingId = order.escrow_booking_id || `escrow:${order.order_display_id}`;
     const result = await recordDepositTx(bookingId, txHash, customerWallet);
 
@@ -1520,7 +1538,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
       escrow_status: 'funded',
       deposit_tx_hash: result.txHash,
       escrow_deposited_at: new Date().toISOString(),
-    }).eq('id', orderId);
+    }).eq('id', orderId).eq('escrow_status', 'funding');
 
     if (updateErr) {
       logger.error('[confirm-deposit] DB update failed:', updateErr.message);
@@ -1531,6 +1549,21 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requireRole(['cus
   } catch (err) {
     logger.error('[confirm-deposit] Exception:', err.message);
     res.status(500).json({ error: 'Internal Server Error' });
+  } finally {
+    if (redisClient && lockValue) {
+      const luaScript = `
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+          redis.call('DEL', KEYS[1])
+          return 1
+        end
+        return 0
+      `;
+      try {
+        await redisClient.eval(luaScript, 1, lockKey, lockValue);
+      } catch (err) {
+        logger.warn('[confirm-deposit] Failed to release deposit lock for key %s: %s', lockKey, err.message);
+      }
+    }
   }
 });
 

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -113,6 +113,17 @@ export async function recordDepositTx(bookingId, txHash, expectedSenderAddress =
     return { error: 'Invalid transaction hash' };
   }
 
+  // Idempotency: check if this booking already has a funded escrow on-chain
+  try {
+    const escrow = await escrowContract.escrows(bookingId);
+    if (escrow && (escrow.status === 1 || Number(escrow.status) === 1)) {
+      logger.info(`[escrow] Booking ${bookingId} already has a funded escrow — idempotency skip.`);
+      return { txHash: txHash, bookingId, alreadyFunded: true };
+    }
+  } catch (err) {
+    logger.warn(`[escrow] Failed to check existing escrow status for ${bookingId}: ${err.message}, proceeding.`);
+  }
+
   const provider = escrowContract.runner.provider;
   const receipt = await provider.waitForTransaction(txHash, 1);
   if (!receipt || receipt.status === 0) {


### PR DESCRIPTION
## Description

The order bid-acceptance → escrow-deposit → delivery-completion lifecycle suffers from multiple race conditions and a lack of atomicity between blockchain state and database state that could result in double-spending, lost funds, and inconsistent order states.

## Changes

### 1. Distributed lock on confirm-deposit endpoint (`orderRoutes.js`)
- Added a Redis distributed lock (same pattern as bid-accept) before reading order state
- Prevents two concurrent `confirm-deposit` requests from both passing the status check

### 2. Optimistic WHERE on status transitions (`orderRoutes.js`)
- Added `.eq('escrow_status', 'funding')` to the DB update in confirm-deposit
- Ensures only one request can transition `funding → funded`

### 3. Move escrow pre-update after RPC in bid-accept (`orderRoutes.js`)
- The `escrow_booking_id` / `escrow_status = 'funding'` DB write was moved from Phase 1 to **after** `accept_bid_tx` RPC succeeds
- Prevents the order being stuck in `escrow_status='funding'` with no driver assigned if the process crashes between DB update and RPC call

### 4. Idempotency check in recordDepositTx (`escrow.js`)
- Added on-chain check: if `escrows(bookingId).status === 1` (funded), skip and return `alreadyFunded: true`
- Prevents double-funding when the same txHash is submitted twice

### 5. Fetch customerWallet in confirm-deposit (`orderRoutes.js`)
- Added lookup of `profiles.polygon_wallet_address` for the customer
- The `customerWallet` variable was previously undefined (passed as `null`), which skipped sender verification

Closes #1558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow handling during bid acceptance and deposit confirmation to reduce duplicate or conflicting updates.
  * Added safeguards so deposit confirmations are processed only once at a time.
  * Better handles cases where an escrow is already funded, avoiding unnecessary повтор processing and speeding up repeat confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->