### PR TITLE
fix: consult snapshot when event stream is empty in getAggregateState (#3848)

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -230,7 +230,11 @@ class EventStore {
 
     async getAggregateState(aggregateId) {
         const events = await this.getEventStream(aggregateId);
-        if (events.length === 0) return null;
+        if (events.length === 0) {
+            // Check snapshot for last known state when event stream is empty
+            const snapshot = await this.getSnapshot(aggregateId);
+            return snapshot ? snapshot.state : null;
+        }
 
         // Apply events to build state
         let state = { id: aggregateId, version: 0 };


### PR DESCRIPTION
## Description

\	akeSnapshot()\ in \ackend/eventsourcing/event-store.js\ clears the in-memory event stream (\	his.eventStreams.set(aggregateId, [])\), but \getAggregateState()\ returned \
ull\ when encountering an empty stream — the snapshot was never consulted. This caused all aggregate state to be lost after the first snapshot.

### Changes
- Added snapshot lookup in \getAggregateState()\ when the event stream is empty
- Returns snapshot state if available, null otherwise

Closes #3848

GSSoC