### PR TITLE
fix(customer): isolate invalid cached settings

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -242,7 +242,13 @@ class CacheManager {
     final result = <String, dynamic>{};
 
     for (final row in rows) {
-      result[row['key'] as String] = _safeDecode(row['value'] as String);
+      final key = row['key'] as String;
+      final decoded = _safeDecode(row['value'] as String);
+      if (decoded == null) {
+        await db.delete('settings', where: 'key = ?', whereArgs: [key]);
+        continue;
+      }
+      result[key] = decoded;
     }
 
     return result;


### PR DESCRIPTION
## Summary
- decode cached settings one entry at a time
- skip invalid values so valid settings still load
- delete corrupted settings keys after detection

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #2987
