### PR TITLE
fix(api): validate unregister device token

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -137,9 +137,10 @@ export async function unregisterDeviceToken(req, res) {
       });
     }
 
-    if (!fcmToken) {
+    const tokenErr = validateFcmToken(fcmToken);
+    if (tokenErr) {
       return res.status(400).json({
-        error: 'fcmToken is required'
+        error: tokenErr
       });
     }
 


### PR DESCRIPTION
## Summary
- reuse FCM token validation for device unregister requests
- reject malformed tokens before delete and profile update queries
- align unregister input handling with registration input handling

## Validation
- `git diff --check`
- Backend dependencies are not installed in this checkout, so tests were not run here

Closes #3535
