### PR TITLE
fix(notificationService): stop retrying non-transient FCM errors immediately

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -17,7 +17,6 @@ const INVALID_TOKEN_CODES = new Set([
 ]);
 
 const MAX_RETRIES = 3;
-const RETRY_DELAYS = [1000, 2000, 4000];
 const RETRY_BASE_DELAY = 500;
 const RETRY_MAX_DELAY = 5000;
 
@@ -102,9 +101,14 @@ export async function sendFcmNotification(userId, notification, data = {}) {
         return { success: false, error: err.message, errorCode: err.code };
       }
 
-      if (isTransientError(err.code) && attempt < MAX_RETRIES - 1) {
-        logger.info(`[FCM] Retrying after ${RETRY_DELAYS[attempt]}ms for user ${userId}`);
-        const delay = calculateRetryBackoff(attempt); await new Promise(resolve => setTimeout(resolve, delay));
+      if (!isTransientError(err.code)) {
+        return { success: false, error: err.message, errorCode: err.code };
+      }
+
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = calculateRetryBackoff(attempt);
+        logger.info(`[FCM] Retrying after ${delay}ms for user ${userId}`);
+        await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
   }


### PR DESCRIPTION
## Summary

Non-retryable FCM errors (e.g. `messaging/invalid-payload`, permission errors) were being retried `MAX_RETRIES` times in rapid succession without any delay, wasting time and potentially triggering FCM rate limits.

## Changes

- Added early return for non-transient, non-invalid-token errors so they don't consume retry attempts
- Fixed log line that referenced unused `RETRY_DELAYS` constant instead of `calculateRetryBackoff()`
- Removed the dead `RETRY_DELAYS` constant

## Testing

- Verified transient errors still retry with exponential backoff
- Verified invalid tokens still clear the token and return immediately
- Verified non-retryable errors now return immediately without consuming retries

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3485
