### PR TITLE
feat(security): add reusable HTTP security headers middleware

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -1,0 +1,34 @@
+/**
+ * Security Headers Middleware
+ *
+ * Adds common HTTP security headers while preserving any
+ * existing Content-Security-Policy configuration.
+ */
+
+export default function securityHeaders(req, res, next) {
+  // Prevent MIME-type sniffing
+  if (!res.getHeader('X-Content-Type-Options')) {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+  }
+
+  // Control referrer information
+  if (!res.getHeader('Referrer-Policy')) {
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  }
+
+  // Restrict browser features
+  if (!res.getHeader('Permissions-Policy')) {
+    res.setHeader(
+      'Permissions-Policy',
+      'camera=(), microphone=(), geolocation=()'
+    );
+  }
+
+  // Prevent cross-origin resource abuse
+  if (!res.getHeader('Cross-Origin-Resource-Policy')) {
+    res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  }
+
+  // Do NOT override an existing CSP
+  next();
+}


### PR DESCRIPTION
## Summary

This PR introduces a reusable HTTP security headers middleware to centralize the application of common security-related response headers across the API.

## Changes

* Added a reusable `securityHeaders` middleware.
* Configured the following HTTP security headers:

  * `X-Content-Type-Options: nosniff`
  * `Referrer-Policy`
  * `Permissions-Policy`
  * `Cross-Origin-Resource-Policy`
* Preserved any existing `Content-Security-Policy` configuration to avoid overriding application-specific CSP settings.
* Designed the middleware to be easily integrated into the global Express middleware stack.

## Why

Applying common security headers consistently helps improve the application's security posture by reducing exposure to browser-based attacks such as MIME type sniffing, limiting unnecessary browser capabilities, and controlling cross-origin resource behavior. Centralizing this logic also improves maintainability and ensures consistent behavior across all routes.

## Testing

* Verified that the middleware sets the expected HTTP security headers.
* Confirmed that existing `Content-Security-Policy` headers are not overwritten.
* Ensured existing API behavior remains unchanged after integrating the middleware.

**Related Issue:** #4098
