### PR TITLE
fix: add PATCH to CORS allowlist (#2007)

### DIFF
--- a/backend/api/src/middleware/cors.js
+++ b/backend/api/src/middleware/cors.js
@@ -29,6 +29,6 @@ export const corsMiddleware = cors({
 
     return callback(null, false);
   },
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: corsAllowedHeaders,
 });


### PR DESCRIPTION
Adds `PATCH` to the CORS allowed HTTP methods list so that partial-update endpoints (e.g. trip stop completion, profile updates) work correctly from browser-based clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cross-origin request handling to allow `PATCH` requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->