### PR TITLE
fix: add catchError handlers to Future.wait to prevent cascading failure

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -174,9 +174,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     try {
       final results = await Future.wait([
-        _earningsService.fetchTodayEarningsSummary(),
-        _earningsService.fetchDriverStats(),
-        _tripService.fetchTripHistory(limit: 50),
+        _earningsService.fetchTodayEarningsSummary().catchError((_) => null),
+        _earningsService.fetchDriverStats().catchError((_) => null),
+        _tripService.fetchTripHistory(limit: 50).catchError((_) => null),
       ]);
 
       if (!mounted) return;


### PR DESCRIPTION
This PR addresses #1751.

---
Part of GirlScript Summer of Code (GSSoC) 2025