### PR TITLE
fix load offer order validation

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -138,7 +138,7 @@ router.get('/', authenticate, userLimiter, requireRole(['driver']), async (req, 
       sortBy = 'extra_distance_km';
     }
 
-    const ascending = req.query.order === 'asc';
+    const ascending = filters.order === 'asc';
 
     query = query.order(sortBy, { ascending }).range(from, to);
 

--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -16,6 +16,7 @@ export const loadFilterQuerySchema = z.object({
   min_price: nonNegativeDecimalString('min_price').optional(),
   max_price: nonNegativeDecimalString('max_price').optional(),
   distance: nonNegativeDecimalString('distance').optional(),
+  order: z.enum(['asc', 'desc']).optional(),
 }).superRefine((filters, ctx) => {
   if (
     filters.min_price !== undefined

--- a/backend/api/test/integration/loadOffers.test.js
+++ b/backend/api/test/integration/loadOffers.test.js
@@ -338,6 +338,21 @@ describe('Load Offers Routes Integration Tests', () => {
       expect(call.order).toEqual({ col: 'extra_distance_km', ascending: false });
     });
 
+    it('rejects unsupported order values', async () => {
+      const res = await request(buildApp())
+        .get('/api/loads?order=ascending')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'order' }),
+        ])
+      );
+      expect(m.calls.find(call => call.table === 'load_offers')).toBeUndefined();
+    });
+
     it('returns 500 without leaking database details on db error', async () => {
       m.programError('Internal DB deadlock');
 


### PR DESCRIPTION
﻿## Summary
- validate `order` on the load offer listing endpoint
- keep `asc` and `desc` as the only accepted sort directions
- add integration coverage for unsupported direction values

## Validation
- `npx vitest run test/integration/loadOffers.test.js -t "order values|maps sort_by" --reporter=default`

Closes #1719
