### PR TITLE
fix(api): guardMlApiKey scope, escrow ABI names, OTP length, escapeLike safety

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -1,5 +1,5 @@
 export function escapeLike(value) {
-  if (typeof value !== 'string') return value;
+  if (typeof value !== 'string') return '';
   return value
     .replace(/\\/g, '\\\\')
     .replace(/%/g, '\\%')

--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -1,5 +1,4 @@
 import rateLimit, { MemoryStore } from 'express-rate-limit';
-import { RedisStore } from 'rate-limit-redis';
 import { redisClient } from '../config/db.js';
 import logger from './logger.js';
 

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -95,9 +95,8 @@ export async function buildDepositTx(orderDisplayId, customerWalletAddress, driv
 
   let txData;
   try {
-    txData = await escrowContract.deposit.populateTransaction(
+    txData = await escrowContract.createBooking.populateTransaction(
       bookingId,
-      customerWalletAddress,
       driverWalletAddress,
       {
         value: amountWei,
@@ -199,8 +198,8 @@ export async function escrowRelease(orderDisplayId) {
   }
 
   try {
-    const tx = await escrowContract.releaseFunds(bookingId);
-    logger.info(`[escrow] releaseFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
+    const tx = await escrowContract.releasePayment(bookingId);
+    logger.info(`[escrow] releasePayment tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
     const receipt = await tx.wait(1);
     logger.info(`[escrow] releaseFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
     return { txHash: receipt.hash, bookingId };
@@ -224,8 +223,8 @@ export async function submitEscrowRefund(orderDisplayId) {
 
   let tx;
   try {
-    tx = await escrowContract.refundFunds(bookingId);
-    logger.info(`[escrow] refundFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
+    tx = await escrowContract.cancelBooking(bookingId);
+    logger.info(`[escrow] cancelBooking tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
   } catch (err) {
     logger.error(`[escrow] refundFunds failed for booking ${orderDisplayId}: ${err.message}`);
     return { txHash: null, bookingId, error: err.message };

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -23,12 +23,12 @@ mlBreaker.fallback(() => {
 // Startup validation
 if (!process.env.ML_API_KEY) {
     logger.warn('[ML] WARNING: ML_API_KEY is not set. ML features will be unavailable.');
+}
 
 function guardMlApiKey() {
   if (!process.env.ML_API_KEY) {
     throw new Error("[ML] ML_API_KEY is not configured. ML features are unavailable.");
   }
-}
 }
 
 /**

--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -3,7 +3,7 @@ import logger from '../middleware/logger.js';
 import crypto from 'crypto';
 
 const OTP_TTL_SECONDS = 300;
-const OTP_LENGTH = 4;
+const OTP_LENGTH = 6;
 
 export async function generateAndStoreOtp(phone) {
   if (!redisClient) {


### PR DESCRIPTION
Closes #2140 #2141 #2142 #2143 #2153

- guardMlApiKey declared inside if block causes ReferenceError when ML_API_KEY is set
- escrow.js calls deposit/releaseFunds/refundFunds but ABI defines createBooking/releasePayment/cancelBooking - all escrow operations broken
- OTP_LENGTH=4 gives only 9000 possible values
- escapeLike returns non-strings unescaped (SQL injection risk in LIKE clauses)
- Unused RedisStore import in rateLimiter.js