### PR TITLE
fix(config): remove process.exit(0) from shutdown handler to allow event loop drain -- closes #4146

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -323,8 +323,10 @@ export function validateConfig() {
 async function shutdown(signal) {
   logger.info({ signal }, 'Received signal, starting graceful shutdown...');
   await closeDbConnections();
-  logger.info('Graceful shutdown complete.');
-  process.exit(0);
+  logger.info('Graceful shutdown complete. Exiting...');
+  // Allow the event loop to drain so other shutdown handlers (WebSocket tracker,
+  // reconciliation timers, FraudDetectionService cleanup) can finish their work.
+  // unref'd timers will not prevent exit; the process will exit naturally.
 }
 
 process.on('SIGINT', () => shutdown('SIGINT'));


### PR DESCRIPTION
﻿## Closes #4146

### Problem
process.exit(0) in the shutdown handler kills the process before other shutdown handlers (WebSocket tracker, reconciliation timers, FraudDetectionService cleanup) can finish their work, causing data loss on deploy.

### Fix
Removed process.exit(0) to allow the event loop to drain naturally. Unref'd timers will not prevent exit, and other shutdown handlers can complete their work.

### Changes
- backend/api/src/config/db.js: Removed process.exit(0) from shutdown handler

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling to allow cleanup tasks to finish before the process exits.
  * Added clearer shutdown completion logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->