### PR TITLE
fix: Create shared Redis client at module level to prevent connection leak

### DIFF
--- a/backend/ml/routes/safety_routes.py
+++ b/backend/ml/routes/safety_routes.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import APIRouter, HTTPException, UploadFile, File
 from pydantic import BaseModel
 from typing import Dict, Any, Optional
@@ -9,6 +10,7 @@ import soundfile as sf
 import io
 from datetime import datetime
 import logging
+import redis
 
 from multimodal.vision_monitor import VisionMonitor
 from multimodal.audio_monitor import AudioMonitor
@@ -16,6 +18,10 @@ from multimodal.sensor_fusion import SensorFusion
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/safety", tags=["Driver Safety"])
+
+# Shared Redis client initialized once at module level
+_redis_url = os.environ.get('REDIS_URL', 'redis://localhost:6379')
+redis_client = redis.Redis.from_url(_redis_url, decode_responses=True)
 
 # Initialize monitors
 vision_monitor = VisionMonitor()
@@ -198,10 +204,8 @@ async def trigger_alert(level: str = "WARNING"):
             'timestamp': datetime.now().isoformat()
         }
         
-        # Store alert
-        import redis
-        r = redis.Redis.from_url('redis://localhost:6379')
-        r.setex('safety:alert:latest', 300, json.dumps(alert))
+        # Store alert using shared Redis client
+        redis_client.setex('safety:alert:latest', 300, json.dumps(alert))
         
         return {
             'success': True,


### PR DESCRIPTION
## Description

The `trigger_alert` endpoint in `backend/ml/routes/safety_routes.py` created a new `redis.Redis` connection on every request that was never closed, exhausting file descriptors and crashing the ML service within minutes under load.

## Changes

- Moved `import redis` to module level
- Created a shared `redis_client` at module level using `REDIS_URL` env var with localhost fallback
- Replaced per-request Redis connection with the shared client

## Files Changed

- `backend/ml/routes/safety_routes.py:1,12,22-24,204` — Shared Redis client at module level

Closes #3847