### PR TITLE
fix: replace invalid Supabase .groupBy() with JS-based aggregation (#4237)

### DIFF
--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -171,11 +171,15 @@ class EventRepository {
     try {
       const { data, error } = await supabase
         .from('events')
-        .select('event_type, count')
-        .groupBy('event_type');
+        .select('event_type');
 
       if (error) throw error;
-      return data;
+
+      const stats = {};
+      for (const row of data ?? []) {
+        stats[row.event_type] = (stats[row.event_type] || 0) + 1;
+      }
+      return Object.entries(stats).map(([event_type, count]) => ({ event_type, count }));
     } catch (error) {
       logger.error('Failed to get event stats:', error);
       return [];


### PR DESCRIPTION
## Description

`getEventStats()` in `backend/kafka/repositories/event.repository.js` uses `.select('event_type, count').groupBy('event_type')` which is not valid Supabase PostgREST syntax — PostgREST does not support `.groupBy()`. This throws a runtime error.

**Fix:** Fetch all `event_type` values and group/count in JavaScript instead.

Closes #4237

GSSoC