### PR TITLE
fix(customer): validate weight before submitting order

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -106,6 +106,15 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       return;
     }
 
+    final weight = double.tryParse(widget.draft.weightTonnes);
+    if (weight == null || weight <= 0) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invalid weight. Please enter a valid weight.')),
+      );
+      return;
+    }
+
     setState(() => _isSubmitting = true);
 
     try {
@@ -118,7 +127,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
         dropLng: finalDropLng,
         pickupTime: widget.draft.dateLabel,
         goodsType: widget.draft.goodsType,
-        weightTonnes: double.tryParse(widget.draft.weightTonnes) ?? 0,
+        weightTonnes: weight!,
         paymentMethodId: _selectedPayment?.id,
       );
 


### PR DESCRIPTION
Closes #1771

booking_confirmation_screen.dart silently defaulted to weight=0 on non-numeric input, submitting invalid orders. Now validates weight > 0 with user-facing error message before submission.

@KanishJebaMathewM **Why important**: Non-numeric weight values silently become 0, submitting orders with invalid data that the API rejects with confusing errors.