### PR TITLE
fix(backend): add TRUST_PROXY to .env.example documentation (#2681)

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -71,3 +71,6 @@ ESCROW_RECONCILIATION_INTERVAL_MS=60000
 # unavailable. Created with 0o600 permissions. PII (driver_id, lat, lng)
 # is scrubbed before writing. Defaults to os.tmpdir()/truxify-telemetry-recovery.jsonl
 # RECOVERY_FILE_PATH=C:\tmp\truxify-recovery.jsonl
+
+# Trust proxy setting - set to 1 if behind Nginx/ALB reverse proxy
+# TRUST_PROXY=0


### PR DESCRIPTION
## Description

Adds `TRUST_PROXY` environment variable to `.env.example` so deployers know this configuration exists. Used in index.js for `app.set('trust proxy', ...)`.

Fixes #2681