### PR TITLE
fix(api): validate driver trip pagination integers

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -23,6 +23,12 @@ function requireDriverRole(req, res, next) {
   next();
 }
 
+function parseIntegerQuery(value) {
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(String(value))) return NaN;
+  return Number.parseInt(value, 10);
+}
+
 
 // ============================================================================
 // 1. GET DRIVER STATS (DRIVER)
@@ -196,8 +202,8 @@ router.get('/trips', authenticate, userLimiter, requirePolicy('driver:view-trips
   const { status } = req.query;
   const rawPage = req.query.page;
   const rawLimit = req.query.limit;
-  const parsedPage = parseInt(rawPage, 10);
-  const parsedLimit = parseInt(rawLimit, 10);
+  const parsedPage = parseIntegerQuery(rawPage);
+  const parsedLimit = parseIntegerQuery(rawLimit);
   if (rawPage !== undefined && (!Number.isInteger(parsedPage) || parsedPage < 1)) {
     return res.status(400).json({ error: 'page must be a positive integer' });
   }


### PR DESCRIPTION
## Summary
- add strict integer parsing for driver trip pagination
- reject partially numeric page and limit query values
- keep existing defaults and limit clamping unchanged

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3274
