### PR TITLE
fix(driver): supabase_config import path + wallet URL uses env var

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -12,7 +12,7 @@ import '../theme/app_theme.dart';
 import '../widgets/common_widgets.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../services/fcm_service.dart';
-import '../../core/supabase_config.dart';
+import '../core/supabase_config.dart';
 import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen;
 import 'notifications_screen.dart';
 import '../utils/validators.dart';
@@ -495,7 +495,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     final token = client.auth.currentSession?.accessToken;
                     final userId = client.auth.currentUser?.id ?? '';
                     final response = await http.put(
-                      Uri.parse('http://localhost:5000/api/profile/wallet'),
+                      Uri.parse('${const String.fromEnvironment('TRUXIFY_API_BASE_URL', defaultValue: 'http://localhost:5000')}/api/profile/wallet'),
                       headers: <String, String>{
                         'Content-Type': 'application/json',
                         if (token != null) 'Authorization': 'Bearer $token',


### PR DESCRIPTION
Closes #1635 and #1637

## #1635 - Wrong import path
\pps/driver/lib/screens/profile_screen.dart\ imported \../../core/supabase_config.dart\ which resolves to a non-existent file. Fixed to \../core/supabase_config.dart\.

## #1637 - Hardcoded localhost URL
Wallet endpoint hardcoded \http://localhost:5000/api/profile/wallet\. Now reads from \TRUXIFY_API_BASE_URL\ env var.

@KanishJebaMathewM **Why important**: #1635 is a compilation error - the app can't build. #1637 breaks wallet updates in production. Both are shipping blockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the wallet address save flow to use the configured API base URL, with a localhost fallback.
  * Corrected an app configuration reference so the profile screen can load settings more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->