### PR TITLE
fix: SQLAlchemy session not closed on error in traffic_pipeline.py connection leak (#3680)

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -99,9 +99,14 @@ class TrafficPipeline:
             )
             
             session = self.Session()
-            session.add(traffic_entry)
-            session.commit()
-            session.close()
+            try:
+                session.add(traffic_entry)
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+            finally:
+                session.close()
             
             # Cache in Redis
             self.redis.setex(


### PR DESCRIPTION
## Fix: Ensure SQLAlchemy session is closed on error in traffic_pipeline.py

Wrapped session usage in `try/finally` so `session.close()` is always called even when `session.commit()` raises an exception, preventing connection pool exhaustion.

Closes #3680

GSSoC