### PR TITLE
fix: Remove duplicate ReentrancyGuard import causing compilation error

### DIFF
--- a/blockchain/contracts/MEVProtectedEscrow.sol
+++ b/blockchain/contracts/MEVProtectedEscrow.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";


### PR DESCRIPTION
## Description

`MEVProtectedEscrow.sol` imported `ReentrancyGuard` from both `@openzeppelin/contracts/security/` (v4 path) and `@openzeppelin/contracts/utils/` (v5 path), causing a Solidity `DeclarationError: Identifier already declared` compilation failure.

## Changes

- Removed the legacy `security/ReentrancyGuard.sol` import, keeping only the v5 `utils/ReentrancyGuard.sol` path

## Files Changed

- `blockchain/contracts/MEVProtectedEscrow.sol:5` — Removed duplicate import

Closes #3845