### PR TITLE
fix : replaced Math.random() with crypto.randomInt() in otpService.js

### DIFF
--- a/backend/api/package-lock.json
+++ b/backend/api/package-lock.json
@@ -6677,6 +6677,28 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opossum": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-10.0.0.tgz",
+      "integrity": "sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^26 || ^24 || ^22"
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #2285.

Summary of What Has Been Done:
Replaced insecure `Math.random()` OTP generation with `crypto.randomInt()` from Node.js built-in crypto module. Also updated `OTP_LENGTH` from 4 to 6 for consistency with delivery OTP.

Changes Made:
- backend/api/src/services/otpService.js: replaced Math.random() with crypto.randomInt() and updated OTP_LENGTH to 6

Impact it Made:
- Cryptographically secure OTP generation (CSPRNG)
- Prevents OTP prediction attacks
- Consistent 6-digit OTP across platform (works with PR #2284)

Note: Please assign this PR to the `tmdeveloper007` account.