### PR TITLE
fix(dao): change hasVoted to per-proposal mapping

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -58,7 +58,7 @@ contract TruxifyUpgradeable is
     mapping(uint256 => Escrow) public escrows;
     mapping(uint256 => Proposal) public proposals;
     mapping(uint256 => UpgradeRecord) public upgradeHistory;
-    mapping(address => bool) public hasVoted;
+    mapping(uint256 => mapping(address => bool)) public hasVoted;
 
     uint256 public daoVotingPeriod;
     uint256 public daoQuorum;
@@ -189,9 +189,9 @@ contract TruxifyUpgradeable is
         Proposal storage proposal = proposals[proposalId];
         require(proposal.proposer != address(0), "Proposal not found");
         require(block.timestamp < proposal.votingEndsAt, "Voting ended");
-        require(!hasVoted[msg.sender], "Already voted");
+        require(!hasVoted[proposalId][msg.sender], "Already voted");
 
-        hasVoted[msg.sender] = true;
+        hasVoted[proposalId][msg.sender] = true;
 
         if (support) {
             proposal.votesFor++;


### PR DESCRIPTION
## Problem

The `hasVoted` mapping in `TruxifyUpgradeable.sol` was a single global map shared across all proposals:

```solidity
mapping(address => bool) public hasVoted;
```

Once any address voted on proposal #1, `hasVoted[addr] = true` was set permanently and never cleared. That address could then never vote on proposal #2, #3, or any future proposal. The entire DAO governance mechanism was broken after the first proposal.

## Fix

Changed to a nested mapping keyed by proposalId:

```solidity
mapping(uint256 => mapping(address => bool)) public hasVoted;
```

Updated the `vote()` function to check and set the per-proposal mapping:

```solidity
require(!hasVoted[proposalId][msg.sender], "Already voted");
hasVoted[proposalId][msg.sender] = true;
```

## Impact

- Each address can now vote once per proposal (instead of once globally)
- The DAO governance system is functional across multiple proposals
- No changes to the storage layout that would affect upgradeability (mappings are not slot-addressed)

## Testing

- Verified that the mapping is correctly scoped per proposalId
- Verified that the same address can vote on different proposals
- Verified that double-voting on the same proposal is still rejected

Fixes #3464

GSSoC
