### PR TITLE
Fix: Auto-reconnect WebSocket live tracking on app resume (#1947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Fix issue 1947


### PR DESCRIPTION
Fixed an issue where the Driver App's live tracking WebSocket stayed disconnected after the OS backgrounded the app. Added a lifecycle listener to auto-reconnect on resume. Closes #1947.