### PR TITLE
fix: import paramIdSchema in driverRoutes

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -5,7 +5,7 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter, createStore } from '../middleware/rateLimiter.js';
 
 import { validateBody, validateParams } from '../middleware/validate.js';
-import { driverOnlineSchema, withdrawSchema, uuidParamSchema } from '../validation/requestSchemas.js';
+import { driverOnlineSchema, withdrawSchema, uuidParamSchema, paramIdSchema } from '../validation/requestSchemas.js';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
## Summary

This PR fixes a missing import in `driverRoutes.js`.

### Changes
- Added `paramIdSchema` to the existing import from `requestSchemas.js`.
- Restored the missing schema dependency used by the route validation middleware.

### Issue Fixed
Closes #2977