### PR TITLE
fix: retry HTTP 408 as transient status

### DIFF
--- a/backend/api/src/core/retry.js
+++ b/backend/api/src/core/retry.js
@@ -17,6 +17,7 @@ const NETWORK_ERROR_CODES = new Set([
 
 function isTransientHttpStatus(status) {
   if (status == null) return false;
+  if (status === 408) return true;
   if (status >= 500 && status <= 599) return true;
   if (status === 429) return true;
   return false;
@@ -52,7 +53,7 @@ function isNonRetryableSupabaseError(error) {
 
   if (error.status != null) {
     const s = Number(error.status);
-    if (s >= 200 && s < 500 && s !== 429) return true;
+    if (s >= 200 && s < 500 && s !== 429 && s !== 408) return true;
   }
 
   return false;


### PR DESCRIPTION
This PR was incorrectly linked to issue #3909. The actual fix addresses a different bug — removing the auto-close linkage.