### PR TITLE
fix(orderLifecycleService): guard against unmapped milestones setting status to undefined

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -385,6 +385,11 @@ export class OrderLifecycleService {
     }
 
     const status = milestoneMap[milestone];
+    if (status === undefined) {
+      throw new DomainError(400, {
+        error: `Milestone "${milestone}" does not map to an order status. Use the delivery verification endpoint instead.`,
+      });
+    }
     const updates = { status, updated_at: new Date().toISOString() };
     let generatedOtp = null;
 


### PR DESCRIPTION
## Summary

The `milestoneMap` in `orderLifecycleService.js` maps milestone names to order status strings, but does not include `'Delivered'`, `'Order Placed'`, `'Truck Assigned'`, or `'En Route to Pickup'`. If `updateMilestone` is called with one of these, `milestoneMap[milestone]` returns `undefined`, and line 388 sets `updates = { status: undefined, ... }`, writing NULL to the order's status column.

## Changes

Added a guard that throws `DomainError(400)` for unmapped milestones, directing callers to use the appropriate endpoint (e.g., `/verify-delivery` for delivery confirmation).

## Testing

- Verified 'Delivered' milestone now throws a clear error instead of setting status to undefined
- Verified mapped milestones ('In Transit', 'Arriving', etc.) still work correctly

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3507
