### PR TITLE
fix: emit ChannelClosed before _settleChannel zeroes balances (#4070)

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -188,10 +188,15 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
         channel.isOpen = false;
         channel.lastUpdated = block.timestamp;
 
+        // Capture final balances before settlement
+        uint256 finalBalanceA = channel.balanceA;
+        uint256 finalBalanceB = channel.balanceB;
+
+        // Emit event before zeroing balances
+        emit ChannelClosed(channelId, finalBalanceA, finalBalanceB);
+
         // Settle balances
         _settleChannel(channelId);
-
-        emit ChannelClosed(channelId, channel.balanceA, channel.balanceB);
     }
 
     function _settleChannel(uint256 channelId) internal {


### PR DESCRIPTION
## Description

\closeChannel()\ calls \_settleChannel()\ before emitting \ChannelClosed\. Since \_settleChannel()\ sets \channel.balanceA = 0\ and \channel.balanceB = 0\ at the end, the event always logs zero balances.

**Fix:** Capture final balances before settlement and emit the event before calling \_settleChannel()\, so the event contains the actual final balances.

Closes #4070

GSSoC