### PR TITLE
feat: Support X-Log-Level request header in logger (#1810)

### DIFF
--- a/backend/api/src/middleware/requestId.js
+++ b/backend/api/src/middleware/requestId.js
@@ -9,10 +9,20 @@ export function requestIdMiddleware(req, res, next) {
 
 export function requestLogger(req, res, next) {
   const start = Date.now();
+  const requestedLogLevel = req.headers['x-log-level'];
+  let reqLogger = logger;
+  
+  if (requestedLogLevel && ['info', 'warn', 'error', 'debug', 'trace'].includes(requestedLogLevel.toLowerCase())) {
+    reqLogger = logger.child({});
+    reqLogger.level = requestedLogLevel.toLowerCase();
+  }
+  
+  req.log = reqLogger;
+
   res.on('finish', () => {
     const durationMs = Date.now() - start;
     const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
-    logger[level]({
+    reqLogger[level]({
       requestId: req.requestId,
       method: req.method,
       path: req.originalUrl,


### PR DESCRIPTION
Closes #1810. Adds dynamic log-level child logger support based on 'X-Log-Level' header.