### PR TITLE
fix(customer): validate cache clear table names

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -4,6 +4,15 @@ import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
 
 class CacheManager {
+  static const Set<String> _cacheTables = {
+    'orders',
+    'profile',
+    'documents',
+    'settings',
+    'last_location',
+    'milestones',
+  };
+
   dynamic _safeDecode(String json) {
     try {
       return jsonDecode(json);
@@ -361,6 +370,9 @@ class CacheManager {
   }
 
   Future<int> clearTable(String tableName) async {
+    if (!_cacheTables.contains(tableName)) {
+      throw ArgumentError.value(tableName, 'tableName', 'unknown cache table');
+    }
     final db = await open();
     return db.delete(tableName);
   }


### PR DESCRIPTION
## Summary
- add an allowlist of local cache tables
- reject unknown table names before clearing cache rows
- keep `clearAll` behavior unchanged for known tables

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3271
