### PR TITLE
fix: rate-limiter security — proxy-aware IP, Redis store on route-level limiters (#1938)

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -77,14 +77,15 @@ function buildStore(prefix) {
 }
 
 /**
- * Generates a rate-limit key from the actual TCP connection address instead of
- * req.ip (which trusts the client-controlled X-Forwarded-For header). This
- * prevents attackers from bypassing rate limits by rotating the header value.
+ * Generates a rate-limit key from the proxy-resolved IP address.
+ *
+ * Express's trust-proxy setting (1 hop) resolves X-Forwarded-For to req.ip.
+ * Using req.socket.remoteAddress directly would see the load balancer / proxy
+ * IP instead of the real client, collapsing all users behind the same proxy
+ * into one rate-limit bucket.
  */
 export function safeIpKeyGenerator(req) {
-  return req.socket?.remoteAddress
-    || req.connection?.remoteAddress
-    || 'unknown';
+  return req.ip || req.socket?.remoteAddress || 'unknown';
 }
 
 /**


### PR DESCRIPTION
## Changes

1. **Proxy-aware IP**: Changed `safeIpKeyGenerator` to use `req.ip` (resolved by Express's `trust proxy` setting from `X-Forwarded-For`) instead of `req.socket.remoteAddress` which only sees the load balancer/proxy IP behind a reverse proxy. This prevents all users behind the same proxy from collapsing into a single rate-limit bucket.

2. **Redis store promotion**: All route-level limiters (globalLimiter, userLimiter, healthLimiter, authLimiter, bidLimiter, deviceLimiter) already use `DeferredRedisStore` which defers the Redis/memory decision and promotes to RedisStore once the Redis client is ready — no change needed here.