### PR TITLE
fix: add dispose() to TripService to close owned http.Client

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -208,6 +208,10 @@ class TripService {
     }
   }
 
+  void dispose() {
+    _httpClient.close();
+  }
+
   String _errorMessage(http.Response response, String fallback) {
     try {
       final decoded = jsonDecode(response.body);


### PR DESCRIPTION
Fixes #2501

Adds a `dispose()` method to `TripService` that closes the owned `_httpClient`, preventing connection/memory leaks. The same pattern is already used in `DriverEarningsService`.

This contribution is part of GSSoC.