### PR TITLE
fix: remove redundant _loadOrders call from didChangeDependencies in OrdersScreen

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -293,7 +293,6 @@ class _OrdersScreenState extends State<OrdersScreen>
         !_tabController.indexIsChanging) {
       _tabController.animateTo(controller.ordersTabIndex);
     }
-    _loadOrders();
   }
 
   RealtimeChannel? _ordersChannel;


### PR DESCRIPTION
## Summary
Removes the redundant `_loadOrders()` call from `didChangeDependencies()` in `OrdersScreen`, preventing duplicate API calls on first build and on every InheritedWidget change.

## Problem
`_loadOrders()` was called from both `initState()` (line 78) and `didChangeDependencies()` (line 296). Since `didChangeDependencies()` runs immediately after `initState()`, this caused duplicate API calls on first build. Additionally, `didChangeDependencies()` runs on every `InheritedWidget` change (theme, locale), triggering redundant reloads.

## Fix
Removed the `_loadOrders()` call from `didChangeDependencies()`. The data is already loaded from `initState()` and refreshed via the realtime subscription callback.

## Testing
- Customer app compiles successfully
- Orders load correctly on first build
- No redundant API calls on theme/locale changes

Closes #4232

GSSoC
