### PR TITLE
test : add unit tests for pricing.js readRateCard and DEFAULTS

### DIFF
--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -13,11 +13,19 @@
  *   - computeOrderPricing throws RangeError for zero or negative weight
  *   - computeOrderPricing throws TypeError for non-object input
  *   - computeOrderPricing throws RangeError for zero computed rate
+ *   - readRateCard returns defaults when no env vars are set
+ *   - readRateCard parses custom env var values correctly
+ *   - readRateCard falls back to defaults for empty-string or non-numeric env vars
+ *   - DEFAULTS has expected static values and is frozen
  *
  * Run with:  npm run test:unit -- test/unit/pricing.test.js
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { haversineKm, computeOrderPricing } from '../../src/lib/pricing.js';
+
+// Access private helpers via __testing
+const { __testing } = await import('../../src/lib/pricing.js');
+const { readRateCard, DEFAULTS } = __testing;
 
 // Mumbai CST (19.0855, 72.8450) to Delhi NDLS (28.8428, 77.2781)
 // Approximate great-circle distance: ~1154 km
@@ -141,5 +149,93 @@ describe('computeOrderPricing', () => {
   it('netProfit equals baseFreight minus fuelCost minus tollEstimate', () => {
     const result = computeOrderPricing(baseInput, rateCard);
     expect(result.netProfit).toBe(result.baseFreight - result.fuelCost - result.tollEstimate);
+  });
+});
+
+describe('readRateCard via __testing', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns defaults when no pricing env vars are set', () => {
+    delete process.env.TRUXIFY_RATE_PER_TONNE_KM;
+    delete process.env.TRUXIFY_FRAGILE_MULTIPLIER;
+    delete process.env.TRUXIFY_STACKABLE_DISCOUNT;
+    delete process.env.TRUXIFY_HANDLING_FEE;
+    delete process.env.TRUXIFY_PLATFORM_FEE_PCT;
+    delete process.env.TRUXIFY_FUEL_COST_PCT;
+    delete process.env.TRUXIFY_TOLL_PER_KM;
+
+    const card = readRateCard();
+
+    expect(card.ratePerTonneKm).toBe(DEFAULTS.RATE_PER_TONNE_KM);
+    expect(card.fragileMultiplier).toBe(DEFAULTS.FRAGILE_MULTIPLIER);
+    expect(card.stackableDiscount).toBe(DEFAULTS.STACKABLE_DISCOUNT);
+    expect(card.handlingFee).toBe(DEFAULTS.HANDLING_FEE);
+    expect(card.platformFeePct).toBe(DEFAULTS.PLATFORM_FEE_PCT);
+    expect(card.fuelCostPct).toBe(DEFAULTS.FUEL_COST_PCT);
+    expect(card.tollPerKm).toBe(DEFAULTS.TOLL_PER_KM);
+  });
+
+  it('parses custom env var values correctly', () => {
+    process.env.TRUXIFY_RATE_PER_TONNE_KM = '75';
+    process.env.TRUXIFY_FRAGILE_MULTIPLIER = '2.0';
+    process.env.TRUXIFY_STACKABLE_DISCOUNT = '0.85';
+    process.env.TRUXIFY_HANDLING_FEE = '50000';
+    process.env.TRUXIFY_PLATFORM_FEE_PCT = '10';
+    process.env.TRUXIFY_FUEL_COST_PCT = '40';
+    process.env.TRUXIFY_TOLL_PER_KM = '300';
+
+    const card = readRateCard();
+
+    expect(card.ratePerTonneKm).toBe(75);
+    expect(card.fragileMultiplier).toBe(2.0);
+    expect(card.stackableDiscount).toBe(0.85);
+    expect(card.handlingFee).toBe(50000);
+    expect(card.platformFeePct).toBe(10);
+    expect(card.fuelCostPct).toBe(40);
+    expect(card.tollPerKm).toBe(300);
+  });
+
+  it('falls back to defaults for empty-string env vars', () => {
+    process.env.TRUXIFY_RATE_PER_TONNE_KM = '';
+    process.env.TRUXIFY_FRAGILE_MULTIPLIER = '';
+    process.env.TRUXIFY_TOLL_PER_KM = '';
+
+    const card = readRateCard();
+
+    expect(card.ratePerTonneKm).toBe(DEFAULTS.RATE_PER_TONNE_KM);
+    expect(card.fragileMultiplier).toBe(DEFAULTS.FRAGILE_MULTIPLIER);
+    expect(card.tollPerKm).toBe(DEFAULTS.TOLL_PER_KM);
+  });
+
+  it('falls back to defaults for non-numeric env vars', () => {
+    process.env.TRUXIFY_RATE_PER_TONNE_KM = 'invalid';
+    process.env.TRUXIFY_FRAGILE_MULTIPLIER = 'not-a-number';
+    process.env.TRUXIFY_TOLL_PER_KM = 'NaN';
+
+    const card = readRateCard();
+
+    expect(card.ratePerTonneKm).toBe(DEFAULTS.RATE_PER_TONNE_KM);
+    expect(card.fragileMultiplier).toBe(DEFAULTS.FRAGILE_MULTIPLIER);
+    expect(card.tollPerKm).toBe(DEFAULTS.TOLL_PER_KM);
+  });
+});
+
+describe('DEFAULTS constant', () => {
+  it('has expected static values for all pricing parameters', () => {
+    expect(DEFAULTS.RATE_PER_TONNE_KM).toBe(50);
+    expect(DEFAULTS.FRAGILE_MULTIPLIER).toBe(1.5);
+    expect(DEFAULTS.STACKABLE_DISCOUNT).toBe(0.9);
+    expect(DEFAULTS.HANDLING_FEE).toBe(30000);
+    expect(DEFAULTS.PLATFORM_FEE_PCT).toBe(5);
+    expect(DEFAULTS.FUEL_COST_PCT).toBe(45);
+    expect(DEFAULTS.TOLL_PER_KM).toBe(200);
+  });
+
+  it('is frozen to prevent accidental mutation', () => {
+    expect(Object.isFrozen(DEFAULTS)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #2033.

Summary of What Has Been Done:
Extended pricing.test.js with tests for readRateCard (via __testing) and DEFAULTS constant. Covers env var parsing, fallback to defaults for empty/non-numeric values, DEFAULTS value verification, and DEFAULTS immutability.

Changes Made:
- backend/api/test/unit/pricing.test.js: Added 6 new test cases covering readRateCard env var handling and DEFAULTS constant validation.

Impact it Made:
- Test coverage: readRateCard and DEFAULTS had no tests. New tests verify that custom pricing env vars are parsed correctly and that defaults are used as fallback.

Note: Please assign this PR to the `tmdeveloper007` account.