### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: truxify-lint-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/KanishJebaMathewM/Truxify/security/code-scanning/28](https://github.com/KanishJebaMathewM/Truxify/security/code-scanning/28)

Add an explicit top-level `permissions` block in `.github/workflows/lint.yml` so all jobs inherit restricted token scope.  
Best minimal fix (without changing behavior): set:

- `contents: read`

This is sufficient for checkout and lint/analyze tasks and documents intended access. Place it at workflow root (after `on:` block and before `concurrency:` is a clean location), so it applies to `backend-lint`, `customer-lint`, and `driver-lint` without duplicating config.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to use read-only repository access during checks, improving security for automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->