### PR TITLE
fix(infra): add env_file to api service in docker-compose (#2688)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ./backend/api
       target: development
+    env_file:
+      - .env
     ports:
       - "5000:5000"
     env_file:


### PR DESCRIPTION
## Description

Adds `env_file: .env` to the api service definition so DATABASE_URL can be read from .env file without requiring `docker-compose.override.yml`.

Fixes #2688