### PR TITLE
fix(driver): guard marketplace auth headers

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/app_models.dart';
@@ -31,11 +32,28 @@ class MarketplaceRepository {
 
   String _encodePathSegment(String value) => Uri.encodeComponent(value);
 
+  Future<String?> _firebaseAccessToken() async {
+    try {
+      return await FirebaseAuth.instance.currentUser?.getIdToken();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String? _supabaseAccessToken() {
+    try {
+      return _client.auth.currentSession?.accessToken;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<Map<String, String>> _authHeaders() async {
-    final accessToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+    final accessToken = await _firebaseAccessToken() ?? _supabaseAccessToken();
     return <String, String>{
       'Content-Type': 'application/json',
-      if (accessToken != null) 'Authorization': 'Bearer $accessToken',
+      if (accessToken != null && accessToken.isNotEmpty)
+        'Authorization': 'Bearer $accessToken',
     };
   }
 


### PR DESCRIPTION
## Summary
- restore the Firebase auth import used by marketplace auth headers
- catch Firebase token lookup failures before building headers
- fall back to the Supabase session token when Firebase is unavailable

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #2988
