### PR TITLE
fix(shardMiddleware): guard Redis cache write to prevent crash when Redis is down -- closes #4157

### DIFF
--- a/backend/api/src/middleware/shardMiddleware.js
+++ b/backend/api/src/middleware/shardMiddleware.js
@@ -46,12 +46,16 @@ export const shardMiddleware = async (req, res, next) => {
       req.shard = shardName;
       req.shardConnection = await shardManager.getShardConnection(shardName);
       
-      // Cache shard info for this request
-      await shardManager.redis.setex(
-        `request:${req.requestId}:shard`,
-        300,
-        shardName
-      );
+      // Cache shard info for this request (non-critical — don't crash if Redis is down)
+      try {
+        await shardManager.redis.setex(
+          `request:${req.requestId}:shard`,
+          300,
+          shardName
+        );
+      } catch (redisErr) {
+        logger.warn('Failed to cache shard info:', redisErr.message);
+      }
       
       logger.info(`Request ${req.requestId} routed to shard: ${shardName}`);
     } else {


### PR DESCRIPTION
## Summary
Wraps the Redis cache write in `shardMiddleware.js` with a try/catch so that a Redis outage doesn't crash shard routing.

## Problem
`shardMiddleware.js:50` calls `await shardManager.redis.setex(...)` without error handling. If Redis is temporarily unavailable, this throws and the catch block (line 68) attempts a fallback that may also fail, resulting in an unhandled rejection.

## Fix
Wrapped the `redis.setex()` call in its own try/catch with a warning log. The shard routing still works even if caching fails — the cache is an optimization, not a requirement.

## Testing
- With Redis running: shard info is cached as before
- With Redis stopped: requests route to the correct shard without crashing

GSSoC