### PR TITLE
fix: merge duplicate dispose() in ShellScreen to prevent resource leak

### DIFF
--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -195,6 +195,7 @@ class _ShellScreenState extends State<ShellScreen> {
 
   @override
   void dispose() {
+    _weighStationSub?.cancel();
     ForegroundNotificationHandler.dispose();
     _currentIndex.dispose();
     super.dispose();
@@ -297,13 +298,7 @@ class _ShellScreenState extends State<ShellScreen> {
     );
   }
 
-  @override
-  
-  @override
-  void dispose() {
-    _weighStationSub?.cancel();
-    super.dispose();
-  }
+
 
   void _showBypassAlert(WeighStationEvent event) {
     if (!mounted) return;


### PR DESCRIPTION
﻿## Summary
Merges two duplicate dispose() method definitions in _ShellScreenState into a single method, preventing resource leaks.

## Problem
ShellScreen had two dispose() definitions:
- **First** (line 197): disposed ForegroundNotificationHandler and _currentIndex
- **Second** (line 303): cancelled _weighStationSub and called super.dispose()

In Dart, the second definition silently overrides the first, meaning _weighStationHandler was never cancelled and _currentIndex was never disposed.

## Fix
Combined both into a single dispose():
`dart
@override
void dispose() {
  _weighStationSub?.cancel();
  ForegroundNotificationHandler.dispose();
  _currentIndex.dispose();
  super.dispose();
}
`

Removed the duplicate @override + dispose() block.

## Testing
- Driver app compiles successfully
- Shell screen properly cleans up all resources on dispose

Closes #4168

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application cleanup when closing the driver screen.
  * Prevented redundant disposal handling that could affect stream subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->