### PR TITLE
fix: change FCM token unregister from DELETE to POST to avoid body-stripping issues

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -67,7 +67,7 @@ class FcmService {
     }
     final accessToken = await firebaseUser.getIdToken();
 
-    final response = await http.delete(
+    final response = await http.post(
       Uri.parse('$_apiBaseUrl/api/devices/unregister'),
       headers: <String, String>{
         'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes #2647

Changes the HTTP method from `http.delete` to `http.post` for the FCM token unregister call. HTTP DELETE with a request body is non-standard and may be stripped by proxies/CDNs.

GSSoC