### PR TITLE
fix: replace undefined UUID_RE with existing uuidRegex in timeline handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -487,7 +487,7 @@ router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSch
 
   try {
     let order = null;
-    if (UUID_RE.test(orderId)) {
+    if (uuidRegex.test(orderId)) {
       const { data: orderById } = await orderRepository.findOrderForTimeline(orderId);
       order = orderById;
     }


### PR DESCRIPTION
## Description

Replaced undefined `UUID_RE` reference with the existing `uuidRegex` variable in the order timeline handler. `UUID_RE` was never declared in `orderRoutes.js` causing ReferenceError at runtime. The `uuidRegex` variable was already defined on line 486.

Closes #3298

GSSoC