### PR TITLE
fix(backend): disable Swagger UI in production (#2707)

### DIFF
--- a/backend/api/src/config/swagger.js
+++ b/backend/api/src/config/swagger.js
@@ -1,3 +1,4 @@
+import logger from '../middleware/logger.js';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
 
@@ -29,5 +30,9 @@ const options = {
 const swaggerSpec = swaggerJsdoc(options);
 
 export const setupSwagger = (app) => {
+  if (process.env.NODE_ENV === 'production') {
+    logger.warn('[Swagger] Disabling Swagger UI in production');
+    return;
+  }
   app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 };


### PR DESCRIPTION
## Description

Adds production guard to skip Swagger UI setup in production environments, preventing exposure of API documentation.

Fixes #2707