### PR TITLE
fix: remove duplicate router.delete handler in profileRoutes.js

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import { authenticate, requireRole } from '../middleware/auth.js';
-import { userLimiter, adminRateLimiter } from '../middleware/rateLimiter.js';
+import { authenticate } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { z } from 'zod';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
@@ -340,7 +340,6 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
 // Invalidates the profile cache for a specific user, forcing the next
 // authenticated request to refetch from Supabase. Use this after admin
 // operations that change role, status, or other cached profile fields.
-router.delete('/admin/cache/:userId', authenticate, adminRateLimiter, requireRole(['admin']), validateParams(uuidParamSchema), async (req, res) => {
 router.delete('/admin/cache/:userId', authenticate, userLimiter, requirePolicy('admin:invalidate-cache'), validateParams(z.object({ userId: z.string().min(1, 'userId is required') })), async (req, res) => {
   try {
     const targetUserId = req.params.userId;


### PR DESCRIPTION
## Description
`profileRoutes.js` has a duplicate `router.delete('/admin/cache/:userId')` handler — merge debris that registers the route twice on every request.

### Changes
- Remove the duplicate handler (lines 343-348)

Closes #3448

GSSoC