### PR TITLE
fix: guard trip event coordinate mapping

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -71,6 +71,10 @@ const validateBatchPayload = (schema) => (req, res, next) => {
   }
 };
 
+function hasCoordinatePayload(payload = {}) {
+  return payload.lat !== undefined || payload.lng !== undefined;
+}
+
 async function verifyTripIdsBelongToUser(tripIds, user) {
   const uniqueTripIds = [...new Set(tripIds.filter(Boolean))];
   if (uniqueTripIds.length === 0) return { ok: true };
@@ -169,10 +173,15 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
     }
 
     const recordsToInsert = events.map(event => {
-      const lat = event.payload?.lat !== undefined ? Number(event.payload.lat) : null;
-      const lng = event.payload?.lng !== undefined ? Number(event.payload.lng) : null;
+      const shouldMapCoordinates = event.type === 'gpsUpdate' || event.type === 'location_update';
+      const lat = shouldMapCoordinates && event.payload?.lat !== undefined ? Number(event.payload.lat) : null;
+      const lng = shouldMapCoordinates && event.payload?.lng !== undefined ? Number(event.payload.lng) : null;
 
       const safeMetadata = { ...event.payload };
+      if (!shouldMapCoordinates && hasCoordinatePayload(safeMetadata)) {
+        delete safeMetadata.lat;
+        delete safeMetadata.lng;
+      }
       for (const field of SENSITIVE_FIELDS) {
         delete safeMetadata[field];
       }

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -329,6 +329,58 @@ describe('Trip Routes', () => {
         expect(upsertCall.payload[0].metadata).not.toHaveProperty('password');
         expect(upsertCall.payload[0].metadata.lat).toBe(19.076);
     });
+
+    it('POST /events/batch does not map coordinates from non-coordinate events', async () => {
+        const originalFrom = m.supabase.from.bind(m.supabase);
+        m.supabase.from = table => {
+            const builder = originalFrom(table);
+            if (table === 'trip_events') {
+                builder.upsert = vi.fn(async payload => {
+                    m.calls.push({
+                        table: 'trip_events',
+                        mode: 'upsert',
+                        payload,
+                    });
+                    m.store.trip_events.push(...payload);
+                    return { data: payload, error: null };
+                });
+            }
+            return builder;
+        };
+
+        const res = await request(buildApp())
+            .post('/api/v1/trips/events/batch')
+            .set(DRIVER_HEADERS)
+            .send({
+                idempotencyKey: 'batch-non-coordinate',
+                events: [
+                    {
+                        id: 'event-note',
+                        trip_id: 'trip-1',
+                        type: 'status_note',
+                        occurred_at: new Date().toISOString(),
+                        payload: {
+                            lat: 'not-a-number',
+                            lng: 'still-not-a-number',
+                            note: 'Arrived at dock',
+                        },
+                    },
+                ],
+            });
+
+        m.supabase.from = originalFrom;
+
+        expect(res.status).toBe(202);
+        const upsertCall = m.calls.find(
+            c => c.table === 'trip_events' && c.mode === 'upsert' && c.payload[0].event_id === 'event-note'
+        );
+        expect(upsertCall).toBeTruthy();
+        expect(upsertCall.payload[0].latitude).toBeNull();
+        expect(upsertCall.payload[0].longitude).toBeNull();
+        expect(upsertCall.payload[0].metadata).not.toHaveProperty('lat');
+        expect(upsertCall.payload[0].metadata).not.toHaveProperty('lng');
+        expect(upsertCall.payload[0].metadata.note).toBe('Arrived at dock');
+    });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- map latitude and longitude columns only for coordinate event types
- remove coordinate-looking metadata from non-coordinate batch events
- add a regression test for malformed coordinate fields on a status event

## Validation
- npm test -- --run test/integration/tripRoutes.test.js

Closes #1901
