### PR TITLE
fix: invalid ticket category silently defaults to general in PATCH update (#3678)

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -337,7 +337,12 @@ router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicke
 
     if (category !== undefined) {
       const normalized = category.toLowerCase().trim();
-      const dbCategory = CATEGORY_MAP[normalized] || 'general';
+      const dbCategory = CATEGORY_MAP[normalized];
+      if (!dbCategory) {
+        return res.status(400).json({
+          error: `Invalid category. Must be one of: ${Object.keys(CATEGORY_MAP).join(', ')}`,
+        });
+      }
       updates.category = dbCategory;
     }
 


### PR DESCRIPTION
## Fix: Return 400 for invalid ticket category in PATCH instead of silent default

The user/update endpoint silently mapped unrecognized categories to 'general'. Changed to return 400, matching the CREATE endpoint's behavior.

Closes #3678

GSSoC