### PR TITLE
fix: add max reconnect attempt cap and exponential backoff to ResilientWebSocket

### DIFF
--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -8,6 +8,7 @@ class ResilientWebSocket {
     this.url, {
     this.initialDelay = const Duration(seconds: 2),
     this.maxDelay = const Duration(seconds: 60),
+    this.maxAttempts = 10,
     this.onConnect,
     this.urlFactory,
   });
@@ -15,6 +16,7 @@ class ResilientWebSocket {
   final String url;
   final Duration initialDelay;
   final Duration maxDelay;
+  final int maxAttempts;
   final void Function()? onConnect;
   final String Function()? urlFactory;
 
@@ -70,8 +72,16 @@ class ResilientWebSocket {
     }
 
     _heartbeatTimer?.cancel();
-    final delay = Duration(seconds: _attempt == 0 ? 2 : 2 * _attempt);
-    final capped = delay > maxDelay ? maxDelay : delay;
+
+    if (_attempt >= maxAttempts) {
+      _controller.addError(Exception('Max reconnect attempts reached ($maxAttempts)'));
+      return;
+    }
+
+    final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5));
+    final capped = Duration(
+      milliseconds: delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs,
+    );
     _attempt += 1;
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(capped, () async {
@@ -107,22 +117,4 @@ class ResilientWebSocket {
     _subscription = null;
     _channel = null;
   }
-}
-
-class ConnectionStats {
-  int reconnectCount = 0;
-  bool isConnected = false;
-  bool forceClosed = false;
-  static const int maxReconnects = 10;
-  static const int baseDelayMs = 1000;
-  static const int maxDelayMs = 30000;
-
-  bool get shouldReconnect => !forceClosed && reconnectCount < maxReconnects;
-  int get backoffMs {
-    final exponential = baseDelayMs * (1 << reconnectCount.clamp(0, 5));
-    return exponential > maxDelayMs ? maxDelayMs : exponential;
-  }
-  void reset() { reconnectCount = 0; forceClosed = false; }
-  void recordFailure() { reconnectCount++; isConnected = false; }
-  void recordSuccess() { reconnectCount = 0; isConnected = true; }
 }


### PR DESCRIPTION
## fix: Add maximum reconnect attempt cap and exponential backoff to ResilientWebSocket

Closes #3634

### Problem
`ResilientWebSocket` had no maximum reconnect attempt limit. The `_attempt` counter incremented on every failed connection with only linear backoff (`2 * _attempt` seconds, capped at 60s), causing infinite retry — if the server was permanently unreachable, the client retried every 60 seconds forever (3600 requests/hour), draining battery and creating unnecessary server load.

A dead `ConnectionStats` class in the same file already implemented the correct pattern but was never used.

### Changes
- **`apps/customer/lib/core/offline/websocket/resilient_websocket.dart`**
  - Added configurable `maxAttempts` parameter (default: 10) to stop retrying after a threshold
  - Replaced linear backoff with exponential backoff (`2^attempt` ms, clamped at `maxDelay`)
  - Added attempt cap check that emits an error on the stream when max attempts reached
  - Removed dead `ConnectionStats` class that was never referenced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reconnection behavior with exponential backoff.
  * Added a configurable limit to reconnection attempts, preventing indefinite retries.
  * Reports an error when the maximum number of reconnect attempts is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->