### PR TITLE
fix: preserve order IDs across WebSocket reconnections in LocationService

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -87,6 +87,8 @@ class LocationService {
     _maxIntervalTimer = null;
     _lastSentPosition = null;
     _lastTriggeredMilestone = null;
+    _activeOrderId = null;
+    _activeOrderDisplayId = null;
     _closeWebSocket();
   }
 
@@ -399,7 +401,5 @@ class LocationService {
     }
     _channel?.sink.close();
     _channel = null;
-    _activeOrderId = null;
-    _activeOrderDisplayId = null;
   }
 }


### PR DESCRIPTION
## Summary
Preserves `_activeOrderId` and `_activeOrderDisplayId` across WebSocket reconnections by moving the clearing logic from `_closeWebSocket()` to `stopTracking()`.

## Problem
`_closeWebSocket()` cleared both order IDs on every WebSocket disconnect, including during automatic reconnections. After reconnection, the next ping cycle found both IDs null and silently dropped the location ping, requiring a redundant database query to re-resolve the active order.

This caused: (a) one lost ping cycle per reconnection, and (b) a redundant DB query that could have been avoided.

## Fix
- Removed `_activeOrderId = null` and `_activeOrderDisplayId = null` from `_closeWebSocket()`
- Added them to `stopTracking()` instead, so they are only cleared when tracking actually stops (not during reconnections)

## Testing
- Driver app compiles successfully
- Location pings continue seamlessly across WebSocket reconnections
- Order IDs are still properly cleared when tracking stops

Closes #4219

GSSoC
