### PR TITLE
fix(api): remove duplicate /ready route handler in healthRoutes.js

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -109,8 +109,5 @@ router.get('/live', healthLimiter, (req, res) => {
 // GET /api/health/ready � readiness probe for k8s
 router.get('/ready', healthLimiter, (req, res) => res.json({ status: 'ready' }));
 
-// GET /api/health/ready — readiness probe for k8s
-router.get('/ready', healthLimiter, (req, res) => res.json({ status: 'ready' }));
-
 export default router;
 


### PR DESCRIPTION
Removes the duplicate router.get('/ready', ...) definition to prevent Express from registering two identical handlers for the same route.