### PR TITLE
fix(telemetry): remove dead scrubPII function to prevent accidental use in recovery path — closes #3506

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -57,20 +57,6 @@ let _orderRepository = null;
 let telemetryDropCounter = 0;
 const RECOVERY_FILE_PATH = process.env.RECOVERY_FILE_PATH || path.join(os.tmpdir(), 'truxify-telemetry-recovery.jsonl');
 
-function scrubPII(record) {
-  const scrubbed = { ...record };
-  if (scrubbed.driver_id) {
-    scrubbed.driver_id = 'scrubbed:' + crypto.createHash('sha256').update(scrubbed.driver_id).digest('hex').slice(0, 12);
-  }
-  if (typeof scrubbed.lat === 'number') {
-    scrubbed.lat = Math.round(scrubbed.lat * 100) / 100;
-  }
-  if (typeof scrubbed.lng === 'number') {
-    scrubbed.lng = Math.round(scrubbed.lng * 100) / 100;
-  }
-  return scrubbed;
-}
-
 // In-memory mapping of active client subscriptions
 const trackingSubscriptions = new Map();
 


### PR DESCRIPTION
﻿## Closes #3506

### Problem
The \scrubPII\ function in \	racker.js\ hashes \driver_id\ and rounds lat/lng coordinates. While it's currently dead code (never called), its existence in the telemetry recovery path is a maintenance hazard — any future caller could accidentally invoke it before flushing to MongoDB, permanently corrupting the recovery data with hashed, unqueryable driver_ids.

### Fix
Removed the dead \scrubPII\ function entirely. The recovery file is ephemeral (deleted after loading on startup), so PII scrubbing is unnecessary and counterproductive.

### Changes
- `backend/api/src/sockets/tracker.js`: Removed unused \scrubPII\ function (14 lines)

### Testing
- Verified the function was never called anywhere in the codebase
- Verified the recovery file write path serializes raw buffer records directly
