### PR TITLE
fix(wallet): target most recent credit transaction to prevent bulk update — closes #1942

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -505,7 +505,9 @@ export class OrderRepository {
       .update(updates)
       .eq('driver_id', driverId)
       .eq('order_display_id', orderDisplayId)
-      .eq('txn_type', 'credit'), 'updateWalletTransaction');
+      .eq('txn_type', 'credit')
+      .order('created_at', { ascending: false })
+      .limit(1), 'updateWalletTransaction');
   }
 
   // ===================================================================


### PR DESCRIPTION
﻿## Closes #1942

### Problem
\updateWalletTransaction\ filters by \driver_id\ + \order_display_id\ + \	xn_type = 'credit'\ — three non-unique columns. If duplicate credit transactions exist for the same order (e.g., from retries or reconciliation), **all matching rows** are updated simultaneously, corrupting multiple wallet entries.

### Fix
Added \.order('created_at', { ascending: false }).limit(1)\ to target only the most recent matching credit transaction.

### Changes
- `backend/api/src/repositories/orderRepository.js`: Added ordering and limit to \updateWalletTransaction\ to prevent bulk updates

### Testing
- Verified that the query now targets only the most recent credit transaction
- Verified that the fix prevents accidental bulk updates on duplicate transactions
