### PR TITLE
fix(driver): guard route point response parsing

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -160,7 +160,9 @@ class TripService {
     final path = '/api/trips/${_encodePathSegment(tripDisplayId)}/route-points';
     try {
       final body = await _apiClient.get(path);
-      if (body is! List) return [];
+      if (body is! List) {
+        throw StateError('Unexpected route points response type');
+      }
       return List<Map<String, dynamic>>.from(body);
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);


### PR DESCRIPTION
## Summary
- validate route point responses before conversion
- raise a controlled service error for malformed payloads
- preserve valid list handling for route point data

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3268
