### PR TITLE
fix: encode driver name lookup id

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -261,7 +261,7 @@ class OrderService {
   Future<String?> fetchDriverName(String driverId) async {
     try {
       final body = await _apiClient.get(
-        '/api/profile/$driverId/name',
+        '/api/profile/${_encodePathSegment(driverId)}/name',
       ) as Map<String, dynamic>?;
       final fullName = body?['full_name']?.toString().trim();
       return (fullName != null && fullName.isNotEmpty) ? fullName : null;

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -76,6 +76,18 @@ void main() {
     expect(order404, isNull);
   });
 
+  test('fetchDriverName encodes driver id path segment', () async {
+    when(() => apiClient.get('/api/profile/driver%2F123%3Fname%3DA/name'))
+        .thenAnswer((_) async => {'full_name': 'Driver A'});
+
+    final name = await orderService.fetchDriverName('driver/123?name=A');
+
+    expect(name, equals('Driver A'));
+    verify(
+      () => apiClient.get('/api/profile/driver%2F123%3Fname%3DA/name'),
+    ).called(1);
+  });
+
   group('estimatePriceRange', () {
     test('returns correct min and max when prices are integers', () async {
       when(() => apiClient.get(


### PR DESCRIPTION
## Summary
- encode the driver id path segment before requesting a driver name
- add a unit test that verifies reserved URL characters are escaped

## Validation
- Not run: `flutter test test/services/order_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver name lookup so driver IDs are safely URL-encoded in request paths.
  * Added test coverage to ensure the encoded driver path is used and the returned full name is displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->