### PR TITLE
fix: remove redundant healthLimiter from health route handlers

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
-import { healthLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
@@ -68,7 +67,7 @@ const CRITICAL_UNHEALTHY = new Set(['failed', 'not_configured']);
 const CRITICAL_UNHEALTHY_OPTIONAL = new Set(['failed']);
 
 // GET /api/health — full dependency check; returns 503 when a critical service fails
-router.get('/', healthLimiter, async (req, res) => {
+router.get('/', async (req, res) => {
   const [supabaseStatus, mongoStatus, redisStatus] = await Promise.all([
     checkSupabase(),
     checkMongo(),
@@ -102,12 +101,12 @@ router.get('/', healthLimiter, async (req, res) => {
 });
 
 // GET /api/health/live — liveness probe; always 200 as long as the process is up
-router.get('/live', healthLimiter, (req, res) => {
+router.get('/live', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
 
 // GET /api/health/ready — readiness probe for k8s
-router.get('/ready', healthLimiter, async (req, res) => {
+router.get('/ready', async (req, res) => {
   const [supabaseStatus, mongoStatus, redisStatus] = await Promise.all([
     checkSupabase(),
     checkMongo(),


### PR DESCRIPTION
Removes healthLimiter middleware from individual health routes in healthRoutes.js since it is already applied at the app level in index.js.