### PR TITLE
fix(escrow): use post-RPC verifiedOrder.escrow_status instead of stale order — closes #3787

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -209,7 +209,7 @@ export class DeliveryVerificationService {
 
     let releaseTxHash = null;
     let escrowAlreadyReleased = false;
-    if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
+    if (verifiedOrder.escrow_status === 'funded' || verifiedOrder.escrow_status === 'release_failed') {
       try {
         const releaseResult = await this.escrowReleaseFn(order.order_display_id);
         if (releaseResult.txHash) {
@@ -227,7 +227,7 @@ export class DeliveryVerificationService {
         });
       }
     } else {
-      logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
+      logger.info(`[escrow] Escrow not funded (status: ${verifiedOrder.escrow_status}) — skipping on-chain release.`);
     }
 
     let escrowUpdateFailed = false;


### PR DESCRIPTION
## Summary
Replaces stale order.escrow_status (fetched before the RPC) with fresh erifiedOrder.escrow_status (fetched after the RPC) in deliveryVerificationService.js.

## Changes
- ackend/api/src/services/order/deliveryVerificationService.js:212 � order.escrow_status ? erifiedOrder.escrow_status
- ackend/api/src/services/order/deliveryVerificationService.js:230 � same fix in the else branch log message

## Why
After complete_trip_tx RPC mutates the order, the code re-fetches into erifiedOrder (line 194) but still reads order.escrow_status (the pre-RPC snapshot) on lines 212 and 230. If a concurrent request or the RPC itself changed the escrow status, this stale check can trigger a double release or miss a release entirely.

Closes #3787