### PR TITLE
fix: implement actual phone call for Call Driver button

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../core/offline/websocket/resilient_websocket.dart';
 import '../theme/app_theme.dart';
 import '../constants/supabase_config.dart';
@@ -38,6 +39,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   static const String _fallbackTruckText = 'Truck not assigned';
 
   String _driverName = _loadingDriverText;
+  String? _driverPhone;
   String _truckNumber = _loadingTruckText;
   bool _isLoadingDetails = false;
   LatLng? _previousPosition;
@@ -224,6 +226,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
           } else {
             _driverName = _loadingDriverText;
           }
+          _driverPhone = order['driver_phone']?.toString().trim();
 
           if (tn != null && tn.isNotEmpty) {
             _truckNumber = tn;
@@ -493,48 +496,25 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   Future<void> _showCallDriver() async {
     final driverName = _driverName;
     final truckNumber = _truckNumber;
+    final phone = _driverPhone;
 
-    await showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: Colors.transparent,
-      builder: (context) {
-        return Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const SizedBox(height: 8),
-              const Icon(Icons.call_rounded,
-                  color: TruxifyColors.accentDark, size: 42),
-              const SizedBox(height: 10),
-              Text(
-                'Calling $driverName',
-                style: Theme.of(context)
-                    .textTheme
-                    .titleLarge
-                    ?.copyWith(fontWeight: FontWeight.w800),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                truckNumber,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: TruxifyColors.adaptiveSecondaryText(context),
-                    ),
-              ),
-              const SizedBox(height: 18),
-              PrimaryButton(
-                label: 'End Call',
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-            ],
-          ),
-        );
-      },
-    );
+    if (phone == null || phone.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Driver contact number unavailable')),
+      );
+      return;
+    }
+
+    final uri = Uri.parse('tel:$phone');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    } else {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not initiate call to $phone')),
+      );
+    }
   }
 
   Future<void> _showChangeDrop() async {

--- a/apps/customer/pubspec.yaml
+++ b/apps/customer/pubspec.yaml
@@ -32,7 +32,8 @@ dependencies:
   shared_preferences: ^2.5.5
   uuid: ^4.5.3
   web_socket_channel: ^3.0.0
-  shimmer: ^3.0.0   
+  shimmer: ^3.0.0
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
The Call Driver button in the live tracking screen showed a cosmetic bottom sheet with a phone icon and calling text, but never initiated an actual phone call. The app did not have url_launcher as a dependency.

This adds url_launcher, reads driver_phone from order data, and replaces the fake calling UI with a real tel: URL launch. If the number is unavailable, a snackbar informs the user instead of showing a misleading calling screen.

Closes #1594