### PR TITLE
fix: stop storing plaintext secret in mev_commitments DB table (#3852)

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -50,7 +50,6 @@ class MEVService {
             await this.storeCommitment({
                 userId,
                 secretHash,
-                secret,
                 txHash: receipt.hash
             });
             
@@ -256,7 +255,6 @@ class MEVService {
             .insert([{
                 user_id: data.userId,
                 secret_hash: data.secretHash,
-                secret: data.secret,
                 tx_hash: data.txHash,
                 created_at: new Date().toISOString()
             }]);


### PR DESCRIPTION
## Description

\createCommitment()\ and \storeCommitment()\ in \ackend/mev/mev.service.js\ stored the plaintext \secret\ in the \mev_commitments\ database table. The entire purpose of a commit-reveal scheme is that the secret is hidden until reveal time. Storing it in plaintext in the DB means anyone with DB access can read the secret and front-run the reveal transaction, completely defeating MEV protection.

### Changes
- Removed \secret\ from the \storeCommitment()\ call payload
- Removed \secret\ column from the database insert — only the \secret_hash\ is stored

Closes #3852

GSSoC