### PR TITLE
fix: add cancelled status guard to order cancel refund path to prevent double refund

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -813,13 +813,14 @@ router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cance
           updated_at: attemptAt,
         },
         [
-          { op: 'not', column: 'status', operator: 'in', value: '("delivered","payment_released")' },
+          { op: 'not', column: 'status', operator: 'in', value: '("delivered","payment_released","cancelled")' },
+          { op: 'eq', column: 'escrow_status', value: order.escrow_status },
         ]
       );
 
       if (pendingErr) {
         if (pendingErr.code === 'PGRST116') {
-          return res.status(409).json({ error: 'Order was already delivered or payment released. Cannot cancel.' });
+          return res.status(409).json({ error: 'Order was already delivered, payment released, or cancelled. Cannot cancel.' });
         }
         return res.status(500).json({
           error: 'Failed to place the order into refund reconciliation.',


### PR DESCRIPTION
## fix: Add `cancelled` status guard to order cancel refund path to prevent double refund

Closes #3637

### Problem
The refund path's optimistic lock filter only blocked `delivered` and `payment_released` statuses, missing `cancelled`. This allowed two concurrent cancel requests for the same funded order to both pass the guard, both transition to `refund_pending`, and both call `submitEscrowRefund` — resulting in a double on-chain refund.

### Changes
- **`backend/api/src/routes/orderRoutes.js`**
  - Added `'cancelled'` to the blocked statuses filter in the refund path's `updateOrderWithFilter` call
  - Added `escrow_status` equality guard for stale-read protection against concurrent requests
  - Updated error message to reflect all blocked statuses