### PR TITLE
fix: add missing import os in llm_service.py (#3838)

### DIFF
--- a/backend/llm/llm_service.py
+++ b/backend/llm/llm_service.py
@@ -9,6 +9,7 @@ from sentence_transformers import SentenceTransformer
 import chromadb
 from chromadb.config import Settings
 import json
+import os
 import redis
 import logging
 from typing import Dict, List, Any, Optional

--- a/issue-body.txt
+++ b/issue-body.txt
@@ -1,0 +1,14 @@
+## Description
+
+**mev.service.js stores commitment secret in plaintext in database — defeats commit-reveal scheme**
+
+### Problem
+In backend/mev/mev.service.js, createCommitment() stores the plaintext secret in the database via storeCommitment() (line 53: secret: data.secret), and storeCommitment() persists it to the mev_commitments table (line 259: secret: data.secret). The entire purpose of a commit-reveal scheme is that the secret is hidden until reveal time. Storing it in plaintext in the database means anyone with DB access (or SQL injection) can read the secret and front-run the reveal transaction.
+
+### Impact
+Complete defeat of MEV protection — the commit-reveal scheme is reduced to a facade, as the "secret" is stored in plaintext alongside the commitment hash.
+
+### Location
+backend/mev/mev.service.js lines 50-55 (createCommitment) and 253-263 (storeCommitment)
+
+GSSoC


### PR DESCRIPTION
## Description

Added \import os\ to \ackend/llm/llm_service.py\ which calls \os.getenv()\ on line 28 but was missing the import, causing \NameError: name 'os' is not defined\ at startup.

Closes #3838

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved configuration support for selecting the AI model through environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->