### PR TITLE
fix(api): remove premature clearOtpState before post-RPC verification

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1091,8 +1091,6 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['dri
       return res.status(500).json({ error: 'Failed to complete trip and release payment.', details: rpcErr.message });
     }
 
-    // Clear brute-force state only after the OTP and trip transaction commits.
-    await clearOtpState(orderId);
     // Post-RPC verification: confirm the order was actually updated to payment_released
     const { data: verifiedOrder, error: verifyErr } = await supabase
       .from('orders')


### PR DESCRIPTION
Moves clearOtpState after the post-RPC verification check to prevent brute-force lockout from being cleared before payment release is confirmed.