### PR TITLE
fix(infra): remove exposed database ports from docker-compose (#2695)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,39 +46,10 @@ services:
       start_period: 30s
   db:
     image: postgis/postgis:15-3.3-alpine
-    ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgrespassword}
-      POSTGRES_DB: ${POSTGRES_DB:-truxify}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
   mongo:
     image: mongo:6-jammy
-    ports:
-      - "27017:27017"
-    volumes:
-      - mongo_data:/data/db
-    healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
-
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
 volumes:
   mongo_data:
   postgres_data:


### PR DESCRIPTION
## Description

Removes port mappings for PostgreSQL (5432), MongoDB (27017), and Redis (6379) from docker-compose.yml to prevent unauthenticated host access to databases.

Fixes #2695