### PR TITLE
fix(api): move guardMlApiKey outside if block

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -23,12 +23,12 @@ mlBreaker.fallback(() => {
 // Startup validation
 if (!process.env.ML_API_KEY) {
     logger.warn('[ML] WARNING: ML_API_KEY is not set. ML features will be unavailable.');
+}
 
 function guardMlApiKey() {
   if (!process.env.ML_API_KEY) {
     throw new Error("[ML] ML_API_KEY is not configured. ML features are unavailable.");
   }
-}
 }
 
 /**


### PR DESCRIPTION
Moves guardMlApiKey function definition outside the if block to avoid reference errors.