### PR TITLE
fix: remove await from synchronous train_fn call in base.py

### DIFF
--- a/backend/ml/app/models/base.py
+++ b/backend/ml/app/models/base.py
@@ -58,7 +58,7 @@ async def ensure_model_loaded(model_name: str, train_fn, *args, **kwargs) -> Opt
     async with _get_lock(model_name):
         if not model_exists(model_name):
             logger.info("Model '%s' not found, training...", model_name)
-            await train_fn(*args, **kwargs)
+            train_fn(*args, **kwargs)
         return load_model(model_name)
 
 SUPPORTED_MODELS: list[str] = [


### PR DESCRIPTION
## Description
`base.py:ensure_model_loaded()` uses `await` on `train_fn()`, but `train_fn` is a synchronous function — causes `TypeError` if ever called.

### Changes
- Remove the `await` from the `train_fn()` call

Closes #3452

GSSoC