### PR TITLE
fix(customer): surface malformed truck search responses

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -187,7 +187,10 @@ class OrderService {
       final body = await _apiClient.get(
         path,
       );
-      final List<dynamic> listBody = body is List<dynamic> ? body : <dynamic>[];
+      if (body is! List) {
+        throw StateError('Unexpected truck search response type');
+      }
+      final listBody = body;
       return listBody.cast<Map<String, dynamic>>();
     } on ApiException catch (e) {
       throw StateError(e.message);

--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -88,6 +88,28 @@ void main() {
     ).called(1);
   });
 
+  test('searchTrucks rejects malformed response payloads', () async {
+    when(() => apiClient.get(any(that: startsWith('/api/trucks/search'))))
+        .thenAnswer((_) async => {'trucks': []});
+
+    await expectLater(
+      () => orderService.searchTrucks(
+        pickupLat: 12.3,
+        pickupLng: 45.6,
+        dropLat: 78.9,
+        dropLng: 12.3,
+        weightTonnes: 5.5,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('Failed to search trucks'),
+        ),
+      ),
+    );
+  });
+
   group('estimatePriceRange', () {
     test('returns correct min and max when prices are integers', () async {
       when(() => apiClient.get(


### PR DESCRIPTION
## Summary
- stop treating non-list truck search payloads as empty results
- raise a controlled search failure for unexpected response shapes
- add a regression test for malformed truck search responses

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so the targeted Flutter test could not be run here

Closes #2982
