### PR TITLE
fix : trim whitespace from name query param in truck search

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -76,7 +76,7 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
       .eq('owner_id', req.user.id);
 
     if (name) {
-      query = query.ilike('name', `%${name}%`);
+      query = query.ilike('name', `%${name.trim()}%`);
     }
     if (min_capacity) {
       query = query.gte('max_capacity_tons', Number(min_capacity));


### PR DESCRIPTION
Closes #1692.

Summary of What Has Been Done:
Trims leading and trailing whitespace from the name query parameter before using it in the truck search ilike query. Previously, a caller passing ' Tata ' (with spaces) would get zero results because the database stores 'Tata' without leading space.

Changes Made:
- backend/api/src/routes/truckRoutes.js: Changed ilike pattern from percent-name-percent to percent-name.trim()-percent

Impact it Made:
- Fixes unexpected zero-result truck name searches caused by accidental whitespace
- 328 backend unit tests pass (same pre-existing failures as upstream)

Note: Please assign this PR to the tmdeveloper007 account.