### PR TITLE
fix(driver): isolate trip cache section decoding

### DIFF
--- a/apps/driver/lib/services/trip_cache.dart
+++ b/apps/driver/lib/services/trip_cache.dart
@@ -12,6 +12,33 @@ class TripCache {
   static const String _savedAtKey = 'truxify_driver_cached_trips_saved_at';
   static const Duration _ttl = Duration(hours: 24);
 
+  static Map<String, List<Map<String, dynamic>>> _decodeTripSections(
+    String? raw,
+  ) {
+    if (raw == null) {
+      return <String, List<Map<String, dynamic>>>{};
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, List<Map<String, dynamic>>>{};
+      }
+
+      final sections = <String, List<Map<String, dynamic>>>{};
+      decoded.forEach((key, value) {
+        if (value is! List) return;
+        sections[key.toString()] = value
+            .whereType<Map>()
+            .map((item) => Map<String, dynamic>.from(item))
+            .toList(growable: false);
+      });
+      return sections;
+    } catch (_) {
+      return <String, List<Map<String, dynamic>>>{};
+    }
+  }
+
   static Future<void> save({
     required List<Map<String, dynamic>> trips,
     required Map<String, List<Map<String, dynamic>>> stopsByTripId,
@@ -40,39 +67,10 @@ class TripCache {
             .map((e) => Map<String, dynamic>.from(e as Map)),
       );
 
-      final stopsRaw = prefs.getString(_stopsKey);
-      final stopsByTripId = <String, List<Map<String, dynamic>>>{};
-      if (stopsRaw != null) {
-        final decoded = jsonDecode(stopsRaw) as Map<String, dynamic>;
-        decoded.forEach((key, value) {
-          stopsByTripId[key] = List<Map<String, dynamic>>.from(
-            (value as List).map((e) => Map<String, dynamic>.from(e as Map)),
-          );
-        });
-      }
-
-      final routePointsRaw = prefs.getString(_routePointsKey);
-      final routePointsByTripId = <String, List<Map<String, dynamic>>>{};
-      if (routePointsRaw != null) {
-        final decoded = jsonDecode(routePointsRaw) as Map<String, dynamic>;
-        decoded.forEach((key, value) {
-          routePointsByTripId[key] = List<Map<String, dynamic>>.from(
-            (value as List).map((e) => Map<String, dynamic>.from(e as Map)),
-          );
-        });
-      }
-
-      final itemsRaw = prefs.getString(_itemsKey);
-      final itemsByTripId = <String, List<Map<String, dynamic>>>{};
-
-      if (itemsRaw != null) {
-      final decoded = jsonDecode(itemsRaw) as Map<String, dynamic>;
-      decoded.forEach((key, value) {
-      itemsByTripId[key] = List<Map<String, dynamic>>.from(
-      (value as List).map((e) => Map<String, dynamic>.from(e as Map)),
-      );
-      });
-    }
+      final stopsByTripId = _decodeTripSections(prefs.getString(_stopsKey));
+      final routePointsByTripId =
+          _decodeTripSections(prefs.getString(_routePointsKey));
+      final itemsByTripId = _decodeTripSections(prefs.getString(_itemsKey));
 
       final savedAtRaw = prefs.getString(_savedAtKey);
       final savedAt = savedAtRaw != null ? DateTime.tryParse(savedAtRaw) : null;


### PR DESCRIPTION
## Summary
- decode cached stops, route points, and items independently
- keep valid cached trip lists when an optional section is malformed
- normalize decoded section rows into map lists safely

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3197
