### PR TITLE
fix(backend): add search_path to SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql
+++ b/supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql
@@ -6,6 +6,7 @@ CREATE OR REPLACE FUNCTION complete_trip_tx(p_order_id UUID, p_otp_id UUID, p_re
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public
 AS $$
 DECLARE
   v_order RECORD;

--- a/supabase/migrations/20260628000000_add_rpc_functions.sql
+++ b/supabase/migrations/20260628000000_add_rpc_functions.sql
@@ -20,7 +20,9 @@ create or replace function accept_bid_tx(
 ) returns void
 language plpgsql
 security definer
-as $$
+-- Set search_path to avoid search_path injection attacks
+set search_path = public
+as $
 declare
   v_load_status text;
   v_order_status text;
@@ -85,7 +87,9 @@ create or replace function withdraw_funds_tx(
 ) returns void
 language plpgsql
 security definer
-as $$
+-- Set search_path to avoid search_path injection attacks
+set search_path = public
+as $
 declare
   v_confirmed int;
   v_pending   int;
@@ -126,7 +130,9 @@ create or replace function submit_rating_tx(
 ) returns void
 language plpgsql
 security definer
-as $$
+-- Set search_path to avoid search_path injection attacks
+set search_path = public
+as $
 declare
   v_new_avg numeric(3,2);
 begin


### PR DESCRIPTION
Closes #1760 #1761

Added SET search_path = public to all SECURITY DEFINER functions in both migration files. Without an explicit search_path, PostgreSQL functions are vulnerable to search_path injection attacks where users can create malicious objects in public schemas.

Files fixed:
- supabase/migrations/20260628000000_add_rpc_functions.sql (3 functions)
- supabase/migrations/20260624223000_make_delivery_otp_completion_atomic.sql (1 function)

@KanishJebaMathewM **Why important**: SECURITY DEFINER functions without search_path are a PostgreSQL security vulnerability. A user could create a malicious table/function in a public schema to hijack the elevated privileges of these functions.