### PR TITLE
fix(api): handle empty fraud connection lookups

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -245,16 +245,25 @@ class FraudDetectionService {
 
   async getUserConnections(userId) {
     // Get all connections (orders, trips, shared routes)
-    const { data: orders } = await supabase
+    const { data: orders, error } = await supabase
       .from('orders')
       .select('customer_id, driver_id')
       .or(`customer_id.eq.${userId},driver_id.eq.${userId}`);
 
+    if (error) {
+      logger.error('Failed to load user fraud connections:', error);
+      return [];
+    }
+
+    if (!Array.isArray(orders)) {
+      return [];
+    }
+
     const connections = new Set();
     orders.forEach(order => {
-      if (order.customer_id === userId) {
+      if (order.customer_id === userId && order.driver_id) {
         connections.add(order.driver_id);
-      } else if (order.driver_id === userId) {
+      } else if (order.driver_id === userId && order.customer_id) {
         connections.add(order.customer_id);
       }
     });


### PR DESCRIPTION
## Summary
- handle failed order lookups when building fraud connection graphs
- return an empty connection list when the query result is not an array
- skip missing customer or driver ids while collecting connections

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3349
