### PR TITLE
fix: rename undefined pl/pw/ph variables to pkg_length/pkg_width/pkg_height in bin_packing.py (#1993)

### DIFF
--- a/backend/ml/app/models/bin_packing.py
+++ b/backend/ml/app/models/bin_packing.py
@@ -150,7 +150,7 @@ def _pack_packages(
         if not placed:
             # Open a new shelf
             z_offset = sum(s.shelf_height for s in shelves)
-            if z_offset + ph > truck_h:
+            if z_offset + pkg_height > truck_h:
                 arrangements[idx] = {
                     "package_index": idx,
                     "position": {"x": 0.0, "y": 0.0, "z": 0.0},
@@ -161,7 +161,7 @@ def _pack_packages(
                 continue
 
             new_shelf = _Shelf(z_offset, truck_l, truck_w, truck_h - z_offset)
-            pos = new_shelf.try_place(pl, pw, ph)
+            pos = new_shelf.try_place(pkg_length, pkg_width, pkg_height)
             if pos is not None:
                 arrangements[idx] = {
                     "package_index": idx,


### PR DESCRIPTION
Fixes a runtime `NameError` in `_pack_packages()` where the variables `pl`, `pw`, `ph` (line 153, 164) were never defined — they should be `pkg_length`, `pkg_width`, `pkg_height` which are already correctly extracted from the package dict on line 121.