### PR TITLE
fix: remove duplicate keyGenerator property from resendOtpLimiter and changeDropLimiter

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -185,7 +185,6 @@ const telemetryLimiter = rateLimit({
 const resendOtpLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: process.env.NODE_ENV === 'test' ? 1000 : 5,
-  keyGenerator: (req) => req.user?.id || 'unauthenticated',
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => req.user?.id || 'unknown',
@@ -197,7 +196,6 @@ const resendOtpLimiter = rateLimit({
 const changeDropLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: process.env.NODE_ENV === 'test' ? 1000 : 5,
-  keyGenerator: (req) => req.user?.id || 'unauthenticated',
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => req.user?.id || 'unknown',


### PR DESCRIPTION
Clean up duplicate keyGenerator properties in both rate limiter config objects.

Fixes #2549


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted request throttling behavior for two unauthenticated endpoints, changing how missing user IDs are grouped.
  * Improved consistency in rate limiting when no user is logged in, helping prevent unexpected bucket labels for those requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->