### PR TITLE
fix(timeline): insert Cancelled milestone on cancel instead of re-completing Order Placed -- closes #4123

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -654,7 +654,7 @@ export class OrderLifecycleService {
             };
           }
 
-          await this.orderTimelineService.markMilestoneCompleted(order.order_display_id, 'Order Placed');
+          await this.orderTimelineService.insertCancelEvent(order.order_display_id);
           await expireDeliveryOtps(order.id);
 
           return {
@@ -713,7 +713,7 @@ export class OrderLifecycleService {
 
       const cancellationFee = updatedOrder?.cancellation_fee ?? 0;
 
-      await this.orderTimelineService.markMilestoneCompleted(order.order_display_id, 'Order Placed');
+      await this.orderTimelineService.insertCancelEvent(order.order_display_id);
       await expireDeliveryOtps(order.id);
 
       return {

--- a/backend/api/src/services/order/orderTimelineService.js
+++ b/backend/api/src/services/order/orderTimelineService.js
@@ -144,4 +144,8 @@ export class OrderTimelineService {
   async deleteTimeline(orderDisplayId) {
     return this.orderRepository.deleteTimeline(orderDisplayId);
   }
+
+  async insertCancelEvent(orderDisplayId) {
+    return this.insertEntry(orderDisplayId, 'Cancelled', 70);
+  }
 }


### PR DESCRIPTION
﻿## Closes #4123

### Problem
cancelOrder marks 'Order Placed' milestone (already completed at order creation) instead of inserting a 'Cancelled' milestone. Customers see no timeline indication that their order was cancelled.

### Fix
Added insertCancelEvent method to OrderTimelineService and replaced the incorrect markMilestoneCompleted('Order Placed') calls with insertCancelEvent in both cancel paths.

### Changes
- backend/api/src/services/order/orderTimelineService.js: Added insertCancelEvent method
- backend/api/src/services/order/orderLifecycleService.js: Use insertCancelEvent instead of markMilestoneCompleted in 2 cancel paths
