### PR TITLE
test(backend): add unit tests for profileService.js logic

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -1,4 +1,4 @@
-import { supabase } from '../config/db.js';
+import { supabase, redisClient } from '../config/db.js';
 
 export async function getProfile(userId) {
   if (!supabase) {
@@ -43,4 +43,28 @@ export async function getDriverDetails(userId) {
 
   if (error) throw error;
   return data;
+}
+
+export async function createProfile(profileData) {
+  if (!supabase) throw new Error('Supabase client not configured');
+  const { data, error } = await supabase.from('profiles').insert(profileData).select().single();
+  if (error) throw error;
+  return data;
+}
+
+export async function updateProfile(userId, updateData) {
+  if (!supabase) throw new Error('Supabase client not configured');
+  const { data, error } = await supabase.from('profiles').update(updateData).eq('id', userId).select().single();
+  if (error) throw error;
+  return data;
+}
+
+export async function invalidateProfileCache(userId) {
+  if (redisClient) {
+    try {
+      await redisClient.del(`profile:${userId}`);
+    } catch (err) {
+      console.error('Redis cache invalidation error:', err);
+    }
+  }
 }

--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -179,3 +179,71 @@ describe('getDriverDetails', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('createProfile', () => {
+  beforeEach(() => {
+    supabaseRef.current = defaultMockSupabase;
+  });
+
+  it('throws when supabase is not configured', async () => {
+    supabaseRef.current = null;
+    const { createProfile } = await import('../../src/services/profileService.js');
+    await expect(createProfile({})).rejects.toThrow('Supabase client not configured');
+  });
+
+  it('creates profile on successful query', async () => {
+    const mockInsertSelectSingle = vi.fn().mockResolvedValue({ data: { id: 'new' }, error: null });
+    supabaseRef.current = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: mockInsertSelectSingle
+          })
+        })
+      })
+    };
+    const { createProfile } = await import('../../src/services/profileService.js');
+    const result = await createProfile({ name: 'test' });
+    expect(result).toEqual({ id: 'new' });
+  });
+});
+
+describe('updateProfile', () => {
+  beforeEach(() => {
+    supabaseRef.current = defaultMockSupabase;
+  });
+
+  it('throws when supabase is not configured', async () => {
+    supabaseRef.current = null;
+    const { updateProfile } = await import('../../src/services/profileService.js');
+    await expect(updateProfile('id', {})).rejects.toThrow('Supabase client not configured');
+  });
+
+  it('updates profile on successful query', async () => {
+    const mockUpdateEqSelectSingle = vi.fn().mockResolvedValue({ data: { id: 'id' }, error: null });
+    supabaseRef.current = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: mockUpdateEqSelectSingle
+            })
+          })
+        })
+      })
+    };
+    const { updateProfile } = await import('../../src/services/profileService.js');
+    const result = await updateProfile('id', { name: 'test' });
+    expect(result).toEqual({ id: 'id' });
+  });
+});
+
+describe('invalidateProfileCache', () => {
+  it('calls redisClient.del correctly', async () => {
+    const mockDel = vi.fn().mockResolvedValue(1);
+    vi.mocked(await import('../../src/config/db.js')).redisClient = { del: mockDel };
+    const { invalidateProfileCache } = await import('../../src/services/profileService.js');
+    await invalidateProfileCache('123');
+    expect(mockDel).toHaveBeenCalledWith('profile:123');
+  });
+});


### PR DESCRIPTION
Resolves #2459

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile creation and profile updates through the app’s backend services.
  * Added profile cache invalidation so refreshed profile data can be served after changes.

* **Tests**
  * Expanded automated coverage for profile creation, profile updates, and cache invalidation.
  * Added checks for proper behavior when backend configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->