### PR TITLE
fix: call channel.subscribe() on Supabase Realtime channel for driver location broadcasts

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -546,6 +546,7 @@ export async function handleLocationPing(ws, data) {
   if (supabase && orderUUID) {
     if (!locationChannels.has(orderUUID)) {
       const channel = supabase.channel(`driver-location:${orderUUID}`);
+      channel.subscribe();
       locationChannels.set(orderUUID, channel);
     }
     const channel = locationChannels.get(orderUUID);


### PR DESCRIPTION
## Description

In `tracker.js`, the Supabase Realtime channel for driver-location broadcasts is created via `supabase.channel()` but `channel.subscribe()` is never called. Without subscribing, the channel is never activated and all `channel.send()` calls silently fail. This means all real-time driver location updates through this path are effectively non-functional.

## Changes

- Added `channel.subscribe()` after channel creation (1 line)

Closes #1586