### PR TITLE
fix(driver): validate monthly earnings rows

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -132,7 +132,14 @@ class DriverEarningsService {
           .gte('day_date', start.toIso8601String().split('T').first)
           .lt('day_date', end.toIso8601String().split('T').first)
           .order('day_date');
-      return List<Map<String, dynamic>>.from(response);
+      if (response is! List) {
+        throw StateError('Unexpected monthly earnings response type');
+      }
+      return response.map((item) {
+        if (item is Map<String, dynamic>) return item;
+        if (item is Map) return Map<String, dynamic>.from(item);
+        throw StateError('Unexpected monthly earnings item type');
+      }).toList(growable: false);
     }
 
     final days = daysSinceMonthStart.clamp(1, 365);


### PR DESCRIPTION
## Summary
- validate historical monthly earnings responses before returning rows
- convert map-like rows safely after checking the list shape
- replace direct row casting with clear response errors

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3527
