### PR TITLE
fix: validate allowed status values in admin ticket list endpoint

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -405,6 +405,10 @@ router.get('/admin/tickets', authenticate, userLimiter, requireRole(['admin']), 
       .select(TICKET_DETAIL_COLUMNS, { count: 'exact' });
 
     if (status) {
+      const ADMIN_ALLOWED_STATUSES = ['open', 'in_progress', 'resolved', 'closed'];
+      if (!ADMIN_ALLOWED_STATUSES.includes(status)) {
+        return res.status(400).json({ error: 'Unsupported support ticket status.' });
+      }
       query = query.eq('status', status);
     }
 


### PR DESCRIPTION
Adds validation for allowed status values in the admin ticket listing route to prevent invalid status queries from reaching the database.