### PR TITLE
fix(backend): use pino logger in profileService.js instead of console.error (#2664)

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -1,4 +1,5 @@
 import { supabase, redisClient } from '../config/db.js';
+import logger from '../middleware/logger.js';
 
 export async function getProfile(userId) {
   if (!supabase) {
@@ -64,7 +65,7 @@ export async function invalidateProfileCache(userId) {
     try {
       await redisClient.del(`profile:${userId}`);
     } catch (err) {
-      console.error('Redis cache invalidation error:', err);
+      logger.error({ err }, 'Redis cache invalidation error');
     }
   }
 }


### PR DESCRIPTION
## Description

Replaces `console.error()` with `logger.error()` for Redis cache invalidation errors in profileService.js. Error events now appear in structured pino logs.

Fixes #2664