### PR TITLE
fix: move setState out of form validator to prevent infinite rebuild (closes #3883)

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -532,28 +532,25 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
 
   String? _validateWeight(String? value) {
     final text = value?.trim() ?? '';
-    String? error;
 
     if (text.isEmpty) {
-      error = 'Weight must be greater than 0.';
-    } else {
-      final weight = double.tryParse(text);
-      if (weight == null) {
-        error = 'Please enter a valid numeric weight.';
-      } else if (weight <= 0) {
-        error = 'Weight must be greater than 0.';
-      } else if (weight < 0.1 || weight > 50) {
-        error = 'Weight must be between 0.1 and 50 tonnes.';
-      }
+      return 'Weight must be greater than 0.';
     }
+    final weight = double.tryParse(text);
+    if (weight == null) {
+      return 'Please enter a valid numeric weight.';
+    }
+    if (weight <= 0) {
+      return 'Weight must be greater than 0.';
+    }
+    if (weight < 0.1 || weight > 50) {
+      return 'Weight must be between 0.1 and 50 tonnes.';
+    }
+    return null;
+  }
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        setState(() => _weightErrorText = error);
-      }
-    });
-
-    return error;
+  void _onWeightChanged(String value) {
+    setState(() => _weightErrorText = _validateWeight(value));
   }
 
   void _onFindTrucks() {
@@ -1158,6 +1155,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
                             controller: _weightController,
                             keyboardType: TextInputType.number,
                             validator: _validateWeight,
+                            onChanged: _onWeightChanged,
                             decoration: const InputDecoration(
                               labelText: 'Weight (t)',
                               hintText: '3',


### PR DESCRIPTION
Closes #3883

`_validateWeight()` called `setState()` inside a form validator via `addPostFrameCallback`. With `autovalidateMode: always`, this triggers a rebuild that re-runs validation, risking an infinite loop.

Fix:
- Remove `setState` call from the validator function
- Move error state management to a new `_onWeightChanged` callback
- Validator now only computes and returns the error string