### PR TITLE
fix(webrtc): guard this.redis calls with null check — closes #4031

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -100,11 +100,13 @@ class WebRTCSignalingServer {
     switch (message.type) {
       case 'location-update':
         peer.location = message.location;
-        await this.redis.setex(
-          `peer:${peerId}:location`,
-          60,
-          JSON.stringify(message.location)
-        );
+        if (this.redis) {
+          await this.redis.setex(
+            `peer:${peerId}:location`,
+            60,
+            JSON.stringify(message.location)
+          );
+        }
         // Relay location to nearby peers
         this.relayLocation(peerId, message.location);
         break;
@@ -221,11 +223,13 @@ class WebRTCSignalingServer {
     await supabase.from('gps_offline_data').insert([gpsEntry]);
 
     // Store locally in Redis for quick access
-    await this.redis.setex(
-      `gps:${peerId}:latest`,
-      300,
-      JSON.stringify(normalizedData)
-    );
+    if (this.redis) {
+      await this.redis.setex(
+        `gps:${peerId}:latest`,
+        300,
+        JSON.stringify(normalizedData)
+      );
+    }
 
     // Relayed to peers in mesh
     await this.relayLocation(peerId, normalizedData.location);


### PR DESCRIPTION
﻿## Closes #4031

### Problem
WebRTCSignalingServer crashes with TypeError when Redis is not configured. The 	his.redis.setex() calls in handleMessage (location-update) and handleGPSData run without null checks, causing TypeError: Cannot read properties of null (reading 'setex').

### Fix
Added if (this.redis) guards before both Redis calls. Location updates and GPS data now work correctly without Redis — they just skip the Redis cache write.

### Changes
- ackend/api/src/services/webrtc/WebRTCSignalingServer.js: Added null guards for 	his.redis in location-update handler and handleGPSData


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection resilience when Redis is unavailable.
  * Location updates and latest GPS data continue processing without Redis caching.
  * Existing data relay, storage, messaging, and disconnect behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->