### PR TITLE
feat: Add GET /api/devices/platforms endpoint (#1808)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -97,3 +97,25 @@ export async function registerDeviceToken(req, res) {
     });
   }
 }
+
+/**
+ * Get list of unique registered device platforms
+ */
+export async function getDevicePlatforms(req, res) {
+  try {
+    const { data, error } = await supabase
+      .from('user_devices')
+      .select('platform');
+
+    if (error) {
+      logger.error('[DeviceController] Failed to query device platforms:', error.message);
+      return res.status(500).json({ error: 'Failed to retrieve platforms' });
+    }
+
+    const platforms = [...new Set((data || []).map((d) => d.platform).filter(Boolean))];
+    return res.json({ platforms });
+  } catch (err) {
+    logger.error('[DeviceController] Unexpected error in getDevicePlatforms:', err.message);
+    return res.status(500).json({ error: 'An unexpected error occurred' });
+  }
+}

--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { registerDeviceToken } from '../controllers/deviceController.js';
+import { registerDeviceToken, getDevicePlatforms } from '../controllers/deviceController.js';
 import { authenticate } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
 import { registerDeviceSchema } from '../validation/requestSchemas.js';
@@ -9,5 +9,8 @@ const router = express.Router();
 
 // POST /api/devices/register
 router.post('/register', authenticate, deviceLimiter, validateBody(registerDeviceSchema), registerDeviceToken);
+
+// GET /api/devices/platforms
+router.get('/platforms', authenticate, getDevicePlatforms);
 
 export default router;


### PR DESCRIPTION
Closes #1808. Adds a new endpoint GET /api/devices/platforms to retrieve unique platform values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new device platforms endpoint that returns the list of supported platforms seen in user devices.
  * Exposed this information through a new authenticated API route.

* **Bug Fixes**
  * Improved error handling for platform lookups, with clearer failure responses when data retrieval is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->