### PR TITLE
[GSSoC'26] fix: stop swallowing errors in orderTimelineService methods

### DIFF
--- a/backend/api/src/services/order/orderTimelineService.js
+++ b/backend/api/src/services/order/orderTimelineService.js
@@ -106,6 +106,7 @@ export class OrderTimelineService {
 
     if (error) {
       this.logger?.error?.('Timeline Reset Error:', error.message);
+      throw new DomainError(500, { error: 'Failed to reset order timeline.', details: error.message });
     }
   }
 
@@ -134,7 +135,8 @@ export class OrderTimelineService {
     }
 
     if (error) {
-      this.logger?.warn?.('Failed to update timeline for change-drop:', error.message);
+      this.logger?.error?.('Failed to update timeline for change-drop:', error.message);
+      throw new DomainError(500, { error: 'Failed to record drop-change event.', details: error.message });
     }
   }
 
@@ -155,6 +157,7 @@ export class OrderTimelineService {
 
     if (error) {
       this.logger?.error?.('Failed to update Order Placed milestone on cancel:', error.message);
+      throw new DomainError(500, { error: 'Failed to update Order Placed milestone.', details: error.message });
     }
   }
 
@@ -173,6 +176,7 @@ export class OrderTimelineService {
 
     if (error) {
       this.logger?.error?.('Failed to delete order timeline:', error.message);
+      throw new DomainError(500, { error: 'Failed to delete order timeline.', details: error.message });
     }
   }
 


### PR DESCRIPTION
## Description

- `OrderTimelineService` has four methods that **swallow** database errors: `resetMilestone`, `insertDropChangedEvent` (logs at `warn`), `completeOrderPlacedMilestone`, and `deleteOrderTimeline`. They log the error but never throw, unlike their siblings (`createOrderTimeline`, `getOrderTimeline`, `completeMilestone`) which raise `DomainError(500, ...)`.
- As a result, callers believe the timeline operation succeeded when it actually failed, masking data-integrity problems (e.g. a failed drop-change event or a failed timeline deletion goes unnoticed).
- Made all four methods throw a `DomainError(500, …)` on error, consistent with the rest of the service.

## Files Changed

- `backend/api/src/services/order/orderTimelineService.js`: added `throw new DomainError(500, …)` to the four error branches (and upgraded the `insertDropChangedEvent` log from `warn` to `error`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/services/order/orderTimelineService.js
```

Result: Syntax check passes (exit 0). No Supabase stack locally, so the methods were not executed end-to-end.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2929
