### PR TITLE
fix(ml): reorder predictPrice to fetch before validating — function was completely broken

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -120,28 +120,6 @@ export async function predictPrice({
       route_destination: routeDestination,
   };
 
-    const raw = await handleResponse(response);
-
-    const result = validatePricePrediction(raw);
-    if (!result.ok) {
-        logger.warn({
-            reason: result.reason,
-            detail: result.detail,
-            response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
-        }, '[ML] Price prediction rejected by validator');
-        throw new Error(`[ML] Invalid prediction: ${result.reason} — ${result.detail}`);
-    }
-
-    logger.debug({
-        estimated_price_inr: result.validated.estimated_price,
-        confidence: result.validated.confidence,
-    }, '[ML] Price prediction validated successfully');
-
-    return {
-        ...result.validated,
-        estimatedPricePaisa: convertToPaisa(result.validated.estimated_price),
-        estimatedPriceInr: result.validated.estimated_price,
-    };
   const response = await fetch(url, {
       method: 'POST',
       headers: getHeaders(),
@@ -149,9 +127,30 @@ export async function predictPrice({
       signal: AbortSignal.timeout(5000),
   });
 
-  const result = await handleResponse(response);
-  priceCache.set(cacheKey, result);
-  return result;
+  const raw = await handleResponse(response);
+
+  const result = validatePricePrediction(raw);
+  if (!result.ok) {
+      logger.warn({
+          reason: result.reason,
+          detail: result.detail,
+          response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
+      }, '[ML] Price prediction rejected by validator');
+      throw new Error(`[ML] Invalid prediction: ${result.reason} — ${result.detail}`);
+  }
+
+  logger.debug({
+      estimated_price_inr: result.validated.estimated_price,
+      confidence: result.validated.confidence,
+  }, '[ML] Price prediction validated successfully');
+
+  const validated = {
+      ...result.validated,
+      estimatedPricePaisa: convertToPaisa(result.validated.estimated_price),
+      estimatedPriceInr: result.validated.estimated_price,
+  };
+  priceCache.set(cacheKey, validated);
+  return validated;
 }
 
 /**


### PR DESCRIPTION
## Summary

The predictPrice function in ml.js had two disconnected code paths:
1. **Lines 123-144**: Validation code referencing esponse (undeclared variable) — always threw ReferenceError
2. **Lines 145-154**: The actual etch() call — unreachable because it came after a eturn statement

This meant price prediction was completely non-functional. Any route calling predictPrice() would crash.

## Changes

- Reordered the function to: etch → handleResponse → alidatePricePrediction → cache → return
- Added caching for the validated result (was missing in the old code path)

## Testing

- Verified the function now correctly fetches, validates, caches, and returns
- Verified handleResponse, alidatePricePrediction, and convertToPaisa are all imported and available

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3471