### PR TITLE
fix: log warning when fraud check is skipped due to missing userId

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -5,6 +5,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
   try {
     const userId = req.user?.id;
     if (!userId) {
+      logger.warn('[Fraud] Skipping fraud check — no userId on request');
       return next();
     }
 
@@ -68,6 +69,7 @@ export const networkAnalysisMiddleware = async (req, res, next) => {
   try {
     const userId = req.user?.id;
     if (!userId) {
+      logger.warn('[Fraud] Skipping network analysis — no userId on request');
       return next();
     }
 


### PR DESCRIPTION
## Description

Added a warning log when `fraudDetectionMiddleware` or `networkAnalysisMiddleware` silently bypasses the fraud check due to a missing `userId` on the request. Previously, when `req.user?.id` was falsy, the middleware called `next()` without any indication, making it impossible to debug why fraud checks weren't running for certain requests.

**Changes:**
- Added `logger.warn(...)` call in both middleware functions before the `return next()` when `userId` is missing

Closes #3394

GSSoC