### PR TITLE
fix(backend): add delivered/completed guard before refund cancellation (#2693)

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -108,6 +108,9 @@ export async function reconcilePendingEscrowRefunds() {
 
         const receipt = await confirmEscrowRefund(refundTxHash);
         const refundedAt = new Date().toISOString();
+        const { data: cur } = await supabase.from('orders').select('status').eq('id', order.id).maybeSingle();
+        if (cur && (cur.status === 'delivered' || cur.status === 'payment_released')) { logger.info('[escrow] Order already delivered - skip refund'); continue; }
+
         const { error: updateError } = await supabase
           .from('orders')
           .update({


### PR DESCRIPTION
## Description

Adds a status check before cancelling orders in the refund reconciliation loop. If the order was already delivered/completed by a concurrent operation, skip the refund to prevent overwriting the correct state.

Fixes #2693