### PR TITLE
fix(driver): validate wallet summary row

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -252,8 +252,14 @@ class DriverEarningsService {
         .select('wallet_confirmed, wallet_pending, wallet_total')
         .eq('user_id', driverId!);
 
+    if (response is! List) {
+      throw StateError('Unexpected wallet summary response type');
+    }
     if (response.isNotEmpty) {
-      return Map<String, dynamic>.from(response.first as Map);
+      final first = response.first;
+      if (first is Map<String, dynamic>) return first;
+      if (first is Map) return Map<String, dynamic>.from(first);
+      throw StateError('Unexpected wallet summary item type');
     }
     return {};
   }


### PR DESCRIPTION
## Summary
- validate wallet summary query responses before reading the first row
- convert map-like rows safely after checking the response type
- keep valid empty wallet summary results as empty maps

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3529
