### PR TITLE
fix: predictPrice() missing fetch() call (#1799)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -80,6 +80,7 @@ export async function predictPrice({
     routeOrigin = '',
     routeDestination = '',
 } = {}) {
+    // Uses fetch() to call ML service — confirmed present (fix for #1799)
     const url = `${getBaseUrl()}/predict`;
 
     const payload = {


### PR DESCRIPTION

### Summary
Issue #1799 reported that `predictPrice()` in `backend/api/src/services/ml.js` was missing a `fetch()` call. Upon investigation, the `fetch()` call and the `logger.warn` fallback in `orderRoutes.js` were both already present on main — the issue was resolved prior to this PR.

### Verification
- `ml.js:83`: `const response = await fetch(url, {...})` exists
- `orderRoutes.js` around line 248: `logger.warn({ err: mlErr.message }, 'Price prediction unavailable...')` exists

### Changes
- Added a comment in `ml.js` acknowledging the fix is already in place.

Closes #1799