### PR TITLE
fix: reuse shared Redis client in FraudDetectionService

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -53,6 +53,7 @@ import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 // ============================================================================
 import fraudRoutes from './routes/fraudRoutes.js'
 import { fraudDetectionMiddleware, networkAnalysisMiddleware } from './middleware/fraudMiddleware.js'
+import fraudDetection from './services/fraud/FraudDetectionService.js'
 
 // ============================================================================
 // 🆕 ZK-PROOFS FOR DRIVER KYC
@@ -573,6 +574,7 @@ async function shutdown (signal) {
   stopEscrowRefundReconciliation()
   stopReputationReconciliation()
   stopDlqWorker()
+  fraudDetection.destroy()
 
   const forceExit = setTimeout(() => {
     logger.error('[shutdown] Timeout exceeded — forcing exit.')

--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -1,10 +1,12 @@
 import logger from '../../middleware/logger.js';
-import Redis from 'ioredis';
-import { supabase } from '../../config/db.js';
+import { redisClient, supabase } from '../../config/db.js';
 
 class FraudDetectionService {
   constructor() {
-    this.redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+    this.redis = redisClient;
+    if (!this.redis) {
+      logger.warn('[FraudDetection] Redis not configured — behavior tracking will use Supabase only');
+    }
     this.behavioralProfiles = new Map();
     this.fraudThreshold = parseFloat(process.env.FRAUD_THRESHOLD) || 0.7;
     this.riskScores = new Map();
@@ -43,11 +45,13 @@ class FraudDetectionService {
       this.updateBehavioralPatterns(profile, eventData);
       
       // Store in Redis
-      await this.redis.setex(
-        `behavior:${userId}`,
-        3600,
-        JSON.stringify(profile)
-      );
+      if (this.redis) {
+        await this.redis.setex(
+          `behavior:${userId}`,
+          3600,
+          JSON.stringify(profile)
+        );
+      }
 
       // Calculate risk score
       const riskScore = await this.calculateBehavioralRisk(profile);
@@ -69,7 +73,7 @@ class FraudDetectionService {
 
   async getOrCreateProfile(userId) {
     // Check Redis cache
-    const cached = await this.redis.get(`behavior:${userId}`);
+    const cached = this.redis ? await this.redis.get(`behavior:${userId}`) : null;
     if (cached) {
       return JSON.parse(cached);
     }
@@ -488,15 +492,17 @@ class FraudDetectionService {
       }]);
 
     // Cache in Redis
-    await this.redis.setex(
-      `risk:${userId}`,
-      3600,
-      JSON.stringify({
-        score,
-        components,
-        timestamp: Date.now()
-      })
-    );
+    if (this.redis) {
+      await this.redis.setex(
+        `risk:${userId}`,
+        3600,
+        JSON.stringify({
+          score,
+          components,
+          timestamp: Date.now()
+        })
+      );
+    }
   }
 
   // ============ Auto-Review Queue ============
@@ -604,10 +610,12 @@ class FraudDetectionService {
   }
 
   destroy() {
-    clearInterval(this._cleanupInterval);
+    if (this._cleanupInterval) {
+      clearInterval(this._cleanupInterval);
+      this._cleanupInterval = null;
+    }
     this.riskScores.clear();
     this.behavioralProfiles.clear();
-    this.redis.disconnect();
   }
 }
 


### PR DESCRIPTION
## Fix: Reuse shared Redis client in FraudDetectionService

Closes #3518

### Problem
`FraudDetectionService` created its own Redis connection via `new Redis(process.env.REDIS_URL || 'redis://localhost:6379')`:
1. **Duplicate connection** — doubles Redis connection count, not managed by app lifecycle
2. **Localhost fallback** — silently connects to localhost in production if `REDIS_URL` is unset, degrading fraud detection with no alerting
3. **No graceful shutdown** — `_cleanupInterval` never cleared, Redis connection never closed, causing Node.js process to hang on SIGTERM

### Fix
- Replaced `import Redis from 'ioredis'` with shared `redisClient` from `config/db.js`
- Guarded all Redis operations against null client (falls back to Supabase-only mode)
- Updated `destroy()` to clear interval without closing the shared client
- Registered `fraudDetection.destroy()` in the server shutdown handler

### Files Changed
- `backend/api/src/services/fraud/FraudDetectionService.js` — use shared redisClient, guard operations, cleanup
- `backend/api/src/index.js` — import and call fraudDetection.destroy() on shutdown