### PR TITLE
fix(customer): handle short addresses in city extraction

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -121,8 +121,13 @@ class LocationService {
   }
 
   String extractCity(String address) {
-    final parts = address.split(',');
-    return parts.length > 1 ? parts[parts.length - 3].trim() : parts.first.trim();
+    final parts = address
+        .split(',')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (parts.length >= 3) return parts[parts.length - 3];
+    return parts.isEmpty ? '' : parts.first;
   }
 
   String extractShortAddress(String address) {


### PR DESCRIPTION
## Summary
- trim and filter address segments before city extraction
- avoid negative indexes for one- and two-part addresses
- return an empty string for blank address input

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3269
