### PR TITLE
fix: add .trim() to FCM token in profile update

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -198,11 +198,12 @@ router.put('/fcm-token', authenticate, userLimiter, validateBody(updateFcmTokenS
   try {
     const userId = req.user.id;
     const { fcmToken } = req.body;
+    const trimmedToken = fcmToken?.trim();
 
     const { error } = await supabase
       .from('profiles')
       .update({
-        fcm_token: fcmToken,
+        fcm_token: trimmedToken,
         fcm_token_updated_at: new Date().toISOString(),
       })
       .eq('id', userId);


### PR DESCRIPTION
Adds .trim() to the FCM token value before storing in the database.