### PR TITLE
fix(otp): use crypto.randomInt for generation and SHA-256 hashing for storage

### DIFF
--- a/backend/api/src/services/otpService.js
+++ b/backend/api/src/services/otpService.js
@@ -1,16 +1,21 @@
+import crypto from 'crypto';
 import { redisClient } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
 const OTP_TTL_SECONDS = 300;
 const OTP_LENGTH = 4;
 
+function hashOtp(otp) {
+  return crypto.createHash('sha256').update(String(otp)).digest('hex');
+}
+
 export async function generateAndStoreOtp(phone) {
   if (!redisClient) {
     logger.warn('[otp] Redis not available, cannot generate OTP.');
     return null;
   }
-  const otp = String(Math.floor(1000 + Math.random() * 9000)).slice(0, OTP_LENGTH);
-  await redisClient.set(`otp:${phone}`, otp, 'EX', OTP_TTL_SECONDS);
+  const otp = String(crypto.randomInt(1000, 10000)).slice(0, OTP_LENGTH);
+  await redisClient.set(`otp:${phone}`, hashOtp(otp), 'EX', OTP_TTL_SECONDS);
   logger.info(`[otp] OTP generated for ${phone}`);
   return otp;
 }
@@ -25,7 +30,7 @@ export async function verifyOtp(phone, otp) {
     return false;
   }
   const stored = await redisClient.get(`otp:${phone}`);
-  if (!stored || stored !== otp) return false;
+  if (!stored || stored !== hashOtp(otp)) return false;
   await redisClient.del(`otp:${phone}`);
   return true;
 }


### PR DESCRIPTION
## Description

Two security issues in \otpService.js\:

1. **Non-cryptographic PRNG**: Login OTPs use \Math.random()\ (deterministic xorshift128+) instead of \crypto.randomInt()\. The delivery OTP in \orderRoutes.js\ correctly uses the cryptographic PRNG.

2. **Plaintext OTP storage**: Login OTPs are stored and compared as plaintext in Redis. Delivery OTPs in \
otificationService.js\ are properly SHA-256 hashed before storage.

## Related Issue

Closes #3704

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Replaced \Math.random()\ with \crypto.randomInt()\ for OTP generation
- Added \hashOtp()\ helper using SHA-256
- OTPs are now hashed before storage and compared via hash

## Testing

- Verified OTP generation produces valid 4-digit codes
- Verified hash comparison matches correctly
- Verified plaintext OTPs are never stored in Redis

## Checklist

- [x] My code follows the project style

---

**GSSoC**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved one-time password generation with stronger randomness.
  * OTPs are now securely hashed before storage and verification.
  * Invalid OTPs continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->