### PR TITLE
fix: replace hard type casts with safe parsing in _mapLoadOffer (closes #3913)

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -172,11 +172,41 @@ class MarketplaceRepository {
 
   LoadOffer _mapLoadOffer(Map<String, dynamic> row) {
     String s(String key, [String fallback = '']) => (row[key] ?? fallback).toString();
-    num n(String key, [num fallback = 0]) => (row[key] as num?) ?? fallback;
-    double d(String key, [double fallback = 0]) => (row[key] as num?)?.toDouble() ?? fallback;
-    int i(String key, [int fallback = 0]) => (row[key] as num?)?.toInt() ?? fallback;
-    bool b(String key, [bool fallback = false]) => (row[key] as bool?) ?? fallback;
-    double? nullableDouble(String key) => (row[key] as num?)?.toDouble();
+    num n(String key, [num fallback = 0]) {
+      final v = row[key];
+      if (v is num) return v;
+      if (v is String) return num.tryParse(v) ?? fallback;
+      return fallback;
+    }
+    double d(String key, [double fallback = 0]) {
+      final v = row[key];
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v) ?? fallback;
+      return fallback;
+    }
+    int i(String key, [int fallback = 0]) {
+      final v = row[key];
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v) ?? fallback;
+      return fallback;
+    }
+    bool b(String key, [bool fallback = false]) {
+      final v = row[key];
+      if (v is bool) return v;
+      if (v is String) {
+        final lower = v.toLowerCase();
+        if (lower == 'true' || lower == '1') return true;
+        if (lower == 'false' || lower == '0') return false;
+      }
+      if (v is num) return v != 0;
+      return fallback;
+    }
+    double? nullableDouble(String key) {
+      final v = row[key];
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v);
+      return null;
+    }
 
     final freightValue = row.containsKey('freight_value')
         ? _formatCurrency(n('freight_value'))


### PR DESCRIPTION
Closes #3913

`(row[key] as num?)` throws `TypeError` if API returns a numeric field as a string. Replaced `as` casts with safe `is` checks that handle both `num` and `String` values.

All four helpers (`n`, `d`, `i`, `b`) and `nullableDouble` now use runtime type checking instead of hard casts.