### PR TITLE
fix(api): escapeLike returns empty string for non-string input

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -1,5 +1,5 @@
 export function escapeLike(value) {
-  if (typeof value !== 'string') return value;
+  if (typeof value !== 'string') return '';
   return value
     .replace(/\\/g, '\\\\')
     .replace(/%/g, '\\%')


### PR DESCRIPTION
Fixes escapeLike to return empty string for non-string input instead of crashing.