### PR TITLE
fix(escrow): throw DomainError on changeDrop load offer update failure — closes #3788

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -512,7 +512,10 @@ export class OrderLifecycleService {
     });
 
     if (offerUpdateErr) {
-      logger.error('Load offer update failed for change-drop:', offerUpdateErr.message);
+      throw new DomainError(500, {
+        error: 'Failed to update load offer after drop change.',
+        details: offerUpdateErr.message,
+      });
     }
 
     try {


### PR DESCRIPTION
## Summary
Replaces silent logger.error with a thrown DomainError when the load offer update fails in changeDrop(), so the customer sees a failure response instead of a false success.

## Changes
- ackend/api/src/services/order/orderLifecycleService.js:514-516 � replaced logger.error(...) with 	hrow new DomainError(500, {...})

## Why
When updateLoadOffer fails after a successful order update, the error was only logged. The customer received a success response with updated pricing, but the driver-facing load board still showed the old drop location, route, and pricing. Drivers would then bid on the wrong route and wrong pricing, leading to disputes or refused deliveries.

Closes #3788