### PR TITLE
fix: replace deprecated .transfer() with .call() for refund in purchaseFraction (#4240)

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -171,7 +171,8 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
 
         // Refund excess payment
         if (msg.value > totalCost) {
-            payable(msg.sender).transfer(msg.value - totalCost);
+            (bool refunded, ) = payable(msg.sender).call{value: msg.value - totalCost}("");
+            require(refunded, "Refund failed");
         }
 
         emit FractionalPurchase(assetId, msg.sender, amount);


### PR DESCRIPTION
## Description

In `blockchain/contracts/AssetToken.sol:174`, `purchaseFraction()` uses `.transfer()` for refunds. The `.transfer()` method forwards only 2300 gas, which will revert if the buyer is a contract wallet (multisig, smart contract wallet).

**Fix:** Replace with `.call()` pattern that forwards all remaining gas and verifies success.

Closes #4240

GSSoC