### PR TITLE
fix(driver): URL-encode trip/stop IDs in startTrip and markStopCompleted

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -164,7 +164,7 @@ class TripService {
     String tripDisplayId,
   ) async {
     await verifyTripOwnership(tripDisplayId);
-    final path = '/api/trips/$tripDisplayId/stops/$stopId/complete';
+    final path = '/api/trips/${_encodePathSegment(tripDisplayId)}/stops/${_encodePathSegment(stopId)}/complete';
     try {
       await _apiClient.put(path);
     } catch (e) {
@@ -188,7 +188,7 @@ class TripService {
 
   Future<void> startTrip(String tripDisplayId) async {
     await verifyTripOwnership(tripDisplayId);
-    final path = '/api/trips/$tripDisplayId/start';
+    final path = '/api/trips/${_encodePathSegment(tripDisplayId)}/start';
     try {
       await _apiClient.put(path);
     } catch (e) {


### PR DESCRIPTION
Resolves #2864

`startTrip` and `markStopCompleted` interpolated IDs raw into the path while sibling methods used `_encodePathSegment`. Now both encode path segments consistently.