### PR TITLE
fix: reuse shared Redis client in WebRTCSignalingServer to prevent crash on connection failure

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -1,13 +1,12 @@
 import { WebSocketServer } from 'ws';
 import jwt from 'jsonwebtoken';
 import logger from '../../middleware/logger.js';
-import Redis from 'ioredis';
-import { supabase } from '../../config/db.js';
+import { supabase, redisClient } from '../../config/db.js';
 
 class WebRTCSignalingServer {
   constructor(server) {
     this.wss = new WebSocketServer({ server, path: '/webrtc' });
-    this.redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+    this.redis = redisClient;
     this.peers = new Map(); // peerId -> { ws, location, meshId }
     this.meshes = new Map(); // meshId -> Set of peerIds
     
@@ -308,7 +307,6 @@ class WebRTCSignalingServer {
     this.peers.clear();
     this.meshes.clear();
     this.wss.close();
-    this.redis.disconnect();
   }
 
   async getPeersNearLocation(lat, lng, radius = 10) {


### PR DESCRIPTION
## Fix: Reuse shared Redis client in WebRTCSignalingServer

### Closes #3756

### Problem
`WebRTCSignalingServer.js` created its own dedicated `ioredis` connection instead of reusing the shared `redisClient` from `config/db.js`. This isolated connection had no `.on('error')` handler, causing the Node.js process to crash on connection failure (Redis unreachable, misconfigured `REDIS_URL`, etc.).

### Changes
- Replaced `new Redis(process.env.REDIS_URL)` with the shared `redisClient` from `config/db.js`
- Removed the `Redis` import from `ioredis` (no longer needed)
- Removed `this.redis.disconnect()` from `destroy()` since the shared client is managed elsewhere

### Files Changed
- `backend/api/src/services/webrtc/WebRTCSignalingServer.js`