### PR TITLE
perf(telemetry): replace O(n) splice with O(1) ring buffer for telemetry writes

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -44,11 +44,66 @@ const consecutiveDropCount = new Map();
 // =====================================================================
 // EXTRA STORAGE & BUFFER CONFIGURATIONS (#269)
 // =====================================================================
+class TelemetryRingBuffer {
+  constructor(capacity) {
+    this.capacity = capacity;
+    this.buffer = new Array(capacity);
+    this.head = 0;
+    this.tail = 0;
+    this.size = 0;
+  }
+
+  push(item) {
+    this.buffer[this.tail] = item;
+    this.tail = (this.tail + 1) % this.capacity;
+    if (this.size < this.capacity) {
+      this.size++;
+    } else {
+      this.head = (this.head + 1) % this.capacity;
+    }
+  }
+
+  toArray() {
+    if (this.size === 0) return [];
+    const result = new Array(this.size);
+    for (let i = 0; i < this.size; i++) {
+      result[i] = this.buffer[(this.head + i) % this.capacity];
+    }
+    return result;
+  }
+
+  prepend(items) {
+    if (!items || items.length === 0) return 0;
+    let dropped = 0;
+    for (let i = items.length - 1; i >= 0; i--) {
+      this.head = (this.head - 1 + this.capacity) % this.capacity;
+      this.buffer[this.head] = items[i];
+      if (this.size < this.capacity) {
+        this.size++;
+      } else {
+        dropped++;
+        this.tail = this.head;
+      }
+    }
+    return dropped;
+  }
+
+  clear() {
+    this.head = 0;
+    this.tail = 0;
+    this.size = 0;
+  }
+
+  get length() {
+    return this.size;
+  }
+}
+
 const MAX_BUFFER_SIZE = 5000;
 const BUFFER_WARN_THRESHOLD = 0.5;
 const BUFFER_CRIT_THRESHOLD = 0.8;
 const BUFFER_MONITOR_INTERVAL_MS = 30000;
-let telemetryWriteBuffer = [];
+const telemetryWriteBuffer = new TelemetryRingBuffer(MAX_BUFFER_SIZE);
 let telemetryFlushBuffer = [];
 let currentFlushPromise = null;
 let flushMutex = false;
