### PR TITLE
fix(kafka): propagate errors, validate pagination, replace groupBy, add try/finally

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -225,20 +225,27 @@ class KafkaConfig {
   async resetConsumerOffsets(groupId, topic) {
     const admin = kafka.admin();
     await admin.connect();
-    
-    const offsets = await admin.listConsumerGroupOffsets(groupId);
-    const partitions = Object.keys(offsets[topic] || {});
-    
-    for (const partition of partitions) {
-      await admin.setConsumerGroupOffset(
-        groupId,
-        { topic, partition: parseInt(partition) },
-        'latest'
-      );
+    try {
+      const offsets = await admin.listConsumerGroupOffsets(groupId);
+      const partitions = Object.keys(offsets[topic] || {});
+      
+      for (const partition of partitions) {
+        const parsed = parseInt(partition, 10);
+        if (Number.isNaN(parsed) || parsed < 0) {
+          logger.warn(`Skipping invalid partition key: ${partition}`);
+          continue;
+        }
+        await admin.setConsumerGroupOffset(
+          groupId,
+          { topic, partition: parsed },
+          'latest'
+        );
+      }
+      
+      logger.info(`✅ Consumer offsets reset for ${groupId}`);
+    } finally {
+      await admin.disconnect();
     }
-    
-    await admin.disconnect();
-    logger.info(`✅ Consumer offsets reset for ${groupId}`);
   }
 }
 

--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -122,10 +122,12 @@ class OrderReadModel {
       query = query.order('updated_at', { ascending: false });
       
       if (filters.limit) {
-        query = query.limit(filters.limit);
+        const safeLimit = Math.min(Math.max(1, Math.floor(Number(filters.limit))), 1000);
+        query = query.limit(safeLimit);
       }
       if (filters.offset) {
-        query = query.offset(filters.offset);
+        const safeOffset = Math.max(0, Math.floor(Number(filters.offset)));
+        query = query.offset(safeOffset);
       }
       
       const { data, error } = await query;
@@ -138,22 +140,20 @@ class OrderReadModel {
   }
 
   async getOrderStats() {
-    try {
-      const { data, error } = await supabase
+    const statuses = ['pending', 'accepted', 'in_transit', 'delivered', 'cancelled', 'payment_released'];
+    const stats = {};
+
+    for (const status of statuses) {
+      const { count, error } = await supabase
         .from('order_read_models')
-        .select('status, count')
-        .groupBy('status');
+        .select('*', { count: 'exact', head: true })
+        .eq('status', status);
 
       if (error) throw error;
-      
-      return data.reduce((acc, curr) => {
-        acc[curr.status] = curr.count;
-        return acc;
-      }, {});
-    } catch (error) {
-      logger.error('Failed to get order stats:', error);
-      return {};
+      stats[status] = count ?? 0;
     }
+
+    return stats;
   }
 
   async clearCache() {

--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -26,53 +26,41 @@ class EventRepository {
   }
 
   async getEventsByOrderId(orderId, limit = 100) {
-    try {
-      const { data, error } = await supabase
-        .from('events')
-        .select('*')
-        .eq('order_id', orderId)
-        .order('timestamp', { ascending: false })
-        .limit(limit);
+    const { data, error } = await supabase
+      .from('events')
+      .select('*')
+      .eq('order_id', orderId)
+      .order('timestamp', { ascending: false })
+      .limit(limit);
 
-      if (error) throw error;
-      return data;
-    } catch (error) {
-      logger.error('Failed to get events:', error);
-      return [];
-    }
+    if (error) throw error;
+    return data;
   }
 
   async getEventsByType(eventType, limit = 100) {
-    try {
-      const { data, error } = await supabase
-        .from('events')
-        .select('*')
-        .eq('event_type', eventType)
-        .order('timestamp', { ascending: false })
-        .limit(limit);
+    const { data, error } = await supabase
+      .from('events')
+      .select('*')
+      .eq('event_type', eventType)
+      .order('timestamp', { ascending: false })
+      .limit(limit);
 
-      if (error) throw error;
-      return data;
-    } catch (error) {
-      logger.error('Failed to get events by type:', error);
-      return [];
-    }
+    if (error) throw error;
+    return data;
   }
 
   async getEventById(eventId) {
-    try {
-      const { data, error } = await supabase
-        .from('events')
-        .select('*')
-        .eq('event_id', eventId)
-        .single();
+    const { data, error } = await supabase
+      .from('events')
+      .select('*')
+      .eq('event_id', eventId)
+      .single();
 
-      if (error) throw error;
-      return data;
-    } catch (error) {
-      logger.error('Failed to get event:', error);
-      return null;
+    if (error) {
+      if (error.code === 'PGRST116') return null;
+      throw error;
     }
+    return data;
   }
 
   async replayEvents(orderId) {


### PR DESCRIPTION
## Description

Multiple issues across the kafka subsystem:

1. **Event repository** (event.repository.js): getEventsByOrderId, getEventsByType, and getEventById catch all errors and return empty lists/null, making database errors indistinguishable from legitimate empty results. Callers cannot tell the difference between no events and a broken query.

2. **Order read model** (order.read.model.js): getAllOrdersReadModel applies ilters.limit and ilters.offset directly without validation — string, negative, or very large values cause inconsistent query behavior. getOrderStats calls .groupBy('status') which is unsupported by the Supabase JS client and throws at runtime.

3. **Kafka config** (kafka.config.js): esetConsumerOffsets connects an admin client but only disconnects in the happy path — if any offset update throws, the admin client leaks. Partition keys are also passed through parseInt without validation.

## Related Issues

Closes #3605, #3606, #3607, #3608, #3609, #3610, #3611

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Fix |
|------|-----|
| event.repository.js | Propagate Supabase errors; only return null for PGRST116 (not found) |
| order.read.model.js | Validate/cap limit (1-1000) and offset (≥0) before query |
| order.read.model.js | Replace unsupported .groupBy('status') with per-status count queries |
| kafka.config.js | Wrap admin client in try/finally so disconnect always runs |
| kafka.config.js | Validate partition ids with strict base-10 parseInt, skip invalid keys |

## Testing

- Verified event repository methods now throw on DB errors instead of returning empty
- Verified limit is capped at 1000 and offset is clamped to ≥0
- Verified getOrderStats returns correct counts per status without groupBy
- Verified admin client disconnect runs even when offset updates throw

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**