### PR TITLE
fix offline sync terminal failures

### DIFF
--- a/apps/customer/lib/core/offline/db/offline_event_db.dart
+++ b/apps/customer/lib/core/offline/db/offline_event_db.dart
@@ -20,7 +20,7 @@ class OfflineEventDb {
 
     _database = await openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE $_tableName (
@@ -31,9 +31,15 @@ class OfflineEventDb {
             occurred_at TEXT NOT NULL,
             sync_status TEXT NOT NULL,
             retry_count INTEGER NOT NULL,
-            last_retry_at TEXT
+            last_retry_at TEXT,
+            sync_error TEXT
           )
         ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute('ALTER TABLE $_tableName ADD COLUMN sync_error TEXT');
+        }
       },
     );
 
@@ -76,7 +82,7 @@ class OfflineEventDb {
     final db = await open();
     await db.update(
       _tableName,
-      {'sync_status': 'synced', 'last_retry_at': null},
+      {'sync_status': 'synced', 'last_retry_at': null, 'sync_error': null},
       where: 'id = ?',
       whereArgs: [id],
     );
@@ -89,6 +95,21 @@ class OfflineEventDb {
       {
         'sync_status': 'failed',
         'retry_count': retryCount,
+        'last_retry_at': DateTime.now().toUtc().toIso8601String(),
+        'sync_error': null,
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<void> markRejected(String id, {required String reason}) async {
+    final db = await open();
+    await db.update(
+      _tableName,
+      {
+        'sync_status': 'rejected',
+        'sync_error': reason,
         'last_retry_at': DateTime.now().toUtc().toIso8601String(),
       },
       where: 'id = ?',

--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -9,6 +9,12 @@ import '../conflict/conflict_resolver.dart';
 import '../db/offline_event_db.dart';
 import '../models/trip_event.dart';
 
+enum SyncUploadOutcome {
+  success,
+  retryableFailure,
+  permanentFailure,
+}
+
 class SyncEngine {
   SyncEngine({
     required this.db,
@@ -55,12 +61,19 @@ class SyncEngine {
 
     await _markAsSyncing(resolved);
 
-    final uploaded = await _uploadBatch(resolved);
-    if (uploaded) {
+    final uploadOutcome = await _uploadBatch(resolved);
+    if (uploadOutcome == SyncUploadOutcome.success) {
       for (final event in resolved) {
         await db.markSynced(event.id);
       }
       return resolved.length;
+    }
+
+    if (uploadOutcome == SyncUploadOutcome.permanentFailure) {
+      for (final event in resolved) {
+        await db.markRejected(event.id, reason: 'Server rejected this offline event batch as non-retryable.');
+      }
+      return 0;
     }
 
     for (final event in resolved) {
@@ -75,7 +88,7 @@ class SyncEngine {
     }
   }
 
-  Future<bool> _uploadBatch(List<TripEvent> events) async {
+  Future<SyncUploadOutcome> _uploadBatch(List<TripEvent> events) async {
     final body = jsonEncode({
       'events': events.map((event) => event.toJson()).toList(),
       'idempotencyKey': events.map((event) => event.id).join(','),
@@ -89,7 +102,7 @@ class SyncEngine {
 
       if (token == null) {
         developer.log('[SyncEngine] ⚠️ Cannot sync batch: User session token is null/expired.');
-        return false;
+        return SyncUploadOutcome.retryableFailure;
       }
 
       final response = await http.post(
@@ -102,27 +115,27 @@ class SyncEngine {
       ).timeout(AppConfig.syncTimeout);
 
       if (response.statusCode == 200 || response.statusCode == 202) {
-        return true;
+        return SyncUploadOutcome.success;
       }
 
       if (response.statusCode == 401) {
         developer.log('[SyncEngine] 🚨 Auth rejected by server (401 Unauthorized).');
-        return false;
+        return SyncUploadOutcome.retryableFailure;
       }
 
       if (response.statusCode == 409 || response.statusCode == 422 || response.statusCode == 400) {
-        return false;
+        return SyncUploadOutcome.permanentFailure;
       }
 
       if (response.statusCode == 429 || response.statusCode >= 500) {
         await Future<void>.delayed(_backoffDelay(_maxRetryCount(events)));
-        return false;
+        return SyncUploadOutcome.retryableFailure;
       }
 
-      return false;
+      return SyncUploadOutcome.retryableFailure;
     } catch (_) {
       await Future<void>.delayed(_backoffDelay(_maxRetryCount(events)));
-      return false;
+      return SyncUploadOutcome.retryableFailure;
     }
   }
 


### PR DESCRIPTION
﻿## Summary
- add a terminal `rejected` state for non-retryable offline sync failures
- stop retrying batches rejected with 400, 409, or 422 responses
- add a local DB upgrade with a `sync_error` diagnostic column

## Validation
- Not run: Flutter/Dart tooling is not installed in this environment.

Closes #1725
