### PR TITLE
fix: remove unreachable in-memory guard in reputationReconciliation.js

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -40,13 +40,6 @@ export async function reconcileFailedReputationUpdates() {
   }
 
   if (!lockAcquired) {
-    // Without Redis there is no distributed lock and no per-row claim key, so
-    // multiple service instances would reconcile the same rows concurrently and
-    // double-award reputation. In that case skip rather than run unprotected.
-    if (!redisClient) {
-      logger.error('[reputation-reconciliation] Redis unavailable: cannot acquire a distributed lock. Skipping reconciliation to avoid unsafe concurrent awards across instances.');
-      return;
-    }
     if (reconciliationRunning) return;
     reconciliationRunning = true;
   }


### PR DESCRIPTION
## fix: remove unreachable in-memory guard in reputationReconciliation.js

### Closes #4175

### Problem
`backend/api/src/services/reputationReconciliation.js` has an in-memory `reconciliationRunning` guard (lines 50-51) intended to prevent concurrent reconciliation runs in single-instance deployments without Redis. However, this guard was unreachable dead code: when `redisClient` is falsy, the code always returned at line 47 before reaching the guard. This meant reputation reconciliation **never ran at all** in single-instance mode without Redis.

### Fix
Removed the early return for no-Redis mode that made the in-memory guard unreachable:
```javascript
if (!lockAcquired) {
  if (reconciliationRunning) return;
  reconciliationRunning = true;
}
```