### PR TITLE
fix: add missing paramIdSchema import in driverRoutes (#2897)

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -5,7 +5,7 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter, createStore } from '../middleware/rateLimiter.js';
 
 import { validateBody, validateParams } from '../middleware/validate.js';
-import { driverOnlineSchema, withdrawSchema, uuidParamSchema } from '../validation/requestSchemas.js';
+import { driverOnlineSchema, withdrawSchema, uuidParamSchema, paramIdSchema } from '../validation/requestSchemas.js';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
Adds the missing paramIdSchema import to driverRoutes.js.

Closes #2897

GSSoC