### PR TITLE
fix: add atomic Redis lock in idempotency middleware to prevent duplicate orders

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -76,6 +76,20 @@ export function requireIdempotency(ttlSeconds = 3600) {
         return res.status(cached.statusCode).json(cached.body);
       }
 
+      if (redisClient) {
+        const lockKey = `${key}:lock`;
+        const lockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', 10000);
+        if (!lockAcquired) {
+          await new Promise(r => setTimeout(r, 200));
+          const retryRaw = await redisClient.get(key);
+          const retryCached = retryRaw ? readAndParse(retryRaw) : null;
+          if (retryCached) {
+            return res.status(retryCached.statusCode).json(retryCached.body);
+          }
+          return res.status(409).json({ error: 'Duplicate request being processed' });
+        }
+      }
+
       let responded = false;
 
       const originalJson = res.json.bind(res);
@@ -93,6 +107,11 @@ export function requireIdempotency(ttlSeconds = 3600) {
           } else {
             setInMemory(key, cacheData, ttlMs);
           }
+        }
+
+        if (redisClient) {
+          const lockKey = `${key}:lock`;
+          redisClient.del(lockKey).catch(() => {});
         }
 
         return originalJson(body);


### PR DESCRIPTION
## fix: Add atomic Redis lock in idempotency middleware to prevent duplicate orders

Closes #4001

### Problem
The idempotency middleware checks Redis for a cached response and on cache miss immediately calls `next()`. Two concurrent requests with the same `X-Idempotency-Key` both find the cache empty and both execute the handler, creating duplicate orders and double escrow deposits.

### Fix
Added an atomic lock using Redis `SET NX` before proceeding on cache miss:
- First request acquires the lock and proceeds
- Subsequent concurrent requests wait 200ms, retry the cache read, and return the cached response
- If still no cached response (race condition), returns `409 Conflict`
- Lock is released after the response is cached in `res.json`

### Files Changed
- `backend/api/src/middleware/idempotency.js` — Added `SET NX` lock acquisition and retry logic between cache check and `next()`
