### PR TITLE
fix(driver): scope maintenance ticket updates

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -58,6 +58,7 @@ class TruckRepository {
 
   Future<TruckMaintenanceTicket?> updateTicketStatus({
     required int ticketId,
+    required String driverId,
     required String status,
     String? resolutionNotes,
   }) async {
@@ -70,9 +71,10 @@ class TruckRepository {
         .from('truck_maintenance_tickets')
         .update(update)
         .eq('id', ticketId)
+        .eq('driver_id', driverId)
         .select()
-        .single();
-    return TruckMaintenanceTicket.fromJson(response);
+        .maybeSingle();
+    return response == null ? null : TruckMaintenanceTicket.fromJson(response);
   }
 
   Future<bool> updateTruckMileage({


### PR DESCRIPTION
## Summary
- require driver context when updating maintenance ticket status
- scope the update by both ticket id and driver id
- return `null` when no matching ticket is updated

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3194
