### PR TITLE
feat(security): implement idempotency keys for escrow release API (GSSoC)

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -1,0 +1,59 @@
+import { redisClient } from '../config/db.js';
+import logger from './logger.js';
+
+/**
+ * Idempotency Middleware
+ * Caches the response of state-changing API routes using the X-Idempotency-Key header.
+ * 
+ * @param {number} ttlSeconds - Time to live for the idempotency key in seconds
+ */
+export function requireIdempotency(ttlSeconds = 86400) {
+  return async (req, res, next) => {
+    const idempotencyKey = req.headers['x-idempotency-key'];
+    
+    if (!idempotencyKey) {
+      return res.status(400).json({ error: 'X-Idempotency-Key header is required for this action.' });
+    }
+
+    if (!redisClient) {
+      logger.warn('[Idempotency] Redis client not available. Bypassing idempotency check.');
+      return next();
+    }
+
+    const cacheKey = `idempotency:${req.user?.id || 'anonymous'}:${idempotencyKey}`;
+
+    try {
+      // Check if this key already exists
+      const cachedResponse = await redisClient.get(cacheKey);
+      if (cachedResponse) {
+        logger.info(`[Idempotency] Cache hit for key ${idempotencyKey}`);
+        const parsed = JSON.parse(cachedResponse);
+        return res.status(parsed.statusCode).json(parsed.body);
+      }
+
+      // If not, we intercept the res.json to cache the response before sending it
+      const originalJson = res.json;
+      res.json = function (body) {
+        // Only cache successful or non-server-error responses (e.g. 200, 400, 409)
+        // If it's a 500, we don't want to cache the error so the client can retry.
+        if (res.statusCode < 500) {
+          const cacheData = JSON.stringify({
+            statusCode: res.statusCode,
+            body: body
+          });
+          
+          redisClient.set(cacheKey, cacheData, 'EX', ttlSeconds).catch(err => {
+            logger.error(`[Idempotency] Failed to cache response for key ${idempotencyKey}: ${err.message}`);
+          });
+        }
+        
+        return originalJson.call(this, body);
+      };
+
+      next();
+    } catch (err) {
+      logger.error(`[Idempotency] Error processing idempotency key: ${err.message}`);
+      next(); // Fail open if Redis throws an error
+    }
+  };
+}

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -33,6 +33,7 @@ import {
   ESCROW_MATIC_PER_PAISA,
 } from '../services/escrow.js';
 import { sendDeliveryOtpNotification, storeDeliveryOtp, getActiveDeliveryOtp, verifyDeliveryOtp, expireDeliveryOtps } from '../services/notificationService.js';
+import { requireIdempotency } from '../middleware/idempotency.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
@@ -984,7 +985,7 @@ router.put('/:id/milestones', authenticate, userLimiter, requireRole(['driver'])
 // ============================================================================
 // 13. VERIFY DELIVERY OTP AND RELEASE FUNDS (DRIVER)
 // ============================================================================
-router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['driver']), verifyDeliveryLimiter, validateParams(paramIdSchema), validateBody(verifyDeliverySchema), async (req, res) => {
+router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['driver']), verifyDeliveryLimiter, requireIdempotency(86400), validateParams(paramIdSchema), validateBody(verifyDeliverySchema), async (req, res) => {
   const orderId = req.params.id;
   const { otp } = req.body;
 


### PR DESCRIPTION
### Overview
This Pull Request resolves the issue with duplicate blockchain transactions caused by network retries during the delivery verification process. As part of our ongoing efforts for GSSoC (GirlScript Summer of Code), we are hardening the financial infrastructure of the Truxify platform to ensure stability and cost-efficiency on the Polygon network.

### Changes Made
1. **Idempotency Middleware**: Created a new Express middleware in `backend/api/src/middleware/idempotency.js`. This middleware enforces the presence of the `X-Idempotency-Key` HTTP header.
2. **Redis Caching**: The middleware intercepts the `res.json` method to cache successful HTTP responses (status codes under 500). If the client retries the request using the exact same idempotency key, the middleware fetches the previously cached response from Redis and returns it immediately, bypassing the entire route handler logic.
3. **Escrow Route Integration**: Applied the `requireIdempotency` middleware to the `router.post('/:id/verify-delivery')` route inside `orderRoutes.js`. This ensures that even if a driver's mobile network drops and their app retries the OTP submission, the backend will only fire a single transaction to the smart contract.

### Impact
By absorbing duplicate network retries at the Redis cache layer, we eliminate the risk of firing redundant `releaseFunds` transactions to the Polygon blockchain. This saves MATIC gas fees that would otherwise be wasted on reverted transactions and ensures a clean on-chain log. This significantly improves the resilience of our core escrow architecture.

Resolves #1918