### PR TITLE
fix: add missing scanDocument import in documentController.js

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -4,6 +4,7 @@ import {
   validateDocumentBuffer,
   DocumentValidationError,
 } from '../lib/documentValidation.js';
+import { scanDocument } from '../lib/malwareScanner.js';
 
 const ALLOWED_DOCUMENT_TYPES = Object.freeze([
   'aadhaar_card',


### PR DESCRIPTION
## fix: add missing `scanDocument` import in documentController.js

### Closes #4176

### Problem
`backend/api/src/controllers/documentController.js` calls `scanDocument(req.file.buffer)` at line 44 to scan uploaded KYC documents for malware, but `scanDocument` was never imported. This caused `ReferenceError: scanDocument is not defined` for every document upload request, returning a 500 error and blocking drivers from completing KYC verification.

### Fix
Added the missing import from `../lib/malwareScanner.js`:
```javascript
import { scanDocument } from '../lib/malwareScanner.js';
```