### PR TITLE
fix: add missing orderId and reason variable declarations in order cancel route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -783,6 +783,8 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
 // ============================================================================
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
   try {
+    const orderId = req.params.id;
+    const { reason } = req.body;
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, '*');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertCustomerOwnership(order, req.user.id);


### PR DESCRIPTION
## fix: Add missing `orderId` and `reason` variable declarations in order cancel route

Closes #3636

### Problem
The POST `/:id/cancel` route handler referenced `orderId` and `reason` variables without declaring them in scope. Every invocation threw a `ReferenceError`, making order cancellation completely non-functional.

### Changes
- **`backend/api/src/routes/orderRoutes.js`**
  - Added `const orderId = req.params.id;` at the top of the try block
  - Added `const { reason } = req.body;` at the top of the try block
  - Matches the pattern used in every other route in the same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up formatting in the order cancellation request handling.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->