### PR TITLE
fix: remove unused paramIdSchema import from truckRoutes

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -3,7 +3,7 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
-import { paramIdSchema, uuidParamSchema, registerTruckSchema } from '../validation/requestSchemas.js';
+import { uuidParamSchema, registerTruckSchema } from '../validation/requestSchemas.js';
 import { getRouteEstimate } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 import { predictPrice } from '../services/ml.js';


### PR DESCRIPTION
Removes unused paramIdSchema import from truckRoutes.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up an internal request schema import with no change to API behavior or routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->