### PR TITLE
fix(customer): make order timeline parsing safe

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -27,6 +27,13 @@ class OrderService {
     }).toList(growable: false);
   }
 
+  List<Map<String, dynamic>> _timelineFromResponse(dynamic body) {
+    if (body is Map<String, dynamic>) {
+      return _mapList(body['timeline'], 'order timeline');
+    }
+    return _mapList(body, 'order timeline');
+  }
+
   List<Map<String, dynamic>> _historyFromResponse(dynamic body) {
     if (body is Map<String, dynamic>) {
       final history = body['history'];
@@ -154,7 +161,7 @@ class OrderService {
       final body = await _apiClient.get(
         '/api/orders/${_encodePathSegment(orderDisplayId)}/timeline',
       );
-      return List<Map<String, dynamic>>.from(body as List);
+      return _timelineFromResponse(body);
     } on ApiException catch (e) {
       throw StateError(e.message);
     } catch (e) {

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -77,6 +77,38 @@ void main() {
     expect(order404, isNull);
   });
 
+  test('fetchOrderTimeline accepts wrapped and bare timeline lists', () async {
+    when(() => apiClient.get('/api/orders/ORD-123/timeline'))
+        .thenAnswer((_) async => {'timeline': [{'title': 'Booked'}]});
+
+    expect(await orderService.fetchOrderTimeline('ORD-123'), [
+      {'title': 'Booked'},
+    ]);
+
+    when(() => apiClient.get('/api/orders/ORD-456/timeline'))
+        .thenAnswer((_) async => [{'title': 'Assigned'}]);
+
+    expect(await orderService.fetchOrderTimeline('ORD-456'), [
+      {'title': 'Assigned'},
+    ]);
+  });
+
+  test('fetchOrderTimeline rejects malformed timeline payloads', () async {
+    when(() => apiClient.get('/api/orders/ORD-123/timeline'))
+        .thenAnswer((_) async => {'timeline': 'not-a-list'});
+
+    await expectLater(
+      () => orderService.fetchOrderTimeline('ORD-123'),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('Failed to fetch order timeline'),
+        ),
+      ),
+    );
+  });
+
   test('fetchOrders accepts wrapped and bare history lists', () async {
     when(() => apiClient.get('/api/orders/history'))
         .thenAnswer((_) async => {'history': [{'id': 'ORD-1'}]});


### PR DESCRIPTION
## Summary
- parse order timeline responses through a shape guard
- support both bare list payloads and wrapped `timeline` lists
- add service tests for valid and malformed timeline responses

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so the targeted Flutter test could not be run here

Closes #2980
