### PR TITLE
fix(api): reject malformed pagination integers

### DIFF
--- a/backend/api/src/middleware/pagination.js
+++ b/backend/api/src/middleware/pagination.js
@@ -7,12 +7,18 @@ export function validatePagination(options = {}) {
   const maxOffset = options.maxOffset || 10000;
   const defaultLimit = options.defaultLimit || 10;
   const defaultOffset = options.defaultOffset || 0;
+  const parseInteger = (value) => {
+    if (!/^\d+$/.test(String(value))) {
+      return null;
+    }
+    return Number.parseInt(value, 10);
+  };
 
   return (req, res, next) => {
     // 1. Parse limit
     let limit = defaultLimit;
     if (req.query.limit) {
-      const parsed = parseInt(req.query.limit, 10);
+      const parsed = parseInteger(req.query.limit);
       if (Number.isFinite(parsed) && parsed > 0) {
         limit = Math.min(parsed, maxLimit);
       } else {
@@ -23,14 +29,14 @@ export function validatePagination(options = {}) {
     // 2. Parse offset (or page)
     let offset = defaultOffset;
     if (req.query.offset) {
-      const parsed = parseInt(req.query.offset, 10);
+      const parsed = parseInteger(req.query.offset);
       if (Number.isFinite(parsed) && parsed >= 0) {
         offset = Math.min(parsed, maxOffset);
       } else {
         return res.status(400).json({ error: 'Invalid offset parameter' });
       }
     } else if (req.query.page) {
-       const parsedPage = parseInt(req.query.page, 10);
+       const parsedPage = parseInteger(req.query.page);
        if (Number.isFinite(parsedPage) && parsedPage > 0) {
           offset = Math.min((parsedPage - 1) * limit, maxOffset);
        } else {

--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -109,6 +109,19 @@ describe('Pagination Middleware', () => {
     expect(res.json).toHaveBeenCalledWith({ error: 'Invalid limit parameter' });
   });
 
+  it('returns 400 for partially numeric limit values', () => {
+    const middleware = validatePagination();
+    const req = { query: { limit: '10abc' } };
+    const res = mockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid limit parameter' });
+  });
+
   it('calculates offset correctly from page parameter', () => {
     const middleware = validatePagination();
     const req = { query: { limit: '20', page: '3' } };


### PR DESCRIPTION
## Summary
- reject partially numeric pagination query values
- use a full-string integer parser for limit, offset, and page
- add a regression test for malformed limit input

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so Vitest could not be run here

Closes #3199
