### PR TITLE
[GSSoC'26] fix: skip reputation reconciliation when distributed lock is unavailable

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -36,6 +36,13 @@ export async function reconcileFailedReputationUpdates() {
   }
 
   if (!lockAcquired) {
+    // Without Redis there is no distributed lock and no per-row claim key, so
+    // multiple service instances would reconcile the same rows concurrently and
+    // double-award reputation. In that case skip rather than run unprotected.
+    if (!redisClient) {
+      logger.error('[reputation-reconciliation] Redis unavailable: cannot acquire a distributed lock. Skipping reconciliation to avoid unsafe concurrent awards across instances.');
+      return;
+    }
     if (reconciliationRunning) return;
     reconciliationRunning = true;
   }


### PR DESCRIPTION
## Description

- `reconcileFailedReputationUpdates` relies on a Redis distributed lock (`reputation:reconciliation:lock`) and a per-row claim key (`reputation:claim:<id>`) to prevent concurrent awarding across service instances.
- When `redisClient` is `null` (Redis down / not configured), the entire `if (redisClient)` block is skipped: no distributed lock is taken AND the per-row claim is skipped. The only remaining guard is the in-memory `reconciliationRunning` flag, which is per-process — so **multiple instances run the reconciliation unlocked and concurrently**, double-awarding the same reputation rows.
- When Redis is unavailable, the function now logs an error and returns early instead of running without a distributed lock, avoiding unsafe concurrent awards.

## Files Changed

- `backend/api/src/services/reputationReconciliation.js`: in the `!lockAcquired` branch, return early (with an error log) when `redisClient` is missing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/services/reputationReconciliation.js
```

Result: Syntax check passes (exit 0). No Redis/Supabase stack locally, so the lock path was not exercised at runtime.

## Known Limitations

- When Redis is down, reconciliation is skipped entirely (queued rows are not retried until Redis returns). This is the safe choice versus double-awarding; if you prefer best-effort retries without Redis, a DB advisory lock fallback could be added later.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2927
