### PR TITLE
fix(api): protect fraud routes

### DIFF
--- a/backend/api/src/routes/fraudRoutes.js
+++ b/backend/api/src/routes/fraudRoutes.js
@@ -2,11 +2,13 @@ import express from 'express';
 import fraudDetection from '../services/fraud/FraudDetectionService.js';
 import { fraudDetectionMiddleware } from '../middleware/fraudMiddleware.js';
 import { authenticate } from '../middleware/auth.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
 // Get fraud stats
-router.get('/fraud/stats', authenticate, async (req, res) => {
+router.get('/fraud/stats', authenticate, userLimiter, requirePolicy('fraud:view-stats'), async (req, res) => {
   try {
     const stats = await fraudDetection.getFraudStats();
     res.json({
@@ -22,7 +24,7 @@ router.get('/fraud/stats', authenticate, async (req, res) => {
 });
 
 // Get user risk score
-router.get('/fraud/risk/:userId', authenticate, async (req, res) => {
+router.get('/fraud/risk/:userId', authenticate, userLimiter, requirePolicy('fraud:view-risk'), async (req, res) => {
   try {
     const { userId } = req.params;
     const profile = await fraudDetection.getOrCreateProfile(userId);
@@ -47,7 +49,7 @@ router.get('/fraud/risk/:userId', authenticate, async (req, res) => {
 });
 
 // Get review queue
-router.get('/fraud/review-queue', authenticate, async (req, res) => {
+router.get('/fraud/review-queue', authenticate, userLimiter, requirePolicy('fraud:manage-review'), async (req, res) => {
   try {
     const queue = await fraudDetection.getReviewQueue(50);
     res.json({
@@ -64,7 +66,7 @@ router.get('/fraud/review-queue', authenticate, async (req, res) => {
 });
 
 // Resolve review
-router.post('/fraud/review/:reviewId/resolve', authenticate, async (req, res) => {
+router.post('/fraud/review/:reviewId/resolve', authenticate, userLimiter, requirePolicy('fraud:manage-review'), async (req, res) => {
   try {
     const { reviewId } = req.params;
     const { action, notes } = req.body;
@@ -83,7 +85,7 @@ router.post('/fraud/review/:reviewId/resolve', authenticate, async (req, res) =>
 });
 
 // Track behavior (for client reporting)
-router.post('/fraud/track', authenticate, fraudDetectionMiddleware, async (req, res) => {
+router.post('/fraud/track', authenticate, userLimiter, requirePolicy('fraud:track'), fraudDetectionMiddleware, async (req, res) => {
   try {
     const { userId: bodyUserId, eventType, data } = req.body;
     const userId = req.user.id;
@@ -113,7 +115,7 @@ router.post('/fraud/track', authenticate, fraudDetectionMiddleware, async (req, 
 });
 
 // Analyze network (for manual trigger)
-router.post('/fraud/analyze-network/:userId', authenticate, async (req, res) => {
+router.post('/fraud/analyze-network/:userId', authenticate, userLimiter, requirePolicy('fraud:analyze-network'), async (req, res) => {
   try {
     const { userId } = req.params;
     const result = await fraudDetection.analyzeNetwork(userId);

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -80,6 +80,12 @@ const POLICIES = {
   'shard:view':                { roles: [ROLES.ADMIN] },
   'shard:query-orders':        { roles: [ROLES.ADMIN] },
 
+  'fraud:view-stats':          { roles: [ROLES.ADMIN] },
+  'fraud:view-risk':           { roles: [ROLES.ADMIN] },
+  'fraud:manage-review':       { roles: [ROLES.ADMIN] },
+  'fraud:track':               {},
+  'fraud:analyze-network':     { roles: [ROLES.ADMIN] },
+
   'trip:sync-events':          {},
   'trip:view-events':          { ownership: (u, r) => r?.trip && (u.role === ROLES.ADMIN || r.trip.driver_id === u.id || r.trip.customer_id === u.id) },
 


### PR DESCRIPTION
## Summary
- add authentication and per-user rate limiting to fraud management endpoints
- gate fraud statistics, risk lookup, review, tracking, and analysis routes with policies
- register fraud policy actions for existing role-based authorization

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3347
