### PR TITLE
fix: Restrict releaseEscrowWithProof to owner and fix _verifyDisputeProof stub

### DIFF
--- a/blockchain/contracts/MEVProtectedEscrow.sol
+++ b/blockchain/contracts/MEVProtectedEscrow.sol
@@ -125,7 +125,7 @@ contract MEVProtectedEscrow is Ownable, ReentrancyGuard, Pausable {
         Escrow storage escrow = escrows[escrowId];
         require(escrow.customer != address(0), "Escrow not found");
         require(!escrow.released, "Already released");
-        require(msg.sender == escrow.driver || msg.sender == escrow.customer, "Not authorized");
+        require(msg.sender == owner(), "Only owner can release");
         require(!escrow.disputed, "Escrow disputed");
 
         // Verify commit-reveal
@@ -183,9 +183,17 @@ contract MEVProtectedEscrow is Ownable, ReentrancyGuard, Pausable {
     }
 
     function _verifyDisputeProof(bytes memory proof, uint256 escrowId) internal view returns (bool) {
-        // Verify dispute proof
-        // In production: verify signatures from validators
-        return true;
+        require(proof.length > 0, "Empty proof");
+        // Verify validator signature on the dispute
+        bytes32 messageHash = keccak256(abi.encodePacked(escrowId, escrows[escrowId].customer, escrows[escrowId].driver));
+        bytes32 ethSignedMessageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        address validator = ecrecover(
+            ethSignedMessageHash,
+            uint8(proof[0]),
+            bytes32(proof[1:33]),
+            bytes32(proof[33:65])
+        );
+        return validator == owner();
     }
 
     // ============ Flashbots Integration ============


### PR DESCRIPTION
## Description

Two critical authorization flaws in `MEVProtectedEscrow.sol`:
1. `releaseEscrowWithProof` allowed the customer to directly release funds, bypassing OTP and GPS geofence checks
2. `_verifyDisputeProof` was a stub that always returned `true`, allowing anyone to freeze any escrow with arbitrary data

## Changes

- Changed `releaseEscrowWithProof` authorization from `driver || customer` to `onlyOwner`, matching `TruxifyEscrow.sol` behavior
- Implemented actual ECDSA signature verification in `_verifyDisputeProof` using `ecrecover`

## Files Changed

- `blockchain/contracts/MEVProtectedEscrow.sol:128,185-189` — Fixed authorization and dispute verification

Closes #3846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Escrow releases using proof-based authorization are now restricted to the contract owner.
  * Dispute proofs are validated for completeness and authenticity before approval.
  * Invalid or unauthorized proofs can no longer trigger escrow release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->