### PR TITLE
fix: define orderId and reason in cancel order route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -880,6 +880,8 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
 
   try {
+    const orderId = req.params.id;   
+    const { reason } = req.body;   
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertCustomerOwnership(order, req.user.id);


### PR DESCRIPTION
## Description

### Summary

This PR fixes a runtime `ReferenceError` in the `POST /:id/cancel` route by declaring the missing `orderId` and `reason` variables before they are used.

### Changes

* Extracted `orderId` from `req.params.id`.
* Extracted `reason` from `req.body`.
* Preserved the existing order cancellation and escrow refund logic without modifying its behavior.

### Problem

The cancel order route referenced `orderId` and `reason` without declaring them, causing a `ReferenceError` whenever the endpoint was called. As a result, order cancellation requests failed before the cancellation flow could execute.

### Solution

Added the missing variable declarations at the beginning of the route handler:

```javascript
const orderId = req.params.id;
const { reason } = req.body;
```

This aligns the implementation with other routes in `orderRoutes.js` that retrieve the order ID from `req.params.id`.

### Impact

* Fixes runtime `ReferenceError` in the cancel order endpoint.
* Restores the order cancellation flow.
* Ensures the cancellation reason is correctly propagated during cancellation and refund processing.
* No breaking changes.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/3636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order cancellation processing so cancellation and refund requests correctly use the selected order and cancellation reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->