### PR TITLE
Surface active tracking token lookup failures

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -125,7 +125,11 @@ export class TrackingTokenService {
       .order('created_at', { ascending: false });
 
     if (error) {
-      return [];
+      this._logger.error(
+        { error, orderDisplayId },
+        'Failed to fetch active tracking tokens'
+      );
+      throw new Error('Failed to fetch active tracking tokens');
     }
 
     return data || [];


### PR DESCRIPTION
## Summary
- log Supabase failures when active tracking tokens cannot be loaded
- stop returning an empty list for backend lookup errors
- preserve the normal empty-list result when the query succeeds without rows

## Validation
- Reviewed the service branch locally
- Existing automated checks were not run for this single-service change

Fixes #4185