### PR TITLE
Fix undefined orderId, stars, comment in orderRoutes.js rating route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -604,6 +604,8 @@ router.post('/:id/bids', authenticate, userLimiter, requireRole(['driver']), bid
 // ============================================================================
 router.post('/:id/ratings', authenticate, userLimiter, requireRole(['customer']), validateParams(paramIdSchema), validateBody(submitRatingSchema), async (req, res) => {
   try {
+    const orderId = req.params.id;
+    const { stars, comment } = req.body;
     const { data: order, error: orderErr } = await orderRepository.findOrderById(orderId, 'id, order_display_id, customer_id, driver_id, status');
 
     if (orderErr) {


### PR DESCRIPTION
## Summary
Added the missing destructuring assignments at the top of the rating submission handler: `const orderId = req.params.id;` and `const { stars, comment } = req.body;`. These were causing `ReferenceError` on every rating submission.

Fixes #2899

GSSoC