### PR TITLE
fix(escrow): guard waitForConfirmation call in refund reconciliation -- closes #4144

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -107,7 +107,12 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
 
         if (!refundTxHash) {
           const submitted = await submitEscrowRefund(order.order_display_id);
-          receipt = await submitted.waitForConfirmation();
+          if (submitted.waitForConfirmation) {
+            receipt = await submitted.waitForConfirmation();
+          } else {
+            logger.warn(`[escrow-reconciliation] waitForConfirmation unavailable for ${order.order_display_id} — escrow contract may not be initialized.`);
+            receipt = { hash: submitted.txHash };
+          }
           refundTxHash = receipt.hash ?? submitted.txHash;
         } else {
           receipt = await confirmEscrowRefund(refundTxHash);


### PR DESCRIPTION
﻿## Closes #4144

### Problem
escrowRefundReconciliation crashes with TypeError when submitEscrowRefund returns an object without waitForConfirmation (happens when escrow contract is not initialized). Orders get permanently stuck in refund_pending after MAX_RETRIES.

### Fix
Added null check for waitForConfirmation before calling it. When unavailable, logs a warning and proceeds with the txHash.

### Changes
- backend/api/src/services/escrowRefundReconciliation.js: Added waitForConfirmation guard

GSSoC
