### PR TITLE
fix : remove duplicate limit and offset declarations in comments endpoint

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -499,16 +499,6 @@ router.get('/tickets/:id/comments', authenticate, userLimiter, async (req, res) 
 
     const limit = Math.min(100, parsedLimit.value);
     const offset = parsedOffset.value;
-    const rawLimit = req.query.limit;
-    const rawOffset = req.query.offset;
-    if (rawLimit !== undefined && (!Number.isFinite(Number(rawLimit)) || Number(rawLimit) < 1)) {
-      return res.status(400).json({ error: 'limit must be a positive integer' });
-    }
-    if (rawOffset !== undefined && (!Number.isFinite(Number(rawOffset)) || Number(rawOffset) < 0)) {
-      return res.status(400).json({ error: 'offset must be a non-negative integer' });
-    }
-    const limit = Math.min(100, Math.max(1, Number(rawLimit) || 100));
-    const offset = Math.max(0, Number(rawOffset) || 0);
 
     const { data: comments, error: commentsError } = await supabase
       .from('support_ticket_comments')


### PR DESCRIPTION
Closes #1675.

Summary of What Has Been Done:
Removed duplicate const declarations of 'limit' and 'offset' in the GET /tickets/:id/comments route handler. The endpoint had two sets of declarations - the first used parsedLimit.value and parsedOffset.value (already validated via parseIntegerQuery), while the second used raw query values directly. Removed the redundant second set which caused a SyntaxError at load time.

Changes Made:
- backend/api/src/routes/supportRoutes.js: Removed the duplicate const limit and const offset declarations and their associated raw value validation that was redundant with the already-validated parseIntegerQuery results.

Impact it Made:
- Fixes SyntaxError that prevented the support routes from loading
- 328 backend unit tests pass (same pre-existing failures as upstream)

Note: Please assign this PR to the tmdeveloper007 account.