### PR TITLE
[GSSoC'26] fix: remove duplicate redisClient import in deliveryVerificationService.js

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -1,7 +1,5 @@
 import crypto from 'crypto';
 import { redisClient } from '../../config/db.js';
-import { DomainError } from './bidAcceptanceService.js';
-import { supabase, redisClient } from '../../config/db.js';
 import { DomainError } from './domainError.js';
 import {
   sendDeliveryOtpNotification,


### PR DESCRIPTION
## Description

- `backend/api/src/services/order/deliveryVerificationService.js` had a duplicate `redisClient` import binding and a conflicting `DomainError` import, which throws a `SyntaxError` ("Identifier 'redisClient' has already been declared") and prevents the module from loading.
- Removed the redundant `import { supabase, redisClient } from '../../config/db.js';` (redisClient was already imported on line 2; `supabase` is unused in this file) and kept the canonical `DomainError` import from `./domainError.js` (the module that actually defines the class).

## Files Changed

- `backend/api/src/services/order/deliveryVerificationService.js`: collapsed the duplicate import lines into a single clean import block.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/services/order/deliveryVerificationService.js
```

Result: Syntax check passes (exit 0). `redisClient` is still imported once from `../../config/db.js`; `DomainError` resolves to the real class.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2921
