### PR TITLE
fix: atomically claim DLQ events before processing

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -37,20 +37,28 @@ export const dlqService = {
   async processQueue(processFnMap) {
     try {
       const now = new Date().toISOString();
-      const { data: pendingEvents, error: fetchErr } = await supabase
+
+      // Atomically claim pending events by updating status to 'processing'
+      // This prevents concurrent workers from processing the same events
+      const { data: claimedEvents, error: claimErr } = await supabase
         .from('webhook_failures')
-        .select('*')
+        .update({ status: 'processing', updated_at: now })
         .eq('status', 'pending')
         .lte('next_retry_at', now)
         .order('next_retry_at', { ascending: true })
-        .limit(50); // Process in batches
+        .limit(50)
+        .select();
 
-      if (fetchErr) {
-        logger.error(`[DLQ] Failed to fetch pending events: ${fetchErr.message}`);
+      if (claimErr) {
+        logger.error(`[DLQ] Failed to claim pending events: ${claimErr.message}`);
         return;
       }
 
-      for (const event of pendingEvents || []) {
+      if (!claimedEvents || claimedEvents.length === 0) {
+        return;
+      }
+
+      for (const event of claimedEvents) {
         try {
           const handler = processFnMap[event.provider];
           if (!handler) {


### PR DESCRIPTION
# Pull Request

## Description
The DLQ `processQueue` fetched pending events with a bare `SELECT` and processed them immediately without atomically claiming them. If two worker instances ran concurrently, both would fetch and process the same batch of 50 events, causing duplicate state transitions — double refunds, double delivery confirmations, or duplicate notifications.

Replaced the `SELECT` with `UPDATE status='processing' ... SELECT` to atomically claim events before processing. Failed events are reset to their appropriate status (`pending` for retry, `failed_permanently` for exhausted retries).

**GSSoC**

## Related Issue
Fixes #3557

## Type of Change
- [x] Bug Fix

## Changes
- Replaced bare `SELECT * WHERE status='pending'` with `UPDATE ... SET status='processing' WHERE status='pending' ... SELECT` for atomic claiming
- Added early return when no events are claimed
- No behavioral change for single-worker deployments

## How to Test
1. Start two worker instances processing the DLQ simultaneously
2. Insert 10 pending events into webhook_failures
3. Both workers should process different events (no overlap)
4. All events should be marked `resolved` or `failed_permanently` exactly once

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
