### PR TITLE
fix: add phone validation to OTP verification service

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -19,6 +19,10 @@ export async function generateAndStoreOtp(phone) {
 }
 
 export async function verifyOtp(phone, otp) {
+  if (!phone || typeof phone !== 'string' || !phone.trim()) {
+    logger.warn('[otp] Invalid phone number provided for verification.');
+    return false;
+  }
   if (!redisClient) {
     if (process.env.NODE_ENV === 'production') {
       logger.error('[otp] Redis unavailable in production — rejecting OTP verification.');


### PR DESCRIPTION
Adds null/empty/type validation for the phone parameter in verifyOtp to match generateAndStoreOtp.