### PR TITLE
fix(security): add RLS coverage for webhook_failures and tracking_tokens tables

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -38,12 +38,15 @@ const ALL_TABLES = [
   'driver_documents',
   'vehicle_types',
   'regions',
+  'webhook_failures',
+  'tracking_tokens',
 ];
 
 // Tables with RLS policies in the main RLS migration (20240101000000_rls.sql).
-// user_devices and driver_documents have RLS in their own individual migrations.
+// user_devices, driver_documents, webhook_failures, and tracking_tokens have
+// RLS in their own individual migrations.
 const MAIN_RLS_TABLES = ALL_TABLES.filter(
-  (t) => !['user_devices', 'driver_documents'].includes(t)
+  (t) => !['user_devices', 'driver_documents', 'webhook_failures', 'tracking_tokens'].includes(t)
 );
 
 describe('RLS Migration (20240101000000_rls.sql)', () => {
@@ -122,6 +125,21 @@ describe('Individual migration files with RLS policies', () => {
     expect(content).toMatch(/CREATE POLICY "Service role full access on driver_documents"/);
     expect(content).toMatch(/CREATE POLICY "Drivers read own driver_documents"/);
   });
+
+  it('webhook_failures migration has RLS (20260710000000)', async () => {
+    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260710000000_create_webhook_failures.sql');
+    const content = await fs.readFile(p, 'utf8');
+    expect(content).toMatch(/ALTER TABLE webhook_failures ENABLE ROW LEVEL SECURITY/i);
+    expect(content).toMatch(/CREATE POLICY "Allow Service Role full access to webhook_failures"/);
+  });
+
+  it('tracking_tokens migration has RLS and customer SELECT policy (20260716000000)', async () => {
+    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260716000000_add_public_tracking_tokens.sql');
+    const content = await fs.readFile(p, 'utf8');
+    expect(content).toMatch(/alter table tracking_tokens enable row level security/i);
+    expect(content).toMatch(/create policy "Service role full access on tracking_tokens"/i);
+    expect(content).toMatch(/create policy "Customers select own tracking tokens"/i);
+  });
 });
 
 describe('Revoke anon privileges (revoke_anon_privileges.sql)', () => {
@@ -168,7 +186,7 @@ describe('RPC Security Fix (20260708000000_fix_rpc_security.sql)', () => {
   });
 });
 
-describe('accept_bid_tx — no regression in latest migration chain', () => {
+describe('accept_bid_tx — auth.uid() verification present in migration chain', () => {
   let secureRpcContent;
 
   beforeAll(async () => {
@@ -176,9 +194,20 @@ describe('accept_bid_tx — no regression in latest migration chain', () => {
     secureRpcContent = await fs.readFile(path2, 'utf8');
   });
 
-  it('the 20260706075009 version of accept_bid_tx is missing auth.uid() — proving the regression existed', () => {
-    // The version in 20260706075009 lacks auth.uid() — our fix migration restores it.
+  it('the 20260706075009 version of accept_bid_tx has auth.uid() check restored', () => {
+    // The 20260706075009 migration restores auth.uid() in accept_bid_tx,
+    // ensuring only the order's customer can accept bids.
     const hasAuthCheck = /IF auth\.uid\(\) <> v_customer_id THEN/i.test(secureRpcContent);
-    expect(hasAuthCheck).toBe(false);
+    expect(hasAuthCheck).toBe(true);
+  });
+
+  it('complete_trip_tx has auth.uid() check verifying driver assignment', () => {
+    const hasAuthCheck = /IF auth\.uid\(\) <> v_order.driver_id THEN/i.test(secureRpcContent);
+    expect(hasAuthCheck).toBe(true);
+  });
+
+  it('withdraw_funds_tx has auth.uid() check verifying caller owns the wallet', () => {
+    const hasAuthCheck = /IF auth\.uid\(\) <> p_driver_id THEN/i.test(secureRpcContent);
+    expect(hasAuthCheck).toBe(true);
   });
 });

--- a/supabase/migrations/revoke_anon_privileges.sql
+++ b/supabase/migrations/revoke_anon_privileges.sql
@@ -33,6 +33,8 @@ REVOKE ALL ON TABLE public.user_devices FROM anon;
 REVOKE ALL ON TABLE public.driver_documents FROM anon;
 REVOKE ALL ON TABLE public.vehicle_types FROM anon;
 REVOKE ALL ON TABLE public.regions FROM anon;
+REVOKE ALL ON TABLE public.webhook_failures FROM anon;
+REVOKE ALL ON TABLE public.tracking_tokens FROM anon;
 
 -- Note: RLS policies should still be enabled and strictly defined 
 -- for authenticated users, but revoking from anon adds an extra layer 


### PR DESCRIPTION
## Description

This PR closes the remaining gaps in Row-Level Security (RLS) coverage identified during the audit for issue #3741. The main RLS policies were already implemented in PR #2437 (resolving #2413), but two tables created after that migration were missing from test coverage and anon privilege revocation.

**Issue:** Closes #3741

## Changes Made

### 1. `supabase/migrations/revoke_anon_privileges.sql`
Added `REVOKE ALL` statements for two tables not previously covered:
- `webhook_failures` — internal dead-letter queue (service_role only)
- `tracking_tokens` — customer-owned order sharing tokens

### 2. `backend/api/test/unit/rlsSecurity.test.js`
- Added `webhook_failures` and `tracking_tokens` to `ALL_TABLES` array (covers RLS enablement, service_role policy, and anon revocation checks)
- Added dedicated test cases verifying RLS policies in their respective migration files
- Updated `accept_bid_tx` regression test to reflect current state (the `auth.uid()` check is now present in `20260706075009` along with `complete_trip_tx` and `withdraw_funds_tx`)

## Security Considerations

- Both tables already had RLS policies in their creation migrations — this PR only adds test coverage and anon revocation for defense-in-depth
- `webhook_failures` is restricted to `service_role` only (no authenticated user access)
- `tracking_tokens` allows customers to `SELECT` their own tokens via `created_by` matching

## Verification

- [x] 108/108 RLS security tests pass (was 101/102 before the fix)
- [x] Unit test suite: 745 passed, 33 failed (all pre-existing failures unrelated to this change)
- [x] Lint: no new errors introduced
- [x] Full anon privilege revocation coverage for all 33 tables
- [x] All 4 individually-migrated tables (user_devices, driver_documents, webhook_failures, tracking_tokens) have test coverage
