### PR TITLE
fix: add whenNotPaused modifier to raiseDispute in TruxifyEscrow.sol (#3033)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -212,7 +212,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
      *
      * @param bookingId The booking to flag
      */
-    function raiseDispute(uint256 bookingId) external {
+    function raiseDispute(uint256 bookingId) external whenNotPaused {
         Booking storage booking = bookings[bookingId];
 
         require(


### PR DESCRIPTION
Disputes raised during a paused state could lead to inconsistent state. The whenNotPaused modifier prevents dispute creation while the contract is paused.

GSSoC