### PR TITLE
Fix merge conflict artifact in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -221,8 +221,6 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), requireId
   try {
     for (let attempt = 0; attempt < MAX_ID_RETRIES; attempt++) {
       orderDisplayId = generateOrderDisplayId();
-      const result = await orderRepository
-        .createOrder({
       const result = await supabase
         .from('orders')
         .insert({
@@ -240,7 +238,6 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), requireId
           total_amount: pricing.totalAmount,
           estimated_price: estimatedPrice,
           payment_method_id, upi_id
-        });
         })
         .select('id, order_display_id, status, created_at')
         .single();


### PR DESCRIPTION
## Summary
Removed the old `orderRepository.createOrder` path that was left behind during a merge conflict, leaving only the correct `supabase.from('orders').insert()` chain. Also removed the orphaned closing brace.

Fixes #2895

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order creation handling to make new orders more reliably saved and returned to the app.
  * Order details now include the expected display ID, status, and creation time when an order is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->