### PR TITLE
fix: remove stray else block with undefined response variable in _showWalletSheet

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -506,18 +506,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           backgroundColor: TruxifyColors.success,
                         ),
                       );
-                    } else {
-                      final body = jsonDecode(response.body)
-                          as Map<String, dynamic>;
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(body['error']?.toString() ??
-                                AppLocalizations.of(context)!.failedToUpdateWallet),
-                            backgroundColor: TruxifyColors.errorRed,
-                          ),
-                        );
-                      }
                     } finally {
                       apiClient.dispose();
                     }


### PR DESCRIPTION
## Summary
Removes a stray `} else { ... }` block in `_showWalletSheet` that references an undefined `response` variable and doesn't match any `if` statement, causing a compile error.

## Problem
Lines 509-520 of `profile_screen.dart`:
```dart
try {
  final apiClient = ApiClient();
  try {
    await apiClient.put(...);
    // ... success handling ...
  } else {       // <-- SYNTAX ERROR: no matching if
    final body = jsonDecode(response.body) // <-- 'response' is undefined
    // ...
  } finally {
    apiClient.dispose();
  }
} on ApiException catch (e) { ... }
```
- `} else {` has no matching `if` — this is invalid Dart syntax
- `response` variable is undefined — leftover from a previous refactor
- `ApiClient` throws exceptions on HTTP errors, so the `catch (ApiException)` block already handles error cases

## Fix
Removed the entire `} else { ... }` block (lines 509-520).

## Testing
- Driver app compiles successfully
- Wallet save functionality works via the `catch` error handling path

Closes #4170

GSSoC
