### PR TITLE
fix: replace undefined normalizeCategoryAlias calls with inline CATEGORY_MAP lookup

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -167,7 +167,8 @@ router.get('/tickets', authenticate, userLimiter, async (req, res) => {
   const pageNum = parsedPage;
   const limitNum = Math.min(100, parsedLimit);
   const offset = (pageNum - 1) * limitNum;
-  const dbCategory = normalizeCategoryAlias(category);
+  const normalizedCategory = typeof category === 'string' ? category.toLowerCase().trim() : '';
+  const dbCategory = CATEGORY_MAP[normalizedCategory] || null;
 
   if (category && !dbCategory) {
     return res.status(400).json({ error: 'Unsupported support ticket category.' });
@@ -347,7 +348,8 @@ router.get('/admin/tickets', authenticate, userLimiter, requireRole(['admin']), 
   const pageNum = parsedPage;
   const limitNum = Math.min(100, parsedLimit);
   const offset = (pageNum - 1) * limitNum;
-  const dbCategory = normalizeCategoryAlias(category);
+  const normalizedCategory = typeof category === 'string' ? category.toLowerCase().trim() : '';
+  const dbCategory = CATEGORY_MAP[normalizedCategory] || null;
 
   if (category && !dbCategory) {
     return res.status(400).json({ error: 'Unsupported support ticket category.' });


### PR DESCRIPTION
## Description

In `supportRoutes.js`, two endpoints (GET /tickets and GET /admin/tickets) call `normalizeCategoryAlias(category)` which is **never defined** anywhere in the file or imported from any module. Any request that passes a `category` query parameter will throw `ReferenceError: normalizeCategoryAlias is not defined`, returning an unhandled 500 error.

Every other route in the file that needs category normalization uses inline code with `CATEGORY_MAP`. This fix applies the same pattern.

## Changes

- Replaced both `normalizeCategoryAlias(category)` calls with inline `typeof category === 'string' ? category.toLowerCase().trim() : ''` and `CATEGORY_MAP[normalizedCategory] || null` lookup

Closes #1590