### PR TITLE
fix: correct OrderTimelineService constructor args

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -62,10 +62,7 @@ const router = express.Router();
 const orderRepository = new OrderRepository(supabase);
 
 const orderValidationService = new OrderValidationService({ supabase, logger });
-const orderTimelineService = new OrderTimelineService({
-  supabase,
-  logger,
-});
+const orderTimelineService = new OrderTimelineService(orderRepository);
 const orderMilestoneService = new OrderMilestoneService({ orderValidationService, orderRepository, orderTimelineService });
 
 const bidAcceptanceService = new BidAcceptanceService({


### PR DESCRIPTION
## Description
Fixes `OrderTimelineService` constructor call in `orderRoutes.js` at line 65.

The constructor expects a single `orderRepository` instance, but was being called with `{ supabase, logger }`. This caused `this.orderRepository` to be set to `{ supabase, logger }`, making every call to `this.orderRepository.createTimeline()` or `this.orderRepository.getTimeline()` throw `TypeError`.

Changed to `new OrderTimelineService(orderRepository)` — matching the correct instantiation pattern in `container.js`.

Closes #3574

GSSoC