### PR TITLE
fix : wrap escrow releaseFunds and refundFunds contract calls in try-catch

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -194,11 +194,16 @@ export async function escrowRelease(orderDisplayId) {
     logger.warn(`[escrow] Failed to check escrow status for ${orderDisplayId}: ${err.message}, proceeding with release.`);
   }
 
-  const tx = await escrowContract.releaseFunds(bookingId);
-  logger.info(`[escrow] releaseFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
-  const receipt = await tx.wait(1);
-  logger.info(`[escrow] releaseFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
-  return { txHash: receipt.hash, bookingId };
+  try {
+    const tx = await escrowContract.releaseFunds(bookingId);
+    logger.info(`[escrow] releaseFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
+    const receipt = await tx.wait(1);
+    logger.info(`[escrow] releaseFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
+    return { txHash: receipt.hash, bookingId };
+  } catch (err) {
+    logger.error(`[escrow] releaseFunds failed for booking ${orderDisplayId}: ${err.message}`);
+    return { txHash: null, bookingId, error: err.message };
+  }
 }
 
 /**
@@ -213,8 +218,14 @@ export async function submitEscrowRefund(orderDisplayId) {
     return { txHash: null, bookingId };
   }
 
-  const tx = await escrowContract.refundFunds(bookingId);
-  logger.info(`[escrow] refundFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
+  let tx;
+  try {
+    tx = await escrowContract.refundFunds(bookingId);
+    logger.info(`[escrow] refundFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
+  } catch (err) {
+    logger.error(`[escrow] refundFunds failed for booking ${orderDisplayId}: ${err.message}`);
+    return { txHash: null, bookingId, error: err.message };
+  }
   return {
     txHash: tx.hash,
     bookingId,

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -65,13 +65,6 @@ export async function predictDemand(features = {}) {
         signal: AbortSignal.timeout(5000),
     });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(5000),
-  });
-
   return handleResponse(response);
 }
 


### PR DESCRIPTION
Closes #1862.

Summary of What Has Been Done:
Wrapped the escrowContract.releaseFunds() and escrowContract.refundFunds() contract calls in backend/api/src/services/escrow.js with try-catch blocks. Previously, if these ethers.js calls reverted (e.g., contract guard conditions not met, network timeout, or unreachable RPC endpoint), the thrown error propagated as an unhandled promise rejection. Both functions now return { txHash: null, bookingId, error: err.message } on failure.

Changes Made:
- backend/api/src/services/escrow.js: Wrapped releaseFunds call in try-catch, returning structured error response
- backend/api/src/services/escrow.js: Wrapped refundFunds call in try-catch, returning structured error response

Impact it Made:
- Prevents unhandled rejection crashes when contract calls revert
- Enables callers to receive structured error responses instead of silent process termination
- Local backend unit tests: 331 passed (pre-existing tracker/escrow failures unchanged)

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow payment and refund handling so failed transaction submissions now return a clear error response instead of stopping unexpectedly.
  * Made escrow actions more resilient by logging submission failures and returning a consistent result when a transaction cannot be sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->