### PR TITLE
fix: add missing supabase import in order.service.js (#4064)

### DIFF
--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -2,6 +2,7 @@ import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
+import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
 
 const typeDefs = gql`


### PR DESCRIPTION
## Description

Added missing \import { supabase }\ to \ackend/graphql/services/order.service.js\. Every resolver calls \supabase.from(...)\ on 8 different lines but the import was missing, causing \ReferenceError: supabase is not defined\ on every GraphQL query to the order subgraph.

Closes #4064

GSSoC