### PR TITLE
fix(api): move guardMlApiKey outside if block so it's always defined

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -23,12 +23,12 @@ mlBreaker.fallback(() => {
 // Startup validation
 if (!process.env.ML_API_KEY) {
     logger.warn('[ML] WARNING: ML_API_KEY is not set. ML features will be unavailable.');
+}
 
 function guardMlApiKey() {
   if (!process.env.ML_API_KEY) {
     throw new Error("[ML] ML_API_KEY is not configured. ML features are unavailable.");
   }
-}
 }
 
 /**


### PR DESCRIPTION
Moves guardMlApiKey() function definition outside the startup validation if block so it is always available at module scope. Previously it was only defined when ML_API_KEY was not set, causing a crash when trying to call it with ML_API_KEY configured.