### PR TITLE
fix : log errors with structured pino format in sentry.js flushSentry

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -14,7 +14,7 @@ export async function flushSentry(timeoutMs = 2000) {
   try {
     await Sentry.flush(timeoutMs);
   } catch (err) {
-    logger.warn('[sentry] Sentry.flush failed during teardown: %s', err.message);
+    logger.warn({ err }, 'Sentry.flush failed during teardown');
   }
 }
 


### PR DESCRIPTION
Closes #1832.

Summary of What Has Been Done:
Changed the logger.warn call in the sentry.js flushSentry function to use the proper pino structured logging format. Instead of logger.warn('[sentry] ...: %s', err.message), it now uses logger.warn({ err }, 'Sentry.flush failed during teardown').

Changes Made:
- backend/api/src/middleware/sentry.js: Changed logger.warn('[sentry] Sentry.flush failed during teardown: %s', err.message) to logger.warn({ err }, 'Sentry.flush failed during teardown')

Impact it Made:
- Error now appears in the structured err field for proper log aggregation and alerting
- Consistent with pino best practices throughout the codebase
- Improves debuggability of Sentry teardown failures in production

Verification: Backend unit tests pass (4 pre-existing failures in upstream main unrelated to this change)

Note: Please assign this PR to the tmdeveloper007 account.