### PR TITLE
fix: add backpressure handling to subscribeToNewLoads StreamController

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -190,7 +190,9 @@ class MarketplaceRepository {
             final newRecord = payload.newRecord;
             if (newRecord.isNotEmpty) {
               final offer = _mapLoadOffer(newRecord);
-              controller.add(offer);
+              if (!controller.add(offer)) {
+                developer.log('No active subscribers, dropping load offer');
+              }
             }
           } catch (e, st) {
             developer.log('Error mapping load offer', error: e, stackTrace: st);


### PR DESCRIPTION
Fixes #2651

Checks the return value of `controller.add()` and skips the offer silently when there are no active subscribers, preventing events from being dropped silently.

GSSoC