### PR TITLE
fix: reorder verifyDelivery to execute DB RPC before blockchain escrow release

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -162,31 +162,11 @@ export class OrderMilestoneService {
 
     let releaseTxHash = null;
     let escrowAlreadyReleased = false;
-    if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
-      try {
-        const releaseResult = await escrowRelease(order.order_display_id);
-        if (releaseResult.txHash) {
-          releaseTxHash = releaseResult.txHash;
-        } else if (releaseResult.alreadyReleased) {
-          escrowAlreadyReleased = true;
-        } else {
-          throw new Error('Escrow release returned no transaction hash');
-        }
-      } catch (releaseErr) {
-        logger.error('[escrow] Blockchain release failed for order', orderId, ':', releaseErr.message);
-        throw new DomainError(503, {
-          error: 'Blockchain escrow release failed. Payment cannot be processed. Please retry.',
-          retryable: true,
-        });
-      }
-    } else {
-      logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
-    }
 
     const { data: tripData, error: rpcErr } = await this.orderRepository.executeRpc('complete_trip_tx', {
       p_order_id: orderId,
       p_otp_id: otpRecord.id,
-      p_release_tx_hash: releaseTxHash,
+      p_release_tx_hash: null,
     });
     if (rpcErr) {
       logger.error('complete_trip_tx RPC failed:', rpcErr.message);
@@ -209,6 +189,27 @@ export class OrderMilestoneService {
 
     await verifyDeliveryOtp(otpRecord.id);
     await clearOtpState(orderId);
+
+    if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
+      try {
+        const releaseResult = await escrowRelease(order.order_display_id);
+        if (releaseResult.txHash) {
+          releaseTxHash = releaseResult.txHash;
+        } else if (releaseResult.alreadyReleased) {
+          escrowAlreadyReleased = true;
+        } else {
+          throw new Error('Escrow release returned no transaction hash');
+        }
+      } catch (releaseErr) {
+        logger.error('[escrow] Blockchain release failed for order', orderId, ':', releaseErr.message);
+        throw new DomainError(503, {
+          error: 'Blockchain escrow release failed. Payment cannot be processed. Please retry.',
+          retryable: true,
+        });
+      }
+    } else {
+      logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
+    }
 
     if (releaseTxHash || escrowAlreadyReleased) {
       const { error: releaseUpdateErr } = await this.orderRepository.updateOrder(orderId, {


### PR DESCRIPTION
## fix: Reorder `verifyDelivery` to execute DB RPC before blockchain escrow release

Closes #3638

### Problem
`orderMilestoneService.verifyDelivery` called blockchain `escrowRelease` **before** the `complete_trip_tx` Supabase RPC. If the RPC failed after the blockchain transaction confirmed, the driver was paid on-chain but the trip was never recorded in the database — leaving funds unrecoverable with no reconciliation path.

### Changes
- **`backend/api/src/services/order/orderMilestoneService.js`**
  - Moved `complete_trip_tx` RPC call **before** blockchain `escrowRelease` (matching `deliveryVerificationService.js` pattern)
  - RPC now executes with `p_release_tx_hash: null` since the hash isn't known yet
  - Blockchain escrow release now happens only **after** DB commit and status verification
  - New execution order: Guard check → DB RPC → Verify status → Complete OTP → Blockchain release → Update DB