### PR TITLE
fix: add 60s timeout to waitForTransaction calls in escrow.js

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -130,7 +130,7 @@ export async function recordDepositTx(bookingId, txHash, expectedSenderAddress =
   }
 
   const provider = escrowContract.runner.provider;
-  const receipt = await provider.waitForTransaction(txHash, 1);
+  const receipt = await provider.waitForTransaction(txHash, 1, 60_000);
   if (!receipt || receipt.status === 0) {
     return { error: 'Transaction reverted or not found on chain' };
   }
@@ -254,7 +254,7 @@ export async function confirmEscrowRefund(txHash) {
     throw new Error('Invalid escrow refund transaction hash.');
   }
 
-  const receipt = await escrowContract.runner.provider.waitForTransaction(txHash, 1);
+  const receipt = await escrowContract.runner.provider.waitForTransaction(txHash, 1, 60_000);
   if (!receipt || receipt.status === 0) {
     throw new Error('Escrow refund transaction reverted or was not found.');
   }


### PR DESCRIPTION
Add 60-second timeout to waitForTransaction calls in escrow.js

Both recordDepositTx and confirmEscrowRefund called provider.waitForTransaction(txHash, 1) with no timeout argument. If the RPC node goes out of sync or the transaction is dropped from the mempool, these calls hang indefinitely, blocking the HTTP response and leaking memory.

Fixes #2552
