### PR TITLE
fix(profileRoutes): remove duplicate admin cache invalidation route handler

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -340,7 +340,6 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
 // Invalidates the profile cache for a specific user, forcing the next
 // authenticated request to refetch from Supabase. Use this after admin
 // operations that change role, status, or other cached profile fields.
-router.delete('/admin/cache/:userId', authenticate, adminRateLimiter, requireRole(['admin']), validateParams(uuidParamSchema), async (req, res) => {
 router.delete('/admin/cache/:userId', authenticate, userLimiter, requirePolicy('admin:invalidate-cache'), validateParams(z.object({ userId: z.string().min(1, 'userId is required') })), async (req, res) => {
   try {
     const targetUserId = req.params.userId;


### PR DESCRIPTION
## Summary

Two outer.delete handlers were registered for the same path /admin/cache/:userId on consecutive lines (343-344). The old handler used dminRateLimiter + equireRole(['admin']), while the new one used userLimiter + equirePolicy('admin:invalidate-cache').

Express registers both handlers and runs them sequentially. The first handler executes and either handles the request or throws, making the second (policy-based) handler dead code. This means the intended policy-based authorization is never enforced.

## Changes

- Removed the old handler (line 343) that used dminRateLimiter + equireRole(['admin'])
- Kept only the new policy-based handler with userLimiter + equirePolicy('admin:invalidate-cache')

## Testing

- Verified the route now has exactly one handler
- Verified the policy-based middleware (equirePolicy) is properly imported and used

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3472