### PR TITLE
chore: remove unused defaultApiBaseUrl constant from OrderService (#3233)

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -7,11 +7,6 @@ class OrderService {
     ApiClient? apiClient,
   }) : _apiClient = apiClient ?? ApiClient();
 
-  static const String defaultApiBaseUrl = String.fromEnvironment(
-    'TRUXIFY_API_BASE_URL',
-    defaultValue: 'http://localhost:5000',
-  );
-
   final ApiClient _apiClient;
 
   String _encodePathSegment(String value) => Uri.encodeComponent(value);


### PR DESCRIPTION
﻿## Description
Removes the unused `defaultApiBaseUrl` constant from `OrderService`. The constant was declared but never referenced — the class uses `_apiClient` which handles base URL configuration internally.

### Changes
- Removed `static const String defaultApiBaseUrl` declaration (4 lines including environment variable access)

Closes #3233

GSSoC
