### PR TITLE
fix: use spread copy before reverse to prevent in-place mutation (#4236)

### DIFF
--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -80,7 +80,7 @@ class EventRepository {
       const events = await this.getEventsByOrderId(orderId);
       
       // Replay events in order
-      for (const event of events.reverse()) {
+      for (const event of [...events].reverse()) {
         // Emit event again
         await this.reemitEvent(event);
       }
@@ -123,7 +123,7 @@ class EventRepository {
         timeline: [],
       };
       
-      for (const event of events.reverse()) {
+      for (const event of [...events].reverse()) {
         snapshot.timeline.push({
           eventId: event.event_id,
           type: event.event_type,


### PR DESCRIPTION
## Description

In `backend/kafka/repositories/event.repository.js`, both `replayEvents()` (line 83) and `getSnapshot()` (line 126) call `events.reverse()` on the array returned by `getEventsByOrderId()`. `Array.reverse()` mutates the array in-place, causing corrupted replay data and incorrect state snapshots.

**Fix:** Use `[...events].reverse()` to create a copy before reversing, preserving the original array.

Closes #4236

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event replay and snapshot reconstruction reliability by preventing event history from being reordered unexpectedly.
  * Preserved existing replay order and snapshot results while avoiding side effects during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->