### PR TITLE
fix: rethrow reputation update errors

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -113,6 +113,7 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
     }, REPUTATION_RETRY_MAX, REPUTATION_RETRY_DELAY_MS);
   } catch (err) {
     logger.error(`[reputation] increaseReputation failed for driver ${driverWalletAddress} after ${REPUTATION_RETRY_MAX} retries: ${err.message}`);
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR updates `awardReputationPoints()` to rethrow exceptions after logging them.

Closes #2555

### Changes Made

- Re-throw caught exceptions after logging.
- Allows callers to detect failures and handle retry or reconciliation logic appropriately.
- Preserves existing logging behavior.

