### PR TITLE
Log public tracking driver location failures

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -188,7 +188,7 @@ export class TrackingTokenService {
       return null;
     }
 
-    const { data: location } = await this._supabase
+    const { data: location, error: locationError } = await this._supabase
       .from('driver_locations')
       .select('latitude, longitude, last_updated_at')
       .eq('driver_id', order.driver_id)
@@ -196,6 +196,14 @@ export class TrackingTokenService {
       .order('last_updated_at', { ascending: false })
       .limit(1)
       .single();
+
+    if (locationError) {
+      this._logger.error(
+        { error: locationError, orderDisplayId, driverId: order.driver_id },
+        'Failed to fetch public tracking driver location'
+      );
+      return null;
+    }
 
     return location || null;
   }


### PR DESCRIPTION
## Summary
- capture Supabase errors from the public driver-location lookup
- log failures with order and driver context
- preserve the existing null result for unavailable active locations

## Validation
- Reviewed the service branch locally
- Existing automated checks were not run for this single-service change

Fixes #4187