### PR TITLE
fix(webrtc): add JWT authentication and replace dynamic imports

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -1,6 +1,8 @@
 import { WebSocketServer } from 'ws';
+import jwt from 'jsonwebtoken';
 import logger from '../../middleware/logger.js';
 import Redis from 'ioredis';
+import { supabase } from '../../config/db.js';
 
 class WebRTCSignalingServer {
   constructor(server) {
@@ -17,13 +19,35 @@ class WebRTCSignalingServer {
 
   setupWebSocket() {
     this.wss.on('connection', (ws, req) => {
-      const peerId = this.generatePeerId();
       const url = new URL(req.url, `http://${req.headers.host}`);
+
+      // Authenticate via token query parameter or Authorization header
+      const token = url.searchParams.get('token')
+        || req.headers.authorization?.replace('Bearer ', '');
+
+      if (!token) {
+        logger.warn('WebRTC connection rejected: no token provided');
+        ws.close(4001, 'Authentication required');
+        return;
+      }
+
+      let decoded;
+      try {
+        decoded = jwt.verify(token, process.env.JWT_SECRET);
+      } catch (err) {
+        logger.warn(`WebRTC connection rejected: invalid token — ${err.message}`);
+        ws.close(4001, 'Invalid token');
+        return;
+      }
+
+      const peerId = this.generatePeerId();
       const meshId = url.searchParams.get('meshId') || this.getOrCreateMesh();
-      
-      // Store peer
+
+      // Store peer with authenticated user info
       this.peers.set(peerId, {
         ws,
+        userId: decoded.sub,
+        role: decoded.role,
         location: null,
         meshId,
         connectedAt: Date.now(),
@@ -190,7 +214,6 @@ class WebRTCSignalingServer {
     };
 
     // Store in MongoDB
-    const { supabase } = await import('../../config/db.js');
     await supabase.from('gps_offline_data').insert([gpsEntry]);
 
     // Store locally in Redis for quick access
@@ -315,7 +338,6 @@ class WebRTCSignalingServer {
   }
 
   async getOfflineGPSData(peerId, since) {
-    const { supabase } = await import('../../config/db.js');
     const { data } = await supabase
       .from('gps_offline_data')
       .select('*')
@@ -328,7 +350,6 @@ class WebRTCSignalingServer {
 
   async syncOfflineData(peerId) {
     // Mark data as synced for this peer
-    const { supabase } = await import('../../config/db.js');
     await supabase
       .from('gps_offline_data')
       .update({ synced: true })


### PR DESCRIPTION
## Problem

The `/webrtc` WebSocket endpoint in `WebRTCSignalingServer.js` accepted connections with no authentication. Any anonymous client could:

- Connect to the entire P2P mesh network
- Inject fake GPS data into the mesh
- Read all peer locations
- Relay messages to arbitrary peers without authorization

Compare with `locationServer.js` which properly uses `verifyDriverToken` / `verifyCustomerToken` middleware for Socket.IO connections.

## Fix

Added JWT verification before accepting the WebSocket connection:

1. **Token extraction**: Reads JWT from either the `token` query parameter or the `Authorization: Bearer <token>` header
2. **Token verification**: Validates the JWT using `jwt.verify()` with the configured `JWT_SECRET`
3. **Connection rejection**: Closes the WebSocket with code `4001` if no token is provided or the token is invalid
4. **User context**: Stores the decoded `userId` (from `decoded.sub`) and `role` on each peer for future authorization checks

```javascript
const token = url.searchParams.get('token')
  || req.headers.authorization?.replace('Bearer ', '');

if (!token) {
  ws.close(4001, 'Authentication required');
  return;
}

const decoded = jwt.verify(token, process.env.JWT_SECRET);
// ... store decoded.sub and decoded.role on the peer
```

### Bonus: Removed redundant dynamic imports

Three methods (`handleGPSData`, `getOfflineGPSData`, `syncOfflineData`) used `await import('../../config/db.js')` to get the supabase client on every call. Replaced with the static import already available at the top of the file.

## Testing

- Connection without token: rejected with close code 4001
- Connection with invalid token: rejected with close code 4001
- Connection with valid JWT: accepted, peer stored with userId and role
- All existing mesh/relay/discovery functionality preserved

Fixes #3460

GSSoC
