### PR TITLE
fix(kafka): preserve event lookup errors

### DIFF
--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -50,17 +50,19 @@ class EventRepository {
   }
 
   async getEventById(eventId) {
-    const { data, error } = await supabase
-      .from('events')
-      .select('*')
-      .eq('event_id', eventId)
-      .single();
+    try {
+      const { data, error } = await supabase
+        .from('events')
+        .select('*')
+        .eq('event_id', eventId)
+        .maybeSingle();
 
-    if (error) {
-      if (error.code === 'PGRST116') return null;
+      if (error) throw error;
+      return data;
+    } catch (error) {
+      logger.error('Failed to get event:', error);
       throw error;
     }
-    return data;
   }
 
   async replayEvents(orderId) {


### PR DESCRIPTION
## Summary
- use maybeSingle for event lookups so missing rows return null
- propagate unexpected event lookup errors to callers
- avoid treating database failures as missing events

## Validation
- `git diff --check`
- Kafka dependencies are not installed locally, so tests were not run here

Closes #3607
