### PR TITLE
fix(ml): fix relative import in export_schema.py that crashes with documented command (#2668)

### DIFF
--- a/backend/ml/export_schema.py
+++ b/backend/ml/export_schema.py
@@ -12,7 +12,7 @@ import os
 # Add the parent directory to path so we can import main
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from .main import app
+from main import app
 
 def export_schema():
     schema = app.openapi()


### PR DESCRIPTION
## Description

Changes `from .main import app` to `from main import app` in export_schema.py. Python relative imports require running as a module, but the docstring instructs `python backend/ml/export_schema.py` which fails.

Fixes #2668