### PR TITLE
fix(flutter): remove unused bare import of truxify_shared (#2700)

### DIFF
--- a/apps/customer/lib/screens/notifications_screen.dart
+++ b/apps/customer/lib/screens/notifications_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:truxify_shared/truxify_shared.dart';
 import 'package:truxify_shared/truxify_shared.dart' as shared;
 
 class NotificationsScreen extends StatelessWidget {


### PR DESCRIPTION
## Description

Removes unused bare `import 'package:truxify_shared/truxify_shared.dart'` line. The file only uses the namespaced import (`as shared`), making the bare import redundant.

Fixes #2700