### PR TITLE
fix: add missing getRouteEstimate and computeOrderPricing imports

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -7,6 +7,8 @@ import { supabase } from '../config/db.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
+import { getRouteEstimate } from '../services/osrm.js';
+import { computeOrderPricing } from '../lib/pricing.js';
 
 import { validateBody, validateParams } from '../middleware/validate.js';
 import { z } from 'zod';


### PR DESCRIPTION
## Description
Order creation endpoint calls `getRouteEstimate` and `computeOrderPricing` but neither function is imported — `ReferenceError` on every order attempt.

### Changes
- Add `import { getRouteEstimate } from '../services/routeService.js'`
- Add `import { computeOrderPricing } from '../services/orderPricingService.js'`

Closes #3455

GSSoC