### PR TITLE
fix: change initialValue to value in my_truck_screen (#3030)

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -106,8 +106,8 @@ class _MyTruckScreenState extends State<MyTruckScreen> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    initialValue: selectedCategory,
+                    DropdownButtonFormField<String>(
+                    value: selectedCategory,
                     decoration: InputDecoration(
                       contentPadding: const EdgeInsets.symmetric(
                           horizontal: 14, vertical: 12),


### PR DESCRIPTION
Changes initialValue to alue in my_truck_screen.dart to use the correct Flutter DropdownButtonFormField property.

Closes #3030

GSSoC