### PR TITLE
fix: GPS telemetry recovery file security (#1801)

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -50,3 +50,9 @@ ESCROW_MATIC_PER_PAISA=
 MAX_ESCROW_MATIC=5
 # Poll interval for confirmed refunds that still need a Supabase state update.
 ESCROW_RECONCILIATION_INTERVAL_MS=60000
+
+# ⚠️ SECURITY — RECOVERY_FILE_PATH
+# Path for telemetry recovery file written during shutdown if MongoDB is
+# unavailable. Created with 0o600 permissions. PII (driver_id, lat, lng)
+# is scrubbed before writing. Defaults to os.tmpdir()/truxify-telemetry-recovery.jsonl
+# RECOVERY_FILE_PATH=C:\tmp\truxify-recovery.jsonl

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -10,7 +10,21 @@ let mongoDbOverride = null;
 const getMongoDb = () => mongoDbOverride || mongoDb;
 
 let telemetryDropCounter = 0;
-const RECOVERY_FILE_PATH = path.join(os.tmpdir(), 'truxify-telemetry-recovery.jsonl');
+const RECOVERY_FILE_PATH = process.env.RECOVERY_FILE_PATH || path.join(os.tmpdir(), 'truxify-telemetry-recovery.jsonl');
+
+function scrubPII(record) {
+  const scrubbed = { ...record };
+  if (scrubbed.driver_id) {
+    scrubbed.driver_id = 'scrubbed:' + require('crypto').createHash('sha256').update(scrubbed.driver_id).digest('hex').slice(0, 12);
+  }
+  if (typeof scrubbed.lat === 'number') {
+    scrubbed.lat = Math.round(scrubbed.lat * 100) / 100;
+  }
+  if (typeof scrubbed.lng === 'number') {
+    scrubbed.lng = Math.round(scrubbed.lng * 100) / 100;
+  }
+  return scrubbed;
+}
 
 // In-memory mapping of active client subscriptions
 const trackingSubscriptions = new Map();
@@ -747,8 +761,8 @@ export async function closeWebSocketServer() {
       const dataLoss = telemetryWriteBuffer.length;
       if (dataLoss > 0) {
         try {
-          const lines = telemetryWriteBuffer.map(r => JSON.stringify(r)).join('\n');
-          fs.writeFileSync(RECOVERY_FILE_PATH, lines + '\n', 'utf-8');
+          const lines = telemetryWriteBuffer.map(r => JSON.stringify(scrubPII(r))).join('\n');
+          fs.writeFileSync(RECOVERY_FILE_PATH, lines + '\n', { encoding: 'utf-8', mode: 0o600 });
           logger.warn(`[TRUXIFY SHUTDOWN] MongoDB not available. Wrote ${dataLoss} telemetry records to recovery file: ${RECOVERY_FILE_PATH}`);
         } catch (fileErr) {
           logger.error(`[TRUXIFY SHUTDOWN] Failed to write recovery file: ${fileErr.message}. ${dataLoss} records lost.`);

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -5,6 +5,7 @@ import logger from '../middleware/logger.js';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import crypto from 'crypto';
 
 let mongoDbOverride = null;
 const getMongoDb = () => mongoDbOverride || mongoDb;
@@ -15,7 +16,7 @@ const RECOVERY_FILE_PATH = process.env.RECOVERY_FILE_PATH || path.join(os.tmpdir
 function scrubPII(record) {
   const scrubbed = { ...record };
   if (scrubbed.driver_id) {
-    scrubbed.driver_id = 'scrubbed:' + require('crypto').createHash('sha256').update(scrubbed.driver_id).digest('hex').slice(0, 12);
+    scrubbed.driver_id = 'scrubbed:' + crypto.createHash('sha256').update(scrubbed.driver_id).digest('hex').slice(0, 12);
   }
   if (typeof scrubbed.lat === 'number') {
     scrubbed.lat = Math.round(scrubbed.lat * 100) / 100;


### PR DESCRIPTION
### Summary
Make RECOVERY_FILE_PATH configurable, write with 0o600 permissions, and scrub PII before persisting telemetry.

### Changes
1. **`backend/api/src/sockets/tracker.js`**
   - Read RECOVERY_FILE_PATH from env var (fallback to os.tmpdir() default).
   - Add `scrubPII()` function: SHA-256 hash of driver_id (12 hex chars), lat/lng rounded to 0.01° (~1 km precision).
   - Apply scrubber before writing recovery file.
   - Write with `{ encoding: 'utf-8', mode: 0o600 }`.
2. **`backend/api/.env.example`** — Document RECOVERY_FILE_PATH.

Closes #1801
