### PR TITLE
fix: add UUID validation to admin cache delete endpoint in profileRoutes

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -324,7 +324,7 @@ router.get('/driver/statement', authenticate, requireRole(['driver']), userLimit
 // Invalidates the profile cache for a specific user, forcing the next
 // authenticated request to refetch from Supabase. Use this after admin
 // operations that change role, status, or other cached profile fields.
-router.delete('/admin/cache/:userId', authenticate, requireRole(['admin']), async (req, res) => {
+router.delete('/admin/cache/:userId', authenticate, requireRole(['admin']), validateParams(uuidParamSchema), async (req, res) => {
   try {
     const targetUserId = req.params.userId;
     if (!targetUserId) {


### PR DESCRIPTION
Adds validateParams middleware with uuidParamSchema to the admin cache delete endpoint to ensure the userId parameter is a valid UUID.