### PR TITLE
fix(orderMilestoneService): remove duplicate timeline writes and dead module-level instance

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -21,8 +21,6 @@ import { DomainError } from './domainError.js';
 import { OrderTimelineService } from './orderTimelineService.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
-const orderTimelineService = new OrderTimelineService({ supabase, logger });
-
 export class OrderMilestoneService {
   constructor(args = {}) {
     if (args.orderRepository) this.orderRepository = args.orderRepository;
@@ -87,13 +85,10 @@ export class OrderMilestoneService {
       }
     }
 
-    const { error: timelineErr } = await this.orderRepository.updateTimelineMilestone(order.order_display_id, milestone, { completed: true, milestone_time: new Date().toISOString() });
-    if (timelineErr) throw new DomainError(500, { error: 'Failed to update order timeline.', details: timelineErr.message });
     await this.orderTimelineService.completeMilestone(order.order_display_id, milestone);
 
     const { data: updatedOrder, error: updateErr } = await this.orderRepository.updateOrder(orderId, updates);
     if (updateErr) {
-      await this.orderRepository.updateTimelineMilestone(order.order_display_id, milestone, { completed: false, milestone_time: null });
       await this.orderTimelineService.resetMilestone(order.order_display_id, milestone);
       throw new DomainError(500, { error: 'Failed to update order.', details: updateErr.message });
     }


### PR DESCRIPTION
## Summary

Two issues fixed in `orderMilestoneService.js`:

### 1. Duplicate timeline milestone writes (#3486)

Every milestone update wrote the same timeline record to the database **twice**:
- Direct call to `orderRepository.updateTimelineMilestone()`
- Then `orderTimelineService.completeMilestone()` which calls the same repo method internally

Same duplication existed in the rollback path. This wasted DB round-trips, doubled the race condition window, and could leave inconsistent state if the second write failed.

**Fix:** Removed the redundant direct repository calls, keeping only the `orderTimelineService` calls which already delegate to the same repo method.

### 2. Dead module-level instance with wrong constructor arg (#3488)

Line 24 created `new OrderTimelineService({ supabase, logger })` but the constructor expects a single `orderRepository` argument. This was dead code that would throw `TypeError` if ever referenced.

**Fix:** Removed the dead code entirely.

## Testing

- Verified milestone updates now make exactly one DB write instead of two
- Verified rollback path also makes exactly one DB write
- Verified no other code references the removed module-level variable

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3486, closes #3488
