### PR TITLE
fix(backend): correct column name in adminRoutes.js (#2661)

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -11,7 +11,7 @@ router.get('/dashboard', authenticate, requireRole(['admin']), async (req, res) 
       .from('profiles')
       .select('*', { count: 'exact', head: true })
       .eq('role', 'driver')
-      .eq('status', 'active');
+      .eq('is_active', true);
       
     if (driversErr) {
       logger.error('Error fetching active drivers:', driversErr.message);


### PR DESCRIPTION
## Description

Changes `.eq('status', 'active')` to `.eq('is_active', true)` in adminRoutes.js to match the actual database schema.

Fixes #2661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the active drivers count in the admin dashboard to use the correct active-status field, improving the accuracy of dashboard metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->