### PR TITLE
fix: add _initialized guard to driver FcmService and store onTokenRefresh subscription

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -9,7 +10,12 @@ import 'api_client.dart';
 class FcmService {
   static final String _apiBaseUrl = 'http://localhost:5000';
   static final ApiClient apiClient = ApiClient();
+  static bool _initialized = false;
+  static StreamSubscription<String>? _tokenRefreshSub;
+
   static Future<void> initializeAndRegister() async {
+    if (_initialized) return;
+    _initialized = true;
     try {
       final messaging = FirebaseMessaging.instance;
 
@@ -30,7 +36,8 @@ class FcmService {
           await _sendTokenToBackend(token);
         }
 
-        messaging.onTokenRefresh.listen((newToken) async {
+        _tokenRefreshSub?.cancel();
+        _tokenRefreshSub = messaging.onTokenRefresh.listen((newToken) async {
           await _sendTokenToBackend(newToken);
         });
       } else {


### PR DESCRIPTION
## Summary
Adds an `_initialized` guard to the driver app's `FcmService.initializeAndRegister()` and stores the `onTokenRefresh` subscription to prevent leaks.

## Problem
The driver `FcmService` had two issues:
1. **No `_initialized` guard** — unlike the shared FCM service, repeated calls to `initializeAndRegister()` would re-subscribe and re-register without limit
2. **Discarded subscription** — `messaging.onTokenRefresh.listen(...)` returned a `StreamSubscription` that was never stored or cancelled

## Fix
- Added `static bool _initialized = false` guard at the top of `initializeAndRegister()`
- Added `static StreamSubscription<String>? _tokenRefreshSub` field
- Cancel previous subscription before creating new one
- Added `dart:async` import for `StreamSubscription`

## Testing
- Driver app compiles successfully
- FCM token registration works correctly on first call
- Subsequent calls are safely no-ops

Closes #4217

GSSoC
