### PR TITLE
fix: add missing closing brace in marketplace_repository dispose

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -34,6 +34,8 @@ class MarketplaceRepository {
 
   void dispose() {
     _apiClient.dispose();
+  }
+
   Future<String?> _firebaseAccessToken() async {
     try {
       return await FirebaseAuth.instance.currentUser?.getIdToken();


### PR DESCRIPTION
## Description

Added a missing closing brace `}` to the `dispose()` method in `marketplace_repository.dart`. The method was missing the closing brace for its function body, which could cause a syntax error or unexpected parsing behavior.

**Changes:**
- Added the missing `}` closing the `dispose()` method body

Closes #3391

GSSoC