### PR TITLE
fix: correct misleading ML API_KEY warning message in main.py (#3232)

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -38,7 +38,7 @@ loaded_models: set[str] = set()
 async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
     ml_api_key = os.environ.get("ML_API_KEY")
     if not ml_api_key:
-        logger.warning("ML_API_KEY not set - ML engine running without authentication")
+        logger.warning("ML_API_KEY not set - ML engine is unavailable (503)")
         raise HTTPException(status_code=503, detail="ML engine not configured: missing ML_API_KEY")
     if not x_api_key or not hmac.compare_digest(x_api_key, ml_api_key):
         raise HTTPException(status_code=401, detail="Unauthorized")


### PR DESCRIPTION
﻿## Description
Fixes a misleading warning message in the ML engine's API key verification. Previously warned "ML engine running without authentication" but then immediately returned HTTP 503, contradicting the log message. Now accurately reflects that the service is unavailable.

### Changes
- Changed warning from `"ML engine running without authentication"` to `"ML engine is unavailable (503)"`

Closes #3232

GSSoC
