### PR TITLE
fix: default validUntil before use to prevent RangeError

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -108,11 +108,13 @@ class DIDService {
             const proof = this.generateProof(subject, credentialType, schema);
             const proofHash = ethers.keccak256(ethers.toUtf8Bytes(proof));
 
+            const validUntilTimestamp = validUntil || Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60;
+
             const tx = await this.didRegistry.issueCredential(
                 subject,
                 credentialType,
                 schemaHash,
-                validUntil || Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60,
+                validUntilTimestamp,
                 proofHash
             );
             const receipt = await tx.wait();
@@ -129,7 +131,7 @@ class DIDService {
                 credentialType,
                 schema,
                 issuedAt: new Date().toISOString(),
-                validUntil: new Date(validUntil * 1000).toISOString(),
+                validUntil: new Date(validUntilTimestamp * 1000).toISOString(),
                 txHash: receipt.hash,
                 proof
             });


### PR DESCRIPTION
Closes #3879

Extract `validUntilTimestamp` with default before both uses — smart contract call and database store — so both consistently use the same value and `new Date(undefined * 1000)` never occurs.