### PR TITLE
fix(tracing): set req._startTime to fix NaN response_time_ms -- closes #4155

### DIFF
--- a/backend/api/src/middleware/tracingMiddleware.js
+++ b/backend/api/src/middleware/tracingMiddleware.js
@@ -8,6 +8,7 @@ export const tracingMiddleware = (req, res, next) => {
         return next();
     }
 
+    req._startTime = Date.now();
     const tracer = tracing.getTracer();
     const span = tracer.startSpan(`HTTP ${req.method} ${req.path}`, {
         attributes: {


### PR DESCRIPTION
## Summary
Sets `req._startTime = Date.now()` at the beginning of the tracing middleware so that `http.response_time_ms` is computed correctly instead of `NaN`.

## Problem
`tracingMiddleware.js:46` computes `Date.now() - req._startTime`, but `req._startTime` is never assigned. The result is always `NaN`, which pollutes all OpenTelemetry span attributes with garbage data.

## Fix
Added `req._startTime = Date.now();` before the span is created (line 12). This is the standard Express pattern for measuring response time.

## Testing
- Verified spans now contain numeric `http.response_time_ms` values
- No regression on health/metrics endpoints (they skip tracing entirely)

GSSoC