### PR TITLE
fix: gate api startup on db/mongo/redis health checks (#1607)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - ./backend/api:/app
       - /app/node_modules
     depends_on:
+      db:
+        condition: service_healthy
       mongo:
         condition: service_healthy
       redis:
@@ -49,11 +51,29 @@ services:
       retries: 5
       start_period: 30s
   db:
-    image: postgis/postgis:15-3.3-alpine
+       image: postgis/postgis:15-3.3-alpine
+       healthcheck:
+         test: ["CMD-SHELL", "pg_isready -U postgres"]
+         interval: 10s
+         timeout: 5s
+         retries: 5
+         start_period: 10s
   mongo:
     image: mongo:6-jammy
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
   redis:
     image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 volumes:
   mongo_data:
   postgres_data:


### PR DESCRIPTION
Fixes #1607

## Problem
`api`'s `depends_on` only waited for `db`, `mongo`, and `redis` containers to
*start*, not for them to actually be ready to accept connections. `db`,
`mongo`, and `redis` had no `healthcheck` blocks at all, so Compose had no
way to know when they were truly ready. This caused intermittent
`ECONNREFUSED` errors on first bring-up, especially on slower machines/CI.

## Changes
- Added a `pg_isready` healthcheck to `db`
- Added a `mongosh --eval "db.adminCommand('ping')"` healthcheck to `mongo`
- Added a `redis-cli ping` healthcheck to `redis`
- Updated `api`'s `depends_on` to use `condition: service_healthy` for
  `db`, `mongo`, and `redis`

## Testing
- Ran `docker compose down -v && docker compose up --build` for a full
  cold start (no cached volumes)
- Confirmed `db`, `mongo`, `redis` report `(healthy)` in `docker compose ps`
  before `api` starts
- Confirmed no `ECONNREFUSED` errors in `api` logs on first bring-up
- Repeated the cold start a few times to confirm the race condition no
  longer occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability by waiting for the database to be fully ready before the API starts.
  * Added readiness checks for the database, MongoDB, and Redis so services are verified as healthy during launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->