### PR TITLE
fix(support): use paramIdSchema for tickets/:id/comments to match oth…

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -3,7 +3,7 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateBody, validateParams } from '../middleware/validate.js';
-import { createTicketSchema, updateTicketSchema, createTicketCommentSchema, uuidParamSchema } from '../validation/requestSchemas.js';
+import { createTicketSchema, updateTicketSchema, createTicketCommentSchema, paramIdSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -477,7 +477,7 @@ router.post('/tickets/:id/comments', authenticate, userLimiter, validateBody(cre
 // ============================================================================
 // 8. GET ALL COMMENTS/REPLIES FOR A TICKET (CUSTOMER OR DRIVER OWNER OR ADMIN)
 // ============================================================================
-router.get('/tickets/:id/comments', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
+router.get('/tickets/:id/comments', authenticate, userLimiter, validateParams(paramIdSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { sort } = req.query;
   if (sort !== undefined && sort !== 'asc' && sort !== 'desc') {


### PR DESCRIPTION
## Description
Fixes #2025. 

The `GET /api/support/tickets/:id/comments` route was previously using `validateParams(uuidParamSchema)`, which strictly rejected the non-UUID strings (`t-123`) used in the `supportRoutes.test.js` integration tests, resulting in a `400 Bad Request` test failure.

This PR swaps `uuidParamSchema` for `paramIdSchema` on this endpoint. This ensures it successfully handles the mocked test IDs and is completely consistent with how ID validation is handled by all other routes in `supportRoutes.js`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] All new and existing tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated ticket comment requests to use the current identifier validation rules, improving consistency for the `GET /tickets/:id/comments` endpoint.
  - Requests with an invalid ticket ID format will now be rejected according to the revised parameter checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->