### PR TITLE
feat(customer): implement offline-first caching for order history

### DIFF
--- a/apps/customer/lib/services/order_cache.dart
+++ b/apps/customer/lib/services/order_cache.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+class OrderCache {
+  static Database? _db;
+
+  static Future<Database> get database async {
+    if (_db != null) return _db!;
+    _db = await _initDB();
+    return _db!;
+  }
+
+  static Future<Database> _initDB() async {
+    String path = join(await getDatabasesPath(), 'order_cache.db');
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute(
+          '''
+          CREATE TABLE orders(
+            id TEXT PRIMARY KEY,
+            data TEXT,
+            timestamp INTEGER
+          )
+          '''
+        );
+      },
+    );
+  }
+
+  static Future<void> cacheOrders(List<Map<String, dynamic>> orders) async {
+    final db = await database;
+    Batch batch = db.batch();
+    
+    // Clear old cache before inserting new
+    batch.delete('orders');
+
+    for (var order in orders) {
+      batch.insert(
+        'orders',
+        {
+          'id': order['id'],
+          'data': jsonEncode(order),
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  static Future<List<Map<String, dynamic>>> getCachedOrders() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'orders',
+      orderBy: 'timestamp DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return jsonDecode(maps[i]['data'] as String) as Map<String, dynamic>;
+    });
+  }
+}

--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../core/api_client.dart';
+import 'order_cache.dart';
 
 class OrderService {
   OrderService({
@@ -248,10 +249,25 @@ class OrderService {
 
   Future<List<Map<String, dynamic>>> fetchHistoryOrders() async {
     try {
-      final body = await _apiClient.get(
-        '/api/orders/history',
-      );
-      return _historyFromResponse(body);
+      final cachedOrders = await OrderCache.getCachedOrders();
+      if (cachedOrders.isNotEmpty) {
+        _refreshHistoryOrders().catchError((_) {});
+        return cachedOrders;
+      }
+      return await _refreshHistoryOrders();
+    } catch (e) {
+      final cachedOrders = await OrderCache.getCachedOrders();
+      if (cachedOrders.isNotEmpty) return cachedOrders;
+      throw StateError('Failed to fetch history orders: $e');
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _refreshHistoryOrders() async {
+    try {
+      final body = await _apiClient.get('/api/orders/history');
+      final orders = _historyFromResponse(body);
+      await OrderCache.cacheOrders(orders);
+      return orders;
     } on ApiException catch (e) {
       throw StateError(e.message);
     } catch (e) {


### PR DESCRIPTION
Resolves #2409. Implements an SQLite-backed OrderCache to store order history for offline use.