### PR TITLE
fix(zkp): use userData.wallet_address instead of userData.address -- closes #4119

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -81,7 +81,7 @@ class ZKPService {
         proof.b,
         proof.c,
         proof.input,
-        userData.address
+        userData.wallet_address
       );
       
       const receipt = await tx.wait();
@@ -143,7 +143,7 @@ class ZKPService {
       const userData = await this.getUserAddress(userId);
       if (!userData) return false;
       
-      const verified = await this.contract.isVerified(userData.address);
+      const verified = await this.contract.isVerified(userData.wallet_address);
       return verified;
     } catch (error) {
       logger.error('Verification check failed:', error);
@@ -156,7 +156,7 @@ class ZKPService {
       const userData = await this.getUserAddress(userId);
       if (!userData) return null;
       
-      const hash = await this.contract.getDocumentHash(userData.address);
+      const hash = await this.contract.getDocumentHash(userData.wallet_address);
       return hash;
     } catch (error) {
       logger.error('Document hash fetch failed:', error);


### PR DESCRIPTION
﻿## Closes #4119

### Problem
getUserAddress() returns { wallet_address: '0x...' } but all three callers access userData.address (undefined), breaking the entire ZKP on-chain verification pipeline.

### Fix
Changed userData.address to userData.wallet_address in verifyKYCOnChain, isVerified, and getDocumentHash.

### Changes
- backend/api/src/services/zkp/zkp.service.js: Fixed property name in 3 locations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved on-chain KYC verification by using the account’s linked wallet address.
  - KYC verification status and document hash lookups now reference the correct wallet, providing more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->