### PR TITLE
fix(customer): validate address before default switch

### DIFF
--- a/apps/customer/lib/repositories/address_repository.dart
+++ b/apps/customer/lib/repositories/address_repository.dart
@@ -37,7 +37,18 @@ class AddressRepository {
   /// Set an address as the default, clearing all others.
   Future<void> setDefault(String addressId) async {
     final userId = SupabaseService.requireUserId();
-    await _clearDefaults(userId);
+    final existing = await SupabaseService.client
+        .from(_table)
+        .select('id')
+        .eq('id', addressId)
+        .eq('user_id', userId)
+        .maybeSingle();
+
+    if (existing == null) {
+      throw StateError('Address not found.');
+    }
+
+    await _clearDefaults(userId, exceptId: addressId);
     await SupabaseService.client
         .from(_table)
         .update({'is_default': true})


### PR DESCRIPTION
## Summary
- verify the target address before changing defaults
- avoid clearing the selected address during default demotion
- raise a clear error when the address is missing for the user

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3195
