### PR TITLE
fix(security): add authentication and role-based access to ZKP routes

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import zkpService from '../services/zkp/zkp.service.js';
 import logger from '../middleware/logger.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
 // Verify driver KYC using ZK-SNARK
-router.post('/zkp/verify', async (req, res) => {
+router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
   try {
     const { userId, name, licenseNumber, rcNumber, insuranceNumber, issueDate, expiryDate } = req.body;
     
@@ -50,7 +52,7 @@ router.post('/zkp/verify', async (req, res) => {
 });
 
 // Check verification status
-router.get('/zkp/status/:userId', async (req, res) => {
+router.get('/zkp/status/:userId', authenticate, userLimiter, async (req, res) => {
   try {
     const { userId } = req.params;
     const verified = await zkpService.isVerified(userId);
@@ -73,10 +75,9 @@ router.get('/zkp/status/:userId', async (req, res) => {
 });
 
 // Get document hash (regulator only)
-router.get('/zkp/document-hash/:userId', async (req, res) => {
+router.get('/zkp/document-hash/:userId', authenticate, userLimiter, requireRole(['REGULATOR']), async (req, res) => {
   try {
     const { userId } = req.params;
-    // Check if user is regulator (add middleware)
     const hash = await zkpService.getDocumentHash(userId);
     
     res.json({
@@ -97,7 +98,7 @@ router.get('/zkp/document-hash/:userId', async (req, res) => {
 });
 
 // Get verification stats
-router.get('/zkp/stats', async (req, res) => {
+router.get('/zkp/stats', authenticate, userLimiter, requireRole(['REGULATOR']), async (req, res) => {
   try {
     const stats = await zkpService.getVerificationStats();
     


### PR DESCRIPTION
# Pull Request

## Description
All 4 ZKP endpoints had zero authentication middleware, allowing any anonymous user to submit KYC verification for any userId, read document hashes, and access full verification stats. This is a critical security vulnerability — KYC verification can be spoofed and private identity document hashes are exposed to unauthenticated callers.

Added authenticate + userLimiter to all 4 routes, and requireRole(['REGULATOR']) to the document-hash and stats endpoints (which the original code had a TODO comment for but never implemented).

## Related Issue
Fixes #3538

## Type of Change
- [x] Bug Fix (Security)

## Changes
- POST /zkp/verify: added authenticate + userLimiter
- GET /zkp/status/:userId: added authenticate + userLimiter
- GET /zkp/document-hash/:userId: added authenticate + userLimiter + requireRole(['REGULATOR'])
- GET /zkp/stats: added authenticate + userLimiter + requireRole(['REGULATOR'])
- Removed stale TODO comment "Check if user is regulator (add middleware)"

## How to Test
1. POST /zkp/verify without auth header → 401
2. GET /zkp/status/:userId without auth header → 401
3. GET /zkp/document-hash/:userId as STUDENT role → 403
4. GET /zkp/stats as DRIVER role → 403
5. All endpoints work normally for authenticated REGULATOR users

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added authentication and rate limiting to zero-knowledge proof verification and status requests.
  * Restricted document hash and statistics endpoints to authenticated regulators.
  * Improved protection against unauthorized access and excessive requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->