### PR TITLE
perf: add const constructor to HomeScreen for widget optimization

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -29,13 +29,12 @@ import 'destination_picker_screen.dart';
 import '../widgets/pulsing_location_dot.dart';
 
 class HomeScreen extends StatefulWidget {
-  HomeScreen({
+  const HomeScreen({
     super.key,
-    MarketplaceRepository? marketplaceRepo,
-    DriverEarningsService? earningsService,
+    required this.marketplaceRepo,
+    required this.earningsService,
     this.mockLocationText,
-  }) : marketplaceRepo = marketplaceRepo ?? MarketplaceRepository(),
-       earningsService = earningsService ?? DriverEarningsService();
+  });
 
   final MarketplaceRepository marketplaceRepo;
   final DriverEarningsService earningsService;


### PR DESCRIPTION
Fixes #2511

Makes `marketplaceRepo` and `earningsService` parameters required to allow a `const` constructor, enabling Flutter's const widget optimizations.

This contribution is part of GSSoC.