### PR TITLE
fix: generate fresh RSA keypair per DID instead of reusing constructor keypair (#4238)

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -45,12 +45,6 @@ class DIDService {
             this.wallet
         );
 
-        this.keyPair = crypto.generateKeyPairSync('rsa', {
-            modulusLength: 2048,
-            publicKeyEncoding: { type: 'spki', format: 'pem' },
-            privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
-        });
-
         logger.info('✅ DID Service initialized');
     }
 
@@ -64,8 +58,12 @@ class DIDService {
             await this.addServiceEndpoint(did, 'identity', 'IdentityService', `${process.env.API_URL}/api/did/identity`, 'Main identity service');
             await this.addServiceEndpoint(did, 'credentials', 'CredentialService', `${process.env.API_URL}/api/did/credentials`, 'Credential management service');
 
-            const publicKey = this.keyPair.publicKey;
-            const publicKeyMultibase = Buffer.from(publicKey).toString('base64');
+            const keyPair = crypto.generateKeyPairSync('rsa', {
+                modulusLength: 2048,
+                publicKeyEncoding: { type: 'spki', format: 'pem' },
+                privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+            });
+            const publicKeyMultibase = Buffer.from(keyPair.publicKey).toString('base64');
             await this.addVerificationMethod(did, 'key-1', 'RsaVerificationKey2018', did, publicKeyMultibase);
 
             await this.identityWallet.createWallet(did);


### PR DESCRIPTION
## Description

In `backend/did/did.service.js`, a single RSA keypair is generated once in the constructor and reused for every DID created in `createDID()`. This means all DIDs share the same public key, defeating per-identity key management. An attacker who compromises one DID's key can impersonate all DID holders.

**Fix:** Generate a fresh RSA keypair inside `createDID()` for each DID, and remove the constructor-level keypair.

Closes #4238

GSSoC