### PR TITLE
fix(ml): clamp match_score upper bound to 1.0

### DIFF
--- a/backend/ml/app/models/bilateral_matcher.py
+++ b/backend/ml/app/models/bilateral_matcher.py
@@ -174,7 +174,7 @@ def match_bilateral(
     for r, c in zip(row_idx, col_idx):
         if cost[r, c] >= _PENALTY_INFEASIBLE:
             continue  # infeasible pairing – skip
-        score = round(max(0.0, 1.0 - cost[r, c] / 200.0), 4)  # 0‥1
+        score = round(min(1.0, max(0.0, 1.0 - cost[r, c] / 200.0)), 4)  # 0‥1
         assignments.append(
             {"load_index": int(r), "driver_index": int(c), "match_score": float(score)}
         )


### PR DESCRIPTION
Resolves #2866

`match_bilateral` only clamped the lower bound, so a negative cost (from the rating bonus) produced `match_score > 1.0`. Now clamped to `[0, 1]`.