### PR TITLE
fix(dlq): recover events stuck in processing for more than 5 minutes -- closes #4148

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -39,6 +39,14 @@ export const dlqService = {
     try {
       const now = new Date().toISOString();
 
+      // Recover events stuck in 'processing' for more than 5 minutes (e.g., after process crash)
+      const staleThreshold = new Date(Date.now() - 5 * 60000).toISOString();
+      await supabase
+        .from('webhook_failures')
+        .update({ status: 'pending', updated_at: now })
+        .eq('status', 'processing')
+        .lt('updated_at', staleThreshold);
+
       // Atomically claim pending events by updating status to 'processing'
       // This prevents concurrent workers from processing the same events
       const { data: claimedEvents, error: claimErr } = await supabase


### PR DESCRIPTION
﻿## Closes #4148

### Problem
DLQ processQueue leaves events stuck in 'processing' forever after process crash. The query only selects 'pending' events, so stuck 'processing' events are never recovered.

### Fix
Added a recovery step at the beginning of processQueue that resets events stuck in 'processing' for more than 5 minutes back to 'pending'.

### Changes
- backend/api/src/services/webhook/dlqService.js: Added stale processing recovery query

GSSoC
