### PR TITLE
fix: clean up empty meshes on disconnect and store discovery interval

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -232,7 +232,11 @@ class WebRTCSignalingServer {
     if (peer) {
       const meshId = peer.meshId;
       if (this.meshes.has(meshId)) {
-        this.meshes.get(meshId).delete(peerId);
+        const mesh = this.meshes.get(meshId);
+        mesh.delete(peerId);
+        if (mesh.size === 0) {
+          this.meshes.delete(meshId);
+        }
       }
       this.peers.delete(peerId);
       logger.info(`🔌 Peer ${peerId} disconnected`);
@@ -284,14 +288,27 @@ class WebRTCSignalingServer {
   }
 
   startDiscovery() {
-    // Broadcast discovery every 30 seconds
-    setInterval(() => {
+    this._discoveryInterval = setInterval(() => {
       for (const [peerId, peer] of this.peers) {
         if (peer.ws.readyState === 1) {
           this.sendPeerList(peerId);
         }
       }
     }, 30000);
+  }
+
+  destroy() {
+    if (this._discoveryInterval) {
+      clearInterval(this._discoveryInterval);
+      this._discoveryInterval = null;
+    }
+    for (const [peerId, peer] of this.peers) {
+      try { peer.ws.close(1001, 'Server shutting down'); } catch {}
+    }
+    this.peers.clear();
+    this.meshes.clear();
+    this.wss.close();
+    this.redis.disconnect();
   }
 
   async getPeersNearLocation(lat, lng, radius = 10) {


### PR DESCRIPTION
# Pull Request

## Description
Two resource leaks in WebRTCSignalingServer:

**1. Mesh Map leak (#3643):** `handleDisconnect` removed peers from mesh Sets but never cleaned up empty Sets, causing unbounded growth of `this.meshes` Map. Every connection created a new mesh entry that was never garbage collected.

**2. Discovery interval leak (#3645):** `startDiscovery` created a `setInterval` without storing the ID, making it impossible to clear during shutdown. The interval held a closure reference to `this.peers`, preventing GC.

**Fixes:**
- Clean up empty mesh Sets after peer removal (delete from Map when size === 0)
- Store interval ID in `this._discoveryInterval`
- Add `destroy()` method that clears interval, closes all peer WebSockets, clears maps, closes WSS, and disconnects Redis

**GSSoC**

## Related Issue
Fixes #3643
Fixes #3645

## Type of Change
- [x] Bug Fix

## Changes
- `handleDisconnect`: after deleting peer from mesh Set, check if Set is empty and delete the mesh entry
- `startDiscovery`: store setInterval return value in `this._discoveryInterval`
- Added `destroy()` method for graceful shutdown

## How to Test
1. Connect multiple WebRTC peers, then disconnect them all
2. Verify `this.meshes` is empty after all disconnections
3. Call `destroy()` — interval should stop, all resources cleaned up

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
