### PR TITLE
fix: replace .transfer() with pull-based withdrawal in StateChannel

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -49,6 +49,7 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
     mapping(uint256 => State[]) public channelStates;
     mapping(uint256 => Dispute) public disputes;
     mapping(address => uint256[]) public userChannels;
+    mapping(uint256 => mapping(address => uint256)) public pendingWithdrawals;
 
     uint256 public channelCounter;
     uint256 public constant CHALLENGE_PERIOD = 1 days;
@@ -62,6 +63,7 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
     event DisputeRaised(uint256 indexed channelId, address indexed challenger);
     event DisputeResolved(uint256 indexed channelId, bool resolved);
     event BatchSettled(uint256 indexed channelId, uint256 count);
+    event Withdrawal(uint256 indexed channelId, address indexed participant, uint256 amount);
 
     // ============ Constructor ============
 
@@ -198,17 +200,25 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
         Channel storage channel = channels[channelId];
         require(!channel.isSettled, "Already settled");
 
-        // Transfer balances
         if (channel.balanceA > 0) {
-            payable(channel.participantA).transfer(channel.balanceA);
+            pendingWithdrawals[channelId][channel.participantA] += channel.balanceA;
         }
         if (channel.balanceB > 0) {
-            payable(channel.participantB).transfer(channel.balanceB);
+            pendingWithdrawals[channelId][channel.participantB] += channel.balanceB;
         }
 
         channel.isSettled = true;
         channel.balanceA = 0;
         channel.balanceB = 0;
+    }
+
+    function withdraw(uint256 channelId) external nonReentrant {
+        uint256 amount = pendingWithdrawals[channelId][msg.sender];
+        require(amount > 0, "Nothing to withdraw");
+        pendingWithdrawals[channelId][msg.sender] = 0;
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "Withdraw failed");
+        emit Withdrawal(channelId, msg.sender, amount);
     }
 
     // ============ Dispute Resolution ============


### PR DESCRIPTION
## fix: Replace .transfer() with pull-based withdrawal in StateChannel

Closes #4004

### Problem
`_settleChannel` in `StateChannel.sol` uses `.transfer()` which forwards only 2300 gas. Smart contract wallets (Gnosis Safe, Argent, multisigs) need more gas for their `receive()` functions and revert, permanently locking channel funds with no recovery mechanism.

### Fix
Replaced direct `.transfer()` with a pull-based withdrawal pattern:
- Added `pendingWithdrawals` mapping to credit balances during settlement
- Added `withdraw()` function using `.call{value:}` with full gas forwarding
- Added `Withdrawal` event for transparency

### Files Changed
- `blockchain/contracts/StateChannel.sol` — Added `pendingWithdrawals` mapping, replaced `.transfer()` with withdrawal credits in `_settleChannel`, added `withdraw()` function