### PR TITLE
fix: consolidate two competing module.exports in hardhat.config.cjs (fix #1560)

### DIFF
--- a/blockchain/hardhat.config.cjs
+++ b/blockchain/hardhat.config.cjs
@@ -38,36 +38,3 @@ module.exports = {
     },
   },
 };
-
-/** @type import('hardhat/config').HardhatUserConfig */
-module.exports = {
-  solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
-      },
-    },
-  },
-  networks: {
-    // Local Hardhat network for testing
-    hardhat: {},
-
-    // Polygon Mumbai testnet (for staging)
-    polygonMumbai: {
-      url: process.env.POLYGON_MUMBAI_RPC_URL || "",
-      accounts: process.env.DEPLOYER_PRIVATE_KEY
-        ? [process.env.DEPLOYER_PRIVATE_KEY]
-        : [],
-    },
-
-    // Polygon Mainnet (production)
-    polygon: {
-      url: process.env.POLYGON_MAINNET_RPC_URL || "",
-      accounts: process.env.DEPLOYER_PRIVATE_KEY
-        ? [process.env.DEPLOYER_PRIVATE_KEY]
-        : [],
-    },
-  },
-};


### PR DESCRIPTION
## Description

`blockchain/hardhat.config.cjs` contains two separate `module.exports` blocks. In CommonJS, the second `module.exports` completely overwrites the first. This causes the Amoy (Polygon testnet, chainId 80002, Solidity 0.8.24) configuration to be silently dropped, and the deprecated Mumbai network (Solidity 0.8.20) is used instead.

## Changes

- Removed the second `module.exports` block (lines 42-73) containing the deprecated Mumbai config
- Kept the first config with:
  - Solidity 0.8.24 with optimizer enabled
  - Amoy testnet (chainId 80002, via `POLYGON_RPC_URL`)
  - Polygon mainnet (chainId 137)
  - Etherscan API key configuration for contract verification

Closes #1560