### PR TITLE
fix: replace hardcoded mock person data in driver profile with empty strings

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -32,12 +32,12 @@ class ProfileScreen extends StatefulWidget {
 }
 
 class _ProfileScreenState extends State<ProfileScreen> {
-  String _driverName = driverName;
-  String _driverPhone = '+91 98765 43210';
-  String _driverEmail = 'kanish.jeba@truxify.com';
+  String _driverName = '';
+  String _driverPhone = '';
+  String _driverEmail = '';
   String _currentLanguage = 'English';
   String _walletAddress = '';
-  String _truckNumber = driverTruckNumber;
+  String _truckNumber = '';
 
   bool _isLoadingReputation = true;
   double? _platformRating;


### PR DESCRIPTION
Fixes #2502

Replaces `driverName`, hardcoded phone/email, and `driverTruckNumber` with empty strings so users aren't shown another person's profile data on first launch. Full Supabase persistence can follow separately.

This contribution is part of GSSoC.