### PR TITLE
fix(backend): distinguish 'Goods Loaded' from 'In Transit' milestones (#2666)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -732,7 +732,7 @@ router.put('/:id/milestones', authenticate, userLimiter, requireRole(['driver'])
     const { milestone } = req.body;
     const milestoneMap = {
       'Arrived at Pickup': 'at_pickup',
-      'Goods Loaded': 'in_transit',
+      'Goods Loaded': 'loaded',
       'In Transit': 'in_transit',
       'Arrived at Drop-off': 'at_dropoff',
       'Goods Unloaded': 'at_dropoff'


### PR DESCRIPTION
## Description

Maps 'Goods Loaded' to `loaded` instead of `in_transit` so the database can distinguish between goods being loaded and the shipment being in transit.

Fixes #2666