### PR TITLE
fix(conflict): validate attachment rows before casting in POD metadata merge

### DIFF
--- a/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
+++ b/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
@@ -76,10 +76,11 @@ class ConflictResolver {
     if (incomingPayload['attachments'] is List && mergedPayload['attachments'] is List) {
       final merged = <Map<String, dynamic>>[];
       final seen = <String>{};
-      for (final item in <Map<String, dynamic>>[
-        ...List<Map<String, dynamic>>.from(mergedPayload['attachments']),
-        ...List<Map<String, dynamic>>.from(incomingPayload['attachments']),
+      for (final item in [
+        ...mergedPayload['attachments'],
+        ...incomingPayload['attachments'],
       ]) {
+        if (item is! Map<String, dynamic>) continue;
         final hash = '${item['name'] ?? ''}:${item['hash'] ?? ''}';
         if (!seen.contains(hash)) {
           seen.add(hash);


### PR DESCRIPTION
## Description

ConflictResolver._mergePodMetadata casts merged POD attachments with List<Map<String, dynamic>>.from(...). One malformed attachment row (e.g. a String, 
ull, or non-map type) crashes the cast and blocks offline event replay for the entire trip.

This PR replaces the unsafe List<Map<String, dynamic>>.from() cast with an is Map<String, dynamic> check per item, skipping malformed rows gracefully.

## Related Issue

Closes #3604

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified malformed rows (strings, nulls, ints) are skipped without crashing
- Valid attachment rows are still merged correctly with deduplication

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**