### PR TITLE
fix(blockchain): convert deploy.js from CJS require to ESM import (#2669)

### DIFF
--- a/blockchain/scripts/deploy.js
+++ b/blockchain/scripts/deploy.js
@@ -1,6 +1,6 @@
-const { ethers } = require("hardhat");
+import { ethers } from "hardhat";
 
-async function main() {
+export async function main() {
   const [deployer] = await ethers.getSigners();
   console.log("Deploying contracts with account:", deployer.address);
   console.log("Account balance:", (await ethers.provider.getBalance(deployer.address)).toString());


### PR DESCRIPTION
## Description

Converts `require("hardhat")` to `import { ethers } from "hardhat"` in deploy.js. The blockchain/package.json has `"type": "module"`, making all .js files ES Modules where `require` is not available.

Fixes #2669