### PR TITLE
fix(notifications): widen dedup window to 48h to prevent duplicate expiry alerts — closes #3809

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -48,7 +48,7 @@ function endOfDay(date) {
 async function hasExistingNotification(userId, documentId, daysRemaining) {
   if (!supabase) return false;
   try {
-    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const cutoff = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
     const { data, error } = await supabase
       .from('notifications')
       .select('id, metadata')


### PR DESCRIPTION
Fixes #3809