### PR TITLE
fix : removed extra closing brace before finally block in tracker.js

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -733,7 +733,6 @@ async function flushTelemetryBuffer() {
           logger.warn(`[TRUXIFY BUFFER DROP] Dropped ${overflowDrop} oldest records due to capacity after flush failure.`);
         }
       }
-      }
     } finally {
       currentFlushPromise = null;
       flushMutex = false;


### PR DESCRIPTION
Closes #2388.

Summary of What Has Been Done:
Removed the stray extra closing brace on line 738 of tracker.js that was sitting between the catch block body and the finally block in the flushTelemetryBuffer function. This caused a JavaScript syntax error that prevented tracker.js from being transformed and loaded.

Changes Made:
- backend/api/src/sockets/tracker.js: Removed one extraneous } character that caused a syntax error

Impact it Made:
- Fixes the malformed finally block syntax error
- Allows tracker.js module to be properly transformed by the bundler
- The remaining tracker test failures are pre-existing and unrelated to this fix

Note: Please assign this PR to the `tmdeveloper007` account.