### PR TITLE
fix: validate client-controlled request ID against UUID format (#2006)

### DIFF
--- a/backend/api/src/middleware/requestId.js
+++ b/backend/api/src/middleware/requestId.js
@@ -1,8 +1,11 @@
 import { randomUUID } from 'crypto';
 import logger from './logger.js';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function requestIdMiddleware(req, res, next) {
-  req.requestId = req.headers['x-request-id'] || randomUUID();
+  const header = req.headers['x-request-id'];
+  req.requestId = (typeof header === 'string' && UUID_RE.test(header)) ? header : randomUUID();
   res.setHeader('X-Request-Id', req.requestId);
   next();
 }


### PR DESCRIPTION
Rejects non-UUID `x-request-id` headers from clients instead of trusting them blindly. Falls back to a server-generated `randomUUID()` when the client-supplied value is missing or not a valid UUID.

Previously any string (including injection payloads) passed through from the client into logs and downstream services.