### PR TITLE
fix: add missing orderId declaration in view-bids handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -625,7 +625,7 @@ router.post('/:id/ratings', authenticate, userLimiter, requirePolicy('order:subm
 // 10. VIEW BIDS FOR AN ORDER (CUSTOMER)
 // ============================================================================
 router.get('/:id/bids', authenticate, userLimiter, requirePolicy('order:view-bids'), validateParams(paramIdSchema), async (req, res) => {
-
+  const orderId = req.params.id;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'order_display_id, customer_id');
     if (!order) return res.status(403).json({ error: 'Access Denied: You do not own this order.' });


### PR DESCRIPTION
## Description
Fixes `ReferenceError` in the `GET /:id/bids` handler.

The handler uses `orderId` at line 630 but never declares it. Added `const orderId = req.params.id;` at the start of the handler.

Closes #3579

GSSoC