### PR TITLE
fix(api): remove unused RedisStore import from rateLimiter

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -1,5 +1,4 @@
 import rateLimit, { MemoryStore } from 'express-rate-limit';
-import { RedisStore } from 'rate-limit-redis';
 import { redisClient } from '../config/db.js';
 import logger from './logger.js';
 


### PR DESCRIPTION
Removes unused RedisStore import from rateLimiter.js to clean up dependencies.