### PR TITLE
fix(customer): send real pickup_date and HH:mm pickup_time on order create

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -11,6 +11,7 @@ class RouteDraft {
     required this.stacked,
     required this.fragile,
     required this.requirements,
+    this.pickupDate,
     this.pickupLat,
     this.pickupLng,
     this.dropLat,
@@ -26,6 +27,7 @@ class RouteDraft {
   final bool stacked;
   final bool fragile;
   final List<String> requirements;
+  final DateTime? pickupDate;
   final double? pickupLat;
   final double? pickupLng;
   final double? dropLat;

--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -118,6 +118,12 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     setState(() => _isSubmitting = true);
 
     try {
+      final pickupDate = widget.draft.pickupDate;
+      final pickupTime = pickupDate != null
+          ? '${pickupDate.hour.toString().padLeft(2, '0')}:'
+              '${pickupDate.minute.toString().padLeft(2, '0')}'
+          : widget.draft.dateLabel;
+
       final orderId = await _orderService.createOrder(
         pickupAddress: widget.draft.pickup,
         dropAddress: _selectedAddress?.fullAddress ?? widget.draft.drop,
@@ -125,7 +131,8 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
         pickupLng: widget.draft.pickupLng!,
         dropLat: finalDropLat,
         dropLng: finalDropLng,
-        pickupTime: widget.draft.dateLabel,
+        pickupTime: pickupTime,
+        pickupDate: pickupDate,
         goodsType: widget.draft.goodsType,
         weightTonnes: weight,
         paymentMethodId: _selectedPayment?.id,

--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -263,6 +263,17 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
   }
 
   RouteDraft _buildDraft() {
+    DateTime? pickupDate;
+    final parsed = _parseDateTimeLabel(_composeDateTimeLabel());
+    if (parsed != null) {
+      pickupDate = DateTime(
+        parsed.date.year,
+        parsed.date.month,
+        parsed.date.day,
+        parsed.time.hour,
+        parsed.time.minute,
+      );
+    }
     return RouteDraft(
       pickup: _pickupController.text,
       drop: _dropController.text,
@@ -273,6 +284,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       stacked: _stacked,
       fragile: _fragile,
       requirements: _requirements.toList(),
+      pickupDate: pickupDate,
       pickupLat: _pickupPoint?.latitude,
       pickupLng: _pickupPoint?.longitude,
       dropLat: _dropPoint?.latitude,


### PR DESCRIPTION
Resolves #2857

`booking_confirmation_screen` passed the human-readable `dateLabel` as `pickup_time` and never sent `pickup_date` (defaulting to today). Now a `pickupDate` is derived from the selected date/time and passed to `createOrder`, and `pickup_time` is sent as a valid `HH:mm` string.