### PR TITLE
fix: add test for health /ready endpoint

### DIFF
--- a/backend/api/test/integration/healthRoutes.test.js
+++ b/backend/api/test/integration/healthRoutes.test.js
@@ -158,3 +158,17 @@ describe('GET /api/health/live', () => {
     expect(res.body.uptime).toBeTypeOf('number');
   });
 });
+
+describe('GET /api/health/ready', () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  it('returns ready status with services information', async () => {
+    const res = await request(app).get('/api/health/ready');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ready');
+  });
+});


### PR DESCRIPTION
Adds a test suite for the GET /api/health/ready endpoint to improve test coverage.