### PR TITLE
fix: add logger.error() to all catch blocks in driverRoutes.js

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -115,6 +115,7 @@ router.get('/stats', authenticate, userLimiter, requireRole(['driver']), async (
     });
 
   } catch (err) {
+    logger.error('Driver stats fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -143,6 +144,7 @@ router.put('/online', authenticate, userLimiter, requireRole(['driver']), valida
     });
 
   } catch (err) {
+    logger.error('Driver online status update error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -237,6 +239,7 @@ router.get('/earnings/summary', authenticate, userLimiter, requireRole(['driver'
     res.json(summary || []);
 
   } catch (err) {
+    logger.error('Driver earnings summary fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -283,6 +286,7 @@ router.get('/trips', authenticate, userLimiter, requireRole(['driver']), async (
       trips: trips || []
     });
   } catch (err) {
+    logger.error('Driver trips fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -302,6 +306,7 @@ router.get('/trips/:tripDisplayId/items', authenticate, userLimiter, requireRole
     if (error) return res.status(500).json({ error: 'Failed to fetch trip items.', details: error.message });
     res.json(items || []);
   } catch (err) {
+    logger.error('Driver trip items fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -321,6 +326,7 @@ router.get('/trips/:tripDisplayId/stops', authenticate, userLimiter, requireRole
     if (error) return res.status(500).json({ error: 'Failed to fetch trip stops.', details: error.message });
     res.json(stops || []);
   } catch (err) {
+    logger.error('Driver trip stops fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -340,6 +346,7 @@ router.get('/trips/:tripDisplayId/route-points', authenticate, userLimiter, requ
     if (error) return res.status(500).json({ error: 'Failed to fetch route points.', details: error.message });
     res.json(points || []);
   } catch (err) {
+    logger.error('Driver route points fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -380,6 +387,7 @@ router.get('/bids', authenticate, userLimiter, requireRole(['driver']), async (r
       bids: bids || []
     });
   } catch (err) {
+    logger.error('Driver bids fetch error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
@@ -430,6 +438,7 @@ router.post('/wallet/withdraw', authenticate, userLimiter, requireRole(['driver'
     });
 
   } catch (err) {
+    logger.error('Driver wallet withdrawal error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });


### PR DESCRIPTION
Add logger.error() calls to 9 catch blocks in driverRoutes.js that silently swallowed exceptions.

Previously only the wallet history endpoint (GET /wallet/history) logged errors. All other driver endpoints returned a generic 500 with zero server-side visibility. This adds descriptive error logging consistent with the existing pattern.

Fixes #2551
