### PR TITLE
fix: prevent distributed lock bypass when Redis is unavailable

### DIFF
--- a/backend/api/src/lib/redisLock.js
+++ b/backend/api/src/lib/redisLock.js
@@ -7,16 +7,18 @@ import logger from '../middleware/logger.js';
  * @param {string} resourceKey - The unique key identifying the resource to lock (e.g. `escrow_lock:123`)
  * @param {number} ttlMs - Time to live in milliseconds
  * @returns {Promise<string|null>} lockValue if acquired, null if failed
+ * @throws {Error} if Redis is unavailable — callers MUST catch this and fail closed
+ * (e.g. respond with HTTP 503) rather than proceeding without a lock.
  */
 export async function acquireLock(resourceKey, ttlMs = 10000) {
   if (!redisClient) {
-    logger.warn('[RedisLock] redisClient not available, bypassing lock for', resourceKey);
-    return crypto.randomUUID();
+    logger.error('[RedisLock] redisClient not available — cannot acquire lock for', resourceKey);
+    throw new Error('Distributed lock unavailable: Redis is not connected');
   }
 
   const lockValue = crypto.randomUUID();
   const acquired = await redisClient.set(resourceKey, lockValue, 'PX', ttlMs, 'NX');
-  
+
   if (acquired) {
     return lockValue;
   }
@@ -38,7 +40,7 @@ export async function releaseLock(resourceKey, lockValue) {
     end
     return 0
   `;
-  
+
   try {
     const result = await redisClient.eval(luaScript, 1, resourceKey, lockValue);
     return result === 1;

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -564,7 +564,18 @@ export class OrderLifecycleService {
 
     if (requiresRefund) {
       const lockKey = `escrow_lock:${workingOrder.id}`;
-      const lockValue = await acquireLock(lockKey, 30000);
+
+      let lockValue;
+      try {
+        lockValue = await acquireLock(lockKey, 30000);
+      } catch (lockErr) {
+        logger.error('[escrow] Lock service unavailable during cancellation for order', orderId, ':', lockErr.message);
+        throw new DomainError(503, {
+          error: 'Refund processing is temporarily unavailable. Please try again shortly.',
+          retryable: true,
+        });
+      }
+      
       if (!lockValue) {
         throw new DomainError(409, { error: 'Refund is currently being processed. Please try again later.' });
       }


### PR DESCRIPTION
## Summary

Updated the Redis distributed locking mechanism to fail closed when Redis is unavailable instead of returning a fake lock value. Added proper error handling in the order cancellation flow to prevent critical operations from proceeding without a valid distributed lock.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/2919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling so requests now fail safely when the distributed lock service is unavailable instead of continuing without protection.
  * Order cancellation now returns a clear retryable error if lock acquisition fails, helping avoid partial processing.
  * Lock release errors are now handled more gracefully, with failures logged and reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->