### PR TITLE
fix: use waitForConfirmation receipt directly instead of second confirmEscrowRefund call (closes #3916)

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -42,7 +42,6 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
   reconciliationRunning = true;
 
   try {
-    // Acquire a global lock just to prevent multiple instances from pulling the exact same batch unnecessarily
     let globalLockAcquired = false;
     if (redisClient) {
       try {
@@ -55,8 +54,6 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         logger.info('[escrow-reconciliation] Global lock held by another instance, skipping batch pull.');
         return;
       }
-    } else {
-      // Redis not configured — single-instance mode, proceed without distributed lock
     }
 
     const instanceId = process.env.HOSTNAME || os.hostname();
@@ -69,7 +66,7 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
 
     for (const order of pendingOrders ?? []) {
       const lockKey = `escrow_lock:${order.id}`;
-      const lockValue = await acquireLock(lockKey, 30000); // 30 seconds for blockchain confirmation
+      const lockValue = await acquireLock(lockKey, 30000);
       if (!lockValue) {
         logger.info(`[escrow-reconciliation] Order ${order.order_display_id} locked by another process (API or Job), skipping.`);
         continue;
@@ -98,13 +95,16 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         }
 
         let refundTxHash = order.refund_tx_hash;
+        let receipt;
+
         if (!refundTxHash) {
           const submitted = await submitEscrowRefund(order.order_display_id);
-          await submitted.waitForConfirmation();
-          refundTxHash = submitted.txHash;
+          receipt = await submitted.waitForConfirmation();
+          refundTxHash = receipt.hash ?? submitted.txHash;
+        } else {
+          receipt = await confirmEscrowRefund(refundTxHash);
         }
 
-        const receipt = await confirmEscrowRefund(refundTxHash);
         const refundedAt = new Date().toISOString();
         const { error: updateError } = await orderRepository.updateOrderWithFilter(order.id, {
           status: 'cancelled',


### PR DESCRIPTION
Closes #3916