### PR TITLE
refactor: remove redundant clamping from safeSubtract in reputation.js (#3234)

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -22,14 +22,15 @@
 import { ethers } from 'ethers';
 import logger from '../middleware/logger.js';
 
-// Safe math utilities for reputation calculations
+// Safe math utilities for reputation calculations.
+// Boundary clamping (0–MAX_REPUTATION) is handled by clampReputation.
 function safeAdd(a, b) {
   const result = Number(a) + Number(b);
   return Number.isFinite(result) ? result : 0;
 }
 
 function safeSubtract(a, b) {
-  const result = Math.max(0, Number(a) - Number(b));
+  const result = Number(a) - Number(b);
   return Number.isFinite(result) ? result : 0;
 }
 


### PR DESCRIPTION
﻿## Description
Simplifies `safeSubtract` by removing built-in `Math.max(0, ...)` clamping — boundary enforcement is already delegated to `clampReputation`. This eliminates redundant logic and follows the single-responsibility principle: safe math utilities handle edge cases (non-finite), clampReputation handles boundary enforcement.

### Changes
- Removed `Math.max(0, ...)` from `safeSubtract` — clampReputation already ensures the final value is within valid range

Closes #3234

GSSoC
