### PR TITLE
fix(ml): avoid IndexError on empty delivery_addresses in packing

### DIFF
--- a/backend/ml/app/models/bin_packing.py
+++ b/backend/ml/app/models/bin_packing.py
@@ -267,6 +267,10 @@ def optimise_packing(
             "utilization_pct": 0.0,
         }
 
+    if not delivery_addresses and packages:
+        raise ValueError(
+            "delivery_addresses must contain at least one address when packages are provided"
+        )
     if len(delivery_addresses) < len(packages):
         logger.warning(
             "Fewer delivery addresses (%d) than packages (%d); "


### PR DESCRIPTION
Resolves #2860

`optimise_packing` padded `delivery_addresses` by copying `[0]`, which `IndexError`s when the list is empty. Now raises a clear `ValueError` (-> 422) when packages are present but no addresses are supplied.