### PR TITLE
fix(shared): safe casts in notification and faq repositories

### DIFF
--- a/packages/truxify_shared/lib/src/repositories/faq_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/faq_repository.dart
@@ -13,7 +13,9 @@ class FaqRepository {
         .select()
         .eq('is_active', true)
         .order('sort_order');
-    final List<Map<String, dynamic>> rows = List<Map<String, dynamic>>.from(response as List);
+    final List<Map<String, dynamic>> rows = response is List
+        ? List<Map<String, dynamic>>.from(response)
+        : <Map<String, dynamic>>[];
     return rows
         .map(Faq.fromMap)
         .where((faq) => faq.appType == 'both' || faq.appType == appType)

--- a/packages/truxify_shared/lib/src/repositories/notification_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/notification_repository.dart
@@ -13,7 +13,9 @@ class NotificationRepository {
         .select()
         .eq('user_id', userId)
         .order('created_at', ascending: false);
-    final List<Map<String, dynamic>> rows = List<Map<String, dynamic>>.from(response as List);
+    final List<Map<String, dynamic>> rows = response is List
+        ? List<Map<String, dynamic>>.from(response)
+        : <Map<String, dynamic>>[];
     return rows.map(NotificationItem.fromMap).toList();
   }
 


### PR DESCRIPTION
Closes #1762 #1763

Both repositories used 'response as List' which throws TypeError if Supabase returns null or a non-List. Changed to 'response is List' safe check with empty fallback.

@KanishJebaMathewM **Why important**: Runtime crashes on the notifications and FAQ screens whenever Supabase returns an unexpected response. Both screens are unusable until this is fixed.