### PR TITLE
fix: validate allowed status values in user ticket list endpoint

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -219,6 +219,10 @@ router.get('/tickets', authenticate, userLimiter, async (req, res) => {
       .eq('user_id', req.user.id);
 
     if (status) {
+      const ALLOWED_STATUSES = ['open', 'in_progress', 'resolved', 'closed'];
+      if (!ALLOWED_STATUSES.includes(status)) {
+        return res.status(400).json({ error: 'Unsupported support ticket status.' });
+      }
       query = query.eq('status', status);
     }
 


### PR DESCRIPTION
Adds validation for allowed status values ('open', 'in_progress', 'resolved', 'closed') when users filter their own support tickets. Prevents invalid status queries from reaching the database.