### PR TITLE
fix(driver): validate wallet transaction response

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -92,7 +92,7 @@ class DriverEarningsService {
 
       final transactions = decoded['transactions'];
       if (transactions is! List) {
-        return [];
+        throw StateError('Unexpected wallet transactions response type');
       }
 
       return transactions
@@ -103,6 +103,9 @@ class DriverEarningsService {
           .whereType<Map<String, dynamic>>()
           .toList();
     } catch (e) {
+      if (e is StateError) {
+        throw Exception(e.message);
+      }
       if (e is ApiException) {
         throw Exception(e.message.isNotEmpty ? e.message : 'Failed to load wallet history.');
       }


### PR DESCRIPTION
## Summary
- reject wallet history payloads when transactions is not a list
- keep valid empty transaction lists as empty results
- return a clear service error for malformed wallet history data

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when wallet transaction data is malformed or unexpected.
  * Preserved the original error message for clearer diagnostics instead of treating invalid responses as network or API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->