### PR TITLE
fix: reject invalid trip history cursor

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -87,7 +87,10 @@ class TripService {
     int limit = 20,
     String? status,
   }) async {
-    final page = int.tryParse(cursor ?? '1') ?? 1;
+    final page = int.tryParse(cursor ?? '1');
+    if (page == null || page < 1) {
+      throw ArgumentError.value(cursor, 'cursor', 'must be a positive integer');
+    }
     var uriString = '$_apiBaseUrl/api/driver/trips?page=$page&limit=$limit';
     if (status != null) {
       uriString += '&status=${Uri.encodeQueryComponent(status)}';

--- a/apps/driver/test/trip_service_test.dart
+++ b/apps/driver/test/trip_service_test.dart
@@ -153,6 +153,28 @@ void main() {
   final mockUser = FakeUser(driverId);
   final mockAuth = MockGoTrueClient(mockUser: mockUser);
 
+  group('TripService.fetchTripHistory Tests', () {
+    test('Rejects invalid cursor before sending request', () async {
+      final requests = <http.Request>[];
+      final mockHttp = MockClient((request) async {
+        requests.add(request);
+        return http.Response('{"trips":[]}', 200);
+      });
+
+      final client = FakeSupabaseClient(auth: mockAuth, onFrom: (relation) {
+        throw UnimplementedError('No Supabase access expected');
+      });
+
+      final service = TripService(client: client, httpClient: mockHttp);
+
+      expect(
+        () => service.fetchTripHistory(cursor: 'abc'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(requests, isEmpty);
+    });
+  });
+
   group('TripService.markStopCompleted Tests', () {
     // markStopCompleted now verifies ownership via Supabase and then
     // delegates the stop completion to the backend API; the progression


### PR DESCRIPTION
## Summary
- reject malformed trip history cursors before building the request
- add a driver service test that verifies no request is sent for an invalid cursor

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for trip history requests so invalid pagination values are rejected instead of being silently adjusted.
  * Improved error handling when the pagination cursor is not a valid positive number.
  * Updated automated checks to confirm invalid requests fail before any network call is made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->