### PR TITLE
fix(backend): restrict Socket.IO CORS origins in production (#2709)

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -49,10 +49,11 @@ export function initLocationServer(httpServer) {
   }
   io = new Server(httpServer, {
     cors: {
-      origin: process.env.ALLOWED_ORIGINS?.split(",") || [
-        "http://localhost:3000",
-        "http://localhost:5000",
-      ],
+      origin: process.env.ALLOWED_ORIGINS?.split(",") || (
+        process.env.NODE_ENV === 'production'
+          ? []
+          : ["http://localhost:3000", "http://localhost:5000"]
+      ),
       methods: ["GET", "POST"],
       credentials: true,
     },


### PR DESCRIPTION
## Description

Adds production guard to Socket.IO CORS in locationServer.js. When NODE_ENV=production, no default origins are allowed; ALLOWED_ORIGINS env var must be explicitly set. In development, defaults to localhost:3000/5000.

Fixes #2709