### PR TITLE
fix: add safe type checks in ProfitPrediction.fromJson to prevent crash on malformed response

### DIFF
--- a/apps/driver/lib/services/driver_insights_service.dart
+++ b/apps/driver/lib/services/driver_insights_service.dart
@@ -14,13 +14,19 @@ class ProfitPrediction {
   final String currency;
 
   factory ProfitPrediction.fromJson(Map<String, dynamic> json) {
-    final prediction = json['prediction'] as Map<String, dynamic>;
-    final ci = prediction['confidence_interval'] as Map<String, dynamic>;
+    final prediction = json['prediction'];
+    if (prediction is! Map<String, dynamic>) {
+      throw FormatException('Missing or invalid "prediction" field');
+    }
+    final ci = prediction['confidence_interval'];
+    if (ci is! Map<String, dynamic>) {
+      throw FormatException('Missing or invalid "confidence_interval" field');
+    }
 
     return ProfitPrediction(
-      predictedProfit: (prediction['predicted_profit'] as num).toDouble(),
-      lowerBound: (ci['lower'] as num).toDouble(),
-      upperBound: (ci['upper'] as num).toDouble(),
+      predictedProfit: (prediction['predicted_profit'] as num?)?.toDouble() ?? 0.0,
+      lowerBound: (ci['lower'] as num?)?.toDouble() ?? 0.0,
+      upperBound: (ci['upper'] as num?)?.toDouble() ?? 0.0,
       currency: (prediction['currency'] as String?) ?? 'INR',
     );
   }


### PR DESCRIPTION
## Summary
Adds safe type checks in `ProfitPrediction.fromJson()` to prevent crashes on malformed API responses.

## Problem
`fromJson()` used hard `as Map<String, dynamic>` casts with no null check. If the API response was missing `prediction` or `confidence_interval`, or if numeric fields were null, the cast threw a `TypeError`. The caller catches `Exception`, not `TypeError`, so the crash propagated as unhandled.

## Fix
- Added `is!` type checks with `FormatException` for missing/invalid map fields
- Used nullable casts `as num?` with `?.toDouble() ?? 0.0` fallback for numeric fields
- Currency field already had safe fallback

## Testing
- Driver app compiles successfully
- Malformed API responses now throw `FormatException` (caught by caller) instead of `TypeError`

Closes #4230

GSSoC
