### PR TITLE
feat: add GET /api/devices/platforms endpoint

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -165,3 +165,25 @@ export async function unregisterDeviceToken(req, res) {
     });
   }
 }
+
+/**
+ * Get list of unique registered device platforms
+ */
+export async function getDevicePlatforms(req, res) {
+  try {
+    const { data, error } = await supabase
+      .from('user_devices')
+      .select('platform');
+
+    if (error) {
+      logger.error('[DeviceController] Failed to query device platforms:', error.message);
+      return res.status(500).json({ error: 'Failed to retrieve platforms' });
+    }
+
+    const platforms = [...new Set((data || []).map((d) => d.platform).filter(Boolean))];
+    return res.json({ platforms });
+  } catch (err) {
+    logger.error('[DeviceController] Unexpected error in getDevicePlatforms:', err.message);
+    return res.status(500).json({ error: 'An unexpected error occurred' });
+  }
+}

--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { registerDeviceToken, unregisterDeviceToken } from '../controllers/deviceController.js';
+import { registerDeviceToken, unregisterDeviceToken, getDevicePlatforms } from '../controllers/deviceController.js';
 import { authenticate } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
 import { registerDeviceSchema, unregisterDeviceSchema } from '../validation/requestSchemas.js';
@@ -13,5 +13,8 @@ router.post('/register', authenticate, deviceLimiter, validateBody(registerDevic
 // DELETE /api/devices/unregister
 // Called on logout so a signed-out device stops receiving push notifications.
 router.delete('/unregister', authenticate, deviceLimiter, validateBody(unregisterDeviceSchema), unregisterDeviceToken);
+
+// GET /api/devices/platforms
+router.get('/platforms', authenticate, getDevicePlatforms);
 
 export default router;


### PR DESCRIPTION
Closes #2362. This PR implements the GET /api/devices/platforms endpoint to query and return a unique list of registered device platforms.