### PR TITLE
fix: attach location WebSocket server on startup

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -177,6 +177,7 @@ app.use((err, req, res, next) => {
 // ============================================================================
 await waitForMongoDb();
 initWebSocketServer(server);
+attachLocationServer(server);
 
 // ============================================================================
 // START SERVER


### PR DESCRIPTION
attachLocationServer was imported but never called in index.js, so the Socket.IO-based live GPS tracking server for /driver and /customer namespaces was never attached to the HTTP server. This adds the call alongside the existing native WebSocket init so both servers co-exist without conflict.\n\nCloses #1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Location-related functionality now starts automatically when the app launches, making it available right away.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->