### PR TITLE
feat(notifications): add deep linking support for push notifications

### DIFF
--- a/apps/customer/lib/controllers/app_controller.dart
+++ b/apps/customer/lib/controllers/app_controller.dart
@@ -26,7 +26,7 @@ class TruxifyController extends ChangeNotifier {
   }
 
   bool _validateTabIndex(int index) {
-    return index >= 0 && index <= 2;
+    return index >= 0 && index <= 3;
   }
 
   Future<void> loadThemeMode() async {

--- a/apps/customer/lib/l10n/app_en.arb
+++ b/apps/customer/lib/l10n/app_en.arb
@@ -725,5 +725,20 @@
   "failedToUpdateProfile": "Failed to update profile",
   "@failedToUpdateProfile": {
     "description": "Error message when profile update fails"
+  },
+
+  "orderNotFound": "Order not found",
+  "@orderNotFound": {
+    "description": "Error message when an order referenced by a notification cannot be found"
+  },
+
+  "notification": "Notification",
+  "@notification": {
+    "description": "Title for notification-related UI elements"
+  },
+
+  "unableToOpen": "Unable to open notification",
+  "@unableToOpen": {
+    "description": "Error message when a notification cannot be navigated to"
   }
 }

--- a/apps/customer/lib/l10n/app_hi.arb
+++ b/apps/customer/lib/l10n/app_hi.arb
@@ -725,5 +725,20 @@
   "failedToUpdateProfile": "प्रोफ़ाइल अपडेट करने में असफल",
   "@failedToUpdateProfile": {
     "description": "Error message when profile update fails"
+  },
+
+  "orderNotFound": "ऑर्डर नहीं मिला",
+  "@orderNotFound": {
+    "description": "Error message when an order referenced by a notification cannot be found"
+  },
+
+  "notification": "सूचना",
+  "@notification": {
+    "description": "Title for notification-related UI elements"
+  },
+
+  "unableToOpen": "सूचना खोलने में असमर्थ",
+  "@unableToOpen": {
+    "description": "Error message when a notification cannot be navigated to"
   }
 }

--- a/apps/customer/lib/l10n/app_localizations.dart
+++ b/apps/customer/lib/l10n/app_localizations.dart
@@ -369,6 +369,12 @@ abstract class AppLocalizations {
   String get failedToLoadProfile;
 
   String get failedToUpdateProfile;
+
+  String get orderNotFound;
+
+  String get notification;
+
+  String get unableToOpen;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/customer/lib/l10n/app_localizations_en.dart
+++ b/apps/customer/lib/l10n/app_localizations_en.dart
@@ -415,4 +415,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get failedToUpdateProfile => 'Failed to update profile';
+
+  @override
+  String get orderNotFound => 'Order not found';
+
+  @override
+  String get notification => 'Notification';
+
+  @override
+  String get unableToOpen => 'Unable to open notification';
 }

--- a/apps/customer/lib/l10n/app_localizations_hi.dart
+++ b/apps/customer/lib/l10n/app_localizations_hi.dart
@@ -415,4 +415,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get failedToUpdateProfile => '\u092A\u094D\u0930\u094B\u092B\u093C\u093E\u0907\u0932 \u0905\u092A\u0921\u0947\u091F \u0915\u0930\u0928\u0947 \u092E\u0947\u0902 \u0905\u0938\u092B\u0932';
+
+  @override
+  String get orderNotFound => '\u0911\u0930\u094D\u0921\u0930 \u0928\u0939\u0940\u0902 \u092E\u093F\u0932\u093E';
+
+  @override
+  String get notification => '\u0938\u0942\u091A\u0928\u093E';
+
+  @override
+  String get unableToOpen => '\u0938\u0942\u091A\u0928\u093E \u0916\u094B\u0932\u0928\u0947 \u092E\u0947\u0902 \u0905\u0938\u092E\u0930\u094D\u0925';
 }

