### PR TITLE
fix(bidAcceptance): re-validate wallets before escrow deposit to close TOCTOU race -- closes #4158

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -73,6 +73,19 @@ export class BidAcceptanceService {
       truckInfo = truck;
     }
 
+    // Re-validate wallets immediately before escrow deposit (close TOCTOU window)
+    const { data: freshDriverDetails } = await this.orderRepository.findDriverDetail(bid.driver_id);
+    const { data: freshCustomerProfile } = await this.orderRepository.findCustomerWallet(customerId);
+    const freshDriverWallet = freshDriverDetails?.polygon_wallet_address ?? null;
+    const freshCustomerWallet = freshCustomerProfile?.polygon_wallet_address ?? null;
+
+    if (!freshDriverWallet || !freshCustomerWallet) {
+      this.logger?.warn?.(`[escrow] Wallet disconnected between validation and deposit: driver=${!!freshDriverWallet}, customer=${!!freshCustomerWallet}`);
+      throw new DomainError(422, {
+        error: 'A wallet was disconnected before the escrow deposit could be initiated. Please reconnect your wallet and try again.'
+      });
+    }
+
     // Build the escrow deposit transaction
     let depositTx = null;
     let bookingId = null;


### PR DESCRIPTION
## Summary
Re-validates customer and driver wallet addresses immediately before the escrow deposit transaction is built, closing a TOCTOU race window.

## Problem
`bidAcceptanceService.js` checks that both wallets exist at lines 47-60, then performs several more DB queries (profile, rating, truck info) before building the escrow deposit at line 81. During this window (potentially seconds), either user could disconnect their wallet, causing the escrow deposit to fail with an opaque blockchain error.

## Fix
Added a fresh wallet check right before `buildDepositTxFn()`. If a wallet was disconnected in the interim, the user gets a clear 422 error message instead of a confusing blockchain failure.

## Testing
- Normal flow: no change in behavior
- Simulated wallet disconnect between initial check and deposit: clear error message returned

GSSoC