### PR TITLE
fix resilient websocket reconnect cleanup

### DIFF
--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -75,6 +75,10 @@ class ResilientWebSocket {
     _attempt += 1;
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(capped, () async {
+      await _cleanupChannel();
+      if (_closed) {
+        return;
+      }
       await _connectOnce();
     });
   }
@@ -93,9 +97,14 @@ class ResilientWebSocket {
     _closed = true;
     _heartbeatTimer?.cancel();
     _reconnectTimer?.cancel();
+    await _cleanupChannel();
+    await _controller.close();
+  }
+
+  Future<void> _cleanupChannel() async {
     await _subscription?.cancel();
     await _channel?.sink.close();
+    _subscription = null;
     _channel = null;
-    await _controller.close();
   }
 }


### PR DESCRIPTION
﻿## Summary
- clean up the previous WebSocket subscription and channel before reconnecting
- keep close cleanup going through the same channel cleanup helper
- avoid stale listeners and sockets across reconnect cycles

## Validation
- Not run: Flutter/Dart tooling is not installed in this environment.

Closes #1727
