### PR TITLE
fix(api): protect WebRTC routes

### DIFF
--- a/backend/api/src/routes/webrtcRoutes.js
+++ b/backend/api/src/routes/webrtcRoutes.js
@@ -1,10 +1,13 @@
 import express from 'express';
 import { getWebRTCSignaling } from '../sockets/webrtc.js';
+import { authenticate } from '../middleware/auth.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
 // Get WebRTC stats
-router.get('/webrtc/stats', (req, res) => {
+router.get('/webrtc/stats', authenticate, userLimiter, requirePolicy('webrtc:view-stats'), (req, res) => {
   const signaling = getWebRTCSignaling();
   if (!signaling) {
     return res.status(503).json({
@@ -19,7 +22,7 @@ router.get('/webrtc/stats', (req, res) => {
 });
 
 // Get nearby peers
-router.get('/webrtc/nearby', async (req, res) => {
+router.get('/webrtc/nearby', authenticate, userLimiter, requirePolicy('webrtc:view-nearby'), async (req, res) => {
   try {
     const { lat, lng, radius } = req.query;
     if (!lat || !lng) {
@@ -57,7 +60,7 @@ router.get('/webrtc/nearby', async (req, res) => {
 });
 
 // Get offline GPS data
-router.get('/webrtc/offline/:peerId', async (req, res) => {
+router.get('/webrtc/offline/:peerId', authenticate, userLimiter, requirePolicy('webrtc:view-offline'), async (req, res) => {
   try {
     const { peerId } = req.params;
     const { since } = req.query;
@@ -84,7 +87,7 @@ router.get('/webrtc/offline/:peerId', async (req, res) => {
 });
 
 // Sync offline data
-router.post('/webrtc/sync/:peerId', async (req, res) => {
+router.post('/webrtc/sync/:peerId', authenticate, userLimiter, requirePolicy('webrtc:sync-offline'), async (req, res) => {
   try {
     const { peerId } = req.params;
 

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -83,6 +83,11 @@ const POLICIES = {
   'device:register':           {},
   'device:unregister':         {},
   'device:view-platforms':     {},
+
+  'webrtc:view-stats':         { roles: [ROLES.ADMIN] },
+  'webrtc:view-nearby':        { roles: [ROLES.DRIVER, ROLES.ADMIN] },
+  'webrtc:view-offline':       { roles: [ROLES.DRIVER, ROLES.ADMIN] },
+  'webrtc:sync-offline':       { roles: [ROLES.DRIVER, ROLES.ADMIN] },
 };
 
 export class PolicyEngine {


### PR DESCRIPTION
## Summary
- require authentication on WebRTC HTTP routes
- add policy checks for stats, nearby peers, offline data, and sync operations
- register WebRTC policy actions in the policy engine

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Secured WebRTC endpoints with authentication and per-user rate limiting.
  * Added role-based access controls for viewing statistics, finding nearby peers, offline connections, and synchronization.
  * Restricted WebRTC statistics to administrators and other actions to authorized drivers and administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->