### PR TITLE
fix: compute trip itemCount from items list instead of duplicating distance

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -295,7 +295,7 @@ class _TripsScreenState extends State<TripsScreen> {
       route: row['route_label']?.toString() ?? 'Unknown route',
       date: row['trip_date']?.toString() ?? '',
       items: tripItems.map((i) => i.goods).toList(),
-      itemCount: row['distance']?.toString() ?? '',
+      itemCount: '${tripItems.length} item${tripItems.length == 1 ? '' : 's'} · ${row['distance']?.toString() ?? ''}',
       distance: row['distance']?.toString() ?? '',
       earnings: '₹${((row['net_earnings'] ?? 0) / 100).toStringAsFixed(0)}',
       status: _mapStatus(row['status']?.toString()),


### PR DESCRIPTION
## Summary
Computes `Trip.itemCount` from the actual trip items list instead of duplicating the `distance` field value.

## Problem
`itemCount` was set to `row['distance']`, identical to the `distance` field. Both fields showed the same bare distance number instead of `itemCount` showing the expected item count summary.

## Fix
Computed `itemCount` from `tripItems.length`:
```dart
itemCount: '${tripItems.length} item${tripItems.length == 1 ? '' : 's'} · ${row['distance']?.toString() ?? ''}'
```

## Testing
- Driver app compiles successfully
- Trip list cards now show correct item count summary

Closes #4234

GSSoC
