### PR TITLE
fix: remove duplicate const declarations for page/limit in GET /trips handler

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -250,16 +250,6 @@ router.get('/trips', authenticate, userLimiter, requireRole(['driver']), async (
   const { status } = req.query;
   const pageParam = req.query.page ?? '1';
   const limitParam = req.query.limit ?? '10';
-  const page = typeof pageParam === 'string' ? Number(pageParam) : NaN;
-  const limit = typeof limitParam === 'string' ? Number(limitParam) : NaN;
-
-  if (!Number.isInteger(page) || page < 1) {
-    return res.status(400).json({ error: 'page must be greater than or equal to 1' });
-  }
-
-  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
-    return res.status(400).json({ error: 'limit must be between 1 and 100' });
-  }
   const rawPage = req.query.page;
   const rawLimit = req.query.limit;
   const parsedPage = parseInt(rawPage, 10);


### PR DESCRIPTION
## Description

In `driverRoutes.js`, the GET `/trips` route handler declares `const page` and `const limit` **twice** in the same block scope (lines 253-254 and 273-274). In strict mode (ES modules are always strict), redeclaring a `const` variable in the same scope throws a `SyntaxError` at parse time.

This prevents the entire arrow function from being parsed, meaning the route is never registered. Six route endpoints become unavailable (GET /trips, GET /stats, PUT /online, GET /wallet/history, GET /earnings/summary, GET /bids).

## Changes

- Removed the redundant first declaration block (lines 253-262) that used `Number()` coercion, keeping the second block that uses `parseInt()` for more tolerant parsing

Closes #1589