### PR TITLE
fix(ci): remove unused hasProgramSignal function

### DIFF
--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -13,11 +13,6 @@ function loadRules(rulesPath = DEFAULT_RULES_PATH) {
   return JSON.parse(fs.readFileSync(rulesPath, 'utf8'));
 }
 
-function hasProgramSignal({ title = '', body = '', rules }) {
-  const source = normalize(`${title}\n${body}`);
-  return (rules.programSignals || []).some((signal) => source.includes(normalize(signal)));
-}
-
 function findLinkedIssueNumbers(text = '') {
   const issueNumbers = new Set();
   const closingKeyword =


### PR DESCRIPTION
Closes #1658

hasProgramSignal function was defined but never called anywhere in pr-labeler.js. Removed as dead code.

@KanishJebaMathewM **Why important**: Dead code clutters the script and can confuse maintainers into thinking program signal detection is active when it's actually done inline.