### PR TITLE
fix : remove duplicate dead fetch block in ml.js predictDemand

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -65,13 +65,6 @@ export async function predictDemand(features = {}) {
         signal: AbortSignal.timeout(5000),
     });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(5000),
-  });
-
   return handleResponse(response);
 }
 


### PR DESCRIPTION
Closes #1860.

Summary of What Has Been Done:
Removed the duplicate unreachable fetch block from predictDemand() in backend/api/src/services/ml.js. The second fetch declaration referenced an undefined 'payload' variable and would have caused a ReferenceError if reached. The function now correctly makes a single fetch call using the 'features' parameter as the request body and returns the ML engine response.

Changes Made:
- backend/api/src/services/ml.js: Removed the duplicate 'const response = await fetch(...)' block (7 lines of dead code referencing undefined 'payload' variable)

Impact it Made:
- Eliminates dead code with a ReferenceError hazard
- predictDemand() now correctly returns the ML engine demand prediction response
- Local backend unit tests pass (331 passed, pre-existing tracker/escrow failures unchanged)

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demand prediction requests so they send the correct input data, helping ensure more reliable prediction results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->