### PR TITLE
fix(backend): remove unused ipKeyGenerator import in rateLimiter.js (#2708)

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -1,4 +1,4 @@
-import rateLimit, { MemoryStore, ipKeyGenerator } from 'express-rate-limit';
+import rateLimit, { MemoryStore } from 'express-rate-limit';
 import { RedisStore } from 'rate-limit-redis';
 import { redisClient } from '../config/db.js';
 import logger from './logger.js';


### PR DESCRIPTION
## Description

Removes destructured `ipKeyGenerator` from the `express-rate-limit` import. The function was imported but never used in the file.

Fixes #2708