### PR TITLE
fix: resolve merge conflicts in orderRepository.js

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -61,24 +61,6 @@ export class OrderRepository {
       .select(columns)
       .eq('id', id)
       .maybeSingle(), 'findOrderById');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findOrderByDisplayId(displayId, columns = '*') {
-    return this._retryableQuery(() => this.supabase
-      .from('orders')
-      .select(columns)
-      .eq('order_display_id', displayId)
-      .maybeSingle(), 'findOrderByDisplayId');
-    return this._cachedQuery(`order:id:${id}:${columns}`, () =>
-      this.supabase
-        .from('orders')
-        .select(columns)
-        .eq('id', id)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findOrderByDisplayId(displayId, columns = '*') {
@@ -132,24 +114,6 @@ export class OrderRepository {
       .select('customer_id, driver_id, order_display_id')
       .eq('id', id)
       .maybeSingle(), 'findOrderForTimeline');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findOrderByDisplayForTimeline(displayId) {
-    return this._retryableQuery(() => this.supabase
-      .from('orders')
-      .select('customer_id, driver_id, order_display_id')
-      .eq('order_display_id', displayId)
-      .maybeSingle(), 'findOrderByDisplayForTimeline');
-    return this._cachedQuery(`order:timeline:${id}`, () =>
-      this.supabase
-        .from('orders')
-        .select('customer_id, driver_id, order_display_id')
-        .eq('id', id)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findOrderByDisplayForTimeline(displayId) {
@@ -240,24 +204,6 @@ export class OrderRepository {
       .select('milestone, milestone_time, completed, sort_order')
       .eq('order_display_id', orderDisplayId)
       .order('sort_order', { ascending: true }), 'getTimeline');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async getTimelineWithSortCheck(orderDisplayId) {
-    return this._retryableQuery(() => this.supabase
-      .from('order_timeline')
-      .select('milestone, sort_order, completed')
-      .eq('order_display_id', orderDisplayId)
-      .order('sort_order', { ascending: true }), 'getTimelineWithSortCheck');
-    return this._cachedQuery(`timeline:${orderDisplayId}`, () =>
-      this.supabase
-        .from('order_timeline')
-        .select('milestone, milestone_time, completed, sort_order')
-        .eq('order_display_id', orderDisplayId)
-        .order('sort_order', { ascending: true })
-    );
-=======
->>>>>>> main
   }
 
   async getTimelineWithSortCheck(orderDisplayId) {
@@ -305,24 +251,6 @@ export class OrderRepository {
       .select(columns)
       .eq('id', id)
       .maybeSingle(), 'findLoadOfferById');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findLoadOfferByOrderDisplayId(displayId) {
-    return this._retryableQuery(() => this.supabase
-      .from('load_offers')
-      .select('id')
-      .eq('order_display_id', displayId)
-      .maybeSingle(), 'findLoadOfferByOrderDisplayId');
-    return this._cachedQuery(`load_offer:id:${id}:${columns}`, () =>
-      this.supabase
-        .from('load_offers')
-        .select(columns)
-        .eq('id', id)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findLoadOfferByOrderDisplayId(displayId) {
@@ -382,16 +310,6 @@ export class OrderRepository {
       .select('*')
       .eq('id', id)
       .maybeSingle(), 'findBidById');
-<<<<<<< feature/dependency-injection-services
-    return this._cachedQuery(`bid:${id}`, () =>
-      this.supabase
-        .from('load_bids')
-        .select('*')
-        .eq('id', id)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findBidsByLoad(loadId, status, options = {}) {
@@ -466,32 +384,6 @@ export class OrderRepository {
       .select(columns)
       .eq('id', userId)
       .maybeSingle(), 'findProfile');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findCustomerWallet(userId) {
-    return this._retryableQuery(() => this.supabase
-      .from('profiles')
-      .select('polygon_wallet_address')
-      .eq('id', userId)
-      .maybeSingle(), 'findCustomerWallet');
-  }
-
-  async findProfileWallet(userId) {
-    return this._retryableQuery(() => this.supabase
-      .from('profiles')
-      .select('polygon_wallet_address')
-      .eq('id', userId)
-      .maybeSingle(), 'findProfileWallet');
-    return this._cachedQuery(`profile:${userId}:${columns}`, () =>
-      this.supabase
-        .from('profiles')
-        .select(columns)
-        .eq('id', userId)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findCustomerWallet(userId) {
@@ -520,16 +412,6 @@ export class OrderRepository {
       .select(columns)
       .eq('user_id', userId)
       .maybeSingle(), 'findDriverDetail');
-<<<<<<< feature/dependency-injection-services
-    return this._cachedQuery(`driver:detail:${userId}:${columns}`, () =>
-      this.supabase
-        .from('driver_details')
-        .select(columns)
-        .eq('user_id', userId)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findDriverDetails(userIds) {
@@ -545,32 +427,6 @@ export class OrderRepository {
       .select('truck_id')
       .eq('user_id', userId)
       .maybeSingle(), 'findDriverDetailMinimal');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findDriverWallet(userId) {
-    return this._retryableQuery(() => this.supabase
-      .from('driver_details')
-      .select('polygon_wallet_address')
-      .eq('user_id', userId)
-      .maybeSingle(), 'findDriverWallet');
-  }
-
-  async findDriverDetailWithRating(userId) {
-    return this._retryableQuery(() => this.supabase
-      .from('driver_details')
-      .select('rating, truck_id')
-      .eq('user_id', userId)
-      .maybeSingle(), 'findDriverDetailWithRating');
-    return this._cachedQuery(`driver:minimal:${userId}`, () =>
-      this.supabase
-        .from('driver_details')
-        .select('truck_id')
-        .eq('user_id', userId)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findDriverWallet(userId) {
@@ -599,24 +455,6 @@ export class OrderRepository {
       .select(columns)
       .eq('id', id)
       .maybeSingle(), 'findTruckById');
-<<<<<<< feature/dependency-injection-services
-  }
-
-  async findTruckWithDetails(id) {
-    return this._retryableQuery(() => this.supabase
-      .from('trucks')
-      .select('id, name, number_plate')
-      .eq('id', id)
-      .maybeSingle(), 'findTruckWithDetails');
-    return this._cachedQuery(`truck:${id}:${columns}`, () =>
-      this.supabase
-        .from('trucks')
-        .select(columns)
-        .eq('id', id)
-        .maybeSingle()
-    );
-=======
->>>>>>> main
   }
 
   async findTruckWithDetails(id) {


### PR DESCRIPTION
## Description

Resolved 9 merge conflicts in `orderRepository.js` between `feature/dependency-injection-services` and `main`. All conflicts followed the same pattern where the feature branch added `_cachedQuery` wrappers with unreachable duplicate returns. Kept `main` versions using only `_retryableQuery`.

## Conflicts resolved
1. `findOrderById`
2. `findOrderForTimeline`
3. `getTimeline`
4. `findLoadOfferById`
5. `findBidById`
6. `findProfile`
7. `findDriverDetail`
8. `findDriverDetailMinimal`
9. `findTruckById`

Closes #3301

GSSoC