### PR TITLE
fix: handle submit bid error responses

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -83,11 +83,11 @@ class MarketplaceRepository {
       }),
     );
 
-    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(decoded['error']?.toString() ?? 'Failed to submit bid.');
+      throw StateError(_errorMessage(response, 'Failed to submit bid.'));
     }
 
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
     return DriverBid.fromJson(Map<String, dynamic>.from(decoded['bid'] as Map));
   }
 
@@ -210,6 +210,19 @@ class MarketplaceRepository {
     };
 
     return controller.stream;
+  }
+
+  String _errorMessage(http.Response response, String fallback) {
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        final message = decoded['error'] ?? decoded['message'];
+        if (message != null) return message.toString();
+      }
+    } catch (_) {
+      // Fall through to the status-aware fallback below.
+    }
+    return '$fallback (${response.statusCode})';
   }
 
   String _formatCurrency(num value) {


### PR DESCRIPTION
## Summary
- check bid submission status before decoding a success body
- parse backend error responses defensively and fall back to the HTTP status

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2177
