### PR TITLE
fix(driver): validate truck document rows

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -108,6 +108,13 @@ class TruckRepository {
         .select()
         .eq('truck_id', truckId)
         .order('expires_at', ascending: true);
-    return List<Map<String, dynamic>>.from(response);
+    if (response is! List) {
+      throw StateError('Unexpected truck document response type');
+    }
+    return response.map((item) {
+      if (item is Map<String, dynamic>) return item;
+      if (item is Map) return Map<String, dynamic>.from(item);
+      throw StateError('Unexpected truck document item type');
+    }).toList(growable: false);
   }
 }


### PR DESCRIPTION
## Summary
- reject non-list truck document query responses
- validate document rows before returning them
- replace direct row casting with clear response errors

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3531
