### PR TITLE
Keep WebRTC GPS relay alive on storage errors

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -219,16 +219,26 @@ class WebRTCSignalingServer {
       synced: false
     };
 
-    // Store in MongoDB
-    await supabase.from('gps_offline_data').insert([gpsEntry]);
+    try {
+      const { error } = await supabase.from('gps_offline_data').insert([gpsEntry]);
+      if (error) {
+        logger.warn(`Failed to persist WebRTC GPS payload for peer ${peerId}: ${error.message}`);
+      }
+    } catch (err) {
+      logger.warn(`Failed to persist WebRTC GPS payload for peer ${peerId}: ${err.message}`);
+    }
 
     // Store locally in Redis for quick access
-    if (this.redis) {
-      await this.redis.setex(
-        `gps:${peerId}:latest`,
-        300,
-        JSON.stringify(normalizedData)
-      );
+    try {
+      if (this.redis) {
+        await this.redis.setex(
+          `gps:${peerId}:latest`,
+          300,
+          JSON.stringify(normalizedData)
+        );
+      }
+    } catch (err) {
+      logger.warn(`Failed to cache WebRTC GPS payload for peer ${peerId}: ${err.message}`);
     }
 
     // Relayed to peers in mesh


### PR DESCRIPTION
## Summary
- isolate offline GPS persistence errors from the live relay flow
- log Supabase insert and Redis cache failures with peer context
- continue relaying valid GPS updates to mesh peers after storage-side failures

## Validation
- Reviewed the updated GPS handling path locally
- Full backend checks were not run because local dependencies are not installed

Fixes #4192