### PR TITLE
fix(orderRoutes): resolve broken imports crashing milestone PUT handler

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -26,22 +26,11 @@ import { predictDemand, predictPrice } from '../services/ml.js';
 import { requireIdempotency } from '../middleware/idempotency.js';
 import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
-import { OrderLifecycleService } from '../services/order/orderLifecycleService.js';
-import { DomainError } from '../services/order/domainError.js';
-
-import { LoadOfferCacheService } from '../services/order/loadOfferCacheService.js';
-const router = express.Router();
-const orderRepository = new OrderRepository(supabase);
-
-const orderValidationService = new OrderValidationService({ supabase, logger });
-const orderTimelineService = new OrderTimelineService(orderRepository);
-const orderMilestoneService = new OrderMilestoneService({ orderValidationService, orderRepository, orderTimelineService });
-
-const bidAcceptanceService = new BidAcceptanceService({
+import {
   orderRepository,
   orderValidationService,
-  orderMilestoneService,
   orderTimelineService,
+  orderMilestoneService,
   orderLifecycleService,
   deliveryVerificationService,
   buildDepositTx,
@@ -50,6 +39,8 @@ const bidAcceptanceService = new BidAcceptanceService({
   confirmEscrowRefund,
   escrowRefund,
 } from '../core/container.js';
+import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
+import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Fix: Resolve broken imports crashing milestone PUT handler and entire orderRoutes module

### Closes #3745

### Problem

`orderRoutes.js` failed to parse entirely due to multiple stacked import/declaration errors introduced by separate contributors across several commits. Because the module threw a `SyntaxError` at load time, **every route in the file was unreachable** — including the milestone `PUT /:id/milestones` handler reported in the issue.

The specific errors were:

- **Duplicate `import { DomainError }`** on lines 24 and 30 → `SyntaxError: Identifier 'DomainError' has already been declared`
- **Unused class imports** for `OrderLifecycleService` and `LoadOfferCacheService` — instances of both are already exported by `container.js` and should be imported from there, not re-instantiated locally
- **Corrupted service initialisation block** (lines 33–54): a mix of local `new ServiceClass(...)` calls (using undefined classes not imported as constructors) tangled with a broken `} from '../core/container.js'` — syntactically invalid and would cause a `ReferenceError` even if the `SyntaxError` above were absent
- **Duplicate `const router = express.Router()`** — a second declaration that would also fail
- **Missing function imports** for `getRouteEstimate`, `getRouteGeometry`, `buildStraightLineGeometry` (from `services/osrm.js`) and `computeOrderPricing` (from `lib/pricing.js`), all called inside route handlers but never imported

The milestone PUT handler's variable declarations (`orderId` from `req.params.id`, `milestone` from `req.body`) were logically correct in the handler body; the file-level parse failure was preventing them from ever executing.

### Changes

- Removed duplicate `import { DomainError }` (line 30)
- Removed unused `import { OrderLifecycleService }` and `import { LoadOfferCacheService }`
- Replaced the corrupted 22-line block with a single clean destructured import of all required service instances and escrow utilities from `../core/container.js`
- Removed the duplicate `const router = express.Router()` declaration
- Added missing imports: `getRouteEstimate`, `getRouteGeometry`, `buildStraightLineGeometry` from `../services/osrm.js` and `computeOrderPricing` from `../lib/pricing.js`

### Files Changed

- `backend/api/src/routes/orderRoutes.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved freight pricing calculations for orders.
  * Added route estimates and route geometry support, including fallback straight-line routes.
* **Refactor**
  * Centralized order services and dependencies for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->