### PR TITLE
fix(customer): validate document rows

### DIFF
--- a/apps/customer/lib/screens/my_documents_screen.dart
+++ b/apps/customer/lib/screens/my_documents_screen.dart
@@ -62,11 +62,21 @@ class _MyDocumentsScreenState extends State<MyDocumentsScreen> {
           .select()
           .eq('user_id', userId)
           .order('updated_at', ascending: false);
+
+      if (response is! List) {
+        throw StateError('Unexpected document response type');
+      }
+
+      final documents = response.map((item) {
+        if (item is Map<String, dynamic>) return item;
+        if (item is Map) return Map<String, dynamic>.from(item);
+        throw StateError('Unexpected document item type');
+      }).toList(growable: false);
           
       if (!mounted) return;
 
       setState(() {
-        _documents = List<Map<String, dynamic>>.from(response);
+        _documents = documents;
         _isLoading = false;
       });
     } catch (e) {


### PR DESCRIPTION
## Summary
- validate customer document query responses before updating state
- convert map-like document rows safely
- surface malformed document payloads through the existing error path

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3533
