### PR TITLE
fix: remove duplicate const offers declarations in load-offers handlers

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -376,7 +376,6 @@ router.get('/load-offers', authenticate, userLimiter, async (req, res) => {
   const page = Math.max(1, parseInt(req.query.page) || 1);
   const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 20));
   try {
-    const { data: offers, error } = await orderRepository.findLoadOffers({ is_en_route: false });
     const { data: offers, error } = await orderRepository.findLoadOffers(
       { is_en_route: false },
       { pagination: { page, limit } }
@@ -397,7 +396,6 @@ router.get('/load-offers/en-route', authenticate, userLimiter, async (req, res) 
   const page = Math.max(1, parseInt(req.query.page) || 1);
   const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 20));
   try {
-    const { data: offers, error } = await orderRepository.findLoadOffers({ is_en_route: true });
     const { data: offers, error } = await orderRepository.findLoadOffers(
       { is_en_route: true },
       { pagination: { page, limit } }


### PR DESCRIPTION
## Description

Removed duplicate `const { data: offers, error }` destructuring declarations in `orderRoutes.js`. Both the `/load-offers` and `/load-offers/en-route` handlers had duplicate `const` declarations that cause SyntaxError at startup.

## Changes
- Removed the old non-paginated calls (kept paginated versions)

Closes #3297

GSSoC