### PR TITLE
fix: include HTTP method and path in idempotency cache key

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -38,7 +38,7 @@ function isCacheable(statusCode) {
 
 function cacheKey(req, idempotencyKey) {
   const identity = req.user?.id || 'anonymous';
-  return `idempotency:${identity}:${idempotencyKey}`;
+  return `idempotency:${req.method}:${req.path}:${identity}:${idempotencyKey}`;
 }
 
 function readAndParse(str) {


### PR DESCRIPTION
# Pull Request

## Description
The idempotency middleware cache key was missing req.method and req.path. Same X-Idempotency-Key sent to different endpoints (e.g., POST /orders vs POST /orders/:id/cancel) would return the wrong cached response — potentially returning an order creation response when the user asked to cancel.

Added req.method and req.path to the cache key to scope it per-endpoint.

## Related Issue
Fixes #3539

## Type of Change
- [x] Bug Fix

## Changes
- Updated cacheKey() to include req.method and req.path: `idempotency:${req.method}:${req.path}:${identity}:${idempotencyKey}`

## How to Test
1. POST /orders with X-Idempotency-Key: abc123 → 201 (order created)
2. POST /orders/xxx/cancel with same X-Idempotency-Key: abc123 → should NOT return the cached order creation response, should process cancellation normally
3. Repeat POST /orders with same key → should return cached 201 (idempotency within same endpoint still works)

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
