### PR TITLE
fix: bound trip history limit

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -88,6 +88,9 @@ class TripService {
     String? status,
   }) async {
     final page = int.tryParse(cursor ?? '1') ?? 1;
+    if (limit < 1 || limit > 100) {
+      throw ArgumentError.value(limit, 'limit', 'must be between 1 and 100');
+    }
     var uriString = '$_apiBaseUrl/api/driver/trips?page=$page&limit=$limit';
     if (status != null) {
       uriString += '&status=${Uri.encodeQueryComponent(status)}';

--- a/apps/driver/test/trip_service_test.dart
+++ b/apps/driver/test/trip_service_test.dart
@@ -153,6 +153,28 @@ void main() {
   final mockUser = FakeUser(driverId);
   final mockAuth = MockGoTrueClient(mockUser: mockUser);
 
+  group('TripService.fetchTripHistory Tests', () {
+    test('Rejects out of range limit before sending request', () async {
+      final requests = <http.Request>[];
+      final mockHttp = MockClient((request) async {
+        requests.add(request);
+        return http.Response('{"trips":[]}', 200);
+      });
+
+      final client = FakeSupabaseClient(auth: mockAuth, onFrom: (relation) {
+        throw UnimplementedError('No Supabase access expected');
+      });
+
+      final service = TripService(client: client, httpClient: mockHttp);
+
+      expect(
+        () => service.fetchTripHistory(limit: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(requests, isEmpty);
+    });
+  });
+
   group('TripService.markStopCompleted Tests', () {
     // markStopCompleted now verifies ownership via Supabase and then
     // delegates the stop completion to the backend API; the progression


### PR DESCRIPTION
## Summary
- reject trip history limits outside the supported range before sending a request
- add a driver service test for the invalid limit path

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1903
