### PR TITLE
fix(escrow): change bookings ABI key from bytes32 to uint256

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -36,7 +36,7 @@ const ESCROW_ABI = [
   'function createBooking(uint256 bookingId, address payable driver) external payable',
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
-  'function bookings(bytes32 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, uint256 createdAt)'
+  'function bookings(uint256 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, uint256 createdAt)'
 ]
 
 const rpcUrl            = process.env.POLYGON_RPC_URL;


### PR DESCRIPTION
The Escrow ABI declared the bookings getter with bytes32 but the Solidity contract TruxifyEscrow.sol uses uint256 for the mapping key. This mismatch causes ethers.js to encode the wrong function selector, breaking all escrow lookups including recordDepositTx, escrowRelease, and checkEscrowHealth.

Fixes #3093