### PR TITLE
fix(a11y): add screen-reader label to notifications button on customer home screen

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -147,6 +147,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
           IconButton(
+            tooltip: 'Notifications',
             onPressed: () => Navigator.of(context).push(
               AppPageRoute(builder: (_) => const NotificationsScreen()),
             ),


### PR DESCRIPTION
## Summary
Adds an accessible label to the notifications `IconButton` on the customer app's home screen, so screen readers (TalkBack/VoiceOver) announce it as "Notifications" instead of an unlabeled "button."

This is a first, small step toward addressing #1606, which tracks the broader lack of `Semantics`/accessibility labels across both the Customer and Driver apps. Rather than one large PR, I'm starting with a single, easy-to-review file and will follow up with additional screens in separate PRs.

## Changes
- `apps/customer/lib/screens/home_screen.dart`: added `tooltip: 'Notifications'` to the notifications `IconButton`, which Flutter automatically surfaces as the accessibility label for screen readers.

## Testing
- Ran `flutter analyze lib/screens/home_screen.dart` - confirmed the 5 pre-existing issues (1 unused field warning, 4 missing `AppLocalizations` members) are unrelated to this change and exist identically on `main` (verified via `git stash`/`git stash pop`).
- No new analyzer issues introduced by this change.

## Related issue
Closes part of #1606 (first of several planned follow-up PRs for other screens/widgets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added a tooltip to the notifications button on the home screen, improving clarity and accessibility for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->