### PR TITLE
fix: extend Redis lock during escrow refund reconciliation processing loop

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -68,6 +68,14 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
     }
 
     for (const order of pendingOrders ?? []) {
+      if (globalLockAcquired && redisClient) {
+        try {
+          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+        } catch (err) {
+          logger.warn('[escrow-reconciliation] Failed to refresh lock:', err.message);
+        }
+      }
+
       const lockKey = `escrow_lock:${order.id}`;
       const lockValue = await acquireLock(lockKey, 30000); // 30 seconds for blockchain confirmation
       if (!lockValue) {


### PR DESCRIPTION
## fix: Extend Redis lock during escrow refund reconciliation processing loop

Closes #4000

### Problem
`escrowRefundReconciliation.js` acquires a global Redis lock with a 120-second TTL but never extends it during processing. Each refund involves blockchain transaction submission + `waitForConfirmation` (up to 60s per order). Processing 50 orders can easily exceed 120 seconds, causing the lock to expire. Another instance then acquires it and processes the same `refund_pending` orders concurrently, resulting in double refunds and wasted gas.

### Fix
Added lock extension at the start of each iteration in the processing loop, matching the pattern already used in `escrowReleaseReconciliation.js`:

```js
if (globalLockAcquired && redisClient) {
  try {
    await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
  } catch (err) {
    logger.warn('[escrow-reconciliation] Failed to refresh lock:', err.message);
  }
}
```

### Files Changed
backend/api/src/services/escrowRefundReconciliation.js — Added redisClient.expire() call inside the for loop before processing each order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow refund reconciliation reliability for large batches by keeping the reconciliation lock active throughout processing.
  * Lock-refresh issues are now handled without interrupting the batch operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->