### PR TITLE
fix(infra): add env_file to ml-engine service in docker-compose (#2673)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     build:
       context: ./backend/ml
     container_name: truxify-ml-engine
+    env_file:
+      - .env
     ports:
       - "8001:8000"
     environment:


### PR DESCRIPTION
## Description

Adds `env_file: .env` to the ml-engine service so `ML_API_KEY` can be read from `.env` file, matching the api service pattern.

Fixes #2673