### PR TITLE
fix logout timeout cleanup

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -17,6 +17,17 @@ import logger from '../middleware/logger.js';
 
 const router = express.Router();
 
+export function withTimeout(operation, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  return Promise.race([operation, timeout]).finally(() => {
+    clearTimeout(timer);
+  });
+}
+
 /**
  * POST /api/auth/logout
  * Requires: Bearer token (Firebase or Supabase)
@@ -28,17 +39,14 @@ router.post('/logout', authenticate, async (req, res) => {
   // ── 1. Invalidate Redis profile cache ──────────────────────────────
   // Bounded timeout prevents Redis hangs from blocking the logout response.
   try {
-    const redisTimer = setTimeout(() => {}, 2001);
-    await Promise.race([
+    await withTimeout(
       Promise.all([
         uid ? invalidateCachedProfile(uid) : Promise.resolve(),
         req.user && req.user.id ? invalidateCachedSupabaseProfile(req.user.id) : Promise.resolve(),
       ]),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Redis invalidation timeout')), 2000)
-      ),
-    ]);
-    clearTimeout(redisTimer);
+      2000,
+      'Redis invalidation timeout'
+    );
   } catch (err) {
     logger.warn(`[auth/logout] Cache invalidation skipped for uid=${uid}: ${err?.message}`);
   }
@@ -47,13 +55,11 @@ router.post('/logout', authenticate, async (req, res) => {
   // Bounded timeout prevents Firebase hangs from blocking the logout response.
   if (uid && firebaseAdmin) {
     try {
-      let fbTimer;
-      await Promise.race([
+      await withTimeout(
         firebaseAdmin.auth().revokeRefreshTokens(uid),
-        new Promise((_, reject) => {
-          fbTimer = setTimeout(() => reject(new Error('Firebase revocation timeout')), 3000);
-        }),
-      ]).finally(() => clearTimeout(fbTimer));
+        3000,
+        'Firebase revocation timeout'
+      );
     } catch (err) {
       logger.error(`[auth/logout] Firebase token revocation failed for uid=${uid}: ${err?.message}`);
     }

--- a/backend/api/test/integration/authRoutes.test.js
+++ b/backend/api/test/integration/authRoutes.test.js
@@ -7,10 +7,12 @@ import request from 'supertest';
 import express from 'express';
 
 const invalidateCachedProfileMock = vi.fn().mockResolvedValue(undefined);
+const invalidateCachedSupabaseProfileMock = vi.fn().mockResolvedValue(undefined);
 const revokeRefreshTokensMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../src/lib/profileCache.js', () => ({
   invalidateCachedProfile: invalidateCachedProfileMock,
+  invalidateCachedSupabaseProfile: invalidateCachedSupabaseProfileMock,
   getCachedProfile: vi.fn().mockResolvedValue(null),
   setCachedProfile: vi.fn().mockResolvedValue(undefined),
   isValidCachedProfile: vi.fn().mockReturnValue(true),
@@ -46,7 +48,7 @@ vi.mock('../../src/middleware/auth.js', () => ({
   requireRole: () => (_req, _res, next) => next(),
 }));
 
-const { default: authRouter } = await import('../../src/routes/authRoutes.js');
+const { default: authRouter, withTimeout } = await import('../../src/routes/authRoutes.js');
 
 function buildApp() {
   const app = express();
@@ -135,5 +137,32 @@ describe('POST /api/auth/logout', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+  });
+
+  it('clears timeout timers when the operation settles first', async () => {
+    vi.useFakeTimers();
+
+    try {
+      await withTimeout(Promise.resolve('ok'), 2000, 'too slow');
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears timeout timers when the operation times out', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const result = withTimeout(new Promise(() => {}), 2000, 'too slow');
+      const assertion = expect(result).rejects.toThrow('too slow');
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await assertion;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
﻿## Summary
- replace ad hoc logout timeout timers with a reusable cleanup helper
- clear timeout handles on both success and timeout paths
- add focused fake-timer coverage for timer cleanup

## Validation
- `npx vitest run test/integration/authRoutes.test.js --reporter=default`

Closes #1721
