### PR TITLE
fix: declare io variable and add closeLocationServer export 

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -4,6 +4,8 @@ import logger from "../middleware/logger.js";
 import { GpsLog } from "../models/GpsLog.js";
 import { supabase } from "../config/db.js";
 
+let io = null;
+
 /**
  * Initializes the Truxify Live Location WebSocket server on top of an existing
  * Node.js HTTP server. Should be called once during startup after MongoDB
@@ -321,5 +323,12 @@ async function verifyBookingOwnership(customerId, bookingId) {
   } catch (err) {
     logger.error({ err }, '[WS] isCustomerAuthorized error');
     return false;
+  }
+}
+
+export async function closeLocationServer() {
+  if (io) {
+    io.close();
+    io = null;
   }
 }


### PR DESCRIPTION
## Fix: Declare `io` variable and add `closeLocationServer` export

### Closes #3752

### Problem
`locationServer.js` uses `io` on line 28 and assigns it on line 32, but never declares it with `let`/`const`/`var`. In ES modules this throws `ReferenceError`. Additionally, `index.js` imports and calls `closeLocationServer()` during shutdown, but the function was never defined.

### Changes
- Added `let io = null;` at module scope
- Added exported `closeLocationServer()` function that closes the Socket.IO server and resets `io`

### Files Changed
- `backend/api/src/sockets/locationServer.js`