### PR TITLE
fix(fraud): build graph once in getRealTimeRisk -- closes #4036

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -398,13 +398,10 @@ class FraudDetectionService {
       );
 
       // 2. Network risk
-      const networkRisk = await this.calculateNetworkRisk(
-        userId, 
-        await this.buildGraph(userId, await this.getUserConnections(userId)),
-        await this.detectFraudRings(
-          await this.buildGraph(userId, await this.getUserConnections(userId))
-        )
-      );
+      const connections = await this.getUserConnections(userId);
+      const graph = await this.buildGraph(userId, connections);
+      const fraudRings = await this.detectFraudRings(graph);
+      const networkRisk = await this.calculateNetworkRisk(userId, graph, fraudRings);
 
       // 3. Transaction risk
       const transactionRisk = this.calculateTransactionRisk(transactionData);


### PR DESCRIPTION
﻿## Closes #4036

### Problem
getRealTimeRisk calls getUserConnections and buildGraph twice redundantly, causing 6+ extra async DB round-trips per risk assessment. The two calls can return different data if orders change between them, causing inconsistent graph snapshots and incorrect risk scoring.

### Fix
Build the graph once and reuse it for both detectFraudRings and calculateNetworkRisk.

### Changes
- backend/api/src/services/fraud/FraudDetectionService.js: Deduplicated graph construction in getRealTimeRisk
