### PR TITLE
fix(orderRoutes): import DomainError to prevent ReferenceError on validation failures

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -54,6 +54,7 @@ import { requireIdempotency } from '../middleware/idempotency.js';
 import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
 import { OrderLifecycleService } from '../services/order/orderLifecycleService.js';
+import { DomainError } from '../services/order/domainError.js';
 
 const router = express.Router();
 const orderRepository = new OrderRepository(supabase);


### PR DESCRIPTION
## Summary

Adds the missing DomainError import to orderRoutes.js. Without it, all 18 instanceof DomainError checks throw ReferenceError: DomainError is not defined at runtime, causing raw 500 errors instead of structured validation responses.

## Changes

- Added import { DomainError } from '../services/order/domainError.js'; to orderRoutes.js

## Testing

- Verified DomainError is exported from ../services/order/domainError.js
- Verified all 18 instanceof DomainError usages in orderRoutes.js now resolve correctly

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for order-related requests, ensuring domain errors are recognized and returned appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->