### PR TITLE
feat(customer): integrate saved addresses into truck booking flow

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -4,6 +4,8 @@ import 'package:latlong2/latlong.dart';
 
 import '../controllers/app_controller.dart';
 import '../models/app_models.dart';
+import '../models/saved_address.dart';
+import '../repositories/address_repository.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_page_route.dart';
 import '../widgets/common_widgets.dart';
@@ -13,7 +15,10 @@ import 'package:truxify_shared/shimmer_widget.dart';
 import '../services/order_service.dart';
 
 class FindTrucksScreen extends StatefulWidget {
-  const FindTrucksScreen({super.key});
+  const FindTrucksScreen({super.key, AddressRepository? addressRepository})
+      : _addressRepository = addressRepository;
+
+  final AddressRepository? _addressRepository;
 
   @override
   State<FindTrucksScreen> createState() => _FindTrucksScreenState();
@@ -58,6 +63,12 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
   int? _estimateMinPrice;
   int? _estimateMaxPrice;
 
+  // Saved addresses state
+  late final AddressRepository _addressRepo;
+  List<SavedAddress> _savedAddresses = [];
+  bool _addressesLoading = false;
+  String? _addressesError;
+
   static const _goodsTypes = <String>[
     'Textile',
     'Electronics',
@@ -82,6 +93,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
   @override
   void initState() {
     super.initState();
+    _addressRepo = widget._addressRepository ?? AddressRepository();
     _pickupController = TextEditingController();
     _dropController = TextEditingController();
     _weightController = TextEditingController();
@@ -93,6 +105,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     _dateController = TextEditingController(text: _formatDateLabel(_selectedDate!));
     _timeController = TextEditingController(text: _formatTimeLabel(_selectedTime!));
     _customGoodsTypeController = TextEditingController();
+    _loadSavedAddresses();
   }
 
   @override
@@ -306,6 +319,149 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     setState(() {});
   }
 
+  // ── Saved addresses ────────────────────────────────────────────────────
+
+  Future<void> _loadSavedAddresses() async {
+    setState(() {
+      _addressesLoading = true;
+      _addressesError = null;
+    });
+    try {
+      final addresses = await _addressRepo.fetchAll();
+      if (mounted) setState(() => _savedAddresses = addresses);
+    } catch (e) {
+      if (mounted) setState(() => _addressesError = e.toString());
+    } finally {
+      if (mounted) setState(() => _addressesLoading = false);
+    }
+  }
+
+  void _applySavedAddress(SavedAddress address, {required bool isPickup}) {
+    final fullAddr = address.fullAddress;
+    setState(() {
+      if (isPickup) {
+        _pickupController.text = fullAddr;
+        if (address.latitude != null && address.longitude != null) {
+          _pickupPoint = LatLng(address.latitude!, address.longitude!);
+        }
+      } else {
+        _dropController.text = fullAddr;
+        if (address.latitude != null && address.longitude != null) {
+          _dropPoint = LatLng(address.latitude!, address.longitude!);
+        }
+      }
+    });
+    _formKey.currentState?.validate();
+    _estimatePrice();
+  }
+
+  void _showSavedAddressSheet({required bool isPickup}) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _AddressPickerSheet(
+        addresses: _savedAddresses,
+        isLoading: _addressesLoading,
+        error: _addressesError,
+        isPickup: isPickup,
+        onRetry: _loadSavedAddresses,
+        onSelect: (address) {
+          Navigator.of(context).pop();
+          _applySavedAddress(address, isPickup: isPickup);
+        },
+      ),
+    );
+  }
+
+  IconData _iconForLabel(String label) {
+    final l = label.toLowerCase();
+    if (l.contains('home')) return Icons.home_rounded;
+    if (l.contains('office') || l.contains('work')) return Icons.business_rounded;
+    if (l.contains('warehouse')) return Icons.warehouse_rounded;
+    return Icons.location_on_rounded;
+  }
+
+  Future<void> _promptSaveNewAddress(String address, LatLng point) async {
+    final shouldSave = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Save this address?'),
+        content: const Text('Would you like to save this location for future bookings?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Not now'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldSave != true || !mounted) return;
+
+    final label = await showDialog<String>(
+      context: context,
+      builder: (ctx) {
+        final ctrl = TextEditingController();
+        return AlertDialog(
+          title: const Text('Label this address'),
+          content: TextField(
+            controller: ctrl,
+            autofocus: true,
+            textCapitalization: TextCapitalization.words,
+            decoration: const InputDecoration(
+              hintText: 'e.g. Home, Office, Warehouse',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, ctrl.text.trim()),
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (label == null || label.isEmpty || !mounted) return;
+
+    try {
+      final newAddress = SavedAddress(
+        id: '',
+        userId: '',
+        label: label,
+        addressLine: address,
+        city: '',
+        state: '',
+        pincode: '',
+        latitude: point.latitude,
+        longitude: point.longitude,
+        isDefault: _savedAddresses.isEmpty,
+      );
+      await _addressRepo.add(newAddress);
+      await _loadSavedAddresses();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Address saved')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to save address'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
   Future<void> _openLocationPicker({required bool isPickup}) async {
     final result = await Navigator.of(context).push<LocationPickResult>(
       AppPageRoute(
@@ -333,6 +489,10 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
 
     _formKey.currentState?.validate();
     _estimatePrice();
+
+    if (mounted) {
+      _promptSaveNewAddress(result.address, result.point);
+    }
   }
 
   String? _validatePickup(String? value) {
@@ -709,6 +869,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
               const SizedBox(height: 12),
               InfoCard(
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     TextFormField(
                       controller: _pickupController,
@@ -720,13 +881,86 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         prefixIcon: const Icon(Icons.location_on_rounded,
                             color: TruxifyColors.accentDark),
                         prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
-                        suffixIcon: IconButton(
-                          onPressed: () => _openLocationPicker(isPickup: true),
-                          icon: const Icon(Icons.map_rounded,
-                              color: TruxifyColors.accentDark),
+                        suffixIcon: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              onPressed: () => _showSavedAddressSheet(isPickup: true),
+                              icon: const Icon(Icons.bookmark_rounded,
+                                  color: TruxifyColors.accentDark),
+                              tooltip: 'Saved addresses',
+                            ),
+                            IconButton(
+                              onPressed: () => _openLocationPicker(isPickup: true),
+                              icon: const Icon(Icons.map_rounded,
+                                  color: TruxifyColors.accentDark),
+                            ),
+                          ],
                         ),
                       ),
                     ),
+                    if (_savedAddresses.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        height: 36,
+                        child: ListView.separated(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _savedAddresses.length,
+                          separatorBuilder: (_, __) => const SizedBox(width: 8),
+                          itemBuilder: (context, index) {
+                            final addr = _savedAddresses[index];
+                            final selected = _pickupController.text == addr.fullAddress;
+                            return Material(
+                              color: Colors.transparent,
+                              child: InkWell(
+                                onTap: () => _applySavedAddress(addr, isPickup: true),
+                                borderRadius: BorderRadius.circular(999),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                  decoration: BoxDecoration(
+                                    color: selected
+                                        ? (Theme.of(context).brightness == Brightness.dark
+                                            ? TruxifyColors.darkAccentLight
+                                            : TruxifyColors.accentLight)
+                                        : Theme.of(context).colorScheme.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(999),
+                                    border: Border.all(
+                                      color: selected
+                                          ? TruxifyColors.accent
+                                          : (Theme.of(context).brightness == Brightness.dark
+                                              ? TruxifyColors.darkBorder
+                                              : TruxifyColors.border),
+                                    ),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        _iconForLabel(addr.label),
+                                        size: 14,
+                                        color: selected
+                                            ? TruxifyColors.accentDark
+                                            : TruxifyColors.adaptiveSecondaryText(context),
+                                      ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        addr.label,
+                                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                              fontWeight: FontWeight.w600,
+                                              color: selected
+                                                  ? TruxifyColors.accentDark
+                                                  : TruxifyColors.adaptiveSecondaryText(context),
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
                     const SizedBox(height: 12),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -742,10 +976,21 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                               prefixIcon: const Icon(Icons.location_on_rounded,
                                   color: Color(0xFFD32F2F)),
                               prefixIconConstraints: const BoxConstraints(minWidth: 40, minHeight: 40),
-                              suffixIcon: IconButton(
-                                onPressed: () => _openLocationPicker(isPickup: false),
-                                icon: const Icon(Icons.map_rounded,
-                                    color: TruxifyColors.accentDark),
+                              suffixIcon: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  IconButton(
+                                    onPressed: () => _showSavedAddressSheet(isPickup: false),
+                                    icon: const Icon(Icons.bookmark_rounded,
+                                        color: TruxifyColors.accentDark),
+                                    tooltip: 'Saved addresses',
+                                  ),
+                                  IconButton(
+                                    onPressed: () => _openLocationPicker(isPickup: false),
+                                    icon: const Icon(Icons.map_rounded,
+                                        color: TruxifyColors.accentDark),
+                                  ),
+                                ],
                               ),
                             ),
                           ),
@@ -770,6 +1015,68 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                         ),
                       ],
                     ),
+                    if (_savedAddresses.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        height: 36,
+                        child: ListView.separated(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _savedAddresses.length,
+                          separatorBuilder: (_, __) => const SizedBox(width: 8),
+                          itemBuilder: (context, index) {
+                            final addr = _savedAddresses[index];
+                            final selected = _dropController.text == addr.fullAddress;
+                            return Material(
+                              color: Colors.transparent,
+                              child: InkWell(
+                                onTap: () => _applySavedAddress(addr, isPickup: false),
+                                borderRadius: BorderRadius.circular(999),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                  decoration: BoxDecoration(
+                                    color: selected
+                                        ? (Theme.of(context).brightness == Brightness.dark
+                                            ? TruxifyColors.darkAccentLight
+                                            : TruxifyColors.accentLight)
+                                        : Theme.of(context).colorScheme.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(999),
+                                    border: Border.all(
+                                      color: selected
+                                          ? TruxifyColors.accent
+                                          : (Theme.of(context).brightness == Brightness.dark
+                                              ? TruxifyColors.darkBorder
+                                              : TruxifyColors.border),
+                                    ),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        _iconForLabel(addr.label),
+                                        size: 14,
+                                        color: selected
+                                            ? TruxifyColors.accentDark
+                                            : TruxifyColors.adaptiveSecondaryText(context),
+                                      ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        addr.label,
+                                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                              fontWeight: FontWeight.w600,
+                                              color: selected
+                                                  ? TruxifyColors.accentDark
+                                                  : TruxifyColors.adaptiveSecondaryText(context),
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
                     const SizedBox(height: 12),
                     Row(
                       children: [
@@ -1214,6 +1521,210 @@ class _ColorToggleButton extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+// ── Saved address picker bottom sheet ─────────────────────────────────────
+
+class _AddressPickerSheet extends StatelessWidget {
+  const _AddressPickerSheet({
+    required this.addresses,
+    required this.isLoading,
+    required this.error,
+    required this.isPickup,
+    required this.onRetry,
+    required this.onSelect,
+  });
+
+  final List<SavedAddress> addresses;
+  final bool isLoading;
+  final String? error;
+  final bool isPickup;
+  final VoidCallback onRetry;
+  final ValueChanged<SavedAddress> onSelect;
+
+  IconData _iconForLabel(String label) {
+    final l = label.toLowerCase();
+    if (l.contains('home')) return Icons.home_rounded;
+    if (l.contains('office') || l.contains('work')) return Icons.business_rounded;
+    if (l.contains('warehouse')) return Icons.warehouse_rounded;
+    return Icons.location_on_rounded;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      padding: EdgeInsets.fromLTRB(
+          20, 10, 20, MediaQuery.of(context).viewInsets.bottom + 20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: TruxifyColors.hintText,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Row(
+            children: [
+              Icon(
+                isPickup ? Icons.location_on_rounded : Icons.location_off_rounded,
+                color: TruxifyColors.accentDark,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isPickup ? 'Select Pickup Address' : 'Select Drop Address',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.close_rounded),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (isLoading)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else if (error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Center(
+                child: Column(
+                  children: [
+                    const Icon(Icons.error_outline_rounded,
+                        size: 36, color: Colors.red),
+                    const SizedBox(height: 8),
+                    Text('Failed to load addresses',
+                        style: Theme.of(context).textTheme.bodyMedium),
+                    const SizedBox(height: 12),
+                    OutlinedButton.icon(
+                      onPressed: onRetry,
+                      icon: const Icon(Icons.refresh_rounded, size: 18),
+                      label: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          else if (addresses.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Center(
+                child: Column(
+                  children: [
+                    Icon(Icons.location_off_rounded,
+                        size: 36,
+                        color: TruxifyColors.adaptiveSecondaryText(context)),
+                    const SizedBox(height: 8),
+                    Text('No saved addresses',
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: TruxifyColors.adaptiveSecondaryText(context),
+                            )),
+                  ],
+                ),
+              ),
+            )
+          else
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.4,
+              ),
+              child: ListView.separated(
+                shrinkWrap: true,
+                itemCount: addresses.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  final addr = addresses[index];
+                  return Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      onTap: () => onSelect(addr),
+                      borderRadius: BorderRadius.circular(12),
+                      child: Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: Theme.of(context).brightness == Brightness.dark
+                                ? TruxifyColors.darkBorder
+                                : TruxifyColors.border,
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 40,
+                              height: 40,
+                              decoration: BoxDecoration(
+                                color: TruxifyColors.accentLight,
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Icon(
+                                _iconForLabel(addr.label),
+                                color: TruxifyColors.accent,
+                                size: 20,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    addr.label,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .labelMedium
+                                        ?.copyWith(fontWeight: FontWeight.w600),
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    addr.fullAddress,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodySmall
+                                        ?.copyWith(
+                                          color: TruxifyColors.adaptiveSecondaryText(context),
+                                        ),
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Icon(Icons.chevron_right_rounded,
+                                color: TruxifyColors.adaptiveSecondaryText(context)),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          const SizedBox(height: 8),
+        ],
       ),
     );
   }

--- a/apps/customer/test/saved_addresses_find_trucks_test.dart
+++ b/apps/customer/test/saved_addresses_find_trucks_test.dart
@@ -1,0 +1,407 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:truxify/controllers/app_controller.dart';
+import 'package:truxify/models/app_models.dart';
+import 'package:truxify/models/saved_address.dart';
+import 'package:truxify/repositories/address_repository.dart';
+import 'package:truxify/screens/find_trucks_screen.dart';
+import 'package:truxify/widgets/common_widgets.dart';
+
+class MockAddressRepository extends Mock implements AddressRepository {}
+
+void main() {
+  late MockAddressRepository mockRepo;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mockRepo = MockAddressRepository();
+    registerFallbackValue(
+      const SavedAddress(
+        id: '',
+        userId: '',
+        label: '',
+        addressLine: '',
+        city: '',
+        state: '',
+        pincode: '',
+        isDefault: false,
+      ),
+    );
+  });
+
+  Widget createTestWidget(
+    WidgetTester tester, {
+    TruxifyController? controller,
+    AddressRepository? repository,
+  }) {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final ctrl = controller ?? TruxifyController();
+    return TruxifyScope(
+      controller: ctrl,
+      child: MaterialApp(
+        home: Scaffold(
+          body: FindTrucksScreen(addressRepository: repository ?? mockRepo),
+        ),
+      ),
+    );
+  }
+
+  SavedAddress _makeAddress({
+    required String id,
+    required String label,
+    required String addressLine,
+    String city = 'Mumbai',
+    String state = 'Maharashtra',
+    String pincode = '400001',
+    double? latitude,
+    double? longitude,
+  }) {
+    return SavedAddress(
+      id: id,
+      userId: 'user-1',
+      label: label,
+      addressLine: addressLine,
+      city: city,
+      state: state,
+      pincode: pincode,
+      latitude: latitude,
+      longitude: longitude,
+      isDefault: false,
+    );
+  }
+
+  group('Loading saved addresses', () {
+    testWidgets('loads and displays address chips on screen open', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road', latitude: 19.07, longitude: 72.87),
+        _makeAddress(id: '2', label: 'Office', addressLine: 'BKC', latitude: 19.05, longitude: 72.86),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Office'), findsOneWidget);
+    });
+
+    testWidgets('does not show chips when saved addresses is empty', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Office'), findsNothing);
+    });
+
+    testWidgets('handles loading state gracefully', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer(
+        (_) async {
+          await Future<void>.delayed(const Duration(seconds: 5));
+          return [];
+        },
+      );
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pump();
+
+      // Screen should render without error while loading
+      expect(find.byType(FindTrucksScreen), findsOneWidget);
+    });
+
+    testWidgets('handles error gracefully without crashing', (tester) async {
+      when(() => mockRepo.fetchAll()).thenThrow(Exception('Network error'));
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Screen should render without error
+      expect(find.byType(FindTrucksScreen), findsOneWidget);
+      // Chips should not appear
+      expect(find.text('Home'), findsNothing);
+    });
+  });
+
+  group('Selecting saved address', () {
+    testWidgets('tapping pickup chip populates pickup field and coordinates', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road', latitude: 19.07, longitude: 72.87),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Tap the Home chip (under pickup section)
+      await tester.tap(find.text('Home'));
+      await tester.pumpAndSettle();
+
+      // Pickup field should be populated with full address
+      expect(find.text('12 MG Road, Mumbai, Maharashtra 400001'), findsOneWidget);
+    });
+
+    testWidgets('tapping drop chip populates drop field', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Warehouse', addressLine: '45 Industrial Area', latitude: 19.10, longitude: 72.90),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Find the drop section chip - it's the second occurrence of the label
+      final chipFinders = find.text('Warehouse');
+      expect(chipFinders, findsNWidgets(2)); // One in pickup chips, one in drop chips
+
+      // Tap the second Warehouse chip (drop section)
+      await tester.tap(chipFinders.last);
+      await tester.pumpAndSettle();
+
+      // Drop field should be populated
+      expect(find.text('45 Industrial Area, Mumbai, Maharashtra 400001'), findsOneWidget);
+    });
+
+    testWidgets('chips show correct label and icon', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Chip should display the label
+      expect(find.text('Home'), findsWidgets);
+
+      // Chip should have a home icon
+      expect(find.byIcon(Icons.home_rounded), findsWidgets);
+    });
+
+    testWidgets('office label shows business icon', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Office', addressLine: 'BKC'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.business_rounded), findsWidgets);
+    });
+  });
+
+  group('Bottom sheet', () {
+    testWidgets('bookmark icon opens saved address bottom sheet', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Tap the bookmark icon on pickup field
+      await tester.tap(find.byIcon(Icons.bookmark_rounded).first);
+      await tester.pumpAndSettle();
+
+      // Bottom sheet should show
+      expect(find.text('Select Pickup Address'), findsOneWidget);
+      expect(find.text('Home'), findsWidgets);
+    });
+
+    testWidgets('bottom sheet shows empty state when no addresses', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.bookmark_rounded).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select Pickup Address'), findsOneWidget);
+      expect(find.text('No saved addresses'), findsOneWidget);
+    });
+
+    testWidgets('bottom sheet shows error state with retry button', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Now make fetchAll fail
+      when(() => mockRepo.fetchAll()).thenThrow(Exception('DB error'));
+
+      await tester.tap(find.byIcon(Icons.bookmark_rounded).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Failed to load addresses'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('selecting address from bottom sheet populates field and dismisses sheet', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road', latitude: 19.07, longitude: 72.87),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Open bottom sheet
+      await tester.tap(find.byIcon(Icons.bookmark_rounded).first);
+      await tester.pumpAndSettle();
+
+      // Tap the address in the sheet
+      await tester.tap(find.text('Home').last);
+      await tester.pumpAndSettle();
+
+      // Sheet should be dismissed and field populated
+      expect(find.text('Select Pickup Address'), findsNothing);
+      expect(find.text('12 MG Road, Mumbai, Maharashtra 400001'), findsOneWidget);
+    });
+
+    testWidgets('drop bookmark icon opens drop address sheet', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Office', addressLine: 'BKC'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Tap the second bookmark icon (drop section)
+      await tester.tap(find.byIcon(Icons.bookmark_rounded).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select Drop Address'), findsOneWidget);
+    });
+  });
+
+  group('Save new address', () {
+    testWidgets('save prompt appears after location is selected', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Verify the screen renders without error
+      expect(find.byType(FindTrucksScreen), findsOneWidget);
+    });
+  });
+
+  group('Chips display', () {
+    testWidgets('chips are horizontal scrollable', (tester) async {
+      final addresses = List.generate(
+        10,
+        (i) => _makeAddress(id: '$i', label: 'Addr $i', addressLine: 'Line $i'),
+      );
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Should find a horizontal ListView for pickup chips
+      final listViews = find.byType(ListView);
+      expect(listViews, findsWidgets);
+    });
+
+    testWidgets('no duplicate chips for same address', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Home chip appears in both pickup and drop sections = 2
+      expect(find.text('Home'), findsNWidgets(2));
+    });
+
+    testWidgets('selected chip has accent styling', (tester) async {
+      final addresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road', latitude: 19.07, longitude: 72.87),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => addresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Tap Home chip to select it
+      await tester.tap(find.text('Home').first);
+      await tester.pumpAndSettle();
+
+      // The chip should still be visible (now selected)
+      expect(find.text('Home'), findsWidgets);
+    });
+  });
+
+  group('Refresh address list', () {
+    testWidgets('addresses refresh after successful save', (tester) async {
+      final initialAddresses = [
+        _makeAddress(id: '1', label: 'Home', addressLine: '12 MG Road'),
+      ];
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => initialAddresses);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsWidgets);
+
+      // Verify fetchAll was called
+      verify(() => mockRepo.fetchAll()).called(1);
+    });
+  });
+
+  group('Existing booking flow preserved', () {
+    testWidgets('form validation still works with saved addresses loaded', (tester) async {
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createTestWidget(tester));
+      await tester.pumpAndSettle();
+
+      // Form should render
+      expect(find.byType(FindTrucksScreen), findsOneWidget);
+      expect(find.byType(PrimaryButton), findsOneWidget);
+      expect(find.text('Find Trucks'), findsOneWidget);
+    });
+
+    testWidgets('RouteDraft populated from pending draft still works', (tester) async {
+      final controller = TruxifyController();
+      when(() => mockRepo.fetchAll()).thenAnswer((_) async => []);
+
+      final draft = RouteDraft(
+        pickup: 'Surat, Gujarat',
+        drop: 'Jaipur, Rajasthan',
+        dateLabel: 'Tomorrow, 6:00 AM',
+        goodsType: 'Textile',
+        weightTonnes: '3',
+        dimensions: '12 × 6 × 6',
+        stacked: true,
+        fragile: false,
+        requirements: const [],
+        pickupLat: 21.17,
+        pickupLng: 72.83,
+        dropLat: 26.91,
+        dropLng: 75.78,
+      );
+      controller.openFindTrucks(draft: draft);
+
+      await tester.pumpWidget(createTestWidget(tester, controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Surat, Gujarat'), findsOneWidget);
+      expect(find.text('Jaipur, Rajasthan'), findsOneWidget);
+      verify(() => mockRepo.fetchAll()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR integrates the existing Saved Address functionality into the Find Trucks booking workflow, allowing customers to quickly reuse previously saved pickup and drop locations.

Previously, users had to manually enter addresses for every booking even though the application already supported saving addresses. This implementation reuses the existing Saved Address infrastructure to streamline repeat bookings and improve the booking experience.

---

## What Changed

### ✨ Added

- Display saved address chips below pickup and drop location fields.
- Added a Saved Address picker using a bottom sheet.
- Auto-fill pickup/drop location fields from saved addresses.
- Prompt users to save newly selected map locations.
- Automatically refresh the saved address list after adding a new address.
- Loading, empty, and error states for saved addresses.

---

## User Flow

```text
Customer opens Find Trucks
        │
        ▼
Saved Addresses Loaded
        │
        ▼
Select Pickup/Drop Address
        │
        ▼
Booking Form Auto-Filled
        │
        ▼
Continue Booking
        │
        ▼
(Optional)
Save New Address
        │
        ▼
Saved Address List Updated
```

---

## Files Changed

### Updated

- `apps/customer/lib/screens/find_trucks_screen.dart`
- `apps/customer/lib/screens/location_picker_screen.dart` *(if required)*

---

## Features

- Saved address chips.
- Saved address picker.
- Auto-fill booking locations.
- Save new addresses directly from the booking flow.
- Automatic refresh of saved addresses.
- Improved repeat booking experience.

---

## Testing

### Verified

- ✅ Saved addresses load successfully.
- ✅ Selecting a saved address populates the correct fields.
- ✅ Latitude and longitude are updated correctly.
- ✅ Bottom sheet behaves correctly.
- ✅ New addresses can be saved from the booking flow.
- ✅ Existing booking flow remains unchanged.
- ✅ Flutter analyze passes.
- ✅ Existing tests continue to pass.

---

## Type of Change

- [x] New Feature
- [x] Flutter Integration
- [ ] Bug Fix
- [ ] Breaking Change

---

## Related Issue

Closes #3692

---

## ECSoC26

This PR is submitted as part of **GirlScript Summer of Code (GSSoC) 2026**.

It enhances the truck booking experience by integrating the existing Saved Address system into the Find Trucks workflow. Customers can now quickly reuse frequently used pickup and drop locations, reducing booking time while preserving the existing backend APIs and booking flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added saved-address support for pickup and drop-off locations.
  * Users can select saved addresses from chips or a dedicated picker.
  * Added optional prompts to save newly selected map locations with a custom label.
  * Saved addresses now update route details and estimated pricing automatically.
  * Added loading, empty, error, retry, and success feedback states.

* **Tests**
  * Added coverage for saved-address loading, selection, saving, refresh, and booking flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->