### PR TITLE
fix: store handleBackgroundTap subscription to prevent listener leak

### DIFF
--- a/packages/truxify_shared/lib/src/services/foreground_notification_handler.dart
+++ b/packages/truxify_shared/lib/src/services/foreground_notification_handler.dart
@@ -13,6 +13,7 @@ class ForegroundNotificationHandler {
   ForegroundNotificationHandler._();
 
   static StreamSubscription<RemoteMessage>? _subscription;
+  static StreamSubscription<RemoteMessage>? _bgTapSubscription;
 
   /// Begins listening for foreground messages.
   ///
@@ -33,6 +34,8 @@ class ForegroundNotificationHandler {
   static void dispose() {
     _subscription?.cancel();
     _subscription = null;
+    _bgTapSubscription?.cancel();
+    _bgTapSubscription = null;
   }
 
   /// Handles a cold-start (app terminated) notification tap.
@@ -48,7 +51,8 @@ class ForegroundNotificationHandler {
   static void handleBackgroundTap({
     required NotificationNavigationCallback onTap,
   }) {
-    FirebaseMessaging.onMessageOpenedApp.listen((message) {
+    _bgTapSubscription?.cancel();
+    _bgTapSubscription = FirebaseMessaging.onMessageOpenedApp.listen((message) {
       NotificationRouter.navigateFromRemoteMessage(message, onTap);
     });
   }


### PR DESCRIPTION
## Summary
Stores the `StreamSubscription` returned by `FirebaseMessaging.onMessageOpenedApp.listen` in `ForegroundNotificationHandler.handleBackgroundTap` and cancels it in `dispose()`, preventing subscription leaks.

## Problem
`handleBackgroundTap()` discarded the returned `StreamSubscription`, so each call leaked a new listener. The foreground subscription (`_subscription`) was properly managed, but the background-tap subscription was not. If called more than once (e.g. hot restart), duplicate listeners accumulated.

## Fix
- Added `_bgTapSubscription` static field
- Cancel previous subscription before creating new one in `handleBackgroundTap`
- Cancel and null out in `dispose()`

## Testing
- App compiles successfully
- Background notification tap handler works correctly without duplicate firings

Closes #4216

GSSoC
