### PR TITLE
fix(driver): use owner_id instead of driver_id in truck_repository query

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -12,7 +12,7 @@ class TruckRepository {
     final response = await _client
         .from('trucks')
         .select()
-        .eq('driver_id', driverId)
+        .eq('owner_id', driverId)
         .maybeSingle();
 
     if (response == null) {


### PR DESCRIPTION
Changes the truck query from .eq('driver_id', driverId) to .eq('owner_id', driverId) to match the actual database schema column.