### PR TITLE
fix(driver): normalize route label separator before split

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -826,7 +826,8 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
 
   Future<_RouteResult?> _loadRouteForTrip(String routeLabel) async {
     try {
-      final parts = routeLabel.split('→');
+      final normalized = routeLabel.replaceAll('->', '→').replaceAll('=>', '→');
+      final parts = normalized.split('→');
       final startLabel = parts.isNotEmpty ? parts[0].trim() : '';
       final endLabel = parts.length > 1 ? parts[1].trim() : '';
 


### PR DESCRIPTION
Closes #1642

trip_detail_screen.dart:829 split routeLabel on Unicode '→' only. If the backend sends '->' or '=>', the destination geocoding silently fails. Now normalizes all common separators before splitting.

@KanishJebaMathewM **Why important**: Route map display breaks silently if the backend ever changes its separator format, causing poor UX with incomplete routes shown to drivers.