### PR TITLE
fix(backend): pass correct bookingId and txHash to recordDepositTxFn (#2694)

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -127,7 +127,7 @@ export class BidAcceptanceService {
 
     // Record the deposit transaction
     try {
-      await this.recordDepositTxFn(order.order_display_id, depositTx?.to, depositTx?.data);
+      await this.recordDepositTxFn(bookingId, depositTx?.hash || depositTx?.transactionHash || '');
     } catch (recordErr) {
       this.logger?.warn?.('[escrow] Failed to record deposit TX:', recordErr.message);
     }


### PR DESCRIPTION
## Description

Fixes argument mismatch in bidAcceptanceService.js line 130. The function `recordDepositTxFn` expects `(bookingId, txHash)` but was called with `(order_display_id, depositTx?.to, depositTx?.data)`. Now passes the computed `bookingId` variable and the actual transaction hash.

Fixes #2694