### PR TITLE
fix(ml): rename /predict to /predict/price for endpoint consistency

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -87,7 +87,7 @@ export async function predictPrice({
     routeOrigin = '',
     routeDestination = '',
 } = {}) {
-    const url = `${getBaseUrl()}/predict`;
+    const url = `${getBaseUrl()}/predict/price`;
 
     const payload = {
         distance_km: distanceKm,

--- a/backend/api/test/unit/ml.test.js
+++ b/backend/api/test/unit/ml.test.js
@@ -153,7 +153,7 @@ describe('ml service — predictPrice', () => {
     });
 
     const [url, opts] = mockFetch.mock.calls[0];
-    expect(url).toContain('/predict');
+    expect(url).toContain('/predict/price');
     const body = JSON.parse(opts.body);
     expect(body.distance_km).toBe(250);
     expect(body.cargo_weight_kg).toBe(1000);

--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -406,7 +406,7 @@ async def predict_demand_endpoint(input: DemandForecastInput, _auth=Depends(veri
 # Price Prediction
 # ---------------------------------------------------------------------------
 
-@app.post("/predict", response_model=PricePredictOutput)
+@app.post("/predict/price", response_model=PricePredictOutput)
 async def predict_price_endpoint(input: PricePredictInput, _auth=Depends(verify_api_key)):
     try:
         result = predict_price(

--- a/backend/ml/tests/test_endpoints.py
+++ b/backend/ml/tests/test_endpoints.py
@@ -125,7 +125,7 @@ def test_predict_price_valid():
         "route_origin": "Mumbai",
         "route_destination": "Delhi",
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert "estimated_price" in data
@@ -139,7 +139,7 @@ def test_predict_price_minimal():
         "distance_km": 100.0,
         "cargo_weight_kg": 1000.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["estimated_price"] > 0
@@ -150,7 +150,7 @@ def test_predict_price_invalid_distance():
         "distance_km": 0,
         "cargo_weight_kg": 1000.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 422
 
 

--- a/backend/ml/tests/test_price_prediction.py
+++ b/backend/ml/tests/test_price_prediction.py
@@ -29,7 +29,7 @@ def test_predict_price_valid():
         "fuel_price": 110.0,
         "cargo_type": "general",
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert "estimated_price" in data
@@ -46,7 +46,7 @@ def test_predict_price_minimal():
         "distance_km": 100.0,
         "cargo_weight_kg": 1000.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["estimated_price"] > 0
@@ -63,7 +63,7 @@ def test_predict_price_invalid_distance():
         "distance_km": 0,
         "cargo_weight_kg": 1000.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 422
 
 
@@ -73,7 +73,7 @@ def test_predict_price_invalid_weight():
         "distance_km": 100.0,
         "cargo_weight_kg": 0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 422
 
 
@@ -89,7 +89,7 @@ def test_predict_price_confidence_range():
         "truck_type": "medium_truck",
         "fuel_price": 105.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["min_price"] <= data["estimated_price"] <= data["max_price"]
@@ -106,7 +106,7 @@ def test_predict_price_auth_missing(monkeypatch):
         "distance_km": 500.0,
         "cargo_weight_kg": 10000.0,
     }
-    response = client.post("/predict", json=payload)
+    response = client.post("/predict/price", json=payload)
     assert response.status_code == 401
     assert response.json() == {"detail": "Unauthorized"}
 
@@ -119,7 +119,7 @@ def test_predict_price_auth_valid(monkeypatch):
         "cargo_weight_kg": 10000.0,
     }
     response = client.post(
-        "/predict",
+        "/predict/price",
         json=payload,
         headers={"X-API-Key": "test-secret-key"},
     )


### PR DESCRIPTION
Closes #1778

The price prediction endpoint was at /predict while all other predictions use /predict/<type>. Now at /predict/price to match the convention. Updated tests and backend API service to use the new path.

@KanishJebaMathewM **Why important**: Inconsistent API naming forces API consumers to special-case the price endpoint, increasing maintenance burden and risk of misrouting requests.