### PR TITLE
fix(customer): validate active orders response shape

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -172,8 +172,14 @@ class OrderService {
       final body = await _apiClient.get(
         '/api/orders/my/active',
       );
-      if (body is! List) return <Map<String, dynamic>>[];
-      return List<Map<String, dynamic>>.from(body);
+      if (body is! List) {
+        throw StateError('Unexpected active orders response type');
+      }
+      return body.map((item) {
+        if (item is Map<String, dynamic>) return item;
+        if (item is Map) return Map<String, dynamic>.from(item);
+        throw StateError('Unexpected active order item type');
+      }).toList(growable: false);
     } on ApiException catch (e) {
       throw StateError(e.message);
     } catch (e) {


### PR DESCRIPTION
## Summary
- reject non-list active order responses from the API
- validate each active order row before converting it to a map
- keep valid empty active-order responses as empty lists

## Validation
- `git diff --check`
- Flutter SDK is unavailable locally, so Flutter tests could not be run here

Closes #3374
