### PR TITLE
Add missing acquireLock and releaseLock imports in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -53,6 +53,7 @@ import {
 } from '../services/order/deliveryVerificationService.js';
 import { predictDemand, predictPrice } from '../services/ml.js';
 import { requireIdempotency } from '../middleware/idempotency.js';
+import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
 import { OrderTimelineService } from '../services/order/orderTimelineService.js';


### PR DESCRIPTION
## Summary
Added the missing import for `acquireLock` and `releaseLock` from `../lib/redisLock.js`. These functions are used in the cancel order and confirm-deposit routes, and their absence was causing `ReferenceError` at runtime.

Fixes #2900

GSSoC