### PR TITLE
fix: add aggregate KPI calculator with named parameters

### DIFF
--- a/apps/driver/lib/utils/driver_metrics.dart
+++ b/apps/driver/lib/utils/driver_metrics.dart
@@ -172,3 +172,12 @@ class DriverMetrics {
     return text.endsWith('.0') ? text.substring(0, text.length - 2) : text;
   }
 }
+
+class KpiCalculator {
+  static double acceptanceRate(int accepted, int total) => total > 0 ? (accepted / total) * 100 : 0;
+  static double earningsPerKm(double totalEarnings, double totalKm) => totalKm > 0 ? totalEarnings / totalKm : 0;
+  static double earningsPerHour(double totalEarnings, double totalHours) => totalHours > 0 ? totalEarnings / totalHours : 0;
+  static double completionRate(int completed, int total) => total > 0 ? (completed / total) * 100 : 0;
+  static double avgRating(double totalStars, int totalRatings) => totalRatings > 0 ? totalStars / totalRatings : 0;
+  static double utilizationRate(double drivingHours, double onlineHours) => onlineHours > 0 ? (drivingHours / onlineHours) * 100 : 0;
+}

--- a/apps/driver/lib/utils/driver_metrics.dart
+++ b/apps/driver/lib/utils/driver_metrics.dart
@@ -180,4 +180,18 @@ class KpiCalculator {
   static double completionRate(int completed, int total) => total > 0 ? (completed / total) * 100 : 0;
   static double avgRating(double totalStars, int totalRatings) => totalRatings > 0 ? totalStars / totalRatings : 0;
   static double utilizationRate(double drivingHours, double onlineHours) => onlineHours > 0 ? (drivingHours / onlineHours) * 100 : 0;
+
+  static Map<String, double> all({
+    required int accepted, required int totalOffers,
+    required double earnings, required double km, required double hours,
+    required int completed, required double stars, required int ratings,
+    required double drivingHours, required double onlineHours,
+  }) => {
+    'acceptanceRate': acceptanceRate(accepted, totalOffers),
+    'earningsPerKm': earningsPerKm(earnings, km),
+    'earningsPerHour': earningsPerHour(earnings, hours),
+    'completionRate': completionRate(completed, totalOffers),
+    'avgRating': avgRating(stars, ratings),
+    'utilizationRate': utilizationRate(drivingHours, onlineHours),
+  };
 }


### PR DESCRIPTION
Adds KpiCalculator.all() returning all metrics as a map.