### PR TITLE
fix(driver+customer): trip_service safety, test cleanup, Supabase log

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -75,6 +75,8 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     if (SupabaseConfig.isConfigured) {
       _subscribeToOrderUpdates();
       _subscribeToTracking();
+    } else {
+      debugPrint('[LiveTracking] Supabase not configured — real-time updates disabled');
     }
   }
 

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -75,11 +75,17 @@ class TripService {
       throw StateError('Failed to fetch trips');
     }
 
-    final body = jsonDecode(response.body);
+    final dynamic body;
+    try {
+      body = jsonDecode(response.body);
+    } catch (_) {
+      throw StateError('Failed to parse trips response');
+    }
     if (body is Map<String, dynamic>) {
       return List<Map<String, dynamic>>.from(body['trips'] as List? ?? []);
     }
-    return List<Map<String, dynamic>>.from(body as List);
+    if (body is! List) throw StateError('Unexpected trips response type');
+    return List<Map<String, dynamic>>.from(body);
   }
 
   Future<Map<String, dynamic>> fetchTripHistory({

--- a/apps/driver/test/driver_metrics_test.dart
+++ b/apps/driver/test/driver_metrics_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truxify_driver/data/mock_data.dart' as mock;
 import 'package:truxify_driver/utils/driver_metrics.dart';
-import 'setup/test_setup.dart';  // ← Changed from '../setup/' to 'setup/'
+import 'setup/test_setup.dart';
 
 void main() {
   setUpAll(() async {

--- a/apps/driver/test/home_screen_test.dart
+++ b/apps/driver/test/home_screen_test.dart
@@ -10,7 +10,7 @@ import 'package:truxify_driver/services/marketplace_repository.dart';
 import 'package:truxify_driver/theme/app_theme.dart';
 import 'package:truxify_driver/services/driver_earnings_service.dart';
 import 'package:truxify_driver/models/earnings_daily_model.dart';
-import 'setup/test_setup.dart';  // ← ADD THIS IMPORT
+import 'setup/test_setup.dart';
 
 // --- FAKE CLASSES ---
 
@@ -108,14 +108,11 @@ Future<void> _pumpTransition(WidgetTester tester) async {
 // --- TESTS ---
 
 void main() {
-  // ADD THIS - Initialize test environment before all tests
   setUpAll(() async {
     await setupTestEnvironment();
   });
 
-  // ADD THIS - Reset mocks between tests
   setUp(() {
-    // Reset any state if needed
   });
 
   testWidgets('driver home shows a compact search bar', (


### PR DESCRIPTION
Closes #1773 #1775 #1776 #1777

## #1773 - jsonDecode crash
trip_service.dart fetchTrips wrapped jsonDecode in try-catch to prevent unhandled FormatException from HTML error pages.

## #1775/#1776 - Test debug comments
Removed stale debug comments from home_screen_test.dart and driver_metrics_test.dart.

## #1777 - Silent Supabase skip
Added debugPrint warning when Supabase is not configured and subscriptions are skipped.

@KanishJebaMathewM **Why important**: #1773 crashes the trip list when backend returns non-JSON. #1775/#1776 are code quality. #1777 helps debug silent Supabase failures.