### PR TITLE
fix(#3409): use ApiClient.defaultBaseUrl and add auth token to WebSocket URL

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import '../core/api_client.dart';
 import '../services/order_service.dart';
 import '../services/voice_ai_service.dart';
 import 'package:flutter/material.dart';
@@ -98,7 +99,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   }
 
   void _subscribeToTracking() {
-    final apiBaseUrl = OrderService.defaultApiBaseUrl;
+    final apiBaseUrl = ApiClient.defaultBaseUrl;
     final baseUri = Uri.parse(apiBaseUrl);
     final wsScheme = baseUri.scheme == 'https' ? 'wss' : 'ws';
     
@@ -109,17 +110,21 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     wsPath = '$wsPath/ws/tracking';
 
     String buildUrl() {
+      final session = Supabase.instance.client.auth.currentSession;
+      final token = session?.accessToken ?? '';
       final wsUri = Uri(
         scheme: wsScheme,
         host: baseUri.host,
         port: baseUri.hasPort ? baseUri.port : null,
         path: wsPath,
+        queryParameters: token.isNotEmpty ? {'token': token} : null,
       );
       return wsUri.toString();
     }
 
     final initialWsUrl = buildUrl();
-    debugPrint('Connecting to tracking WebSocket at: $initialWsUrl');
+    final redactedUrl = initialWsUrl.replaceAll(RegExp(r'token=[^&]+'), 'token=[REDACTED]');
+    debugPrint('Connecting to tracking WebSocket at: $redactedUrl');
 
     _trackingWebSocket = ResilientWebSocket(
       initialWsUrl,


### PR DESCRIPTION
## Summary
Fixes #3409 — WebSocket connections now authenticate with the Supabase session token instead of using `OrderService.defaultApiBaseUrl` which contained a broken `null/api` base URL.

## Changes
- `live_tracking_screen.dart`: Replaced `OrderService.defaultApiBaseUrl` → `ApiClient.defaultBaseUrl`
- Added Supabase session token as query parameter in `buildUrl()`
- Redacted token from debug log

## Testing
- Run `dart analyze` to verify no analysis errors
- Test WebSocket connection with authenticated user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live order tracking connection reliability by using the standard application API endpoint.
  * Added authenticated session support for tracking connections.
  * Enhanced connection logs to protect sensitive authentication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->