### PR TITLE
fix: fail-closed sender verification in recordDepositTx 

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -263,9 +263,12 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
   // We can still verify the on-chain sender (tx.from) is expected.
 
   // If an expected sender address was provided (from order record), verify it matches.
-  if (expectedSenderAddress && tx.from.toLowerCase() !== expectedSenderAddress.toLowerCase()) {
-    return { error: 'Transaction sender does not match the registered customer wallet for this order' }
+  // Reject if no wallet is on file rather than silently skipping sender verification (fail closed).
+  if (!expectedSenderAddress) {
+    return { error: 'No registered customer wallet on file to verify transaction sender against' }
   }
+  if (tx.from.toLowerCase() !== expectedSenderAddress.toLowerCase()) {
+    return { error: 'Transaction sender does not match the registered customer wallet for this order' }
 
   logger.info(`[escrow] deposit confirmed for booking ${bookingId} in block ${receipt.blockNumber}`)
   return { txHash: receipt.hash, bookingId }

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -269,6 +269,7 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
   }
   if (tx.from.toLowerCase() !== expectedSenderAddress.toLowerCase()) {
     return { error: 'Transaction sender does not match the registered customer wallet for this order' }
+  }
 
   logger.info(`[escrow] deposit confirmed for booking ${bookingId} in block ${receipt.blockNumber}`)
   return { txHash: receipt.hash, bookingId }

--- a/backend/api/test/unit/escrowSenderVerification.test.js
+++ b/backend/api/test/unit/escrowSenderVerification.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for recordDepositTx() sender verification (fail-closed check)
+ * in backend/api/src/services/escrow.js — covers issue #1112.
+ *
+ * Mocks ethers so escrowContract is initialised (unlike the default
+ * no-contract fallback tests), letting us reach the sender-verification
+ * branch inside recordDepositTx().
+ *
+ * Run with: npm test -- test/unit/escrowSenderVerification.test.js
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+const mockBookings = vi.fn()
+const mockWaitForTransaction = vi.fn()
+const mockGetTransaction = vi.fn()
+const mockParseTransaction = vi.fn()
+
+vi.mock('ethers', async (importOriginal) => {
+const actual = await importOriginal()
+return {
+    ...actual,
+    ethers: {
+    ...actual.ethers,
+    JsonRpcProvider: vi.fn(function () { return {} }),
+    Wallet: vi.fn(function () { return {} }),
+    Contract: vi.fn(function () {
+        return {
+            bookings: mockBookings,
+            interface: { parseTransaction: mockParseTransaction },
+            runner: {
+            provider: {
+                waitForTransaction: mockWaitForTransaction,
+                getTransaction: mockGetTransaction,
+            },
+        },
+    }
+    }),
+    },
+}
+})
+
+const CONTRACT_ADDRESS = '0x' + 'c'.repeat(40)
+const oldRpc = process.env.POLYGON_RPC_URL
+const oldAddr = process.env.ESCROW_CONTRACT_ADDRESS
+const oldKey = process.env.RELAYER_WALLET_PRIVATE_KEY
+
+process.env.POLYGON_RPC_URL = 'http://localhost:8545'
+process.env.ESCROW_CONTRACT_ADDRESS = CONTRACT_ADDRESS
+process.env.RELAYER_WALLET_PRIVATE_KEY = '0x' + '1'.repeat(64)
+
+const { recordDepositTx, getEscrowBookingId } = await import('../../src/services/escrow.js')
+
+afterAll(() => {
+    if (oldRpc !== undefined) process.env.POLYGON_RPC_URL = oldRpc
+    else delete process.env.POLYGON_RPC_URL
+    if (oldAddr !== undefined) process.env.ESCROW_CONTRACT_ADDRESS = oldAddr
+    else delete process.env.ESCROW_CONTRACT_ADDRESS
+    if (oldKey !== undefined) process.env.RELAYER_WALLET_PRIVATE_KEY = oldKey
+    else delete process.env.RELAYER_WALLET_PRIVATE_KEY
+})
+
+describe('recordDepositTx() — sender verification (fail-closed)', () => {
+    const bookingId = getEscrowBookingId('#FF20260600')
+    const txHash = '0x' + 'a'.repeat(64)
+    const driverAddr = '0x' + '3'.repeat(40)
+    const someSender = '0x' + '9'.repeat(40)
+
+beforeEach(() => {
+    mockBookings.mockResolvedValue({ amount: 0n })
+    mockWaitForTransaction.mockResolvedValue({ status: 1, blockNumber: 100, hash: txHash })
+    mockGetTransaction.mockResolvedValue({
+        to: CONTRACT_ADDRESS,
+        data: '0xdeadbeef',
+        value: 0n,
+        from: someSender,
+    })
+    mockParseTransaction.mockReturnValue({
+        name: 'createBooking',
+        args: [BigInt(bookingId), driverAddr],
+    })
+})
+
+it('rejects with an error when no expectedSenderAddress is on file (fails closed)', async () => {
+    const result = await recordDepositTx(bookingId, txHash, null)
+    expect(result.error).toBeDefined()
+    expect(result.error).toMatch(/no registered customer wallet/i)
+})
+
+it('rejects when tx.from does not match expectedSenderAddress', async () => {
+    const wrongExpected = '0x' + '5'.repeat(40)
+    const result = await recordDepositTx(bookingId, txHash, wrongExpected)
+    expect(result.error).toMatch(/does not match/i)
+})
+
+it('succeeds when tx.from matches expectedSenderAddress', async () => {
+    const result = await recordDepositTx(bookingId, txHash, someSender)
+    expect(result.error).toBeUndefined()
+    expect(result.txHash).toBe(txHash)
+})
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Truxify",
+  "name": "Truxify-Parnita-Singh",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -2934,7 +2934,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
Fixes #1112

## Description
`recordDepositTx()` in `escrow.js` verifies that the on-chain transaction sender matches the customer's registered wallet — but only when a wallet address was actually on file. If the customer had no wallet registered, the check was silently skipped, allowing a deposit to be confirmed from any sender's transaction.

## Fix
The sender check now fails closed: if there's no registered wallet to verify against, `recordDepositTx` returns an error immediately instead of skipping the check.

## Testing
Added `test/unit/escrowSenderVerification.test.js`, which mocks `ethers`so `escrowContract` is initialised (the existing unit tests only cover the no-contract fallback path and never reach this branch). Covers:
- rejects when no wallet is on file
- rejects when tx.from doesn't match the registered wallet
- succeeds when tx.from matches

All 3 tests pass locally via `npm test -- test/unit/escrowSenderVerification.test.js`.
<img width="1181" height="411" alt="Screenshot 2026-07-10 145128" src="https://github.com/user-attachments/assets/ee60e483-a970-4384-9e75-7360498a1b07" />
