### PR TITLE
fix(flutter): replace initialValue with value in DropdownButtonFormField (#2676)

### DIFF
--- a/apps/customer/lib/screens/payment_methods_screen.dart
+++ b/apps/customer/lib/screens/payment_methods_screen.dart
@@ -400,7 +400,7 @@ class _AddPaymentSheetState extends State<_AddPaymentSheet> {
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
-              initialValue: _selectedType,
+              value: _selectedType,
               decoration: const InputDecoration(labelText: 'Payment Type'),
               items: _types
                   .map((t) => DropdownMenuItem(value: t, child: Text(t)))


### PR DESCRIPTION
## Description

Replaces invalid `initialValue` property with correct `value` property on `DropdownButtonFormField` in payment_methods_screen.dart.

Fixes #2676