### PR TITLE
fix(customer): validate location search response

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -59,7 +59,9 @@ class LocationService {
     }
 
     final decoded = jsonDecode(response.body);
-    if (decoded is! List) return const <LocationSuggestion>[];
+    if (decoded is! List) {
+      throw Exception('Search failed: unexpected response type (${uri.path})');
+    }
     final results = decoded
         .map((item) {
           if (item is! Map<String, dynamic>) return null;


### PR DESCRIPTION
## Summary
- reject non-list location search responses
- keep valid empty geocoder results as empty suggestion lists
- surface malformed search responses as clear errors

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3532
