### PR TITLE
fix(driver): safe type casts in marketplace and geocode services

### DIFF
--- a/apps/driver/lib/services/geocode_service.dart
+++ b/apps/driver/lib/services/geocode_service.dart
@@ -48,7 +48,12 @@ class GeocodeService {
         return null;
       }
 
-      final item = decoded.first as Map<String, dynamic>;
+      final first = decoded.first;
+      if (first is! Map<String, dynamic>) {
+        _addToCache(key, null);
+        return null;
+      }
+      final item = first;
       final lat = double.tryParse('${item['lat']}');
       final lon = double.tryParse('${item['lon']}');
       if (lat == null || lon == null) {

--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -48,8 +48,9 @@ class MarketplaceRepository {
       throw StateError('Failed to fetch load offers');
     }
 
-    final body = jsonDecode(response.body) as List;
-    return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List) throw StateError('Unexpected response type');
+    return decoded.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
   }
 
   Future<List<LoadOffer>> fetchEnRouteLoads() async {
@@ -60,7 +61,8 @@ class MarketplaceRepository {
       throw StateError('Failed to fetch en-route loads');
     }
 
-    final body = jsonDecode(response.body) as List;
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List) throw StateError('Unexpected response type');
     return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
   }
 


### PR DESCRIPTION
Closes #1645 and #1660

## #1645 - Unsafe as List cast
marketplace_repository.dart lines 51,63 used jsonDecode(response.body) as List which throws TypeError if the API returns an error object. Now uses is! List check first.

## #1660 - Unsafe as Map cast
geocode_service.dart line 51 used decoded.first as Map<String, dynamic> which throws if Nominatim returns unexpected data. Now uses is! check.

@KanishJebaMathewM **Why important**: Both are runtime crashes that can happen from non-2xx API responses. Crash = app termination for driver.