### PR TITLE
fix: check buffer lengths before timingSafeEqual to prevent RangeError

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -32,7 +32,15 @@ function verifyWebhookSignature(req, res, next) {
     .update(rawBody)
     .digest('hex');
 
-  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+  const sigBuf = Buffer.from(signature);
+  const expectedBuf = Buffer.from(expectedSignature);
+
+  if (sigBuf.length !== expectedBuf.length) {
+    logger.warn('[Webhook] Invalid webhook signature length — rejecting request');
+    return res.status(401).json({ error: 'Invalid webhook signature' });
+  }
+
+  if (!crypto.timingSafeEqual(sigBuf, expectedBuf)) {
     logger.warn('[Webhook] Invalid webhook signature — rejecting request');
     return res.status(401).json({ error: 'Invalid webhook signature' });
   }


### PR DESCRIPTION
## Fix: Check buffer lengths before `timingSafeEqual` to prevent RangeError

### Closes #3755

### Problem
`webhookRoutes.js` called `crypto.timingSafeEqual()` without verifying both buffers have the same byte length. A malformed `X-Webhook-Signature` header with a different length caused an uncaught `RangeError`, returning 500 and potentially leaking stack traces.

### Changes
- Added buffer length comparison before calling `timingSafeEqual`
- Malformed signatures now return 401 instead of crashing with 500

### Files Changed
- `backend/api/src/routes/webhookRoutes.js`