### PR TITLE
fix: remove duplicate ESM import bindings in tripRoutes.js (#3226)

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -6,8 +6,6 @@ import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams } from '../middleware/validate.js';
 import { uuidParamSchema } from '../validation/requestSchemas.js';
 import logger from '../middleware/logger.js';
-import { validateParams } from '../middleware/validate.js';
-import { uuidParamSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
﻿## Description
Removes duplicate ESM import bindings in `tripRoutes.js`. Lines 9-10 were stale duplicates of lines 6-7, causing a `SyntaxError: Identifier 'validateParams' has already been declared` when loading the module.

### Changes
- Removed duplicate `import { validateParams }` (line 9)
- Removed duplicate `import { uuidParamSchema }` (line 10)
- Kept logger import (line 8) which was unique

Closes #3226

GSSoC
