### PR TITLE
[GSSoC'26] fix: prevent double reputation award when delete fails

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -70,7 +70,10 @@ export async function reconcileFailedReputationUpdates() {
 
       try {
         await awardReputationPoints(row.driver_wallet, row.stars);
-        await supabase.from('reputation_failures').delete().eq('id', row.id);
+        const { error: deleteError } = await supabase.from('reputation_failures').delete().eq('id', row.id);
+        if (deleteError) {
+          throw new Error(`Award succeeded but failed to delete reconciled reputation failure ${row.id}: ${deleteError.message}`);
+        }
         logger.info(`[reputation-reconciliation] Successfully retried reputation update for ${row.driver_wallet}`);
       } catch (err) {
         const newRetryCount = (row.retry_count ?? 0) + 1;


### PR DESCRIPTION
## Description

- In `reconcileFailedReputationUpdates`, `awardReputationPoints(...)` is called and then the `reputation_failures` row is deleted. A Supabase `delete()` that fails returns an `error` object but does **not** throw, so the `catch` block is never entered. The row stays in the table, and on the next reconcile tick (after the 300s claim key expires) it is awarded **again** — a double reputation award.
- Captured the delete result and throw when `deleteError` is present, so the existing `catch` block records the failure, increments `retry_count`, and the row is retried (and eventually exhausted at `MAX_RETRIES`) instead of being silently left for a duplicate award.

## Files Changed

- `backend/api/src/services/reputationReconciliation.js`: check the `delete()` result and throw on error in the per-row reconciliation loop.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/services/reputationReconciliation.js
```

Result: Syntax check passes (exit 0). No Supabase/Redis stack locally, so the reconcile loop was not executed end-to-end.

## Known Limitations

- The award is side-effecting and best-effort; this fix prevents the *false success* log and bounds retries via `MAX_RETRIES`, but a truly atomic award-then-delete would need a DB-backed claim. Acceptable as a targeted fix.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2926
