### PR TITLE
fix: replace out-of-scope buildResult with depositTx

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -87,7 +87,7 @@ export class BidAcceptanceService {
 
     // Guard against silent escrow disable: if buildDepositTx returned
     // null txData (contract not initialised), reject immediately.
-    if (!buildResult?.txData) {
+    if (!depositTx?.txData) {
       this.logger?.error?.('[escrow] Escrow deposit tx could not be built — escrow contract is not reachable or misconfigured.');
       throw new DomainError(502, {
         error: 'Escrow is not configured. Escrow deposit transaction could not be built.',


### PR DESCRIPTION
## Description

Fixed a `ReferenceError` in `bidAcceptanceService.js` where `buildResult` was used in the catch/finally blocks but was never declared or assigned before use. The variable was supposed to reference `depositTx`, which is declared in the outer scope and assigned inside the try block.

**Changes:**
- Replaced `buildResult` with `depositTx` in the catch and finally blocks

Closes #3390

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when accepting bids by reliably checking the stored escrow transaction data.
  * Preserved existing error handling and logging for unavailable or misconfigured escrow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->