### PR TITLE
fix(customer): divide cancellation fee by 100 for rupee display

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -637,7 +637,9 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
 
   Future<void> _showCancel() async {
     bool isLoading = false;
-    String? feeText = _order?['cancellation_fee'] != null ? 'Cancellation fee ₹${_order!['cancellation_fee']}' : null;
+    final rawFee = _order?['cancellation_fee'];
+    final feeInRupees = rawFee != null ? (rawFee as num) / 100 : null;
+    String? feeText = feeInRupees != null ? 'Cancellation fee ₹${feeInRupees.toStringAsFixed(2)}' : null;
 
     await showModalBottomSheet<void>(
       context: context,
@@ -669,11 +671,12 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                           setModalState(() => isLoading = true);
                           try {
                             final resp = await _orderService.cancelOrder(orderDisplayId: widget.orderId);
-                            final fee = resp['cancellation_fee'];
+                            final rawFee = resp['cancellation_fee'];
+                            final feeInRupees = rawFee != null ? (rawFee as num) / 100 : 0;
                             await _loadOrder();
                             if (!mounted) return;
                             Navigator.of(context).pop();
-                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Order cancelled. Fee: ₹${fee ?? 0}')));
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Order cancelled. Fee: ₹${feeInRupees.toStringAsFixed(2)}')));
                           } catch (e) {
                             setModalState(() => isLoading = false);
                             if (!mounted) return;


### PR DESCRIPTION
Closes #1766

live_tracking_screen.dart displayed cancellation_fee values (stored in paise) directly as rupees. ₹50000 would display as ₹50000 instead of ₹500.00. Now divides by 100 for correct rupee display.

@KanishJebaMathewM **Why important**: Customers see incorrect cancellation fees that are 100x higher than actual. A ₹500 fee appears as ₹50000 causing confusion and support tickets.