### PR TITLE
fix(api): validate device metadata

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -15,6 +15,18 @@ function validatePlatform(platform) {
   return VALID_PLATFORMS.includes(platform) ? null : `Platform must be one of: ${VALID_PLATFORMS.join(', ')}`;
 }
 
+function normalizeMetadata(metadata) {
+  if (metadata === undefined || metadata === null) return {};
+  if (typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return { error: 'metadata must be an object' };
+  }
+  const prototype = Object.getPrototypeOf(metadata);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return { error: 'metadata must be an object' };
+  }
+  return metadata;
+}
+
 /**
  * Register / update FCM token for a user device
  */
@@ -39,6 +51,11 @@ export async function registerDeviceToken(req, res) {
       return res.status(400).json({ error: platErr });
     }
 
+    const normalizedMetadata = normalizeMetadata(metadata);
+    if (normalizedMetadata.error) {
+      return res.status(400).json({ error: normalizedMetadata.error });
+    }
+
     const tokenUpdatedAt = new Date().toISOString();
     const { data: existingDevice, error: lookupError } = await supabase
       .from('user_devices')
@@ -60,7 +77,7 @@ export async function registerDeviceToken(req, res) {
         user_id: userId,
         fcm_token: fcmToken,
         platform: platform || 'android',
-        metadata: metadata || {}
+        metadata: normalizedMetadata
       },
       { onConflict: 'fcm_token' }
     );


### PR DESCRIPTION
## Summary
- default missing device metadata to an empty object
- reject non-object metadata before saving a device token
- keep device registration payloads consistent for later consumers

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests were not run here

Closes #3534
