### PR TITLE
fix(trips): return 500 on database errors instead of masking as 404 — closes #1603

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -236,6 +236,7 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
 
       if (existingEventErr) {
         logger.error('[TripRoutes] Failed to check existing trip events:', existingEventErr.message);
+        return res.status(500).json({ error: 'Internal Server Error' });
       }
 
       // If no events found at all, check via orders whether this trip/order exists
@@ -247,6 +248,7 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
 
       if (orderErr) {
         logger.error('[TripRoutes] Failed to check order for trip:', orderErr.message);
+        return res.status(500).json({ error: 'Internal Server Error' });
       }
 
       if (!order && !existingEvent) {


### PR DESCRIPTION
﻿## Closes #1603

### Problem
When Supabase queries fail (network error, auth error, schema mismatch), the error is only logged and not returned. The code falls through to a \404\ response because \order\ is \
ull\ due to the query failure — not because the trip doesn't exist. The Flutter client sees "Trip not found" and may delete local trip data, causing data loss.

### Fix
Added early \eturn res.status(500)\ when database queries fail, before the 404 check.

### Changes
- `backend/api/src/routes/tripRoutes.js`: Added early return 500 for \existingEventErr\ and \orderErr\ in the GET \/:id/events\ route

### Testing
- Verified that database errors now return 500 instead of being masked as 404
- Verified that legitimate "not found" still returns 404 when both queries succeed but return no data
