### PR TITLE
Fix: Strip EXIF rotation before hashing documents (#1948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Fix issue 1948


### PR DESCRIPTION
Resolved on-chain hash mismatches for uploaded RC books and licenses by stripping Android EXIF rotation metadata and baking orientation into pixels before SHA-256 hashing. Closes #1948.