### PR TITLE
fix(driver): guard trip stop response parsing

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -146,7 +146,9 @@ class TripService {
     final path = '/api/trips/${_encodePathSegment(tripDisplayId)}/stops';
     try {
       final body = await _apiClient.get(path);
-      if (body is! List) return [];
+      if (body is! List) {
+        throw StateError('Unexpected trip stops response type');
+      }
       return List<Map<String, dynamic>>.from(body);
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);


### PR DESCRIPTION
## Summary
- validate trip stop responses before conversion
- surface malformed payloads as service errors
- preserve valid list handling for stop data

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3267
