### PR TITLE
fix: remove duplicate import declarations in tripRoutes.js (#3025)

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -6,8 +6,6 @@ import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams } from '../middleware/validate.js';
 import { uuidParamSchema } from '../validation/requestSchemas.js';
 import logger from '../middleware/logger.js';
-import { validateParams } from '../middleware/validate.js';
-import { uuidParamSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Remove duplicate import lines for validateParams and uuidParamSchema that caused a SyntaxError.

GSSoC