### PR TITLE
fix: add missing destructuring in change-drop handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -778,6 +778,7 @@ router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requ
 // ============================================================================
 router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, requirePolicy('order:change-drop'), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
   const { id: orderId } = req.params;
+  const { drop_address, drop_lat, drop_lng } = req.body;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);


### PR DESCRIPTION
## Description
Fixes `ReferenceError` in the `PUT /:id/change-drop` handler.

The handler uses `drop_address`, `drop_lat`, and `drop_lng` extensively (lines 793–830) but never destructures them from `req.body`. Added `const { drop_address, drop_lat, drop_lng } = req.body;` after extracting `orderId`.

Closes #3577

GSSoC