### PR TITLE
ci: fix PR labeler workflow cancellation (GSSoC)

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: pr-labeler-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   label:


### PR DESCRIPTION
### Overview
This Pull Request resolves an issue where the `PR Labeler` GitHub Action workflow is repeatedly cancelled after a few seconds. The root cause is the `concurrency` setting combining the issue/PR number with `cancel-in-progress: true`. When a PR is opened and immediately labeled or commented upon by other bots or events, multiple triggers fire in rapid succession. The strict cancellation policy causes the older run to be terminated prematurely.

### Changes Made
Disabled the `cancel-in-progress` flag in `.github/workflows/pr-labeler.yml`. This ensures that all instances of the labeler are allowed to complete their execution, preventing the UI noise of cancelled workflows and ensuring that labels are reliably applied regardless of concurrent triggers.

### Impact
This fix stabilizes our continuous integration pipeline and improves the developer experience for all contributors participating in GSSoC (GirlScript Summer of Code).

Resolves #1921