### PR TITLE
fix: preserve payment default on insert failure

### DIFF
--- a/apps/customer/lib/repositories/payment_repository.dart
+++ b/apps/customer/lib/repositories/payment_repository.dart
@@ -17,14 +17,17 @@ class PaymentRepository {
 
   Future<PaymentMethod> add(PaymentMethod method) async {
     final userId = SupabaseService.requireUserId();
-    if (method.isDefault) await _clearDefaults(userId);
     final payload = method.toMap()..['user_id'] = userId;
     final row = await SupabaseService.client
         .from(_table)
         .insert(payload)
         .select()
         .single();
-    return PaymentMethod.fromMap(row);
+    final savedMethod = PaymentMethod.fromMap(row);
+    if (method.isDefault) {
+      await _clearDefaults(userId, exceptId: savedMethod.id);
+    }
+    return savedMethod;
   }
 
   Future<void> setDefault(String methodId) async {
@@ -57,10 +60,14 @@ class PaymentRepository {
         .eq('user_id', userId);
   }
 
-  Future<void> _clearDefaults(String userId) async {
-    await SupabaseService.client
+  Future<void> _clearDefaults(String userId, {String? exceptId}) async {
+    var query = SupabaseService.client
         .from(_table)
         .update({'is_default': false})
         .eq('user_id', userId);
+    if (exceptId != null) {
+      query = query.neq('id', exceptId);
+    }
+    await query;
   }
 }


### PR DESCRIPTION
## Summary
- insert a new default payment method before demoting existing defaults
- preserve the newly-created method as default while clearing older defaults
- avoid mutating existing defaults when the insert fails

## Validation
- Not run: `flutter test test/services/profile_service_test.dart` (`flutter` is not available on PATH in this shell)

Closes #2185
