### PR TITLE
fix(driver): normalize maintenance ticket ids

### DIFF
--- a/apps/driver/lib/models/truck_models.dart
+++ b/apps/driver/lib/models/truck_models.dart
@@ -73,9 +73,9 @@ class TruckMaintenanceTicket {
 
   factory TruckMaintenanceTicket.fromJson(Map<String, dynamic> json) {
     return TruckMaintenanceTicket(
-      id: json['id'] as String,
-      truckId: json['truck_id'] as String,
-      driverId: json['driver_id'] as String,
+      id: json['id'].toString(),
+      truckId: json['truck_id'].toString(),
+      driverId: json['driver_id'].toString(),
       category: json['category'] as String,
       description: json['description'] as String,
       status: json['status'] as String,


### PR DESCRIPTION
## Summary
- normalize maintenance ticket ids with `toString()` during model parsing
- keep the existing string-based model fields unchanged
- cover numeric ids returned by database-backed responses

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance ticket data handling when identifier values are returned in unexpected formats.
  * Prevented parsing failures for non-text or missing truck, driver, and ticket identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->