### PR TITLE
fix(api): add missing closing brace in truckRoutes.js

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -199,6 +199,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
 
   if (!isLatitude(numPickupLat) || !isLatitude(numDropLat) || !isLongitude(numPickupLng) || !isLongitude(numDropLng)) {
     return res.status(400).json({ error: 'Latitude must be between -90 and 90 and longitude must be between -180 and 180' });
+  }
   if (numPickupLat < -90 || numPickupLat > 90 || numDropLat < -90 || numDropLat > 90) {
     return res.status(400).json({ error: 'Latitude must be between -90 and 90' });
   }


### PR DESCRIPTION
Adds a missing closing brace that caused a parse error in the GET /api/trucks/search endpoint.