### PR TITLE
fix: add missing supabase import in driver.service.js (#4065)

### DIFF
--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -2,6 +2,7 @@ import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
+import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
 
 const typeDefs = gql`


### PR DESCRIPTION
## Description

Added missing \import { supabase }\ to \ackend/graphql/services/driver.service.js\. Every resolver calls \supabase.from(...)\ on 6 different lines but the import was missing, causing \ReferenceError: supabase is not defined\ on every GraphQL query to the driver subgraph.

Closes #4065

GSSoC