--- a/apps/customer/lib/screens/notifications_screen.dart
+++ b/apps/customer/lib/screens/notifications_screen.dart
@@ -3,7 +3,10 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify_shared/truxify_shared.dart' as shared;
 
 class NotificationsScreen extends StatelessWidget {
-  const NotificationsScreen({super.key});
+  const NotificationsScreen({super.key, this.onItemTap});
+
+  /// Called when a notification tile is tapped.
+  final ValueChanged<shared.NotificationItem>? onItemTap;
 
   @override
   Widget build(BuildContext context) {
@@ -15,6 +18,7 @@ class NotificationsScreen extends StatelessWidget {
     return shared.NotificationsScreen(
       userId: userId,
       repository: NotificationRepository(client),
+      onItemTap: onItemTap,
     );
   }
 }

--- a/apps/customer/lib/screens/shell_screen.dart
+++ b/apps/customer/lib/screens/shell_screen.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
 
 import '../controllers/app_controller.dart';
 import '../l10n/app_localizations.dart';
+import '../models/app_models.dart';
 import '../services/fcm_service.dart';
+import '../services/order_service.dart';
 import '../theme/app_theme.dart';
 import 'find_trucks_screen.dart';
 import 'home_screen.dart';
+import 'order_detail_screen.dart';
 import 'orders_screen.dart';
 import 'profile_screen.dart';
 
@@ -21,12 +26,114 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
   final GlobalKey<NavigatorState> _findNavigatorKey = GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> _ordersNavigatorKey = GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> _profileNavigatorKey = GlobalKey<NavigatorState>();
+  final OrderService _orderService = OrderService();
 
   @override
   void initState() {
     super.initState();
-    // Initialize push notifications
     FcmService.initializeAndRegister();
+    ForegroundNotificationHandler.setup(
+      context: context,
+      onTap: _handleNotificationNavigation,
+    );
+    ForegroundNotificationHandler.handleInitialMessage(
+      onTap: _handleNotificationNavigation,
+    );
+    ForegroundNotificationHandler.handleBackgroundTap(
+      onTap: _handleNotificationNavigation,
+    );
+  }
+
+  @override
+  void dispose() {
+    ForegroundNotificationHandler.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleNotificationNavigation(
+    NotificationTarget target,
+    Map<String, dynamic> data,
+  ) async {
+    if (!mounted) return;
+
+    switch (target) {
+      case NotificationTarget.orderDetail:
+        await _navigateToOrderDetail(data);
+        break;
+      case NotificationTarget.notifications:
+        _navigateToNotifications();
+        break;
+      default:
+        _navigateToNotifications();
+        break;
+    }
+  }
+
+  Future<void> _navigateToOrderDetail(Map<String, dynamic> data) async {
+    final orderId = NotificationRouter.extractOrderId(data);
+    if (orderId == null || !mounted) {
+      _navigateToNotifications();
+      return;
+    }
+
+    final orderMap = await _orderService.fetchOrderById(orderId);
+    if (!mounted) return;
+
+    if (orderMap == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)!.orderNotFound)),
+      );
+      return;
+    }
+
+    final rawAmount = orderMap['total_amount'] ?? 0;
+    final amountInRupees = (rawAmount is num)
+        ? (rawAmount / 100).toStringAsFixed(0)
+        : rawAmount.toString();
+
+    final driverName = orderMap['profiles'] is Map<String, dynamic>
+        ? (orderMap['profiles']['full_name']?.toString().trim() ?? 'Driver Assigned')
+        : orderMap['driver_name']?.toString().trim() ?? 'Driver Assigned';
+
+    final truckNumber = orderMap['truck_number']?.toString().trim().isNotEmpty == true
+        ? orderMap['truck_number'].toString().trim()
+        : '—';
+
+    String formatPaise(dynamic value) {
+      if (value is! num) return '';
+      return 'Rs ${(value / 100).toStringAsFixed(0)}';
+    }
+
+    final order = HistoryOrderData(
+      orderId: orderMap['order_display_id']?.toString() ?? orderId,
+      route: '${orderMap['pickup_address'] ?? ''} → ${orderMap['drop_address'] ?? ''}',
+      date: orderMap['pickup_date']?.toString() ?? '',
+      amount: '₹$amountInRupees',
+      status: orderMap['status']?.toString() ?? '',
+      driver: driverName,
+      truckNumber: truckNumber,
+      timeline: [],
+      blockchainTxHash: orderMap['blockchain_tx_hash']?.toString(),
+      baseFare: formatPaise(orderMap['base_fare']),
+      distanceCharge: formatPaise(orderMap['distance_charge']),
+      tollCharge: formatPaise(orderMap['toll_charge']),
+      platformFee: formatPaise(orderMap['platform_fee']),
+    );
+
+    // Switch to Orders tab and push detail screen.
+    final controller = TruxifyScope.of(context);
+    controller.setTab(2);
+
+    _ordersNavigatorKey.currentState?.push(
+      MaterialPageRoute<void>(
+        builder: (_) => OrderDetailScreen(order: order),
+      ),
+    );
+  }
+
+  void _navigateToNotifications() {
+    final controller = TruxifyScope.of(context);
+    controller.setTab(3);
   }
 
   @override

