### PR TITLE
feat: sanitize and trim truck search name parameter (#1685)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -75,8 +75,11 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
       .select('id, name, number_plate, max_capacity_tons, created_at')
       .eq('owner_id', req.user.id);
 
-    if (name) {
-      query = query.ilike('name', `%${name}%`);
+    if (name && typeof name === 'string') {
+      const cleanName = name.trim();
+      if (cleanName) {
+        query = query.ilike('name', `%${cleanName}%`);
+      }
     }
     if (min_capacity) {
       query = query.gte('max_capacity_tons', Number(min_capacity));


### PR DESCRIPTION
Sanitizes name search values by trimming whitespace, avoiding unnecessary database wildcard searches for empty parameters. Resolves #1685.