### PR TITLE
fix : clear timeout timer in getDriverReputation Promise.race

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -112,15 +112,18 @@ export async function getDriverReputation(walletAddress) {
     logger.warn(`[reputation] Invalid wallet address "${walletAddress}" — skipping.`);
     return null;
   }
+  let timeoutId;
   try {
     const score = await Promise.race([
       reputationContract.getReputation(walletAddress),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('RPC timeout')), 5000)
-      ),
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('RPC timeout')), 5000);
+      }),
     ]);
+    clearTimeout(timeoutId);
     return Number(score);
   } catch (err) {
+    clearTimeout(timeoutId);
     logger.error(`[reputation] Failed to fetch on-chain reputation for ${walletAddress}: ${err.message}`);
     return null;
   }


### PR DESCRIPTION
Closes #1688.

Summary of What Has Been Done:
Added explicit clearTimeout calls on both the success and error paths of the Promise.race timeout in getDriverReputation. Previously the setTimeout timer was created but never cleared on the success path, causing a timer resource leak.

Changes Made:
- backend/api/src/services/reputation.js: Store timer ID in timeoutId variable, call clearTimeout(timeoutId) after reputation resolves and in the catch block.

Impact it Made:
- Fixes timer resource leak that accumulates active handles on busy servers
- 328 backend unit tests pass (5 pre-existing test failures in unrelated modules)

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of driver reputation lookups by ensuring pending timeout timers are cleared after both successful and failed requests.
  * Continued to return reputation scores when available, and safely fall back to no result if the request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->