### PR TITLE
fix(fraud): guard req.body with optional chaining for GET requests — closes #3786

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -30,7 +30,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
 
     if (criticalEndpoints.some(endpoint => req.path.startsWith(endpoint))) {
       const risk = await fraudDetection.getRealTimeRisk(userId, {
-        amount: req.body.amount || 0,
+        amount: req.body?.amount || 0,
         frequency: 1,
         deviceChanged: req.deviceChanged || false
       });


### PR DESCRIPTION
## Summary
Adds optional chaining on eq.body?.amount in raudMiddleware.js to prevent TypeError when GET requests hit critical endpoints.

## Changes
- ackend/api/src/middleware/fraudMiddleware.js:33 � eq.body.amount ? eq.body?.amount

## Why
Express does not parse request bodies for GET requests, so eq.body is undefined. The middleware accesses eq.body.amount unconditionally on line 33, causing a TypeError caught by the catch block, which returns a 503 � silently breaking all GET requests to /api/orders/*, /api/payments/*, /api/escrow/*, and /api/trips/*.

Closes #3786