### PR TITLE
fix(oracle): capture provider url/apiKey before arrow functions

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -15,13 +15,15 @@ class OracleService {
   initializeProviders() {
     // Provider 1: Chainlink
     if (process.env.CHAINLINK_ENABLED === 'true') {
+      const chainlinkUrl = process.env.CHAINLINK_API_URL || 'http://localhost:8545';
+      const chainlinkApiKey = process.env.CHAINLINK_API_KEY;
       this.providers.push({
         name: 'Chainlink',
-        url: process.env.CHAINLINK_API_URL || 'http://localhost:8545',
-        apiKey: process.env.CHAINLINK_API_KEY,
+        url: chainlinkUrl,
+        apiKey: chainlinkApiKey,
         confirmDelivery: async (data) => {
-          const response = await axios.post(`${this.url}/verify-delivery`, data, {
-            headers: { 'X-API-Key': this.apiKey }
+          const response = await axios.post(`${chainlinkUrl}/verify-delivery`, data, {
+            headers: { 'X-API-Key': chainlinkApiKey }
           });
           return response.data;
         }
@@ -46,11 +48,12 @@ class OracleService {
 
     // Provider 3: Backup/Third Party
     if (process.env.BACKUP_ORACLE_ENABLED === 'true') {
+      const backupUrl = process.env.BACKUP_ORACLE_URL;
       this.providers.push({
         name: 'BackupOracle',
-        url: process.env.BACKUP_ORACLE_URL,
+        url: backupUrl,
         confirmDelivery: async (data) => {
-          const response = await axios.post(`${this.url}/confirm`, data);
+          const response = await axios.post(`${backupUrl}/confirm`, data);
           return response.data;
         }
       });


### PR DESCRIPTION
## Problem

The Chainlink and BackupOracle provider confirmDelivery functions used 	his.url and 	his.apiKey inside arrow functions. Because arrow functions capture lexical 	his, these referenced the OracleService instance (which has no url or piKey properties) instead of the provider object.

This caused xios.post to call undefined/verify-delivery with no auth header, silently breaking oracle delivery verification. The consensus threshold was never met for delivery confirmations involving these providers.

## Fix

Captured the provider's url and piKey values in local const variables before the arrow function, ensuring they reference the correct provider configuration:

`javascript
const chainlinkUrl = process.env.CHAINLINK_API_URL || 'http://localhost:8545';
const chainlinkApiKey = process.env.CHAINLINK_API_KEY;
this.providers.push({
  name: 'Chainlink',
  url: chainlinkUrl,
  apiKey: chainlinkApiKey,
  confirmDelivery: async (data) => {
    const response = await axios.post(${chainlinkUrl}/verify-delivery, data, {
      headers: { 'X-API-Key': chainlinkApiKey }
    });
    return response.data;
  }
});
`

Applied the same fix to the BackupOracle provider.

## Testing

- Chainlink provider now correctly calls the configured URL with proper API key
- BackupOracle provider now correctly calls the configured URL
- CustomVerifier provider was already correct (it uses 	his.verifyOTPAndGPS which is a method on OracleService)

Fixes #3462

GSSoC