### PR TITLE
fix(escrow): use post-RPC verifiedOrder.escrow_status — closes #3787

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -182,31 +182,10 @@ export class DeliveryVerificationService {
     let releaseTxHash = null;
     let escrowAlreadyReleased = false;
 
-    if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
-      try {
-        const releaseResult = await this.escrowReleaseFn(order.order_display_id);
-        if (releaseResult.txHash) {
-          releaseTxHash = releaseResult.txHash;
-        } else if (releaseResult.alreadyReleased) {
-          escrowAlreadyReleased = true;
-        } else {
-          throw new Error('Escrow release returned no transaction hash');
-        }
-      } catch (releaseErr) {
-        logger.error('[escrow] Blockchain release failed for order', orderId, ':', releaseErr.message);
-        throw new DomainError(503, {
-          error: 'Blockchain escrow release failed. Payment cannot be processed. Please retry.',
-          retryable: true,
-        });
-      }
-    } else {
-      logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
-    }
-
     const { data: tripData, error: rpcErr } = await this.orderRepository.executeRpc('complete_trip_tx', {
       p_order_id: orderId,
       p_otp_id: otpRecord.id,
-      p_release_tx_hash: releaseTxHash,
+      p_release_tx_hash: null,
     });
 
     if (rpcErr) {
@@ -229,6 +208,27 @@ export class DeliveryVerificationService {
     }
 
     await this.completeDeliveryOtp({ otpRecordId: otpRecord.id, orderId });
+
+    if (verifiedOrder.escrow_status === 'funded' || verifiedOrder.escrow_status === 'release_failed') {
+      try {
+        const releaseResult = await this.escrowReleaseFn(order.order_display_id);
+        if (releaseResult.txHash) {
+          releaseTxHash = releaseResult.txHash;
+        } else if (releaseResult.alreadyReleased) {
+          escrowAlreadyReleased = true;
+        } else {
+          throw new Error('Escrow release returned no transaction hash');
+        }
+      } catch (releaseErr) {
+        logger.error('[escrow] Blockchain release failed for order', orderId, ':', releaseErr.message);
+        throw new DomainError(503, {
+          error: 'Blockchain escrow release failed. Payment cannot be processed. Please retry.',
+          retryable: true,
+        });
+      }
+    } else {
+      logger.info(`[escrow] Escrow not funded (status: ${verifiedOrder.escrow_status}) — skipping on-chain release.`);
+    }
 
     let escrowUpdateFailed = false;
     if (releaseTxHash || escrowAlreadyReleased) {


### PR DESCRIPTION
﻿## Closes #3787

### Problem
The escrow release in \deliveryVerificationService.js\ uses \order.escrow_status\ — the **pre-RPC stale value** — to decide whether to trigger on-chain release. After the RPC mutation (\complete_trip_tx\), the order is re-fetched as \erifiedOrder\, but its fresh \escrow_status\ is never consulted for the release decision. This means:

1. If the RPC itself changed \escrow_status\ (e.g., from \unded\ to \eleased\), the post-RPC code still sees the old \unded\ status and triggers a **duplicate release**.
2. If the order was already released by another concurrent path, the stale check still proceeds, risking double escrow release on-chain.

### Fix
Moved the escrow release decision **after** the RPC call and the \erifiedOrder\ re-fetch, using \erifiedOrder.escrow_status\ instead of the stale \order.escrow_status\. Also passes \
ull\ for \p_release_tx_hash\ since release now happens post-RPC.

### Changes
- `backend/api/src/services/order/deliveryVerificationService.js`: Moved escrow release after RPC, use \erifiedOrder.escrow_status\

### Testing
- Verified escrow release now uses the fresh post-RPC status
- Verified no duplicate release when RPC already changed escrow_status
- Verified the release still triggers correctly when escrow is funded
