### PR TITLE
fix(driver): trips_screen disabled button + excess route markers

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -1067,7 +1067,11 @@ class _TripsScreenState extends State<TripsScreen> {
             ],
           ),
           MarkerLayer(
-            markers: routePoints.map((point) {
+            markers: routePoints.where((p) =>
+              p == routePoints.first ||
+              p == routePoints.last ||
+              p['is_claimed'] == true
+            ).map((point) {
               return Marker(
                 point: ll.LatLng(
                   (point['latitude'] as num).toDouble(),
@@ -1180,10 +1184,10 @@ class _MarketplaceBody extends StatelessWidget {
                 const SizedBox(height: 8),
                 Text(error!, style: Theme.of(context).textTheme.bodyMedium),
                 const SizedBox(height: 14),
-                const OutlinedAccentButton(
-                  label: 'Pull to refresh',
-                  onPressed: null,
-                ),
+                Text('Could not load marketplace. Pull down to retry.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                    )),
               ],
             ),
           ),


### PR DESCRIPTION
Closes #1646 and #1651

## #1646 - Disabled button
OutlinedAccentButton with onPressed: null showed a disabled button that looked clickable but did nothing. Replaced with informational text.

## #1651 - Hundreds of route markers
MarkerLayer created a Marker for every single polyline point (hundreds). Now filters to first, last, and claimed points only.

@KanishJebaMathewM **Why important**: #1651 causes severe performance lag on trips with long routes. #1646 is confusing UX showing a disabled button that appears interactive.