### PR TITLE
fix: remove extra }, after FlutterMap closing brace causing Dart compilation error

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -901,7 +901,6 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                     ),
                   ],
                 );
-              },
             ),
           ),
           Positioned(


### PR DESCRIPTION
Closes #3888