### PR TITLE
fix(customer): validate cache size table names

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -4,6 +4,15 @@ import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
 
 class CacheManager {
+  static const Set<String> _cacheTables = {
+    'orders',
+    'profile',
+    'documents',
+    'settings',
+    'last_location',
+    'milestones',
+  };
+
   dynamic _safeDecode(String json) {
     try {
       return jsonDecode(json);
@@ -382,6 +391,9 @@ class CacheManager {
   }
 
   Future<int> getCacheSize(String tableName) async {
+    if (!_cacheTables.contains(tableName)) {
+      throw ArgumentError.value(tableName, 'tableName', 'unknown cache table');
+    }
     final db = await open();
     final result = await db.rawQuery('SELECT COUNT(*) as cnt FROM $tableName');
     if (result.isEmpty) return 0;


### PR DESCRIPTION
## Summary
- add an allowlist of local cache tables
- reject unknown table names before raw count queries
- keep existing size reporting for known cache tables

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3270
