### PR TITLE
fix: align model input_shape with feature vector size in audio_monitor.py (#4068)

### DIFF
--- a/backend/ml/multimodal/audio_monitor.py
+++ b/backend/ml/multimodal/audio_monitor.py
@@ -42,7 +42,7 @@ class AudioMonitor:
     def _load_emergency_model(self):
         """Load emergency sound detection model"""
         model = keras.Sequential([
-            keras.layers.Conv1D(64, 3, activation='relu', input_shape=(16000, 1)),
+            keras.layers.Conv1D(64, 3, activation='relu', input_shape=(3000, 1)),
             keras.layers.MaxPooling1D(2),
             keras.layers.Conv1D(128, 3, activation='relu'),
             keras.layers.MaxPooling1D(2),
@@ -62,7 +62,7 @@ class AudioMonitor:
     def _load_emotion_model(self):
         """Load speech emotion recognition model"""
         model = keras.Sequential([
-            keras.layers.Conv1D(64, 3, activation='relu', input_shape=(16000, 1)),
+            keras.layers.Conv1D(64, 3, activation='relu', input_shape=(3000, 1)),
             keras.layers.MaxPooling1D(2),
             keras.layers.Conv1D(128, 3, activation='relu'),
             keras.layers.MaxPooling1D(2),


### PR DESCRIPTION
## Description

All three models (\emergency_sound_model\, \honk_detection_model\, \speech_emotion_model\) declared \input_shape=(16000, 1)\ but \extract_features()\ returns a 3000-element vector (1000 mel + 1000 MFCC + 1000 chroma). When features are reshaped to \(1, 3000, 1)\, TensorFlow raises a shape mismatch error.

**Fix:** Change \input_shape\ from \(16000, 1)\ to \(3000, 1)\ to match the actual feature vector size.

Closes #4068

GSSoC