### PR TITLE
fix: use passed hybrid_key instead of self.classical_key in hybrid_encrypt (closes #3872)

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -39,7 +39,7 @@ class HybridCrypto:
         # Combine keys
         hybrid_keys = {
             'classical': {
-                'public': self.classical_key.public_key(),
+                'public': hybrid_key['classical']['public'],
                 'private': self.classical_key
             },
             'quantum': self.quantum_key,
@@ -61,7 +61,7 @@ class HybridCrypto:
             )
             
             # Classical RSA encryption of data + quantum secret
-            encrypted_data = self.classical_key.public_key().encrypt(
+            encrypted_data = hybrid_key['classical']['public'].encrypt(
                 data + quantum_secret,
                 padding.OAEP(
                     mgf=padding.MGF1(algorithm=hashes.SHA256()),


### PR DESCRIPTION
Closes #3872

Fixes `hybrid_encrypt()` using `self.classical_key.public_key()` instead of the passed `hybrid_key['classical']['public']` parameter. This caused AttributeError when called from a separate HybridCrypto instance (e.g., receiver generating their own instance for decryption).