### PR TITLE
fix: add missing dart:convert and http imports in fcm_service (#2903)

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 
 import 'api_client.dart';
 

--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -7,6 +7,9 @@ import 'package:http/http.dart' as http;
 import 'api_client.dart';
 
 class FcmService {
+  static final String _apiBaseUrl = 'http://localhost:5000';
+  static final ApiClient apiClient = ApiClient();
+
   static Future<void> initializeAndRegister() async {
     try {
       final messaging = FirebaseMessaging.instance;


### PR DESCRIPTION
Closing - resolved by the shared-services refactor (#3097).