### PR TITLE
fix(backend): start reputation reconciliation background job in index.js (#2665)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -33,6 +33,10 @@ import {
   startEscrowRefundReconciliation,
   stopEscrowRefundReconciliation
 } from './services/escrowRefundReconciliation.js'
+import {
+  startReputationReconciliation,
+  stopReputationReconciliation,
+} from './services/reputationReconciliation.js'
 
 // Configuration load from root folder is handled in db.js
 
@@ -204,6 +208,7 @@ server.listen(PORT, () => {
   logger.info(`Truxify API listening on port ${PORT}`)
   startEscrowRefundReconciliation()
   startEscrowReleaseReconciliation()
+  startReputationReconciliation()
 })
 
 // ============================================================================
@@ -228,6 +233,7 @@ async function shutdown (signal) {
   // Stop reconciliation timers so no new work starts during the drain.
   stopEscrowRefundReconciliation()
   stopEscrowReleaseReconciliation()
+  stopReputationReconciliation()
 
   const forceExit = setTimeout(() => {
     logger.error('[shutdown] Timeout exceeded — forcing exit.')


### PR DESCRIPTION
## Description

Adds import and call for `startReputationReconciliation()` in index.js so that failed on-chain reputation updates are retried. The function was defined but never started.

Fixes #2665