### PR TITLE
fix(api): increase OTP_LENGTH from 4 to 6

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -3,7 +3,7 @@ import logger from '../middleware/logger.js';
 import crypto from 'crypto';
 
 const OTP_TTL_SECONDS = 300;
-const OTP_LENGTH = 4;
+const OTP_LENGTH = 6;
 
 export async function generateAndStoreOtp(phone) {
   if (!redisClient) {


### PR DESCRIPTION
Increases OTP length from 4 to 6 digits for improved security against brute-force attacks.