### PR TITLE
fix: swap escrow release order to prevent funds stuck on-chain

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -102,7 +102,7 @@ export async function reconcilePendingEscrowReleases() {
             updated_at: releasedAt,
           })
           .eq('id', order.id)
-          .eq('escrow_status', 'release_failed')
+      .in('escrow_status', ['release_failed', 'funded'])
           .is('reconciled_by', null);
 
         if (updateError) {

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -211,6 +211,33 @@ export class DeliveryVerificationService {
     }
 
 
+    const { data: tripData, error: rpcErr } = await this.orderRepository.executeRpc('complete_trip_tx', {
+      p_order_id: orderId,
+      p_otp_id: otpRecord.id,
+      p_release_tx_hash: null,
+    });
+
+    if (rpcErr) {
+      logger.error('complete_trip_tx RPC failed:', rpcErr.message);
+      throw new DomainError(500, { error: 'Failed to complete trip.', details: rpcErr.message });
+    }
+
+    const { data: verifiedOrder, error: verifyErr } = await this.orderRepository.findOrderById(orderId, 'status, escrow_status, escrow_release_attempts');
+
+    if (verifyErr || !verifiedOrder) {
+      logger.error(`[verify-delivery] Failed to verify order status after RPC for order ${orderId}`);
+      throw new DomainError(500, { error: 'Failed to verify order status after payment release.' });
+    }
+
+    if (verifiedOrder.status !== 'payment_released') {
+      logger.warn(`[verify-delivery] Order ${orderId} status changed to "${verifiedOrder.status}" — payment was not released.`);
+      throw new DomainError(409, {
+        error: 'Order status changed during processing. Payment was not released.',
+      });
+    }
+
+    await this.completeDeliveryOtp({ otpRecordId: otpRecord.id, orderId });
+
     let releaseTxHash = null;
     let escrowAlreadyReleased = false;
     if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
@@ -233,33 +260,6 @@ export class DeliveryVerificationService {
     } else {
       logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
     }
-
-    const { data: tripData, error: rpcErr } = await this.orderRepository.executeRpc('complete_trip_tx', {
-      p_order_id: orderId,
-      p_otp_id: otpRecord.id,
-      p_release_tx_hash: releaseTxHash,
-    });
-
-    if (rpcErr) {
-      logger.error('complete_trip_tx RPC failed:', rpcErr.message);
-      throw new DomainError(500, { error: 'Failed to complete trip and release payment.', details: rpcErr.message });
-    }
-
-    const { data: verifiedOrder, error: verifyErr } = await this.orderRepository.findOrderById(orderId, 'status, escrow_status, escrow_release_attempts');
-
-    if (verifyErr || !verifiedOrder) {
-      logger.error(`[verify-delivery] Failed to verify order status after RPC for order ${orderId}`);
-      throw new DomainError(500, { error: 'Failed to verify order status after payment release.' });
-    }
-
-    if (verifiedOrder.status !== 'payment_released') {
-      logger.warn(`[verify-delivery] Order ${orderId} status changed to "${verifiedOrder.status}" — payment was not released.`);
-      throw new DomainError(409, {
-        error: 'Order status changed during processing. Payment was not released.',
-      });
-    }
-
-    await this.completeDeliveryOtp({ otpRecordId: otpRecord.id, orderId });
 
     let escrowUpdateFailed = false;
     if (releaseTxHash || escrowAlreadyReleased) {


### PR DESCRIPTION
## Fix: Swap escrow release order to prevent funds stuck on-chain

Closes #3517

### Problem
In `verifyDelivery`, the on-chain escrow release was executed **before** the `complete_trip_tx` RPC. If the RPC failed after escrow was released:
- On-chain: funds already transferred to driver's wallet
- Database: order status stuck in `arriving`, `escrow_status` stuck in `funded`
- Reconciliation service never picks it up (queries for `release_failed` only)
- Order permanently stuck requiring manual intervention

### Fix
Swapped the order of operations — the RPC is now called first (database-first), then the on-chain escrow release. This ensures a DB/RPC failure prevents the on-chain transfer.

Also updated `escrowReleaseReconciliation.js` to query for both `release_failed` and `funded` orders to catch partial-failure states.

### Files Changed
- `backend/api/src/services/order/deliveryVerificationService.js` — reordered escrow release after RPC
- `backend/api/src/services/escrowReleaseReconciliation.js` — query both `release_failed` and `funded`