### PR TITLE
fix(fraud): unref cleanup interval timer to allow graceful shutdown -- closes #4145

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -18,6 +18,7 @@ class FraudDetectionService {
     this._totalRiskScoresEvicted = 0;
     this._totalBehavioralProfilesEvicted = 0;
     this._cleanupInterval = setInterval(() => this._evictStale(), 300_000); // every 5 min
+    this._cleanupInterval.unref?.();
     
     // Initialize ML models (in production, load from FastAPI)
     this.models = {


### PR DESCRIPTION
﻿## Closes #4145

### Problem
FraudDetectionService cleanup timer is not unref'd, preventing Node.js from exiting gracefully during shutdown.

### Fix
Added .unref?.() to the setInterval call, matching the pattern used by every other timer in the codebase.

### Changes
- backend/api/src/services/fraud/FraudDetectionService.js: Added .unref?.() to cleanup interval

GSSoC
