### PR TITLE
fix(backend): use calculateRetryBackoff in FCM retry loop (#2689)

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -103,7 +103,7 @@ export async function sendFcmNotification(userId, notification, data = {}) {
 
       if (isTransientError(err.code) && attempt < MAX_RETRIES - 1) {
         logger.info(`[FCM] Retrying after ${RETRY_DELAYS[attempt]}ms for user ${userId}`);
-        await new Promise(resolve => setTimeout(resolve, RETRY_DELAYS[attempt]));
+        const delay = calculateRetryBackoff(attempt); await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
   }


### PR DESCRIPTION
## Description

Replaces hardcoded `RETRY_DELAYS[attempt]` with `calculateRetryBackoff(attempt)` in the FCM notification retry loop so exponential backoff is actually used.

Fixes #2689