### PR TITLE
fix(backend+customer): dynamic ws URL + snake_case profile fields

### DIFF
--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -72,8 +72,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       await ApiClient().put(
         '/api/profile',
         body: {
-          'fullName': _nameController.text.trim(),
-          'companyName': _companyController.text.trim(),
+          'full_name': _nameController.text.trim(),
+          'company_name': _companyController.text.trim(),
           'phone': _phoneController.text.trim(),
         },
       );

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -154,7 +154,9 @@ setupSwagger(app);
 
 // Root route
 app.get('/', (req, res) => {
-  res.send('<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://localhost:5000/ws/tracking</code></p>');
+  const wsHost = req.hostname || 'localhost';
+  const wsPort = process.env.PORT || 5000;
+  res.send(`<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://${wsHost}:${wsPort}/ws/tracking</code></p>`);
 });
 
 // Handling 404 Route Not Found


### PR DESCRIPTION
Closes #1764 #1765

## #1764 - Hardcoded WebSocket URL
index.js root route showed ws://localhost:5000 in production. Now uses req.hostname and PORT env var.

## #1765 - camelCase vs snake_case  
edit_profile_screen sent 'fullName'/'companyName' but backend expects 'full_name'/'company_name'. Zod .strict() strips unknown fields making updates silently fail.

@KanishJebaMathewM **Why important**: #1764 misleads operators in production. #1765 causes silent profile update failure - customers can't edit their profile.