### PR TITLE
fix load offer sort validation

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -150,13 +150,14 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
     }
 
     // Sorting
-    const validSortFields = ['estimated_price', 'created_at'];
-    const sortByParam = validSortFields.includes(req.query.sort_by) ? req.query.sort_by : 'created_at';
+    const sortByParam = filters.sort_by || 'created_at';
     
     // Map sort fields to database columns
     let sortBy = 'created_at';
     if (sortByParam === 'estimated_price') {
       sortBy = 'freight_value';
+    } else if (sortByParam === 'distance') {
+      sortBy = 'extra_distance_km';
     }
 
     const ascending = filters.order === 'asc';

--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -19,6 +19,7 @@ export const loadFilterQuerySchema = z.object({
     message: 'distance must be a positive number',
   }),
   order: z.enum(['asc', 'desc']).optional(),
+  sort_by: z.enum(['estimated_price', 'created_at', 'distance']).optional(),
 }).superRefine((filters, ctx) => {
   if (
     filters.min_price !== undefined

--- a/backend/api/test/integration/loadOffers.test.js
+++ b/backend/api/test/integration/loadOffers.test.js
@@ -353,6 +353,21 @@ describe('Load Offers Routes Integration Tests', () => {
       expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
     });
 
+    it('rejects unsupported sort_by values', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?sort_by=freight_valuee')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'sort_by' }),
+        ])
+      );
+      expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
+    });
+
     it('returns 500 without leaking database details on db error', async () => {
       m.programError('Internal DB deadlock');
 


### PR DESCRIPTION
﻿## Summary
- validate `sort_by` on the load offer listing endpoint
- use the parsed query value instead of silently falling back on invalid input
- add integration coverage for unsupported sort fields

## Validation
- `npx vitest run test/integration/loadOffers.test.js -t "sort_by" --reporter=default`

Closes #1718


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded sorting options for load listings and improved validation for invalid sort values.
  * Requests with unsupported sort values now return a clear validation error instead of proceeding.

* **Tests**
  * Added coverage to confirm invalid sorting requests are rejected and do not trigger a database query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->