### PR TITLE
fix: encode trip items id

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -35,6 +35,8 @@ class TripService {
     return value.endsWith('/') ? value.substring(0, value.length - 1) : value;
   }
 
+  String _encodePathSegment(String value) => Uri.encodeComponent(value);
+
   Future<Map<String, String>> _authHeaders() async {
     String? accessToken;
     try {
@@ -122,7 +124,9 @@ class TripService {
   Future<List<Map<String, dynamic>>> fetchTripItems(
     String tripDisplayId,
   ) async {
-    final uri = Uri.parse('$_apiBaseUrl/api/trips/$tripDisplayId/items');
+    final uri = Uri.parse(
+      '$_apiBaseUrl/api/trips/${_encodePathSegment(tripDisplayId)}/items',
+    );
     final response = await _httpClient.get(uri, headers: await _authHeaders());
 
     if (response.statusCode < 200 || response.statusCode >= 300) {


### PR DESCRIPTION
## Summary
- encode the trip id path segment before loading trip items
- keep the existing trip items endpoint and response handling unchanged

## Validation
- Not run: `flutter test test/trip_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2180
