### PR TITLE
fix: remove unused duplicate tripHistory field in home_screen.dart

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -131,8 +131,6 @@ class _HomeScreenState extends State<HomeScreen> {
   String _activeTripPayout = '';
   bool _isLoadingLocation = true;
   String? _locationError;
-  final List<TripRecord> tripHistory = [];
-
   late final MarketplaceRepository _marketplaceRepo;
   StreamSubscription<LoadOffer>? _loadSubscription;
   Timer? _autoHideTimer;


### PR DESCRIPTION
## Description
`home_screen.dart` declares `tripHistory` twice — dead code from an incomplete refactor that shadows the real field.

### Changes
- Remove the unused duplicate `tripHistory` field declaration

Closes #3453

GSSoC