### PR TITLE
fix: add missing hashlib and time imports in hybrid_crypto.py (#4063)

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -1,4 +1,6 @@
 import json
+import hashlib
+import time
 from datetime import datetime
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.asymmetric import rsa, padding


### PR DESCRIPTION
## Description

Added missing \import hashlib\ and \import time\ to \ackend/pqc/hybrid_crypto.py\. The file calls \hashlib.sha256(str(time.time()).encode())\ on line 52 but these imports were missing, causing a NameError at runtime. The \datetime\ and \
umpy\ imports were already added by a previous fix.

Closes #4063

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved hybrid cryptography key identifier generation for greater uniqueness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->