### PR TITLE
fix(backend): fix duplicate keys in swagger servers array (#2662)

### DIFF
--- a/backend/api/src/config/swagger.js
+++ b/backend/api/src/config/swagger.js
@@ -18,8 +18,6 @@ const options = {
         description: process.env.API_PUBLIC_URL
           ? 'Configured server'
           : 'Development server',
-        url: process.env.API_PUBLIC_URL || 'http://localhost:5000/api',
-        description: process.env.API_PUBLIC_URL ? 'Server' : 'Development server',
       },
     ],
   },


### PR DESCRIPTION
## Description

Removes duplicate `url` and `description` keys in swagger.js servers array. Each server object now has exactly one `url` and one `description`.

Fixes #2662