### PR TITLE
fix: remove OTP from notification body to prevent plaintext leak

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -181,7 +181,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
   logger.info(`[NotificationService] Delivering OTP for Order ${orderDisplayId} to Customer ${customerId}`);
 
   const title = 'Delivery Verification OTP';
-  const body = `Your delivery OTP for order ${orderDisplayId} is ${otp}. Share this with the driver only after verifying your cargo has arrived safely.`;
+  const body = `Your delivery OTP for order ${orderDisplayId} has been sent. Share this with the driver only after verifying your cargo has arrived safely.`;
   const otpHash = crypto.createHash('sha256').update(String(otp)).digest('hex');
 
   let dbSuccess = false;


### PR DESCRIPTION
This PR addresses #1749.

---
Part of GirlScript Summer of Code (GSSoC) 2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated delivery OTP notifications so the message no longer displays the OTP value directly.
  * Improved the notification text to better guide recipients on when to share the OTP with the driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->