### PR TITLE
fix: correct API_BASE_URL to TRUXIFY_API_BASE_URL in dart_defines/dev.env

### DIFF
--- a/dart_defines/dev.env
+++ b/dart_defines/dev.env
@@ -8,6 +8,6 @@
 ENV=dev
 SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=your-local-supabase-anon-key
-API_BASE_URL=http://localhost:3000
+TRUXIFY_API_BASE_URL=http://localhost:3000
 ML_ENGINE_URL=http://localhost:8000
 POLYGON_RPC_URL=https://rpc-amoy.polygon.technology


### PR DESCRIPTION
Fixes #2648

Renames `API_BASE_URL` to `TRUXIFY_API_BASE_URL` in `dart_defines/dev.env` to match the variable name read by all Flutter services.

GSSoC