### PR TITLE
fix(kafka): validate offset reset partition ids

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -222,6 +222,17 @@ class KafkaConfig {
     return offsets;
   }
 
+  parsePartitionId(partition) {
+    if (!/^\d+$/.test(String(partition))) {
+      throw new Error(`Invalid Kafka partition id: ${partition}`);
+    }
+    const parsed = Number(partition);
+    if (!Number.isSafeInteger(parsed)) {
+      throw new Error(`Invalid Kafka partition id: ${partition}`);
+    }
+    return parsed;
+  }
+
   async resetConsumerOffsets(groupId, topic) {
     const admin = kafka.admin();
     await admin.connect();
@@ -230,11 +241,7 @@ class KafkaConfig {
       const partitions = Object.keys(offsets[topic] || {});
       
       for (const partition of partitions) {
-        const parsed = parseInt(partition, 10);
-        if (Number.isNaN(parsed) || parsed < 0) {
-          logger.warn(`Skipping invalid partition key: ${partition}`);
-          continue;
-        }
+        const parsed = this.parsePartitionId(partition);
         await admin.setConsumerGroupOffset(
           groupId,
           { topic, partition: parsed },


### PR DESCRIPTION
## Summary
- validate Kafka partition ids before resetting consumer offsets
- reject non-numeric or unsafe partition keys instead of passing partial parses
- pass parsed partition ids into the offset reset call

## Validation
- `git diff --check`
- Kafka dependencies are not installed locally, so tests were not run here

Closes #3611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Kafka partition identifiers.
  * Invalid partition IDs now trigger an error instead of being silently skipped, helping prevent incomplete consumer offset resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->