### PR TITLE
fix: encode load id for bid submission

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -31,6 +31,8 @@ class MarketplaceRepository {
   final http.Client _httpClient;
   final String _apiBaseUrl;
 
+  String _encodePathSegment(String value) => Uri.encodeComponent(value);
+
   Future<Map<String, String>> _authHeaders() async {
     final accessToken = await FirebaseAuth.instance.currentUser?.getIdToken();
     final userId = _client.auth.currentUser?.id ?? '';
@@ -70,7 +72,9 @@ class MarketplaceRepository {
     required String loadId,
     required num amount,
   }) async {
-    final uri = Uri.parse('$_apiBaseUrl/api/orders/$loadId/bids');
+    final uri = Uri.parse(
+      '$_apiBaseUrl/api/orders/${_encodePathSegment(loadId)}/bids',
+    );
     final accessToken = await FirebaseAuth.instance.currentUser?.getIdToken();
     final response = await _httpClient.post(
       uri,


### PR DESCRIPTION
## Summary
- encode the load id path segment before posting a driver bid
- keep bid submission pointed at the existing backend endpoint

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bid submission reliability by correctly handling special characters in load IDs when building request links.
  * Prevented malformed network requests for certain orders, helping bid submissions succeed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->