### PR TITLE
fix(escrow): skip refund reconciliation when Redis distributed lock is unavailable

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -11,19 +11,27 @@ let reconciliationTimer = null;
 let reconciliationRunning = false;
 
 export async function reconcilePendingEscrowRefunds() {
+  let globalLockAcquired = false;
+  if (redisClient) {
+    try {
+      globalLockAcquired = await redisClient.set(GLOBAL_LOCK_KEY, process.pid.toString(), 'NX', 'EX', GLOBAL_LOCK_TTL_SECONDS);
+    } catch (err) {
+      logger.warn('[escrow-reconciliation] Redis unavailable, cannot acquire global lock — skipping batch pull.');
+      return;
+    }
+    if (!globalLockAcquired) {
+      logger.info('[escrow-reconciliation] Global lock held by another instance, skipping batch pull.');
+      return;
+    }
+  } else {
+    logger.warn('[escrow-reconciliation] Redis not configured, cannot acquire distributed lock — skipping.');
+    return;
+  }
+
   if (reconciliationRunning) return;
   reconciliationRunning = true;
 
   try {
-    // Acquire a global lock just to prevent multiple instances from pulling the exact same batch unnecessarily
-    let globalLockAcquired = false;
-    if (redisClient) {
-      globalLockAcquired = await redisClient.set(GLOBAL_LOCK_KEY, process.pid.toString(), 'NX', 'EX', GLOBAL_LOCK_TTL_SECONDS);
-      if (!globalLockAcquired) {
-        logger.info('[escrow-reconciliation] Global lock held by another instance, skipping batch pull.');
-        return;
-      }
-    }
 
     const instanceId = process.env.HOSTNAME || os.hostname();
     const { data: pendingOrders, error } = await supabase


### PR DESCRIPTION
## Description

When Redis was unavailable, econcilePendingEscrowRefunds() fell through to process refunds using only an in-memory econciliationRunning boolean. In multi-instance deployments, all instances would process the same refunds simultaneously ? causing duplicate blockchain transactions.

## Changes

- Redis lock acquisition is now performed **before** the in-memory econciliationRunning guard
- Added 	ry/catch ? if Redis is down, returns early with a warning
- If Redis is not configured at all, returns early with a warning
- The in-memory flag is preserved as a **secondary** guard (not primary)

Fixes #2277
