### PR TITLE
Add missing _verificationId field in driver login_screen.dart

### DIFF
--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -32,6 +32,7 @@ class _LoginScreenState extends State<LoginScreen> {
   final AuthService _authService = AuthService();
   bool _loading = false;
   int? _resendToken;
+  String? _verificationId;
   String _selectedCode = '+91';
   int _expectedDigits = 10;
 


### PR DESCRIPTION
## Summary
Added `String? _verificationId;` field declaration to the `_LoginScreenState` class. The field was being assigned in `setState` on line 81 but never declared, causing a compile error.

Fixes #2901

GSSoC