### PR TITLE
fix: claim_release_reconciliation RPC missing (#1800)

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -2,7 +2,6 @@ import { supabase, redisClient } from '../config/db.js';
 import { escrowRelease } from './escrow.js';
 import logger from '../middleware/logger.js';
 import os from 'os';
-import logger from '../middleware/logger.js';
 const DEFAULT_INTERVAL_MS = 60_000;
 const LOCK_KEY = 'escrow:release:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;
@@ -67,7 +66,7 @@ export async function reconcilePendingEscrowReleases() {
             p_instance_id: instanceId,
           });
 
-        if ((!claimed || claimed.length === 0) && !claimError) {
+        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0)) && !claimError) {
           logger.info(`[escrow-release-reconciliation] Order ${order.order_display_id} already claimed by another instance, skipping.`);
           continue;
         }

--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -105,7 +105,8 @@ export async function reconcilePendingEscrowReleases() {
             updated_at: releasedAt,
           })
           .eq('id', order.id)
-          .eq('escrow_status', 'release_failed');
+          .eq('escrow_status', 'release_failed')
+          .is('reconciled_by', null);
 
         if (updateError) {
           logger.error(

--- a/supabase/migrations/20260703000000_add_claim_release_reconciliation.sql
+++ b/supabase/migrations/20260703000000_add_claim_release_reconciliation.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION claim_release_reconciliation(p_order_id UUID, p_instance_id TEXT)
+RETURNS SETOF orders
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  UPDATE orders
+  SET
+    escrow_release_attempts = escrow_release_attempts + 1,
+    escrow_release_last_attempt_at = NOW(),
+    reconciled_by = p_instance_id,
+    reconciled_at = NOW()
+  WHERE id = p_order_id
+    AND escrow_status = 'release_failed'
+    AND reconciled_by IS NULL
+  RETURNING *;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
### Summary
Create the `claim_release_reconciliation` RPC (only `claim_refund_reconciliation` existed) and guard the final DB update against races.

### Changes
1. **`supabase/migrations/20260703000000_add_claim_release_reconciliation.sql`** — New migration creating `claim_release_reconciliation` RPC that atomically claims a `release_failed` order by setting `reconciled_by` and `reconciled_at`.
2. **`backend/api/src/services/escrowReleaseReconciliation.js`** — Added `.is('reconciled_by', null)` to the final `escrow_status` update to prevent two reconciliation instances from updating the same order.

Closes #1800