### PR TITLE
feat(security): add suspicious request detection middleware

### DIFF
--- a/backend/api/src/middleware/suspiciousRequests.js
+++ b/backend/api/src/middleware/suspiciousRequests.js
@@ -1,0 +1,67 @@
+import logger from './logger.js';
+
+const SQLI_PATTERNS = [
+  /union\s+select/i,
+  /drop\s+table/i,
+  /insert\s+into/i,
+  /or\s+1=1/i,
+  /--/,
+];
+
+const XSS_PATTERNS = [
+  /<script/i,
+  /javascript:/i,
+  /onerror=/i,
+  /onload=/i,
+];
+
+const PATH_TRAVERSAL_PATTERNS = [
+  /\.\.\//,
+  /\.\.\\/,
+  /%2e%2e/i,
+];
+
+const SUSPICIOUS_UA = [
+  /sqlmap/i,
+  /nikto/i,
+  /curl/i,
+  /wget/i,
+];
+
+function matches(patterns, value) {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+export default function suspiciousRequests(req, res, next) {
+  const body = JSON.stringify(req.body || {});
+  const query = JSON.stringify(req.query || {});
+  const url = req.originalUrl || "";
+  const ua = req.headers["user-agent"] || "";
+
+  const findings = [];
+
+  if (matches(SQLI_PATTERNS, body) || matches(SQLI_PATTERNS, query))
+    findings.push("SQL Injection");
+
+  if (matches(XSS_PATTERNS, body) || matches(XSS_PATTERNS, query))
+    findings.push("Cross-Site Scripting");
+
+  if (matches(PATH_TRAVERSAL_PATTERNS, url))
+    findings.push("Path Traversal");
+
+  if (matches(SUSPICIOUS_UA, ua))
+    findings.push("Suspicious User Agent");
+
+  if (findings.length) {
+    logger.warn({
+      requestId: req.requestId,
+      ip: req.ip,
+      method: req.method,
+      path: req.originalUrl,
+      findings,
+      userAgent: ua,
+    }, "Suspicious request detected");
+  }
+
+  next();
+}


### PR DESCRIPTION
## Summary

This PR introduces a reusable middleware for passively detecting suspicious HTTP requests and logging potential security events without affecting normal request processing.

## Changes

* Added a reusable `suspiciousRequests` middleware.
* Detects common SQL injection patterns.
* Detects common Cross-Site Scripting (XSS) payloads.
* Detects path traversal attempts.
* Detects suspicious user agents commonly associated with automated scanners.
* Logs detected events with request metadata while allowing requests to continue normally.

## Why

Early detection of suspicious traffic improves visibility into potential attacks without introducing breaking changes or blocking legitimate users. The middleware provides a centralized location for monitoring common attack patterns and can serve as a foundation for future alerting or automated protection.

## Testing

* Verified SQL injection payloads are logged.
* Verified XSS payloads are detected.
* Verified path traversal attempts generate security logs.
* Verified suspicious user agents are logged.
* Confirmed legitimate requests continue without interruption.

**Related Issue:** #4101
