### PR TITLE
fix: remove dead lat/lng range checks in truckRoutes search

### DIFF
--- a/backend/abe/abe_core.py
+++ b/backend/abe/abe_core.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import serialization
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR was incorrectly linked to issue #3893. The actual fix addresses a different bug — removing the auto-close linkage.