### PR TITLE
fix: handle online status error responses

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -183,8 +183,7 @@ class TripService {
     );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      final body = jsonDecode(response.body) as Map<String, dynamic>?;
-      throw Exception(body?['error'] as String? ?? 'Failed to update online status');
+      throw Exception(_errorMessage(response, 'Failed to update online status'));
     }
   }
 


### PR DESCRIPTION
## Summary
- use defensive response parsing for online status update failures
- preserve backend error messages when JSON is valid and fall back to the HTTP status otherwise

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2179
