### PR TITLE
fix(orderRoutes): add missing redisClient and createUserClient imports -- closes #4120, #4121

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 
 import { bidLimiter, userLimiter, userKeyGenerator, createStore } from '../middleware/rateLimiter.js';
-import { mongoDb, supabase } from '../config/db.js';
+import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateBody, validateParams } from '../middleware/validate.js';


### PR DESCRIPTION
﻿## Closes #4120, #4121

### Problem
orderRoutes.js references createUserClient (line 478) and edisClient (lines 307, 333) without importing them from ../config/db.js, causing ReferenceError crashes on rating submission and load offers endpoints.

### Fix
Added edisClient and createUserClient to the import from ../config/db.js.

### Changes
- backend/api/src/routes/orderRoutes.js: Added missing imports
