### PR TITLE
fix: remove deprecated req.connection from safeIpKeyGenerator fallback

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -81,7 +81,7 @@ class DeferredRedisStore {
  * into one rate-limit bucket.
  */
 export function safeIpKeyGenerator(req) {
-  let ip = req.ip || req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || req.connection?.remoteAddress || 'unknown';
+  let ip = req.ip || req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
   if (typeof ip === 'string') {
     ip = ip.replace(/^::ffff:/, '');
     if (ip === '::1') ip = '127.0.0.1';


### PR DESCRIPTION
Closes #3898