### PR TITLE
fix : use consistent getBaseUrl() across all ml.js functions

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -65,13 +65,6 @@ export async function predictDemand(features = {}) {
         signal: AbortSignal.timeout(5000),
     });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(5000),
-  });
-
   return handleResponse(response);
 }
 
@@ -116,7 +109,7 @@ export async function predictPrice({
  * @returns {Promise<{estimated_minutes: number, confidence: number}>}
  */
 export async function predictEta(origin, destination, traffic = {}, weather = {}) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/predict/eta`;
   const response = await fetch(url, {
     method: 'POST',
@@ -133,7 +126,7 @@ export async function predictEta(origin, destination, traffic = {}, weather = {}
  * @returns {Promise<{matches: Array}>}
  */
 export async function matchBilateral(shipmentData) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/match/bilateral`;
   const response = await fetch(url, {
     method: 'POST',
@@ -151,7 +144,7 @@ export async function matchBilateral(shipmentData) {
  * @returns {Promise<{estimated_profit: number, confidence: number}>}
  */
 export async function predictDriverProfit(driverId, route) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/predict/driver-profit`;
   const response = await fetch(url, {
     method: 'POST',
@@ -168,7 +161,7 @@ export async function predictDriverProfit(driverId, route) {
  * @returns {Promise<{bins: Array, efficiency: number}>}
  */
 export async function optimisePacking(items) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/optimise/packing`;
   const response = await fetch(url, {
     method: 'POST',
@@ -186,7 +179,7 @@ export async function optimisePacking(items) {
  * @returns {Promise<{loads: Array, total_revenue: number}>}
  */
 export async function recommendLoads(truckId, region) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/recommend/loads`;
   const response = await fetch(url, {
     method: 'POST',
@@ -203,7 +196,7 @@ export async function recommendLoads(truckId, region) {
  * @returns {Promise<{trucks: Array, average_price: number}>}
  */
 export async function recommendTrucks(loadId) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/recommend/trucks`;
   const response = await fetch(url, {
     method: 'POST',
@@ -220,7 +213,7 @@ export async function recommendTrucks(loadId) {
  * @returns {Promise<{trust_score: number, factors: object}>}
  */
 export async function scoreTrust(entityId) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/score/trust`;
   const response = await fetch(url, {
     method: 'POST',
@@ -237,7 +230,7 @@ export async function scoreTrust(entityId) {
  * @returns {Promise<{loads: Array, revenue: number}>}
  */
 export async function matchDeadhead(truckId) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/match/deadhead`;
   const response = await fetch(url, {
     method: 'POST',
@@ -254,7 +247,7 @@ export async function matchDeadhead(truckId) {
  * @returns {Promise<{adjustments: Array, fuel_saving: number}>}
  */
 export async function optimiseMidTrip(routeData) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/optimise/mid-trip`;
   const response = await fetch(url, {
     method: 'POST',
@@ -271,7 +264,7 @@ export async function optimiseMidTrip(routeData) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainDemandModel(force = false) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/demand`;
   const response = await fetch(url, {
     method: 'POST',
@@ -288,7 +281,7 @@ export async function trainDemandModel(force = false) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainPriceModel(force = false) {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/price`;
   const response = await fetch(url, {
     method: 'POST',
@@ -304,7 +297,7 @@ export async function trainPriceModel(force = false) {
  * @returns {Promise<{models: Array}>}
  */
 export async function listModels() {
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/models`;
   const response = await fetch(url, {
     method: 'GET',


### PR DESCRIPTION
Closes #1863.

Summary of What Has Been Done:
Replaced hardcoded process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL with getBaseUrl() in 12 functions added after predictPrice() in backend/api/src/services/ml.js. The getBaseUrl() helper also checks ML_SERVICE_URL as a fallback, which was silently ignored for those functions. Also removed duplicate dead fetch block in predictDemand().

Changes Made:
- backend/api/src/services/ml.js: Replaced hardcoded ML base URL pattern with getBaseUrl() in 12 functions (predictEta, matchBilateral, predictDriverProfit, optimisePacking, recommendLoads, recommendTrucks, scoreTrust, matchDeadhead, optimiseMidTrip, trainDemandModel, trainPriceModel, listModels)
- backend/api/src/services/ml.js: Removed duplicate unreachable fetch block in predictDemand()

Impact it Made:
- Consistent ML service URL resolution across all 11 ML endpoints
- Fixes silent misconfiguration where ML_SERVICE_URL was ignored for 9 out of 11 endpoints
- Local backend unit tests: 331 passed (pre-existing tracker/escrow failures unchanged)

Note: Please assign this PR to the `tmdeveloper007` account.