### PR TITLE
fix: merge duplicate NotificationRouter classes and remove stray imports

### DIFF
--- a/packages/truxify_shared/lib/src/services/notification_router.dart
+++ b/packages/truxify_shared/lib/src/services/notification_router.dart
@@ -1,5 +1,8 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../models/notification_item.dart';
 import '../models/notification_payload.dart';
 
 /// Defines which app is using the router so it navigates to the correct
@@ -43,7 +46,32 @@ class NavigateToNotificationsList extends NotificationRoute {
   const NavigateToNotificationsList();
 }
 
-/// Resolves a [NotificationPayload] into a [NotificationRoute] action.
+/// The screen target determined from a notification payload.
+enum NotificationTarget {
+  orderDetail,
+  tripDetail,
+  earnings,
+  loadDetail,
+  notifications,
+  documents,
+  unknown,
+}
+
+/// Signature for the app-specific navigation callback.
+///
+/// The callback receives the resolved [target] and the raw [data] map so it
+/// can look up any required IDs (orderDisplayId, tripId, etc.) and perform
+/// the actual navigation using the app's own navigation framework.
+typedef NotificationNavigationCallback = Future<void> Function(
+  NotificationTarget target,
+  Map<String, dynamic> data,
+);
+
+/// Resolves notification payloads into navigation actions.
+///
+/// This class is intentionally stateless and has only static methods so it
+/// can be used from any context without coupling to a specific navigation
+/// package or widget tree.
 class NotificationRouter {
   NotificationRouter({required this.appType});
 
@@ -56,7 +84,8 @@ class NotificationRouter {
     _appType = type;
   }
 
-  /// Resolves a payload to a route based on the globally configured app type.
+  /// Resolves a [NotificationPayload] to a route based on the globally
+  /// configured app type.
   static NotificationRoute resolve(NotificationPayload payload) {
     return _resolveForAppType(payload, _appType);
   }
@@ -136,38 +165,10 @@ class NotificationRouter {
     } else {
       debugPrint('[NotificationRouter] No navigation callback registered.');
     }
-import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/foundation.dart';
+  }
 
-import '../models/notification_item.dart';
+  // ── FCM / raw data map navigation ──────────────────────────────────────
 
-/// The screen target determined from a notification payload.
-enum NotificationTarget {
-  orderDetail,
-  tripDetail,
-  earnings,
-  loadDetail,
-  notifications,
-  documents,
-  unknown,
-}
-
-/// Signature for the app-specific navigation callback.
-///
-/// The callback receives the resolved [target] and the raw [data] map so it
-/// can look up any required IDs (orderDisplayId, tripId, etc.) and perform
-/// the actual navigation using the app's own navigation framework.
-typedef NotificationNavigationCallback = Future<void> Function(
-  NotificationTarget target,
-  Map<String, dynamic> data,
-);
-
-/// Parses notification payloads and dispatches navigation via a callback.
-///
-/// This class is intentionally stateless and has only static methods so it
-/// can be used from any context without coupling to a specific navigation
-/// package or widget tree.
-class NotificationRouter {
   /// Resolves the [NotificationTarget] from a raw data map (FCM data payload
   /// or [NotificationItem.metadata]).
   static NotificationTarget resolveTarget(Map<String, dynamic> data) {
@@ -228,7 +229,7 @@ class NotificationRouter {
     }
   }
 
-  /// Convenience: navigate from an [NotificationItem].
+  /// Convenience: navigate from a [NotificationItem].
   static Future<void> navigateFromItem(
     NotificationItem item,
     NotificationNavigationCallback callback,
@@ -240,7 +241,7 @@ class NotificationRouter {
     await navigate(data, callback);
   }
 
-  /// Navigates from an [RemoteMessage]'s data payload.
+  /// Navigates from a [RemoteMessage]'s data payload.
   static Future<void> navigateFromRemoteMessage(
     RemoteMessage message,
     NotificationNavigationCallback callback,


### PR DESCRIPTION
## Summary
Merges two duplicate `NotificationRouter` class definitions and removes stray import statements embedded inside a class body, fixing a compile error in `notification_router.dart`.

## Problem
`packages/truxify_shared/lib/src/services/notification_router.dart` contained:
1. **First class** (lines 47-138): `setAppType`, `resolve`, `registerNavigateCallback`, `executeNavigation` — used by `shell_screen.dart` and `home_screen.dart`
2. **Stray imports** (lines 139-142): `firebase_messaging`, `flutter/foundation`, `notification_item` — embedded inside the unclosed first class body
3. **Second class** (lines 170-260): `resolveTarget`, `navigate`, `navigateFromItem`, `navigateFromRemoteMessage` — a completely different API

The first class was never closed with `}`, and a second class with the same name started at line 170. This made the file fail to compile.

## Fix
Merged both classes into a single `NotificationRouter` class containing all methods from both implementations:
- From first class: `setAppType`, `resolve`, `resolvePayload`, `registerNavigateCallback`, `clearNavigateCallback`, `isCallbackRegistered`, `executeNavigation`
- From second class: `resolveTarget`, `extractOrderId`, `extractTripId`, `extractBidId`, `navigate`, `navigateFromItem`, `navigateFromRemoteMessage`

Moved stray imports to the top of the file. Removed the incomplete first class definition.

## Testing
- Both customer and driver apps compile successfully
- All existing `NotificationRouter` call sites continue to work

Closes #4171

GSSoC
