### PR TITLE
fix(auth): add typeof guard before decoded.iss.includes()

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -77,7 +77,7 @@ export async function authenticate(req, res, next) {
       // ignore decoding errors and let verification handle it
     }
 
-    const isSupabaseToken = decoded && decoded.iss && (decoded.iss.includes('supabase') || decoded.iss.includes('supabase.co'));
+    const isSupabaseToken = decoded && typeof decoded.iss === 'string' && (decoded.iss.includes('supabase') || decoded.iss.includes('supabase.co'));
 
     if (isSupabaseToken) {
       if (!supabase) {


### PR DESCRIPTION
## Description

In uth.js, the isSupabaseToken check calls decoded.iss.includes() without verifying the type of decoded.iss. If the JWT has an iss claim that is not a string (e.g., a number or array), .includes() throws a TypeError, crashing the auth middleware.

Added a 	ypeof decoded.iss === 'string' guard before calling .includes().

Fixes #2272
