### PR TITLE
fix : use proper pino { err } format in auth.js catch blocks

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -130,7 +130,7 @@ export async function authenticate(req, res, next) {
       const cachedProfile = await getCachedProfile(firebaseUid);
       if (cachedProfile) {
         if (!isValidCachedProfile(firebaseUid, cachedProfile)) {
-          try { await invalidateCachedProfile(firebaseUid); } catch (_) { logger.error('Cache invalidation failed', _); }
+          try { await invalidateCachedProfile(firebaseUid); } catch (err) { logger.error({ err }, 'Cache invalidation failed'); }
         } else {
           if (cachedProfile.isActive === false) {
             return res.status(403).json({
@@ -185,7 +185,7 @@ export async function authenticate(req, res, next) {
       }
 
       if (firebaseUid) {
-        try { await setCachedProfile(firebaseUid, { isActive: false }, TOMBSTONE_TTL_SECONDS); } catch (_) { logger.error('Cache set failed', _); }
+        try { await setCachedProfile(firebaseUid, { isActive: false }, TOMBSTONE_TTL_SECONDS); } catch (err) { logger.error({ err }, 'Cache set failed'); }
       }
       if (supabaseUserId) {
         void setCachedSupabaseProfile(supabaseUserId, { isActive: false }, TOMBSTONE_TTL_SECONDS);
@@ -215,7 +215,7 @@ export async function authenticate(req, res, next) {
 
     // Populate cache on successful DB fetch
     if (userProfile.firebase_uid) {
-      try { await setCachedProfile(userProfile.firebase_uid, req.user); } catch (_) { logger.error('Cache set failed', _); }
+      try { await setCachedProfile(userProfile.firebase_uid, req.user); } catch (err) { logger.error({ err }, 'Cache set failed'); }
     }
     if (supabaseUserId) {
       // Clamp the cache lifetime to the token's remaining validity so a cached


### PR DESCRIPTION
Closes #1829.

Summary of What Has Been Done:
Changed three catch blocks in backend/api/src/middleware/auth.js to use the proper pino structured logging format. Instead of logger.error('message', _) which places the error in field 0, the code now uses logger.error({ err }, 'message') which places the error in the structured err field.

Changes Made:
- backend/api/src/middleware/auth.js line 133: Changed catch (_) { logger.error('Cache invalidation failed', _); } to catch (err) { logger.error({ err }, 'Cache invalidation failed'); }
- backend/api/src/middleware/auth.js line 188: Changed catch (_) { logger.error('Cache set failed', _); } to catch (err) { logger.error({ err }, 'Cache set failed'); }
- backend/api/src/middleware/auth.js line 218: Changed catch (_) { logger.error('Cache set failed', _); } to catch (err) { logger.error({ err }, 'Cache set failed'); }

Impact it Made:
- Errors now appear in the structured err field for proper log aggregation and alerting
- Consistent with pino best practices throughout the codebase
- Makes debugging cache failures easier in production environments

Verification: Backend unit tests pass (4 pre-existing failures in upstream main unrelated to this change)

Note: Please assign this PR to the tmdeveloper007 account.