### PR TITLE
fix: duplicate FastAPI app initialization in main.py – federated routes dropped (#3671)

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -25,16 +25,8 @@ from app.models.mid_trip_reoptimiser import find_mid_trip_loads
 from app.models.base import model_exists
 from app.models.demand_forecast import MODEL_NAME as DEMAND_MODEL_NAME
 from app.models.price_prediction import MODEL_NAME as PRICE_MODEL_NAME
-from fastapi import FastAPI
-from routes import federated_routes  # Add this
-import os
+from routes import federated_routes
 
-app = FastAPI(title="Truxify ML Engine")
-
-# Add federated routes
-app.include_router(federated_routes.router)
-
-# Rest of your existing code...
 # ============================================================================
 # 🆕 REAL-TIME TRAFFIC ETA IMPORTS
 # ============================================================================
@@ -75,6 +67,9 @@ app = FastAPI(
 )
 
 
+
+# Add federated routes
+app.include_router(federated_routes.router)
 
 # CORS: restrict to known origins — no wildcard "*" to prevent unauthorized cross-origin access
 app.add_middleware(


### PR DESCRIPTION
## Fix: Remove duplicate FastAPI app initialization in main.py

Removes the first `app = FastAPI(...)` declaration (lines 32-35) which was overwritten by the second declaration (line 69), causing federated routes to be silently dropped.

**Changes:**
1. Removed duplicate `from fastapi import FastAPI` and `import os`
2. Removed first `app = FastAPI(...)` and its `app.include_router()` call
3. Moved `app.include_router(federated_routes.router)` to after the correct `FastAPI()` instantiation
4. Kept `from routes import federated_routes` import

Closes #3671

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved federated route registration in the ML service so the related endpoints are reliably exposed through the main application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->