### PR TITLE
Fix missing imports and undeclared variables in driver fcm_service.dart

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -1,10 +1,14 @@
+import 'dart:convert';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 
 import 'api_client.dart';
 
 class FcmService {
+  static final String _apiBaseUrl = 'http://localhost:5000';
+  static final ApiClient apiClient = ApiClient();
   static Future<void> initializeAndRegister() async {
     try {
       final messaging = FirebaseMessaging.instance;


### PR DESCRIPTION
## Summary
Added the missing imports (`dart:convert` for `jsonEncode`, `package:http/http.dart` for `http`) and the missing `_apiBaseUrl` and `apiClient` field declarations. The `_unregisterTokenFromBackend` method was using four undeclared identifiers, causing compile errors.

Fixes #2903

GSSoC