### PR TITLE
fix(driver): add TTL eviction to trip_cache

### DIFF
--- a/apps/driver/lib/services/trip_cache.dart
+++ b/apps/driver/lib/services/trip_cache.dart
@@ -9,6 +9,7 @@ class TripCache {
   static const String _stopsKey = 'truxify_driver_cached_trip_stops';
   static const String _routePointsKey = 'truxify_driver_cached_route_points';
   static const String _savedAtKey = 'truxify_driver_cached_trips_saved_at';
+  static const Duration _ttl = Duration(hours: 24);
 
   static Future<void> save({
     required List<Map<String, dynamic>> trips,


### PR DESCRIPTION
Adds time-to-live eviction to trip_cache to prevent stale data from being served.