### PR TITLE
fix: add missing guardMlApiKey call in predictDemand

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -77,6 +77,7 @@ function getBaseUrl() {
  * @returns {Promise<object>}
  */
 export async function predictDemand(features = {}) {
+  guardMlApiKey();
     const url = `${getBaseUrl()}/predict/demand`;
 
     const response = await mlBreaker.fire(url, {


### PR DESCRIPTION
Adds the guardMlApiKey() check to the predictDemand function, ensuring ML_API_KEY is configured before making requests to the ML engine.