### PR TITLE
fix(driver): show selected country code on OTP screen

### DIFF
--- a/apps/driver/lib/app.dart
+++ b/apps/driver/lib/app.dart
@@ -72,6 +72,7 @@ class _TruxifyAppState extends State<TruxifyApp> {
                 (context) => OtpScreen(
                   phone: args['phone'] ?? '',
                   verificationId: args['verificationId'] ?? '',
+                  countryCode: args['countryCode'] ?? '+91',
                 ),
               );
 

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -86,6 +86,7 @@ class _LoginScreenState extends State<LoginScreen> {
             arguments: <String, String>{
               'phone': phone,
               'verificationId': verificationId,
+              'countryCode': _selectedCode,
             },
           );
         },

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -10,10 +10,16 @@ import '../widgets/app_logo.dart';
 import '../widgets/common_widgets.dart';
 
 class OtpScreen extends StatefulWidget {
-  const OtpScreen({super.key, required this.phone, required this.verificationId});
+  const OtpScreen({
+    super.key,
+    required this.phone,
+    required this.verificationId,
+    this.countryCode = '+91',
+  });
 
   final String phone;
   final String verificationId;
+  final String countryCode;
 
   @override
   State<OtpScreen> createState() => _OtpScreenState();
@@ -118,7 +124,7 @@ class _OtpScreenState extends State<OtpScreen> {
               ),
               const SizedBox(height: 8),
               Text(
-                'Sent to +91 ${widget.phone}',
+                'Sent to ${widget.countryCode} ${widget.phone}',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: TruxifyColors.adaptiveSecondaryText(context),
                     ),


### PR DESCRIPTION
Resolves #2863

`otp_screen` hardcoded `+91` regardless of the selected region. The chosen country code is now passed through route args and displayed.