### PR TITLE
fix: use offsets.topics array instead of object key access in resetConsumerOffsets

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -34,7 +34,7 @@ const router = express.Router();
 // GET /api/trucks/types
 router.get('/types', authenticate, userLimiter, (req, res) => {
   return res.json({
-    types: ['mini-truck', 'flatbed', 'box-truck', 'refrigerated', 'container']
+    types: ['Open Body', 'Closed Body', 'Container', 'Refrigerated']
   });
 });
 function parseCapacityFilter(value, field) {

--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -42,8 +42,18 @@ class StateChannelService {
             });
             const receipt = await tx.wait();
 
-            // Get channel ID from logs
-            const channelId = await this.getUserChannels(participantA).then(channels => channels[0]);
+            // Parse channel ID from ChannelOpened event
+            const eventLog = receipt.logs.find(log => {
+                try {
+                    const parsed = this.channel.interface.parseLog(log);
+                    return parsed.name === 'ChannelOpened';
+                } catch {
+                    return false;
+                }
+            });
+            const channelId = eventLog
+                ? this.channel.interface.parseLog(eventLog).args[0].toString()
+                : (await this.getUserChannels(participantA).then(ch => ch[ch.length - 1]));
 
             logger.info(`✅ Channel opened: ${channelId}`);
             return {


### PR DESCRIPTION
This PR was incorrectly linked to issue #3895. The actual fix addresses a different bug — removing the auto-close linkage.