### PR TITLE
fix: remove duplicate userLimiter import in authRoutes.js

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -15,7 +15,6 @@ import { userLimiter } from '../middleware/rateLimiter.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile } from '../lib/profileCache.js';
 import { firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
-import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Description
Removes duplicate `import { userLimiter }` in `authRoutes.js`.

ES modules throw a SyntaxError when the same binding is imported more than once from the same module. The second import at line 18 is redundant — `userLimiter` is already imported at line 14.

Closes #3575

GSSoC