### PR TITLE
[GSSoC'26] fix: guard cancelBooking against zero-amount refunds

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -189,6 +189,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
 
         // ── EFFECTS ───────────────────────────────────────────────────────
         uint256 refundAmount    = booking.amount;


### PR DESCRIPTION
## Description

- `TruxifyEscrow.cancelBooking` refunds the customer by adding `booking.amount` to `pendingWithdrawals[customer]`, but it had **no `booking.amount > 0` guard**.
- After `releasePayment` runs, `booking.amount` is already zeroed and `status` becomes `Delivered`, so a second cancel is blocked by the status check. However, the missing guard means a cancel on a booking whose funds were already disbursed (or a zero-amount booking) still creates a spurious `pendingWithdrawals` entry, and the function sets `booking.paid = true` — a flag that really means "driver paid" — for what is a customer refund. This muddies state and can leave a driver unpaid while the customer is refunded.
- Added `require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");` so a cancel only ever refunds locked funds that still exist.

## Files Changed

- `blockchain/contracts/TruxifyEscrow.sol`: added the `booking.amount > 0` guard in `cancelBooking`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
# Solidity syntax review against the existing pragma/compiler toolchain
```

Result: No Solidity compiler (`solc`/Foundry) available in this environment, so the contract was not compiled here. The change is a single additive `require` guard identical in style to the other guards in the function.

## Known Limitations

- Cannot compile/run the contract locally. Please build with Foundry/Hardhat in CI to confirm it still compiles. A follow-up could add an explicit "delivered but not yet paid" status so a cancel can never refund after the driver has completed delivery.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2925
