### PR TITLE
fix : added { cause: err } to preserve-caught-error ESLint rule in ml.js handleResponse

### DIFF
--- a/backend/api/package-lock.json
+++ b/backend/api/package-lock.json
@@ -6677,6 +6677,28 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opossum": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-10.0.0.tgz",
+      "integrity": "sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^26 || ^24 || ^22"
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #2234.

Summary of What Has Been Done:
Added { cause: err } option to the Error constructor in ml.js handleResponse catch block, preserving the original error chain.

Changes Made:
- backend/api/src/services/ml.js: changed throw new Error(...) to throw new Error(..., { cause: err })

Impact it Made:
- Fixes ESLint preserve-caught-error violation
- Full error stack traces preserved for Sentry and debugging
- Error chain intact for monitoring tools

Note: Please assign this PR to the `tmdeveloper007` account.