### PR TITLE
Use shared telemetry rate limit key generator

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 
-import { bidLimiter, userLimiter, safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
+import { bidLimiter, userLimiter, userKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
@@ -86,12 +86,7 @@ const predictDemandLimiter = rateLimit({
 const telemetryLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: process.env.NODE_ENV === 'test' ? 1000 : 30,
-  keyGenerator: (req) => {
-    if (!req.user || !req.user.id) {
-      return req.ip ? safeIpKeyGenerator(req) : 'unknown-ip';
-    }
-    return req.user.id;
-  },
+  keyGenerator: userKeyGenerator,
   store: createStore('rl:telemetry:'),
   standardHeaders: true,
   legacyHeaders: false,


### PR DESCRIPTION
## Summary
- use the shared userKeyGenerator for the telemetry limiter
- remove custom inline fallback logic that triggered express-rate-limit IPv6 key validation warnings

## Validation
- npm test -- test/integration/orders.test.js --testNamePattern "bid ownership" (the IPv6 key validation warning no longer appears; tests still fail on the separate missing bidAcceptanceService issue)
- npx eslint src/routes/orderRoutes.js --max-warnings=0 (still fails on separate ratingData and bidAcceptanceService issues)

Closes #2343
