### PR TITLE
fix: duplicate _verificationId field in LoginScreen comp error (#3673)

### DIFF
--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -34,7 +34,6 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _loading = false;
   String? _verificationId;
   int? _resendToken;
-  String? _verificationId;
   String _selectedCode = '+91';
   int _expectedDigits = 10;
 


### PR DESCRIPTION
## Fix: Remove duplicate `_verificationId` declaration in LoginScreen

The `_LoginScreenState` class declared `String? _verificationId` twice (lines 35 and 37), causing a Dart compilation error.

Closes #3673

GSSoC