### PR TITLE
fix(backend): use env var for Swagger server URL

### DIFF
--- a/backend/api/src/config/swagger.js
+++ b/backend/api/src/config/swagger.js
@@ -11,8 +11,8 @@ const options = {
     },
     servers: [
       {
-        url: 'http://localhost:5000/api',
-        description: 'Development server',
+        url: process.env.API_BASE_URL || 'http://localhost:5000/api',
+        description: 'API server',
       },
     ],
   },


### PR DESCRIPTION
Closes #1770

Swagger server URL was hardcoded to http://localhost:5000/api. Now reads from API_BASE_URL env var with localhost fallback.

@KanishJebaMathewM **Why important**: Swagger UI 'Try it out' sends requests to localhost in production which fails for all API testing.