### PR TITLE
fix(driver): rename body to decoded in fetchEnRouteLoads

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -63,7 +63,7 @@ class MarketplaceRepository {
 
     final decoded = jsonDecode(response.body);
     if (decoded is! List) throw StateError('Unexpected response type');
-    return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
+    return decoded.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
   }
 
   Future<DriverBid> submitBid({


### PR DESCRIPTION
Closes #1759

marketplace_repository.dart:66 referenced undefined variable 'body' which was renamed to 'decoded' at line 64. This is a compilation error making fetchEnRouteLoads() non-functional.

@KanishJebaMathewM **Why important**: Compilation error blocks the entire driver app build. fetchEnRouteLoads() will always fail to compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could prevent en-route load offers from loading correctly.
  - Improved reliability when displaying marketplace results by ensuring the returned data is properly converted into offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->