### PR TITLE
fix: add missing reason destructuring in cancel handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -872,6 +872,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
   const { id: orderId } = req.params;
+  const { reason } = req.body;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);


### PR DESCRIPTION
## Description
Fixes `ReferenceError` in the `POST /:id/cancel` handler.

The handler uses `reason` at lines 898, 966, and 1026 but never destructures it from `req.body`. Added `const { reason } = req.body;` after extracting `orderId`.

Closes #3578

GSSoC