### PR TITLE
fix: make parsePositiveInt reject 0 to match parsePositiveFloat behavior

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -40,7 +40,7 @@ const DEFAULTS = Object.freeze({
 function parsePositiveInt(raw, fallback) {
   if (raw === null || raw === undefined || raw === '') return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
 function parsePositiveFloat(raw, fallback) {


### PR DESCRIPTION
Make parsePositiveInt reject 0 to match parsePositiveFloat behavior

Fixes #2619

GSSOC
