### PR TITLE
fix: implement unregisterAllDeviceTokens in deviceController.js

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -203,7 +203,14 @@ export async function unregisterDeviceToken(req, res) {
 }
 
 export async function unregisterAllDeviceTokens(userId) {
-  // delete all rows for this user from user_devices
+  const { error } = await supabase
+    .from('user_devices')
+    .delete()
+    .eq('user_id', userId);
+  if (error) {
+    logger.error('[DeviceController] Failed to unregister device tokens:', error.message);
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## fix: implement `unregisterAllDeviceTokens` in deviceController.js

### Closes #4178

### Problem
`backend/api/src/controllers/deviceController.js` exported `unregisterAllDeviceTokens(userId)` but the function body was completely empty (just a comment). When called during logout or account deletion, it silently did nothing — all device tokens remained in the `user_devices` table, causing logged-out users to continue receiving push notifications including OTP codes and location-tracking prompts.

### Fix
Implemented the actual deletion:
```javascript
export async function unregisterAllDeviceTokens(userId) {
  const { error } = await supabase
    .from('user_devices')
    .delete()
    .eq('user_id', userId);
  if (error) {
    logger.error('[DeviceController] Failed to unregister device tokens:', error.message);
    throw error;
  }
}
```