### PR TITLE
fix(customer): build API URIs from components

### DIFF
--- a/apps/customer/test/core/api_client_test.dart
+++ b/apps/customer/test/core/api_client_test.dart
@@ -277,6 +277,25 @@ void main() {
       verify(() => httpClient.get(Uri.parse('http://localhost:5000/api/orders'), headers: any(named: 'headers'))).called(1);
     });
 
+    test('encodes raw path segments while preserving query strings', () async {
+      when(() => httpClient.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => jsonResponse({'ok': true}));
+
+      final client = buildClient(
+          httpClient: httpClient, supabaseClient: supabaseClient);
+
+      await client.get('/api/orders/ORD 123/timeline?include=driver notes');
+
+      final captured = verify(
+        () => httpClient.get(captureAny(), headers: any(named: 'headers')),
+      ).captured;
+      final uri = captured.single as Uri;
+      expect(
+        uri.toString(),
+        equals('http://localhost:5000/api/orders/ORD%20123/timeline?include=driver%20notes'),
+      );
+    });
+
     test('accepts custom headers and merges them', () async {
       when(() => httpClient.get(any(), headers: any(named: 'headers')))
           .thenAnswer((_) async => jsonResponse({'ok': true}));

--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -180,8 +180,23 @@ class ApiClient {
   // ── URI building and path normalization ───────────────────────────
 
   Uri _buildUri(String path) {
-    final cleanPath = path.startsWith('/') ? path : '/$path';
-    return Uri.parse('$_baseUrl$cleanPath');
+    final baseUri = Uri.parse(_baseUrl);
+    final cleanPath = path.startsWith('/') ? path.substring(1) : path;
+    final queryStart = cleanPath.indexOf('?');
+    final rawPath = queryStart == -1
+        ? cleanPath
+        : cleanPath.substring(0, queryStart);
+    final rawQuery =
+        queryStart == -1 ? null : cleanPath.substring(queryStart + 1);
+    final baseSegments =
+        baseUri.pathSegments.where((segment) => segment.isNotEmpty);
+    final requestSegments =
+        rawPath.split('/').where((segment) => segment.isNotEmpty);
+
+    return baseUri.replace(
+      pathSegments: <String>[...baseSegments, ...requestSegments],
+      query: rawQuery?.isEmpty == true ? null : rawQuery,
+    );
   }
 
   // ── HTTP methods ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- build request URIs from parsed base and path components
- encode raw path segments and query text consistently
- add a focused API client test that captures the outgoing URI

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so the targeted Flutter test could not be run here

Closes #2983
