### PR TITLE
fix(ml): add missing guardMlApiKey to 4 endpoints -- closes #4038

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -456,6 +456,7 @@ export async function matchDeadhead({ driverDestination, truckSpecs, arrivalTime
  * @returns {Promise<{adjustments: Array, fuel_saving: number}>}
  */
 export async function optimiseMidTrip(routeData) {
+  guardMlApiKey();
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/optimise/mid-trip`;
   const response = await fetch(url, {
@@ -473,6 +474,7 @@ export async function optimiseMidTrip(routeData) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainDemandModel(force = false) {
+  guardMlApiKey();
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/train/demand`;
   const response = await fetch(url, {
@@ -490,6 +492,7 @@ export async function trainDemandModel(force = false) {
  * @returns {Promise<{status: string, model_version: string}>}
  */
 export async function trainPriceModel(force = false) {
+  guardMlApiKey();
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/train/price`;
   const response = await fetch(url, {
@@ -506,6 +509,7 @@ export async function trainPriceModel(force = false) {
  * @returns {Promise<{models: Array}>}
  */
 export async function listModels() {
+  guardMlApiKey();
   const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
   const url = `${baseUrl}/models`;
   const response = await fetch(url, {


### PR DESCRIPTION
﻿## Closes #4038

### Problem
4 exported functions (optimiseMidTrip, trainDemandModel, trainPriceModel, listModels) skip guardMlApiKey(), so they silently send unauthenticated requests when ML_API_KEY is missing.

### Fix
Added guardMlApiKey() call at the top of all 4 functions.

### Changes
- backend/api/src/services/ml.js: Added guardMlApiKey() to optimiseMidTrip, trainDemandModel, trainPriceModel, listModels
