### PR TITLE
fix(api): validate profile pagination query values

### DIFF
--- a/backend/api/src/schemas/profile.js
+++ b/backend/api/src/schemas/profile.js
@@ -16,6 +16,8 @@ export const profileQuerySchema = z.object({
   role: z.enum(['customer', 'driver', 'admin']).optional(),
   is_active: z.string().transform(v => v === 'true').optional(),
   search: z.string().max(100).optional(),
-  page: z.string().transform(v => Math.max(1, parseInt(v) || 1)).optional(),
-  limit: z.string().transform(v => Math.min(100, Math.max(1, parseInt(v) || 20))).optional(),
+  page: z.string().regex(/^\d+$/, 'page must be a positive integer')
+    .transform(v => Math.max(1, Number(v))).optional(),
+  limit: z.string().regex(/^\d+$/, 'limit must be a positive integer')
+    .transform(v => Math.min(100, Math.max(1, Number(v)))).optional(),
 });


### PR DESCRIPTION
## Summary
- reject malformed profile pagination query values before transformation
- keep positive integer values normalized for downstream query handling
- avoid partial integer parsing for page and limit

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3368
