### PR TITLE
fix: remove unused requireRole import from tripRoutes

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { z } from 'zod';
 import { supabase } from '../config/db.js';
-import { authenticate, requireRole } from '../middleware/auth.js';
+import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 


### PR DESCRIPTION
Removes unused requireRole import from tripRoutes.js.