### PR TITLE
fix: add require(points>0) guard in increaseReputation and decreaseReputation (#3032)

### DIFF
--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -54,6 +54,7 @@ contract Reputation is Ownable, Pausable {
     /// @param driver Address of the driver.
     /// @param points Amount to increase.
     function increaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
+        require(points > 0, "Points must be > 0");
         require(driver != address(0), "Invalid driver");
         uint256 current = scores[driver];
         if (current >= MAX_REPUTATION) revert("already at max reputation");
@@ -70,6 +71,7 @@ contract Reputation is Ownable, Pausable {
     /// @param driver Address of the driver.
     /// @param points Amount to decrease.
     function decreaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
+        require(points > 0, "Points must be > 0");
         require(driver != address(0), "Invalid driver");
         uint256 current = scores[driver];
         scores[driver] = points >= current ? 0 : current - points;


### PR DESCRIPTION
Both functions accepted points=0 without reverting, allowing no-op calls that waste gas and emit misleading events.

GSSoC