### PR TITLE
docs: fix missing directory change for flutter run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Note: Truxify is in active development (Phase 2). The core platform features are
 ### Run the Customer App
 ```bash
 git clone https://github.com/KanishJebaMathewM/Truxify.git
-cd Truxify
+cd Truxify/customer_app  # (or driver_app)
 flutter pub get
 flutter run
 ```


### PR DESCRIPTION
Description:

This PR fixes a functional bug in the Getting Started instructions that causes a terminal error for new contributors. The current instructions tell developers to run flutter pub get and flutter run directly in the project root. Because this is a monorepo structure without a root pubspec.yaml, running those commands immediately throws a No pubspec.yaml file found error. I added the missing cd command to navigate into the specific Flutter app directory so the project builds successfully.

 Closes #None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the setup instructions for running the Customer App so the `cd` step points to the correct app directory.
  * Clarified the project path used before running the remaining setup and launch commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->