### PR TITLE
fix(driver): null-safe field access in location_service

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -166,8 +166,8 @@ class LocationService {
             .maybeSingle();
 
         if (activeOrder != null) {
-          _activeOrderId = activeOrder['id'] as String;
-          _activeOrderDisplayId = activeOrder['order_display_id'] as String;
+          _activeOrderId = activeOrder['id']?.toString();
+          _activeOrderDisplayId = activeOrder['order_display_id']?.toString();
         }
       }
 


### PR DESCRIPTION
Closes #1648

location_service.dart:169-170 used activeOrder['id'] as String and activeOrder['order_display_id'] as String. These crash if Supabase returns null for these fields. Changed to null-safe ?.toString() access.

@KanishJebaMathewM **Why important**: Runtime crash when order field is null, causing the location service to terminate midpoint during trip tracking - driver loses GPS updates.