### PR TITLE
fix: replace hardcoded +91 with country code picker in both login screens

### DIFF
--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -16,6 +16,19 @@ class LoginScreen extends StatefulWidget {
   State<LoginScreen> createState() => _LoginScreenState();
 }
 
+const _countryCodes = [
+  ('+1', 'US +1', 10),
+  ('+91', 'IN +91', 10),
+  ('+44', 'UK +44', 10),
+  ('+61', 'AU +61', 9),
+  ('+81', 'JP +81', 10),
+  ('+86', 'CN +86', 11),
+  ('+49', 'DE +49', 10),
+  ('+33', 'FR +33', 9),
+  ('+55', 'BR +55', 10),
+  ('+7', 'RU +7', 10),
+];
+
 class _LoginScreenState extends State<LoginScreen> {
   final AuthService _authService = AuthService();
   final TextEditingController _phoneController = TextEditingController();
@@ -28,6 +41,8 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _verifyingOtp = false;
   String? _verificationId;
   int? _resendToken;
+  String _selectedCode = '+91';
+  int _expectedDigits = 10;
 
   @override
   void dispose() {
@@ -71,15 +86,6 @@ class _LoginScreenState extends State<LoginScreen> {
       return;
     }
 
-    if (phone.length != 10) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Phone number must be exactly 10 digits'),
-        ),
-      );
-      return;
-    }
-
     if (int.tryParse(phone) == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -89,11 +95,21 @@ class _LoginScreenState extends State<LoginScreen> {
       return;
     }
 
+    if (phone.length != _expectedDigits) {
+      final msg = _expectedDigits == 10
+          ? 'Phone number must be exactly $_expectedDigits digits for $_selectedCode'
+          : 'Phone number must be $_expectedDigits digits for $_selectedCode';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(msg)),
+      );
+      return;
+    }
+
     setState(() => _sendingOtp = true);
 
     try {
       await _authService.verifyPhoneNumber(
-        phoneNumber: '+91$phone',
+        phoneNumber: '$_selectedCode$phone',
         forceResendingToken: _resendToken,
         onCodeSent: (verificationId, resendToken) {
           if (!mounted) return;
@@ -249,7 +265,7 @@ class _LoginScreenState extends State<LoginScreen> {
         const SizedBox(height: 12),
         TextField(
           controller: _phoneController,
-          maxLength: 10,
+          maxLength: _expectedDigits,
           keyboardType: TextInputType.phone,
           inputFormatters: [
             FilteringTextInputFormatter.digitsOnly,
@@ -258,17 +274,40 @@ class _LoginScreenState extends State<LoginScreen> {
           decoration: InputDecoration(
             prefixIcon: Container(
               alignment: Alignment.center,
-              width: 70,
+              width: 90,
               margin: const EdgeInsets.only(right: 8),
               decoration: BoxDecoration(
                 border: Border(
                   right: BorderSide(color: borderColor),
                 ),
               ),
-              child: Text('+91',
+              child: DropdownButtonHideUnderline(
+                child: DropdownButton<String>(
+                  value: _selectedCode,
+                  isDense: true,
+                  dropdownColor: colorScheme.surface,
                   style: TextStyle(
-                      color: colorScheme.onSurface,
-                      fontWeight: FontWeight.w700)),
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                  ),
+                  items: _countryCodes.map((c) {
+                    return DropdownMenuItem(
+                      value: c.$1,
+                      child: Text(c.$2),
+                    );
+                  }).toList(),
+                  onChanged: (val) {
+                    if (val == null) return;
+                    final code = _countryCodes.firstWhere((c) => c.$1 == val);
+                    setState(() {
+                      _selectedCode = val;
+                      _expectedDigits = code.$3;
+                      _phoneController.clear();
+                    });
+                  },
+                ),
+              ),
             ),
             hintText: '9876543210',
           ),

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -14,12 +14,27 @@ class LoginScreen extends StatefulWidget {
   State<LoginScreen> createState() => _LoginScreenState();
 }
 
+const _countryCodes = [
+  ('+1', 'US +1', 10),
+  ('+91', 'IN +91', 10),
+  ('+44', 'UK +44', 10),
+  ('+61', 'AU +61', 9),
+  ('+81', 'JP +81', 10),
+  ('+86', 'CN +86', 11),
+  ('+49', 'DE +49', 10),
+  ('+33', 'FR +33', 9),
+  ('+55', 'BR +55', 10),
+  ('+7', 'RU +7', 10),
+];
+
 class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _phoneController = TextEditingController();
   final AuthService _authService = AuthService();
   bool _loading = false;
   String? _verificationId;
   int? _resendToken;
+  String _selectedCode = '+91';
+  int _expectedDigits = 10;
 
   @override
   void dispose() {
@@ -37,9 +52,19 @@ class _LoginScreenState extends State<LoginScreen> {
       return;
     }
 
-    if (phone.length != 10 || int.tryParse(phone) == null) {
+    if (int.tryParse(phone) == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Enter a valid 10-digit phone number')),
+        const SnackBar(content: Text('Enter a valid phone number')),
+      );
+      return;
+    }
+
+    if (phone.length != _expectedDigits) {
+      final msg = _expectedDigits == 10
+          ? 'Phone number must be exactly $_expectedDigits digits for $_selectedCode'
+          : 'Phone number must be $_expectedDigits digits for $_selectedCode';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(msg)),
       );
       return;
     }
@@ -48,7 +73,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
     try {
       await _authService.verifyPhoneNumber(
-        phoneNumber: '+91$phone',
+        phoneNumber: '$_selectedCode$phone',
         forceResendingToken: _resendToken,
         onCodeSent: (verificationId, resendToken) {
           if (!mounted) return;
@@ -133,14 +158,50 @@ class _LoginScreenState extends State<LoginScreen> {
               const SizedBox(height: 10),
               TextField(
                 controller: _phoneController,
-                maxLength: 10,
+                maxLength: _expectedDigits,
                 inputFormatters: [
                   FilteringTextInputFormatter.digitsOnly,
                 ],
                 style: TextStyle(color: colorScheme.onSurface),
                 keyboardType: TextInputType.phone,
-                decoration: const InputDecoration(
-                  prefixText: '+91  ',
+                decoration: InputDecoration(
+                  prefixIcon: Container(
+                    alignment: Alignment.center,
+                    width: 90,
+                    margin: const EdgeInsets.only(right: 8),
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: BorderSide(color: colorScheme.outlineVariant),
+                      ),
+                    ),
+                    child: DropdownButtonHideUnderline(
+                      child: DropdownButton<String>(
+                        value: _selectedCode,
+                        isDense: true,
+                        dropdownColor: colorScheme.surface,
+                        style: TextStyle(
+                          color: colorScheme.onSurface,
+                          fontWeight: FontWeight.w700,
+                          fontSize: 14,
+                        ),
+                        items: _countryCodes.map((c) {
+                          return DropdownMenuItem(
+                            value: c.$1,
+                            child: Text(c.$2),
+                          );
+                        }).toList(),
+                        onChanged: (val) {
+                          if (val == null) return;
+                          final code = _countryCodes.firstWhere((c) => c.$1 == val);
+                          setState(() {
+                            _selectedCode = val;
+                            _expectedDigits = code.$3;
+                            _phoneController.clear();
+                          });
+                        },
+                      ),
+                    ),
+                  ),
                   hintText: '9876543210',
                 ),
               ),


### PR DESCRIPTION
Both customer and driver login screens hardcoded India-only (+91) phone number validation, making the app unusable for international users. Added a country code dropdown with 10 common codes (US, IN, UK, AU, JP, CN, DE, FR, BR, RU) and corresponding digit validation lengths. The selected country code is used when sending the phone number to Firebase auth instead of the hardcoded +91 prefix.

Changes:
- Added _countryCodes list with country code, label, and expected digit count
- Replaced hardcoded +91 prefix text with DropdownButton in both login screens
- Updated _sendOtp validation to check against the selected country's digit count
- Updated phoneNumber param to use the selected country code
- Dynamically adjusts maxLength on the TextField when country changes

Closes #1592