### PR TITLE
fix(driver): guard cached access token lookup

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -104,8 +104,14 @@ class ApiClient {
     return _supabase.auth.currentSession?.accessToken;
   }
 
-  String? get _accessToken =>
-      _cachedFirebaseToken ?? _supabase.auth.currentSession?.accessToken;
+  String? get _accessToken {
+    if (_cachedFirebaseToken != null) return _cachedFirebaseToken;
+    try {
+      return _supabase.auth.currentSession?.accessToken;
+    } catch (_) {
+      return null;
+    }
+  }
 
   Map<String, String> _headers({String? token, Map<String, String>? additionalHeaders}) {
     final t = token ?? _accessToken;


### PR DESCRIPTION
## Summary
- guard Supabase session access in the cached token getter
- return unauthenticated headers when auth state is unavailable
- keep cached Firebase token behavior unchanged

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3005
