### PR TITLE
fix(driver): saveCsv saves to disk instead of sharing — closes #3792

### DIFF
--- a/apps/driver/lib/services/earnings_export_service.dart
+++ b/apps/driver/lib/services/earnings_export_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
@@ -16,11 +17,11 @@ class EarningsExportService {
     await Share.shareXFiles([XFile(file.path)], text: 'Earnings Statement');
   }
 
-  Future<void> saveCsv(String csvContent, String filename) async {
-    final tempDir = Directory.systemTemp;
-    final file = File('${tempDir.path}/$filename');
+  Future<String> saveCsv(String csvContent, String filename) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/$filename');
     await file.writeAsString(csvContent);
-    await Share.shareXFiles([XFile(file.path)], text: 'Earnings Statement');
+    return file.path;
   }
 
   Future<Uint8List> generatePdf(EarningsStatementModel statement) async {


### PR DESCRIPTION
## Description
Fixes `saveCsv` in `EarningsExportService` to actually save the CSV file to disk instead of opening the OS share sheet. Previously, `saveCsv` was an exact copy of `shareCsv` — both called `Share.shareXFiles()`. Now `saveCsv` writes to the application documents directory and returns the saved file path.

## Related Issue
Closes #3792

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Verified that `saveCsv` now writes to `getApplicationDocumentsDirectory()` instead of `Directory.systemTemp`
- Verified that `shareCsv` still works as before (unchanged)
- Verified that `saveCsv` returns the saved file path for downstream use

## Screenshots / Video
No UI changes.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
