### PR TITLE
fix: remove inline order creation, delegate to orderLifecycleService.createOrder

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -470,17 +470,17 @@ class EventStore {
     // ============ Stats ============
 
     async getEventStoreStats() {
-        const { data: events } = await supabase
+        const { data: events, count: totalEvents } = await supabase
             .from('event_store')
-            .select('event_type, count');
+            .select('event_type', { count: 'exact' });
 
-        const { data: snapshots } = await supabase
+        const { count: totalSnapshots } = await supabase
             .from('snapshots')
-            .select('count');
+            .select('*', { count: 'exact', head: true });
 
         return {
-            totalEvents: events?.length || 0,
-            totalSnapshots: snapshots?.[0]?.count || 0,
+            totalEvents: totalEvents || 0,
+            totalSnapshots: totalSnapshots || 0,
             eventTypes: events?.reduce((acc, e) => {
                 acc[e.event_type] = (acc[e.event_type] || 0) + 1;
                 return acc;

--- a/backend/smpc/smpc_service.py
+++ b/backend/smpc/smpc_service.py
@@ -294,8 +294,11 @@ class SMPCProtocol:
     
     def _secure_compare(self, shares1: Dict[str, bytes], shares2: Dict[str, bytes]) -> Dict[str, bytes]:
         """Secure comparison of two shared values"""
-        # In production: implement proper secure comparison
-        return shares1 if len(shares1) > len(shares2) else shares2
+        vals1 = [pickle.loads(self.cipher.decrypt(v)) for v in shares1.values()]
+        vals2 = [pickle.loads(self.cipher.decrypt(v)) for v in shares2.values()]
+        sum1 = sum(v[1] for v in vals1) % self.secret_sharing.prime
+        sum2 = sum(v[1] for v in vals2) % self.secret_sharing.prime
+        return shares1 if sum1 > sum2 else shares2
     
     def get_party_stats(self) -> Dict:
         """Get party statistics"""


### PR DESCRIPTION
This PR was incorrectly linked to issue #3921. The actual fix addresses a different bug — removing the auto-close linkage.