### PR TITLE
fix: remove duplicate timeline declaration in orderMilestoneService

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -46,8 +46,6 @@ export class OrderMilestoneService {
     if (orderErr || !order) throw new DomainError(404, { error: 'Order not found.' });
     if (order.driver_id !== driverId) throw new DomainError(403, { error: 'Access Denied: You are not assigned to this order.' });
 
-    const { data: timeline, error: tlErr } = await this.orderRepository.getTimelineWithSortCheck(order.order_display_id);
-    if (tlErr) throw new DomainError(500, { error: 'Failed to fetch order timeline.' });
     const timeline = await orderTimelineService.getOrderTimeline(order.order_display_id);
 
     const canonicalMilestones = new Set([...Object.keys(milestoneMap), 'Order Placed', 'Delivered']);


### PR DESCRIPTION
## Summary

This PR removes the duplicate `timeline` declaration in `orderMilestoneService.js`, resolving the parse-time error caused by redeclaring a `const` variable in the same scope.

### Changes
- Removed the duplicate `timeline` declaration.
- Eliminated the `SyntaxError` caused by redeclaring `timeline`.

### Issue Fixed
Closes #2976