### PR TITLE
[GSSoC'26] fix: reject infeasible loads even when rating bonus lowers cost below penalty

### DIFF
--- a/backend/ml/app/models/bilateral_matcher.py
+++ b/backend/ml/app/models/bilateral_matcher.py
@@ -37,6 +37,10 @@ def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 
 _MAX_DISTANCE_KM = 3_000.0  # normalisation ceiling
 _PENALTY_INFEASIBLE = 1e6   # effectively forbids the pairing
+# Cost above this is treated as infeasible. Must sit well below the 1e6 penalty
+# so that a negative `_rating_bonus` (−10 for a 5-star driver) cannot pull an
+# infeasible pairing's cost back under the threshold and get it accepted.
+_INFEASIBLE_THRESHOLD = 1e5
 
 
 def _distance_cost(driver: dict, load: dict) -> float:
@@ -172,7 +176,7 @@ def match_bilateral(
     matched_drivers = set()
 
     for r, c in zip(row_idx, col_idx):
-        if cost[r, c] >= _PENALTY_INFEASIBLE:
+        if cost[r, c] >= _INFEASIBLE_THRESHOLD:
             continue  # infeasible pairing – skip
         score = round(min(1.0, max(0.0, 1.0 - cost[r, c] / 200.0)), 4)  # 0‥1
         assignments.append(


### PR DESCRIPTION
## Description

- In `backend/ml/app/models/bilateral_matcher.py`, infeasible pairings (overweight / oversized / impossible deadline) are penalised by adding `_PENALTY_INFEASIBLE = 1e6` to the cost. The post-assignment loop rejects a pairing only when `cost[r, c] >= _PENALTY_INFEASIBLE`.
- `_rating_bonus(driver)` is **negative** for high-rated drivers (5-star → −10). For a high-rated driver paired with an overweight load, the total cost becomes `1e6 − 10 + small_terms ≈ 999990`, which is **strictly less than 1e6**, so the `>=` check fails and the infeasible pairing is incorrectly accepted as a valid assignment.
- Added `_INFEASIBLE_THRESHOLD = 1e5` (far below the 1e6 penalty, far above any realistic feasible cost of a few hundred) and used it in the skip check, so any penalised pairing stays above the threshold even after the rating discount.

## Files Changed

- `backend/ml/app/models/bilateral_matcher.py`: added `_INFEASIBLE_THRESHOLD` and used it in the infeasibility rejection test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
python3 -m py_compile backend/ml/app/models/bilateral_matcher.py
```

Result: Byte-compiles cleanly. A logic test against a 5-star driver + overweight load was not executed because `numpy`/`scipy` are not installed in this environment; the fix is a threshold change that keeps penalised pairings above the rejection cutoff.

## Known Limitations

- Cannot run the full Hungarian-algorithm test locally (no numpy/scipy). Please add a unit test or run `pytest` in CI to confirm overweight loads are now left unmatched.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2923
