### PR TITLE
fix: predictPrice — reorder fetch before handleResponse, remove merge debris

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -120,28 +120,6 @@ export async function predictPrice({
       route_destination: routeDestination,
   };
 
-    const raw = await handleResponse(response);
-
-    const result = validatePricePrediction(raw);
-    if (!result.ok) {
-        logger.warn({
-            reason: result.reason,
-            detail: result.detail,
-            response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
-        }, '[ML] Price prediction rejected by validator');
-        throw new Error(`[ML] Invalid prediction: ${result.reason} — ${result.detail}`);
-    }
-
-    logger.debug({
-        estimated_price_inr: result.validated.estimated_price,
-        confidence: result.validated.confidence,
-    }, '[ML] Price prediction validated successfully');
-
-    return {
-        ...result.validated,
-        estimatedPricePaisa: convertToPaisa(result.validated.estimated_price),
-        estimatedPriceInr: result.validated.estimated_price,
-    };
   const response = await fetch(url, {
       method: 'POST',
       headers: getHeaders(),
@@ -149,7 +127,28 @@ export async function predictPrice({
       signal: AbortSignal.timeout(5000),
   });
 
-  const result = await handleResponse(response);
+  const raw = await handleResponse(response);
+
+  const validated = validatePricePrediction(raw);
+  if (!validated.ok) {
+      logger.warn({
+          reason: validated.reason,
+          detail: validated.detail,
+          response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
+      }, '[ML] Price prediction rejected by validator');
+      throw new Error(`[ML] Invalid prediction: ${validated.reason} — ${validated.detail}`);
+  }
+
+  logger.debug({
+      estimated_price_inr: validated.validated.estimated_price,
+      confidence: validated.validated.confidence,
+  }, '[ML] Price prediction validated successfully');
+
+  const result = {
+      ...validated.validated,
+      estimatedPricePaisa: convertToPaisa(validated.validated.estimated_price),
+      estimatedPriceInr: validated.validated.estimated_price,
+  };
   priceCache.set(cacheKey, result);
   return result;
 }

--- a/issue_body_1.txt
+++ b/issue_body_1.txt
@@ -1,0 +1,32 @@
+## Description
+
+In `backend/api/src/services/order/orderCreationService.js` at lines 18-19, there are two consecutive `export async function createOrder` declarations:
+
+```javascript
+export async function createOrder({ orderData, userId, user, supabase = defaultSupabase }) {
+export async function createOrder({ orderData, userId, user }) {
+```
+
+In JavaScript, the second `function` declaration silently replaces the first in the same scope. This means:
+1. The `supabase` parameter override on line 18 is never used
+2. Any caller importing `createOrder` from `container.js` will get the second (simpler) signature, which lacks the `supabase` override
+
+## Expected Behavior
+
+Only one `createOrder` function should be declared to avoid confusion and ensure the `supabase` parameter override works correctly.
+
+## Steps to Reproduce
+
+1. Import `createOrder` from this module
+2. Call it with a custom `supabase` instance
+3. Observe that the custom `supabase` is silently ignored
+
+## Suggested Fix
+
+Remove the duplicate declaration on line 18, keeping only the intended signature on line 19.
+
+## Impact
+
+Medium - Function silently ignores parameter override; could cause subtle bugs when custom supabase instances are needed.
+
+GSSoC

--- a/issue_body_10.txt
+++ b/issue_body_10.txt
@@ -1,0 +1,40 @@
+## Description
+
+In `apps/customer/lib/services/location_service.dart` at lines 123-126, the `extractCity` method has an insufficient boundary check:
+
+```dart
+String extractCity(String address) {
+    final parts = address.split(',');
+    return parts.length > 1 ? parts[parts.length - 3].trim() : parts.first.trim();
+}
+```
+
+The guard condition `parts.length > 1` is not strict enough:
+- When `parts.length` is exactly **2**, `parts.length - 3` evaluates to **`-1`**, and `parts[-1]` throws a **RangeError** in Dart (Dart lists do not support negative indexing, unlike Python)
+- When `parts.length` is exactly **3**, `parts[0]` is accessed (the street name, not the city component)
+
+For example, an address like `"123 Main St, Mumbai"` splits into `["123 Main St", "Mumbai"]` (length 2). The guard `length > 1` passes (2 > 1 is true), but `parts[2 - 3] = parts[-1]` crashes.
+
+## Impact
+
+**High** - Customer app crashes when viewing orders with 2-part addresses (e.g., "Street, City" format without state/country).
+
+## Steps to Reproduce
+
+1. Have an order with a simple 2-part address like `"123 Main St, Mumbai"`
+2. Navigate to any screen that calls `extractCity()`
+3. Observe RangeError crash
+
+## Suggested Fix
+
+Change the guard to `parts.length >= 3` (or `parts.length > 2`) to ensure the index `parts.length - 3` is always non-negative:
+
+```dart
+String extractCity(String address) {
+    final parts = address.split(',');
+    if (parts.length >= 3) return parts[parts.length - 3].trim();
+    return parts.first.trim();
+}
+```
+
+GSSoC

--- a/issue_body_2.txt
+++ b/issue_body_2.txt
@@ -1,0 +1,33 @@
+## Description
+
+In `backend/api/src/routes/orderRoutes.js` at lines 379-383 and 400-404, there are duplicate `const { data: offers, error }` destructuring declarations in the same scope.
+
+**GET /load-offers handler (lines 379-383):**
+```javascript
+const { data: offers, error } = await orderRepository.findLoadOffers({ is_en_route: false });
+const { data: offers, error } = await orderRepository.findLoadOffers(
+  { is_en_route: false },
+  { pagination: { page, limit } }
+);
+```
+
+**GET /load-offers/en-route handler (lines 400-404):**
+```javascript
+const { data: offers, error } = await orderRepository.findLoadOffers({ is_en_route: true });
+const { data: offers, error } = await orderRepository.findLoadOffers(
+  { is_en_route: true },
+  { pagination: { page, limit } }
+);
+```
+
+`const` does not allow redeclaration in the same block scope. This will cause a **SyntaxError** at load time, crashing the entire server on startup.
+
+## Impact
+
+**Critical** - The server fails to start, making all order routes unavailable.
+
+## Suggested Fix
+
+Remove the old non-paginated calls (lines 379 and 400) since the paginated versions on the following lines are the correct replacements.
+
+GSSoC

--- a/issue_body_3.txt
+++ b/issue_body_3.txt
@@ -1,0 +1,31 @@
+## Description
+
+In `backend/api/src/routes/orderRoutes.js` at line 490, the identifier `UUID_RE` is used to test an order ID format:
+
+```javascript
+if (UUID_RE.test(orderId)) {
+```
+
+However, `UUID_RE` is **never declared or imported** anywhere in `orderRoutes.js`. A search of the entire file reveals no `const UUID_RE` declaration or import statement for it.
+
+When the `GET /:id/timeline` endpoint is hit, this will throw a **ReferenceError: UUID_RE is not defined**, crashing the request handler.
+
+## Impact
+
+**High** - The timeline endpoint crashes on every request, making order timeline data unavailable.
+
+## Steps to Reproduce
+
+1. Start the server
+2. Send GET request to `/api/orders/{id}/timeline`
+3. Observe 500 error with ReferenceError
+
+## Suggested Fix
+
+Either import `UUID_RE` from `orderLifecycleService.js` (where it's defined) or add a local definition:
+
+```javascript
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+```
+
+GSSoC

--- a/issue_body_4.txt
+++ b/issue_body_4.txt
@@ -1,0 +1,30 @@
+## Description
+
+In `backend/api/src/routes/orderRoutes.js` in the `GET /:id/timeline` handler, `order` is declared with `let` on line 489 and reassigned on lines 492/496. Then at line 504, a **duplicate `const order = await ...`** redeclaration appears:
+
+```javascript
+// Line 489
+let order = null;
+
+// Lines 492/496 - reassignments using let
+if (UUID_RE.test(orderId)) {
+  order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
+} else {
+  order = await orderValidationService.findOrderByDisplayForTimeline(orderId);
+}
+
+// Line 504 - DUPLICATE const redeclaration (SyntaxError)
+const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'customer_id, driver_id, order_display_id');
+```
+
+`const` does not allow redeclaration of an existing variable in the same scope. This will cause a **SyntaxError** at load time, preventing the server from starting.
+
+## Impact
+
+**Critical** - Server fails to start due to SyntaxError in route file.
+
+## Suggested Fix
+
+Remove the duplicate code block on lines 504-506, which appears to be leftover dead code from an older implementation.
+
+GSSoC

--- a/issue_body_5.txt
+++ b/issue_body_5.txt
@@ -1,0 +1,43 @@
+## Description
+
+In `backend/api/src/services/order/orderTimelineService.js`, the constructor only assigns `this.orderRepository` but never initializes `this.logger`:
+
+```javascript
+constructor(orderRepository) {
+  this.orderRepository = orderRepository;
+}
+```
+
+However, multiple methods use `this.logger?.error?.()` to log failures:
+- Line 55: `this.logger?.error?.('Timeline Reset Error:', error.message);`
+- Line 72: `this.logger?.error?.('Failed to update timeline for change-drop:', error.message);`
+- Line 83: `this.logger?.error?.('Failed to update Order Placed milestone on cancel:', error.message);`
+- Line 92: `this.logger?.error?.('Failed to delete order timeline:', error.message);`
+
+The optional chaining prevents a crash, but **all error messages are silently swallowed** in production. When timeline operations fail (reset, cancel, delete), developers have no way to debug the issue.
+
+## Impact
+
+**Medium** - Silent error swallowing makes production debugging extremely difficult.
+
+## Suggested Fix
+
+Update the constructor to accept and store a logger:
+
+```javascript
+constructor(orderRepository, logger) {
+  this.orderRepository = orderRepository;
+  this.logger = logger;
+}
+```
+
+Or accept a dependencies object:
+
+```javascript
+constructor({ orderRepository, logger }) {
+  this.orderRepository = orderRepository;
+  this.logger = logger;
+}
+```
+
+GSSoC

--- a/issue_body_6.txt
+++ b/issue_body_6.txt
@@ -1,0 +1,34 @@
+## Description
+
+In `backend/api/src/repositories/orderRepository.js`, there are **multiple unresolved git merge conflict markers** at lines 64-81, 135-152, 243-260, 308-325, 385-394, 469-494, 523-532, 548-573, and 602-619. These markers are left over from an incomplete merge between `feature/dependency-injection-services` and `main`.
+
+For example (lines 64-81):
+```javascript
+<<<<<<< feature/dependency-injection-services
+  }
+
+  async findOrderByDisplayId(displayId, columns = '*') {
+    ...
+    return this._cachedQuery(`order:id:${id}:${columns}`, () =>
+    ...
+=======
+>>>>>>> main
+```
+
+The `=======` side of `main` is empty (meaning main deleted these methods), but the conflict was never resolved. This produces invalid JavaScript that will throw a **SyntaxError** at module load time.
+
+## Impact
+
+**Critical** - The entire order repository fails to load, making all order-related features unavailable.
+
+## Steps to Reproduce
+
+1. Start the server
+2. Observe SyntaxError at module load time
+3. All order API endpoints return 500 errors
+
+## Suggested Fix
+
+Resolve all merge conflicts by removing the conflict markers and the duplicate method bodies. The `main` branch side (empty `=======` blocks) indicates these methods should be removed as they are redeclared elsewhere.
+
+GSSoC

--- a/issue_body_7.txt
+++ b/issue_body_7.txt
@@ -1,0 +1,27 @@
+## Description
+
+In `backend/api/src/lib/redisLock.js` at lines 22-86, there is an **unresolved git merge conflict** between `fix/redis-lock-failure-handling` and `main`.
+
+The conflict pits two competing implementations:
+- **fix/redis-lock-failure-handling** side: Adds a `renewLock` function and returns `null` on Redis failures (defensive/fail-open approach)
+- **main** side: Throws exceptions on Redis unavailability (fail-closed approach)
+
+```javascript
+<<<<<<< fix/redis-lock-failure-handling
+  // renewLock function + null-returning implementation
+=======
+  // throwing implementation
+>>>>>>> main
+```
+
+This produces invalid JavaScript that causes a **SyntaxError** when the module is loaded, completely breaking distributed locking functionality.
+
+## Impact
+
+**Critical** - The distributed locking mechanism is completely broken. This affects concurrent order processing, OTP verification, and any other feature relying on Redis locks.
+
+## Suggested Fix
+
+Resolve the merge conflict by choosing one approach and removing all conflict markers. The `fix/redis-lock-failure-handling` branch is more defensive (returns null on failure), while `main` fails closed (throws). Choose based on the project's desired error-handling strategy.
+
+GSSoC

--- a/issue_body_8.txt
+++ b/issue_body_8.txt
@@ -1,0 +1,36 @@
+## Description
+
+In `backend/api/src/routes/adminRoutes.js`, there are **unresolved git merge conflict markers** at lines 3-10 and 15-19, left over from an incomplete merge between `security/admin-rate-limiter` and `main`.
+
+**Conflict 1 (imports, lines 3-10):**
+```javascript
+<<<<<<< security/admin-rate-limiter
+import { authenticate, requireRole } from '../middleware/auth.js';
+import { adminRateLimiter } from '../middleware/rateLimiter.js';
+=======
+import { authenticate } from '../middleware/auth.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
+>>>>>>> main
+```
+
+**Conflict 2 (route handler, lines 15-19):**
+```javascript
+<<<<<<< security/admin-rate-limiter
+router.get('/dashboard', authenticate, adminRateLimiter, requireRole(['admin']), async (req, res) => {
+=======
+router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-dashboard'), async (req, res) => {
+>>>>>>> main
+```
+
+These conflict markers produce invalid JavaScript, causing a **SyntaxError** that prevents the admin routes from loading. Both the old role-based auth (`requireRole`) and the new policy-based auth (`requirePolicy`) are left in limbo.
+
+## Impact
+
+**Critical** - All admin dashboard and management routes are unavailable.
+
+## Suggested Fix
+
+Resolve both conflicts by choosing one authentication approach. `main` uses the newer RBAC/policy-based approach (`requirePolicy` + `userLimiter`), which is likely the intended direction.
+
+GSSoC

--- a/issue_body_9.txt
+++ b/issue_body_9.txt
@@ -1,0 +1,36 @@
+## Description
+
+In `backend/api/src/services/order/orderLifecycleService.js` at lines 3-8, the module imports `sendOtpNotification` from `./deliveryVerificationService.js`:
+
+```javascript
+import {
+  verifyDelivery,
+  generateDeliveryOtp,
+  resendDeliveryOtp,
+  sendOtpNotification,
+} from './deliveryVerificationService.js';
+```
+
+However, `deliveryVerificationService.js` **does not export** any standalone function named `sendOtpNotification`. It only exports the class `DeliveryVerificationService`, which has an *instance method* called `sendOtpNotification` (line 215). The file does not have any top-level `export function sendOtpNotification` statement.
+
+When `orderLifecycleService.js` calls `await sendOtpNotification({...})` at line 413, it will throw a **TypeError: sendOtpNotification is not a function**.
+
+Similarly, `verifyDelivery`, `generateDeliveryOtp`, and `resendDeliveryOtp` are also imported but not exported as standalone functions.
+
+## Impact
+
+**Critical** - The `updateMilestone` method in `OrderLifecycleService` crashes whenever the "In Transit" milestone is triggered, breaking the core order fulfillment flow.
+
+## Steps to Reproduce
+
+1. Start the server
+2. Update an order's milestone to "In Transit"
+3. Observe TypeError crash
+
+## Suggested Fix
+
+Option A: Add standalone exported wrappers in `deliveryVerificationService.js`
+Option B: Change `orderLifecycleService.js` to import from `../notificationService.js` (where `sendDeliveryOtpNotification` actually lives)
+Option C: Call these as methods on a `DeliveryVerificationService` instance
+
+GSSoC


### PR DESCRIPTION
## Description
Fixes `predictPrice` in `ml.js` where merge debris caused `response` to be used before declaration and a duplicate `const result`.

### Changes
- Move `fetch()` call before `handleResponse(response)` so `response` is declared before use
- Remove duplicate `const result` declarations
- Cache the validated result (with `estimatedPricePaisa`/`estimatedPriceInr`) instead of the raw API response

Closes #3446

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added issue reports covering backend startup failures, order timeline errors, delivery verification crashes, Redis locking conflicts, and admin route availability.
  * Documented a customer app address-parsing crash affecting some location formats.
  * Added guidance, reproduction steps, impacts, and suggested resolutions for each issue.

* **Refactor**
  * Improved the handling and caching flow for estimated property prices without changing the displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->