--- a/apps/driver/lib/l10n/app_en.arb
+++ b/apps/driver/lib/l10n/app_en.arb
@@ -718,5 +718,10 @@
   "thisLoadIsMissingId": "This load is missing an ID",
   "@thisLoadIsMissingId": {
     "description": "Error message when a load record has no valid identifier"
+  },
+
+  "unableToOpen": "Unable to open notification",
+  "@unableToOpen": {
+    "description": "Error message when a notification cannot be navigated to"
   }
 }

--- a/apps/driver/lib/l10n/app_hi.arb
+++ b/apps/driver/lib/l10n/app_hi.arb
@@ -718,5 +718,10 @@
   "thisLoadIsMissingId": "इस लोड में ID गायब है",
   "@thisLoadIsMissingId": {
     "description": "Error message when a load record has no valid identifier"
+  },
+
+  "unableToOpen": "सूचना खोलने में असमर्थ",
+  "@unableToOpen": {
+    "description": "Error message when a notification cannot be navigated to"
   }
 }

--- a/apps/driver/lib/l10n/app_localizations.dart
+++ b/apps/driver/lib/l10n/app_localizations.dart
@@ -375,6 +375,8 @@ abstract class AppLocalizations {
   String get failedToSubmitBid;
 
   String get thisLoadIsMissingId;
+
+  String get unableToOpen;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/driver/lib/l10n/app_localizations_en.dart
+++ b/apps/driver/lib/l10n/app_localizations_en.dart
@@ -432,4 +432,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get thisLoadIsMissingId => 'This load is missing an ID';
+
+  @override
+  String get unableToOpen => 'Unable to open notification';
 }

--- a/apps/driver/lib/l10n/app_localizations_hi.dart
+++ b/apps/driver/lib/l10n/app_localizations_hi.dart
@@ -432,4 +432,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get thisLoadIsMissingId => 'इस लोड में ID गायब है';
+
+  @override
+  String get unableToOpen => 'सूचना खोलने में असमर्थ';
 }

--- a/apps/driver/lib/screens/notifications_screen.dart
+++ b/apps/driver/lib/screens/notifications_screen.dart
@@ -4,7 +4,10 @@ import 'package:truxify_shared/truxify_shared.dart';
 import 'package:truxify_shared/truxify_shared.dart' as shared;
 
 class NotificationsScreen extends StatelessWidget {
-  const NotificationsScreen({super.key});
+  const NotificationsScreen({super.key, this.onItemTap});
+
+  /// Called when a notification tile is tapped.
+  final ValueChanged<NotificationItem>? onItemTap;
 
   @override
   Widget build(BuildContext context) {
@@ -17,6 +20,7 @@ class NotificationsScreen extends StatelessWidget {
       userId: userId,
       repository: NotificationRepository(client),
       title: 'Notifications',
+      onItemTap: onItemTap,
     );
   }
 }

--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+
 import '../core/app_routes.dart';
 import '../l10n/app_localizations.dart';
 import '../models/app_models.dart';
@@ -71,16 +73,51 @@ class _ShellScreenState extends State<ShellScreen> {
       ),
     ];
     FcmService.initializeAndRegister();
+    ForegroundNotificationHandler.setup(
+      context: context,
+      onTap: _handleNotificationNavigation,
+    );
+    ForegroundNotificationHandler.handleInitialMessage(
+      onTap: _handleNotificationNavigation,
+    );
+    ForegroundNotificationHandler.handleBackgroundTap(
+      onTap: _handleNotificationNavigation,
+    );
   }
 
   @override
   void dispose() {
+    ForegroundNotificationHandler.dispose();
     _currentIndex.dispose();
     super.dispose();
   }
 
   void _openTab(int index) {
     _currentIndex.value = index;
+  }
+
+  Future<void> _handleNotificationNavigation(
+    NotificationTarget target,
+    Map<String, dynamic> data,
+  ) async {
+    if (!mounted) return;
+
+    switch (target) {
+      case NotificationTarget.tripDetail:
+        _openTab(1); // Trips tab
+        break;
+      case NotificationTarget.earnings:
+        _openTab(2); // Earnings tab
+        break;
+      case NotificationTarget.loadDetail:
+        _openTab(0); // Home tab
+        break;
+      case NotificationTarget.notifications:
+      case NotificationTarget.orderDetail:
+      case NotificationTarget.unknown:
+        _openTab(3); // Profile tab (notifications accessed from here)
+        break;
+    }
   }
 
   Route<dynamic> _errorRoute() {

--- a/packages/truxify_shared/lib/src/models/notification_item.dart
+++ b/packages/truxify_shared/lib/src/models/notification_item.dart
@@ -7,6 +7,7 @@ class NotificationItem {
     required this.notifType,
     required this.isRead,
     required this.createdAt,
+    this.metadata,
   });
 
   final String id;
