### PR TITLE
fix: correct typo currentOrder to _currentOrder in order_detail_screen.dart

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -428,7 +428,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                   dimensions: '12 × 6 × 6',
                   stacked: true,
                   fragile: false,
-                  requirements: currentOrder.specialRequirements != null && _cgit pull upstream mainurrentOrder.specialRequirements!.isNotEmpty
+                  requirements: _currentOrder.specialRequirements != null && _currentOrder.specialRequirements!.isNotEmpty
           ? [_currentOrder.specialRequirements!]
           : const [],
                 ),


### PR DESCRIPTION
## Description

Fixed typo `currentOrder` → `_currentOrder` in `order_detail_screen.dart`. The private field `_currentOrder` was declared but a method reference used `currentOrder` (missing underscore), causing a compile error. Also removed a stray git conflict marker (`>>>>>>>`).

## Changes
- Changed `currentOrder` to `_currentOrder` in method reference
- Removed stray `>>>>>>>` git conflict marker

Closes #3227

GSSoC