### PR TITLE
fix(customer): add location lookup timeouts

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -14,6 +14,7 @@ class LocationService {
   static const String _host = 'nominatim.openstreetmap.org';
   static const String _userAgent = 'Truxify Customer App';
   static const int _maxCacheSize = 200;
+  static const Duration _lookupTimeout = Duration(seconds: 8);
   static final Map<String, List<LocationSuggestion>> _searchCache = {};
   static final Map<String, String> _reverseCache = {};
 
@@ -56,7 +57,7 @@ class LocationService {
         'Accept': 'application/json',
         'User-Agent': _userAgent,
       },
-    );
+    ).timeout(_lookupTimeout);
     if (response.statusCode != 200) {
       throw Exception('Search failed: ${response.statusCode} (${uri.path})');
     }
@@ -107,7 +108,7 @@ class LocationService {
         'Accept': 'application/json',
         'User-Agent': _userAgent,
       },
-    );
+    ).timeout(_lookupTimeout);
     if (response.statusCode != 200) {
       throw Exception('Reverse lookup failed: ${response.statusCode} (${uri.path})');
     }


### PR DESCRIPTION
## Summary
- add a shared timeout for Nominatim requests
- apply the timeout to search lookups
- apply the timeout to reverse geocoding lookups

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3011
