### PR TITLE
fix: fix wrong status mapping for Goods Loaded milestone in OrderLifecycleService (#3228)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -341,7 +341,7 @@ export class OrderLifecycleService {
   async updateMilestone(orderId, milestone, driverId) {
     const milestoneMap = {
       'Arrived at Pickup': 'at_pickup',
-      'Goods Loaded': 'in_transit',
+      'Goods Loaded': 'picked_up',
       'In Transit': 'in_transit',
       'Arrived at Drop-off': 'at_dropoff',
       'Goods Unloaded': 'at_dropoff',


### PR DESCRIPTION
﻿## Description
Fixes the milestone status mapping in `OrderLifecycleService.updateMilestone()`. The 'Goods Loaded' milestone was incorrectly mapped to `in_transit` instead of `picked_up`, causing the `picked_up` order status to never be set. This matches the correct mapping used in `OrderMilestoneService`.

### Changes
- Changed `'Goods Loaded': 'in_transit'` to `'Goods Loaded': 'picked_up'` in milestoneMap

Closes #3228

GSSoC
