### PR TITLE
fix: make graceful shutdown timeout configurable via SHUTDOWN_TIMEOUT_MS env var

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -564,7 +564,7 @@ server.listen(PORT, () => {
 // ============================================================================
 // GRACEFUL SHUTDOWN
 // ============================================================================
-const SHUTDOWN_TIMEOUT_MS = 10_000
+const SHUTDOWN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_TIMEOUT_MS || "10000", 10)
 
 /** @type {boolean} */
 let shuttingDown = false


### PR DESCRIPTION
This PR was incorrectly linked to issue #3904. The actual fix addresses a different bug — removing the auto-close linkage.