### PR TITLE
fix: implement SecureStorage class using flutter_secure_storage

### DIFF
--- a/apps/customer/lib/secure_storage.dart
+++ b/apps/customer/lib/secure_storage.dart
@@ -1,1 +1,17 @@
-class SecureStorage {}
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorage {
+  static const _storage = FlutterSecureStorage();
+
+  static Future<void> save(String key, String value) async {
+    await _storage.write(key: key, value: value);
+  }
+
+  static Future<String?> read(String key) async {
+    return await _storage.read(key: key);
+  }
+
+  static Future<void> delete(String key) async {
+    await _storage.delete(key: key);
+  }
+}


### PR DESCRIPTION
Fixes #2258

## Changes
- Implemented the previously empty `SecureStorage` class with `save`, `read`, and `delete` methods using `flutter_secure_storage`
- Added `flutter_secure_storage` dependency to `pubspec.yaml`
- This prevents a false sense of security where callers expected secure token storage but got nothing

## GSSoC
This contribution is part of GirlScript Summer of Code (GSSoC).