### PR TITLE
fix: close StreamController in catch block when subscription setup fails

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -200,6 +200,8 @@ class MarketplaceRepository {
       ).subscribe();
     } catch (e, st) {
       developer.log('Supabase/Realtime not available', error: e, stackTrace: st);
+      controller.close();
+      return const Stream.empty();
     }
 
     controller.onCancel = () {


### PR DESCRIPTION
Fixes #2505

Closes the `StreamController` and returns an empty stream when the Supabase/Realtime subscription fails, preventing a controller leak.

This contribution is part of GSSoC.