### PR TITLE
fix: pass _activeDraft instead of widget.draft to TruckCard after filter clear

### DIFF
--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -380,7 +380,7 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
                 padding: const EdgeInsets.only(bottom: 14),
                 child: TruckCard(
                   truck: entry.value,
-                  draft: widget.draft,
+                  draft: _activeDraft,
                   isHighlighted: entry.key == 0,
                 ),
               );


### PR DESCRIPTION
Closes #3884