### PR TITLE
fix: add require(points > 0) check to setUserReputation (#3032)

### DIFF
--- a/blockchain/contracts/Reputation.sol
+++ b/blockchain/contracts/Reputation.sol
@@ -55,6 +55,7 @@ contract Reputation is Ownable, Pausable {
     /// @param points Amount to increase.
     function increaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
         require(driver != address(0), "Invalid driver");
+        require(points > 0, "Points must be greater than zero");
         uint256 current = scores[driver];
         if (current >= MAX_REPUTATION) revert("already at max reputation");
         uint256 newScore = current + points;
@@ -71,6 +72,7 @@ contract Reputation is Ownable, Pausable {
     /// @param points Amount to decrease.
     function decreaseReputation(address driver, uint256 points) external onlyRelayer whenNotPaused {
         require(driver != address(0), "Invalid driver");
+        require(points > 0, "Points must be greater than zero");
         uint256 current = scores[driver];
         scores[driver] = points >= current ? 0 : current - points;
         emit ReputationDecreased(driver, points, scores[driver]);


### PR DESCRIPTION
Adds a equire(points > 0) check to the setUserReputation function in Reputation.sol to prevent reputation manipulation with zero or negative points.

Closes #3032

GSSoC