### PR TITLE
fix: replace non-existent standalone imports with DeliveryVerificationService instance

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1,11 +1,6 @@
 import crypto from 'crypto';
 import { DomainError } from './bidAcceptanceService.js';
-import {
-  verifyDelivery,
-  generateDeliveryOtp,
-  resendDeliveryOtp,
-  sendOtpNotification,
-} from './deliveryVerificationService.js';
+import { DeliveryVerificationService } from './deliveryVerificationService.js';
 import { expireDeliveryOtps } from '../notificationService.js';
 import { acquireLock, releaseLock } from '../../lib/redisLock.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
@@ -36,6 +31,7 @@ export class OrderLifecycleService {
     this.orderRepository = orderRepository;
     this.orderTimelineService = orderTimelineService;
     this.bidAcceptanceService = bidAcceptanceService;
+    this.deliveryVerification = new DeliveryVerificationService(orderRepository);
   }
 
   async createOrder(customerId, customerName, body) {
@@ -396,7 +392,7 @@ export class OrderLifecycleService {
     let generatedOtp = null;
 
     if (milestone === 'In Transit') {
-      const result = await generateDeliveryOtp({ orderId });
+      const result = await this.deliveryVerification.generateDeliveryOtp({ orderId });
       generatedOtp = result.otp;
     }
 
@@ -410,7 +406,7 @@ export class OrderLifecycleService {
     }
 
     if (generatedOtp) {
-      await sendOtpNotification({
+      await this.deliveryVerification.sendOtpNotification({
         orderId,
         customerId: order.customer_id,
         orderDisplayId: order.order_display_id,
@@ -424,7 +420,7 @@ export class OrderLifecycleService {
 
   async verifyDeliveryFn(orderId, driverId, otp) {
     return measureExecution('OrderLifecycleService.verifyDeliveryFn', () =>
-      verifyDelivery({ orderId, driverId, otp })
+      this.deliveryVerification.verifyDelivery({ orderId, driverId, otp })
     );
   }
 
@@ -434,7 +430,7 @@ export class OrderLifecycleService {
     if (orderErr || !order) throw new DomainError(404, { error: 'Order not found.' });
     if (order.driver_id !== driverId) throw new DomainError(403, { error: 'Access Denied: You are not assigned to this order.' });
 
-    const { expiresInMinutes } = await resendDeliveryOtp({
+    const { expiresInMinutes } = await this.deliveryVerification.resendDeliveryOtp({
       orderId,
       customerId: order.customer_id,
       orderDisplayId: order.order_display_id,


### PR DESCRIPTION
## Description

`orderLifecycleService.js` imported `sendOtpNotification`, `verifyDelivery`, `generateDeliveryOtp`, and `resendDeliveryOtp` as standalone functions from `deliveryVerificationService.js`, but that file only exports the `DeliveryVerificationService` class. The import destructured `undefined` values, causing `TypeError: sendOtpNotification is not a function` when the "In Transit" milestone is triggered.

## Changes
- Import `DeliveryVerificationService` class instead of non-existent standalone functions
- Instantiate `DeliveryVerificationService` with `orderRepository` in constructor
- Call methods as `this.deliveryVerificationService.sendOtpNotification(...)` etc.
- All four call sites updated to use the instance method pattern

## Testing
- `updateMilestone` no longer crashes on "In Transit" milestone
- Delivery OTP generation, verification, resend, and notification all work correctly

Closes #3304

GSSoC