### PR TITLE
fix: stop infinite WebSocket reconnect after auth rejection

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -34,6 +34,7 @@ class LocationService {
   String? _activeOrderId;
   String? _activeOrderDisplayId;
   int _reconnectAttempts = 0;
+  int? _lastCloseCode;
   Position? _lastSentPosition;
   DateTime? _lastSentTime;
 
@@ -257,6 +258,7 @@ class LocationService {
       debugPrint('[LocationService] Connecting to WebSocket at: ${wsUri.toString()}');
       _channel = WebSocketChannel.connect(wsUri);
       _reconnectAttempts = 0;
+      _lastCloseCode = null;
       
       _startHeartbeat();
 
@@ -264,9 +266,20 @@ class LocationService {
         (message) {
           if (message == 'pong') return;
           debugPrint('[LocationService] Received WebSocket message: $message');
+          try {
+            final parsed = jsonDecode(message.toString());
+            if (parsed is Map && parsed['code'] != null) {
+              _lastCloseCode = parsed['code'] as int;
+            }
+          } catch (_) {}
         },
         onDone: () {
-          debugPrint('[LocationService] WebSocket closed');
+          debugPrint('[LocationService] WebSocket closed (code: $_lastCloseCode)');
+          if (_lastCloseCode == 4001 || _lastCloseCode == 4003) {
+            debugPrint('[LocationService] Auth rejected (code $_lastCloseCode) — not reconnecting');
+            _isTracking = false;
+            return;
+          }
           _scheduleReconnect();
         },
         onError: (error) {

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -329,11 +329,13 @@ export function initWebSocketServer(server, orderRepository) {
 
     if (bypassAuth) {
       if (process.env.NODE_ENV === 'production') {
+        ws.send(JSON.stringify({ error: 'BYPASS_AUTH is not allowed in production', code: 4003 }));
         ws.close(4003, 'BYPASS_AUTH is not allowed in production');
         return;
       }
       const devToken = reqUrl.searchParams.get('dev_access_token');
       if (!devToken || !process.env.DEV_ACCESS_TOKEN || devToken !== process.env.DEV_ACCESS_TOKEN) {
+        ws.send(JSON.stringify({ error: 'Unauthorized: Missing or invalid dev_access_token', code: 4001 }));
         ws.close(4001, 'Unauthorized: Missing or invalid dev_access_token');
         return;
       }
@@ -345,6 +347,7 @@ export function initWebSocketServer(server, orderRepository) {
       logger.warn({ event: 'WS_BYPASS_AUTH_USED', driverId: ws.driverId, role: ws.user.role }, 'WS Auth bypassed via DEV_ACCESS_TOKEN');
     } else {
       if (!token) {
+        ws.send(JSON.stringify({ error: 'Unauthorized: No token provided', code: 4001 }));
         ws.close(4001, 'Unauthorized: No token provided');
         return;
       }
@@ -364,6 +367,7 @@ export function initWebSocketServer(server, orderRepository) {
 
         if (isSupabaseToken) {
           if (!supabase) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: Supabase client is not configured', code: 4001 }));
             ws.close(4001, 'Unauthorized: Supabase client is not configured');
             return;
           }
@@ -371,6 +375,7 @@ export function initWebSocketServer(server, orderRepository) {
           const user = response?.data?.user;
           const authError = response?.error;
           if (authError || !user) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: Invalid or expired Supabase token', code: 4001 }));
             ws.close(4001, 'Unauthorized: Invalid or expired Supabase token');
             return;
           }
@@ -383,6 +388,7 @@ export function initWebSocketServer(server, orderRepository) {
             .maybeSingle();
 
           if (error || !userProfile) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: User profile not found', code: 4001 }));
             ws.close(4001, 'Unauthorized: User profile not found');
             return;
           }
@@ -390,11 +396,13 @@ export function initWebSocketServer(server, orderRepository) {
         } else {
           // Firebase Verification
           if (!firebaseAdmin) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: Firebase Auth is not configured', code: 4001 }));
             ws.close(4001, 'Unauthorized: Firebase Auth is not configured');
             return;
           }
           const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
           if (!supabase) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: Profile lookup is not configured', code: 4001 }));
             ws.close(4001, 'Unauthorized: Profile lookup is not configured');
             return;
           }
@@ -407,6 +415,7 @@ export function initWebSocketServer(server, orderRepository) {
             .maybeSingle();
 
           if (error || !userProfile) {
+            ws.send(JSON.stringify({ error: 'Unauthorized: User profile not found', code: 4001 }));
             ws.close(4001, 'Unauthorized: User profile not found');
             return;
           }
@@ -423,6 +432,7 @@ export function initWebSocketServer(server, orderRepository) {
         logger.info(`✅ WS Authenticated user: ${ws.user.id}`);
       } catch (err) {
         logger.error({ err }, 'WS Auth failed');
+        ws.send(JSON.stringify({ error: 'Unauthorized: Invalid token', code: 4001 }));
         ws.close(4001, 'Unauthorized: Invalid token');
         return;
       }
@@ -552,6 +562,7 @@ export async function handleLocationPing(ws, data, req) {
     }, 'Location spoofing attempt detected: Driver ID mismatch');
 
     if (typeof ws.close === 'function') {
+      ws.send(JSON.stringify({ error: 'Spoofed location detected: Driver ID mismatch', code: 4010 }));
       ws.close(4010, 'Spoofed location detected: Driver ID mismatch');
     }
     return;


### PR DESCRIPTION
## Fix: Stop infinite WebSocket reconnect after auth rejection

Closes #3520

### Problem
When the backend closed a WebSocket with codes 4001 (unauthorized) or 4003 (production bypass blocked), the driver app's `location_service.dart` treated it as any disconnection and entered an infinite reconnect loop (every 30s, capped, never gives up). This wasted battery, generated server log noise, and never prompted the user to re-authenticate.

### Fix
**Client (`location_service.dart`):**
- Added `_lastCloseCode` field to capture close codes
- Parse JSON error messages from the server for close codes
- In `onDone`, check close code — if 4001 or 4003, stop reconnecting and set `_isTracking = false`
- Reset `_lastCloseCode` on each new connection attempt

**Backend (`tracker.js`):**
- Added `ws.send(JSON.stringify({ error: ..., code: ... }))` before every `ws.close()` call with auth-related codes (4001, 4003, 4010) so the client can detect the rejection reason

### Files Changed
- `apps/driver/lib/services/location_service.dart` — close code tracking, auth rejection handling
- `backend/api/src/sockets/tracker.js` — send JSON error before auth close codes