### PR TITLE
fix: add process.exit(1) to unhandledRejection handler to avoid running in undefined state

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -238,6 +238,7 @@ process.on('uncaughtException', async (err) => {
 process.on('unhandledRejection', async (reason) => {
   logger.error({ reason }, 'Unhandled promise rejection');
   await flushSentry(2000);
+  process.exit(1);
 });
 
 process.on('SIGTERM', () => shutdown('SIGTERM')); // Docker / Kubernetes stop


### PR DESCRIPTION
Closes #1741

fix: add process.exit(1) to unhandledRejection handler to avoid running in undefined state.