### PR TITLE
fix: make DriverSession.driverId throw StateError instead of returning empty string

### DIFF
--- a/apps/driver/lib/core/driver_session.dart
+++ b/apps/driver/lib/core/driver_session.dart
@@ -12,7 +12,10 @@ class DriverSession {
   /// live auth session.
   static String get driverId {
     final user = Supabase.instance.client.auth.currentUser;
-    return user?.id ?? '';
+    if (user == null) {
+      throw StateError('No authenticated driver session.');
+    }
+    return user.id;
   }
 
   /// True only when there is a valid Supabase auth session.


### PR DESCRIPTION
Fixes #2256

Changes `DriverSession.driverId` to throw `StateError` when no authenticated user is present, instead of silently returning an empty string which caused confusing foreign key constraint errors in Supabase queries.

This contribution is part of GSSoC.