### PR TITLE
Feat: "Home City" bias for return loads (#1960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Implement feature 1960


### PR DESCRIPTION
Allowed drivers to set a "Home City" in their profile. The Collaborative Filter and Deadhead Eliminator ML models now bias load recommendations towards routes that lead back to their home base. Closes #1960.