### PR TITLE
fix: remove unused paramIdSchema import from profileRoutes

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateBody, validateQuery, validateParams } from '../middleware/validate.js';
-import { updateProfileSchema, updateWalletSchema, driverStatementSchema, paramIdSchema, uuidParamSchema, updateFcmTokenSchema } from '../validation/requestSchemas.js';
+import { updateProfileSchema, updateWalletSchema, driverStatementSchema, uuidParamSchema, updateFcmTokenSchema } from '../validation/requestSchemas.js';
 import logger from '../middleware/logger.js';
 import {
   getProfile,


### PR DESCRIPTION
Removes unused paramIdSchema import from profileRoutes.js.