### PR TITLE
fix(orderRoutes): add missing orderId destructuring in cancel, resend-otp, change-drop

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -757,7 +757,7 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requirePolicy('de
 // 14. RESEND DELIVERY OTP (DRIVER)
 // ============================================================================
 router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requirePolicy('delivery:resend-otp'), validateParams(paramIdSchema), async (req, res) => {
-
+  const { id: orderId } = req.params;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, driver_id, customer_id, status');
     orderValidationService.assertOrderFound(order);
@@ -784,7 +784,7 @@ router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requ
 // 15. CHANGE DROP (CUSTOMER)
 // ============================================================================
 router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, requirePolicy('order:change-drop'), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
-
+  const { id: orderId } = req.params;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);
@@ -878,7 +878,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
 // 16. CANCEL ORDER AND REFUND ESCROW (CUSTOMER)
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
-
+  const { id: orderId } = req.params;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);


### PR DESCRIPTION
## Summary

Three route handlers in orderRoutes.js referenced orderId without ever declaring it:

- POST /:id/resend-otp (line 762)
- PUT /:id/change-drop (line 789)  
- POST /:id/cancel (line 883)

All three threw ReferenceError: orderId is not defined at runtime, making cancel order, resend delivery OTP, and change drop-off completely non-functional. Customers cannot cancel orders, drivers cannot resend OTPs, and customers cannot change delivery addresses.

## Changes

Added const { id: orderId } = req.params; to each handler's try block, matching the pattern used by all other handlers in the same file.

## Testing

- Verified all three handlers now correctly extract orderId from eq.params
- Verified the destructuring pattern matches other working handlers in the file

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3474