### PR TITLE
fix(driver): persist load-point claim to backend

### DIFF
--- a/apps/driver/lib/screens/load_point_detail_screen.dart
+++ b/apps/driver/lib/screens/load_point_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/app_models.dart';
+import '../services/trip_service.dart';
 import '../theme/app_theme.dart';
 
 class LoadPointDetailScreen extends StatefulWidget {
@@ -13,6 +14,8 @@ class LoadPointDetailScreen extends StatefulWidget {
 
 class _LoadPointDetailScreenState extends State<LoadPointDetailScreen> {
   late RouteMapPoint _point;
+  final TripService _tripService = TripService();
+  bool _saving = false;
 
   @override
   void initState() {
@@ -49,14 +52,36 @@ class _LoadPointDetailScreenState extends State<LoadPointDetailScreen> {
                       minimumSize: const Size(120, 44),
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                     ),
-                    onPressed: () {
-                      setState(() {
-                        _point = _point.copyWith(claimed: !_point.claimed);
-                      });
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text(_point.claimed ? 'Marked as claimed' : 'Marked as available')),
-                      );
-                    },
+                    onPressed: _saving
+                        ? null
+                        : () async {
+                            final nextClaimed = !_point.claimed;
+                            setState(() => _saving = true);
+                            try {
+                              await _tripService.setRoutePointClaimed(
+                                _point.id,
+                                nextClaimed,
+                              );
+                              if (!mounted) return;
+                              setState(() {
+                                _point = _point.copyWith(claimed: nextClaimed);
+                              });
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(
+                                    nextClaimed ? 'Marked as claimed' : 'Marked as available',
+                                  ),
+                                ),
+                              );
+                            } catch (e) {
+                              if (!mounted) return;
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Failed to update: $e')),
+                              );
+                            } finally {
+                              if (mounted) setState(() => _saving = false);
+                            }
+                          },
                     child: Text(_point.claimed ? 'Unclaim' : 'Claim'),
                   ),
                   const SizedBox(width: 12),

--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -1176,6 +1176,24 @@ class _TripsScreenState extends State<TripsScreen> {
                 ),
                 width: 12,
                 height: 12,
+                onTap: () {
+                  final mapPoint = RouteMapPoint(
+                    id: point['id']?.toString() ?? '',
+                    title: (point['label'] ?? point['title'] ?? 'Stop').toString(),
+                    subtitle: (point['address'] ?? point['subtitle'] ?? '').toString(),
+                    details: (point['details'] ?? '').toString(),
+                    progress: (point['progress'] as num?)?.toDouble() ?? 0.0,
+                    claimed: point['is_claimed'] == true,
+                    icon: Icons.place,
+                    latitude: (point['latitude'] as num).toDouble(),
+                    longitude: (point['longitude'] as num).toDouble(),
+                    loadOfferId: point['load_offer_id']?.toString(),
+                  );
+                  Navigator.of(context).pushNamed(
+                    AppRoutes.loadPointDetail,
+                    arguments: mapPoint,
+                  );
+                },
                 child: Container(
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -197,6 +197,19 @@ class TripService {
     }
   }
 
+  Future<void> setRoutePointClaimed(String pointId, bool claimed) async {
+    final path = '/api/driver/route-points/${_encodePathSegment(pointId)}/claim';
+    try {
+      await _apiClient.patch(
+        path,
+        body: <String, dynamic>{'claimed': claimed},
+      );
+    } catch (e) {
+      if (e is ApiException) throw Exception(e.message);
+      rethrow;
+    }
+  }
+
   void dispose() {
     _apiClient.dispose();
   }

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -345,6 +345,67 @@ router.get('/trips/:tripDisplayId/route-points', authenticate, userLimiter, requ
 });
 
 // ============================================================================
+// 8b. TOGGLE ROUTE MAP POINT CLAIMED (DRIVER)
+// ============================================================================
+router.patch(
+  '/route-points/:id/claim',
+  authenticate,
+  userLimiter,
+  requireRole(['driver']),
+  validateParams(paramIdSchema),
+  async (req, res) => {
+    const { id } = req.params;
+    const claimed = req.body?.claimed;
+
+    if (typeof claimed !== 'boolean') {
+      return res.status(400).json({ error: 'claimed must be a boolean' });
+    }
+
+    try {
+      const { data: point, error: pointError } = await supabase
+        .from('route_map_points')
+        .select('id, trip_display_id')
+        .eq('id', id)
+        .maybeSingle();
+
+      if (pointError) {
+        return res.status(500).json({ error: 'Failed to fetch route point.', details: pointError.message });
+      }
+      if (!point) {
+        return res.status(404).json({ error: 'Route map point not found.' });
+      }
+
+      const { data: trip } = await supabase
+        .from('trips')
+        .select('id')
+        .eq('trip_display_id', point.trip_display_id)
+        .eq('driver_id', req.user.id)
+        .maybeSingle();
+
+      if (!trip) {
+        return res.status(403).json({ error: 'Access Denied: Route point does not belong to your trip.' });
+      }
+
+      const { data: updated, error: updateError } = await supabase
+        .from('route_map_points')
+        .update({ claimed })
+        .eq('id', id)
+        .select('*')
+        .maybeSingle();
+
+      if (updateError) {
+        return res.status(500).json({ error: 'Failed to update route point.', details: updateError.message });
+      }
+
+      res.json({ point: updated });
+    } catch (err) {
+      logger.error('Driver route point claim error:', err);
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
+
+// ============================================================================
 // 9. FETCH DRIVER BIDS (DRIVER)
 // ============================================================================
 router.get('/bids', authenticate, userLimiter, requireRole(['driver']), async (req, res) => {


### PR DESCRIPTION
Resolves #2862

The load-point Claim/Unclaim button only flipped local UI state. Added `PATCH /api/driver/route-points/:id/claim` (owner-checked) and a `TripService.setRoutePointClaimed` call so the claimed state is server-confirmed.