### PR TITLE
fix: add healthchecks to MongoDB and Redis in docker-compose (#2001)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
       - ./backend/api:/app
       - /app/node_modules
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:5000/api/health/live || curl -sf http://localhost:5000/api/health/live"]
       interval: 30s
@@ -53,11 +55,23 @@ services:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   redis:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
 volumes:
   mongo_data:


### PR DESCRIPTION
Adds Docker healthcheck definitions for MongoDB and Redis services, and updates the API service's `depends_on` to use `condition: service_healthy`.

This prevents the API server from starting before the databases are ready, eliminating connection-refused errors during initial startup.