### PR TITLE
fix: Remove duplicate logger import in escrowReleaseReconciliation.js(#1610)

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -2,7 +2,6 @@ import { supabase, redisClient } from '../config/db.js';
 import { escrowRelease } from './escrow.js';
 import logger from '../middleware/logger.js';
 import os from 'os';
-import logger from '../middleware/logger.js';
 const DEFAULT_INTERVAL_MS = 60_000;
 const LOCK_KEY = 'escrow:release:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;


### PR DESCRIPTION
## Summary
`escrowReleaseReconciliation.js` has `import logger` on both lines 3 and 5, causing an ESLint `no-duplicate-imports` error.

## Changes
- Removed the duplicate `import logger from '../middleware/logger.js'` on line 5

## Testing
- ESLint no longer flags the file

Closes #1610