### PR TITLE
fix(admin): use IST midnight for daily revenue stats -- closes #4159

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -66,8 +66,12 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
       return res.status(500).json({ error: 'Failed to fetch pending orders.' });
     }
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // Compute midnight IST (UTC+5:30) so daily stats align with Indian business day
+    const now = new Date();
+    const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
+    const istNow = new Date(now.getTime() + IST_OFFSET_MS);
+    istNow.setUTCHours(0, 0, 0, 0);
+    const today = new Date(istNow.getTime() - IST_OFFSET_MS);
     const { data: todayOrders, error: revErr } = await supabase
       .from('orders')
       .select('total_amount')


### PR DESCRIPTION
## Summary
Computes daily revenue stats using midnight IST (UTC+5:30) instead of the server's local timezone.

## Problem
`adminRoutes.js:69-70` uses `new Date(); today.setHours(0, 0, 0, 0)` which rounds down to midnight in the server's local timezone. If the server runs in UTC (standard for AWS/GCP), this gives midnight UTC, not midnight IST. For the first 5.5 hours of each IST day (00:00-05:30), the dashboard shows yesterday's data.

## Fix
Compute midnight IST explicitly using UTC offset arithmetic:
1. Add IST offset (5.5h) to current time
2. Zero out hours/minutes/seconds/ms using `setUTCHours`
3. Subtract the offset back to get the correct UTC timestamp

This works regardless of server timezone since `toISOString()` always outputs UTC.

## Testing
- At 02:00 IST (20:30 UTC prev day): dashboard now correctly shows today's partial revenue
- At 12:00 IST (06:30 UTC): no change in behavior

GSSoC