### PR TITLE
fix: enable critical Dart lints by removing explicit error suppressions

### DIFF
--- a/apps/customer/analysis_options.yaml
+++ b/apps/customer/analysis_options.yaml
@@ -3,12 +3,3 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
-  errors:
-    deprecated_member_use: ignore
-    use_build_context_synchronously: ignore
-    unnecessary_brace_in_string_interps: ignore
-    unused_import: ignore
-    unused_field: ignore
-    depend_on_referenced_packages: ignore
-    avoid_print: ignore
-    unused_local_variable: ignore

--- a/apps/driver/analysis_options.yaml
+++ b/apps/driver/analysis_options.yaml
@@ -3,12 +3,3 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
-  errors:
-    deprecated_member_use: ignore
-    use_build_context_synchronously: ignore
-    unnecessary_brace_in_string_interps: ignore
-    unused_import: ignore
-    unused_field: ignore
-    depend_on_referenced_packages: ignore
-    avoid_print: ignore
-    unused_local_variable: ignore


### PR DESCRIPTION
Fixes #2249

Removes the `errors:` block from both `apps/customer/analysis_options.yaml` and `apps/driver/analysis_options.yaml` to re-enable critical lints: `unused_import`, `avoid_print`, `use_build_context_synchronously`, `unused_field`, and others.

This contribution is part of GSSoC.