### PR TITLE
fix: replace truthiness check with null check for lat/lng in truckRoutes.js

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -175,7 +175,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     is_fragile, is_stackable
   } = req.query;
 
-  if (!pickup_lat || !pickup_lng || !drop_lat || !drop_lng || !weight_tonnes) {
+  if (pickup_lat == null || pickup_lng == null || drop_lat == null || drop_lng == null || weight_tonnes == null) {
     return res.status(400).json({ error: 'Missing required query parameters: pickup_lat, pickup_lng, drop_lat, drop_lng, weight_tonnes' });
   }
 


### PR DESCRIPTION
Fixes #2652

Replaces `!pickup_lat` truthiness checks with explicit `== null` checks in truck search parameter validation, so that legitimate coordinates of 0 (Equator, Prime Meridian) are not falsely rejected.

GSSoC