### PR TITLE
fix: remove duplicate imports and nested route handler in supportRoutes

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -1,14 +1,11 @@
 import express from 'express';
 import { supabase } from '../config/db.js';
-import { authenticate, requireRole } from '../middleware/auth.js';
-import { userLimiter, adminRateLimiter } from '../middleware/rateLimiter.js';
 import { authenticate } from '../middleware/auth.js';
-import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateBody, validateParams } from '../middleware/validate.js';
 import logger from '../middleware/logger.js';
 import { createTicketSchema, updateTicketSchema, createTicketCommentSchema, paramIdSchema, uuidParamSchema } from '../validation/requestSchemas.js';
-
 
 const router = express.Router();
 
@@ -383,7 +380,6 @@ router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicke
 // ============================================================================
 // 7. LIST ALL TICKETS (ADMIN ONLY)
 // ============================================================================
-router.get('/admin/tickets', authenticate, adminRateLimiter, requireRole(['admin']), async (req, res) => {
 router.get('/admin/tickets', authenticate, userLimiter, requirePolicy('ticket:admin-view-all'), async (req, res) => {
   const { status, category, user_id, page = '1', limit = '20' } = req.query;
   const parsedPage = parsePositiveInteger(page, 1, 'page');


### PR DESCRIPTION
## Description

Fixed two issues in `supportRoutes.js`:

1. **Duplicate imports** — `authenticate` was imported from `auth.js` twice (lines 3 and 5), and `userLimiter` from `rateLimiter.js` twice (lines 4 and 7). These are likely artifacts of multiple merge commits stacking imports.

2. **Nested/duplicate route handler** — Two `router.get('/admin/tickets', ...)` declarations existed one after another (lines 386-387) with different authorization middleware (`requireRole` vs `requirePolicy`). The first declaration's callback was never closed, essentially nesting the second registration inside it and creating both a syntax issue and an unreachable handler.

**Changes:**
- Removed duplicate import lines
- Removed the redundant `router.get('/admin/tickets', authenticate, adminRateLimiter, requireRole(['admin']), ...)` declaration
- Cleaned up unused imports (`requireRole`, `adminRateLimiter`) from the import statements

Closes #3398

GSSoC