### PR TITLE
fix(api): enforce phone format in otpSendSchema

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -229,7 +229,9 @@ export const driverStatementSchema = z.object({
 const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;
 
 export const otpSendSchema = z.object({
-  phone: z.string().trim().min(10).max(20),
+  phone: z.string().trim().min(10).max(20).refine(isValidPhone, {
+    message: 'Phone must be a valid number (digits, optional +, spaces/dashes/parens)',
+  }),
 }).strict();
 
 export const registerTruckSchema = z.object({


### PR DESCRIPTION
Resolves #2861

`otpSendSchema` only validated phone length, accepting non-numeric values. Now uses the existing `isValidPhone` regex via `.refine()`.