### PR TITLE
fix(ml): remove duplicate const declaration and undefined variable in predictDemand

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -65,13 +65,6 @@ export async function predictDemand(features = {}) {
         signal: AbortSignal.timeout(5000),
     });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(5000),
-  });
-
   return handleResponse(response);
 }
 


### PR DESCRIPTION
## Description

\predictDemand()\ in \ml.js\ contains two \const response = await fetch(...)\ declarations in the same function scope (lines 61 and 68). In ES modules (strict mode), this is a SyntaxError. The second fetch also references an undefined variable \payload\ instead of the parameter \eatures\.

## Related Issue

Closes #3701

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Removed the duplicate fetch block (lines 68-73) which had the wrong variable name
- The first declaration (lines 61-66) is correct and retained

## Testing

- Verified the function parses correctly after the fix
- Verified \eatures\ parameter is properly JSON-stringified in the request body

## Checklist

- [x] My code follows the project style

---

**GSSoC**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected demand prediction requests so the machine-learning service receives the intended feature data.
  * Improved reliability of demand prediction responses without changing the existing request configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->