### PR TITLE
fix(driver): validate trip history limit

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -95,6 +95,9 @@ class TripService {
     if (page == null || page < 1) {
       throw ArgumentError.value(cursor, 'cursor', 'must be a positive integer');
     }
+    if (limit < 1) {
+      throw ArgumentError.value(limit, 'limit', 'must be a positive integer');
+    }
     var path = '/api/driver/trips?page=$page&limit=$limit';
     if (status != null) {
       path += '&status=${Uri.encodeQueryComponent(status)}';


### PR DESCRIPTION
## Summary
- validate trip history `limit` before building the request path
- reject zero and negative limits with an argument error
- keep existing cursor validation behavior unchanged

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3007
