### PR TITLE
fix: add missing userLimiter import in authRoutes.js (#3027)

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -10,7 +10,7 @@
  */
 
 import express from 'express';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, userLimiter } from '../middleware/auth.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
 import { firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
The /session route uses userLimiter middleware but the import was missing, causing a ReferenceError at runtime.

GSSoC