### PR TITLE
fix(profile): reject non-map profile responses instead of returning empty map

### DIFF
--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -21,7 +21,7 @@ class ProfileService {
         await prefs.setString(_profileCacheKey, jsonEncode(result));
         return result;
       }
-      return <String, dynamic>{};
+      throw StateError('Expected profile object but received ${result.runtimeType}');
     } on ApiException catch (e) {
       final cached = prefs.getString(_profileCacheKey);
       if (cached != null) {


### PR DESCRIPTION
## Description

ProfileService.fetchProfile() returns an empty map when /api/profile responds with a non-map payload (e.g. a string, array, or null). A malformed profile response is treated like a valid blank profile, so the home screen renders missing user data instead of surfacing the contract problem.

This PR replaces the silent empty-map fallback with a StateError that clearly indicates the type mismatch, allowing callers to handle the error explicitly.

## Related Issue

Closes #3602

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified non-map responses (string, list, null) now throw StateError
- Verified valid map responses still work normally

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**