### PR TITLE
fix: remove duplicate const order redeclaration in timeline handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -501,9 +501,6 @@ router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSch
     if (order.customer_id !== req.user.id && order.driver_id !== req.user.id) {
       return res.status(403).json({ error: 'Access Denied: You do not own or are not assigned to this order.' });
     }
-    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'customer_id, driver_id, order_display_id');
-    orderValidationService.assertOrderFound(order);
-    orderValidationService.assertOrderAccess(order, req.user);
 
     const timeline = await orderTimelineService.getOrderTimeline(order.order_display_id);
     res.json(timeline);


### PR DESCRIPTION
## Description

Removed duplicate `const order` redeclaration in the timeline handler of `orderRoutes.js`. The variable was already declared as `let order` on line 489 but a `const order` redeclaration appeared later, causing SyntaxError at server startup. The duplicate code was leftover dead validation logic.

Closes #3299

GSSoC