### PR TITLE
fix: encode truck number lookup id

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -274,7 +274,7 @@ class OrderService {
   Future<String?> fetchTruckNumber(String truckId) async {
     try {
       final body = await _apiClient.get(
-        '/api/trucks/$truckId/number',
+        '/api/trucks/${_encodePathSegment(truckId)}/number',
       ) as Map<String, dynamic>?;
       final numberPlate = body?['number_plate']?.toString().trim();
       return (numberPlate != null && numberPlate.isNotEmpty) ? numberPlate : null;

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -76,6 +76,18 @@ void main() {
     expect(order404, isNull);
   });
 
+  test('fetchTruckNumber encodes truck id path segment', () async {
+    when(() => apiClient.get('/api/trucks/truck%2F123%23plate/number'))
+        .thenAnswer((_) async => {'number_plate': 'MH-01-AB-1234'});
+
+    final number = await orderService.fetchTruckNumber('truck/123#plate');
+
+    expect(number, equals('MH-01-AB-1234'));
+    verify(
+      () => apiClient.get('/api/trucks/truck%2F123%23plate/number'),
+    ).called(1);
+  });
+
   group('estimatePriceRange', () {
     test('returns correct min and max when prices are integers', () async {
       when(() => apiClient.get(


### PR DESCRIPTION
## Summary
- encode the truck id path segment before requesting a truck number
- add a unit test that verifies reserved URL characters are escaped

## Validation
- Not run: `flutter test test/services/order_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #1907
