### PR TITLE
fix: remove duplicate code block in location_service.dart searchPlaces (#3230)

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -34,10 +34,6 @@ class LocationService {
     if (_searchCache.containsKey(cacheKey)) {
       return _searchCache[cacheKey]!;
     }
-    final trimmed = query.trim();
-    if (trimmed.length < 3) {
-      return const <LocationSuggestion>[];
-    }
 
     final uri = Uri.https(
       _host,


### PR DESCRIPTION
﻿## Description
Removes a duplicate code block in `location_service.dart` `searchPlaces()` method. Lines 37-40 were an identical copy of the early-return length check (lines 28-31), causing a Dart compile error due to `final trimmed` being redeclared and making the cache lookup unreachable.

### Changes
- Removed the duplicate `final trimmed` / length check block (lines 37-40)
- Cache lookup at lines 33-36 is now correctly reachable for queries with 3+ characters

Closes #3230

GSSoC
