### PR TITLE
fix: duplicate import os in main.py (#3672)

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -27,7 +27,6 @@ from app.models.demand_forecast import MODEL_NAME as DEMAND_MODEL_NAME
 from app.models.price_prediction import MODEL_NAME as PRICE_MODEL_NAME
 from fastapi import FastAPI
 from routes import federated_routes  # Add this
-import os
 
 app = FastAPI(title="Truxify ML Engine")
 


### PR DESCRIPTION
## Fix: Remove duplicate `import os` in main.py

Line 30 had a second `import os` — a leftover from a merge or copy-paste. `os` is already imported on line 4.

Closes #3672

GSSoC