### PR TITLE
fix: check verifyDeliveryOtp return value in completeDeliveryOtp

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -151,7 +151,10 @@ export class DeliveryVerificationService {
   }
 
   async completeDeliveryOtp({ otpRecordId, orderId }) {
-    await verifyDeliveryOtp(otpRecordId);
+    const verified = await verifyDeliveryOtp(otpRecordId);
+    if (!verified) {
+      logger.warn('[DeliveryVerificationService] Failed to mark OTP as verified for order', orderId);
+    }
     await clearOtpState(orderId);
   }
 


### PR DESCRIPTION
Added return value check for verifyDeliveryOtp with warning log on failure.

Fixes #2828 GSSOC
