### PR TITLE
fix(truck-search): add material_type to query destructuring — closes #3791

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -197,7 +197,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     drop_lat, drop_lng,
     weight_tonnes,
     is_fragile, is_stackable,
-    truck_type, min_capacity, max_capacity
+    truck_type, min_capacity, max_capacity, material_type
   } = req.query;
 
   if (pickup_lat == null || pickup_lng == null || drop_lat == null || drop_lng == null || weight_tonnes == null) {


### PR DESCRIPTION
## Description
Adds `material_type` to the query parameter destructuring in the truck search endpoint. Without this, any request that passes coordinate/weight/truck_type validation crashes with `ReferenceError: material_type is not defined`, making the entire search feature unusable.

## Related Issue
Closes #3791

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Verified that `GET /api/trucks/search` no longer crashes when `material_type` is provided
- Verified that requests without `material_type` still work as before

## Screenshots / Video
No UI changes.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed truck search filtering by material type.
  * Invalid or unsupported material types are now properly validated and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->