### PR TITLE
fix: remove duplicate variable in location_service (#2902)

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -34,10 +34,6 @@ class LocationService {
     if (_searchCache.containsKey(cacheKey)) {
       return _searchCache[cacheKey]!;
     }
-    final trimmed = query.trim();
-    if (trimmed.length < 3) {
-      return const <LocationSuggestion>[];
-    }
 
     final uri = Uri.https(
       _host,


### PR DESCRIPTION
Removes a duplicate variable declaration in location_service.dart.

Closes #2902

GSSoC