### PR TITLE
fix(driver): validate ticket rows

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -37,7 +37,16 @@ class TruckRepository {
         .eq('truck_id', truckId)
         .order('created_at', ascending: false);
 
-    return List<Map<String, dynamic>>.from(response)
+    if (response is! List) {
+      throw StateError('Unexpected ticket response type');
+    }
+
+    return response
+        .map((item) {
+          if (item is Map<String, dynamic>) return item;
+          if (item is Map) return Map<String, dynamic>.from(item);
+          throw StateError('Unexpected ticket item type');
+        })
         .map(TruckMaintenanceTicket.fromJson)
         .toList(growable: false);
   }


### PR DESCRIPTION
## Summary
- reject non-list ticket query responses
- validate ticket rows before model mapping
- replace direct row casting with clear response errors

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3530
