### PR TITLE
fix(flutter): remove suppress ignore_for_file directive (#2705)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: unused_element, unused_field
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
## Description

Removes `// ignore_for_file: unused_element, unused_field` from driver home_screen.dart, forcing unused variables to be surfaced during review.

Fixes #2705