### PR TITLE
fix(customer): guard order history response shape

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -16,11 +16,30 @@ class OrderService {
 
   String _encodePathSegment(String value) => Uri.encodeComponent(value);
 
+  List<Map<String, dynamic>> _mapList(dynamic value, String label) {
+    if (value is! List) {
+      throw StateError('Unexpected $label response type');
+    }
+
+    return value.map((item) {
+      if (item is Map<String, dynamic>) {
+        return item;
+      }
+      if (item is Map) {
+        return Map<String, dynamic>.from(item);
+      }
+      throw StateError('Unexpected $label item type');
+    }).toList(growable: false);
+  }
+
   List<Map<String, dynamic>> _historyFromResponse(dynamic body) {
     if (body is Map<String, dynamic>) {
-      return List<Map<String, dynamic>>.from(body['history'] as List? ?? []);
+      final history = body['history'];
+      return history == null
+          ? <Map<String, dynamic>>[]
+          : _mapList(history, 'order history');
     }
-    return List<Map<String, dynamic>>.from(body as List);
+    return _mapList(body, 'order history');
   }
 
   Future<String> createOrder({

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -76,6 +76,38 @@ void main() {
     expect(order404, isNull);
   });
 
+  test('fetchOrders accepts wrapped and bare history lists', () async {
+    when(() => apiClient.get('/api/orders/history'))
+        .thenAnswer((_) async => {'history': [{'id': 'ORD-1'}]});
+
+    expect(await orderService.fetchOrders(), [
+      {'id': 'ORD-1'},
+    ]);
+
+    when(() => apiClient.get('/api/orders/history'))
+        .thenAnswer((_) async => [{'id': 'ORD-2'}]);
+
+    expect(await orderService.fetchHistoryOrders(), [
+      {'id': 'ORD-2'},
+    ]);
+  });
+
+  test('fetchOrders rejects malformed history payloads', () async {
+    when(() => apiClient.get('/api/orders/history'))
+        .thenAnswer((_) async => {'history': 'not-a-list'});
+
+    await expectLater(
+      orderService.fetchOrders,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('Failed to fetch orders'),
+        ),
+      ),
+    );
+  });
+
   test('fetchTruckNumber encodes truck id path segment', () async {
     when(() => apiClient.get('/api/trucks/truck%2F123%23plate/number'))
         .thenAnswer((_) async => {'number_plate': 'MH-01-AB-1234'});


### PR DESCRIPTION
## Summary
- validate wrapped and bare order history payloads before casting
- reject malformed history responses with a controlled error
- add focused service tests for accepted and invalid shapes

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so the targeted Flutter test could not be run here

Closes #2979


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order history response handling for wrapped and unwrapped payloads.
  * Added validation for malformed history data, providing clearer errors instead of silently accepting invalid responses.

* **Tests**
  * Added coverage for supported order history formats and invalid payload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->