### PR TITLE
fix(driver): safe casts, null safety, trip_cache TTL eviction

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -122,8 +122,8 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isLoadMatching(LoadOffer load) {
     if (_currentLocationText != null && _currentLocationText!.isNotEmpty) {
       final locationLower = _currentLocationText!.toLowerCase();
-      final routeLower = load.route.toLowerCase();
-      final pickupLower = load.pickup.toLowerCase();
+      final routeLower = (load.route ?? '').toLowerCase();
+      final pickupLower = (load.pickup ?? '').toLowerCase();
 
       final parts = locationLower
           .split(',')
@@ -197,7 +197,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
       setState(() {
         _todayEarnings = results[0] as EarningsDailyModel?;
-        final stats = results[1] as Map<String, dynamic>;
+        final stats = results[1] as Map<String, dynamic>? ?? <String, dynamic>{};
         _driverRating = (stats['rating'] as num?)?.toDouble();
         _tripHistory = historyList;
         _isLoadingMetrics = false;

--- a/apps/driver/lib/services/trip_cache.dart
+++ b/apps/driver/lib/services/trip_cache.dart
@@ -9,6 +9,7 @@ class TripCache {
   static const String _stopsKey = 'truxify_driver_cached_trip_stops';
   static const String _routePointsKey = 'truxify_driver_cached_route_points';
   static const String _savedAtKey = 'truxify_driver_cached_trips_saved_at';
+  static const Duration _ttl = Duration(hours: 24);
 
   static Future<void> save({
     required List<Map<String, dynamic>> trips,
@@ -60,6 +61,10 @@ class TripCache {
 
       final savedAtRaw = prefs.getString(_savedAtKey);
       final savedAt = savedAtRaw != null ? DateTime.tryParse(savedAtRaw) : null;
+
+      if (savedAt != null && DateTime.now().difference(savedAt) > _ttl) {
+        return null;
+      }
 
       return TripCacheSnapshot(
         trips: trips,

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -130,7 +130,8 @@ class TripService {
     }
 
     final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
+    if (body is! List) return [];
+    return List<Map<String, dynamic>>.from(body);
   }
 
   Future<List<Map<String, dynamic>>> fetchTripStops(
@@ -144,7 +145,8 @@ class TripService {
     }
 
     final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
+    if (body is! List) return [];
+    return List<Map<String, dynamic>>.from(body);
   }
 
   Future<List<Map<String, dynamic>>> fetchRouteMapPoints(
@@ -158,7 +160,8 @@ class TripService {
     }
 
     final body = jsonDecode(response.body);
-    return List<Map<String, dynamic>>.from(body as List);
+    if (body is! List) return [];
+    return List<Map<String, dynamic>>.from(body);
   }
 
   Future<void> markStopCompleted(


### PR DESCRIPTION
Closes #2134 #2146 #2147 #2150

- home_screen: unsafe as cast on nullable results[1] crashes dashboard
- trip_service: 3 unsafe 'as List' casts crash on API error responses
- home_screen: _isLoadMatching calls .toLowerCase() on null route/pickup
- trip_cache: no TTL eviction returns stale data forever