### PR TITLE
fix(backend): remove redundant schema-level TTL from GpsLog.js (#2710)

### DIFF
--- a/backend/api/src/models/GpsLog.js
+++ b/backend/api/src/models/GpsLog.js
@@ -68,8 +68,7 @@ const gpsLogSchema = new mongoose.Schema({
         timeField: "timestamp",
         metaField: "metadata",
         granularity: "seconds",
-    },
-    expireAfterSeconds: process.env.GPS_LOG_TTL || 60 * 60 * 24 * 30, // configurable TTL
+    }
 });
 
 // Compound index for faster queries by bookingId + timestamp


### PR DESCRIPTION
## Description

Removes redundant `expireAfterSeconds` from GpsLog schema-level index since TTL is already configured and managed manually in `db.js`. Duplicate TTL settings cause index creation conflicts.

Fixes #2710