### PR TITLE
fix: missing import numpy as np in eta_routes.py (#3676)

### DIFF
--- a/backend/ml/routes/eta_routes.py
+++ b/backend/ml/routes/eta_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional, Dict, Any
 from services.traffic_pipeline import TrafficPipeline
+import numpy as np
 import os
 from datetime import datetime
 


### PR DESCRIPTION
## Fix: Add missing `import numpy as np` in eta_routes.py

`np.array([[...]])` is used on line 43 but numpy was never imported, causing a `NameError`.

Closes #3676

GSSoC