### PR TITLE
fix(customer): validate fetchOrderById payloads

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -124,8 +124,16 @@ class OrderService {
     try {
       final body = await _apiClient.get(
         '/api/orders/${_encodePathSegment(orderDisplayId)}',
-      ) as Map<String, dynamic>?;
-      return body?['order'] as Map<String, dynamic>?;
+      );
+      if (body is! Map<String, dynamic>) {
+        throw StateError('Unexpected order response type');
+      }
+
+      final order = body['order'];
+      if (order == null) return null;
+      if (order is Map<String, dynamic>) return order;
+      if (order is Map) return Map<String, dynamic>.from(order);
+      throw StateError('Unexpected order payload type');
     } on ApiException catch (e) {
       if (e.statusCode == 404) return null;
       throw StateError(e.message);

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -77,6 +77,29 @@ void main() {
     expect(order404, isNull);
   });
 
+  test('fetchOrderById returns null for null order payload', () async {
+    when(() => apiClient.get('/api/orders/ORD-123'))
+        .thenAnswer((_) async => {'order': null});
+
+    expect(await orderService.fetchOrderById('ORD-123'), isNull);
+  });
+
+  test('fetchOrderById rejects malformed order payloads', () async {
+    when(() => apiClient.get('/api/orders/ORD-123'))
+        .thenAnswer((_) async => {'order': []});
+
+    await expectLater(
+      () => orderService.fetchOrderById('ORD-123'),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('Failed to fetch order'),
+        ),
+      ),
+    );
+  });
+
   test('fetchOrders accepts wrapped and bare history lists', () async {
     when(() => apiClient.get('/api/orders/history'))
         .thenAnswer((_) async => {'history': [{'id': 'ORD-1'}]});


### PR DESCRIPTION
## Summary
- validate the fetch-by-id response before reading `order`
- treat a null order payload as a missing order
- add tests for null and malformed order payloads

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so the targeted Flutter test could not be run here

Closes #2981
