### PR TITLE
fix(trips): expand SENSITIVE_FIELDS and add deep payload sanitization — closes #3781

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -34,7 +34,23 @@ function validateEventPayload(type, payload) {
   return { success: true, data: payload };
 }
 
-const SENSITIVE_FIELDS = ['otp', 'delivery_otp', 'token', 'secret', 'password'];
+const SENSITIVE_FIELDS = [
+  'otp', 'delivery_otp', 'token', 'secret', 'password',
+  'phone_number', 'driver_phone', 'customer_phone', 'email',
+  'current_location', 'driver_location',
+  'license_number', 'aadhaar_number', 'pan_number',
+];
+
+function deepSanitize(obj, keys) {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(item => deepSanitize(item, keys));
+  const clean = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (keys.includes(k)) continue;
+    clean[k] = deepSanitize(v, keys);
+  }
+  return clean;
+}
 
 // Schema for an individual Trip Event from the Flutter offline database
 const tripEventSchema = z.object({
@@ -123,10 +139,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       const lat = event.payload?.lat !== undefined ? Number(event.payload.lat) : null;
       const lng = event.payload?.lng !== undefined ? Number(event.payload.lng) : null;
 
-      const safeMetadata = { ...event.payload };
-      for (const field of SENSITIVE_FIELDS) {
-        delete safeMetadata[field];
-      }
+      const safeMetadata = deepSanitize(event.payload, SENSITIVE_FIELDS);
 
       return {
         event_id: event.id,


### PR DESCRIPTION
## Summary
Expands the SENSITIVE_FIELDS blocklist in 	ripRoutes.js to include common PII field names (phone, email, location, license, Aadhaar, PAN) and replaces the shallow-copy delete loop with a recursive deepSanitize function that strips sensitive keys from nested objects.

## Changes
- ackend/api/src/routes/tripRoutes.js:37 � expanded SENSITIVE_FIELDS array with PII field names
- ackend/api/src/routes/tripRoutes.js:46 � added deepSanitize(obj, keys) recursive helper
- ackend/api/src/routes/tripRoutes.js:137 � replaced shallow copy + loop with deepSanitize(event.payload, SENSITIVE_FIELDS)

## Why
The previous shallow copy only stripped top-level keys from a flat { ...event.payload } spread. Nested objects (e.g. payload.metadata.nested_secret) survived the filter. The blocklist also missed common PII fields like phone_number, email, current_location, and government ID numbers.

Closes #3781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy protection for offline-synced trip events.
  * Sensitive contact, location, license, and identification details are now removed from nested event metadata before storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->