### PR TITLE
fix : skip UUID query when order ID is a display ID

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -475,10 +475,17 @@ router.get('/history', authenticate, userLimiter, requireRole(['customer']), asy
 // ============================================================================
 router.get('/:id', authenticate, userLimiter, validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   try {
-    let { data: order, error: orderErr } = await supabase.from('orders').select('*').eq('id', orderId).maybeSingle();
-    if (!order && !orderErr) {
+    let order = null;
+    let orderErr = null;
+    if (uuidRegex.test(orderId)) {
+      const result = await supabase.from('orders').select('*').eq('id', orderId).maybeSingle();
+      order = result.data;
+      orderErr = result.error;
+    }
+    if (!order) {
       const result = await supabase.from('orders').select('*').eq('order_display_id', orderId).maybeSingle();
       order = result.data;
       orderErr = result.error;
@@ -516,13 +523,15 @@ router.get('/:id', authenticate, userLimiter, validateParams(paramIdSchema), asy
 // ============================================================================
 router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   try {
-    let order;
-    const { data: orderById } = await supabase.from('orders').select('customer_id, driver_id, order_display_id').eq('id', orderId).maybeSingle();
-    if (orderById) {
+    let order = null;
+    if (uuidRegex.test(orderId)) {
+      const { data: orderById } = await supabase.from('orders').select('customer_id, driver_id, order_display_id').eq('id', orderId).maybeSingle();
       order = orderById;
-    } else {
+    }
+    if (!order) {
       const { data: orderByDisplay } = await supabase.from('orders').select('customer_id, driver_id, order_display_id').eq('order_display_id', orderId).maybeSingle();
       order = orderByDisplay;
     }


### PR DESCRIPTION
Closes #1629. Closes #1628.

Summary of What Has Been Done:
In both GET /orders/:id and GET /orders/:id/timeline, added a UUID format check before querying the orders table by the 'id' (UUID) column. If the orderId is not a valid UUID (e.g. a display ID like #FF20260521), the UUID query is skipped and the query by 'order_display_id' runs directly. This prevents a Postgres type error (22P02) from being thrown and returned as a 500 response.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Added uuidRegex test before .eq('id', orderId) queries in GET /:id and GET /:id/timeline routes.

Impact it Made:
- Display IDs now work correctly on both endpoints without causing 500 errors
- 328 backend unit tests pass (same pre-existing failures as upstream)

Note: Please assign this PR to the `tmdeveloper007` account.