### PR TITLE
Fix: Implement OpenZeppelin circuit breaker in smart contracts (#2610)

### DIFF
--- a/blockchain/contracts/Escrow.sol
+++ b/blockchain/contracts/Escrow.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
 /// @title Escrow System for Truxify
 /// @notice Manages escrow deposits, releases, and refunds for bookings.
 /// @dev Uses authorized relayers to trigger state changes.
-contract Escrow {
+contract Escrow is Pausable {
     enum EscrowStatus {
         None,
         Funded,
@@ -25,7 +27,6 @@ contract Escrow {
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;
     bool private locked;
-    bool public paused;
     uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
 
     event RelayerUpdated(address indexed relayer, bool authorized);
@@ -33,8 +34,6 @@ contract Escrow {
     event Released(bytes32 indexed bookingId, address indexed driver, uint256 amount);
     event Refunded(bytes32 indexed bookingId, address indexed customer, uint256 amount);
     event Withdrawn(address indexed recipient, uint256 amount);
-    event Paused(address indexed account);
-    event Unpaused(address indexed account);
     event EmergencyRecovered(address indexed recipient, uint256 amount);
 
     modifier onlyOwner() {
@@ -52,11 +51,6 @@ contract Escrow {
         locked = true;
         _;
         locked = false;
-    }
-
-    modifier whenNotPaused() {
-        require(!paused, "Contract is paused");
-        _;
     }
 
     /// @notice Initializes the contract and sets the initial relayer.
@@ -80,14 +74,12 @@ contract Escrow {
 
     /// @notice Pauses the contract, preventing all deposits, releases, and refunds.
     function pause() external onlyOwner {
-        paused = true;
-        emit Paused(msg.sender);
+        _pause();
     }
 
     /// @notice Unpauses the contract.
     function unpause() external onlyOwner {
-        paused = false;
-        emit Unpaused(msg.sender);
+        _unpause();
     }
 
     /// @notice Deposits funds into escrow for a specific booking.

--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 
 /// @title Reputation System for Truxify
 /// @notice Manages driver reputation scores capped at MAX_REPUTATION.
 /// @dev Only authorized relayers can update scores.
-contract Reputation is Ownable {
+contract Reputation is Ownable, Pausable {
     mapping(address => bool) public authorizedRelayers;
     mapping(address => uint256) private scores;
 
@@ -39,10 +40,20 @@ contract Reputation is Ownable {
         emit RelayerUpdated(relayer, authorized);
     }
 
+    /// @notice Pauses the contract, preventing score updates.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpauses the contract.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
     /// @notice Increases the reputation of a driver.
     /// @param driver Address of the driver.
     /// @param points Amount to increase.
-    function increaseReputation(address driver, uint256 points) external onlyRelayer {
+    function increaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
         require(driver != address(0), "Invalid driver");
         uint256 current = scores[driver];
         if (current >= MAX_REPUTATION) return;
@@ -58,7 +69,7 @@ contract Reputation is Ownable {
     /// @notice Decreases the reputation of a driver.
     /// @param driver Address of the driver.
     /// @param points Amount to decrease.
-    function decreaseReputation(address driver, uint256 points) external onlyRelayer {
+    function decreaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
         require(driver != address(0), "Invalid driver");
         uint256 current = scores[driver];
         scores[driver] = points >= current ? 0 : current - points;

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -42,7 +42,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     // ─── State ───────────────────────────────────────────────────────────────
 
-    mapping(bytes32 => Booking) public bookings;
+    mapping(uint256 => Booking) public bookings;
     uint256 public bookingCount;
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;


### PR DESCRIPTION
### Fixes Issue #2610

**Description of Changes:**
This PR introduces the standard OpenZeppelin `Pausable` extension to `Escrow.sol` and `Reputation.sol`, replacing the ad-hoc naive pause mechanisms. This adds a robust emergency stop (circuit breaker) mechanism that locks down all critical functionality in case a vulnerability is found post-deployment.

- **`Escrow.sol`**:
  - Removed custom `bool public paused` and `whenNotPaused` modifier.
  - Inherited `Pausable` from OpenZeppelin and modified `pause()`/`unpause()` to call internal `_pause()` and `_unpause()`.
- **`Reputation.sol`**:
  - Inherited `Pausable`.
  - Added `pause()` and `unpause()` functions (restricted to `onlyOwner`).
  - Added the `whenNotPaused` modifier to `increaseReputation` and `decreaseReputation` so rating changes can be halted in an emergency.
- **`TruxifyEscrow.sol`**:
  - Fixed a pre-existing type mismatch bug that caused compilation failures (`mapping(bytes32 => Booking)` changed to `mapping(uint256 => Booking)` to match `createBooking`).

**Checklist:**
- [x] Contracts now inherit OpenZeppelin's `Pausable`.
- [x] All critical state-changing and fund-handling operations are protected.
- [x] Contracts successfully compiled using Hardhat (`npx hardhat compile`).
- [x] All changes are isolated to a single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and unpause controls for escrow and reputation-related actions.
  * Booking records now use numeric booking IDs for easier handling.

* **Bug Fixes**
  * Reputation updates are now blocked while the system is paused, helping prevent changes during maintenance or emergencies.

* **Refactor**
  * Streamlined pause handling across contracts for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->