### PR TITLE
fix: replace unsupported Supabase groupBy in ZKP getVerificationStats

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -208,17 +208,21 @@ class ZKPService {
   }
 
   async getVerificationStats() {
-    const { data, error } = await supabase
-      .from('users')
-      .select('kyc_verified, count')
-      .groupBy('kyc_verified');
-    
-    if (error) throw error;
-    
+    const [verifiedResult, unverifiedResult] = await Promise.all([
+      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', true),
+      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', false),
+    ]);
+
+    if (verifiedResult.error) throw verifiedResult.error;
+    if (unverifiedResult.error) throw unverifiedResult.error;
+
+    const totalVerified = verifiedResult.count || 0;
+    const totalUnverified = unverifiedResult.count || 0;
+
     return {
-      totalVerified: data.find(d => d.kyc_verified === true)?.count || 0,
-      totalUnverified: data.find(d => d.kyc_verified === false)?.count || 0,
-      total: data.reduce((sum, d) => sum + d.count, 0)
+      totalVerified,
+      totalUnverified,
+      total: totalVerified + totalUnverified,
     };
   }
 }


### PR DESCRIPTION
# Pull Request

## Description
`getVerificationStats()` called `.groupBy('kyc_verified')` which is not part of the Supabase PostgREST API, causing `TypeError: supabase.from(...).select(...).groupBy is not a function` at runtime. The query also selected a `count` column that doesn't exist in the `users` table.

Replaced with two parallel count queries using `.select('id', { count: 'exact', head: true })` which is the correct Supabase pattern for counting rows with filters.

**GSSoC**

## Related Issue
Fixes #3642

## Type of Change
- [x] Bug Fix

## Changes
- Replaced unsupported `.groupBy()` with two parallel `.select('id', { count: 'exact', head: true }).eq('kyc_verified', true/false)` queries
- Runs both queries in parallel with `Promise.all` for performance

## How to Test
1. GET /api/zkp/stats as a REGULATOR → should return `{ totalVerified, totalUnverified, total }` with correct counts
2. No more TypeError at runtime

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
