### PR TITLE
fix: add missing orderId declaration in resend-otp handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -759,6 +759,7 @@ router.post('/:id/verify-delivery', authenticate, userLimiter, requirePolicy('de
 router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requirePolicy('delivery:resend-otp'), validateParams(paramIdSchema), async (req, res) => {
 
   try {
+    const orderId = req.params.id;
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, driver_id, customer_id, status');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertDriverAssignment(order, req.user.id);


### PR DESCRIPTION
## Description
The resend-otp handler in `orderRoutes.js` uses `orderId` without declaring it — `ReferenceError` on every call.

### Changes
- Add `const orderId = req.params.id;` to the handler body

Closes #3454

GSSoC