### PR TITLE
fix: clear _alertedStations when trip ends to allow weigh station re-alerts

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -21,6 +21,7 @@ import '../services/marketplace_repository.dart';
 import '../services/route_service.dart';
 import '../services/trip_service.dart';
 import '../services/location_service.dart';
+import '../services/weigh_station_service.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import '../theme/app_theme.dart';
 import '../widgets/map_markers.dart';
@@ -642,6 +643,7 @@ class _HomeScreenState extends State<HomeScreen> {
         await LocationService.instance.startTracking();
       } else {
         LocationService.instance.stopTracking();
+        WeighStationService.instance.resetAlertedStations();
         if (mounted) {
           setState(() {
             _activeTripId = null;
@@ -746,6 +748,7 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
   _clearDestination();
+  WeighStationService.instance.resetAlertedStations();
   if (mounted) {
     setState(() {
       _activeTripId = null;

--- a/apps/driver/lib/services/weigh_station_service.dart
+++ b/apps/driver/lib/services/weigh_station_service.dart
@@ -116,6 +116,10 @@ class WeighStationService {
     }
   }
 
+  void resetAlertedStations() {
+    _alertedStations.clear();
+  }
+
   void dispose() {
     _locationSub?.cancel();
     _eventController.close();


### PR DESCRIPTION
## Summary
Adds a `resetAlertedStations()` method to `WeighStationService` and calls it when the driver goes offline or completes a trip, allowing weigh station re-alerts on subsequent trips.

## Problem
`WeighStationService._alertedStations` is a `Set<String>` that tracks which stations the driver has been alerted about. It is never cleared during the app session. Once a station is added, the driver will never be re-alerted for that station — even on a completely different trip.

If a driver passes a weigh station, completes a trip, and later starts a new trip that passes the same station, the alert is silently suppressed.

## Fix
- Added `resetAlertedStations()` public method that clears the set
- Call it in `_toggleOnlineState()` when going offline
- Call it in `_completeRide()` when trip is completed

## Testing
- Driver app compiles successfully
- Weigh station alerts fire correctly on new trips after previous trip completion

Closes #4218

GSSoC
