### PR TITLE
fix(shared): validate FAQ response shape

### DIFF
--- a/packages/truxify_shared/lib/src/repositories/faq_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/faq_repository.dart
@@ -13,9 +13,15 @@ class FaqRepository {
         .select()
         .eq('is_active', true)
         .order('sort_order');
-    final List<Map<String, dynamic>> rows = response is List
-        ? List<Map<String, dynamic>>.from(response)
-        : <Map<String, dynamic>>[];
+    if (response is! List) {
+      throw StateError('Unexpected FAQ response type');
+    }
+
+    final rows = response.map((item) {
+      if (item is Map<String, dynamic>) return item;
+      if (item is Map) return Map<String, dynamic>.from(item);
+      throw StateError('Unexpected FAQ item type');
+    }).toList(growable: false);
     return rows
         .map(Faq.fromMap)
         .where((faq) => faq.appType == 'both' || faq.appType == appType)


### PR DESCRIPTION
## Summary
- reject non-list FAQ responses instead of returning an empty list
- validate FAQ rows before mapping them into models
- keep valid empty responses supported as empty lists

## Validation
- `git diff --check`
- Flutter SDK is unavailable locally, so Flutter tests could not be run here

Closes #3373
