### PR TITLE
fix: remove unused driver bids argument

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -356,8 +356,7 @@ class _TripsScreenState extends State<TripsScreen> {
       final results = await Future.wait([
         _marketplaceRepository.fetchLoadOffers(),
         _marketplaceRepository.fetchEnRouteLoads(),
-        _marketplaceRepository.fetchDriverBids(
-            driverId: DriverSession.driverId),
+        _marketplaceRepository.fetchDriverBids(),
       ]);
 
       final standardLoads = results[0] as List<LoadOffer>;

--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -91,7 +91,7 @@ class MarketplaceRepository {
     return DriverBid.fromJson(Map<String, dynamic>.from(decoded['bid'] as Map));
   }
 
-  Future<List<DriverBid>> fetchDriverBids({required String driverId}) async {
+  Future<List<DriverBid>> fetchDriverBids() async {
     final uri = Uri.parse('$_apiBaseUrl/api/driver/bids');
     final response = await _httpClient.get(uri, headers: await _authHeaders());
 


### PR DESCRIPTION
## Summary
- remove the unused driver id argument from driver bid loading
- update the marketplace refresh caller to use the authenticated driver context from the backend

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2178
