### PR TITLE
fix: wrap invalid api json responses

### DIFF
--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -229,7 +229,15 @@ class ApiClient {
   dynamic _decode(http.Response response) {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       if (response.body.isEmpty) return null;
-      return jsonDecode(response.body);
+      try {
+        return jsonDecode(response.body);
+      } catch (_) {
+        throw ApiException(
+          response.statusCode,
+          'Invalid JSON response',
+          body: response.body,
+        );
+      }
     }
 
     if (kDebugMode) {

--- a/apps/customer/test/core/api_client_test.dart
+++ b/apps/customer/test/core/api_client_test.dart
@@ -239,6 +239,23 @@ void main() {
         ),
       );
     });
+
+    test('throws ApiException when a successful response is not valid JSON', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('not-json', 200));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await expectLater(
+        () => client.get('/api/orders'),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 200)
+              .having((e) => e.message, 'message', 'Invalid JSON response'),
+        ),
+      );
+    });
   });
 
   // ── Core enhancements ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- wrap malformed successful response bodies in ApiException
- add a unit test for non-JSON 2xx responses

## Validation
- Not run: `flutter test test/core/api_client_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1905
