### PR TITLE
fix: remove unused driverId required parameter from submitBid in marketplace repository

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -68,7 +68,6 @@ class MarketplaceRepository {
 
   Future<DriverBid> submitBid({
     required String loadId,
-    required String driverId,
     required num amount,
   }) async {
     final uri = Uri.parse('$_apiBaseUrl/api/orders/$loadId/bids');


### PR DESCRIPTION
Closes #1604

fix: remove unused driverId required parameter from submitBid in marketplace repository.