### PR TITLE
fix(orderRoutes): add cancelled status to refund path guard filter — prevents double refund race condition

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1349,7 +1349,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requireRole(['customer']),
           updated_at: attemptAt,
         })
         .eq('id', order.id)
-        .not('status', 'in', '("delivered","payment_released")')
+        .not('status', 'in', '("delivered","payment_released","cancelled")')
         .select('*')
         .single();
 


### PR DESCRIPTION
## Description

The refund path guard filter at orderRoutes.js:1352 blocks only delivered and payment_released statuses, but is missing cancelled. Two concurrent cancel requests for the same funded order can both pass the guard and both transition to efund_pending, resulting in a double on-chain refund.

The non-refund fallback path at line 1471 correctly blocks all three: delivered, payment_released, cancelled. This PR aligns the refund path guard with the non-refund path.

## Related Issue

Closes #3636 (cancel route crash) and #3637 (double refund race condition)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the .not() filter now matches the non-refund path's guard
- No new runtime behavior — single string literal change

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings
- [x] This PR addresses a single concern

---

**GSSoC**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented cancellation updates from proceeding when an order is already cancelled.
  - Improved protection against duplicate or conflicting order status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->