### PR TITLE
fix: add missing guardMlApiKey call in predictPrice

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -101,6 +101,7 @@ export async function predictPrice({
     routeOrigin = '',
     routeDestination = '',
 } = {}) {
+  guardMlApiKey();
     const url = `${getBaseUrl()}/predict/price`;
 
     const payload = {


### PR DESCRIPTION
Adds the guardMlApiKey() check to the predictPrice function, ensuring ML_API_KEY is configured before making requests to the ML engine.