### PR TITLE
fix(support): enforce UUID validation on GET ticket comments — closes #3807

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -531,7 +531,7 @@ router.post('/tickets/:id/comments', authenticate, userLimiter, validateParams(u
 // ============================================================================
 // 8. GET ALL COMMENTS/REPLIES FOR A TICKET (CUSTOMER OR DRIVER OWNER OR ADMIN)
 // ============================================================================
-router.get('/tickets/:id/comments', authenticate, userLimiter, validateParams(paramIdSchema), async (req, res) => {
+router.get('/tickets/:id/comments', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { sort } = req.query;
   if (sort !== undefined && sort !== 'asc' && sort !== 'desc') {


### PR DESCRIPTION
Fixes #3807