### PR TITLE
fix(driver): clear expired trip cache entries

### DIFF
--- a/apps/driver/lib/services/trip_cache.dart
+++ b/apps/driver/lib/services/trip_cache.dart
@@ -39,6 +39,16 @@ class TripCache {
     }
   }
 
+  static Future<void> _clear(SharedPreferences prefs) async {
+    await Future.wait([
+      prefs.remove(_tripsKey),
+      prefs.remove(_stopsKey),
+      prefs.remove(_routePointsKey),
+      prefs.remove(_itemsKey),
+      prefs.remove(_savedAtKey),
+    ]);
+  }
+
   static Future<void> save({
     required List<Map<String, dynamic>> trips,
     required Map<String, List<Map<String, dynamic>>> stopsByTripId,
@@ -76,6 +86,7 @@ class TripCache {
       final savedAt = savedAtRaw != null ? DateTime.tryParse(savedAtRaw) : null;
 
       if (savedAt != null && DateTime.now().difference(savedAt) > _ttl) {
+        await _clear(prefs);
         return null;
       }
 


### PR DESCRIPTION
## Summary
- add a helper to clear all driver trip cache keys
- remove stale trip cache payloads when the TTL has expired
- avoid repeatedly decoding expired snapshots on later loads

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3198
