### PR TITLE
fix: remove duplicate shardManager.closeAllConnections() call in shutdown

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -624,16 +624,9 @@ async function shutdown (signal) {
     await shardManager.closeAllConnections()
     logger.info('[shutdown] Shard connections closed.')
 
-    // 4. Close database/cache connections
-
-    // 3. Close WebRTC signaling server
+    // 4. Close WebRTC signaling server
     await closeWebRTCSignaling()
     logger.info('[shutdown] WebRTC signaling server closed.')
-
-    // 4. Close shard connections
-    await shardManager.closeAllConnections()
-    logger.info('[shutdown] Shard connections closed.')
-
 
     // 5. Close database/cache connections
 


### PR DESCRIPTION
## fix: remove duplicate `shardManager.closeAllConnections()` call in shutdown

### Closes #4177

### Problem
`backend/api/src/index.js` called `shardManager.closeAllConnections()` twice during graceful shutdown — once at line 624 (step 3) and again at line 634 (step 4, mislabeled). The second call attempted to close already-closed connections, which could throw an error and skip remaining shutdown steps (database connection closure, tracing flush, process exit).

### Fix
Removed the duplicate block and fixed the mislabeled step comments:
```javascript
// 3. Close shard connections
await shardManager.closeAllConnections()

// 4. Close WebRTC signaling server
await closeWebRTCSignaling()

// 5. Close database/cache connections
```