### PR TITLE
fix: resolve map memory leak by scoping AnimatedBuilder (Issue #2604)

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -812,18 +812,15 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
       body: Stack(
         children: [
           Positioned.fill(
-            child: AnimatedBuilder(
-              animation: _movementController,
-              builder: (context, child) {
-                return FlutterMap(
-                  options: const MapOptions(
-                    initialCenter: LatLng(24.25, 74.40),
-                    initialZoom: 6.2,
-                    minZoom: 5,
-                    maxZoom: 16,
-                  ),
-                  children: [
-                    TileLayer(
+            child: FlutterMap(
+              options: const MapOptions(
+                initialCenter: LatLng(24.25, 74.40),
+                initialZoom: 6.2,
+                minZoom: 5,
+                maxZoom: 16,
+              ),
+              children: [
+                TileLayer(
                       urlTemplate:
                           'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                       tileProvider: CancellableNetworkTileProvider(),
@@ -838,24 +835,29 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                         ),
                       ],
                     ),
-                    MarkerLayer(
-                      markers: [
-                        Marker(
-                          point: _routePoints.first,
-                          width: 30,
-                          height: 30,
-                          child: Icon(Icons.trip_origin_rounded,
-                              color: Colors.blue, size: 22),
-                        ),
-                        Marker(
-                          point: _routePoints.last,
-                          width: 34,
-                          height: 34,
-                          child: Icon(Icons.place_rounded,
-                              color: Colors.redAccent, size: 26),
-                        ),
-                        ..._buildTruckMarkers(),
-                      ],
+                    AnimatedBuilder(
+                      animation: _movementController,
+                      builder: (context, _) {
+                        return MarkerLayer(
+                          markers: [
+                            Marker(
+                              point: _routePoints.first,
+                              width: 30,
+                              height: 30,
+                              child: const Icon(Icons.trip_origin_rounded,
+                                  color: Colors.blue, size: 22),
+                            ),
+                            Marker(
+                              point: _routePoints.last,
+                              width: 34,
+                              height: 34,
+                              child: const Icon(Icons.place_rounded,
+                                  color: Colors.redAccent, size: 26),
+                            ),
+                            ..._buildTruckMarkers(),
+                          ],
+                        );
+                      }
                     ),
                   ],
                 );

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -56,6 +56,63 @@ class _HomeScreenState extends State<HomeScreen> {
   Future<List<ll.LatLng>>? _routeFuture;
   DestinationPickResult? _destination;
   bool _isSearchExpanded = false;
+
+  List<Marker>? _cachedMarkers;
+  ll.LatLng? _lastDest;
+  ll.LatLng? _lastLoc;
+  int _lastCheckpointsCount = -1;
+
+  List<Marker> _getMarkers(List<ll.LatLng> checkpoints) {
+    if (_lastDest == _destination?.point &&
+        _lastLoc == _currentLocation &&
+        _lastCheckpointsCount == checkpoints.length &&
+        _cachedMarkers != null) {
+      return _cachedMarkers!;
+    }
+
+    _lastDest = _destination?.point;
+    _lastLoc = _currentLocation;
+    _lastCheckpointsCount = checkpoints.length;
+
+    _cachedMarkers = [
+      if (_currentLocation != null)
+        Marker(
+          point: _currentLocation!,
+          width: 54,
+          height: 54,
+          alignment: Alignment.center,
+          child: const RouteMarker(
+            icon: Icons.my_location_rounded,
+            fillColor: TruxifyColors.success,
+            shadowColor: TruxifyColors.success,
+          ),
+        ),
+      ...checkpoints.asMap().entries.map(
+            (entry) => Marker(
+              point: entry.value,
+              width: 34,
+              height: 34,
+              alignment: Alignment.center,
+              child: RouteCheckpointMarker(
+                  key: ValueKey('chk_${entry.key}'), label: '${entry.key + 1}'),
+            ),
+          ),
+      if (_destination != null)
+        Marker(
+          point: _destination!.point,
+          width: 54,
+          height: 54,
+          alignment: Alignment.center,
+          child: const RouteMarker(
+            icon: Icons.location_on_rounded,
+            fillColor: TruxifyColors.errorRed,
+            shadowColor: TruxifyColors.errorRed,
+          ),
+        ),
+    ];
+    return _cachedMarkers!;
+  }
+
   bool _isDestinationExpanded = false;
   bool _isOnline = true;
   bool _isRefreshingLocation = false;
@@ -1022,40 +1079,7 @@ class _HomeScreenState extends State<HomeScreen> {
               ],
             ),
             MarkerLayer(
-              markers: [
-                Marker(
-                  point: _currentLocation!,
-                  width: 54,
-                  height: 54,
-                  alignment: Alignment.center,
-                  child: const RouteMarker(
-                    icon: Icons.my_location_rounded,
-                    fillColor: TruxifyColors.success,
-                    shadowColor: TruxifyColors.success,
-                  ),
-                ),
-                ...checkpoints.asMap().entries.map(
-                      (entry) => Marker(
-                        point: entry.value,
-                        width: 34,
-                        height: 34,
-                        alignment: Alignment.center,
-                        child:
-                            RouteCheckpointMarker(label: '${entry.key + 1}'),
-                      ),
-                    ),
-                Marker(
-                  point: _destination!.point,
-                  width: 54,
-                  height: 54,
-                  alignment: Alignment.center,
-                  child: const RouteMarker(
-                    icon: Icons.location_on_rounded,
-                    fillColor: TruxifyColors.errorRed,
-                    shadowColor: TruxifyColors.errorRed,
-                  ),
-                ),
-              ],
+              markers: _getMarkers(checkpoints),
             ),
           ],
         );


### PR DESCRIPTION
Closes #2604.

**Description:**
This PR resolves the severe memory leaks caused by `AnimatedBuilder` forcing the entire `FlutterMap` to rebuild continuously in the Home and Live Tracking screens. 

**Changes Made:**
- Cached the `Marker` lists so they aren't unnecessarily recreated every frame.
- Scoped the `AnimatedBuilder` strictly around the `MarkerLayer` rather than wrapping the entire `FlutterMap`. 
- This prevents full teardowns of the map state and stops map tiles from re-fetching constantly, drastically improving performance and memory stability.

**Checklist:**
- [x] Only one commit in this PR.
- [x] Live tracking and home screen maps optimized.
- [x] Prevents unnecessary `FlutterMap` rebuilds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved map responsiveness while tracking movement by reducing unnecessary map redraws.
  * Marker updates on the home and live tracking screens are now more efficient, helping the app feel smoother during route and location changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->