### PR TITLE
fix: add route timing to tripRoutes.js

### DIFF
--- a/backend/api/src/lib/routeTiming.js
+++ b/backend/api/src/lib/routeTiming.js
@@ -1,0 +1,18 @@
+export function startTimer(label) {
+  const id = `${label}_${Date.now()}`;
+  console.time(id);
+  return id;
+}
+
+export function endTimer(id) {
+  console.timeEnd(id);
+}
+
+export function withTiming(label, fn) {
+  const id = startTimer(label);
+  try {
+    return fn();
+  } finally {
+    endTimer(id);
+  }
+}

--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -4,8 +4,10 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
+import { startTimer, endTimer } from '../lib/routeTiming.js';
 
 const router = express.Router();
+const routeTimer = startTimer('tripRoutes');
 
 // ============================================================================
 // 🛡️ OFFLINE SYNC VALIDATION SCHEMAS (ISSUE #362)
@@ -297,4 +299,5 @@ router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
   }
 });
 
+endTimer(routeTimer);
 export default router;


### PR DESCRIPTION
Adds console.time/console.timeEnd timing instrumentation to track route initialization performance.