### PR TITLE
fix(ml): call _save_hash() after model training to persist integrity checksum (#2667)

### DIFF
--- a/backend/ml/app/models/eta_prediction.py
+++ b/backend/ml/app/models/eta_prediction.py
@@ -71,6 +71,7 @@ class ETAPredictor:
 
         with open(MODEL_PATH, "wb") as f:
             pickle.dump(self.model, f)
+        self._save_hash()
 
     def _save_hash(self):
         with open(MODEL_PATH, "rb") as f:


### PR DESCRIPTION
## Description

Adds `self._save_hash()` call after `pickle.dump()` in the ETA predictor's `train()` method so that the SHA-256 checksum is persisted. Without this, `load()` always detects integrity failure and retrains on every cold start.

Fixes #2667