### PR TITLE
fix(tracker): three critical bugs in telemetry flush, WebSocket restore, and recovery file

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -849,11 +849,11 @@ async function flushTelemetryBuffer() {
         } else {
           logger.error(`[TRUXIFY VALIDATION] Bulk insert validation error: ${err.message}`);
         }
-        const succeeded = err.writeErrors
-          ? recordsToFlush.filter((_, i) => !err.writeErrors.some(e => e.index === i))
+        const failed = err.writeErrors
+          ? recordsToFlush.filter((_, i) => err.writeErrors.some(e => e.index === i))
           : [];
-        if (succeeded.length > 0) {
-          const overflowDrop = telemetryWriteBuffer.prepend(succeeded);
+        if (failed.length > 0) {
+          const overflowDrop = telemetryWriteBuffer.prepend(failed);
           if (overflowDrop > 0) {
             telemetryTotalDropped += overflowDrop;
             telemetryOverflowDropped += overflowDrop;
@@ -969,7 +969,7 @@ export async function closeWebSocketServer() {
       const dataLoss = telemetryWriteBuffer.length;
       if (dataLoss > 0) {
         try {
-          const lines = telemetryWriteBuffer.toArray().map(r => JSON.stringify(scrubPII(r))).join('\n');
+          const lines = telemetryWriteBuffer.toArray().map(r => JSON.stringify(r)).join('\n');
           fs.writeFileSync(RECOVERY_FILE_PATH, lines + '\n', { encoding: 'utf-8', mode: 0o600 });
           logger.warn(`[TRUXIFY SHUTDOWN] MongoDB not available. Wrote ${dataLoss} telemetry records to recovery file: ${RECOVERY_FILE_PATH}`);
         } catch (fileErr) {
@@ -1193,9 +1193,9 @@ async function restoreSubscriptions(ws) {
     for (const targetId of targets) {
       const allowed = await canSubscribe(
         ws,
-        targetId.startsWith('ORDER-')
-          ? { order_display_id: targetId }
-          : { driver_id: targetId }
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(targetId)
+          ? { driver_id: targetId }
+          : { order_display_id: targetId }
       );
 
       if (!allowed) {


### PR DESCRIPTION
## Summary

Three critical bugs fixed in `tracker.js`:

### 1. Telemetry flush re-queues SUCCEEDED records (#3504)

When a bulk MongoDB `insertMany` partially failed, the code filtered for **succeeded** records (used `!err.writeErrors.some(...)`) and prepended them back into the write buffer. On the next flush, those already-written records got inserted again, creating infinite duplicate writes.

**Fix:** Removed the negation so only **failed** records are re-queued.

### 2. WebSocket restoreSubscriptions uses wrong ORDER- prefix (#3505)

`restoreSubscriptions` checked `targetId.startsWith('ORDER-')` to distinguish order from driver subscriptions. But order display IDs use `#FF` prefix (e.g., `#FF20260716123456`), never `ORDER-`. Every order subscription was misidentified as a driver subscription, failed authorization, and was silently removed from Redis.

**Fix:** Switched to UUID regex detection — driver IDs are UUIDs, order display IDs are not.

### 3. Recovery file scrubs driver_id making data unqueryable (#3506)

During shutdown, `scrubPII(r)` hashed driver_ids and rounded lat/lng before writing to the ephemeral recovery file. On reload, these hashed records were flushed to MongoDB with unqueryable driver_ids, permanently corrupting telemetry attribution.

**Fix:** Removed `scrubPII` since the recovery file is deleted immediately after loading.

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3504, #3505, #3506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry recovery so failed records are retained and can be retried after partial storage failures.
  * Preserved complete telemetry data in recovery files when the database is unavailable.
  * Improved restoration of subscriptions by more accurately identifying driver and order targets.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->