### PR TITLE
fix: handle already released escrow reconciliation

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -84,8 +84,8 @@ export async function reconcilePendingEscrowReleases() {
         const releaseAttemptedAt = new Date().toISOString();
         const releaseAttempts = (order.escrow_release_attempts || 0) + 1;
 
-        const { txHash } = await escrowRelease(order.order_display_id);
-        if (!txHash) {
+        const { txHash, alreadyReleased } = await escrowRelease(order.order_display_id);
+        if (!txHash && !alreadyReleased) {
           throw new Error('Escrow release did not return a transaction hash');
         }
 
@@ -94,7 +94,7 @@ export async function reconcilePendingEscrowReleases() {
           .from('orders')
           .update({
             escrow_status: 'released',
-            release_tx_hash: txHash,
+            release_tx_hash: txHash || order.release_tx_hash,
             escrow_release_error: null,
             escrow_released_at: releasedAt,
             escrow_release_attempts: releaseAttempts,


### PR DESCRIPTION
## Summary

This PR fixes the escrow release reconciliation logic to correctly handle orders that have already been released on-chain.

### Changes

- Handle the `alreadyReleased` flag returned by `escrowRelease()`.
- Only throw an error when both `txHash` is missing and the order was not already released.
- Preserve the existing `release_tx_hash` when no new transaction hash is returned.

### Why

Previously, orders that had already been released on-chain were incorrectly marked as `release_failed`, causing unnecessary retries and inconsistent database state.

Closes #2978