### PR TITLE
fix: remove duplicate route handler in profileRoutes

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -340,7 +340,6 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
 // Invalidates the profile cache for a specific user, forcing the next
 // authenticated request to refetch from Supabase. Use this after admin
 // operations that change role, status, or other cached profile fields.
-router.delete('/admin/cache/:userId', authenticate, adminRateLimiter, requireRole(['admin']), validateParams(uuidParamSchema), async (req, res) => {
 router.delete('/admin/cache/:userId', authenticate, userLimiter, requirePolicy('admin:invalidate-cache'), validateParams(z.object({ userId: z.string().min(1, 'userId is required') })), async (req, res) => {
   try {
     const targetUserId = req.params.userId;


### PR DESCRIPTION
## Description

Removed the duplicate `router.delete('/admin/cache/:userId', ...)` route handler in `profileRoutes.js`. The duplicate came from a merge conflict resolution that left both copies side by side, causing the second registration to never be reached.

**Changes:**
- Removed the redundant duplicate `router.delete` line

Closes #3389

GSSoC