### PR TITLE
fix: add UUID validation to support ticket endpoints

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -254,7 +254,7 @@ router.get('/tickets', authenticate, userLimiter, async (req, res) => {
 // ============================================================================
 // 5. GET SINGLE SUPPORT TICKET (AUTHENTICATED USER - OWNER)
 // ============================================================================
-router.get('/tickets/:id', authenticate, userLimiter, async (req, res) => {
+router.get('/tickets/:id', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const ticketId = req.params.id;
 
   try {
@@ -454,7 +454,7 @@ router.get('/admin/tickets', authenticate, userLimiter, requireRole(['admin']), 
  * @returns {object} 409 - Cannot comment on a closed ticket
  * @returns {object} 500 - Internal server error
  */
-router.post('/tickets/:id/comments', authenticate, userLimiter, validateBody(createTicketCommentSchema), async (req, res) => {
+router.post('/tickets/:id/comments', authenticate, userLimiter, validateParams(uuidParamSchema), validateBody(createTicketCommentSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { message } = req.body;
 


### PR DESCRIPTION
Closes #2556

## Summary

This PR adds UUID parameter validation to the support ticket endpoints to prevent invalid IDs from reaching the database.

### Changes Made

- Added `validateParams(uuidParamSchema)` to `GET /tickets/:id`.
- Added `validateParams(uuidParamSchema)` to `POST /tickets/:id/comments`.
- Prevents malformed UUIDs from triggering PostgreSQL `22P02` errors.

### Expected Behavior

- Invalid UUIDs are rejected before database queries are executed.
- The endpoints return an appropriate client validation error instead of an internal server error.

