### PR TITLE
[GSSoC'26] fix: ignore cached null/malformed payloads in lookup cache

### DIFF
--- a/backend/api/src/routes/lookupRoutes.js
+++ b/backend/api/src/routes/lookupRoutes.js
@@ -9,7 +9,14 @@ async function getCachedOrFetch(key, fetchFn) {
   if (redisClient) {
     try {
       const cached = await redisClient.get(key);
-      if (cached) return JSON.parse(cached);
+      if (cached) {
+        try {
+          const parsed = JSON.parse(cached);
+          if (parsed !== null) return parsed;
+        } catch {
+          // fall through to fetch on malformed cached payload
+        }
+      }
     } catch (err) {
       logger.error({ err, key }, 'Redis cache get error');
     }


### PR DESCRIPTION
## Description

- `getCachedOrFetch` returned `JSON.parse(cached)` whenever the cached string was truthy. A cached value of the JSON string `"null"` is a non-empty (truthy) string, so `JSON.parse("null")` → `null` was returned and `fetchFn` was skipped entirely — even though a fresh fetch would return a real array.
- This also left no protection against a malformed cached payload (which would throw during `JSON.parse`).
- Now the cached payload is parsed defensively: it is only returned when it is not `null`, and a parse error falls through to `fetchFn`, so a stale `"null"`/corrupt entry can never short-circuit the lookup.

## Files Changed

- `backend/api/src/routes/lookupRoutes.js`: guarded the cache-read path in `getCachedOrFetch`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
node --check backend/api/src/routes/lookupRoutes.js
```

Result: Syntax check passes (exit 0). No Redis/Supabase stack locally, so the cache path was not exercised at runtime.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2933
