### PR TITLE
Fix telemetry flush finally syntax

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -733,7 +733,6 @@ async function flushTelemetryBuffer() {
           logger.warn(`[TRUXIFY BUFFER DROP] Dropped ${overflowDrop} oldest records due to capacity after flush failure.`);
         }
       }
-      }
     } finally {
       currentFlushPromise = null;
       flushMutex = false;


### PR DESCRIPTION
## Summary
- remove an extra closing brace before the telemetry flush finally block
- restore parsing for backend/api/src/sockets/tracker.js

## Validation
- node --check src/sockets/tracker.js
- npm run lint (continues past tracker.js; still fails on existing orderRoutes and bidAcceptanceService issues)
- npm test -- test/unit/tracker.test.js (runs after parse fix; existing buffer behavior assertions still fail)

Closes #2340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * No user-facing behavior changed.
  * Minor cleanup in an internal error-handling path, with no impact on telemetry processing or application output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->