### PR TITLE
Harden profit prediction parsing

### DIFF
--- a/apps/driver/lib/services/driver_insights_service.dart
+++ b/apps/driver/lib/services/driver_insights_service.dart
@@ -14,15 +14,36 @@ class ProfitPrediction {
   final String currency;
 
   factory ProfitPrediction.fromJson(Map<String, dynamic> json) {
-    final prediction = json['prediction'] as Map<String, dynamic>;
-    final ci = prediction['confidence_interval'] as Map<String, dynamic>;
+    final prediction = _requiredMap(json['prediction'], 'prediction');
+    final ci = _requiredMap(
+      prediction['confidence_interval'],
+      'confidence_interval',
+    );
 
     return ProfitPrediction(
-      predictedProfit: (prediction['predicted_profit'] as num).toDouble(),
-      lowerBound: (ci['lower'] as num).toDouble(),
-      upperBound: (ci['upper'] as num).toDouble(),
+      predictedProfit: _requiredDouble(
+        prediction['predicted_profit'],
+        'predicted_profit',
+      ),
+      lowerBound: _requiredDouble(ci['lower'], 'confidence_interval.lower'),
+      upperBound: _requiredDouble(ci['upper'], 'confidence_interval.upper'),
       currency: (prediction['currency'] as String?) ?? 'INR',
     );
+  }
+
+  static Map<String, dynamic> _requiredMap(dynamic value, String field) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw StateError('Missing or invalid profit prediction field: $field');
+  }
+
+  static double _requiredDouble(dynamic value, String field) {
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      final parsed = double.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+    throw StateError('Missing or invalid profit prediction field: $field');
   }
 
   String get formattedProfit {


### PR DESCRIPTION
## Summary
- validate the profit prediction response shape before reading nested fields
- accept map-like payloads and numeric strings for prediction values
- return clear parser errors for missing or invalid fields

## Validation
- Reviewed the parser flow locally
- `dart format` could not be run because the Dart SDK is not installed in this environment

Fixes #4189