### PR TITLE
Remove duplicate trimmed variable declaration in customer location_service.dart

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -34,10 +34,6 @@ class LocationService {
     if (_searchCache.containsKey(cacheKey)) {
       return _searchCache[cacheKey]!;
     }
-    final trimmed = query.trim();
-    if (trimmed.length < 3) {
-      return const <LocationSuggestion>[];
-    }
 
     final uri = Uri.https(
       _host,


### PR DESCRIPTION
## Summary
Removed the duplicate `final trimmed = query.trim();` declaration at line 37 along with the dead code block that follows it. This was a copy-paste error that caused a compile-time error.

Fixes #2902

GSSoC