### PR TITLE
fix(api): exact media-type match in requireJsonContent

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -32,6 +32,7 @@ import lookupRoutes from './routes/lookupRoutes.js'
 import logger from './middleware/logger.js'
 import { setupSwagger } from './config/swagger.js'
 import { requestIdMiddleware, requestLogger } from './middleware/requestId.js'
+import { requireJsonContent } from './middleware/contentType.js'
 import { initSentry, flushSentry, sentryErrorHandler } from './middleware/sentry.js'
 import {
   startEscrowRefundReconciliation,
@@ -144,6 +145,11 @@ app.use(express.urlencoded({ extended: true, limit: '1mb' }))
 // ============================================================================
 app.use(requestIdMiddleware)
 app.use(requestLogger)
+
+// Enforce a known request content-type on mutating requests (POST/PUT/PATCH).
+// `requireJsonContent` only rejects unrecognized media types; the three
+// allowed types match the parsers registered above.
+app.use(requireJsonContent)
 
 // ============================================================================
 // RATE LIMITING

--- a/backend/api/src/middleware/contentType.js
+++ b/backend/api/src/middleware/contentType.js
@@ -7,13 +7,18 @@ export function requireJsonContent(req, res, next) {
       return res.status(415).json({ error: 'Unsupported Media Type. Content-Type header is missing.' });
     }
 
+    // Compare the base media type exactly (ignoring parameters such as
+    // charset). A substring match previously let malformed values like
+    // `text/plain; application/json` or `application/jsonx` through.
+    const mimeType = contentType.split(';')[0].trim().toLowerCase();
+
     // Allow application/json
-    if (contentType.includes('application/json')) {
+    if (mimeType === 'application/json') {
       return next();
     }
 
     // Allow multipart/form-data for specific routes (like document uploads)
-    if (contentType.includes('multipart/form-data')) {
+    if (mimeType === 'multipart/form-data') {
       return next();
     }
 

--- a/backend/api/src/middleware/contentType.js
+++ b/backend/api/src/middleware/contentType.js
@@ -12,13 +12,14 @@ export function requireJsonContent(req, res, next) {
     // `text/plain; application/json` or `application/jsonx` through.
     const mimeType = contentType.split(';')[0].trim().toLowerCase();
 
-    // Allow application/json
-    if (mimeType === 'application/json') {
-      return next();
-    }
-
-    // Allow multipart/form-data for specific routes (like document uploads)
-    if (mimeType === 'multipart/form-data') {
+    // Allow the media types the API actually parses (express.json,
+    // express.urlencoded, multer for uploads). Anything else is rejected.
+    const allowed = [
+      'application/json',
+      'application/x-www-form-urlencoded',
+      'multipart/form-data',
+    ];
+    if (allowed.includes(mimeType)) {
       return next();
     }
 


### PR DESCRIPTION
Resolves #2870

`requireJsonContent` used `contentType.includes('application/json')`, a fragile substring match that let values like `application/jsonx` or `text/plain; application/json` through. Now compares the parsed base media type exactly.