### PR TITLE
fix: optimize driver search with MongoDB $near geospatial query

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { supabase, mongoDb } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
@@ -251,11 +251,38 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
       logger.warn({ err: mlErr.message }, 'Price prediction unavailable during search, falling back to base pricing');
     }
 
+    let nearbyDriverIds = [];
+    if (mongoDb) {
+      try {
+        const maxDistanceMeters = 50000; // 50km radius
+        const nearbyTelemetry = await mongoDb.collection('telemetry').find({
+          location: {
+            $near: {
+              $geometry: {
+                type: "Point",
+                coordinates: [numPickupLng, numPickupLat]
+              },
+              $maxDistance: maxDistanceMeters
+            }
+          }
+        }).toArray();
+
+        nearbyDriverIds = [...new Set(nearbyTelemetry.map(t => t.driver_id))];
+      } catch (mongoErr) {
+        logger.error('MongoDB telemetry search error:', mongoErr.message);
+      }
+    }
+
+    if (nearbyDriverIds.length === 0) {
+      return res.json([]);
+    }
+
     const { data: drivers, error: driversErr } = await supabase
       .from('driver_details')
       .select('user_id, rating, total_trips, completion_rate, truck_id')
       .eq('is_online', true)
-      .not('truck_id', 'is', null);
+      .not('truck_id', 'is', null)
+      .in('user_id', nearbyDriverIds);
 
     if (driversErr) {
       logger.error('Driver search error:', driversErr.message);


### PR DESCRIPTION
Resolves #2606 

### Description
This PR resolves the 504 Gateway Timeouts experienced during peak hours when the "Find Drivers" feature runs. The underlying issue was that the endpoint did not utilize the geospatial index of the telemetry data, resulting in highly inefficient collection scans.

### Changes Made
- Added a `$near` MongoDB geospatial query on the `telemetry` collection to immediately filter nearby drivers within 50km of `pickup_lat` & `pickup_lng`.
- Reduced the Supabase `driver_details` lookup load by constraining it exclusively to the nearby `driver_id`s, mitigating global database scans for all online drivers.
- Included error handling to gracefully return zero results rather than timing out the entire transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Truck search now uses nearby location telemetry to find driver matches within a set radius.
  * Search results are limited to drivers close to the pickup location.

* **Bug Fixes**
  * If no nearby drivers are found, the search now returns an empty result immediately.
  * Results no longer include unrelated online drivers outside the pickup area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->