### PR TITLE
fix: missing timedelta import in eta_routes.py (#3677)

### DIFF
--- a/backend/ml/routes/eta_routes.py
+++ b/backend/ml/routes/eta_routes.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from typing import Optional, Dict, Any
 from services.traffic_pipeline import TrafficPipeline
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 router = APIRouter(prefix="/eta", tags=["ETA Predictions"])
 


### PR DESCRIPTION
## Fix: Add missing `timedelta` import in eta_routes.py

`timedelta(seconds=...)` is used on line 58 but `timedelta` was not imported, causing a `NameError`.

Closes #3677

GSSoC