### PR TITLE
fix(customer): keep logout sign-out reliable

### DIFF
--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -90,7 +90,11 @@ class ProfileService {
     // Unregister this device's FCM token first so a signed-out device stops
     // receiving push notifications intended for the next user of a shared
     // device, then sign out from local clients.
-    await FcmService.unregisterToken();
+    try {
+      await FcmService.unregisterToken();
+    } catch (e) {
+      developer.log('FCM token unregister failed during logout: $e');
+    }
 
     await Future.wait([
       FirebaseAuth.instance.signOut(),


### PR DESCRIPTION
## Summary
- keep customer logout moving when token unregister fails
- log unregister failures without blocking local sign-out
- preserve backend logout handling and local client sign-out behavior

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3603
