### PR TITLE
fix(security): restrict x-log-level to non-production — closes #4035

### DIFF
--- a/backend/api/src/middleware/requestId.js
+++ b/backend/api/src/middleware/requestId.js
@@ -17,7 +17,7 @@ export function requestLogger(req, res, next) {
   const requestedLogLevel = req.headers?.['x-log-level'];
   let reqLogger = logger;
   
-  if (requestedLogLevel && ['info', 'warn', 'error', 'debug', 'trace'].includes(requestedLogLevel.toLowerCase())) {
+  if (process.env.NODE_ENV !== 'production' && requestedLogLevel && ['info', 'warn', 'error', 'debug', 'trace'].includes(requestedLogLevel.toLowerCase())) {
     reqLogger = logger.child({});
     reqLogger.level = requestedLogLevel.toLowerCase();
   }


### PR DESCRIPTION
﻿## Closes #4035

### Problem
The equestLogger middleware allows any external client to set the request-scoped logger's level via the x-log-level HTTP header. In production, attackers can flood logs with debug/trace output (disk exhaustion) and access sensitive data in debug logs (information disclosure).

### Fix
Added process.env.NODE_ENV !== 'production' guard so the header override only works in development/test environments.

### Changes
- ackend/api/src/middleware/requestId.js: Added production guard for x-log-level header
