### PR TITLE
fix: add UUID validation to GET /api/trips/:id/events endpoint

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -4,6 +4,8 @@ import { supabase } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
+import { validateParams } from '../middleware/validate.js';
+import { uuidParamSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
@@ -201,7 +203,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
  *
  * Optional query param: ?type=gpsUpdate  (filters by event_type)
  */
-router.get('/:id/events', authenticate, userLimiter, async (req, res) => {
+router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const tripId = req.params.id;
   const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
   const isAscending = sort !== 'desc';


### PR DESCRIPTION
## Summary

This PR adds UUID parameter validation to the `GET /api/trips/:id/events` endpoint to prevent invalid IDs from reaching the database.

Closes #2554

### Changes Made

- Added `validateParams` middleware to the route.
- Added `uuidParamSchema` validation for the `:id` route parameter.
- Prevents malformed UUIDs from triggering PostgreSQL `22P02` errors.

### Expected Behavior

- Invalid UUIDs are rejected before database queries are executed.
- The endpoint returns an appropriate client validation error instead of an internal server error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added UUID validation for trip event requests, helping prevent invalid trip IDs from reaching the endpoint.
  * Improved request handling for the trip events route with stricter parameter checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->