### PR TITLE
fix(contract): change bookings mapping key from uint256 to bytes32

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -42,7 +42,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     // ─── State ───────────────────────────────────────────────────────────────
 
-    mapping(uint256 => Booking) public bookings;
+    mapping(bytes32 => Booking) public bookings;
     uint256 public bookingCount;
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;


### PR DESCRIPTION
## Description

The ookings mapping in TruxifyEscrow.sol used uint256 as its key type, but the backend (escrow.js) generates booking IDs via ethers.solidityPackedKeccak256() which returns ytes32 hex strings.

This type mismatch means calling createBooking(uint256) with a ytes32 value would either revert or silently truncate the ID.

## Change

- Changed uint256 ? ytes32 on the ookings mapping key to match backend-generated booking IDs

Fixes #2268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking record handling to make escrow actions more reliable.
  * Fixed an inconsistency that could affect booking creation, payment release, and cancellation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->