### PR TITLE
fix(customer): prevent milestone cache key collisions

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -327,11 +327,14 @@ class CacheManager {
     final batch = db.batch();
     final updatedAt = DateTime.now().toUtc().toIso8601String();
 
-    for (final item in milestones) {
+    for (var index = 0; index < milestones.length; index++) {
+      final item = milestones[index];
+      final milestoneId = _stableId(item, const ['id', 'milestoneId', 'milestone_id']) ??
+          '${item['title'] ?? 'milestone'}_$index';
       batch.insert(
         'milestones',
         {
-          'id': '${orderId}_${item['title'] ?? 'milestone'}',
+          'id': '${orderId}_$milestoneId',
           'order_id': orderId,
           'title': item['title'] ?? 'Milestone',
           'completed': item['completed'] == true ? 1 : 0,


### PR DESCRIPTION
## Summary
- use stable milestone ids when caching milestone rows
- include the list index as a fallback for duplicate titles
- prevent same-title milestones from overwriting each other locally

## Validation
- `git diff --check`
- Flutter SDK unavailable locally, so Flutter tests could not be run here

Closes #3272
