### PR TITLE
Remove undefined rating failure reference

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -685,7 +685,6 @@ router.post('/:id/ratings', authenticate, userLimiter, requireRole(['customer'])
         supabase.from('reputation_failures').insert({
           driver_wallet: polygonAddress,
           stars,
-          rating_id: ratingData?.id ?? null,
           failed_at: new Date().toISOString(),
           retry_count: 0,
           last_error: repErr.message,


### PR DESCRIPTION
## Summary
- remove the undefined ratingData reference from reputation failure logging
- keep reputation failure records focused on the wallet, stars, timestamp, retry count, and error message available in this route

## Validation
- npx eslint src/routes/orderRoutes.js --max-warnings=0 (the ratingData error is resolved; the remaining failure is the separate missing bidAcceptanceService issue)

Closes #2342
