### PR TITLE
feat: add validation for min_capacity and max_capacity truck filters (#1683)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -78,11 +78,19 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
     if (name) {
       query = query.ilike('name', `%${name}%`);
     }
-    if (min_capacity) {
-      query = query.gte('max_capacity_tons', Number(min_capacity));
+    if (min_capacity !== undefined) {
+      const minCapNum = Number(min_capacity);
+      if (Number.isNaN(minCapNum) || minCapNum < 0) {
+        return res.status(400).json({ error: 'min_capacity must be a positive number' });
+      }
+      query = query.gte('max_capacity_tons', minCapNum);
     }
-    if (max_capacity) {
-      query = query.lte('max_capacity_tons', Number(max_capacity));
+    if (max_capacity !== undefined) {
+      const maxCapNum = Number(max_capacity);
+      if (Number.isNaN(maxCapNum) || maxCapNum < 0) {
+        return res.status(400).json({ error: 'max_capacity must be a positive number' });
+      }
+      query = query.lte('max_capacity_tons', maxCapNum);
     }
 
     const { data: trucks, error } = await query.order('created_at', { ascending: false });


### PR DESCRIPTION
Validates min_capacity and max_capacity as non-negative numbers before performing database lookup, responding with 400 on invalid input. Resolves #1683.