### PR TITLE
 fix: load active trip details from local cache when offline (Issue #2608)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart' as ll;
 import 'package:truxify_driver/widgets/slide_to_confirm_button.dart';
@@ -45,6 +46,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  bool _isOffline = false;
   // Null until GPS resolves — no hardcoded coordinates anywhere
   ll.LatLng? _currentLocation;
 
@@ -434,23 +436,37 @@ class _HomeScreenState extends State<HomeScreen> {
             ? '$truckPlate · $truckModel'
             : (activeTrip['truck_label'] as String?) ?? 'Truck assigned';
 
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('cached_trip_id', tripId);
+        await prefs.setString('cached_truck_label', truckLabel);
+        await prefs.setString('cached_distance', (activeTrip['distance'] as String?) ?? (activeTrip['trip_distance'] as String?) ?? '');
+        await prefs.setString('cached_duration', (activeTrip['duration'] as String?) ?? (activeTrip['trip_duration'] as String?) ?? '');
+        await prefs.setString('cached_payout', (activeTrip['estimated_payout'] as String?) ?? (activeTrip['price'] as String?) ?? (activeTrip['payout'] as String?) ?? '');
+        
+        final isTripStarted = stops.any((s) => s['is_completed'] == true || s['is_current'] == true);
+        await prefs.setBool('cached_is_started', isTripStarted);
+
         setState(() {
+          _isOffline = false;
           _activeTripId = tripId;
           _activeTruckLabel = truckLabel;
-          _activeTripDistance = (activeTrip['distance'] as String?) ??
-              (activeTrip['trip_distance'] as String?) ?? '';
-          _activeTripDuration = (activeTrip['duration'] as String?) ??
-              (activeTrip['trip_duration'] as String?) ?? '';
-          _activeTripPayout = (activeTrip['estimated_payout'] as String?) ??
-              (activeTrip['price'] as String?) ??
-              (activeTrip['payout'] as String?) ?? '';
-          _isTripStarted = stops.any((s) => s['is_completed'] == true || s['is_current'] == true);
+          _activeTripDistance = prefs.getString('cached_distance') ?? '';
+          _activeTripDuration = prefs.getString('cached_duration') ?? '';
+          _activeTripPayout = prefs.getString('cached_payout') ?? '';
+          _isTripStarted = isTripStarted;
         });
         
         if (stops.isNotEmpty) {
           final lastStop = stops.last;
           final address = lastStop['drop_location'] as String;
+          await prefs.setString('cached_address', address);
+          
           final dropPoint = await GeocodeService.resolvePlace(address);
+          if (dropPoint != null) {
+            await prefs.setDouble('cached_drop_lat', dropPoint.latitude);
+            await prefs.setDouble('cached_drop_lng', dropPoint.longitude);
+          }
+          
           if (dropPoint != null && mounted) {
             setState(() {
               _destination = DestinationPickResult(address: address, point: dropPoint);
@@ -462,8 +478,11 @@ class _HomeScreenState extends State<HomeScreen> {
           }
         }
       } else {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.remove('cached_trip_id');
         if (mounted) {
           setState(() {
+            _isOffline = false;
             _activeTripId = null;
             _isTripStarted = false;
             _destination = null;
@@ -473,6 +492,27 @@ class _HomeScreenState extends State<HomeScreen> {
       }
     } catch (e) {
       debugPrint('Error loading active trip: $e');
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getString('cached_trip_id') != null && mounted) {
+        setState(() {
+          _isOffline = true;
+          _activeTripId = prefs.getString('cached_trip_id');
+          _activeTruckLabel = prefs.getString('cached_truck_label') ?? '';
+          _activeTripDistance = prefs.getString('cached_distance') ?? '';
+          _activeTripDuration = prefs.getString('cached_duration') ?? '';
+          _activeTripPayout = prefs.getString('cached_payout') ?? '';
+          _isTripStarted = prefs.getBool('cached_is_started') ?? false;
+        });
+        final address = prefs.getString('cached_address');
+        final lat = prefs.getDouble('cached_drop_lat');
+        final lng = prefs.getDouble('cached_drop_lng');
+        if (address != null && lat != null && lng != null) {
+          final dropPoint = ll.LatLng(lat, lng);
+          setState(() {
+            _destination = DestinationPickResult(address: address, point: dropPoint);
+          });
+        }
+      }
     }
   }
 
@@ -638,9 +678,34 @@ class _HomeScreenState extends State<HomeScreen> {
               top: 12,
               child: SafeArea(
                 bottom: false,
-                child: _isTripStarted
-                    ? _buildActiveNavigationHeader(context)
-                    : _buildSearchCard(context),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_isOffline)
+                      Container(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: TruxifyColors.errorRed,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(Icons.cloud_off_rounded, color: Colors.white, size: 16),
+                            const SizedBox(width: 8),
+                            Text(
+                              'You are offline. Using cached trip details.',
+                              style: GoogleFonts.dmSans(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                            ),
+                          ],
+                        ),
+                      ),
+                    _isTripStarted
+                        ? _buildActiveNavigationHeader(context)
+                        : _buildSearchCard(context),
+                  ],
+                ),
               ),
             ),
 


### PR DESCRIPTION
Closes #2608.

**Description:**
Resolves the severe UI crash in the driver app that occurred when a driver entered a cellular dead zone. When location sync previously failed, an unhandled network exception prevented the active trip details from rendering, leaving the driver unable to view the drop-off location.

**Changes Made:**
- Integrated `SharedPreferences` to cache active trip details including the drop-off location coordinates, payout, and trip ID upon successful network requests.
- Added a fallback path in `_loadActiveTrip()` to fetch and parse the cached details when a network exception is caught.
- Added a "You are offline" notification banner at the top of the home screen to alert the driver when they are operating with cached data.

**Checklist:**
- [x] Only one commit in this PR.
- [x] Tested graceful offline persistence fallback.
- [x] Offline UI banner added.