### PR TITLE
fix: apply Linear layer after skip connection concat in NeRF model (#3841)

### DIFF
--- a/backend/ml/nerf/model.py
+++ b/backend/ml/nerf/model.py
@@ -93,6 +93,7 @@ class NeRFNetwork(nn.Module):
                 x = layer(x)
             elif i == 4:  # Skip connection
                 x = torch.cat([x, encoded_pos], dim=-1)
+                x = layer(x)
             else:
                 x = layer(x)
         


### PR DESCRIPTION
## Description

In \ackend/ml/nerf/model.py\, the skip-connection at index 4 performed \	orch.cat([x, encoded_pos], dim=-1)\ but never called \layer(x)\ to apply the \
n.Linear(hidden_dim + input_dim, hidden_dim)\ layer. This caused a dimension mismatch crash at the next Linear layer.

### Changes
- Added \x = layer(x)\ after the concatenation in the skip connection forward pass

Closes #3841

GSSoC