### PR TITLE
fix: close old WebSocket before nulling _channel in _scheduleReconnect

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -271,6 +271,7 @@ class LocationService {
   }
 
   void _scheduleReconnect() {
+    _closeWebSocket();
     _channel = null;
     final socketSubscription = _socketSubscription;
     _socketSubscription = null;


### PR DESCRIPTION
Fixes #2650

Calls `_closeWebSocket()` before setting `_channel = null` in `_scheduleReconnect()` to prevent orphan WebSocket connections from accumulating.

GSSoC