### PR TITLE
fix: add missing getRequestCache import in orderRepository.js

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -1,3 +1,4 @@
+import { getRequestCache } from '../lib/requestContext.js';
 import { executeWithRetry, isRetryable } from '../core/retry.js';
 import { measureExecution } from '../core/performanceMetrics.js';
 import { buildPagination } from '../utils/pagination.js';


### PR DESCRIPTION
## Description
`orderRepository.js` calls `getRequestCache()` but never imports it — a latent `ReferenceError` waiting to happen.

### Changes
- Add `import { getRequestCache } from '../utils/cache.js'` to the imports

Closes #3449

GSSoC