### PR TITLE
fix: clean up Supabase Realtime channels on subscriber disconnect

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -78,6 +78,11 @@ const trackingSubscriptions = new Map();
 // channel per location ping. Reused across pings and cleaned up on disconnect.
 const locationChannels = new Map();
 
+// Reverse index from orderDisplayId to the set of orderUUID keys in locationChannels.
+// Used during disconnect cleanup so channels are properly removed when the last
+// subscriber for a display ID disconnects.
+const displayIdToLocationChannelKeys = new Map();
+
 // =====================================================================
 // CLOCK SKEW & CIRCUIT BREAKER CONFIGURATION (#596)
 // =====================================================================
@@ -759,6 +764,12 @@ export async function handleLocationPing(ws, data, req) {
       const channel = supabase.channel(`driver-location:${orderUUID}`);
       channel.subscribe();
       locationChannels.set(orderUUID, channel);
+      if (orderDisplayId) {
+        if (!displayIdToLocationChannelKeys.has(orderDisplayId)) {
+          displayIdToLocationChannelKeys.set(orderDisplayId, new Set());
+        }
+        displayIdToLocationChannelKeys.get(orderDisplayId).add(orderUUID);
+      }
     }
     const channel = locationChannels.get(orderUUID);
     channel.send({
@@ -1111,16 +1122,21 @@ async function removeClientFromAllSubscriptions(ws) {
     }
     if (clients.size === 0) {
       trackingSubscriptions.delete(key);
-      // Clean up the cached Supabase Realtime channel for this orderUUID
-      // so channels do not leak after the last subscriber disconnects.
-      if (locationChannels.has(key)) {
-        const channel = locationChannels.get(key);
-        // Guard against supabase being null (e.g. not configured in dev/test environments)
-        if (supabase) {
-          supabase.removeChannel(channel);
+      // Clean up cached Supabase Realtime channels associated with this
+      // subscription key via the reverse index so channels do not leak.
+      const channelKeys = displayIdToLocationChannelKeys.get(key);
+      if (channelKeys) {
+        for (const uuidKey of channelKeys) {
+          if (locationChannels.has(uuidKey)) {
+            const channel = locationChannels.get(uuidKey);
+            if (supabase) {
+              supabase.removeChannel(channel);
+            }
+            locationChannels.delete(uuidKey);
+            logger.info(`🔌 Removed Supabase Realtime channel for order "${uuidKey}" on last subscriber disconnect.`);
+          }
         }
-        locationChannels.delete(key);
-        logger.info(`🔌 Removed Supabase Realtime channel for order "${key}" on last subscriber disconnect.`);
+        displayIdToLocationChannelKeys.delete(key);
       }
     }
   });


### PR DESCRIPTION
## Summary
Fixes #3289 — `locationChannels` is keyed by `orderUUID` (DB primary key),
but `trackingSubscriptions` is keyed by `order_display_id` (display ID). When
the last subscriber disconnected, `removeClientFromAllSubscriptions` tried
`locationChannels.has(displayKey)` which never matched, so Supabase Realtime
channels leaked.

## Changes
- `backend/api/src/sockets/tracker.js`:
  - Added `displayIdToLocationChannelKeys` reverse index mapping each display
    ID to the set of `orderUUID` keys in `locationChannels`.
  - Registered the reverse mapping when creating new location channels.
  - Updated disconnect cleanup to use the reverse index to find and remove all
    Supabase Realtime channels associated with the disconnecting subscriber.

## Testing
- Verified that on last subscriber disconnect, associated Supabase Realtime
  channels are properly removed.
- Verified no channels leak when multiple subscribers watch the same order.