### PR TITLE
fix: add missing closing brace in orderRepository.js (#3028)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -714,3 +714,5 @@ export class OrderRepository {
       }), 'claimRefundReconciliation');
   }
 }
+
+}


### PR DESCRIPTION
The _cachedQuery method was missing a closing brace causing a SyntaxError.

GSSoC