### PR TITLE
fix: remove dead overflow check in Reputation.sol under Solidity 0.8.24

### DIFF
--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -58,7 +58,7 @@ contract Reputation is Ownable, Pausable {
         uint256 current = scores[driver];
         if (current >= MAX_REPUTATION) return;
         uint256 newScore = current + points;
-        if (newScore < current || newScore > MAX_REPUTATION) {
+        if (newScore > MAX_REPUTATION) {
             scores[driver] = MAX_REPUTATION;
         } else {
             scores[driver] = newScore;


### PR DESCRIPTION
Fixes #2649

Removes the `newScore < current` overflow check from `increaseReputation` in `Reputation.sol`. Solidity 0.8.x automatically reverts on arithmetic overflow, making this check unreachable dead code.

GSSoC