### PR TITLE
fix: add null guard for supabaseAdmin in escrow release reconciliation

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -10,6 +10,11 @@ let reconciliationTimer = null;
 let reconciliationRunning = false;
 
 export async function reconcilePendingEscrowReleases() {
+  if (!supabaseAdmin) {
+    logger.warn('[escrow-release-reconciliation] supabaseAdmin not available — skipping cycle');
+    return;
+  }
+
   let lockAcquired = false;
 
   if (redisClient) {


### PR DESCRIPTION
## Fix: Add null guard for `supabaseAdmin` in escrow release reconciliation

### Closes #3751

### Problem
`escrowReleaseReconciliation.js` uses `supabaseAdmin` without checking if it's null. When `SUPABASE_SERVICE_ROLE_KEY` is missing or misconfigured, `supabaseAdmin` remains null and line 35 throws `TypeError: Cannot read properties of null (reading 'from')` every 60 seconds.

### Changes
- Added early return with warning log at the top of `reconcilePendingEscrowReleases()` when `supabaseAdmin` is null

### Files Changed
- `backend/api/src/services/escrowReleaseReconciliation.js`