### PR TITLE
fix: add whenNotPaused modifier to raiseDispute (#3033)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -212,7 +212,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
      *
      * @param bookingId The booking to flag
      */
-    function raiseDispute(uint256 bookingId) external {
+    function raiseDispute(uint256 bookingId) external whenNotPaused {
         Booking storage booking = bookings[bookingId];
 
         require(


### PR DESCRIPTION
Adds the whenNotPaused modifier to the aiseDispute function in TruxifyEscrow.sol to prevent dispute creation while the contract is paused.

Closes #3033

GSSoC