### PR TITLE
fix(websocket): add max reconnect attempt cap and exponential backoff to ResilientWebSocket

### DIFF
--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -8,6 +8,7 @@ class ResilientWebSocket {
     this.url, {
     this.initialDelay = const Duration(seconds: 2),
     this.maxDelay = const Duration(seconds: 60),
+    this.maxAttempts = 10,
     this.onConnect,
     this.urlFactory,
   });
@@ -15,6 +16,7 @@ class ResilientWebSocket {
   final String url;
   final Duration initialDelay;
   final Duration maxDelay;
+  final int maxAttempts;
   final void Function()? onConnect;
   final String Function()? urlFactory;
 
@@ -70,8 +72,14 @@ class ResilientWebSocket {
     }
 
     _heartbeatTimer?.cancel();
-    final delay = Duration(seconds: _attempt == 0 ? 2 : 2 * _attempt);
-    final capped = delay > maxDelay ? maxDelay : delay;
+
+    if (_attempt >= maxAttempts) {
+      _controller.addError(Exception('Max reconnect attempts ($maxAttempts) reached'));
+      return;
+    }
+
+    final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5));
+    final capped = Duration(milliseconds: delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs);
     _attempt += 1;
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(capped, () async {


### PR DESCRIPTION
## Description

ResilientWebSocket has no maximum reconnect attempt limit. The internal _attempt counter increments on every failed connection and is only used to compute a linear backoff delay (2 * _attempt seconds, capped at 60s). When the server is permanently unreachable, the client retries every 60 seconds forever (3600 requests/hour), draining battery and generating unnecessary server load.

This PR:
1. Adds a configurable maxAttempts parameter (default: 10) to stop retrying after the limit is reached
2. Replaces linear backoff with exponential backoff (2s, 4s, 8s, 16s, 32s, 60s)
3. Emits an error on the stream when max attempts is reached so callers can react

## Related Issue

Closes #3634

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the _attempt counter increments correctly and stops at maxAttempts
- Verified exponential backoff produces correct delays: 2s, 4s, 8s, 16s, 32s, 60s
- Verified connect() resets _attempt to 0 for fresh start

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**