### PR TITLE
fix : replace pino printf positional args with structured object format in osrm.js

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -65,13 +65,6 @@ export async function predictDemand(features = {}) {
         signal: AbortSignal.timeout(5000),
     });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(5000),
-  });
-
   return handleResponse(response);
 }
 

--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -63,7 +63,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
       if (!response.ok) {
         clearTimeout(timeout);
         if (response.status >= 500 && attempt < maxRetries - 1) {
-          logger.warn('[osrm] Server error %d (attempt %d/%d). Retrying...', response.status, attempt + 1, maxRetries);
+          logger.warn({ status: response.status, attempt: attempt + 1, maxRetries }, 'Server error. Retrying...');
           await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
           continue;
         }
@@ -97,10 +97,10 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
       clearTimeout(timeout);
       if (attempt < maxRetries - 1) {
         const delayMs = baseDelayMs * Math.pow(2, attempt);
-        logger.warn('[osrm] Fetch error (attempt %d/%d): %s. Retrying in %d ms...', attempt + 1, maxRetries, err.message, delayMs);
+        logger.warn({ attempt: attempt + 1, maxRetries, errMessage: err.message, delayMs }, 'Fetch error. Retrying...');
         await new Promise(r => setTimeout(r, delayMs));
       } else {
-        logger.error('[osrm] Fetch error after all %d retries: %s', maxRetries, err.message);
+        logger.error({ maxRetries, errMessage: err.message }, 'Fetch error after all retries:');
         return null;
       }
     }

--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -194,7 +194,8 @@ describe('osrm - getRouteEstimate', () => {
     expect(result).toBeNull();
     // After retries are exhausted, error is logged with 'after all retries' message
     expect(mockLogger.error).toHaveBeenCalledWith(
-      '[osrm] Fetch error after all %d retries: %s', 3, 'AbortError'
+      { maxRetries: 3, errMessage: 'AbortError' },
+      'Fetch error after all retries:'
     );
   });
 


### PR DESCRIPTION
Closes #1861.

Summary of What Has Been Done:
Converted three printf-style logger.warn/error calls inside getRouteEstimate() in backend/api/src/services/osrm.js to pino object format for consistent structured logging. Also removed a duplicate unreachable fetch block in ml.js predictDemand() that referenced an undefined 'payload' variable (same fix as #1860). Updated the osrm unit test assertion to match the new log format.

Changes Made:
- backend/api/src/services/osrm.js: Converted 3 logger calls from positional printf args to pino object format (lines 66, 100, 103)
- backend/api/src/services/ml.js: Removed duplicate dead fetch block in predictDemand()
- backend/api/test/unit/osrm.test.js: Updated test assertion to expect pino object format

Impact it Made:
- Consistent structured logging across osrm.js enabling reliable log filtering
- Fixed undefined variable hazard in ml.js predictDemand()
- Local backend unit tests: 331 passed (pre-existing tracker/escrow failures unchanged)

Note: Please assign this PR to the `tmdeveloper007` account.