### PR TITLE
fix(driver): keep token refresh fallback available

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -119,13 +119,22 @@ class ApiClient {
 
   Future<String?> _refreshedToken() async {
     try {
-      // Prefer Firebase token refresh.
       final firebaseUser = FirebaseAuth.instance.currentUser;
       if (firebaseUser != null) {
         final token = await firebaseUser.getIdToken(true);
         _cachedFirebaseToken = token;
         return token;
       }
+    } catch (e) {
+      if (kDebugMode) {
+        developer.log(
+          '[ApiClient] Firebase token refresh failed: $e',
+          name: 'ApiClient',
+        );
+      }
+    }
+
+    try {
       // Fall back to Supabase session refresh.
       final res = await _supabase.auth.refreshSession();
       return res.session?.accessToken;


### PR DESCRIPTION
## Summary
- handle Firebase token refresh failures separately
- keep Supabase session refresh available as the fallback path
- preserve debug logging for both refresh branches

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3004
