### PR TITLE
fix(customer): handle corrupted cached profiles

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -170,8 +170,12 @@ class CacheManager {
     }
 
     final decoded = _safeDecode(rows.first['value'] as String);
-      if (decoded == null) return null;
-      final payload = decoded as Map<String, dynamic>;
+    if (decoded is! Map) {
+      await db.delete('profile', where: 'key = ?', whereArgs: ['profile']);
+      return null;
+    }
+
+    final payload = Map<String, dynamic>.from(decoded);
     return <String, dynamic>{
       ...payload,
       '_cached_at': rows.first['updated_at'],


### PR DESCRIPTION
## Summary
- validate cached profile payloads before casting
- treat malformed profile cache as a cache miss
- clear the invalid profile row so later reads can recover

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #2985
