### PR TITLE
fix: return null on Redis error to prevent thundering herd

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -1,4 +1,8 @@
 import json
+import hashlib
+import time
+from datetime import datetime
+import numpy as np
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import hashes


### PR DESCRIPTION
This PR was incorrectly linked to issue #3912. The actual fix addresses a different bug — removing the auto-close linkage.