### PR TITLE
fix(flutter): remove _estimatePrice side effect from form validator (#2699)

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -374,10 +374,6 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() => _weightErrorText = error);
-        // Trigger estimate update after validation
-        if (error == null) {
-          _estimatePrice();
-        }
       }
     });
 


### PR DESCRIPTION
## Description

Removes `_estimatePrice()` call from `_validateWeight`'s postFrameCallback. Form validators should be pure functions; price estimation is now only triggered on explicit events (location change, toggle).

Fixes #2699