### PR TITLE
fix: consolidate duplicate db.js imports in orderRoutes (#3026)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -3,8 +3,7 @@ import rateLimit from 'express-rate-limit';
 import crypto from 'crypto';
 
 import { bidLimiter, userLimiter, safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
-import { redisClient, mongoDb } from '../config/db.js';
-import { supabase } from '../config/db.js';
+import { redisClient, mongoDb, supabase } from '../config/db.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { validateBody, validateParams } from '../middleware/validate.js';


### PR DESCRIPTION
Consolidates the two separate config/db.js imports (redisClient/mongoDb and supabase) into a single import statement.

Closes #3026

GSSoC