### PR TITLE
fix: align clampReputation max with contract MAX_REPUTATION (100 -> 10000) (#3231)

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -33,8 +33,11 @@ function safeSubtract(a, b) {
   return Number.isFinite(result) ? result : 0;
 }
 
+/** @type {number} Must match Reputation.sol MAX_REPUTATION constant */
+const MAX_REPUTATION = 10000;
+
 function clampReputation(value) {
-  return Math.max(0, Math.min(100, Number(value) || 0));
+  return Math.max(0, Math.min(MAX_REPUTATION, Number(value) || 0));
 }
 
 // Minimal ABI — only the subset the backend needs to call.


### PR DESCRIPTION
﻿## Description
Fixes the reputation scale mismatch between backend and blockchain. `clampReputation` was using an upper bound of 100 while the Reputation.sol contract uses `MAX_REPUTATION = 10000`. Added a shared constant `MAX_REPUTATION` matching the contract value to keep both layers in sync.

### Changes
- Extracted `MAX_REPUTATION = 10000` constant matching Reputation.sol
- Updated `clampReputation` to use `MAX_REPUTATION` instead of hardcoded 100

Closes #3231

GSSoC
