### PR TITLE
fix: cast int to double before calling toStringAsFixed in _sanitizeCoordinate

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -154,7 +154,7 @@ class _HomeScreenState extends State<HomeScreen> {
   String _sanitizeCoordinate(dynamic coord) {
     if (coord == null) return '0.0';
     if (coord is double) return coord.toStringAsFixed(6);
-    if (coord is int) return coord.toStringAsFixed(6);
+    if (coord is int) return coord.toDouble().toStringAsFixed(6);
     return (double.tryParse(coord.toString()) ?? 0.0).toStringAsFixed(6);
   }
 


### PR DESCRIPTION
## Summary
Fixes a runtime crash in `_HomeScreenState._sanitizeCoordinate` where `int.toStringAsFixed(6)` is called — but `int` has no `toStringAsFixed()` method in Dart.

## Problem
Line 157 of `home_screen.dart`:
```dart
if (coord is int) return coord.toStringAsFixed(6);
```
`int` does not inherit `toStringAsFixed()` from `num`. This causes a **NoSuchMethodError** at runtime whenever an integer coordinate is passed to `_sanitizeCoordinate`.

## Fix
Added `.toDouble()` before calling `toStringAsFixed(6)`:
```dart
if (coord is int) return coord.toDouble().toStringAsFixed(6);
```

## Testing
- Driver app compiles successfully
- Integer coordinates are now properly formatted as 6-decimal-place strings

Closes #4169

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinate formatting to consistently preserve six decimal places for whole-number coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->