### PR TITLE
[GSSoC'26] fix: safely normalize route_type in ETA prediction

### DIFF
--- a/backend/ml/app/models/eta_prediction.py
+++ b/backend/ml/app/models/eta_prediction.py
@@ -107,7 +107,8 @@ class ETAPredictor:
         if self.model is None:
             self.load()
 
-        route_type_value = 1 if route_type.lower() == "highway" else 0
+        rt = str(route_type or "").strip().lower()
+        route_type_value = 1 if rt == "highway" else 0
 
         features = np.array([[
             distance,


### PR DESCRIPTION
## Description

- `ETAPredictor.predict` did `route_type_value = 1 if route_type.lower() == "highway" else 0`. If `route_type` arrives as `None` or any non-string (e.g. a numeric value forwarded from JSON), `route_type.lower()` raises `AttributeError`, crashing the request with a 500.
- Normalised `route_type` defensively: `rt = str(route_type or "").strip().lower()` before the comparison, so `None`/non-string inputs no longer crash and default to the non-highway branch.

## Files Changed

- `backend/ml/app/models/eta_prediction.py`: safe string coercion of `route_type` in `predict`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
python3 -m py_compile backend/ml/app/models/eta_prediction.py
```

Result: Byte-compiles cleanly. Input validation should also be added at the API layer; this change prevents the crash for malformed input.

## Known Limitations

- Non-highway route types still collapse to a single `0` feature value. If the model should distinguish route types, an enum/one-hot encoding would be a follow-up enhancement.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2931
