### PR TITLE
fix: parse Redis bytes in get_stats() — parse JSON and return counts (#3842)

### DIFF
--- a/backend/ml/multimodal/sensor_fusion.py
+++ b/backend/ml/multimodal/sensor_fusion.py
@@ -215,10 +215,11 @@ class SensorFusion:
     
     def get_stats(self) -> Dict:
         """Get fusion statistics"""
+        raw = self.redis.get('fusion:latest')
         stats = {
-            'last_fusion': self.redis.get('fusion:latest'),
-            'vision_count': self.redis.keys('vision:*'),
-            'audio_count': self.redis.keys('audio:*'),
+            'last_fusion': json.loads(raw) if raw else None,
+            'vision_count': len(self.redis.keys('vision:*')),
+            'audio_count': len(self.redis.keys('audio:*')),
             'timestamp': datetime.now().isoformat()
         }
         


### PR DESCRIPTION
## Description

\get_stats()\ in \ackend/ml/multimodal/sensor_fusion.py\ returned raw Redis byte values instead of proper types:
- \self.redis.get('fusion:latest')\ returned raw bytes, now parsed with \json.loads()\
- \self.redis.keys('vision:*')\ returned a list of byte keys, now returns \len()\ count
- \self.redis.keys('audio:*')\ same fix applied

Closes #3842

GSSoC