### PR TITLE
fix: log actual FCM retry delay instead of misleading static value

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -103,8 +103,9 @@ export async function sendFcmNotification(userId, notification, data = {}) {
       }
 
       if (isTransientError(err.code) && attempt < MAX_RETRIES - 1) {
-        logger.info(`[FCM] Retrying after ${RETRY_DELAYS[attempt]}ms for user ${userId}`);
-        const delay = calculateRetryBackoff(attempt); await new Promise(resolve => setTimeout(resolve, delay));
+        const delay = calculateRetryBackoff(attempt);
+        logger.info(`[FCM] Retrying after ${delay}ms for user ${userId}`);
+        await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
   }


### PR DESCRIPTION
## Description

Fixed a misleading log statement in the FCM retry logic. The log claimed it was retrying after `${RETRY_DELAYS[attempt]}ms`, but the actual retry used a different value computed by `calculateRetryBackoff(attempt)`. The static `RETRY_DELAYS` array wasn't updated when the backoff strategy changed, so the log always showed stale values.

**Changes:**
- Moved `calculateRetryBackoff(attempt)` before the log call
- Changed the log message to use the actual computed delay (`${delay}ms`)

Closes #3393

GSSoC