### PR TITLE
fix(customer): render cached orders correctly in offline mode

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -197,14 +197,72 @@ class _OrdersScreenState extends State<OrdersScreen>
 
           if (!mounted) return;
 
+          const activeStatuses = {
+            'pending',
+            'active',
+            'driver_assigned',
+            'truck_assigned',
+            'en_route_pickup',
+            'arrived_pickup',
+            'picked_up',
+            'in_transit',
+            'arriving',
+          };
+
+          final activeRaw = cachedOrders
+              .where((o) => activeStatuses.contains(o['status']?.toString()))
+              .toList();
+          final historyRaw = cachedOrders
+              .where((o) => !activeStatuses.contains(o['status']?.toString()))
+              .toList();
+
           setState(() {
             _isOffline = true;
             _isLoading = false;
             _lastUpdatedLabel = updatedAt;
 
-            debugPrint(
-              'Loaded ${cachedOrders.length} cached orders in offline mode',
-            );
+            _activeOrders = activeRaw.map((order) {
+              return ActiveOrderData(
+                orderId: order['order_display_id']?.toString() ?? '',
+                route:
+                    '${order['pickup_address']} → ${order['drop_address']}',
+                driver: _resolveDriverName(order),
+                milestone:
+                    _formatStatus(order['status']?.toString() ?? 'pending'),
+                eta: order['eta']?.toString() ?? '',
+                status:
+                    _formatStatus(order['status']?.toString() ?? 'pending'),
+              );
+            }).toList();
+
+            _historyOrders = historyRaw.map((order) {
+              final rawAmount = order['total_amount'] ?? 0;
+              final amountInRupees = (rawAmount is num)
+                  ? (rawAmount / 100).toStringAsFixed(0)
+                  : rawAmount.toString();
+              return HistoryOrderData(
+                orderId: order['order_display_id']?.toString() ?? '',
+                route:
+                    '${order['pickup_address']} → ${order['drop_address']}',
+                date: order['pickup_date']?.toString() ?? '',
+                amount: '₹$amountInRupees',
+                status: _formatStatus(
+                    order['status']?.toString() ?? 'completed'),
+                driver: _resolveDriverName(order),
+                truckNumber: order['truck_number']?.toString().trim().isNotEmpty == true
+                    ? order['truck_number'].toString().trim()
+                    : '—',
+                timeline: const [],
+                goodsType: order['goods_type']?.toString(),
+                weightTonnes: order['weight_tonnes']?.toString(),
+                dimensions: (order['length_ft'] != null && order['width_ft'] != null && order['height_ft'] != null)
+                    ? '${order['length_ft']} × ${order['width_ft']} × ${order['height_ft']}'
+                    : null,
+                isStackable: order['is_stackable'] as bool?,
+                isFragile: order['is_fragile'] as bool?,
+                specialRequirements: order['special_requirements']?.toString(),
+              );
+            }).toList();
           });
         } else {
           if (!mounted) return;


### PR DESCRIPTION
## Summary

This PR fixes an issue where cached orders were not displayed when the Customer application was offline.

Previously, the offline flow successfully retrieved cached orders from local storage, but the retrieved data was never assigned to the UI state. As a result, users always saw empty order lists despite cached orders being available.

This implementation reuses the existing online partitioning logic to populate the Active and History order lists from cached data while preserving the existing offline experience.

---

## What Changed

### 🛠 Fixed

- Populated `_activeOrders` using cached orders.
- Populated `_historyOrders` using cached orders.
- Reused the existing status-based partitioning logic from the online flow.
- Preserved offline banner and existing UI behaviour.
- Properly handled empty cache scenarios.

---

## User Flow

```text
Customer Opens Orders
        │
        ▼
No Internet Connection
        │
        ▼
Load Cached Orders
        │
        ▼
Partition Orders
        │
        ├── Active Orders
        └── History Orders
        │
        ▼
Display Cached Orders
```

---

## Files Changed

### Updated

- `apps/customer/lib/screens/orders_screen.dart`

---

## Fix Details

- Reused the existing online order partitioning logic.
- Updated offline state assignment.
- Preserved existing loading and connectivity behaviour.
- No changes to cache storage or synchronization logic.

---

## Testing

### Verified

- ✅ Cached orders display correctly in offline mode.
- ✅ Active orders appear in the Active tab.
- ✅ Completed orders appear in the History tab.
- ✅ Empty cache displays the appropriate empty state.
- ✅ Offline banner remains visible.
- ✅ Flutter analyze passes.
- ✅ Existing tests continue to pass.

---

## Type of Change

- [x] Bug Fix
- [x] Flutter UI
- [ ] New Feature
- [ ] Breaking Change

---

## Related Issue

Closes #3563 

---

## GSSoC
#ECSoC26

This PR is submitted as part of **GirlScript Summer of Code (GSSoC) 2026**.

It fixes the offline order rendering workflow by correctly populating the Active and History order lists from cached data. The implementation preserves the existing caching mechanism and online behaviour while ensuring users can access previously cached orders without an internet connection.