### PR TITLE
fix(driver): guard trip history response parsing

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -102,12 +102,18 @@ class TripService {
     
     try {
       final body = await _apiClient.get(path);
-      final mapBody = body as Map<String, dynamic>;
-      final responsePage = mapBody['page'] as int? ?? page;
-      final totalPages = mapBody['totalPages'] as int? ?? responsePage;
+      if (body is! Map<String, dynamic>) {
+        throw StateError('Unexpected trip history response type');
+      }
+      final trips = body['trips'];
+      if (trips is! List) {
+        throw StateError('Unexpected trip history trips type');
+      }
+      final responsePage = body['page'] as int? ?? page;
+      final totalPages = body['totalPages'] as int? ?? responsePage;
       final hasMore = responsePage < totalPages;
       return {
-        'trips': List<Map<String, dynamic>>.from(mapBody['trips'] as List? ?? []),
+        'trips': List<Map<String, dynamic>>.from(trips),
         'nextCursor': hasMore ? '${responsePage + 1}' : null,
         'hasMore': hasMore,
       };


### PR DESCRIPTION
## Summary
- validate the trip history response is a map before reading fields
- require `trips` to be list-valued before converting rows
- return controlled service errors for malformed success payloads

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3008
