### PR TITLE
fix(driver): correct marketplace stream add handling

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -178,8 +178,8 @@ class MarketplaceRepository {
             final newRecord = payload.newRecord;
             if (newRecord.isNotEmpty) {
               final offer = _mapLoadOffer(newRecord);
-              if (!controller.add(offer)) {
-                developer.log('No active subscribers, dropping load offer');
+              if (!controller.isClosed) {
+                controller.add(offer);
               }
             }
           } catch (e, st) {


### PR DESCRIPTION
## Summary
- remove the invalid boolean check around `StreamController.add`
- add realtime load offers only while the controller is open
- keep existing mapping and error logging behavior intact

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3006
