### PR TITLE
fix: create condition iterator once instead of resetting per batch in train_epoch (#4067)

### DIFF
--- a/backend/ml/diffusion/trainer.py
+++ b/backend/ml/diffusion/trainer.py
@@ -80,10 +80,16 @@ class DiffusionTrainer:
         epoch_loss = 0.0
         num_batches = 0
         
+        condition_iter = iter(condition_loader) if condition_loader is not None else None
+
         for batch_idx, x in enumerate(tqdm(dataloader, desc="Training")):
             condition = None
-            if condition_loader is not None:
-                condition = next(iter(condition_loader))[0]
+            if condition_iter is not None:
+                try:
+                    condition = next(condition_iter)[0]
+                except StopIteration:
+                    condition_iter = iter(condition_loader)
+                    condition = next(condition_iter)[0]
             
             loss = self.train_step(x, condition)
             epoch_loss += loss


### PR DESCRIPTION
## Description

In \	rain_epoch()\, \
ext(iter(condition_loader))[0]\ was called on every batch iteration, creating a fresh iterator each time and always yielding the first condition batch. This meant every training batch used the same condition data.

**Fix:** Create the iterator once before the loop. On \StopIteration\, recycle it to continue training.

Closes #4067

GSSoC