### PR TITLE
fix: route driver Flutter app write operations through backend API (fix #1559)

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -150,82 +150,36 @@ class TripService {
     String stopId,
     String tripDisplayId,
   ) async {
-    await _verifyTripOwnership(tripDisplayId);
+    final uri = Uri.parse('$_apiBaseUrl/api/trips/$tripDisplayId/stops/$stopId/complete');
+    final response = await _httpClient.put(uri, headers: await _authHeaders());
 
-    final updatedStop = await _client.from('trip_stops').update({
-      'is_completed': true,
-      'is_current': false,
-    }).eq('id', stopId).eq('trip_display_id', tripDisplayId).select().maybeSingle();
-
-    if (updatedStop == null) {
-      throw Exception('Stop not found or does not belong to this trip');
-    }
-
-    final nextStops = await _client
-        .from('trip_stops')
-        .select()
-        .eq('trip_display_id', tripDisplayId)
-        .eq('is_completed', false)
-        .order('sort_order')
-        .limit(1);
-
-    if (nextStops.isNotEmpty) {
-      await _client
-          .from('trip_stops')
-          .update({'is_current': true})
-          .eq('id', nextStops.first['id'])
-          .eq('trip_display_id', tripDisplayId);
-    } else {
-      await _client
-          .from('trips')
-          .update({'status': 'completed'})
-          .eq('trip_display_id', tripDisplayId)
-          .eq('driver_id', _driverId);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      throw Exception(body?['error'] as String? ?? 'Failed to mark stop completed');
     }
   }
-  Future<void> updateOnlineStatus(bool isOnline) async {
-    final updated = await _client
-        .from('driver_details')
-        .update({
-          'is_online': isOnline,
-          'updated_at': DateTime.now().toIso8601String(),
-        })
-        .eq('user_id', _driverId)
-        .select()
-        .maybeSingle();
 
-    if (updated == null) {
-      throw Exception('Driver profile not found or update failed');
+  Future<void> updateOnlineStatus(bool isOnline) async {
+    final uri = Uri.parse('$_apiBaseUrl/api/driver/online');
+    final response = await _httpClient.put(
+      uri,
+      headers: await _authHeaders(),
+      body: jsonEncode(<String, dynamic>{'is_online': isOnline}),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      throw Exception(body?['error'] as String? ?? 'Failed to update online status');
     }
   }
 
   Future<void> startTrip(String tripDisplayId) async {
-    await _verifyTripOwnership(tripDisplayId);
+    final uri = Uri.parse('$_apiBaseUrl/api/trips/$tripDisplayId/start');
+    final response = await _httpClient.put(uri, headers: await _authHeaders());
 
-    // Find the first stop of this trip that is not completed
-    final stops = await _client
-        .from('trip_stops')
-        .select()
-        .eq('trip_display_id', tripDisplayId)
-        .eq('is_completed', false)
-        .order('sort_order')
-        .limit(1);
-
-    if (stops.isEmpty) {
-      throw Exception('No active stops found for this trip');
-    }
-
-    final firstStopId = stops.first['id'];
-    final updatedStop = await _client
-        .from('trip_stops')
-        .update({'is_current': true})
-        .eq('id', firstStopId)
-        .eq('trip_display_id', tripDisplayId)
-        .select()
-        .maybeSingle();
-
-    if (updatedStop == null) {
-      throw Exception('Failed to start trip: Stop not found or update failed');
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      throw Exception(body?['error'] as String? ?? 'Failed to start trip');
     }
   }
 }

--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -381,4 +381,82 @@ router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
   }
 });
 
+// ============================================================================
+// MARK STOP COMPLETED (DRIVER)
+// ============================================================================
+router.put('/:tripDisplayId/stops/:stopId/complete', authenticate, userLimiter, requireRole(['driver']), async (req, res) => {
+  const { tripDisplayId, stopId } = req.params;
+
+  try {
+    const { data: trip } = await supabase.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
+    if (!trip) return res.status(403).json({ error: 'Access Denied: Trip does not belong to you.' });
+
+    const updatedStop = await supabase.from('trip_stops').update({
+      is_completed: true,
+      is_current: false,
+    }).eq('id', stopId).eq('trip_display_id', tripDisplayId).select().maybeSingle();
+
+    if (!updatedStop.data) return res.status(404).json({ error: 'Stop not found or does not belong to this trip.' });
+
+    const nextStops = await supabase.from('trip_stops').select()
+      .eq('trip_display_id', tripDisplayId)
+      .eq('is_completed', false)
+      .order('sort_order')
+      .limit(1);
+
+    if (nextStops.data && nextStops.data.length > 0) {
+      await supabase.from('trip_stops').update({ is_current: true })
+        .eq('id', nextStops.data[0].id)
+        .eq('trip_display_id', tripDisplayId);
+    } else {
+      await supabase.from('trips').update({ status: 'completed' })
+        .eq('trip_display_id', tripDisplayId)
+        .eq('driver_id', req.user.id);
+    }
+
+    res.json({ message: 'Stop marked as completed.' });
+  } catch (err) {
+    logger.error('[tripRoutes] markStopCompleted error:', err.message);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// START TRIP (DRIVER)
+// ============================================================================
+router.put('/:tripDisplayId/start', authenticate, userLimiter, requireRole(['driver']), async (req, res) => {
+  const { tripDisplayId } = req.params;
+
+  try {
+    const { data: trip } = await supabase.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
+    if (!trip) return res.status(403).json({ error: 'Access Denied: Trip does not belong to you.' });
+
+    const stops = await supabase.from('trip_stops').select()
+      .eq('trip_display_id', tripDisplayId)
+      .eq('is_completed', false)
+      .order('sort_order')
+      .limit(1);
+
+    if (!stops.data || stops.data.length === 0) {
+      return res.status(400).json({ error: 'No active stops found for this trip.' });
+    }
+
+    const firstStopId = stops.data[0].id;
+    const updatedStop = await supabase.from('trip_stops').update({ is_current: true })
+      .eq('id', firstStopId)
+      .eq('trip_display_id', tripDisplayId)
+      .select()
+      .maybeSingle();
+
+    if (!updatedStop.data) {
+      return res.status(500).json({ error: 'Failed to start trip: Stop not found or update failed.' });
+    }
+
+    res.json({ message: 'Trip started.', stop_id: firstStopId });
+  } catch (err) {
+    logger.error('[tripRoutes] startTrip error:', err.message);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Description

The driver Flutter app (`trip_service.dart`) performs critical order lifecycle mutations by calling Supabase directly via the client-side SDK, completely bypassing the Express backend API, its authentication middleware, rate limiters, input validation, audit logging, and escrow integrity checks.

## Changes

### Flutter App (`trip_service.dart`)
- `markStopCompleted()`: Now calls `PUT /api/trips/:displayId/stops/:stopId/complete` instead of `_client.from('trip_stops').update(...)`
- `updateOnlineStatus()`: Now calls `PUT /api/driver/online` instead of `_client.from('driver_details').update(...)`
- `startTrip()`: Now calls `PUT /api/trips/:displayId/start` instead of `_client.from('trip_stops').update(...)`

### Backend (`tripRoutes.js`)
- Added `PUT /:tripDisplayId/stops/:stopId/complete` — marks a stop completed, advances to next stop or completes trip
- Added `PUT /:tripDisplayId/start` — marks the first uncompleted stop as current

Closes #1559