### PR TITLE
fix: include version in order select for optimistic locking

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -17,7 +17,7 @@ export class BidAcceptanceService {
 
   async acceptBid({ orderId, bidId, customerId }) {
     return measureExecution('BidAcceptanceService.acceptBid', async () => {
-    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'order_display_id, customer_id');
+    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'order_display_id, customer_id, version');
     if (orderErr) {
       throw new DomainError(500, { error: 'Failed to retrieve order.', details: orderErr.message });
     }
@@ -103,6 +103,13 @@ export class BidAcceptanceService {
     }
 
     // Execute RPC to accept bid
+    if (order.version == null) {
+      throw new DomainError(500, {
+        error: 'Order version is missing. Cannot safely accept bid.',
+        recovery: 'Please retry the request.',
+      });
+    }
+
     const { error: rpcErr } = await this.orderRepository.executeRpc('accept_bid_tx', {
       p_bid_id: bidId,
       p_order_id: orderId,


### PR DESCRIPTION
## Fix: Include `version` in order select for optimistic locking

Closes #3519

### Problem
In `bidAcceptanceService.js:20`, the order was fetched with a limited column select (`order_display_id, customer_id`) that did not include `version`. At line 117, `order.version` was passed to `accept_bid_tx` as `p_expected_version`, but it was always `undefined` — completely bypassing the optimistic lock.

Two concurrent `acceptBid` requests for the same load could both succeed, assigning the same order to two different drivers with two separate escrow deposits.

### Fix
- Added `version` to the order column select in `acceptBid`
- Added a null guard that rejects the request with a 500 error if version is missing

### Files Changed
- `backend/api/src/services/order/bidAcceptanceService.js` — added `version` to select, added null guard