### PR TITLE
fix : log Redis lock deletion error in escrowRefundReconciliation.js

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -102,7 +102,11 @@ export async function reconcilePendingEscrowRefunds() {
     }
 
     if (globalLockAcquired && redisClient) {
-      await redisClient.del(GLOBAL_LOCK_KEY).catch(() => {});
+      try {
+        await redisClient.del(GLOBAL_LOCK_KEY);
+      } catch (err) {
+        logger.warn('[escrow-reconciliation] Failed to release global lock:', err.message);
+      }
     }
   } finally {
     reconciliationRunning = false;


### PR DESCRIPTION
Closes #2029.

Summary of What Has Been Done:
Replaced a silent .catch(() => {}) in the finally block of reconcilePendingEscrowRefunds() with a try-catch that logs the Redis lock deletion failure at warn level. Previously, if redisClient.del() failed, the error was silently swallowed and the lock persisted until TTL expiry.

Changes Made:
- backend/api/src/services/escrowRefundReconciliation.js: Replaced .catch(() => {}) with try-catch + logger.warn for the global lock deletion call.

Impact it Made:
- Bug fix: Redis lock failures are now visible in logs, making the reconciliation system more observable. Subsequent reconciliation batches will no longer silently skip due to phantom locks.

Note: Please assign this PR to the `tmdeveloper007` account.