### PR TITLE
fix: use buildDeadheadPayload instead of hardcoded zeros in deadhead recommendations

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -498,24 +498,19 @@ class _TripsScreenState extends State<TripsScreen> {
         return;
       }
 
-      final availableLoadMaps = loads.map((load) {
-        return <String, dynamic>{
-          'load_id': load.id,
-          'origin_lat': 0.0,
-          'origin_lng': 0.0,
-          'dest_lat': 0.0,
-          'dest_lng': 0.0,
-          'weight_kg': 0.0,
-          'length_m': 0.0,
-          'width_m': 0.0,
-          'height_m': 0.0,
-          'pickup_deadline':
-              DateTime.now().add(const Duration(days: 7)).toIso8601String(),
-          'payment_inr': 0.0,
-        };
-      }).toList();
-
       final now = DateTime.now();
+      final payload = _marketplaceRepository.buildDeadheadPayload(
+        loads: loads,
+        driverLat: destLat,
+        driverLng: destLng,
+        truckMaxWeightKg: 25000,
+        truckMaxLengthM: 12,
+        truckMaxWidthM: 2.5,
+        truckMaxHeightM: 4,
+        arrivalTime: now.add(const Duration(hours: 6)).toIso8601String(),
+      );
+      final availableLoadMaps = payload['available_loads'] as List<Map<String, dynamic>>;
+
       final recommendations = await _marketplaceRepository
           .fetchDeadheadRecommendations(
         destLat: destLat,


### PR DESCRIPTION
## Summary
Replaces hardcoded zero values in the deadhead recommendation API payload with actual load data using the existing `buildDeadheadPayload()` helper.

## Problem
`_fetchDeadheadRecommendations()` in `trips_screen.dart` built the API payload with `0.0` for every load field (origin/dest coordinates, weight, dimensions, payment). The ML model received garbage input and returned meaningless recommendations.

## Fix
Replaced the manual payload construction with `_marketplaceRepository.buildDeadheadPayload()` which:
- Reads actual `originLat`, `originLng`, `destinationLat`, `destinationLng`, `weightKg`, `lengthM`, `widthM`, `heightM`, `paymentInr` from each `LoadOffer`
- Filters out loads without deadhead data via `hasDeadheadData`
- Includes truck specs and driver destination in the payload

## Testing
- Driver app compiles successfully
- Deadhead recommendations now use real load data for ML inference

Closes #4226

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deadhead load recommendations by using accurate destination details, truck constraints, and estimated arrival times.
  * Replaced placeholder load information with current marketplace availability data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->