### PR TITLE
fix: use Supabase count API in getEventStoreStats (closes #3881)

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -470,17 +470,17 @@ class EventStore {
     // ============ Stats ============
 
     async getEventStoreStats() {
-        const { data: events } = await supabase
+        const { data: events, count: totalEvents } = await supabase
             .from('event_store')
-            .select('event_type, count');
+            .select('event_type', { count: 'exact' });
 
-        const { data: snapshots } = await supabase
+        const { count: totalSnapshots } = await supabase
             .from('snapshots')
-            .select('count');
+            .select('*', { count: 'exact', head: true });
 
         return {
-            totalEvents: events?.length || 0,
-            totalSnapshots: snapshots?.[0]?.count || 0,
+            totalEvents: totalEvents || 0,
+            totalSnapshots: totalSnapshots || 0,
             eventTypes: events?.reduce((acc, e) => {
                 acc[e.event_type] = (acc[e.event_type] || 0) + 1;
                 return acc;


### PR DESCRIPTION
Closes #3881

Replace non-existent `count` column select with Supabase's built-in count API:
- `event_store`: `.select('event_type', { count: 'exact' })` returns rows + count
- `snapshots`: `.select('*', { count: 'exact', head: true })` returns count-only