### PR TITLE
fix(#3411): document onlyOwner invariant on releasePayment() to prevent permissionless escrow release

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -127,6 +127,13 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
      * @dev Release payment to driver after GPS geofence + OTP confirmation.
      *      Called by the Truxify backend (owner) after both conditions are met.
      *
+     * CRITICAL SECURITY INVARIANT: This function is restricted to onlyOwner.
+     * Neither the customer nor the driver may call this directly — all
+     * release requests MUST flow through the backend's delivery verification
+     * pipeline (OTP generation, OTP verification, GPS geofence confirmation).
+     * Any upgradeable variant of this contract MUST preserve this onlyOwner
+     * guard to prevent unauthorized fund releases.
+     *
      * Security: nonReentrant + CEI pattern
      *   State is updated (paid=true, amount=0, status=Delivered) BEFORE
      *   adding to pendingWithdrawals so a re-entrant driver contract cannot


### PR DESCRIPTION
## Summary
Fixes #3411 — Documents the critical security invariant that `releasePayment()` must only be callable by the contract owner (backend).

## Changes
- `TruxifyEscrow.sol`: Added NatSpec documentation to `releasePayment()` documenting the `onlyOwner` invariant and warning against removing it in upgradeable variants

## Notes
- `TruxifyEscrow.sol`'s `releasePayment()` already correctly uses `onlyOwner`
- The issue reported `TruxifyUpgradeable.sol` missing this guard — that contract doesn't exist in the codebase
- This documentation ensures the security model is preserved for future upgradeable variants

## Testing
- Compile with `npx hardhat compile`