### PR TITLE
fix(backend): wrap async flush in try/finally for mutex safety (#2687)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -766,6 +766,9 @@ async function flushTelemetryBuffer() {
     } finally {
       currentFlushPromise = null;
       flushMutex = false;
+      }
+    } finally {
+      flushMutex = false;
     }
   })();
 


### PR DESCRIPTION
## Description

Wraps the async flush operation in try/finally so `flushMutex` is only released after the async operation completes. Prevents concurrent flush corruption of GPS telemetry buffer.

Fixes #2687