### PR TITLE
fix(sharding): throw explicit error when no shard available — closes #4032

### DIFF
--- a/backend/api/src/services/sharding/ShardManager.js
+++ b/backend/api/src/services/sharding/ShardManager.js
@@ -122,11 +122,15 @@ class ShardManager {
 
   async getShardConnection(shardName) {
     const shard = this.shards.get(shardName);
-    if (!shard || !shard.pool) {
-      logger.error(`Shard ${shardName} not available`);
-      return this.shards.get('north').pool;
+    if (shard && shard.pool) {
+      return shard.pool;
     }
-    return shard.pool;
+    logger.error(`Shard ${shardName} not available, falling back to north`);
+    const north = this.shards.get('north');
+    if (north && north.pool) {
+      return north.pool;
+    }
+    throw new Error(`No database shard available (requested: ${shardName}, north fallback also unavailable)`);
   }
 
   async getOrderLocation(orderId) {


### PR DESCRIPTION
﻿## Closes #4032

### Problem
getShardConnection returns 
ull when both the requested shard and the 'north' fallback shard are unavailable. Callers immediately call .execute() on the result, causing TypeError: Cannot read properties of null (reading 'execute'). Also, when the requested shard IS 'north' and north is down, the self-fallback always returns null.

### Fix
Replaced the silent null return with an explicit 	hrow new Error(...) when no shard is available. Added safe null checks on the north fallback.

### Changes
- ackend/api/src/services/sharding/ShardManager.js: Fixed getShardConnection to throw instead of returning null
