### PR TITLE
fix : trim name param and validate capacity filters in truck search

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -76,13 +76,21 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
       .eq('owner_id', req.user.id);
 
     if (name) {
-      query = query.ilike('name', `%${name}%`);
+      query = query.ilike('name', `%${name.trim()}%`);
+    }
+    const parsedMin = Number(min_capacity);
+    const parsedMax = Number(max_capacity);
+    if (min_capacity && (!Number.isFinite(parsedMin) || parsedMin < 0)) {
+      return res.status(400).json({ error: 'min_capacity must be a non-negative number' });
+    }
+    if (max_capacity && (!Number.isFinite(parsedMax) || parsedMax < 0)) {
+      return res.status(400).json({ error: 'max_capacity must be a non-negative number' });
     }
     if (min_capacity) {
-      query = query.gte('max_capacity_tons', Number(min_capacity));
+      query = query.gte('max_capacity_tons', parsedMin);
     }
     if (max_capacity) {
-      query = query.lte('max_capacity_tons', Number(max_capacity));
+      query = query.lte('max_capacity_tons', parsedMax);
     }
 
     const { data: trucks, error } = await query.order('created_at', { ascending: false });


### PR DESCRIPTION
Closes #1691. Closes #1692.

Summary of What Has Been Done:
Two fixes to the GET /trucks endpoint in truckRoutes.js:
1. Trim leading/trailing whitespace from the name search param before using it in the ilike query, preventing zero-result searches from accidental whitespace.
2. Validate min_capacity and max_capacity as finite non-negative numbers before using them in .gte()/.lte() queries, returning 400 for invalid values instead of passing NaN.

Changes Made:
- backend/api/src/routes/truckRoutes.js: Added name.trim() for the name ilike query; added isFinite validation for min_capacity and max_capacity before query construction.

Impact it Made:
- Fixes unexpected zero-result truck searches caused by whitespace in name query param
- Prevents NaN from corrupting capacity filter queries
- 328 backend unit tests pass (same pre-existing failures as upstream)

Note: Please assign this PR to the `tmdeveloper007` account.