### PR TITLE
fix: add release-mode assertion to catch localhost in production

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -15,6 +15,15 @@ class LocationService {
     defaultValue: 'http://localhost:5000',
   );
 
+  static void _assertNotLocalhost() {
+    if (defaultApiBaseUrl.contains('localhost') && kReleaseMode) {
+      throw AssertionError(
+        'TRUXIFY_API_BASE_URL is still set to localhost in release mode. '
+        'Provide a production API URL via --dart-define=TRUXIFY_API_BASE_URL=...'
+      );
+    }
+  }
+
   WebSocketChannel? _channel;
   StreamSubscription<Position>? _positionSubscription;
   StreamSubscription? _socketSubscription;
@@ -43,6 +52,7 @@ class LocationService {
   bool get isTracking => _isTracking;
 
   Future<void> startTracking() async {
+    _assertNotLocalhost();
     if (_isTracking) return;
 
     // Check location permission before starting tracking (fixes #1491)


### PR DESCRIPTION
## Description

Added a release-mode assertion to `location_service.dart` to catch the default `localhost:5000` API URL in production builds. The `String.fromEnvironment` fallback silently defaults to localhost when `TRUXIFY_API_BASE_URL` is not provided via `--dart-define`, which is fine for development but dangerous in release builds.

**Changes:**
- Added `_assertNotLocalhost()` method that throws in `kReleaseMode` when the URL contains `localhost`
- Calls the assertion at the start of `startTracking()` to fail early

Closes #3396

GSSoC