### PR TITLE
fix offline sync idempotency key stability

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -78,7 +78,7 @@ class SyncEngine {
   Future<bool> _uploadBatch(List<TripEvent> events) async {
     final body = jsonEncode({
       'events': events.map((event) => event.toJson()).toList(),
-      'idempotencyKey': events.map((event) => event.id).join(','),
+      'idempotencyKey': _idempotencyKeyFor(events),
     });
 
     try {
@@ -128,6 +128,11 @@ class SyncEngine {
 
   int _maxRetryCount(List<TripEvent> events) {
     return events.map((event) => event.retryCount).reduce((value, element) => value > element ? value : element);
+  }
+
+  String _idempotencyKeyFor(List<TripEvent> events) {
+    final ids = events.map((event) => event.id).toList()..sort();
+    return ids.join(',');
   }
 
   Duration _backoffDelay(int retryCount) {


### PR DESCRIPTION
﻿## Summary
- extract offline sync idempotency key generation
- sort event IDs before building the batch key
- keep retry keys stable when the same events are selected in a different local order

## Validation
- Not run: Flutter/Dart tooling is not installed in this environment.

Closes #1726
