### PR TITLE
fix(api): add missing escapeLike import to loadRoutes.js

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -6,6 +6,7 @@ import logger from '../middleware/logger.js';
 import { loadFilterQuerySchema } from '../validation/loadSchemas.js';
 import { validateParams } from '../middleware/validate.js';
 import { uuidParamSchema } from '../validation/requestSchemas.js';
+import { escapeLike } from '../lib/escapeLike.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Adds the missing escapeLike import that caused a runtime error when filtering loads by pickup/destination location.