### PR TITLE
fix : remove redundant sub-condition in escrow refund claimed check

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -53,7 +53,7 @@ export async function reconcilePendingEscrowRefunds() {
             p_instance_id: instanceId,
           });
 
-        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0) || (!Array.isArray(claimed) && !claimError)) && !claimError) {
+        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0)) && !claimError) {
           logger.info(`[escrow-reconciliation] Order ${order.order_display_id} already claimed by another instance, skipping.`);
           continue;
         }


### PR DESCRIPTION
Closes #1828.

Summary of What Has Been Done:
Removed the redundant  sub-condition from the claimed-order check in the escrow refund reconciliation loop. This sub-condition was always satisfied whenever  was true, effectively making the whole complex OR chain equivalent to just . This caused the reconciliation to incorrectly skip orders whenever the RPC returned any non-empty truthy value.

Changes Made:
- backend/api/src/services/escrowRefundReconciliation.js: Simplified the claimed check to  to match the correct pattern in escrowReleaseReconciliation.js

Impact it Made:
- Fixes reconciliation loop incorrectly skipping orders due to faulty claim detection
- Makes the condition consistent with the equivalent escrowReleaseReconciliation check
- Prevents missed refund reconciliations in production

Verification: Backend unit tests pass (4 pre-existing failures in upstream main unrelated to this change)

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow refund reconciliation so orders are no longer incorrectly skipped when a refund claim response is unexpected.
  * Reconciliation now only treats a claim as already handled when there is no claim result or an empty result and no error, helping ensure eligible refunds are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->