### PR TITLE
[fix]: `PATCH` missing from the CORS allowlist

### DIFF
--- a/backend/api/src/middleware/cors.js
+++ b/backend/api/src/middleware/cors.js
@@ -29,6 +29,6 @@ export const corsMiddleware = cors({
 
     return callback(null, false);
   },
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: corsAllowedHeaders,
 });


### PR DESCRIPTION

**Before:** `methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']` did not include `PATCH`, but `PATCH /api/support/tickets/:id` is the only way to update a support ticket. Any browser client on an allowed origin had its `PATCH` preflight rejected, making that endpoint unreachable from web frontends.
 
**Fix:** #1789 

gssoc
 
---