### PR TITLE
fix(bidAcceptance): add p_expected_version and fix buildResult scope

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -17,7 +17,7 @@ export class BidAcceptanceService {
 
   async acceptBid({ orderId, bidId, customerId }) {
     return measureExecution('BidAcceptanceService.acceptBid', async () => {
-    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'order_display_id, customer_id');
+    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'order_display_id, customer_id, version');
     if (orderErr) {
       throw new DomainError(500, { error: 'Failed to retrieve order.', details: orderErr.message });
     }
@@ -87,7 +87,7 @@ export class BidAcceptanceService {
 
     // Guard against silent escrow disable: if buildDepositTx returned
     // null txData (contract not initialised), reject immediately.
-    if (!buildResult?.txData) {
+    if (!depositTx?.txData) {
       this.logger?.error?.('[escrow] Escrow deposit tx could not be built — escrow contract is not reachable or misconfigured.');
       throw new DomainError(502, {
         error: 'Escrow is not configured. Escrow deposit transaction could not be built.',
@@ -114,6 +114,7 @@ export class BidAcceptanceService {
       p_truck_number: truckInfo?.number_plate || 'N/A',
       p_bid_amount: bid.bid_amount,
       p_order_display_id: order.order_display_id,
+      p_expected_version: order.version ?? 0,
     });
 
     if (rpcErr) {


### PR DESCRIPTION
Two bugs in acceptBid():

1. The accept_bid_tx RPC call was missing the required p_expected_version parameter (added in migration 20260706075009). Without it the call fails with a PostgreSQL missing-parameter error, making every bid acceptance return 500.

2. Line 90 referenced buildResult outside its try block scope, causing a ReferenceError at runtime. Changed to depositTx which is in the outer scope.

3. Added version to the findOrderById select so it is available for the RPC call.

Fixes #3095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bid acceptance reliability by validating escrow transaction data correctly.
  * Added version checks to help prevent conflicting updates when accepting bids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->