### PR TITLE
fix(supportRoutes): remove duplicate admin tickets route handler

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -383,7 +383,6 @@ router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicke
 // ============================================================================
 // 7. LIST ALL TICKETS (ADMIN ONLY)
 // ============================================================================
-router.get('/admin/tickets', authenticate, adminRateLimiter, requireRole(['admin']), async (req, res) => {
 router.get('/admin/tickets', authenticate, userLimiter, requirePolicy('ticket:admin-view-all'), async (req, res) => {
   const { status, category, user_id, page = '1', limit = '20' } = req.query;
   const parsedPage = parsePositiveInteger(page, 1, 'page');


### PR DESCRIPTION
## Summary

Two outer.get handlers were registered for the same path /admin/tickets on consecutive lines (386-387). The old handler used dminRateLimiter + equireRole(['admin']), while the new one used userLimiter + equirePolicy('ticket:admin-view-all').

The old handler always ran first, making the policy-based handler dead code. This meant the admin tickets endpoint used legacy role-based auth instead of the intended policy-based auth.

## Changes

- Removed the old handler (line 386) that used dminRateLimiter + equireRole(['admin'])
- Kept only the new policy-based handler with userLimiter + equirePolicy('ticket:admin-view-all')

## Testing

- Verified the route now has exactly one handler
- Verified the policy-based middleware is properly imported and used

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3473