### PR TITLE
fix(backend): simplify prepend() to fix buffer corruption from confusing capacity logic (#2702)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -74,45 +74,12 @@ class TelemetryRingBuffer {
 
   prepend(items) {
     if (!items || items.length === 0) return 0;
-    let dropped = 0;
-    
-    // If prepending all items would exceed capacity, we drop the oldest ones (the first ones in `items`).
-    let itemsToPrepend = items;
-    if (this.size + items.length > this.capacity) {
-      const dropCount = this.size + items.length - this.capacity;
-      
-      // If we are dropping items, the oldest ones are the ones we drop.
-      // We can drop from `items` (since they are the oldest overall)
-      if (dropCount >= items.length) {
-        // If we drop more than items.length, it means items are entirely dropped,
-        // and we also need to drop from the front of the current buffer.
-        // Actually, if we just push them, the buffer handles dropping oldest.
-        // But wait, prepend adds to the FRONT (oldest). 
-        // If we drop, we just don't add the oldest of the `items`.
-      }
-      
-      dropped = dropCount;
-      // We only keep the last (capacity - this.size) items, unless items is larger than capacity,
-      // in which case we just keep the last `capacity` items and clear the buffer.
-      const keepCount = Math.min(items.length, this.capacity);
-      const startIdx = items.length - keepCount;
-      itemsToPrepend = items.slice(startIdx);
-      
-      // If adding these still exceeds capacity (because this.size is large),
-      // we must drop from the CURRENT buffer's oldest? No, itemsToPrepend ARE the oldest!
-      // So if this.size + itemsToPrepend.length > capacity, we just don't prepend some of itemsToPrepend!
-      // Wait, we just did that! keepCount is at most capacity.
-      // The remaining itemsToPrepend will fit if we drop from the FRONT of itemsToPrepend.
-      const availableSpace = this.capacity - this.size;
-      if (availableSpace < itemsToPrepend.length) {
-         // drop the oldest from itemsToPrepend
-         itemsToPrepend = itemsToPrepend.slice(itemsToPrepend.length - availableSpace);
-      }
-    }
-
-    for (let i = itemsToPrepend.length - 1; i >= 0; i--) {
+    const available = this.capacity - this.size;
+    const toInsert = items.length > available ? items.slice(items.length - available) : items;
+    const dropped = items.length > available ? items.length - available : 0;
+    for (let i = toInsert.length - 1; i >= 0; i--) {
       this.head = (this.head - 1 + this.capacity) % this.capacity;
-      this.buffer[this.head] = itemsToPrepend[i];
+      this.buffer[this.head] = toInsert[i];
       this.size++;
     }
     return dropped;


### PR DESCRIPTION
## Description

Replaces the over-engineered and bug-prone TelemetryRingBuffer.prepend() with a clear 6-line implementation. The old logic had confusing comments, unused branches, and potential size overflow. New logic is straightforward: if items exceed available space, drop oldest; then prepend in reverse order.

Fixes #2702