### PR TITLE
fix: add UUID param validation to trip events endpoint

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { validateParams } from '../middleware/validate.js';
+import { uuidParamSchema } from '../validation/requestSchemas.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
@@ -201,7 +203,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
  *
  * Optional query param: ?type=gpsUpdate  (filters by event_type)
  */
-router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
+router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const tripId = req.params.id;
   const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
   const isAscending = sort !== 'desc';


### PR DESCRIPTION
Adds validateParams middleware with uuidParamSchema to the trip events endpoint to ensure the trip ID is a valid UUID before processing.