### PR TITLE
fix(driver): send FCM token once via shared ApiClient

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -97,19 +97,6 @@ class FcmService {
       debugPrint('[FCM] No authenticated user, skipping token upload.');
       return;
     }
-    final accessToken = await firebaseUser?.getIdToken();
-
-    final response = await http.put(
-      Uri.parse('$_apiBaseUrl/api/profile/fcm-token'),
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        if (accessToken != null && accessToken.isNotEmpty) 'Authorization': 'Bearer $accessToken',
-      },
-      body: jsonEncode(<String, dynamic>{
-        'fcmToken': token,
-      }),
-    );
-
     final apiClient = ApiClient();
     try {
       await apiClient.put(


### PR DESCRIPTION
Resolves #2865

`FcmService._sendTokenToBackend` performed the PUT twice (raw `http` + `ApiClient`). Removed the duplicate raw call; `ApiClient` handles auth correctly.