### PR TITLE
fix: reject all ML requests when ML_API_KEY is not configured (#1998)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -23,6 +23,12 @@ mlBreaker.fallback(() => {
 // Startup validation
 if (!process.env.ML_API_KEY) {
     logger.warn('[ML] WARNING: ML_API_KEY is not set. ML features will be unavailable.');
+
+function guardMlApiKey() {
+  if (!process.env.ML_API_KEY) {
+    throw new Error("[ML] ML_API_KEY is not configured. ML features are unavailable.");
+  }
+}
 }
 
 /**
@@ -73,6 +79,7 @@ function getBaseUrl() {
  * @returns {Promise<object>}
  */
 export async function predictDemand(features = {}) {
+  guardMlApiKey();
     const url = `${getBaseUrl()}/predict/demand`;
 
     const response = await mlBreaker.fire(url, {
@@ -97,6 +104,7 @@ export async function predictPrice({
     routeOrigin = '',
     routeDestination = '',
 } = {}) {
+  guardMlApiKey();
     const url = `${getBaseUrl()}/predict`;
 
     const payload = {
@@ -126,6 +134,7 @@ export async function predictPrice({
  * @returns {Promise<{estimated_minutes: number, confidence: number}>}
  */
 export async function predictEta(origin, destination, traffic = {}, weather = {}) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/predict/eta`;
   const response = await mlBreaker.fire(url, {
@@ -143,6 +152,7 @@ export async function predictEta(origin, destination, traffic = {}, weather = {}
  * @returns {Promise<{matches: Array}>}
  */
 export async function matchBilateral(shipmentData) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/match/bilateral`;
   const response = await mlBreaker.fire(url, {
@@ -161,6 +171,7 @@ export async function matchBilateral(shipmentData) {
  * @returns {Promise<{estimated_profit: number, confidence: number}>}
  */
 export async function predictDriverProfit(driverId, route) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/predict/driver-profit`;
   const response = await mlBreaker.fire(url, {
@@ -178,6 +189,7 @@ export async function predictDriverProfit(driverId, route) {
  * @returns {Promise<{bins: Array, efficiency: number}>}
  */
 export async function optimisePacking(items) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/optimise/packing`;
   const response = await mlBreaker.fire(url, {
@@ -196,6 +208,7 @@ export async function optimisePacking(items) {
  * @returns {Promise<{loads: Array, total_revenue: number}>}
  */
 export async function recommendLoads(truckId, region) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/recommend/loads`;
   const response = await mlBreaker.fire(url, {
@@ -213,6 +226,7 @@ export async function recommendLoads(truckId, region) {
  * @returns {Promise<{trucks: Array, average_price: number}>}
  */
 export async function recommendTrucks(loadId) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/recommend/trucks`;
   const response = await mlBreaker.fire(url, {
@@ -230,6 +244,7 @@ export async function recommendTrucks(loadId) {
  * @returns {Promise<{trust_score: number, factors: object}>}
  */
 export async function scoreTrust(entityId) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/score/trust`;
   const response = await mlBreaker.fire(url, {
@@ -247,6 +262,7 @@ export async function scoreTrust(entityId) {
  * @returns {Promise<{loads: Array, revenue: number}>}
  */
 export async function matchDeadhead(truckId) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/match/deadhead`;
   const response = await mlBreaker.fire(url, {
@@ -264,6 +280,7 @@ export async function matchDeadhead(truckId) {
  * @returns {Promise<{adjustments: Array, fuel_saving: number}>}
  */
 export async function optimiseMidTrip(routeData) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/optimise/mid-trip`;
   const response = await mlBreaker.fire(url, {
@@ -281,6 +298,7 @@ export async function optimiseMidTrip(routeData) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainDemandModel(force = false) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/demand`;
   const response = await mlBreaker.fire(url, {
@@ -298,6 +316,7 @@ export async function trainDemandModel(force = false) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainPriceModel(force = false) {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/price`;
   const response = await mlBreaker.fire(url, {
@@ -314,6 +333,7 @@ export async function trainPriceModel(force = false) {
  * @returns {Promise<{models: Array}>}
  */
 export async function listModels() {
+  guardMlApiKey();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}/models`;
   const response = await mlBreaker.fire(url, {


### PR DESCRIPTION
Adds a `guardMlApiKey()` guard that throws early in every exported function in `ml.js` when `ML_API_KEY` is missing.

Previously, all 14 public functions would proceed to make requests to the ML engine without an API key, receiving 401 errors. Now they fail fast with a clear error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ML-related actions now fail fast with a clear error if the required API key is missing, instead of proceeding with unavailable ML features.
  * Prediction, optimization, matching, scoring, and model management requests now consistently validate configuration before running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->