### PR TITLE
fix(driver): skip malformed route coordinates

### DIFF
--- a/apps/driver/lib/services/route_service.dart
+++ b/apps/driver/lib/services/route_service.dart
@@ -33,8 +33,14 @@ class RouteService {
       final out = <LatLng>[];
       for (final e in coordsList) {
         if (e is List && e.length >= 2) {
-          final lon = (e[0] as num).toDouble();
-          final lat = (e[1] as num).toDouble();
+          final lonValue = e[0];
+          final latValue = e[1];
+          if (lonValue is! num || latValue is! num) {
+            continue;
+          }
+
+          final lon = lonValue.toDouble();
+          final lat = latValue.toDouble();
           out.add(LatLng(lat, lon));
         }
       }


### PR DESCRIPTION
## Summary
- validate OSRM coordinate values before converting them
- skip malformed coordinate pairs instead of discarding the whole route
- preserve existing fallback behavior for invalid top-level route payloads

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3009
