### PR TITLE
fix: Prevent telemetry flush buffer race condition via deep clone and deferred mutex release (#1612)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -587,19 +587,17 @@ async function flushTelemetryBuffer() {
   if (flushMutex) return;
   flushMutex = true;
 
-  // Atomic double-buffer swap: copy flushBuffer, then swap references so active buffer
-  // becomes the new flush buffer and a fresh active buffer is created.
-  // Any concurrent push to the old active buffer is captured in the flush buffer for next cycle.
-  const recordsToFlush = telemetryFlushBuffer.length > 0 ? telemetryFlushBuffer : telemetryWriteBuffer;
+  const recordsToFlush = [...(telemetryFlushBuffer.length > 0 ? telemetryFlushBuffer : telemetryWriteBuffer)];
   if (telemetryFlushBuffer.length > 0) {
     telemetryFlushBuffer = [];
   }
   telemetryFlushBuffer = telemetryWriteBuffer;
   telemetryWriteBuffer = [];
 
-  flushMutex = false;
-
-  if (recordsToFlush.length === 0) return;
+  if (recordsToFlush.length === 0) {
+    flushMutex = false;
+    return;
+  }
 
   currentFlushPromise = (async () => {
     logger.info(`[TRUXIFY BATCH CONTROL] Committing bulk cluster of ${recordsToFlush.length} spatial rows to MongoDB...`);
@@ -622,7 +620,6 @@ async function flushTelemetryBuffer() {
         } else {
           logger.error(`[TRUXIFY VALIDATION] Bulk insert validation error: ${err.message}`);
         }
-        // Prepend succeeded records to the FRONT for oldest-first retry priority
         const succeeded = err.writeErrors
           ? recordsToFlush.filter((_, i) => !err.writeErrors.some(e => e.index === i))
           : [];
@@ -638,7 +635,6 @@ async function flushTelemetryBuffer() {
         }
       } else {
         flushBackoffMs = Math.min(flushBackoffMs * 2, 60000);
-        // Prepend failed records to the FRONT for oldest-first retry priority
         telemetryFlushBuffer = [...recordsToFlush, ...telemetryFlushBuffer];
         if (telemetryFlushBuffer.length > MAX_BUFFER_SIZE) {
           const overflowDrop = telemetryFlushBuffer.length - MAX_BUFFER_SIZE;
@@ -650,6 +646,7 @@ async function flushTelemetryBuffer() {
       }
     } finally {
       currentFlushPromise = null;
+      flushMutex = false;
     }
   })();
 


### PR DESCRIPTION
## Summary
`flushTelemetryBuffer()` in `tracker.js` has a race condition: the buffer swap assigns a reference (not a copy) and releases the mutex before the async `insertMany` completes, allowing concurrent mutations.

## Changes
- Deep-clone `recordsToFlush` via spread `[...]` instead of reference assignment
- Moved `flushMutex = false` into the `finally` block so the mutex is held until `insertMany` completes
- Removed the redundant early `flushMutex = false` between swap and async insert

## Testing
- Concurrent flush calls are now serialized by the mutex
- Buffer swap no longer risks data loss from aliased array references

Closes #1612