### PR TITLE
fix: throw on nullifier check failure instead of returning false (#4239)

### DIFF
--- a/backend/zkp/zkp.service.js
+++ b/backend/zkp/zkp.service.js
@@ -187,7 +187,7 @@ class ZKPService {
             return used;
         } catch (error) {
             logger.error('Nullifier check failed:', error);
-            return false;
+            throw new Error(`Nullifier verification failed: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
## Description

In `backend/zkp/zkp.service.js:184-192`, `isNullifierUsed()` catches blockchain errors and returns `false`. This signals "nullifier not used" when the RPC call fails, potentially allowing a double-spend transaction to proceed.

**Fix:** Throw the error instead of returning `false`, so callers can reject the transaction on nullifier check failure.

Closes #4239

GSSoC