### PR TITLE
fix: move reconciliationRunning guard inside try block to ensure reset (#4245)

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -32,10 +32,10 @@ export async function reconcilePendingEscrowReleases() {
   } else {
     // Redis not configured — single-instance mode, use in-process guard only
     if (reconciliationRunning) return;
-    reconciliationRunning = true;
   }
 
   try {
+    if (!lockAcquired) reconciliationRunning = true;
     const instanceId = process.env.HOSTNAME || os.hostname();
     const { data: failedOrders, error } = await supabaseAdmin
       .from('orders')


### PR DESCRIPTION
## Description

In `backend/api/src/services/escrowReleaseReconciliation.js:35-38`, when Redis is not configured, `reconciliationRunning` is set to `true` at line 35 before the `try` block at line 38. If any error occurs before the `try` block, `reconciliationRunning` is never reset to `false`, permanently blocking future reconciliation cycles.

**Fix:** Move `reconciliationRunning = true` inside the `try` block so the `finally` clause always resets it.

Closes #4245

GSSoC