### PR TITLE
fix: add stored metadata field for timeseries metaField instead of virtual getter

### DIFF
--- a/backend/api/src/models/GpsLog.js
+++ b/backend/api/src/models/GpsLog.js
@@ -59,6 +59,10 @@ const gpsLogSchema = new mongoose.Schema({
         type: Number,
         default: null,
     },
+    metadata: {
+        type: mongoose.Schema.Types.Mixed,
+        default: {},
+    },
 }, {
     timeseries: {
         timeField: "timestamp",
@@ -70,13 +74,5 @@ const gpsLogSchema = new mongoose.Schema({
 
 // Compound index for faster queries by bookingId + timestamp
 gpsLogSchema.index({ bookingId: 1, timestamp: -1 });
-
-// Virtual field to group metadata together
-gpsLogSchema.virtual("metadata").get(function() {
-    return {
-        bookingId: this.bookingId,
-        driverId: this.driverId,
-    };
-});
 
 export const GpsLog = mongoose.model("GpsLog", gpsLogSchema);


### PR DESCRIPTION
## Description

The Mongoose timeseries schema has `metaField: 'metadata'` referencing a **virtual getter** that is never persisted to MongoDB. Virtuals are computed values excluded from serialization by default in Mongoose. Timeseries collections require the `metaField` to be an actual stored field in every document.

## Changes

- Added a real `metadata` field (`Schema.Types.Mixed`) to the schema definition
- Removed the virtual getter since the stored field now serves the same purpose

Closes #1585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how GPS telemetry grouping information is stored, making location logs more reliable and consistent.
  * Ensured telemetry metadata is saved directly with each log entry, helping preserve grouping details across reads and writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->