### PR TITLE
fix: zero-penalty in-transit cancellation exploit

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -36,6 +36,7 @@ const ESCROW_ABI = [
   'function createBooking(uint256 bookingId, address payable driver) external payable',
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
+  'function cancelWithPenalty(uint256 bookingId, uint256 driverFee) external',
   'function bookings(uint256 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, uint256 createdAt)'
 ]
 
@@ -437,6 +438,36 @@ export async function confirmEscrowRefund (txHash) {
 
 export function bookingIdFromUuid (orderId) {
   return getEscrowBookingId(orderId)
+}
+
+export async function submitEscrowCancelWithPenalty (orderDisplayId, driverFeeWei) {
+  return measureExecution('EscrowService.submitEscrowCancelWithPenalty', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping cancelWithPenalty.')
+      return { txHash: null, bookingId }
+    }
+
+    try {
+      const tx = await escrowContract.cancelWithPenalty(bookingId, driverFeeWei)
+      logger.info(`[escrow] cancelWithPenalty tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+      return {
+        txHash: tx.hash,
+        bookingId,
+        waitForConfirmation: async () => {
+          const receipt = await tx.wait(1)
+          if (!receipt || receipt.status === 0) {
+            throw new Error('Escrow cancelWithPenalty transaction reverted or was not found.')
+          }
+          return receipt
+        },
+      }
+    } catch (err) {
+      logger.error(`[escrow] cancelWithPenalty failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+  })
 }
 
 export async function releaseEscrowFunds (orderDisplayId) {

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -8,6 +8,7 @@ import {
   escrowRefund,
   recordDepositTx,
   submitEscrowRefund,
+  submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
 } from '../escrow.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
@@ -639,6 +640,16 @@ export class OrderLifecycleService {
       }
 
       const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(currentOrder.escrow_status);
+      const penaltyBps = currentOrder.status === 'assigned'
+        ? 1000
+        : ['arrived_pickup', 'picked_up', 'in_transit', 'arrived_dropoff'].includes(currentOrder.status)
+          ? 5000
+          : 0;
+      const cancellationFee = currentOrder.total_amount && penaltyBps > 0
+        ? Math.round((Number(currentOrder.total_amount) * penaltyBps) / 10_000)
+        : currentOrder.cancellation_fee ?? 0;
+      const escrowAmountWei = currentOrder.escrow_amount_wei ? BigInt(currentOrder.escrow_amount_wei) : 0n;
+      const driverFeeWei = (escrowAmountWei * BigInt(penaltyBps)) / 10_000n;
 
       if (currentOrder.status === 'cancelled' && (!requiresRefund || currentOrder.escrow_status === 'refunded')) {
         return {
@@ -660,6 +671,7 @@ export class OrderLifecycleService {
           {
             status: 'cancelled',
             cancellation_reason: reason ?? currentOrder.cancellation_reason,
+            cancellation_fee: cancellationFee,
             escrow_status: 'refund_pending',
             escrow_refund_error: null,
             escrow_refund_attempts: (currentOrder.escrow_refund_attempts ?? 0) + 1,
@@ -690,7 +702,9 @@ export class OrderLifecycleService {
           if (refundTxHash) {
             receipt = await confirmEscrowRefund(refundTxHash);
           } else {
-            const submitted = await submitEscrowRefund(workingOrder.order_display_id);
+            const submitted = driverFeeWei > 0n
+              ? await submitEscrowCancelWithPenalty(workingOrder.order_display_id, driverFeeWei)
+              : await submitEscrowRefund(workingOrder.order_display_id);
             refundTxHash = submitted.txHash;
             if (!refundTxHash || !submitted.waitForConfirmation) {
               throw new Error('Escrow refund transaction was not submitted.');
@@ -712,6 +726,7 @@ export class OrderLifecycleService {
             {
               status: 'cancelled',
               cancellation_reason: reason ?? workingOrder.cancellation_reason,
+              cancellation_fee: cancellationFee,
               escrow_status: 'refunded',
               refund_tx_hash: receipt.hash ?? refundTxHash,
               escrow_refunded_at: refundedAt,
@@ -776,6 +791,7 @@ export class OrderLifecycleService {
       const updatePayload = {
         status: 'cancelled',
         cancellation_reason: reason,
+        cancellation_fee: cancellationFee,
         updated_at: new Date().toISOString(),
       };
 
@@ -792,14 +808,14 @@ export class OrderLifecycleService {
         throw new DomainError(500, { error: 'Failed to cancel order.', details: updateErr.message });
       }
 
-      const cancellationFee = updatedOrder?.cancellation_fee ?? 0;
+      const persistedCancellationFee = updatedOrder?.cancellation_fee ?? cancellationFee;
 
       await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
       await expireDeliveryOtps(currentOrder.id);
 
       return {
         status: 200,
-        body: { message: 'Order cancelled successfully.', cancellation_fee: cancellationFee, order: updatedOrder },
+        body: { message: 'Order cancelled successfully.', cancellation_fee: persistedCancellationFee, order: updatedOrder },
       };
     } finally {
       await releaseLock(lockKey, lockValue);

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -71,6 +71,14 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         uint256 refundAmount
     );
 
+    event CancellationPenaltyApplied(
+        uint256 indexed bookingId,
+        address indexed driver,
+        uint256 driverAmount,
+        address customer,
+        uint256 refundAmount
+    );
+
     event BookingDisputed(
         uint256 indexed bookingId,
         address indexed raisedBy
@@ -238,6 +246,55 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
         emit WithdrawalReady(bookingId, customer, refundAmount);
         emit BookingCancelled(bookingId, customer, refundAmount);
+    }
+
+    /**
+     * @dev Cancels an active booking, compensating the assigned driver before
+     *      refunding the remaining escrow to the customer. The backend chooses
+     *      the penalty only after validating the off-chain trip state.
+     */
+    function cancelWithPenalty(uint256 bookingId, uint256 driverFee)
+        external
+        onlyOwner
+        nonReentrant
+        whenNotPaused
+    {
+        Booking storage booking = bookings[bookingId];
+
+        require(
+            booking.customer != address(0) && booking.status == BookingStatus.Active,
+            "TruxifyEscrow: Cannot cancel - booking not active"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
+        require(driverFee <= booking.amount, "TruxifyEscrow: Penalty exceeds escrow");
+
+        uint256 escrowAmount = booking.amount;
+        uint256 customerRefund = escrowAmount - driverFee;
+        address payable customer = booking.customer;
+        address payable driver = booking.driver;
+
+        booking.amount = 0;
+        booking.paid = true;
+        booking.status = BookingStatus.Cancelled;
+
+        uint256 newDeadline = block.timestamp + WITHDRAWAL_TIMEOUT;
+        if (driverFee > 0) {
+            pendingWithdrawals[driver] += driverFee;
+            if (releaseTimestamps[driver] == 0 || newDeadline > releaseTimestamps[driver]) {
+                releaseTimestamps[driver] = newDeadline;
+            }
+            emit WithdrawalReady(bookingId, driver, driverFee);
+        }
+        if (customerRefund > 0) {
+            pendingWithdrawals[customer] += customerRefund;
+            if (releaseTimestamps[customer] == 0 || newDeadline > releaseTimestamps[customer]) {
+                releaseTimestamps[customer] = newDeadline;
+            }
+            emit WithdrawalReady(bookingId, customer, customerRefund);
+        }
+
+        emit CancellationPenaltyApplied(bookingId, driver, driverFee, customer, customerRefund);
     }
 
     /**

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -468,6 +468,31 @@ describe("TruxifyEscrow", function () {
     });
   });
 
+  describe("cancelWithPenalty", function () {
+    it("splits an active booking between driver compensation and customer refund", async function () {
+      const { escrow, owner, customer, driver, bookingId, amount } = await loadFixture(deployWithBookingFixture);
+      const driverFee = ethers.parseEther("0.5");
+
+      await expect(escrow.connect(owner).cancelWithPenalty(bookingId, driverFee))
+        .to.emit(escrow, "CancellationPenaltyApplied")
+        .withArgs(bookingId, driver.address, driverFee, customer.address, amount - driverFee);
+
+      const booking = await escrow.getBooking(bookingId);
+      expect(booking.status).to.equal(2); // Cancelled
+      expect(booking.paid).to.be.true;
+      expect(booking.amount).to.equal(0);
+      expect(await escrow.pendingWithdrawals(driver.address)).to.equal(driverFee);
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount - driverFee);
+    });
+
+    it("rejects a penalty larger than the escrowed amount", async function () {
+      const { escrow, owner, bookingId, amount } = await loadFixture(deployWithBookingFixture);
+
+      await expect(escrow.connect(owner).cancelWithPenalty(bookingId, amount + 1n))
+        .to.be.revertedWith("TruxifyEscrow: Penalty exceeds escrow");
+    });
+  });
+
   // ═══════════════════════════════════════════════════════════════════════════
   // raiseDispute
   // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #2208

**Description**
Resolves a critical exploit where customers could cancel an order mid-transit without incurring any cancellation fees, bypassing driver compensation.

- **Smart Contract ()**: Added `cancelWithPenalty` to allow relayer to split funds between the customer and driver during cancellation.
- **Backend API ()**: Integrated dynamic penalty calculation based on the trip's status (10% if assigned, 50% if picked up / in-transit). Passes the `driverFee` as a penalty to the new blockchain endpoint.
- **Backend Service ()**: Updated ABI and added `submitEscrowCancelWithPenalty` to interface with the smart contract correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cancellation penalties, including appropriate driver compensation and customer refunds.
  * Order cancellation fees are now calculated, recorded, and reflected in escrow processing.
  * Order details retrieval now provides more consistent validation and access handling.

* **Bug Fixes**
  * Improved request ID validation with safe fallback generation.
  * Delivery notifications now consistently store and send their message content.
  * Development authentication is supported during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->