### PR TITLE
fix: use BigInt comparison for booking ID to handle type mismatch 

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -151,7 +151,7 @@ export async function recordDepositTx(bookingId, txHash, expectedSenderAddress =
   }
 
   const [txBookingId, txCustomer] = decoded.args;
-  if (txBookingId !== bookingId) {
+  if (BigInt(txBookingId) !== BigInt(bookingId)) {
     return { error: 'Transaction booking ID does not match' };
   }
 


### PR DESCRIPTION
## Description

Fixes #2080

`recordDepositTx` compared a `bigint` (decoded from on-chain ABI) with a `string`
(booking ID from `getEscrowBookingId`). Strict inequality (`!==`) always returned `true`,
permanently blocking deposit verification.

### Changes (`backend/api/src/services/escrow.js`)

Wrapped both sides of the comparison in `BigInt()` to handle type mismatch regardless
of whether the ABI returns `bigint` or `string`:
```js
if (BigInt(txBookingId) !== BigInt(bookingId))
```

### Impact

- Deposit verification now works correctly across type representations
- Orders can progress past escrow_status = 'funding' to 'funded'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking ID matching for deposit transactions by treating equivalent numeric values as the same, even when represented differently.
  * Reduced false mismatch errors during deposit recording, helping transactions validate more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->