### PR TITLE
fix(api): normalize pagination string inputs

### DIFF
--- a/backend/api/src/utils/pagination.js
+++ b/backend/api/src/utils/pagination.js
@@ -4,10 +4,22 @@ const DEFAULTS = {
   maxLimit: 100,
 };
 
+function normalizeNumber(value) {
+  if (Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && /^\d+(\.\d+)?$/.test(value.trim())) {
+    return Number(value);
+  }
+  return Number.NaN;
+}
+
 export function buildPagination(params = {}) {
-  const page = Number.isFinite(params.page) ? Math.max(1, Math.floor(params.page)) : DEFAULTS.page;
-  const limit = Number.isFinite(params.limit)
-    ? Math.min(Math.max(1, Math.floor(params.limit)), DEFAULTS.maxLimit)
+  const rawPage = normalizeNumber(params.page);
+  const rawLimit = normalizeNumber(params.limit);
+  const page = Number.isFinite(rawPage) ? Math.max(1, Math.floor(rawPage)) : DEFAULTS.page;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(1, Math.floor(rawLimit)), DEFAULTS.maxLimit)
     : DEFAULTS.limit;
 
   const offset = (page - 1) * limit;

--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -39,8 +39,13 @@ describe('buildPagination', () => {
   });
 
   it('returns correct string pagination from string values', () => {
-    const result = buildPagination({ page: 2, limit: 15 });
+    const result = buildPagination({ page: '2', limit: '15' });
     expect(result).toEqual({ page: 2, limit: 15, offset: 15, from: 15, to: 29 });
+  });
+
+  it('falls back to defaults for malformed string values', () => {
+    const result = buildPagination({ page: '2abc', limit: '15abc' });
+    expect(result).toEqual({ page: 1, limit: 20, offset: 0, from: 0, to: 19 });
   });
 
   it('handles page 1 with no limit correctly', () => {


### PR DESCRIPTION
## Summary
- normalize numeric string inputs in `buildPagination`
- keep malformed string values on the default path
- add unit coverage for valid and malformed string pagination values

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so Vitest could not be run here

Closes #3200
