### PR TITLE
cleanup: remove unused import of recent_route_card.dart in customer home_screen.dart

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -11,7 +11,6 @@ import '../widgets/app_logo.dart';
 import '../widgets/app_page_route.dart';
 import '../widgets/shipment_card.dart';
 import '../widgets/common_widgets.dart';
-import '../widgets/recent_route_card.dart';
 import '../services/order_service.dart';
 import '../services/profile_service.dart';
 import 'live_tracking_screen.dart';


### PR DESCRIPTION
Fixes #2253

Removes unused import `import '../widgets/recent_route_card.dart';` from `home_screen.dart`. The `RecentRouteCard` widget is never referenced in this file.

This contribution is part of GSSoC.