@@ -484,11 +539,8 @@ export async function handleLocationPing(ws, data, req) {
 
   // Buffer write with capacity limit (always push to active buffer)
   if (telemetryWriteBuffer.length >= MAX_BUFFER_SIZE) {
-    const dropCount = Math.floor(MAX_BUFFER_SIZE * 0.1);
-    telemetryWriteBuffer.splice(0, dropCount);
-    telemetryTotalDropped += dropCount;
-    telemetryOverflowDropped += dropCount;
-    logger.warn(`[TRUXIFY BUFFER WARN] Telemetry buffer full: dropped ${dropCount} oldest records. Total dropped: ${telemetryTotalDropped}. Size: ${telemetryWriteBuffer.length}/${MAX_BUFFER_SIZE}`);
+    telemetryTotalDropped++;
+    telemetryOverflowDropped++;
   }
   telemetryWriteBuffer.push({
     driver_id,
@@ -614,10 +666,10 @@ async function flushTelemetryBuffer() {
   // snapshot (instead of aliasing the active buffer as the flush buffer)
   // avoids re-queueing the same array twice on transient failures.
   const recordsToFlush = telemetryFlushBuffer.length > 0
-    ? [...telemetryFlushBuffer, ...telemetryWriteBuffer]
-    : telemetryWriteBuffer;
+    ? [...telemetryFlushBuffer, ...telemetryWriteBuffer.toArray()]
+    : telemetryWriteBuffer.toArray();
   telemetryFlushBuffer = [];
-  telemetryWriteBuffer = [];
+  telemetryWriteBuffer.clear();
 
   flushMutex = false;
 
@@ -651,10 +703,8 @@ async function flushTelemetryBuffer() {
           ? recordsToFlush.filter((_, i) => !err.writeErrors.some(e => e.index === i))
           : [];
         if (succeeded.length > 0) {
-          telemetryWriteBuffer = [...succeeded, ...telemetryWriteBuffer];
-          if (telemetryWriteBuffer.length > MAX_BUFFER_SIZE) {
-            const overflowDrop = telemetryWriteBuffer.length - MAX_BUFFER_SIZE;
-            telemetryWriteBuffer.splice(0, overflowDrop);
+          const overflowDrop = telemetryWriteBuffer.prepend(succeeded);
+          if (overflowDrop > 0) {
             telemetryTotalDropped += overflowDrop;
             telemetryOverflowDropped += overflowDrop;
             logger.warn(`[TRUXIFY BUFFER DROP] Dropped ${overflowDrop} oldest records due to capacity after partial insert.`);
@@ -662,15 +712,13 @@ async function flushTelemetryBuffer() {
         }
       } else {
         flushBackoffMs = Math.min(flushBackoffMs * 2, 60000);
-        // Prepend failed records to the FRONT for oldest-first retry priority
-        telemetryWriteBuffer = [...recordsToFlush, ...telemetryWriteBuffer];
-        if (telemetryWriteBuffer.length > MAX_BUFFER_SIZE) {
-          const overflowDrop = telemetryWriteBuffer.length - MAX_BUFFER_SIZE;
-          telemetryWriteBuffer.splice(0, overflowDrop);
+        const overflowDrop = telemetryWriteBuffer.prepend(recordsToFlush);
+        if (overflowDrop > 0) {
           telemetryTotalDropped += overflowDrop;
           telemetryOverflowDropped += overflowDrop;
-          logger.warn(`[TRUXIFY BUFFER DROP] Capacity limit: dropped ${overflowDrop} oldest records from retry merge.`);
+          logger.warn(`[TRUXIFY BUFFER DROP] Dropped ${overflowDrop} oldest records due to capacity after flush failure.`);
         }
+      }
       }
     } finally {
       currentFlushPromise = null;
@@ -720,7 +768,7 @@ function loadRecoveryFile() {
       if (content) {
         const records = content.split('\n').filter(Boolean).map(line => JSON.parse(line));
         if (records.length > 0) {
-          telemetryWriteBuffer = [...records, ...telemetryWriteBuffer].slice(-MAX_BUFFER_SIZE);
+          telemetryWriteBuffer.prepend(records);
           logger.info(`[TRUXIFY RECOVERY] Loaded ${records.length} telemetry records from recovery file. Buffer size: ${telemetryWriteBuffer.length}`);
         }
       }
@@ -772,7 +820,7 @@ export async function closeWebSocketServer() {
       const dataLoss = telemetryWriteBuffer.length;
       if (dataLoss > 0) {
         try {
-          const lines = telemetryWriteBuffer.map(r => JSON.stringify(scrubPII(r))).join('\n');
+          const lines = telemetryWriteBuffer.toArray().map(r => JSON.stringify(scrubPII(r))).join('\n');
           fs.writeFileSync(RECOVERY_FILE_PATH, lines + '\n', { encoding: 'utf-8', mode: 0o600 });
           logger.warn(`[TRUXIFY SHUTDOWN] MongoDB not available. Wrote ${dataLoss} telemetry records to recovery file: ${RECOVERY_FILE_PATH}`);
         } catch (fileErr) {
@@ -1026,13 +1074,14 @@ export const __testing = {
     return telemetryFlushBuffer;
   },
   setTelemetryWriteBuffer(records) {
-    telemetryWriteBuffer = records;
+    telemetryWriteBuffer.clear();
+    if (records) telemetryWriteBuffer.prepend(records);
   },
   setTelemetryFlushBuffer(records) {
     telemetryFlushBuffer = records;
   },
   clearTelemetryWriteBuffer() {
-    telemetryWriteBuffer = [];
+    telemetryWriteBuffer.clear();
   },
   clearTelemetryFlushBuffer() {
     telemetryFlushBuffer = [];


### PR DESCRIPTION
## Description

The telemetry write buffer used Array.splice(0, dropCount) on every GPS ping when at capacity ? an O(n) operation on the hot path that shifts all remaining elements down. The buffer swap also relied on reference aliasing (	elemetryWriteBuffer assigned directly as 	elemetryFlushBuffer), causing potential data loss on transient flush failures.

## Changes

- **Added TelemetryRingBuffer** ? a circular buffer with O(1) push/prepend and automatic oldest-record overwrite on capacity overflow
- **Replaced 	elemetryWriteBuffer** array with ring buffer instance
- **Removed the splice(0, dropCount)** overflow path ? ring buffer handles overflow implicitly in O(1)
- **Added prepend()** ? safely re-queues failed flush records with overflow tracking (returns dropped count)
- **Buffer swap uses 	oArray()** snapshot instead of reference aliasing
- All reassignment sites converted to .clear() + .prepend()

Fixes #2276
