### PR TITLE
fix(webhook): guard timingSafeEqual against mismatched buffer lengths — closes #3806

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -32,7 +32,7 @@ function verifyWebhookSignature(req, res, next) {
     .update(rawBody)
     .digest('hex');
 
-  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+  if (Buffer.byteLength(signature) !== Buffer.byteLength(expectedSignature) || !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
     logger.warn('[Webhook] Invalid webhook signature — rejecting request');
     return res.status(401).json({ error: 'Invalid webhook signature' });
   }


### PR DESCRIPTION
Fixes #3806