### PR TITLE
fix: add positive distance validation to load filter schema

### DIFF
--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -15,7 +15,9 @@ const nonNegativeDecimalString = (field) => z
 export const loadFilterQuerySchema = z.object({
   min_price: nonNegativeDecimalString('min_price').optional(),
   max_price: nonNegativeDecimalString('max_price').optional(),
-  distance: nonNegativeDecimalString('distance').optional(),
+  distance: nonNegativeDecimalString('distance').optional().refine(v => v === undefined || v > 0, {
+    message: 'distance must be a positive number',
+  }),
   order: z.enum(['asc', 'desc']).optional(),
 }).superRefine((filters, ctx) => {
   if (


### PR DESCRIPTION
Adds a refinement to the distance filter field so it rejects zero or negative values, which are invalid for distance-based filtering.