### PR TITLE
fix: reject cancelled orders in complete_trip_tx function

### DIFF
--- a/supabase/migrations/20260704000001_add_auth_verification_to_complete_trip_tx.sql
+++ b/supabase/migrations/20260704000001_add_auth_verification_to_complete_trip_tx.sql
@@ -34,6 +34,10 @@ BEGIN
     RAISE EXCEPTION 'No driver assigned to this order';
   END IF;
 
+  IF v_order.status = 'cancelled' THEN
+    RAISE EXCEPTION 'Cannot complete a cancelled order';
+  END IF;
+
   IF v_order.status = 'payment_released' THEN
     RETURN;
   END IF;


### PR DESCRIPTION
## Summary
Fixes #3288 — The `complete_trip_tx` PostgreSQL function only guarded against
`payment_released` status (idempotent return), but had no guard for
`cancelled` status. This allowed a cancelled order to be completed, crediting
the driver wallet and marking the trip as delivered.

## Changes
- `supabase/migrations/20260704000001_add_auth_verification_to_complete_trip_tx.sql`:
  Added `IF v_order.status = 'cancelled' THEN RAISE EXCEPTION ...` before the
  existing `payment_released` check.

## Testing
- Verified that calling `complete_trip_tx` on a cancelled order raises an
  exception.
- Verified that the existing `payment_released` idempotent return still works.