### PR TITLE
[GSSoC'26] fix: add missing 'Arriving' milestone mapping to unblock delivery OTP

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -343,6 +343,7 @@ export class OrderLifecycleService {
       'Arrived at Pickup': 'at_pickup',
       'Goods Loaded': 'in_transit',
       'In Transit': 'in_transit',
+      'Arriving': 'arriving',
       'Arrived at Drop-off': 'at_dropoff',
       'Goods Unloaded': 'at_dropoff',
     };


### PR DESCRIPTION
## Description

- `orderLifecycleService.updateMilestone` maps milestone names to order statuses via `milestoneMap`. The `'Arriving'` milestone (used by drivers to signal arrival at the delivery location) was missing, so `milestoneMap['Arriving']` evaluated to `undefined`.
- The order status was therefore set to `undefined`, but `deliveryVerificationService.js` only allows OTP verification when `order.status === 'arriving'` (`DELIVERY_OTP_READY_STATUSES`). Result: drivers could never reach the OTP-ready state and delivery verification was permanently blocked.
- Added `'Arriving': 'arriving'` to `milestoneMap`, which also flows into the `canonicalMilestones` set so the milestone is recognized as a valid timeline step.

## Files Changed

- `backend/api/src/services/order/orderLifecycleService.js`: added the `'Arriving'` entry to `milestoneMap`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/services/order/orderLifecycleService.js
```

Result: Syntax check passes (exit 0). The mapping now resolves `'Arriving' -> 'arriving'`, matching `DELIVERY_OTP_READY_STATUSES`.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2922
