### PR TITLE
chore(driver): move test-only packages to dev_dependencies

### DIFF
--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -17,9 +17,6 @@ dependencies:
     sdk: flutter
   truxify_shared:
     path: ../../packages/truxify_shared
-  mockito: ^5.4.4
-  build_runner: ^2.4.8
-  network_image_mock: ^2.1.1
 
   supabase_flutter: ^2.9.1
   web_socket_channel: ^3.0.0
@@ -46,6 +43,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   firebase_core_platform_interface: any
+  mockito: ^5.4.4
+  build_runner: ^2.4.8
+  network_image_mock: ^2.1.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary

This PR improves the Driver Flutter application's dependency configuration by moving test-only and development-only packages from `dependencies` to `dev_dependencies`.

Previously, packages used exclusively for testing and code generation were included as runtime dependencies, increasing production dependency scope unnecessarily. This change aligns the Driver application with Flutter best practices and the dependency structure already used by the Customer application.

No package versions, application logic, or runtime behavior have been changed.

---

## What Changed

### ✅ Updated

- Moved development-only packages from `dependencies` to `dev_dependencies`.

Examples include:

- `mockito`
- `build_runner`
- `network_image_mock`

(Only packages verified to be development-only were moved.)

---

## Architecture

### Before

```text
dependencies
├── flutter
├── provider
├── mockito
├── build_runner
└── network_image_mock
```

### After

```text
dependencies
├── flutter
└── provider

dev_dependencies
├── flutter_test
├── mockito
├── build_runner
└── network_image_mock
```

---

## Files Changed

### Updated

- `apps/driver/pubspec.yaml`

---

## Benefits

- Follows Flutter dependency best practices.
- Reduces production dependency scope.
- Improves project maintainability.
- Aligns the Driver application with the Customer application's dependency organization.
- Preserves existing functionality.

---

## Testing

### Verified

- ✅ `flutter pub get`
- ✅ `flutter analyze`
- ✅ `flutter test`
- ✅ Dependency resolution succeeds.
- ✅ No runtime behavior changes.

---

## Type of Change

- [x] Build Improvement
- [x] Dependency Cleanup
- [x] Flutter Maintenance
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

---

## Related Issue

Closes #3423 

---

## GSSoC
#ECSoC26

This PR is submitted as part of **GirlScript Summer of Code (GSSoC) 2026**.

This change improves dependency organization by moving development-only packages into `dev_dependencies`, aligning the Driver application with Flutter best practices while preserving all existing functionality. Kindly review and consider approving it if it aligns with the project's maintainability and build quality goals. Thank you for your time and valuable feedback!