### PR TITLE
fix(loadRoutes): include NULL extra_distance_km rows in distance filter

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -146,7 +146,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
       query = query.lte('freight_value', Math.round(filters.max_price * 100));
     }
     if (filters.distance !== undefined) {
-      query = query.lte('extra_distance_km', filters.distance);
+      query = query.or(`extra_distance_km.is.null,extra_distance_km.lte.${filters.distance}`);
     }
 
     // Sorting


### PR DESCRIPTION
The distance filter used .lte('extra_distance_km', distance) which excludes rows where extra_distance_km is NULL. Most load offers are not en-route offers and have NULL for this column, causing the filter to return empty results for the majority of loads.

Changed to use .or() to include both NULL rows (no distance constraint) and rows within the specified distance.

Fixes #1943