### PR TITLE
fix: remove duplicate const declarations in predictPrice that made ml.js unparsable

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -151,28 +151,6 @@ export async function predictPrice({
   };
   priceCache.set(cacheKey, result);
   return result;
-  const result = validatePricePrediction(raw);
-  if (!result.ok) {
-      logger.warn({
-          reason: result.reason,
-          detail: result.detail,
-          response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
-      }, '[ML] Price prediction rejected by validator');
-      throw new Error(`[ML] Invalid prediction: ${result.reason} — ${result.detail}`);
-  }
-
-  logger.debug({
-      estimated_price_inr: result.validated.estimated_price,
-      confidence: result.validated.confidence,
-  }, '[ML] Price prediction validated successfully');
-
-  const validated = {
-      ...result.validated,
-      estimatedPricePaisa: convertToPaisa(result.validated.estimated_price),
-      estimatedPriceInr: result.validated.estimated_price,
-  };
-  priceCache.set(cacheKey, validated);
-  return validated;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description
Lines 154-175 in `ml.js` were dead code after `return result;` that re-declared `const result` and `const validated` in the same function scope. In JavaScript (ESM), this is a SyntaxError at parse time, making the entire `ml.js` module unparsable. Since multiple services import from this module, the server crashes on startup.

Removed the 22 lines of dead code.

**GSSoC**

## Related Issue
Fixes #3641

## Type of Change
- [x] Bug Fix

## Changes
- Removed duplicate code block (lines 154-175) that re-declared `const result` and `const validated` after an earlier `return` statement

## How to Test
1. Start the server — should no longer crash with `SyntaxError: Identifier 'result' has already been declared`
2. POST /api/orders with a valid payload — price prediction should work

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
