### PR TITLE
fix: add missing import for attachLocationServer from locationServer.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -12,6 +12,7 @@ import deviceRoutes from './routes/deviceRoutes.js';
 
 import { closeDbConnections, waitForMongoDb, validateConfig } from './config/db.js';
 import { closeWebSocketServer, initWebSocketServer } from './sockets/tracker.js';
+import { attachLocationServer } from './sockets/locationServer.js';
 import { startEscrowReleaseReconciliation } from './services/escrowReleaseReconciliation.js';
 
 // Load REST routes


### PR DESCRIPTION
## Description

In `index.js`, `attachLocationServer(server)` is called at line 179 but the function is never imported. It is defined and exported from `./sockets/locationServer.js` but the only socket import is `{ closeWebSocketServer, initWebSocketServer }` from `./sockets/tracker.js`. Calling an undefined identifier throws a `ReferenceError` at module evaluation time, preventing the server from starting.

## Changes

- Added `import { attachLocationServer } from './sockets/locationServer.js'`

Closes #1587