### PR TITLE
Fix public tracking response parsing

### DIFF
--- a/apps/customer/lib/screens/public_tracking_screen.dart
+++ b/apps/customer/lib/screens/public_tracking_screen.dart
@@ -29,6 +29,20 @@ class _PublicTrackingScreenState extends State<PublicTrackingScreen> {
 
   static const Duration _refreshInterval = Duration(seconds: 15);
 
+  Map<String, dynamic>? _mapFrom(dynamic value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return Map<String, dynamic>.from(value);
+    return null;
+  }
+
+  List<Map<String, dynamic>> _timelineFrom(dynamic value) {
+    if (value is! List) return const [];
+    return value
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item))
+        .toList(growable: false);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -58,12 +72,9 @@ class _PublicTrackingScreenState extends State<PublicTrackingScreen> {
       }
 
       setState(() {
-        _order = data['order'] as Map<String, dynamic>?;
-        _timeline = (data['timeline'] as List<dynamic>?)
-                ?.map((t) => Map<String, dynamic>.from(t as Map))
-                .toList() ??
-            [];
-        _driverLocation = data['driver_location'] as Map<String, dynamic>?;
+        _order = _mapFrom(data['order']);
+        _timeline = _timelineFrom(data['timeline']);
+        _driverLocation = _mapFrom(data['driver_location']);
         _isLoading = false;
       });
     } catch (e) {


### PR DESCRIPTION
## Summary
- normalize public tracking map fields before assigning state
- skip malformed timeline rows instead of failing the whole screen
- keep the existing expired-link and generic load failure behavior

## Validation
- Reviewed the updated parsing path locally
- `dart format` could not be run because the Dart SDK is not installed in this environment

Fixes #4184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking updates to handle unexpected or incomplete data more reliably.
  * Added safer fallbacks for order details, timeline events, and driver location information.
  * Reduced the risk of errors when tracking data contains missing or differently formatted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->