### PR TITLE
Align escrow booking id mapping type

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -42,7 +42,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     // ─── State ───────────────────────────────────────────────────────────────
 
-    mapping(bytes32 => Booking) public bookings;
+    mapping(uint256 => Booking) public bookings;
     uint256 public bookingCount;
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;


### PR DESCRIPTION
## Summary
- change TruxifyEscrow bookings mapping to use uint256 keys
- align storage with the uint256 booking IDs already used by create, release, cancel, dispute, and getter functions

## Validation
- ..\node_modules\.bin\hardhat.cmd test with APPDATA and LOCALAPPDATA pointed to workspace-local directories
- Solidity compilation now succeeds; remaining blockchain test failures are unrelated node:test/mocha compatibility and helper export issues

Closes #2345
