### PR TITLE
fix(api): require driver role for KYC document upload

### DIFF
--- a/backend/api/src/routes/documentRoutes.js
+++ b/backend/api/src/routes/documentRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { uploadDriverDocument } from '../controllers/documentController.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 
 const router = express.Router();
 
@@ -14,6 +14,6 @@ const upload = multer({
 });
 
 // POST /api/driver/documents
-router.post('/', authenticate, upload.single('document'), uploadDriverDocument);
+router.post('/', authenticate, requireRole(['driver']), upload.single('document'), uploadDriverDocument);
 
 export default router;


### PR DESCRIPTION
Resolves #2858

`POST /api/driver/documents` only applied `authenticate`, letting any role upload driver KYC documents. Added `requireRole(['driver'])`.