### PR TITLE
fix: check DB error in trip events order lookup

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -269,11 +269,16 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
     const driverUserId = events[0]?.user_id;
 
     // 3. Also look up the linked order to check customer access
-    const { data: order } = await supabase
+    const { data: order, error: orderErr } = await supabase
       .from('orders')
       .select('id, driver_id, customer_id')
       .eq('id', tripId)
       .maybeSingle();
+
+    if (orderErr) {
+      logger.error(`[TripEvents] Failed to look up order for trip ${tripId}: ${orderErr.message}`);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
 
     // 4. Access control
     if (req.user.role !== 'admin') {


### PR DESCRIPTION
# Pull Request

## Description
The trip events endpoint's order lookup for authorization did not check the `error` field from Supabase. On transient DB errors, `order` was null, causing `order?.driver_id` and `order?.customer_id` to both evaluate to `undefined`. This made `isDriver` and `isCustomer` both `false`, returning a silent 403 Access Denied for the legitimate driver and customer — with no error logging.

Added error checking: on DB failure, log the error and return 500 instead of silently denying access.

**GSSoC**

## Related Issue
Fixes #3558

## Type of Change
- [x] Bug Fix

## Changes
- Destructure `error` from the Supabase order lookup query
- Add error logging on DB failure
- Return 500 Internal Server Error instead of silently falling through to the 403 path

## How to Test
1. GET /trips/:tripId/events as the driver of the trip → 200 (unchanged)
2. GET /trips/:tripId/events as the customer of the trip → 200 (unchanged)
3. GET /trips/:tripId/events as an unauthorized user → 403 (unchanged)
4. Simulate a DB error on the orders table → 500 with logged error (was: silent 403)

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving trip order information.
  * Returns a clear server error instead of continuing when the order lookup fails.
  * Helps prevent event access checks from running with incomplete order data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->