### PR TITLE
fix(sharding): register ShardManager cleanup with SIGINT/SIGTERM handlers -- closes #4147

### DIFF
--- a/backend/api/src/services/sharding/ShardManager.js
+++ b/backend/api/src/services/sharding/ShardManager.js
@@ -6,6 +6,9 @@ class ShardManager {
   constructor() {
     this.shards = new Map();
     this.redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+    this.redis.quit = this.redis.quit.bind(this.redis);
+    process.on('SIGINT', () => this.closeAllConnections().catch(() => {}));
+    process.on('SIGTERM', () => this.closeAllConnections().catch(() => {}));
     this.initializeShards();
   }
 


### PR DESCRIPTION
﻿## Closes #4147

### Problem
ShardManager creates its own Redis connection in the constructor but closeAllConnections() is not wired into the shutdown handler, leaving the connection dangling on process exit.

### Fix
Registered SIGINT/SIGTERM handlers in the constructor to call closeAllConnections() on shutdown.

### Changes
- backend/api/src/services/sharding/ShardManager.js: Added process signal handlers for cleanup

GSSoC