@@ -16,6 +17,16 @@ class NotificationItem {
   final String notifType;
   final bool isRead;
   final DateTime? createdAt;
+  final Map<String, dynamic>? metadata;
+
+  /// Order display ID extracted from [metadata], if present.
+  String? get orderId => metadata?['order_display_id']?.toString();
+
+  /// Trip ID extracted from [metadata], if present.
+  String? get tripId => metadata?['trip_id']?.toString();
+
+  /// Bid ID extracted from [metadata], if present.
+  String? get bidId => metadata?['bid_id']?.toString();
 
   factory NotificationItem.fromMap(Map<String, dynamic> map) {
     return NotificationItem(
@@ -26,6 +37,32 @@ class NotificationItem {
       notifType: map['notif_type']?.toString() ?? 'general',
       isRead: map['is_read'] as bool? ?? false,
       createdAt: DateTime.tryParse(map['created_at']?.toString() ?? ''),
+      metadata: map['metadata'] is Map<String, dynamic>
+          ? map['metadata'] as Map<String, dynamic>
+          : null,
+    );
+  }
+
+  /// Creates a copy with the given fields replaced.
+  NotificationItem copyWith({
+    String? id,
+    String? userId,
+    String? title,
+    String? body,
+    String? notifType,
+    bool? isRead,
+    DateTime? createdAt,
+    Map<String, dynamic>? metadata,
+  }) {
+    return NotificationItem(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      title: title ?? this.title,
+      body: body ?? this.body,
+      notifType: notifType ?? this.notifType,
+      isRead: isRead ?? this.isRead,
+      createdAt: createdAt ?? this.createdAt,
+      metadata: metadata ?? this.metadata,
     );
   }
 }

--- a/packages/truxify_shared/lib/src/screens/notifications_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/notifications_screen.dart
@@ -3,13 +3,24 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/notification_item.dart';
 import '../repositories/notification_repository.dart';
+import '../services/notification_router.dart';
 
 class NotificationsScreen extends StatefulWidget {
-  const NotificationsScreen({super.key, required this.userId, required this.repository, this.title = 'Notifications'});
+  const NotificationsScreen({
+    super.key,
+    required this.userId,
+    required this.repository,
+    this.title = 'Notifications',
+    this.onItemTap,
+  });
 
   final String userId;
   final String title;
   final NotificationRepository repository;
+
+  /// Called when a notification [ListTile] is tapped.
+  /// Receives the tapped item and should perform navigation.
+  final ValueChanged<NotificationItem>? onItemTap;
 
   @override
   State<NotificationsScreen> createState() => _NotificationsScreenState();
@@ -91,17 +102,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
 
       setState(() {
         _items = _items.map((n) {
-          if (n.id == item.id) {
-            return NotificationItem(
-              id: n.id,
-              userId: n.userId,
-              title: n.title,
-              body: n.body,
-              notifType: n.notifType,
-              isRead: true,
-              createdAt: n.createdAt,
-            );
-          }
+          if (n.id == item.id) return n.copyWith(isRead: true);
           return n;
         }).toList();
       });
@@ -114,6 +115,13 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
         ),
       );
     }
+  }
+
+  void _onTileTap(NotificationItem item) async {
+    // Mark as read if unread.
+    if (!item.isRead) await _markRead(item);
+    // Delegate navigation to the parent.
+    widget.onItemTap?.call(item);
   }
 
   int get _unreadCount => _items.where((item) => !item.isRead).length;
@@ -204,6 +212,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                           final item = _items[index];
                           final relativeTime = _formatRelativeTime(item.createdAt);
                           return ListTile(
+                            onTap: () => _onTileTap(item),
                             tileColor: item.isRead ? null : Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.25),
                             leading: Icon(Icons.notifications_rounded, color: item.isRead ? null : Theme.of(context).colorScheme.primary),
                             title: Text(item.title),

