### PR TITLE
fix(shared): isolate platform HTTP client imports

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -5,11 +5,10 @@ import 'dart:developer' as developer;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'dart:io';
-import 'package:http/io_client.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../config/app_config.dart';
+import 'http_client_factory.dart';
 
 /// Exception thrown when an API request fails after token refresh.
 class ApiAuthException implements Exception {
@@ -44,16 +43,6 @@ class ApiException implements Exception {
 /// final data = await client.get('/api/orders');
 /// ```
 class ApiClient {
-  static http.Client _createPinnedClient() {
-    if (kIsWeb) return http.Client();
-    final securityContext = SecurityContext(withTrustedRoots: true);
-    final ioClient = HttpClient(context: securityContext)
-      ..badCertificateCallback = (X509Certificate cert, String host, int port) {
-        return false;
-      };
-    return IOClient(ioClient);
-  }
-
   ApiClient({
     SupabaseClient? supabaseClient,
     http.Client? httpClient,
@@ -61,7 +50,7 @@ class ApiClient {
     Duration? timeout,
   })  : _providedSupabase = supabaseClient,
         _isClientOwned = httpClient == null,
-        _http = httpClient ?? _createPinnedClient(),
+        _http = httpClient ?? createHttpClient(),
         _baseUrl = _normalise(_getBaseUrl(baseUrl)),
         _timeout = timeout ?? AppConfig.apiTimeout;
 

--- a/packages/truxify_shared/lib/src/services/http_client_factory.dart
+++ b/packages/truxify_shared/lib/src/services/http_client_factory.dart
@@ -1,0 +1,3 @@
+export 'http_client_factory_stub.dart'
+    if (dart.library.io) 'http_client_factory_io.dart'
+    if (dart.library.html) 'http_client_factory_web.dart';

--- a/packages/truxify_shared/lib/src/services/http_client_factory_io.dart
+++ b/packages/truxify_shared/lib/src/services/http_client_factory_io.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+http.Client createHttpClient() {
+  final securityContext = SecurityContext(withTrustedRoots: true);
+  final ioClient = HttpClient(context: securityContext)
+    ..badCertificateCallback = (X509Certificate cert, String host, int port) {
+      return false;
+    };
+  return IOClient(ioClient);
+}

--- a/packages/truxify_shared/lib/src/services/http_client_factory_stub.dart
+++ b/packages/truxify_shared/lib/src/services/http_client_factory_stub.dart
@@ -1,0 +1,3 @@
+import 'package:http/http.dart' as http;
+
+http.Client createHttpClient() => http.Client();

--- a/packages/truxify_shared/lib/src/services/http_client_factory_web.dart
+++ b/packages/truxify_shared/lib/src/services/http_client_factory_web.dart
@@ -1,0 +1,3 @@
+import 'package:http/http.dart' as http;
+
+http.Client createHttpClient() => http.Client();


### PR DESCRIPTION
## Summary
- move platform-specific HTTP client creation behind conditional exports
- keep the shared API client free of direct IO-only imports
- preserve the pinned IO client behavior for non-web builds

## Validation
- `git diff --check`
- Flutter SDK is unavailable locally, so Flutter tests could not be run here

Closes #3350
