### PR TITLE
fix: invalidate channelCache on all state-mutating operations (#3850)

### DIFF
--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -58,6 +58,7 @@ class StateChannelService {
     }
 
     async fundChannel(channelId, amount, participant) {
+        this.channelCache.delete(channelId);
         try {
             const tx = await this.channel.fundChannel(channelId, {
                 value: ethers.parseEther(amount.toString()),
@@ -79,6 +80,7 @@ class StateChannelService {
     }
 
     async updateState(channelId, balances, nonce, signatures) {
+        this.channelCache.delete(channelId);
         try {
             const { balanceA, balanceB } = balances;
             
@@ -116,6 +118,7 @@ class StateChannelService {
     }
 
     async closeChannel(channelId) {
+        this.channelCache.delete(channelId);
         try {
             const tx = await this.channel.closeChannel(channelId, {
                 gasLimit: 100000
@@ -142,6 +145,7 @@ class StateChannelService {
     // ============ Dispute Resolution ============
 
     async raiseDispute(channelId, stateHash) {
+        this.channelCache.delete(channelId);
         try {
             const tx = await this.channel.raiseDispute(channelId, stateHash, {
                 gasLimit: 100000
@@ -164,6 +168,7 @@ class StateChannelService {
     // ============ Batch Settlement ============
 
     async batchSettle(channelIds) {
+        channelIds.forEach(id => this.channelCache.delete(id));
         try {
             const tx = await this.channel.batchSettle(channelIds, {
                 gasLimit: 300000


### PR DESCRIPTION
## Description

\getChannel()\ in \ackend/state-channels/channel.service.js\ caches channel data indefinitely, but state-mutating operations (\undChannel\, \updateState\, \closeChannel\, \aiseDispute\, \atchSettle\) never invalidated the cache. This caused stale balances, status, and nonce values to be served after on-chain state changes.

### Changes
- Added \	his.channelCache.delete(channelId)\ at the start of every state-mutating operation
- For \atchSettle\, iterates over all channel IDs to delete them from cache

Closes #3850

GSSoC