### PR TITLE
fix: add _verificationId field to login screen (#2901)

### DIFF
--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -31,6 +31,7 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _phoneController = TextEditingController();
   final AuthService _authService = AuthService();
   bool _loading = false;
+  String? _verificationId;
   int? _resendToken;
   String _selectedCode = '+91';
   int _expectedDigits = 10;


### PR DESCRIPTION
Adds missing _verificationId field to the driver login screen.

Closes #2901

GSSoC