### PR TITLE
fix(orderCreation): remove aliased supabase import that broke all order creation

### DIFF
--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { supabase as defaultSupabase } from '../../config/db.js';
+import { supabase } from '../../config/db.js';
 import { getRouteEstimate } from '../osrm.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
 import { predictPrice } from '../ml.js';


### PR DESCRIPTION
## Problem

The import in orderCreationService.js aliased supabase to defaultSupabase:

`javascript
import { supabase as defaultSupabase } from '../../config/db.js';
`

But all subsequent database calls in the function body referenced the bare name supabase, which was not in scope. This caused a ReferenceError: supabase is not defined on every order creation attempt. No order could ever be created.

The pricing computation and ML prediction phases succeeded (they don't touch the DB), but the very first database call on line 79 crashed.

## Fix

Removed the alias so the import name matches all usages:

`javascript
import { supabase } from '../../config/db.js';
`

## Testing

Verified that all 6 database call sites (lines 79, 123, 127, 131, 153, 154) now reference the correctly imported supabase client.

Fixes #3463

GSSoC