### PR TITLE
fix: add phone validation to OTP service

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -10,6 +10,10 @@ export async function generateAndStoreOtp(phone) {
     logger.warn('[otp] Redis not available, cannot generate OTP.');
     return null;
   }
+  if (!phone || typeof phone !== 'string' || !phone.trim()) {
+    logger.warn('[otp] Invalid phone number provided.');
+    return null;
+  }
   const min = Math.pow(10, OTP_LENGTH - 1);
   const max = Math.pow(10, OTP_LENGTH) - 1;
   const otp = String(crypto.randomInt(min, max + 1));


### PR DESCRIPTION
Adds null/empty/type validation for the phone parameter in the OTP service to prevent storing OTPs with invalid keys.