### PR TITLE
fix : log error when JSON.parse fails in ml.js handleResponse

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -51,8 +51,8 @@ async function handleResponse(response) {
 
     try {
         return JSON.parse(text);
-    } catch {
-        throw new Error('[ML] Invalid JSON response from ML engine');
+    } catch (err) {
+        throw new Error(`[ML] Invalid JSON response from ML engine: ${err.message}`);
     }
 }
 


### PR DESCRIPTION
Closes #2032.

Summary of What Has Been Done:
Replaced bare catch {} in handleResponse() with catch (err) and included err.message in the thrown error. Previously, a JSON parse failure on the ML engine response would lose the original SyntaxError context.

Changes Made:
- backend/api/src/services/ml.js: Changed bare catch to catch (err) with error message preserved.

Impact it Made:
- Bug fix: Malformed ML engine JSON responses now produce informative error messages that include the underlying SyntaxError, making it easier to diagnose data contract issues.

Note: Please assign this PR to the `tmdeveloper007` account.