### PR TITLE
fix(api): use authenticated user in fraud middleware

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -3,7 +3,7 @@ import logger from './logger.js';
 
 export const fraudDetectionMiddleware = async (req, res, next) => {
   try {
-    const userId = req.user?.id || req.headers['x-user-id'];
+    const userId = req.user?.id;
     if (!userId) {
       return next();
     }
@@ -66,7 +66,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
 
 export const networkAnalysisMiddleware = async (req, res, next) => {
   try {
-    const userId = req.user?.id || req.headers['x-user-id'];
+    const userId = req.user?.id;
     if (!userId) {
       return next();
     }


### PR DESCRIPTION
## Summary
- remove direct header fallback identity from fraud detection middleware
- remove direct header fallback identity from network analysis middleware
- keep unauthenticated requests as pass-through when no request user is present

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3348
