### PR TITLE
fix(customer): interpolate defaultBaseUrl in FCM register/unregister URLs

### DIFF
--- a/apps/customer/lib/services/fcm_service.dart
+++ b/apps/customer/lib/services/fcm_service.dart
@@ -70,7 +70,7 @@ class FcmService {
     final accessToken = await firebaseUser.getIdToken();
 
     final response = await http.delete(
-      Uri.parse('defaultBaseUrl/api/devices/unregister'),
+      Uri.parse('$defaultBaseUrl/api/devices/unregister'),
       headers: <String, String>{
         'Content-Type': 'application/json',
         if (accessToken != null && accessToken.isNotEmpty) 'Authorization': 'Bearer $accessToken',
@@ -105,7 +105,7 @@ class FcmService {
     final idToken = await firebaseUser.getIdToken();
 
     final response = await http.put(
-      Uri.parse('defaultBaseUrl/api/profile/fcm-token'),
+      Uri.parse('$defaultBaseUrl/api/profile/fcm-token'),
       headers: <String, String>{
         'Content-Type': 'application/json',
         if (idToken != null && idToken.isNotEmpty)


### PR DESCRIPTION
Resolves #2856

The customer `fcm_service.dart` built the register/unregister URLs with the literal string `'defaultBaseUrl'` (missing the `$` interpolation), which `Uri.parse` treated as a URI scheme and threw a swallowed `UnsupportedError`. Changed to `'$defaultBaseUrl/...'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backend requests for device token unregistration and FCM token upload to use the configured base URL.
  * Improved reliability of push notification setup and token syncing across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->