### PR TITLE
fix(notifications): skip retry for non-retryable FCM errors — closes #3485

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -106,6 +106,9 @@ export async function sendFcmNotification(userId, notification, data = {}) {
         const delay = calculateRetryBackoff(attempt);
         logger.info(`[FCM] Retrying after ${delay}ms for user ${userId}`);
         await new Promise(resolve => setTimeout(resolve, delay));
+      } else if (!isTransientError(err.code)) {
+        logger.warn(`[FCM] Non-retryable error for user ${userId}: ${err.code}`);
+        return { success: false, error: err.message, errorCode: err.code };
       }
     }
   }


### PR DESCRIPTION
﻿## Closes #3485

### Problem
Non-retryable FCM error codes (e.g., \messaging/invalid-payload\, \messaging/invalid-recipient\) fall through the retry loop without any delay, causing up to 3 immediate retries with zero backoff. This wastes resources and may trigger FCM rate-limiting.

### Fix
Added an \else\ clause to detect non-retryable, non-transient errors and return immediately instead of retrying.

### Changes
- `backend/api/src/services/notificationService.js`: Added early return for errors that are neither invalid-token nor transient

### Testing
- Verified that invalid-token errors still clear the token and return immediately
- Verified that transient errors still retry with exponential backoff
- Verified that non-retryable, non-transient errors now return immediately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery error handling by immediately stopping retries for non-retryable failures.
  * Notification failures now return clearer failure results and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->