### PR TITLE
fix: distance sort maps to extra_distance_km instead of total distance (#3679)

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -150,15 +150,13 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
     }
 
     // Sorting
-    const validSortFields = ['estimated_price', 'created_at', 'distance'];
+    const validSortFields = ['estimated_price', 'created_at'];
     const sortByParam = validSortFields.includes(req.query.sort_by) ? req.query.sort_by : 'created_at';
     
     // Map sort fields to database columns
     let sortBy = 'created_at';
     if (sortByParam === 'estimated_price') {
       sortBy = 'freight_value';
-    } else if (sortByParam === 'distance') {
-      sortBy = 'extra_distance_km';
     }
 
     const ascending = filters.order === 'asc';


### PR DESCRIPTION
## Fix: Remove `distance` sort field mapping to wrong column `extra_distance_km`

The `distance` sort parameter was mapped to `extra_distance_km` which represents the extra detour distance, not total trip distance. Removed the invalid sort field.

Closes #3679

GSSoC