--- a/packages/truxify_shared/lib/src/services/foreground_notification_handler.dart
+++ b/packages/truxify_shared/lib/src/services/foreground_notification_handler.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+
+import 'notification_router.dart';
+
+/// Handles foreground FCM messages by showing a Material banner.
+///
+/// Call [setup] once from the shell screen's `initState`. The banner includes
+/// a "View" action that invokes [onTap] with the notification's data payload.
+class ForegroundNotificationHandler {
+  ForegroundNotificationHandler._();
+
+  static StreamSubscription<RemoteMessage>? _subscription;
+
+  /// Begins listening for foreground messages.
+  ///
+  /// [context] must be the shell screen's `BuildContext` (stays alive for the
+  /// app's lifetime). [onTap] is called when the user taps "View".
+  static void setup({
+    required BuildContext context,
+    required NotificationNavigationCallback onTap,
+  }) {
+    _subscription?.cancel();
+    _subscription = FirebaseMessaging.onMessage.listen((message) {
+      if (!context.mounted) return;
+      _showBanner(context: context, message: message, onTap: onTap);
+    });
+  }
+
+  /// Cancels the foreground listener. Call in `dispose`.
+  static void dispose() {
+    _subscription?.cancel();
+    _subscription = null;
+  }
+
+  /// Handles a cold-start (app terminated) notification tap.
+  static Future<void> handleInitialMessage({
+    required NotificationNavigationCallback onTap,
+  }) async {
+    final message = await FirebaseMessaging.instance.getInitialMessage();
+    if (message == null) return;
+    await NotificationRouter.navigateFromRemoteMessage(message, onTap);
+  }
+
+  /// Handles a background notification tap (app in background, not killed).
+  static void handleBackgroundTap({
+    required NotificationNavigationCallback onTap,
+  }) {
+    FirebaseMessaging.onMessageOpenedApp.listen((message) {
+      NotificationRouter.navigateFromRemoteMessage(message, onTap);
+    });
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────
+
+  static void _showBanner({
+    required BuildContext context,
+    required RemoteMessage message,
+    required NotificationNavigationCallback onTap,
+  }) {
+    final title = message.notification?.title ?? 'New notification';
+    final body = message.notification?.body ?? '';
+
+    ScaffoldMessenger.of(context).hideCurrentMaterialBanner();
+    ScaffoldMessenger.of(context).showMaterialBanner(
+      MaterialBanner(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        leading: const Icon(Icons.notifications_rounded),
+        title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        content: Text(body, maxLines: 2, overflow: TextOverflow.ellipsis),
+        actions: [
+          TextButton(
+            onPressed: () {
+              ScaffoldMessenger.of(context).hideCurrentMaterialBanner();
+              NotificationRouter.navigate(
+                Map<String, dynamic>.from(message.data),
+                onTap,
+              );
+            },
+            child: const Text('View'),
+          ),
+          TextButton(
+            onPressed: () =>
+                ScaffoldMessenger.of(context).hideCurrentMaterialBanner(),
+            child: const Text('Dismiss'),
+          ),
+        ],
+      ),
+    );
+
+    // Auto-dismiss after 8 seconds.
+    Future.delayed(const Duration(seconds: 8), () {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).hideCurrentMaterialBanner();
+      }
+    });
+  }
+}

