### PR TITLE
fix(reconciliation): use atomic Lua script for Redis lock release to prevent lock theft

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -12,11 +12,13 @@ let reconciliationRunning = false;
 
 export async function reconcilePendingEscrowRefunds() {
   let lockAcquired = false;
+  let lockValue = null;
   let leaseExtender = null;
 
   if (redisClient) {
     try {
-      const acquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
+      lockValue = process.pid.toString();
+      const acquired = await redisClient.set(LOCK_KEY, lockValue, 'NX', 'EX', LOCK_TTL_SECONDS);
       if (!acquired) {
         logger.info('[escrow-reconciliation] Lock held by another instance, skipping.');
         return;
@@ -111,7 +113,17 @@ export async function reconcilePendingEscrowRefunds() {
       clearInterval(leaseExtender);
     }
     if (lockAcquired && redisClient) {
-      await redisClient.del(LOCK_KEY).catch(() => {});
+      try {
+        const luaScript = `
+          if redis.call('GET', KEYS[1]) == ARGV[1] then
+            redis.call('DEL', KEYS[1])
+            return 1
+          end
+          return 0`;
+        await redisClient.eval(luaScript, 1, LOCK_KEY, lockValue);
+      } catch (err) {
+        logger.warn('[escrow-reconciliation] Failed to release Redis lock:', err.message);
+      }
     }
     if (!lockAcquired) {
       reconciliationRunning = false;

--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -12,11 +12,13 @@ let reconciliationRunning = false;
 
 export async function reconcilePendingEscrowReleases() {
   let lockAcquired = false;
+  let lockValue = null;
   let leaseExtender = null;
 
   if (redisClient) {
     try {
-      const acquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
+      lockValue = process.pid.toString();
+      const acquired = await redisClient.set(LOCK_KEY, lockValue, 'NX', 'EX', LOCK_TTL_SECONDS);
       if (!acquired) {
         logger.info('[escrow-release-reconciliation] Lock held by another instance, skipping.');
         return;
@@ -153,7 +155,13 @@ export async function reconcilePendingEscrowReleases() {
     }
     if (lockAcquired && redisClient) {
       try {
-        await redisClient.del(LOCK_KEY);
+        const luaScript = `
+          if redis.call('GET', KEYS[1]) == ARGV[1] then
+            redis.call('DEL', KEYS[1])
+            return 1
+          end
+          return 0`;
+        await redisClient.eval(luaScript, 1, LOCK_KEY, lockValue);
       } catch (err) {
         logger.warn('[escrow-release-reconciliation] Failed to release Redis lock:', err.message);
       }


### PR DESCRIPTION
## Description

Both \escrowReleaseReconciliation.js\ and \escrowRefundReconciliation.js\ acquire distributed Redis locks using \SET ... NX EX\ but release them using a bare \edisClient.del(LOCK_KEY)\ without verifying ownership. If the lock TTL expires while processing is ongoing, another instance can acquire it. The first instance then deletes the lock held by the second, breaking mutual exclusion.

This PR stores the lock value (\process.pid\) and uses an atomic Lua script for release that checks ownership before deleting, matching the correct pattern already used in \orderRoutes.js\.

## Related Issue

Closes #3703

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Stored lock value in a variable for ownership verification
- Replaced \edisClient.del(LOCK_KEY)\ with atomic Lua script that checks \GET\ matches before \DEL\
- Applied to both \escrowReleaseReconciliation.js\ and \escrowRefundReconciliation.js\

## Testing

- Verified lock is only released when the current process owns it
- Verified concurrent instances cannot steal each other's locks

## Checklist

- [x] My code follows the project style

---

**GSSoC**