### PR TITLE
fix(driver): guard trip item response parsing

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -132,7 +132,9 @@ class TripService {
     final path = '/api/trips/${_encodePathSegment(tripDisplayId)}/items';
     try {
       final body = await _apiClient.get(path);
-      if (body is! List) return [];
+      if (body is! List) {
+        throw StateError('Unexpected trip items response type');
+      }
       return List<Map<String, dynamic>>.from(body);
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);


### PR DESCRIPTION
## Summary
- validate trip item responses before converting them
- return a controlled service error for malformed payloads
- keep valid list responses unchanged

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when trip item data is returned in an unexpected format.
  * The app now reports the invalid response instead of silently displaying an empty trip item list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->