### PR TITLE
fix(customer): wallet API URL uses env var instead of hardcoded localhost

### DIFF
--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -244,7 +244,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       final token = client.auth.currentSession?.accessToken;
                       final userId = client.auth.currentUser?.id ?? '';
                       final response = await http.put(
-                        Uri.parse('http://localhost:5000/api/profile/wallet'),
+                        Uri.parse('${const String.fromEnvironment('TRUXIFY_API_BASE_URL', defaultValue: 'http://localhost:5000')}/api/profile/wallet'),
                         headers: <String, String>{
                           'Content-Type': 'application/json',
                           if (token != null) 'Authorization': 'Bearer $token',


### PR DESCRIPTION
Closes #1638

The wallet address update endpoint in \pps/customer/lib/screens/profile_screen.dart:247\ hardcoded \http://localhost:5000/api/profile/wallet\. Changed to read from \TRUXIFY_API_BASE_URL\ env var like the rest of the app.

@KanishJebaMathewM **Why important**: Wallet updates silently fail in staging/production. Customers can never save their blockchain wallet address outside of local dev.