### PR TITLE
fix(truckRoutes): escape ILIKE wildcards in search -- closes #4156

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -89,6 +89,7 @@ import { uuidParamSchema, registerTruckSchema } from '../validation/requestSchem
 import { getRouteEstimate } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 import { predictPrice } from '../services/ml.js';
+import { escapeLike } from '../lib/escapeLike.js';
 import logger from '../middleware/logger.js';
 
 function sanitizeNumberPlate(plate) {
@@ -291,7 +292,7 @@ router.get('/', authenticate, requirePolicy('truck:list-own'), userLimiter, asyn
     if (name && typeof name === 'string') {
       const cleanName = name.trim();
       if (cleanName) {
-        query = query.ilike('name', `%${cleanName}%`);
+        query = query.ilike('name', `%${escapeLike(cleanName)}%`);
       }
     }
 


### PR DESCRIPTION
## Summary
Uses the existing `escapeLike()` utility to sanitize ILIKE wildcard characters (`%`, `_`) in truck search queries.

## Problem
`truckRoutes.js:294` passes user input directly into `query.ilike('name', `%${cleanName}%`)` without escaping. A search for `100%` matches `100X`, `100K`, etc. The codebase already has `escapeLike()` at `lib/escapeLike.js` but it was never imported here.

## Fix
- Added `import { escapeLike } from '../lib/escapeLike.js'`
- Changed to `query.ilike('name', `%${escapeLike(cleanName)}%`)`

## Testing
- Searching for `Tata%` now only matches trucks literally named `Tata%`, not `Tata 100`
- No regression on normal searches

GSSoC