### PR TITLE
feat: Include memory usage stats in health check endpoint (#1814)

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -95,6 +95,7 @@ router.get('/', healthLimiter, async (req, res) => {
     status,
     services,
     uptime: process.uptime(),
+    memory: process.memoryUsage(),
   });
 });
 


### PR DESCRIPTION
Closes #1814. Adds process.memoryUsage() to GET /api/health response.