### PR TITLE
fix: add missing getRouteGeometry and buildStraightLineGeometry imports

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -6,7 +6,7 @@ import { redisClient, mongoDb, supabase } from '../config/db.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
-import { getRouteEstimate } from '../services/osrm.js';
+import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 
 import { validateBody, validateParams } from '../middleware/validate.js';


### PR DESCRIPTION
## Description
Fixes `ReferenceError` in the `GET /:id/route` handler.

The handler uses `buildStraightLineGeometry` (lines 1226, 1268) and `getRouteGeometry` (line 1263) but neither was imported from `osrm.js`. Added the missing names to the import statement.

Closes #3582

GSSoC