### PR TITLE
fix: remove plaintext OTP from notification body

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -202,7 +202,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
       .insert({
         user_id: customerId,
         title,
-        body,
+        body: `Your delivery verification OTP has been sent for order ${orderDisplayId}.`,
         notif_type: 'order_update',
         metadata: { order_display_id: orderDisplayId, delivery_otp_hash: otpHash },
       });


### PR DESCRIPTION
Closes #2557

## Summary

This PR removes the plaintext delivery OTP from the notification body before it is stored in the database.

### Changes Made

- Replaced the notification body with a generic message.
- Kept the existing OTP hash stored in metadata.
- Prevents sensitive OTP values from being persisted in notification records.

### Expected Behavior

- Notification records no longer contain the plaintext OTP.
- OTP verification continues to work using the stored hash.
