### PR TITLE
fix: remove unused uuidParamSchema import from loadRoutes

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -6,7 +6,6 @@ import logger from '../middleware/logger.js';
 import { loadFilterQuerySchema } from '../validation/loadSchemas.js';
 import { validateParams } from '../middleware/validate.js';
 import { paramIdSchema } from '../validation/requestSchemas.js';
-import { uuidParamSchema } from '../validation/requestSchemas.js';
 import { escapeLike } from '../lib/escapeLike.js';
 
 const router = express.Router();


### PR DESCRIPTION
The uuidParamSchema is imported but never used in loadRoutes.js. paramIdSchema is already used for route validation.