### PR TITLE
feat: Support custom metadata object in device registration (#1826)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -7,7 +7,7 @@ import logger from '../middleware/logger.js';
 export async function registerDeviceToken(req, res) {
   try {
     const userId = req.user?.id;
-    const { fcmToken, platform } = req.body;
+    const { fcmToken, platform, metadata } = req.body;
 
     if (!userId) {
       return res.status(401).json({
@@ -41,7 +41,8 @@ export async function registerDeviceToken(req, res) {
       {
         user_id: userId,
         fcm_token: fcmToken,
-        platform: platform || 'android'
+        platform: platform || 'android',
+        metadata: metadata || {}
       },
       { onConflict: 'fcm_token' }
     );

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -155,6 +155,7 @@ export const registerDeviceSchema = z.object({
   platform: z.enum(['android', 'ios', 'web'], {
     invalid_type_error: 'platform must be one of: android, ios, web',
   }).default('android'),
+  metadata: z.record(z.any()).optional(),
 }).strict();
 
 export const updateFcmTokenSchema = z.object({


### PR DESCRIPTION
Closes #1826. Adds metadata field support to registerDeviceSchema and registerDeviceToken controller.