### PR TITLE
[GSSoC'26] fix: meaningful confidence interval for driver profit prediction

### DIFF
--- a/backend/ml/app/models/driver_profit.py
+++ b/backend/ml/app/models/driver_profit.py
@@ -185,17 +185,33 @@ class DriverProfitPredictor:
 
         prediction = float(self.model.predict(features)[0])
 
-        # Confidence interval from ensemble staged predictions
+        # Confidence interval.
+        # `staged_predict` yields the CUMULATIVE prediction after each boosting
+        # stage (starting near 0 and climbing to the final value). Taking the
+        # std-dev across those cumulative values measures training progression,
+        # not posterior uncertainty, and can produce negative bounds. Instead we
+        # use the spread of the per-stage (per-tree) *contributions*, which is a
+        # meaningful proxy for model disagreement/uncertainty, and we clamp the
+        # lower bound to be non-negative.
         staged_preds = np.array(
             [pred for pred in self.model.staged_predict(features)]
         ).flatten()
-        std_dev = float(np.std(staged_preds)) if len(staged_preds) > 1 else abs(prediction) * 0.1
+        if len(staged_preds) > 1:
+            increments = np.diff(staged_preds)
+            std_dev = float(np.std(increments))
+        else:
+            std_dev = abs(prediction) * 0.1
+        # Guarantee a non-trivial, non-negative band.
+        std_dev = max(std_dev, abs(prediction) * 0.05)
+
+        lower = max(0.0, prediction - 1.96 * std_dev)
+        upper = prediction + 1.96 * std_dev
 
         return {
             "predicted_profit": round(prediction, 2),
             "confidence_interval": {
-                "lower": round(prediction - 1.96 * std_dev, 2),
-                "upper": round(prediction + 1.96 * std_dev, 2),
+                "lower": round(lower, 2),
+                "upper": round(upper, 2),
             },
         }
 


### PR DESCRIPTION
## Description

- `DriverProfitPredictor.predict` built its confidence interval from `np.std(self.model.staged_predict(features))`. `staged_predict` returns the **cumulative** prediction after each boosting stage (starts near 0, climbs to the final value), so the std-dev measures training progression, not prediction uncertainty. The interval width scaled with the point estimate and could produce negative `lower` bounds for positive profits — misleading to drivers.
- Replaced it with the spread of the **per-stage (per-tree) contributions** (`np.diff` of the staged predictions), which is a meaningful proxy for model disagreement, guaranteed the band is non-trivial (`max(std_dev, |prediction| * 0.05)`), and clamped the lower bound to `>= 0`.

## Files Changed

- `backend/ml/app/models/driver_profit.py`: CI now derived from per-stage contribution spread with a non-negative lower bound.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```
python3 -m py_compile backend/ml/app/models/driver_profit.py
```

Result: Byte-compiles cleanly. A full numeric test requires `numpy`/`scikit-learn` and a trained model, which are not installed here.

## Known Limitations

- The per-stage contribution spread is a heuristic uncertainty proxy. For a rigorous interval, quantile regression or bootstrap would be preferable; noted as a follow-up.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2934
