### PR TITLE
fix(verification): convert VerificationService.js from CommonJS to ES module

### DIFF
--- a/backend/api/src/services/verification/VerificationService.js
+++ b/backend/api/src/services/verification/VerificationService.js
@@ -1,4 +1,4 @@
-const OracleService = require('../oracle/OracleService');
+import OracleService from '../oracle/OracleService.js';
 
 class VerificationService {
   constructor() {
@@ -68,4 +68,4 @@ class VerificationService {
   }
 }
 
-module.exports = VerificationService;
+export default VerificationService;


### PR DESCRIPTION
## Summary

`VerificationService.js` uses CommonJS `require()` and `module.exports` but the project declares `"type": "module"` in `package.json`. This means any import of this file throws `ReferenceError: require is not defined` at load time, crashing the process.

## Changes

- Converted `const OracleService = require('../oracle/OracleService')` to `import OracleService from '../oracle/OracleService.js'`
- Converted `module.exports = VerificationService` to `export default VerificationService`
- Added `.js` extension to import path per project conventions

## Testing

- Verified the import matches the pattern used in `oracleRoutes.js` which already imports OracleService as a default import
- Verified the export matches the project's ESM conventions

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3487
