### PR TITLE
fix(api): validate shard middleware coordinates

### DIFF
--- a/backend/api/src/middleware/shardMiddleware.js
+++ b/backend/api/src/middleware/shardMiddleware.js
@@ -1,13 +1,47 @@
 import shardManager from '../services/sharding/ShardManager.js';
 import logger from './logger.js';
 
+function firstDefined(...values) {
+  return values.find(value => value !== undefined && value !== null && value !== '');
+}
+
+function parseCoordinate(value) {
+  if (value === undefined) return null;
+  if (Array.isArray(value)) return { error: 'coordinate must be a single value' };
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return { error: 'coordinate must be a finite number' };
+  return { value: parsed };
+}
+
+function validateCoordinateRange(lat, lng) {
+  if (lat < -90 || lat > 90) return 'lat must be between -90 and 90';
+  if (lng < -180 || lng > 180) return 'lng must be between -180 and 180';
+  return null;
+}
+
 export const shardMiddleware = async (req, res, next) => {
   try {
     // Extract location from request
-    const lat = parseFloat(req.query.lat) || parseFloat(req.body.lat) || null;
-    const lng = parseFloat(req.query.lng) || parseFloat(req.body.lng) || null;
+    const rawLat = firstDefined(req.query.lat, req.body?.lat);
+    const rawLng = firstDefined(req.query.lng, req.body?.lng);
 
-    if (lat && lng) {
+    if (rawLat !== undefined || rawLng !== undefined) {
+      const parsedLat = parseCoordinate(rawLat);
+      const parsedLng = parseCoordinate(rawLng);
+
+      if (rawLat === undefined || rawLng === undefined || parsedLat.error || parsedLng.error) {
+        return res.status(400).json({
+          error: parsedLat.error || parsedLng.error || 'lat and lng are both required when routing by location'
+        });
+      }
+
+      const lat = parsedLat.value;
+      const lng = parsedLng.value;
+      const rangeError = validateCoordinateRange(lat, lng);
+      if (rangeError) {
+        return res.status(400).json({ error: rangeError });
+      }
+
       const shardName = shardManager.getShardForLocation(lat, lng);
       req.shard = shardName;
       req.shardConnection = await shardManager.getShardConnection(shardName);


### PR DESCRIPTION
## Summary
- parse shard routing coordinates without dropping valid zero values
- reject malformed or partial coordinate input with a client error
- enforce latitude and longitude ranges before selecting a shard

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3370
