### PR TITLE
fix(api): validate shard location coordinates

### DIFF
--- a/backend/api/src/routes/shardRoutes.js
+++ b/backend/api/src/routes/shardRoutes.js
@@ -4,6 +4,26 @@ import { shardMiddleware, crossShardQuery } from '../middleware/shardMiddleware.
 
 const router = express.Router();
 
+function parseCoordinate(value, field) {
+  if (value === undefined || value === null || value === '') {
+    return { error: `${field} required` };
+  }
+  if (Array.isArray(value)) {
+    return { error: `${field} must be a single value` };
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return { error: `${field} must be a finite number` };
+  }
+  return { value: parsed };
+}
+
+function validateCoordinateRange(lat, lng) {
+  if (lat < -90 || lat > 90) return 'lat must be between -90 and 90';
+  if (lng < -180 || lng > 180) return 'lng must be between -180 and 180';
+  return null;
+}
+
 // Get shard status
 router.get('/shards/status', async (req, res) => {
   try {
@@ -25,22 +45,33 @@ router.get('/shards/status', async (req, res) => {
 router.get('/shards/location', async (req, res) => {
   try {
     const { lat, lng } = req.query;
-    if (!lat || !lng) {
+    const parsedLat = parseCoordinate(lat, 'lat');
+    const parsedLng = parseCoordinate(lng, 'lng');
+
+    if (parsedLat.error || parsedLng.error) {
       return res.status(400).json({
         success: false,
-        error: 'lat and lng required'
+        error: parsedLat.error || parsedLng.error
       });
     }
+    const rangeError = validateCoordinateRange(parsedLat.value, parsedLng.value);
+    if (rangeError) {
+      return res.status(400).json({
+        success: false,
+        error: rangeError
+      });
+    }
+
     const shardName = shardManager.getShardForLocation(
-      parseFloat(lat),
-      parseFloat(lng)
+      parsedLat.value,
+      parsedLng.value
     );
     res.json({
       success: true,
       data: {
         shard: shardName,
-        lat: parseFloat(lat),
-        lng: parseFloat(lng)
+        lat: parsedLat.value,
+        lng: parsedLng.value
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- validate shard location query coordinates before lookup
- reject arrays, missing values, non-finite numbers, and out-of-range coordinates
- reuse parsed numeric coordinates in the shard response

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3371
