### PR TITLE
fix: destructure reason from req.body in cancel handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -872,6 +872,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
   const { id: orderId } = req.params;
+  const { reason } = req.body;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);


### PR DESCRIPTION
# Pull Request

## Description
The /:id/cancel handler used the variable `reason` at line 898 but never destructured it from req.body. When a cancellation triggers the refund path (requiresRefund is true), this throws ReferenceError: reason is not defined, crashing the request and leaving orders stuck in a non-cancellable state.

Added `const { reason } = req.body;` after the orderId destructuring.

## Related Issue
Fixes #3541

## Type of Change
- [x] Bug Fix

## Changes
- Added `const { reason } = req.body;` in the cancel handler after orderId destructuring

## How to Test
1. POST /orders/:id/cancel with a funded order and a reason in the body → should set cancellation_reason to the provided reason
2. POST /orders/:id/cancel with a funded order and no reason → should fall back to order.cancellation_reason (existing behavior)
3. Both paths should complete without ReferenceError

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
