### PR TITLE
fix: store setInterval handle and add stopHealthChecks in consul.service.js (#4066)

### DIFF
--- a/backend/consul/consul.service.js
+++ b/backend/consul/consul.service.js
@@ -14,6 +14,7 @@ class ConsulService {
         this.services = {};
         this.serviceCache = new Map();
         this.healthChecks = {};
+        this._healthInterval = null;
 
         // Start health checks
         this.startHealthChecks();
@@ -142,9 +143,16 @@ class ConsulService {
     // ============ Health Checks ============
 
     startHealthChecks() {
-        setInterval(async () => {
+        this._healthInterval = setInterval(async () => {
             await this.checkAllServices();
         }, 30000); // Every 30 seconds
+    }
+
+    stopHealthChecks() {
+        if (this._healthInterval) {
+            clearInterval(this._healthInterval);
+            this._healthInterval = null;
+        }
     }
 
     async checkAllServices() {


### PR DESCRIPTION
## Description

The \setInterval\ in \startHealthChecks()\ was never assigned to a property, making it impossible to clear the interval on shutdown or reconfiguration. This fix:
- Stores the interval handle in \	his._healthInterval\
- Adds \stopHealthChecks()\ method that clears the interval

Closes #4066

GSSoC