### PR TITLE
fix(ci): use actions/checkout@v4 instead of non-existent @v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Check for Redis/Upstash credentials in Flutter source
         run: bash scripts/check-no-client-credentials.sh


### PR DESCRIPTION
Closes #2139

Both ml and client-credentials-guard jobs use checkout@v7 which doesn't exist (latest is v4). Jobs silently fail at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow’s checkout action version for two jobs, helping keep build and validation steps current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->