### PR TITLE
fix device token profile sync errors

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -84,6 +84,9 @@ export async function registerDeviceToken(req, res) {
         '[DeviceController] Device token saved but failed to sync profiles.fcm_token:',
         profileSyncError.message
       );
+      return res.status(500).json({
+        error: 'Failed to sync device token to profile'
+      });
     }
 
     return res.json({

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -163,6 +163,14 @@ class SupabaseQueryBuilder {
     };
     this._calls.push(callRecord);
 
+    const matchingErrorIndex = this._programmed?.matchingErrors?.findIndex(item =>
+      item.table === this._table && item.mode === this._mode
+    ) ?? -1;
+    if (matchingErrorIndex !== -1) {
+      const [match] = this._programmed.matchingErrors.splice(matchingErrorIndex, 1);
+      return { data: null, error: match.error };
+    }
+
     // Programmed error path (e.g. simulate a supabase-side failure)
     if (this._programmed?.nextError) {
       const err = this._programmed.nextError;
@@ -303,6 +311,10 @@ export function createSupabaseMock(initialStore = {}) {
     store,
     calls,
     programError(msg = 'mock error')    { programmed.nextError    = { message: msg }; },
+    programErrorFor(table, mode, msg = 'mock error') {
+      programmed.matchingErrors ??= [];
+      programmed.matchingErrors.push({ table, mode, error: { message: msg } });
+    },
     programRpcError(msg = 'mock error') { programmed.nextRpcError = { message: msg }; },
     programData(data)                   { programmed.nextData = data; },
   };

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -151,6 +151,19 @@ describe('Device Routes Integration Tests', () => {
       expect(res.body.error).toBe('Failed to register device');
     });
 
+    it('returns 500 when device token profile sync fails', async () => {
+      m.programErrorFor('profiles', 'update', 'Profile write failed');
+
+      const res = await request(buildApp())
+        .post('/api/devices/register')
+        .set(CUSTOMER_HEADERS)
+        .send({ fcmToken: 'token_profile_sync_fail', platform: 'android' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Failed to sync device token to profile');
+      expect(m.store.user_devices.find(d => d.fcm_token === 'token_profile_sync_fail')).toBeTruthy();
+    });
+
     it('successfully registers multiple devices for the same user', async () => {
       const resA = await request(buildApp())
         .post('/api/devices/register')


### PR DESCRIPTION
﻿## Summary
- return an error when device token profile synchronization fails
- add targeted Supabase mock support for table/mode-specific failures
- cover profile-sync failure in the device registration integration suite

## Validation
- `npx vitest run test/integration/devices.test.js --reporter=default`

Closes #1722
