### PR TITLE
fix: add multi-attack patterns with refund and deposit variants

### DIFF
--- a/blockchain/contracts/ReentrantDriver.sol
+++ b/blockchain/contracts/ReentrantDriver.sol
@@ -3,12 +3,18 @@ pragma solidity ^0.8.24;
 
 interface IEscrow {
     function releaseFunds(bytes32 bookingId) external;
+    function refundFunds(bytes32 bookingId) external;
+    function deposit(bytes32 bookingId, address customer, address driver) external payable;
 }
 
 contract ReentrantDriver {
     IEscrow public escrow;
     bytes32 public bookingId;
     bool public attackEnabled;
+    uint256 public attackCount;
+    uint256 public constant MAX_ATTACKS = 3;
+
+    event AttackExecuted(bytes32 indexed bookingId, uint256 count);
 
     constructor(address escrowAddress) {
         escrow = IEscrow(escrowAddress);
@@ -17,17 +23,44 @@ contract ReentrantDriver {
     function arm(bytes32 targetBookingId) external {
         bookingId = targetBookingId;
         attackEnabled = true;
+        attackCount = 0;
+    }
+
+    function disarm() external {
+        attackEnabled = false;
+        attackCount = 0;
     }
 
     function attackRelease(bytes32 targetBookingId) external {
         bookingId = targetBookingId;
         attackEnabled = true;
+        attackCount = 0;
+        escrow.releaseFunds(targetBookingId);
+    }
+
+    function attackRefund(bytes32 targetBookingId) external {
+        bookingId = targetBookingId;
+        attackEnabled = true;
+        attackCount = 0;
+        escrow.refundFunds(targetBookingId);
+    }
+
+    function attackDepositAndRelease(
+        bytes32 targetBookingId,
+        address customer,
+        address driver
+    ) external payable {
+        bookingId = targetBookingId;
+        escrow.deposit{value: msg.value}(targetBookingId, customer, driver);
+        attackEnabled = true;
+        attackCount = 0;
         escrow.releaseFunds(targetBookingId);
     }
 
     receive() external payable {
-        if (attackEnabled) {
-            attackEnabled = false;
+        if (attackEnabled && attackCount < MAX_ATTACKS) {
+            attackCount++;
+            emit AttackExecuted(bookingId, attackCount);
             escrow.releaseFunds(bookingId);
         }
     }


### PR DESCRIPTION
Adds attackRefund, attackDepositAndRelease, and multi-call receive with attack count limit.