### PR TITLE
fix(driver): null safety on load.route/load.pickup in _isLoadMatching

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -122,8 +122,8 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isLoadMatching(LoadOffer load) {
     if (_currentLocationText != null && _currentLocationText!.isNotEmpty) {
       final locationLower = _currentLocationText!.toLowerCase();
-      final routeLower = load.route.toLowerCase();
-      final pickupLower = load.pickup.toLowerCase();
+      final routeLower = (load.route ?? '').toLowerCase();
+      final pickupLower = (load.pickup ?? '').toLowerCase();
 
       final parts = locationLower
           .split(',')


### PR DESCRIPTION
Adds null safety checks for load.route and load.pickup in _isLoadMatching to prevent null pointer exceptions.