### PR TITLE
fix(flutter): make _defaultBaseUrl public in ApiClient (#2677)

### DIFF
--- a/apps/customer/lib/core/api_client.dart
+++ b/apps/customer/lib/core/api_client.dart
@@ -75,10 +75,10 @@ class ApiClient {
         'Set --dart-define=TRUXIFY_API_BASE_URL=<url> for production builds.',
       );
     }
-    return _defaultBaseUrl;
+    return defaultBaseUrl;
   }
 
-  static String get _defaultBaseUrl {
+  static String get defaultBaseUrl {
     const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
     if (envUrl.isNotEmpty) return envUrl;
     if (kReleaseMode) throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');


### PR DESCRIPTION
## Description

Renames `_defaultBaseUrl` to `defaultBaseUrl` in ApiClient so it can be accessed from outside the library.

Fixes #2677