### PR TITLE
Remove duplicate env_file key in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - .env
     ports:
       - "5000:5000"
-    env_file:
-      - .env
     environment:
       MONGODB_URI: mongodb://mongo:27017
       MONGODB_DB_NAME: truxify_telemetry


### PR DESCRIPTION
## Summary
Removed the second duplicate `env_file` declaration at line 10 of `docker-compose.yml`. YAML dictionaries cannot have duplicate keys — the second one silently overrides the first, creating confusing and fragile configuration.

Fixes #2904

GSSoC