### PR TITLE
[GSSoC'26] fix: validate profile language against VALID_LANGUAGES

### DIFF
--- a/backend/api/src/schemas/profile.js
+++ b/backend/api/src/schemas/profile.js
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-const VALID_LANGUAGES = ['en', 'hi', 'gu', 'mr', 'ta', 'te', 'kn', 'ml', 'bn', 'pa'];
+export const VALID_LANGUAGES = ['en', 'hi', 'gu', 'mr', 'ta', 'te', 'kn', 'ml', 'bn', 'pa'];
 
-function validateLanguage(lang) {
+export function validateLanguage(lang) {
   if (!lang) return true;
   return VALID_LANGUAGES.includes(lang);
 }

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { VALID_LANGUAGES } from '../schemas/profile.js';
 
 // Generic field validation helpers
 function isValidEmail(email) {
@@ -250,7 +251,7 @@ export const registerTruckSchema = z.object({
 
 export const updateProfileSchema = z.object({
   full_name: z.string().trim().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
-  language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').optional(),
+  language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').refine((v) => VALID_LANGUAGES.includes(v), { message: 'Unsupported language code' }).optional(),
   dark_mode: z.boolean().optional(),
   is_online: z.boolean().optional(),
   verification_status: z.enum(['pending', 'verified', 'rejected']).optional(),


### PR DESCRIPTION
## Description

- `updateProfileSchema` in `backend/api/src/validation/requestSchemas.js` (the schema actually used by `profileRoutes.js`) validated `language` only by length (`min(2).max(10)`). Any arbitrary string of 2–10 characters (e.g. `"xx"`, `"zz"`) passed validation even though the app only supports a fixed set of languages.
- Added a `.refine()` that checks the value against `VALID_LANGUAGES`, exporting that constant (and `validateLanguage`) from `backend/api/src/schemas/profile.js` so there is a single source of truth.

## Files Changed

- `backend/api/src/schemas/profile.js`: exported `VALID_LANGUAGES` and `validateLanguage`.
- `backend/api/src/validation/requestSchemas.js`: imported `VALID_LANGUAGES` and refined the `language` field.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/validation/requestSchemas.js
node --check backend/api/src/schemas/profile.js
```

Result: Both syntax-check pass (exit 0). No runtime validation harness locally.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2928
