### PR TITLE
fix: handle non-json trip mutation errors

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -161,8 +161,7 @@ class TripService {
     final response = await _httpClient.put(uri, headers: await _authHeaders());
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      final body = jsonDecode(response.body) as Map<String, dynamic>?;
-      throw Exception(body?['error'] as String? ?? 'Failed to mark stop completed');
+      throw Exception(_errorMessage(response, 'Failed to mark stop completed'));
     }
   }
 
@@ -186,8 +185,20 @@ class TripService {
     final response = await _httpClient.put(uri, headers: await _authHeaders());
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      final body = jsonDecode(response.body) as Map<String, dynamic>?;
-      throw Exception(body?['error'] as String? ?? 'Failed to start trip');
+      throw Exception(_errorMessage(response, 'Failed to start trip'));
     }
+  }
+
+  String _errorMessage(http.Response response, String fallback) {
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        final error = decoded['error'] ?? decoded['message'];
+        if (error != null) return error.toString();
+      }
+    } catch (_) {
+      // Fall back to a status-aware message when the server does not return JSON.
+    }
+    return '$fallback (${response.statusCode})';
   }
 }

--- a/apps/driver/test/trip_service_test.dart
+++ b/apps/driver/test/trip_service_test.dart
@@ -221,6 +221,23 @@ void main() {
       );
     });
 
+    test('Throws fallback message when stop update error is not JSON', () async {
+      final mockHttp = MockClient((request) async {
+        return http.Response('Bad gateway', 502);
+      });
+
+      final service = TripService(client: ownedTripClient(), httpClient: mockHttp);
+
+      expect(
+        () => service.markStopCompleted(stopId, tripDisplayId),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Failed to mark stop completed (502)'),
+        )),
+      );
+    });
+
     test('Throws exception if driver does not own the trip', () async {
       final client = FakeSupabaseClient(
         auth: mockAuth,


### PR DESCRIPTION
## Summary
- parse trip mutation error bodies defensively
- preserve useful fallback messages when the server returns non-JSON errors
- add a regression test for a plain-text mutation failure

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1904
