### PR TITLE
feat(backend): Enforce strict content-type validation for POST/PUT requests

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -28,6 +28,7 @@ import adminRoutes from './routes/adminRoutes.js'
 import logger from './middleware/logger.js'
 import { setupSwagger } from './config/swagger.js'
 import { requestIdMiddleware, requestLogger } from './middleware/requestId.js'
+import { contentTypeMiddleware } from './middleware/contentType.js'
 import { initSentry, flushSentry, sentryErrorHandler } from './middleware/sentry.js'
 import {
   startEscrowRefundReconciliation,
@@ -125,6 +126,7 @@ if (process.env.NODE_ENV === 'production') {
 // Payload parsers
 app.use(express.json({ limit: '1mb' })) // Added payload limit for security
 app.use(express.urlencoded({ extended: true, limit: '1mb' }))
+app.use(contentTypeMiddleware)
 
 // ============================================================================
 // REQUEST ID + REQUEST LOGGER — registered before all routes and rate limiters

--- a/backend/api/src/middleware/contentType.js
+++ b/backend/api/src/middleware/contentType.js
@@ -1,26 +1,14 @@
-export function requireJsonContent(req, res, next) {
-  // Only enforce on mutating requests
+export function contentTypeMiddleware(req, res, next) {
+  // Only check mutating requests that should have a body
   if (['POST', 'PUT', 'PATCH'].includes(req.method)) {
-    const contentType = req.headers['content-type'];
+    const contentType = req.headers['content-type'] || '';
     
-    if (!contentType) {
-      return res.status(415).json({ error: 'Unsupported Media Type. Content-Type header is missing.' });
+    // We expect either application/json or multipart/form-data
+    if (!contentType.includes('application/json') && !contentType.includes('multipart/form-data')) {
+      return res.status(415).json({
+        error: 'Unsupported Media Type: Content-Type must be application/json or multipart/form-data'
+      });
     }
-
-    // Allow application/json
-    if (contentType.includes('application/json')) {
-      return next();
-    }
-
-    // Allow multipart/form-data for specific routes (like document uploads)
-    if (contentType.includes('multipart/form-data')) {
-      return next();
-    }
-
-    // Reject all other content types
-    return res.status(415).json({ error: 'Unsupported Media Type. Expected application/json.' });
   }
-
-  // Pass through for GET, DELETE, etc.
   next();
 }


### PR DESCRIPTION
Resolves #1565. Adds a global middleware to enforce application/json or multipart/form-data for mutating requests.