### PR TITLE
fix(driver+customer): supabase_config defaults + safe cast

### DIFF
--- a/apps/customer/lib/constants/supabase_config.dart
+++ b/apps/customer/lib/constants/supabase_config.dart
@@ -2,10 +2,10 @@
 /// Extracts values passed via --dart-define environment variables.
 class SupabaseConfig {
   /// Supabase project URL.
-  static const String url = String.fromEnvironment('SUPABASE_URL');
+  static const String url = String.fromEnvironment('SUPABASE_URL', defaultValue: '');
 
   /// Supabase anonymous key.
-  static const String anonKey = String.fromEnvironment('SUPABASE_ANON_KEY');
+  static const String anonKey = String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: '');
 
   /// Helper to check if credentials are provided.
   static bool get isConfigured => url.isNotEmpty && anonKey.isNotEmpty;

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -153,7 +153,8 @@ class OrderService {
       final body = await _apiClient.get(
         '/api/orders/my/active',
       );
-      return List<Map<String, dynamic>>.from(body as List);
+      if (body is! List) return <Map<String, dynamic>>[];
+      return List<Map<String, dynamic>>.from(body);
     } on ApiException catch (e) {
       throw StateError(e.message);
     } catch (e) {

--- a/apps/driver/lib/core/supabase_config.dart
+++ b/apps/driver/lib/core/supabase_config.dart
@@ -2,10 +2,10 @@
 /// Extracts values passed via --dart-define environment variables.
 class SupabaseConfig {
   /// Supabase project URL.
-  static const String url = String.fromEnvironment('SUPABASE_URL');
+  static const String url = String.fromEnvironment('SUPABASE_URL', defaultValue: '');
 
   /// Supabase anonymous key.
-  static const String anonKey = String.fromEnvironment('SUPABASE_ANON_KEY');
+  static const String anonKey = String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: '');
 
   /// Helper to check if credentials are provided.
   static bool get isConfigured => url.isNotEmpty && anonKey.isNotEmpty;


### PR DESCRIPTION
Closes #1767 #1768 #1769

## #1767/#1768 - Missing defaultValue
Both supabase_config.dart files used String.fromEnvironment without defaultValue. If --dart-define flags omitted, Supabase silently disabled. Added defaultValue: ''.

## #1769 - Unsafe cast
order_service.dart fetchActiveOrders used body as List which crashes if API returns error object. Now checks is! List first.

@KanishJebaMathewM **Why important**: #1767/1768 cause silent Supabase disable at build time. #1769 crashes the order list screen when API returns unexpected data.