### PR TITLE
fix: resolve merge conflict in OrderMilestoneService imports

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
+import { supabase } from '../../config/db.js';
 import {
   sendDeliveryOtpNotification,
   storeDeliveryOtp,
@@ -17,13 +18,10 @@ import {
 } from './orderNotificationService.js';
 import { escrowRelease } from '../escrow.js';
 import { DomainError } from './domainError.js';
-<<<<<<< feature/dependency-injection-services
-=======
 import { OrderTimelineService } from './orderTimelineService.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const orderTimelineService = new OrderTimelineService({ supabase, logger });
->>>>>>> main
 
 export class OrderMilestoneService {
   constructor(args = {}) {


### PR DESCRIPTION
## Description

Resolved merge conflict in `orderMilestoneService.js`. The `main` branch's import for `orderTimelineService` was clobbered by the `feature/dependency-injection-services` branch. Also added missing `supabase` import that was referenced but never imported.

## Changes
- Fixed imports: kept `orderTimelineService` from `main`, added `supabase` import
- Both were needed for the module to function correctly

Closes #3225

GSSoC