### PR TITLE
fix(shared): DropdownButtonFormField value parameter

### DIFF
--- a/packages/truxify_shared/lib/src/screens/help_center_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/help_center_screen.dart
@@ -97,7 +97,7 @@ class _HelpCenterScreenState extends State<HelpCenterScreen> {
           TextField(controller: _subjectController, decoration: const InputDecoration(labelText: 'Subject')),
           const SizedBox(height: 12),
           DropdownButtonFormField<String>(
-            initialValue: _category,
+            value: _category,
             items: const ['General', 'Booking', 'Billing', 'Technical'].map((value) => DropdownMenuItem(value: value, child: Text(value))).toList(),
             onChanged: (value) => setState(() => _category = value ?? 'General'),
             decoration: const InputDecoration(labelText: 'Category'),


### PR DESCRIPTION
Closes #1636

\packages/truxify_shared/lib/src/screens/help_center_screen.dart:100\ passed \initialValue:\ to \DropdownButtonFormField\, but that parameter doesn't exist in Flutter's API. The correct parameter is \alue:\. This is a compilation error.

@KanishJebaMathewM **Why important**: Compilation error - the shared package can't be built. Blocks both customer and driver apps.