### PR TITLE
fix: guard cached profile decoding

### DIFF
--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -14,6 +14,21 @@ class ProfileService {
   final ApiClient _apiClient;
   static const String _profileCacheKey = 'truxify_profile_cache';
 
+  Future<Map<String, dynamic>?> _readCachedProfile(
+    SharedPreferences prefs,
+  ) async {
+    final cached = prefs.getString(_profileCacheKey);
+    if (cached == null) return null;
+    try {
+      final decoded = jsonDecode(cached);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } catch (_) {
+      // Invalid cache entries are cleared so future fallbacks do not crash.
+    }
+    await prefs.remove(_profileCacheKey);
+    return null;
+  }
+
   Future<Map<String, dynamic>> fetchProfile() async {
     final prefs = await SharedPreferences.getInstance();
     try {
@@ -24,19 +39,19 @@ class ProfileService {
       }
       return <String, dynamic>{};
     } on ApiException catch (e) {
-      final cached = prefs.getString(_profileCacheKey);
+      final cached = await _readCachedProfile(prefs);
       if (cached != null) {
         developer.log('API failed, returning cached profile.');
-        return jsonDecode(cached) as Map<String, dynamic>;
+        return cached;
       }
       throw StateError(e.message);
     } on FormatException {
       throw const FormatException('Invalid JSON response from server.');
     } catch (e) {
-      final cached = prefs.getString(_profileCacheKey);
+      final cached = await _readCachedProfile(prefs);
       if (cached != null) {
         developer.log('Network error, returning cached profile.');
-        return jsonDecode(cached) as Map<String, dynamic>;
+        return cached;
       }
       throw StateError('Failed to fetch profile via backend API: $e');
     }

--- a/apps/customer/test/services/profile_service_test.dart
+++ b/apps/customer/test/services/profile_service_test.dart
@@ -77,4 +77,22 @@ void main() {
       throwsA(isA<StateError>().having((e) => e.message, 'message', 'Bad Request')),
     );
   });
+
+  test('fetchProfile clears corrupted cached data on ApiException', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('truxify_profile_cache', 'not-json');
+
+    when(() => apiClient.get('/api/profile'))
+        .thenThrow(const ApiException(503, 'Service Unavailable'));
+
+    expect(
+      () => profileService.fetchProfile(),
+      throwsA(isA<StateError>().having(
+        (e) => e.message,
+        'message',
+        'Service Unavailable',
+      )),
+    );
+    expect(prefs.getString('truxify_profile_cache'), isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- decode cached profile data defensively before using it as a fallback
- clear invalid cached profile entries instead of crashing the profile load path
- add a regression test for corrupted cached profile data

## Validation
- Not run: `flutter test test/services/profile_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2183
