### PR TITLE
fix(escrow): remove lease extender and tie lock refresh to order lifecycle

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -6,13 +6,11 @@ const DEFAULT_INTERVAL_MS = 60_000;
 const LOCK_KEY = 'escrow:release:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;
 const MAX_RETRIES = 10;
-const LEASE_EXTENSION_INTERVAL_MS = (LOCK_TTL_SECONDS * 1000) / 2;
 let reconciliationTimer = null;
 let reconciliationRunning = false;
 
 export async function reconcilePendingEscrowReleases() {
   let lockAcquired = false;
-  let leaseExtender = null;
 
   if (redisClient) {
     try {
@@ -22,13 +20,6 @@ export async function reconcilePendingEscrowReleases() {
         return;
       }
       lockAcquired = true;
-      leaseExtender = setInterval(async () => {
-        try {
-          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
-        } catch (err) {
-          logger.warn('[escrow-release-reconciliation] Failed to extend lock lease:', err.message);
-        }
-      }, LEASE_EXTENSION_INTERVAL_MS);
     } catch (err) {
       logger.error('[escrow-release-reconciliation] Failed to acquire Redis lock:', err.message);
     }
@@ -59,6 +50,13 @@ export async function reconcilePendingEscrowReleases() {
     }
 
     for (const order of failedOrders ?? []) {
+      if (lockAcquired && redisClient) {
+        try {
+          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+        } catch (err) {
+          logger.warn('[escrow-release-reconciliation] Failed to refresh lock:', err.message);
+        }
+      }
       try {
         const { data: claimed, error: claimError } = await supabase
           .rpc('claim_release_reconciliation', {
@@ -149,9 +147,6 @@ export async function reconcilePendingEscrowReleases() {
       }
     }
   } finally {
-    if (leaseExtender) {
-      clearInterval(leaseExtender);
-    }
     if (lockAcquired && redisClient) {
       try {
         await redisClient.del(LOCK_KEY);


### PR DESCRIPTION
## Description

The econcilePendingEscrowReleases() function used a setInterval-based lease extender that refreshed the Redis lock TTL every 60s on a fixed timer, regardless of actual processing state. If the process crashed between a lease extension and the next order iteration, the lock remained alive for the full 120s TTL, preventing other instances from acquiring it.

## Changes

- Removed the leaseExtender setInterval and its clearInterval cleanup
- Lock TTL is now refreshed once per order iteration (before each order's processing)
- This ties the lock lifecycle to actual processing activity rather than a blind timer
- Removed unused LEASE_EXTENSION_INTERVAL_MS constant

Fixes #2269
