### PR TITLE
fix: add userLimiter to GET /session endpoint for rate protection

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -72,7 +72,7 @@ router.post('/logout', authenticate, async (req, res) => {
 });
 
 // GET /api/auth/session
-router.get('/session', authenticate, (req, res) => {
+router.get('/session', authenticate, userLimiter, (req, res) => {
   return res.json({
     user: req.user
   });


### PR DESCRIPTION
Fixes #2645

Adds `userLimiter` middleware to the `/session` route to apply consistent rate limiting, matching every other authenticated route in the codebase.

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session requests now go through an additional request limit check, helping improve stability during heavier usage.
  * The session response format remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->