### PR TITLE
Fix ReferenceError: uuidRegex is not defined in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -520,7 +520,7 @@ router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSch
 
   try {
     let order = null;
-    if (uuidRegex.test(orderId)) {
+    if (UUID_RE.test(orderId)) {
       const { data: orderById } = await orderRepository.findOrderForTimeline(orderId);
       order = orderById;
     }


### PR DESCRIPTION
## Summary
Changed `uuidRegex` to `UUID_RE` on line 523 to match the actual constant name declared on line 87. JavaScript is case-sensitive, so this was causing a `ReferenceError` at runtime.

Fixes #2896

GSSoC