### PR TITLE
fix: add missing startDlqWorker/stopDlqWorker import in index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -97,6 +97,10 @@ import {
   startDocumentExpiryWorker,
   stopDocumentExpiryWorker,
 } from './services/documentExpiryService.js'
+import {
+  startDlqWorker,
+  stopDlqWorker,
+} from './workers/dlqWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js


### PR DESCRIPTION
## fix: add missing `startDlqWorker`/`stopDlqWorker` import in index.js

### Closes #4174

### Problem
`backend/api/src/index.js` calls `startDlqWorker()` (line 572) inside the `server.listen` callback and `stopDlqWorker()` (line 599) inside the shutdown handler, but neither function is imported anywhere in the file. This causes `ReferenceError: startDlqWorker is not defined` on server startup, triggering the `uncaughtException` handler and shutting down the process immediately.

### Fix
Added the missing import from `./workers/dlqWorker.js`:
```javascript
import {
  startDlqWorker,
  stopDlqWorker,
} from './workers/dlqWorker.js'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server startup and shutdown handling for background failed-message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->