### PR TITLE
Fix undefined variables loadOfferId and bid_amount in orderRoutes.js bid route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -565,6 +565,8 @@ router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSch
 // ============================================================================
 router.post('/:id/bids', authenticate, userLimiter, requireRole(['driver']), bidLimiter, validateParams(paramIdSchema), validateBody(submitBidSchema), async (req, res) => {
   try {
+    const loadOfferId = req.params.id;
+    const { bid_amount } = req.body;
     const { data: offer, error: offerErr } = await orderRepository.findLoadOfferById(loadOfferId);
     if (offerErr || !offer) return res.status(404).json({ error: 'Load offer not found.' });
     if (offer.status !== 'available') return res.status(410).json({ error: 'Load is no longer available for bidding.' });


### PR DESCRIPTION
## Summary
Added the missing destructuring assignments at the top of the bid submission handler: `const loadOfferId = req.params.id;` and `const { bid_amount } = req.body;`. These were causing `ReferenceError` on every bid submission.

Fixes #2898

GSSoC