### PR TITLE
fix(blockchain): add revert on reputation cap instead of silent return (#2683)

### DIFF
--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -56,7 +56,7 @@ contract Reputation is Ownable, Pausable {
     function increaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
         require(driver != address(0), "Invalid driver");
         uint256 current = scores[driver];
-        if (current >= MAX_REPUTATION) return;
+        if (current >= MAX_REPUTATION) revert("already at max reputation");
         uint256 newScore = current + points;
         if (newScore < current || newScore > MAX_REPUTATION) {
             scores[driver] = MAX_REPUTATION;


### PR DESCRIPTION
## Description

Changes silent `return;` to `revert("already at max reputation")` when reputation hits `MAX_REPUTATION` so callers get clear feedback instead of a silent no-op.

Fixes #2683