### PR TITLE
fix: correct Goods Loaded milestone mapping from in_transit to picked_up

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -359,7 +359,7 @@ export class OrderLifecycleService {
     return measureExecution('OrderLifecycleService.updateMilestone', async () => {
     const milestoneMap = {
       'Arrived at Pickup': 'at_pickup',
-      'Goods Loaded': 'in_transit',
+      'Goods Loaded': 'picked_up',
       'In Transit': 'in_transit',
       'Arriving': 'arriving',
       'Arrived at Drop-off': 'at_dropoff',


### PR DESCRIPTION
## Description

Corrected the "Goods Loaded" milestone mapping in `orderLifecycleService.js`. The milestone was incorrectly mapped to `in_transit` status — it should map to `picked_up` since goods being loaded onto the vehicle is a pick-up event, not the start of transit.

## Changes
- Changed `"Goods Loaded": "in_transit"` to `"Goods Loaded": "picked_up"`

Closes #3228

GSSoC