### PR TITLE
fix: require trip id in batch events

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -71,6 +71,18 @@ const validateBatchPayload = (schema) => (req, res, next) => {
   }
 };
 
+function validateEventTripIds(events) {
+  const missingIndex = events.findIndex(event => !event.trip_id);
+  if (missingIndex !== -1) {
+    return {
+      ok: false,
+      status: 400,
+      error: `events.${missingIndex}.trip_id is required`,
+    };
+  }
+  return { ok: true };
+}
+
 async function verifyTripIdsBelongToUser(tripIds, user) {
   const uniqueTripIds = [...new Set(tripIds.filter(Boolean))];
   if (uniqueTripIds.length === 0) return { ok: true };
@@ -161,6 +173,11 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
           details: result.error.issues,
         });
       }
+    }
+
+    const tripIdCheck = validateEventTripIds(events);
+    if (!tripIdCheck.ok) {
+      return res.status(tripIdCheck.status).json({ error: tripIdCheck.error });
     }
 
     const ownershipCheck = await verifyTripIdsBelongToUser(events.map(event => event.trip_id), req.user);

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -231,6 +231,29 @@ describe('Trip Routes', () => {
         expect(res.body.error).toBe('Database failed to process batch.');
     });
 
+    it('POST /events/batch returns 400 when an event omits trip_id', async () => {
+        const res = await request(buildApp())
+            .post('/api/v1/trips/events/batch')
+            .set(DRIVER_HEADERS)
+            .send({
+                idempotencyKey: 'batch-missing-trip',
+                events: [
+                    {
+                        id: 'event-missing-trip',
+                        type: 'location_update',
+                        occurred_at: new Date().toISOString(),
+                        payload: {
+                            lat: 19.076,
+                            lng: 72.8777,
+                        },
+                    },
+                ],
+            });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('events.0.trip_id is required');
+    });
+
     it('POST /events/batch returns 422 for otpDelivery event containing otp', async () => {
         const res = await request(buildApp())
             .post('/api/v1/trips/events/batch')


### PR DESCRIPTION
## Summary
- reject offline trip batch events that do not include a trip id
- cover the missing trip id case in the trip route integration tests

## Validation
- npm test -- --run test/integration/tripRoutes.test.js

Closes #1900


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch event validation so requests now fail fast when any event is missing a required trip ID.
  * Added clearer error responses that point to the exact event index with the missing field.
  * Ensured invalid batch submissions return a **400** before further trip validation runs.

* **Tests**
  * Added coverage for batch event requests missing `trip_id` to confirm the new validation and error message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->