### PR TITLE
fix: use HMAC-SHA256 for generateProof instead of plain JSON string (#4246)

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -184,7 +184,10 @@ class DIDService {
     }
 
     generateProof(subject, credentialType, schema) {
-        return JSON.stringify({ subject, credentialType, schema, timestamp: Date.now() });
+        const secret = process.env.DID_PROOF_SECRET || 'default-proof-secret';
+        const payload = JSON.stringify({ subject, credentialType, schema, timestamp: Date.now() });
+        const proof = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+        return proof;
     }
 
     async getDID(did) {


### PR DESCRIPTION
## Description

In `backend/did/did.service.js:186-188`, `generateProof()` creates a "proof" by JSON-stringifying inputs with `Date.now()`. This is not a cryptographic proof — it is a predictable, replayable string that any party can forge. The proof hash is stored on-chain as verification evidence.

**Fix:** Replace with `crypto.createHmac('sha256', secret)` to generate a proper HMAC-SHA256 digest that cannot be forged without the server-side secret.

Closes #4246

GSSoC