### PR TITLE
fix(flutter): replace initialValue with value in DropdownButtonFormField (#2675)

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -809,7 +809,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                 child: Column(
                   children: [
                     DropdownButtonFormField<String>(
-                      initialValue: _goodsType,
+                      value: _goodsType,
                       items: _goodsTypes
                           .map((type) => DropdownMenuItem(value: type, child: Text(type)))
                           .toList(),


### PR DESCRIPTION
## Description

Replaces invalid `initialValue` property with correct `value` property on `DropdownButtonFormField` in find_trucks_screen.dart.

Fixes #2675