### PR TITLE
fix(security): fail closed in fraud middleware instead of silently bypassing

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -60,8 +60,10 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
 
     next();
   } catch (error) {
-    logger.error('Fraud middleware error:', error);
-    next();
+    logger.error('Fraud middleware error — failing closed:', error);
+    return res.status(503).json({
+      error: 'Fraud detection service is temporarily unavailable. Please retry.',
+    });
   }
 };
 
@@ -85,7 +87,9 @@ export const networkAnalysisMiddleware = async (req, res, next) => {
     req.networkRisk = networkRisk;
     next();
   } catch (error) {
-    logger.error('Network analysis middleware error:', error);
-    next();
+    logger.error('Network analysis middleware error — failing closed:', error);
+    return res.status(503).json({
+      error: 'Fraud detection service is temporarily unavailable. Please retry.',
+    });
   }
 };


### PR DESCRIPTION
# Pull Request

## Description
Both `fraudDetectionMiddleware` and `networkAnalysisMiddleware` had catch blocks that called `next()` on error, silently bypassing all fraud checks. This fail-open design allowed attackers to bypass fraud detection on every request by triggering errors in the pipeline (e.g., Redis down, DB connection pool exhausted).

Changed both catch blocks to return 503 Service Unavailable, failing closed when fraud detection is unavailable. This is the correct pattern for security-critical middleware — deny access when you can't verify, rather than allowing unverified requests through.

**GSSoC**

## Related Issue
Fixes #3644

## Type of Change
- [x] Bug Fix (Security)

## Changes
- `fraudDetectionMiddleware` catch: changed `next()` to `return res.status(503).json({ error: 'Fraud detection service is temporarily unavailable. Please retry.' })`
- `networkAnalysisMiddleware` catch: same change
- Updated log messages to indicate failing closed

## How to Test
1. Normal requests with fraud detection running → 200 (unchanged)
2. Simulate fraud detection failure (e.g., stop Redis) → 503 with clear error message
3. Requests no longer silently bypass fraud checks on error

## Screenshots / Video
No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
