### PR TITLE
fix(customer): harden POD attachment merge

### DIFF
--- a/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
+++ b/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
@@ -65,6 +65,17 @@ class ConflictResolver {
     return leftTime.compareTo(rightTime);
   }
 
+  static Iterable<Map<String, dynamic>> _attachmentRows(Object? value) sync* {
+    if (value is! List) return;
+    for (final item in value) {
+      if (item is Map<String, dynamic>) {
+        yield item;
+      } else if (item is Map) {
+        yield Map<String, dynamic>.from(item);
+      }
+    }
+  }
+
   static TripEvent _mergePodMetadata(TripEvent? existing, TripEvent incoming) {
     if (existing == null) {
       return incoming;
@@ -76,9 +87,9 @@ class ConflictResolver {
     if (incomingPayload['attachments'] is List && mergedPayload['attachments'] is List) {
       final merged = <Map<String, dynamic>>[];
       final seen = <String>{};
-      for (final item in <Map<String, dynamic>>[
-        ...List<Map<String, dynamic>>.from(mergedPayload['attachments']),
-        ...List<Map<String, dynamic>>.from(incomingPayload['attachments']),
+      for (final item in [
+        ..._attachmentRows(mergedPayload['attachments']),
+        ..._attachmentRows(incomingPayload['attachments']),
       ]) {
         final hash = '${item['name'] ?? ''}:${item['hash'] ?? ''}';
         if (!seen.contains(hash)) {


### PR DESCRIPTION
## Summary
- normalize POD attachment rows before merging conflict payloads
- skip malformed attachment entries instead of throwing a cast error
- keep duplicate filtering for valid attachment rows unchanged

## Validation
- `git diff --check`
- Flutter SDK is not installed locally, so Flutter tests were not run here

Closes #3604
