### PR TITLE
fix(database): restore missing update_updated_at_column trigger function for Supabase migrations

### DIFF
--- a/supabase/migrations/20260623140000_restore_update_updated_at_column.sql
+++ b/supabase/migrations/20260623140000_restore_update_updated_at_column.sql
@@ -1,0 +1,30 @@
+-- Migration: Restore update_updated_at_column() trigger function
+-- ---------------------------------------------------------------------------
+-- Historical migrations 20260623142000 (user_devices) and 20260702000000
+-- (driver_documents) create BEFORE UPDATE triggers that call
+-- update_updated_at_column(), but no migration ever created that function.
+-- A later migration (20260707000000) creates set_updated_at() with identical
+-- behaviour for the profiles and orders tables.
+--
+-- On a fresh database (supabase db reset), applying migration
+-- 20260623142000 fails with:
+--   function update_updated_at_column() does not exist
+--
+-- This migration is timestamped BEFORE the first broken migration so that
+-- the function exists when 20260623142000 and 20260702000000 are applied.
+-- It uses CREATE OR REPLACE so it is safe to re-run and harmless on
+-- existing deployments where the function already exists (e.g. created via
+-- supabase_setup.sql).  No existing triggers, tables, or APIs are changed.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION public.update_updated_at_column() IS
+  'Trigger function that auto-sets updated_at on row updates. '
+  'Restores the function referenced by migrations 20260623142000 and 20260702000000.';


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in the Supabase migration chain by restoring the missing `update_updated_at_column()` PostgreSQL trigger function.

Several historical migrations reference this function, but it is never created during a fresh database setup. Instead of modifying historical migrations, this PR introduces a new forward-only migration that restores compatibility while preserving existing database history.

No application logic, API behavior, or database schema has been changed.

---

## What Changed

### ✅ Added

- A new forward-only Supabase migration.
- `update_updated_at_column()` trigger function.
- Documentation explaining the compatibility fix (if appropriate).

### ✅ Preserved

- Existing migration history.
- Existing trigger definitions.
- Existing database schema.
- Existing application behavior.

---

## Architecture

### Before

```text
Historical Migration
        │
        ▼
Trigger references
update_updated_at_column()
        │
        ▼
❌ Function does not exist
        │
        ▼
Fresh migration fails
```

### After

```text
Historical Migration
        │
        ▼
Trigger references
update_updated_at_column()
        │
        ▼
Compatibility migration
creates function
        │
        ▼
Fresh migration succeeds
```

---

## Files Changed

### Added

- `supabase/migrations/<timestamp>_restore_update_updated_at_function.sql`

---

## Benefits

- Restores compatibility for fresh database initialization.
- Fixes `supabase db reset`.
- Improves developer onboarding.
- Prevents migration failures in CI environments.
- Preserves migration history.
- Avoids editing historical migrations.

---

## Testing

### Verified

- ✅ Fresh migration chain completes successfully.
- ✅ `supabase db reset` succeeds.
- ✅ Existing triggers update `updated_at`.
- ✅ Existing schema remains unchanged.
- ✅ Existing backend functionality preserved.

---

## Type of Change

- [x] Database Fix
- [x] Migration Compatibility
- [x] Developer Experience
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

---

## Related Issue

Closes #3211 

---

## GSSoC
#ECSoC26

This PR is submitted as part of **GirlScript Summer of Code (GSSoC) 2026**.

This change restores compatibility for fresh Supabase database setups without modifying historical migrations. Kindly review and consider approving it if it aligns with the project's database maintenance and developer experience goals. Thank you for your valuable feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent database setup from completing successfully.
  * Ensured record update timestamps are automatically refreshed when changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->