### PR TITLE
fix(trucks): consolidate duplicate capacity validation with conflicting messages

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -20,12 +20,12 @@ router.get('/types', authenticate, userLimiter, (req, res) => {
 function parseCapacityFilter(value, field) {
   if (value === undefined) return { value: undefined };
   if (typeof value !== 'string' || value.trim() === '') {
-    return { error: `${field} must be a positive number` };
+    return { error: `${field} must be a non-negative number` };
   }
 
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return { error: `${field} must be a positive number` };
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { error: `${field} must be a non-negative number` };
   }
 
   return { value: parsed };
@@ -133,20 +133,12 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
       }
     }
 
-    if (min_capacity !== undefined) {
-      const minCapNum = Number(min_capacity);
-      if (!Number.isFinite(minCapNum) || minCapNum < 0) {
-        return res.status(400).json({ error: 'min_capacity must be a non-negative number' });
-      }
-      query = query.gte('max_capacity_tons', minCapNum);
+    if (minCapacity.value !== undefined) {
+      query = query.gte('max_capacity_tons', minCapacity.value);
     }
 
-    if (max_capacity !== undefined) {
-      const maxCapNum = Number(max_capacity);
-      if (!Number.isFinite(maxCapNum) || maxCapNum < 0) {
-        return res.status(400).json({ error: 'max_capacity must be a non-negative number' });
-      }
-      query = query.lte('max_capacity_tons', maxCapNum);
+    if (maxCapacity.value !== undefined) {
+      query = query.lte('max_capacity_tons', maxCapacity.value);
     }
 
     const { data: trucks, error } = await query.order('created_at', { ascending: false });


### PR DESCRIPTION
## Description

The GET /api/trucks endpoint had duplicate validation for min_capacity and max_capacity query params with **conflicting error messages**:

1. parseCapacityFilter() rejected values with 'must be a positive number' (> 0) 
2. Inline validation rejected values with 'must be a non-negative number' (>= 0)

Both blocks parsed and validated the same query parameters independently, violating DRY.

## Changes

- Removed the duplicate inline validation block (lines 136-150)
- Used pre-parsed minCapacity.value and maxCapacity.value from parseCapacityFilter in the Supabase query filters
- Unified parseCapacityFilter to use 'non-negative number' (>= 0) to preserve original allow-zero behavior
- Reduced boilerplate: 15 lines ? 7 lines

Fixes #2275
