### PR TITLE
fix(truckRoutes): remove duplicate name filter and close missing brace in GET /

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -94,8 +94,6 @@ router.get('/', authenticate, requireRole(['driver']), userLimiter, async (req, 
       if (cleanName) {
         query = query.ilike('name', `%${cleanName}%`);
       }
-    if (name) {
-      query = query.ilike('name', `%${name.trim()}%`);
     }
     const parsedMin = Number(min_capacity);
     const parsedMax = Number(max_capacity);


### PR DESCRIPTION
## Description

The \GET /\ route handler in \	ruckRoutes.js\ has a missing closing brace for the outer \if (name && typeof name === 'string')\ block (line 92). A duplicate \if (name)\ block starts on line 97 inside the outer block without it being closed first. This causes a SyntaxError that breaks the entire truck listing endpoint.

## Related Issue

Closes #3700

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Removed the duplicate \if (name)\ filter block (lines 97-99)
- Added the missing closing \}\ for the outer \if\ block

## Testing

- Verified the route handler parses correctly after the fix
- Verified name filtering still works via the \cleanName\ path

## Checklist

- [x] My code follows the project style

---

**GSSoC**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truck name filtering by ignoring invalid or blank search terms.
  * Search terms are now trimmed and matched consistently without causing errors for unexpected input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->