### PR TITLE
fix: clean up uploaded document on metadata insert failure

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -79,6 +79,9 @@ export async function uploadDriverDocument(req, res) {
 
     if (insertError) {
       logger.error('[DocumentController] Failed to record document metadata:', insertError.message);
+      await supabase.storage.from('driver-documents').remove([storagePath]).catch((storageCleanErr) => {
+        logger.error('[DocumentController] Failed to clean up document storage path:', storageCleanErr.message);
+      });
       return res.status(500).json({ error: 'Failed to store document' });
     }
 


### PR DESCRIPTION
Closes #2558

## Summary

This PR ensures uploaded driver documents are removed from storage if inserting the document metadata into the database fails.

### Changes Made

- Added cleanup logic to delete the uploaded storage object when metadata insertion fails.
- Logged cleanup failures without masking the original database error.
- Prevents orphaned files from remaining in storage.

### Expected Behavior

- Uploaded files are removed if metadata insertion fails.
- Storage remains consistent with the database.

