### PR TITLE
cleanup: remove orphaned pubspec_additions.yaml with conflicting dependency version

### DIFF
--- a/apps/customer/pubspec_additions.yaml
+++ b/apps/customer/pubspec_additions.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  sqflite: ^2.3.0
-  path: ^1.9.0
-  connectivity_plus: ^5.0.2


### PR DESCRIPTION
Fixes #2257

## Changes
- Deleted `apps/customer/pubspec_additions.yaml`
- This file is a dead artifact: all its dependencies (`sqflite`, `path`, `connectivity_plus`) are already declared in `pubspec.yaml`
- The `connectivity_plus` version (`^5.0.2`) conflicted with the correct version in `pubspec.yaml` (`^7.1.1`)

## GSSoC
This contribution is part of GirlScript Summer of Code (GSSoC).