### PR TITLE
fix: validate admin ticket user filter

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const FAQ_COLUMNS = 'id, question, answer, app_type, sort_order';
 const TICKET_COLUMNS = 'id, subject, description, category, status, created_at, updated_at';
 const TICKET_DETAIL_COLUMNS = 'id, user_id, subject, description, category, status, created_at, updated_at';
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Canonical map of all accepted category aliases -> database values.
 // Shared by ticket creation, ticket update, and the categories endpoint.
@@ -39,6 +40,14 @@ function parseIntegerQuery(value, fallback, field, { min }) {
   }
 
   return { value: parsed };
+}
+
+function parseUuidQuery(value, field) {
+  if (value === undefined) return { value: undefined };
+  if (typeof value !== 'string' || !UUID_REGEX.test(value)) {
+    return { error: `${field} must be a valid UUID` };
+  }
+  return { value };
 }
 
 // ============================================================================
@@ -361,6 +370,11 @@ router.get('/admin/tickets', authenticate, userLimiter, requireRole(['admin']), 
     return res.status(400).json({ error: 'Unsupported support ticket category.' });
   }
 
+  const userIdResult = parseUuidQuery(user_id, 'user_id');
+  if (userIdResult.error) {
+    return res.status(400).json({ error: userIdResult.error });
+  }
+
   try {
     let query = supabase
       .from('support_tickets')
@@ -374,8 +388,8 @@ router.get('/admin/tickets', authenticate, userLimiter, requireRole(['admin']), 
       query = query.eq('category', dbCategory);
     }
 
-    if (user_id) {
-      query = query.eq('user_id', user_id);
+    if (userIdResult.value) {
+      query = query.eq('user_id', userIdResult.value);
     }
 
     const { data: tickets, error, count } = await query

--- a/backend/api/test/integration/supportRoutes.test.js
+++ b/backend/api/test/integration/supportRoutes.test.js
@@ -412,9 +412,9 @@ describe('Support Routes', () => {
   describe('GET /admin/tickets', () => {
     beforeEach(() => {
       m.store.support_tickets.push(
-        { id: 't1', user_id: 'customer-1', subject: 'S1', category: 'payment', status: 'open', created_at: '2026-06-03T00:00:00.000Z' },
-        { id: 't2', user_id: 'customer-2', subject: 'S2', category: 'order', status: 'in_progress', created_at: '2026-06-02T00:00:00.000Z' },
-        { id: 't3', user_id: 'customer-1', subject: 'S3', category: 'technical', status: 'closed', created_at: '2026-06-01T00:00:00.000Z' }
+        { id: 't1', user_id: '11111111-1111-4111-8111-111111111111', subject: 'S1', category: 'payment', status: 'open', created_at: '2026-06-03T00:00:00.000Z' },
+        { id: 't2', user_id: '22222222-2222-4222-8222-222222222222', subject: 'S2', category: 'order', status: 'in_progress', created_at: '2026-06-02T00:00:00.000Z' },
+        { id: 't3', user_id: '11111111-1111-4111-8111-111111111111', subject: 'S3', category: 'technical', status: 'closed', created_at: '2026-06-01T00:00:00.000Z' }
       );
     });
 
@@ -449,7 +449,7 @@ describe('Support Routes', () => {
 
     it('filters by status, category, and user_id', async () => {
       const res = await request(buildApp())
-        .get('/api/support/admin/tickets?status=open&category=payment&user_id=customer-1')
+        .get('/api/support/admin/tickets?status=open&category=payment&user_id=11111111-1111-4111-8111-111111111111')
         .set({
           'x-user-id': 'admin-1',
           'x-user-role': 'admin',
@@ -460,13 +460,26 @@ describe('Support Routes', () => {
       expect(res.body.tickets).toHaveLength(1);
       expect(res.body.tickets[0].id).toBe('t1');
     });
+
+    it('rejects malformed user_id filter values', async () => {
+      const res = await request(buildApp())
+        .get('/api/support/admin/tickets?user_id=customer-1')
+        .set({
+          'x-user-id': 'admin-1',
+          'x-user-role': 'admin',
+          'x-user-name': 'Test Admin',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('user_id must be a valid UUID');
+    });
   });
 
   describe('Support Ticket Comments', () => {
     beforeEach(() => {
       m.store.support_ticket_comments = [];
       m.store.support_tickets = [{
-        id: 't-123',
+        id: '33333333-3333-4333-8333-333333333333',
         user_id: 'customer-1',
         subject: 'Need help',
         category: 'general',
@@ -476,14 +489,14 @@ describe('Support Routes', () => {
 
     it('POST /tickets/:id/comments adds a comment for ticket owner', async () => {
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set(CUSTOMER_HEADERS)
         .send({ message: 'This is a test comment' });
 
       expect(res.status).toBe(201);
       expect(res.body.message).toBe('Comment added successfully.');
       expect(res.body.comment.message).toBe('This is a test comment');
-      expect(res.body.comment.ticket_id).toBe('t-123');
+      expect(res.body.comment.ticket_id).toBe('33333333-3333-4333-8333-333333333333');
 
       const commentInsert = m.calls.find(c => c.table === 'support_ticket_comments' && c.mode === 'insert');
       expect(commentInsert).toBeTruthy();
@@ -492,7 +505,7 @@ describe('Support Routes', () => {
 
     it('POST /tickets/:id/comments returns 403 for non-owner', async () => {
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set({
           'x-user-id': 'customer-2',
           'x-user-role': 'customer',
@@ -507,7 +520,7 @@ describe('Support Routes', () => {
       m.store.support_tickets[0].status = 'closed';
 
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set(CUSTOMER_HEADERS)
         .send({ message: 'New comment after closure' });
 
@@ -522,7 +535,7 @@ describe('Support Routes', () => {
       m.store.support_tickets[0].status = 'closed';
 
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set({
           'x-user-id': 'admin-1',
           'x-user-role': 'admin',
@@ -539,7 +552,7 @@ describe('Support Routes', () => {
 
     it('POST /tickets/:id/comments still accepts comments on open tickets', async () => {
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set(CUSTOMER_HEADERS)
         .send({ message: 'Still open, commenting fine' });
 
@@ -551,7 +564,7 @@ describe('Support Routes', () => {
       m.store.support_tickets[0].status = 'in_progress';
 
       const res = await request(buildApp())
-        .post('/api/support/tickets/t-123/comments')
+        .post('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set(CUSTOMER_HEADERS)
         .send({ message: 'In progress comment' });
 
@@ -562,14 +575,14 @@ describe('Support Routes', () => {
     it('GET /tickets/:id/comments retrieves comments for ticket owner', async () => {
       m.store.support_ticket_comments.push({
         id: 'c-1',
-        ticket_id: 't-123',
+        ticket_id: '33333333-3333-4333-8333-333333333333',
         user_id: 'customer-1',
         message: 'Hello',
         created_at: '2026-06-01T00:00:00.000Z',
       });
 
       const res = await request(buildApp())
-        .get('/api/support/tickets/t-123/comments')
+        .get('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments')
         .set(CUSTOMER_HEADERS);
 
       expect(res.status).toBe(200);
@@ -579,12 +592,12 @@ describe('Support Routes', () => {
 
     it('GET /tickets/:id/comments supports sort=desc for descending chronological sorting', async () => {
       m.store.support_ticket_comments.push(
-        { id: 'c-1', ticket_id: 't-123', user_id: 'customer-1', message: 'First', created_at: '2026-06-01T00:00:00.000Z' },
-        { id: 'c-2', ticket_id: 't-123', user_id: 'customer-1', message: 'Second', created_at: '2026-06-02T00:00:00.000Z' }
+        { id: 'c-1', ticket_id: '33333333-3333-4333-8333-333333333333', user_id: 'customer-1', message: 'First', created_at: '2026-06-01T00:00:00.000Z' },
+        { id: 'c-2', ticket_id: '33333333-3333-4333-8333-333333333333', user_id: 'customer-1', message: 'Second', created_at: '2026-06-02T00:00:00.000Z' }
       );
 
       const res = await request(buildApp())
-        .get('/api/support/tickets/t-123/comments?sort=desc')
+        .get('/api/support/tickets/33333333-3333-4333-8333-333333333333/comments?sort=desc')
         .set(CUSTOMER_HEADERS);
 
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- validate the admin ticket `user_id` filter as a UUID before querying
- add a regression test for malformed `user_id` filter values
- update support route test fixtures to use UUID-shaped comment ticket ids

## Validation
- npm test -- --run test/integration/supportRoutes.test.js

Closes #1909
