### PR TITLE
fix: use fetched metrics instead of hardcoded values in ml_dashboard.dart (#4071)

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -77,6 +77,18 @@ class _MLDashboardState extends State<MLDashboard> {
   }
 
   Widget _buildMetricsCard() {
+    final results = metrics?['results'] as Map<String, dynamic>? ?? {};
+    final rows = <Widget>[];
+    results.forEach((metric, values) {
+      final prod = values['production']?.toStringAsFixed(2) ?? 'N/A';
+      final shadow = values['shadow']?.toStringAsFixed(2) ?? 'N/A';
+      rows.add(_buildMetricRow(metric, prod, shadow, metric == 'rmse'));
+    });
+
+    if (rows.isEmpty) {
+      rows.add(Text('No metrics available'));
+    }
+
     return Card(
       child: Padding(
         padding: EdgeInsets.all(16),
@@ -85,9 +97,7 @@ class _MLDashboardState extends State<MLDashboard> {
           children: [
             Text('📈 Performance Metrics', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
             SizedBox(height: 8),
-            _buildMetricRow('RMSE', '2.5', '2.1', true),
-            _buildMetricRow('MAE', '1.8', '1.5', true),
-            _buildMetricRow('Accuracy', '85%', '89%', false),
+            ...rows,
           ],
         ),
       ),


### PR DESCRIPTION
## Description

\_buildMetricsCard()\ hardcoded RMSE (2.5/2.1), MAE (1.8/1.5), and Accuracy (85%/89%) instead of reading from the fetched \metrics\ response. This meant the dashboard always showed the same static values regardless of actual model performance.

**Fix:** Iterate over \metrics['results']\ dynamically and build metric rows from the fetched data.

Closes #4071

GSSoC