### PR TITLE
fix: persist language preference in driver profile using shared_preferences

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 
 import '../controllers/app_controller.dart';
@@ -49,6 +50,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
     super.initState();
     _loadWalletAddress();
     _fetchReputation();
+  }
+
+  Future<void> _loadSavedLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getString('driver_language');
+    if (saved != null && mounted) {
+      setState(() => _currentLanguage = saved);
+    }
   }
 
   Future<void> _loadWalletAddress() async {


### PR DESCRIPTION
Fixes #2504

Saves the selected language to `shared_preferences` so it survives app restarts. Loads the saved value in `initState`.

This contribution is part of GSSoC.