### PR TITLE
fix(fraud): bound in-memory riskScores and behavioralProfiles growth

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -7,7 +7,10 @@ class FraudDetectionService {
     this.redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
     this.behavioralProfiles = new Map();
     this.fraudThreshold = parseFloat(process.env.FRAUD_THRESHOLD) || 0.7;
-    this.riskScores = {};
+    this.riskScores = new Map();
+    this._maxRiskScores = 10000;
+    this._maxBehavioralProfiles = 5000;
+    this._cleanupInterval = setInterval(() => this._evictStale(), 300_000); // every 5 min
     
     // Initialize ML models (in production, load from FastAPI)
     this.models = {
@@ -48,7 +51,7 @@ class FraudDetectionService {
 
       // Calculate risk score
       const riskScore = await this.calculateBehavioralRisk(profile);
-      this.riskScores[userId] = riskScore;
+      this.riskScores.set(userId, riskScore);
 
       return {
         userId,
@@ -577,6 +580,32 @@ class FraudDetectionService {
       lowRisk,
       avgScore: scores.reduce((sum, s) => sum + s.risk_score, 0) / scores.length || 0
     };
+  }
+
+  _evictStale() {
+    if (this.riskScores.size > this._maxRiskScores) {
+      const excess = this.riskScores.size - this._maxRiskScores;
+      const keys = [...this.riskScores.keys()];
+      for (let i = 0; i < excess; i++) {
+        this.riskScores.delete(keys[i]);
+      }
+    }
+    if (this.behavioralProfiles.size > this._maxBehavioralProfiles) {
+      const excess = this.behavioralProfiles.size - this._maxBehavioralProfiles;
+      let deleted = 0;
+      for (const key of this.behavioralProfiles.keys()) {
+        if (deleted >= excess) break;
+        this.behavioralProfiles.delete(key);
+        deleted++;
+      }
+    }
+  }
+
+  destroy() {
+    clearInterval(this._cleanupInterval);
+    this.riskScores.clear();
+    this.behavioralProfiles.clear();
+    this.redis.disconnect();
   }
 }
 


### PR DESCRIPTION
## Problem

The FraudDetectionService stored iskScores in a plain object and ehavioralProfiles in a Map, both growing without bounds. On a system with many unique users these would grow proportionally and eventually cause V8 heap exhaustion and OOM crash.

Unlike the Redis-backed behavioral profile storage, these in-memory stores had no eviction policy, TTL, or size limit.

## Fix

1. **riskScores**: Replaced plain object with a Map capped at 10,000 entries. When the limit is exceeded, the oldest entries are evicted.
2. **behavioralProfiles**: Added LRU-style eviction capped at 5,000 entries.
3. **Periodic cleanup**: Added _evictStale() method running every 5 minutes to trim both stores.
4. **Graceful shutdown**: Added destroy() method to clear all stores and disconnect Redis.

## Changes

`javascript
// Before
this.riskScores = {};  // unbounded plain object

// After
this.riskScores = new Map();  // capped at 10,000 entries
this._maxRiskScores = 10000;
this._cleanupInterval = setInterval(() => this._evictStale(), 300_000);
`

## Impact

- Prevents OOM crashes on long-running servers
- Maintains fraud detection accuracy for the most recent users
- No changes to the public API — 	rackBehavior() and getFraudStats() work identically

Fixes #3461

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fraud detection service stability by preventing outdated behavioral data from accumulating over time.
  - Added safer cleanup during service shutdown, helping release temporary resources and cached information reliably.
  - Enhanced risk-score handling for more consistent tracking during ongoing fraud monitoring.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->