### PR TITLE
fix(driver): handle truck mileage update result

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -82,8 +82,10 @@ class TruckRepository {
     final response = await _client
         .from('trucks')
         .update({'mileage_km': currentMileage, 'updated_at': DateTime.now().toIso8601String()})
-        .eq('id', truckId);
-    return response > 0;
+        .eq('id', truckId)
+        .select('id')
+        .maybeSingle();
+    return response != null;
   }
 
   Future<List<Map<String, dynamic>>> fetchTruckDocuments(String truckId) async {


### PR DESCRIPTION
## Summary
- request the updated truck id after mileage updates
- return success only when an updated row is returned
- avoid treating the Supabase update response as a numeric count

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3192
