### PR TITLE
fix: add type safety check before List cast in Supabase repository queries (#2000)

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -63,7 +63,7 @@ class MarketplaceRepository {
 
     final decoded = jsonDecode(response.body);
     if (decoded is! List) throw StateError('Unexpected response type');
-    return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
+    return decoded.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
   }
 
   Future<DriverBid> submitBid({


### PR DESCRIPTION
Fixes a bug in `fetchEnRouteLoads()` where `body` (the raw HTTP response body string) was used for `.cast<Map<String, dynamic>>()` instead of `decoded` (the parsed JSON). 

This would cause a runtime `TypeError` since `body` is a `String`, not a `List`.