### PR TITLE
fix: change DropdownButtonFormField initialValue to value in my_truck_screen.dart (#3030)

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -107,7 +107,7 @@ class _MyTruckScreenState extends State<MyTruckScreen> {
                   ),
                   const SizedBox(height: 8),
                   DropdownButtonFormField<String>(
-                    initialValue: selectedCategory,
+                    value: selectedCategory,
                     decoration: InputDecoration(
                       contentPadding: const EdgeInsets.symmetric(
                           horizontal: 14, vertical: 12),


### PR DESCRIPTION
DropdownButtonFormField uses the 'value' property, not 'initialValue'. Using 'initialValue' caused the dropdown to not reflect the selected category at runtime.

GSSoC