### PR TITLE
Handle zero coordinates in load offer cache regions

### DIFF
--- a/backend/api/src/services/order/loadOfferCacheService.js
+++ b/backend/api/src/services/order/loadOfferCacheService.js
@@ -4,8 +4,17 @@ import logger from '../../middleware/logger.js';
 
 export class LoadOfferCacheService {
   static getRegion(lat, lng) {
-    if (!lat || !lng) return 'global';
-    return geohash.encode(Number(lat), Number(lng), 4);
+    if (lat === undefined || lat === null || lat === '') return 'global';
+    if (lng === undefined || lng === null || lng === '') return 'global';
+
+    const parsedLat = Number(lat);
+    const parsedLng = Number(lng);
+
+    if (!Number.isFinite(parsedLat) || !Number.isFinite(parsedLng)) {
+      return 'global';
+    }
+
+    return geohash.encode(parsedLat, parsedLng, 4);
   }
 
   static async getVersion(region) {


### PR DESCRIPTION
## Summary
- replace truthy coordinate checks with explicit missing-value checks
- validate parsed latitude and longitude before geohashing
- keep the global cache fallback for missing or non-finite coordinates

## Validation
- Attempted a Node module import check, but local dependencies are not installed: `ngeohash` could not be resolved

Fixes #4191