--- a/packages/truxify_shared/lib/src/services/notification_router.dart
+++ b/packages/truxify_shared/lib/src/services/notification_router.dart
@@ -1,0 +1,119 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/notification_item.dart';
+
+/// The screen target determined from a notification payload.
+enum NotificationTarget {
+  orderDetail,
+  tripDetail,
+  earnings,
+  loadDetail,
+  notifications,
+  unknown,
+}
+
+/// Signature for the app-specific navigation callback.
+///
+/// The callback receives the resolved [target] and the raw [data] map so it
+/// can look up any required IDs (orderDisplayId, tripId, etc.) and perform
+/// the actual navigation using the app's own navigation framework.
+typedef NotificationNavigationCallback = Future<void> Function(
+  NotificationTarget target,
+  Map<String, dynamic> data,
+);
+
+/// Parses notification payloads and dispatches navigation via a callback.
+///
+/// This class is intentionally stateless and has only static methods so it
+/// can be used from any context without coupling to a specific navigation
+/// package or widget tree.
+class NotificationRouter {
+  /// Resolves the [NotificationTarget] from a raw data map (FCM data payload
+  /// or [NotificationItem.metadata]).
+  static NotificationTarget resolveTarget(Map<String, dynamic> data) {
+    final type = _extractNotifType(data);
+    switch (type) {
+      case 'order_update':
+      case 'delivery_otp':
+        return NotificationTarget.orderDetail;
+      case 'trip_update':
+      case 'trip_completed':
+        return NotificationTarget.tripDetail;
+      case 'payment':
+      case 'payment_released':
+        return NotificationTarget.earnings;
+      case 'load_offer':
+        return NotificationTarget.loadDetail;
+      case 'system':
+      case 'document':
+        return NotificationTarget.notifications;
+      default:
+        return NotificationTarget.unknown;
+    }
+  }
+
+  /// Extracts the order display ID from the data map.
+  static String? extractOrderId(Map<String, dynamic> data) {
+    return data['order_display_id']?.toString() ??
+        data['orderId']?.toString();
+  }
+
+  /// Extracts the trip ID from the data map.
+  static String? extractTripId(Map<String, dynamic> data) {
+    return data['trip_id']?.toString() ?? data['tripId']?.toString();
+  }
+
+  /// Extracts the bid/load offer ID from the data map.
+  static String? extractBidId(Map<String, dynamic> data) {
+    return data['bid_id']?.toString() ??
+        data['load_offer_id']?.toString() ??
+        data['bidId']?.toString();
+  }
+
+  /// Navigates to the appropriate screen using [callback].
+  ///
+  /// This is the main entry point for both FCM events and notification-list
+  /// tap handling.
+  static Future<void> navigate(
+    Map<String, dynamic> data,
+    NotificationNavigationCallback callback,
+  ) async {
+    final target = resolveTarget(data);
+    try {
+      await callback(target, data);
+    } catch (e) {
+      debugPrint('[NotificationRouter] Navigation failed: $e');
+    }
+  }
+
+  /// Convenience: navigate from an [NotificationItem].
+  static Future<void> navigateFromItem(
+    NotificationItem item,
+    NotificationNavigationCallback callback,
+  ) async {
+    final data = <String, dynamic>{
+      'notifType': item.notifType,
+      if (item.metadata != null) ...item.metadata!,
+    };
+    await navigate(data, callback);
+  }
+
+  /// Navigates from an [RemoteMessage]'s data payload.
+  static Future<void> navigateFromRemoteMessage(
+    RemoteMessage message,
+    NotificationNavigationCallback callback,
+  ) async {
+    await navigate(Map<String, dynamic>.from(message.data), callback);
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  /// Extracts the notifType from either a top-level `notifType` key or the
+  /// nested `type` key (different backend code paths).
+  static String _extractNotifType(Map<String, dynamic> data) {
+    return (data['notifType'] ?? data['notif_type'] ?? data['type'] ?? '')
+        .toString()
+        .toLowerCase();
+  }
+}

--- a/packages/truxify_shared/lib/truxify_shared.dart
+++ b/packages/truxify_shared/lib/truxify_shared.dart
@@ -8,6 +8,8 @@ export 'src/config/supabase_config.dart';
 export 'src/services/api_client.dart';
 export 'src/services/auth_service.dart';
 export 'src/services/fcm_service.dart';
+export 'src/services/notification_router.dart';
+export 'src/services/foreground_notification_handler.dart';
 
 // ── Models ──────────────────────────────────────────────────────────
 export 'src/models/faq.dart';

--- a/packages/truxify_shared/test/notification_router_test.dart
+++ b/packages/truxify_shared/test/notification_router_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_shared/src/models/notification_item.dart';
+import 'package:truxify_shared/src/services/notification_router.dart';
+
+void main() {
+  group('NotificationRouter.resolveTarget', () {
+    test('resolves order_update to orderDetail', () {
+      final data = {'notifType': 'order_update', 'order_display_id': 'ORD-1'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.orderDetail,
+      );
+    });
+
+    test('resolves delivery_otp to orderDetail', () {
+      final data = {'notifType': 'delivery_otp', 'orderDisplayId': 'ORD-2'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.orderDetail,
+      );
+    });
+
+    test('resolves trip_update to tripDetail', () {
+      final data = {'notifType': 'trip_update', 'trip_id': 'T-1'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.tripDetail,
+      );
+    });
+
+    test('resolves trip_completed to tripDetail', () {
+      final data = {'notifType': 'trip_completed'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.tripDetail,
+      );
+    });
+
+    test('resolves payment to earnings', () {
+      final data = {'notifType': 'payment'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.earnings,
+      );
+    });
+
+    test('resolves payment_released to earnings', () {
+      final data = {'notifType': 'payment_released'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.earnings,
+      );
+    });
+
+    test('resolves load_offer to loadDetail', () {
+      final data = {'notifType': 'load_offer', 'bid_id': 'B-1'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.loadDetail,
+      );
+    });
+
+    test('resolves system to notifications', () {
+      final data = {'notifType': 'system'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.notifications,
+      );
+    });
+
+    test('resolves document to notifications', () {
+      final data = {'notifType': 'document'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.notifications,
+      );
+    });
+
+    test('resolves unknown type to unknown', () {
+      final data = {'notifType': 'custom_type'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.unknown,
+      );
+    });
+
+    test('resolves empty notifType to unknown', () {
+      final data = <String, dynamic>{};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.unknown,
+      );
+    });
+
+    test('handles notif_type key (DB format)', () {
+      final data = {'notif_type': 'order_update'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.orderDetail,
+      );
+    });
+
+    test('handles type key (fallback)', () {
+      final data = {'type': 'trip_update'};
+      expect(
+        NotificationRouter.resolveTarget(data),
+        NotificationTarget.tripDetail,
+      );
+    });
+  });
+
+  group('NotificationRouter ID extraction', () {
+    test('extractOrderId from order_display_id', () {
+      final data = {'order_display_id': 'ORD-123'};
+      expect(NotificationRouter.extractOrderId(data), 'ORD-123');
+    });
+
+    test('extractOrderId from orderId', () {
+      final data = {'orderId': 'ORD-456'};
+      expect(NotificationRouter.extractOrderId(data), 'ORD-456');
+    });
+
+    test('extractOrderId returns null when missing', () {
+      final data = <String, dynamic>{};
+      expect(NotificationRouter.extractOrderId(data), isNull);
+    });
+
+    test('extractTripId from trip_id', () {
+      final data = {'trip_id': 'T-789'};
+      expect(NotificationRouter.extractTripId(data), 'T-789');
+    });
+
+    test('extractTripId returns null when missing', () {
+      final data = <String, dynamic>{};
+      expect(NotificationRouter.extractTripId(data), isNull);
+    });
+
+    test('extractBidId from bid_id', () {
+      final data = {'bid_id': 'B-101'};
+      expect(NotificationRouter.extractBidId(data), 'B-101');
+    });
+
+    test('extractBidId from load_offer_id', () {
+      final data = {'load_offer_id': 'L-202'};
+      expect(NotificationRouter.extractBidId(data), 'L-202');
+    });
+  });
+
+  group('NotificationRouter.navigate', () {
+    test('calls callback with correct target and data', () async {
+      final data = {'notifType': 'order_update', 'order_display_id': 'ORD-1'};
+      NotificationTarget? receivedTarget;
+      Map<String, dynamic>? receivedData;
+
+      await NotificationRouter.navigate(data, (target, d) async {
+        receivedTarget = target;
+        receivedData = d;
+      });
+
+      expect(receivedTarget, NotificationTarget.orderDetail);
+      expect(receivedData?['order_display_id'], 'ORD-1');
+    });
+
+    test('does not throw on callback error', () async {
+      final data = {'notifType': 'system'};
+      await NotificationRouter.navigate(data, (target, d) async {
+        throw Exception('Navigation failed');
+      });
+      // Should not throw — the router catches the exception.
+    });
+  });
+
+  group('NotificationRouter.navigateFromItem', () {
+    test('navigates from NotificationItem with metadata', () async {
+      final item = NotificationItem(
+        id: 'n-1',
+        title: 'Test',
+        body: 'Body',
+        notifType: 'order_update',
+        isRead: false,
+        createdAt: DateTime.now(),
+        metadata: {'order_display_id': 'ORD-99'},
+      );
+
+      NotificationTarget? receivedTarget;
+      String? receivedOrderId;
+
+      await NotificationRouter.navigateFromItem(item, (target, data) async {
+        receivedTarget = target;
+        receivedOrderId = NotificationRouter.extractOrderId(data);
+      });
+
+      expect(receivedTarget, NotificationTarget.orderDetail);
+      expect(receivedOrderId, 'ORD-99');
+    });
+
+    test('navigates from NotificationItem without metadata', () async {
+      final item = NotificationItem(
+        id: 'n-2',
+        title: 'System',
+        body: 'Info',
+        notifType: 'system',
+        isRead: false,
+        createdAt: DateTime.now(),
+      );
+
+      NotificationTarget? receivedTarget;
+
+      await NotificationRouter.navigateFromItem(item, (target, data) async {
+        receivedTarget = target;
+      });
+
+      expect(receivedTarget, NotificationTarget.notifications);
+    });
+  });
+
+  group('NotificationItem', () {
+    test('fromMap parses metadata', () {
+      final map = {
+        'id': '1',
+        'title': 'Test',
+        'body': 'Body',
+        'notif_type': 'order_update',
+        'is_read': false,
+        'created_at': '2026-01-15T10:00:00Z',
+        'metadata': {'order_display_id': 'ORD-1'},
+      };
+
+      final item = NotificationItem.fromMap(map);
+      expect(item.metadata, isNotNull);
+      expect(item.metadata!['order_display_id'], 'ORD-1');
+      expect(item.orderId, 'ORD-1');
+    });
+
+    test('fromMap handles null metadata', () {
+      final map = {
+        'id': '2',
+        'title': 'Test',
+        'body': 'Body',
+        'notif_type': 'system',
+        'is_read': true,
+        'created_at': '2026-01-15T10:00:00Z',
+      };
+
+      final item = NotificationItem.fromMap(map);
+      expect(item.metadata, isNull);
+      expect(item.orderId, isNull);
+    });
+
+    test('copyWith preserves unchanged fields', () {
+      final original = NotificationItem(
+        id: '1',
+        title: 'Title',
+        body: 'Body',
+        notifType: 'order_update',
+        isRead: false,
+        createdAt: DateTime(2026, 1, 15),
+        metadata: {'key': 'value'},
+      );
+
+      final updated = original.copyWith(isRead: true);
+      expect(updated.id, original.id);
+      expect(updated.title, original.title);
+      expect(updated.isRead, true);
+      expect(updated.metadata, original.metadata);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements deep linking for push notifications across the Customer and Driver applications.

Previously, push notifications successfully reached the device, but tapping them always opened the application without navigating to the relevant screen. The in-app notification list also lacked navigation support.

This implementation introduces a centralized notification routing system, supports foreground, background, and terminated app states, and enables users to navigate directly to the appropriate screen from both system notifications and the in-app notification list.

No backend APIs, notification generation logic, or authentication flows have been modified.

---

## What Changed

### ✨ Added

- `NotificationRouter` service for centralized notification navigation.
- Foreground notification handling using `FirebaseMessaging.onMessage`.
- Background notification handling using `FirebaseMessaging.onMessageOpenedApp`.
- Cold-start navigation using `FirebaseMessaging.getInitialMessage()`.
- Tap navigation from the in-app notification list.
- Read-status updates after navigation.
- Localization strings for notification actions and error states.

---

## Navigation Flow

```text
Push Notification Received
        │
        ├── Foreground
        │      │
        │      ▼
        │  In-App Banner
        │      │
        │      ▼
        │ NotificationRouter
        │
        ├── Background
        │      │
        │      ▼
        │ NotificationRouter
        │
        └── Terminated
               │
               ▼
        getInitialMessage()
               │
               ▼
        NotificationRouter
```

---

## Files Changed

### Updated

- `packages/truxify_shared/lib/src/services/fcm_service.dart`
- `packages/truxify_shared/lib/src/models/notification_item.dart`
- `packages/truxify_shared/lib/src/screens/notifications_screen.dart`
- `apps/customer/lib/screens/shell_screen.dart`
- `apps/driver/lib/screens/shell_screen.dart`

### Added

- `packages/truxify_shared/lib/src/services/notification_router.dart`

---

## Features

- Deep linking from push notifications.
- Foreground notification banner.
- Background notification navigation.
- Cold-start notification handling.
- Notification list navigation.
- Automatic read-state updates.
- Graceful handling of unsupported notification types.

---

## Testing

### Verified

- ✅ Foreground notification handling.
- ✅ Background notification navigation.
- ✅ Cold-start notification navigation.
- ✅ Notification list tap navigation.
- ✅ Unknown notification fallback.
- ✅ Flutter analyze passes.
- ✅ Existing tests continue to pass.

---

## Type of Change

- [x] New Feature
- [x] Flutter UI
- [x] Push Notification Integration
- [ ] Bug Fix
- [ ] Breaking Change

---

## Related Issue

Closes #3482 

---

## GSSoC
#ECSoC26

This PR is submitted as part of **GirlScript Summer of Code (GSSoC) 2026**.

It enhances the notification experience by introducing deep linking across the Customer and Driver applications. Users can now navigate directly to relevant screens from push notifications and the in-app notification list, while preserving all existing backend notification functionality and APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification tap handling with navigation to relevant order, trip, earnings, load, and notification screens.
  * Added foreground notification banners with View and Dismiss actions.
  * Notifications are marked as read when opened.
  * Added notification metadata support for order, trip, and bid details.
  * Expanded the customer app to support an additional navigation tab.

* **Bug Fixes**
  * Added clear messages when notifications cannot be opened or referenced orders are unavailable.
  * Added English and Hindi translations for new notification states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->