### PR TITLE
fix(driver): validate today earnings response shape

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -187,10 +187,14 @@ class DriverEarningsService {
     try {
       final decoded = await _apiClient.get(path);
       
-      if (decoded is! List) return null;
+      if (decoded is! List) {
+        throw StateError('Unexpected earnings summary response type');
+      }
 
       for (final entry in decoded) {
-        if (entry is! Map) continue;
+        if (entry is! Map) {
+          throw StateError('Unexpected earnings summary item type');
+        }
         final dateStr = entry['day_date']?.toString();
         if (dateStr == dayStr) {
           return EarningsDailyModel.fromMap(Map<String, dynamic>.from(entry));
@@ -199,6 +203,9 @@ class DriverEarningsService {
 
       return null;
     } catch (e) {
+      if (e is StateError) {
+        throw Exception(e.message);
+      }
       if (e is ApiException) {
         throw Exception(e.message.isNotEmpty ? e.message : 'Failed to load today\'s earnings.');
       }


### PR DESCRIPTION
## Summary
- reject non-list earnings summary responses for today
- validate each summary item before reading the day data
- keep null only for the valid case where no summary row matches today

## Validation
- `git diff --check`
- Flutter SDK is unavailable locally, so Flutter tests could not be run here

Closes #3375
