### PR TITLE
fix: make OTP generation respect configured OTP_LENGTH constant instead of hardcoded 4 digits

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -9,7 +9,9 @@ export async function generateAndStoreOtp(phone) {
     logger.warn('[otp] Redis not available, cannot generate OTP.');
     return null;
   }
-  const otp = String(Math.floor(1000 + Math.random() * 9000)).slice(0, OTP_LENGTH);
+  const min = Math.pow(10, OTP_LENGTH - 1);
+  const max = Math.pow(10, OTP_LENGTH) - 1;
+  const otp = String(Math.floor(min + Math.random() * (max - min + 1)));
   await redisClient.set(`otp:${phone}`, otp, 'EX', OTP_TTL_SECONDS);
   logger.info(`[otp] OTP generated for ${phone}`);
   return otp;


### PR DESCRIPTION
Closes #1742

fix: make OTP generation respect configured OTP_LENGTH constant instead of hardcoded 4 digits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTP codes are now generated at a consistent length, based on the configured OTP settings.
  * Improved OTP number generation to better match the expected format before delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->