### PR TITLE
fix: remove hardcoded Colors.black for Dark Mode visibility (Issue #2609)

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -457,10 +457,10 @@ class _EarningsScreenState extends State<EarningsScreen> {
                 children: [
                   IconButton(
                     onPressed: _prevMonth,
-                    icon: const Icon(
+                    icon: Icon(
                       Icons.chevron_left_rounded,
                       size: 20,
-                      color: Colors.black,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
                     visualDensity: VisualDensity.compact,
                     style: IconButton.styleFrom(
@@ -479,10 +479,10 @@ class _EarningsScreenState extends State<EarningsScreen> {
                   const SizedBox(width: 8),
                   IconButton(
                     onPressed: _nextMonth,
-                    icon: const Icon(
+                    icon: Icon(
                       Icons.chevron_right_rounded,
                       size: 20,
-                      color: Colors.black,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
                     visualDensity: VisualDensity.compact,
                     style: IconButton.styleFrom(


### PR DESCRIPTION
Closes #2609.

**Description:**
This PR resolves an issue where UI elements (such as icons in the driver Earnings screen) were entirely invisible in system-wide Dark Mode because their colors were hardcoded to `Colors.black`.

**Changes Made:**
- Replaced explicit `Colors.black` assignments with `Theme.of(context).colorScheme.onSurface` in `apps/driver/lib/screens/earnings_screen.dart`. 
- By inheriting from `Theme.of(context).colorScheme.onSurface`, the text and icon elements will automatically adapt and switch to white when the background turns dark, maintaining perfect legibility globally.

**Checklist:**
- [x] Only one commit in this PR.
- [x] Fixed all targeted explicit `Colors.black` calls.
- [x] UI successfully adapts to Dark Mode settings.