### PR TITLE
fix: import userLimiter from rateLimiter.js instead of auth.js

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -10,7 +10,8 @@
  */
 
 import express from 'express';
-import { authenticate, userLimiter } from '../middleware/auth.js';
+import { authenticate } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
 import { firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
## Description\n\nFixed a wrong import source in authRoutes.js. The route uses \userLimiter\ on the \GET /session\ endpoint, but it was imported from \../middleware/auth.js\ instead of \../middleware/rateLimiter.js\ where \userLimiter\ is actually defined. Every other route file imports \userLimiter\ from \ateLimiter.js\.\n\n**Changes:**\n- Removed \userLimiter\ from the \uth.js\ import\n- Added a separate import for \userLimiter\ from \ateLimiter.js\\n\nCloses #3027\n\nGSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication middleware organization without changing logout or session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->