### PR TITLE
fix(api): use request user for fraud tracking

### DIFF
--- a/backend/api/src/routes/fraudRoutes.js
+++ b/backend/api/src/routes/fraudRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import fraudDetection from '../services/fraud/FraudDetectionService.js';
 import { fraudDetectionMiddleware } from '../middleware/fraudMiddleware.js';
+import { authenticate } from '../middleware/auth.js';
 
 const router = express.Router();
 
@@ -82,12 +83,21 @@ router.post('/fraud/review/:reviewId/resolve', async (req, res) => {
 });
 
 // Track behavior (for client reporting)
-router.post('/fraud/track', fraudDetectionMiddleware, async (req, res) => {
+router.post('/fraud/track', authenticate, fraudDetectionMiddleware, async (req, res) => {
   try {
-    const { userId, eventType, data } = req.body;
+    const { userId: bodyUserId, eventType, data } = req.body;
+    const userId = req.user.id;
+
+    if (bodyUserId && bodyUserId !== userId) {
+      return res.status(400).json({
+        success: false,
+        error: 'userId must match the authenticated user'
+      });
+    }
+
     const result = await fraudDetection.trackBehavior(userId, {
       type: eventType,
-      ...data
+      ...(data && typeof data === 'object' && !Array.isArray(data) ? data : {})
     });
     
     res.json({


### PR DESCRIPTION
## Summary
- authenticate fraud tracking requests before recording behavior
- use the request user id instead of trusting the body userId
- reject mismatched body userId values while preserving optional event data

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests could not be run here

Closes #3377
