### PR TITLE
fix: mark async WebSocket close as unawaited in LiveTrackingScreen.dispose

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -98,7 +98,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
       }
     }
     _trackingSubscription?.cancel();
-    _trackingWebSocket?.close();
+    unawaited(_trackingWebSocket?.close());
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
Wraps the async `_trackingWebSocket?.close()` call in `LiveTrackingScreen.dispose()` with `unawaited()` to explicitly mark it as fire-and-forget, making the intent clear and satisfying the `unawaited_futures` lint rule.

## Problem
`dispose()` called `_trackingWebSocket?.close()` which is an `async` method, but `dispose()` returns `void` and cannot await it. This caused an `unawaited_futures` lint warning and made the cleanup intent ambiguous.

## Fix
Wrapped the call with `unawaited()` from `dart:async`:
```dart
unawaited(_trackingWebSocket?.close());
```

This explicitly marks the async cleanup as fire-and-forget. The `ResilientWebSocket.close()` method cancels timers synchronously (immediate cleanup) before performing async channel/controller cleanup, so the critical cleanup still happens before `super.dispose()`.

## Testing
- Customer app compiles successfully
- Live tracking screen properly cleans up WebSocket on dispose

Closes #4220

GSSoC
