### PR TITLE
fix(api): enforce WebRTC mesh relay boundary

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -130,8 +130,20 @@ class WebRTCSignalingServer {
 
   async relayWebRTCMessage(fromPeerId, message) {
     const { targetPeerId, data } = message;
+    const sourcePeer = this.peers.get(fromPeerId);
     const targetPeer = this.peers.get(targetPeerId);
-    if (targetPeer && targetPeer.ws.readyState === 1) {
+
+    if (!sourcePeer || !targetPeer) {
+      logger.warn(`WebRTC relay blocked for missing peer: ${fromPeerId} -> ${targetPeerId}`);
+      return;
+    }
+
+    if (sourcePeer.meshId !== targetPeer.meshId) {
+      logger.warn(`WebRTC relay blocked across meshes: ${fromPeerId} -> ${targetPeerId}`);
+      return;
+    }
+
+    if (targetPeer.ws.readyState === 1) {
       this.sendToPeer(targetPeerId, {
         ...data,
         fromPeerId


### PR DESCRIPTION
## Summary
- require both signaling peers to exist before forwarding relay messages
- block WebRTC relay attempts when source and target peers belong to different meshes
- keep valid same-mesh relay behavior unchanged

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3345
