### PR TITLE
fix: add missing cacheKey declarations in load-offers handlers

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -355,6 +355,7 @@ router.get('/load-offers', authenticate, userLimiter, async (req, res) => {
 
     if (error) return res.status(500).json({ error: 'Failed to fetch load offers.', details: error.message });
 
+    const cacheKey = `load-offers:${page}:${limit}`;
     if (redisClient) {
       await redisClient.set(cacheKey, JSON.stringify(offers), 'EX', 120).catch(() => {});
     }
@@ -380,6 +381,7 @@ router.get('/load-offers/en-route', authenticate, userLimiter, async (req, res) 
 
     if (error) return res.status(500).json({ error: 'Failed to fetch en-route loads.', details: error.message });
 
+    const cacheKey = `load-offers:${page}:${limit}`;
     if (redisClient) {
       await redisClient.set(cacheKey, JSON.stringify(offers), 'EX', 120).catch(() => {});
     }


### PR DESCRIPTION
## Description
Fixes `ReferenceError` in both load-offers handlers.

Both `GET /load-offers` (line 359) and `GET /load-offers/en-route` (line 384) reference `cacheKey` in a Redis write but never declare it. Added `const cacheKey` using the pagination parameters.

Closes #3581

GSSoC