### PR TITLE
fix(dlq): initialize retry_count and use null-safe access — closes #4034

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -17,6 +17,7 @@ export const dlqService = {
           event_type: eventType,
           payload,
           error_message: String(error.message || error).slice(0, 1000),
+          retry_count: 0,
           next_retry_at: new Date(Date.now() + RETRY_BACKOFF[0] * 60000).toISOString(),
         });
 
@@ -79,7 +80,7 @@ export const dlqService = {
         } catch (procErr) {
           logger.error(`[DLQ] Retry failed for event ${event.id}: ${procErr.message}`);
 
-          const newRetryCount = event.retry_count + 1;
+          const newRetryCount = (event.retry_count ?? 0) + 1;
           const nextBackoffMin = RETRY_BACKOFF[newRetryCount] || -1;
 
           if (nextBackoffMin === -1) {


### PR DESCRIPTION
﻿## Closes #4034

### Problem
enqueueFailure does not set etry_count in the initial insert. If the DB column defaults to null, event.retry_count + 1 evaluates to NaN, making RETRY_BACKOFF[NaN] undefined, causing the event to be marked ailed_permanently on its very first retry.

### Fix
1. Added etry_count: 0 to the initial insert in enqueueFailure
2. Changed event.retry_count + 1 to (event.retry_count ?? 0) + 1 for null-safe access

### Changes
- ackend/api/src/services/webhook/dlqService.js: Added retry_count initialization and null-safe access
