### PR TITLE
fix: remove duplicate env_file key in docker-compose (#2904)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - .env
     ports:
       - "5000:5000"
-    env_file:
-      - .env
     environment:
       MONGODB_URI: mongodb://mongo:27017
       MONGODB_DB_NAME: truxify_telemetry


### PR DESCRIPTION
Removes the duplicate env_file key in docker-compose.yml.

Closes #2904

GSSoC