### PR TITLE
fix(orderTimelineService): use module-level logger instead of undefined this.logger

### DIFF
--- a/backend/api/src/services/order/orderTimelineService.js
+++ b/backend/api/src/services/order/orderTimelineService.js
@@ -66,7 +66,7 @@ export class OrderTimelineService {
       sort_order: 25,
     }]);
     if (error) {
-      this.logger?.error?.('Failed to update timeline for change-drop:', error.message);
+      logger.error('Failed to update timeline for change-drop:', error.message);
       throw new DomainError(500, { error: 'Failed to record drop-change event.', details: error.message });
     }
   }


### PR DESCRIPTION
## Summary

`insertDropChangedEvent` in `orderTimelineService.js` referenced `this.logger?.error?.(...)` but `this.logger` is never set in the constructor. Optional chaining prevented a crash, but drop-change timeline failures were silently swallowed with zero diagnostic output.

## Changes

Replaced `this.logger?.error?.(...)` with the imported module-level `logger.error(...)`, matching the pattern used by all other methods in the class.

## Testing

- Verified the module-level `logger` is already imported at the top of the file
- Verified all other error handling in the class uses the same module-level `logger`

## GSSoC

This PR is submitted as part of GSSoC 2025.

Closes #3508
