### PR TITLE
fix(locationServer): remove redundant dynamic import in verifyDriverAssignment

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -286,8 +286,6 @@ async function verifyCustomerToken(socket, next) {
  */
 async function verifyDriverAssignment(driverId, bookingId) {
   try {
-    const { supabase } = await import("../config/db.js");
-
     const { data, error } = await supabase
       .from("bookings")
       .select("id")


### PR DESCRIPTION
The supabase client is already statically imported at the top of the file (line 5). The dynamic import() inside verifyDriverAssignment was redundant and caused Node.js to re-evaluate the module on every WebSocket booking subscription request, adding unnecessary overhead.

Fixes #1940