### PR TITLE
fix: handle Multer validation errors with appropriate HTTP status codes

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -177,6 +177,13 @@ app.use(sentryErrorHandler());
 
 // Error handling middleware
 app.use((err, req, res, next) => {
+  if (err && err.name === 'MulterError') {
+    const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+    return res.status(status).json({
+      error: `File upload error: ${err.message}`,
+      code: err.code
+    });
+  }
   logger.error({ requestId: req.requestId, err }, 'Unhandled express exception');
   res.status(500).json({ error: 'Critical Internal Server Error.' });
 });


### PR DESCRIPTION
Closes #2559

## Summary

This PR updates the global Express error handler to return appropriate client error responses for Multer validation errors instead of always returning HTTP 500.

### Changes Made

- Detects `MulterError` instances in the global error handler.
- Returns **413 Payload Too Large** for `LIMIT_FILE_SIZE`.
- Returns **400 Bad Request** for other Multer validation errors.
- Preserves the existing 500 response for non-Multer errors.

### Expected Behavior

- File upload validation errors return appropriate 4xx status codes.
- Unexpected server errors continue to return HTTP 500.

