### PR TITLE
fix(backend): move health routes before globalLimiter to avoid double rate limiting (#2697)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -136,14 +136,14 @@ app.use(requestLogger)
 // ============================================================================
 // RATE LIMITING
 // ============================================================================
-app.use('/api/', globalLimiter)
 app.use('/api/health', healthLimiter)
+app.use('/api/health', healthRoutes)
+app.use('/api/', globalLimiter)
 app.use('/api/v1/trips', tripRoutes)
 
 // ============================================================================
 // REST API ROUTING
 // ============================================================================
-app.use('/api/health', healthRoutes)
 
 app.use('/api/orders', orderRoutes)
 app.use('/api/driver', driverRoutes)


### PR DESCRIPTION
## Description

Reorders middleware mounting so health routes are registered before the global rate limiter. Health checks were previously limited by both `healthLimiter` and `globalLimiter`.

Fixes #2697