### PR TITLE
fix: replace deprecated .transfer() with .call() for seller payment (#4247)

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -256,7 +256,10 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         order.isActive = false;
 
         // Transfer payment
-        payable(order.seller).transfer(totalCost);
+        {
+            (bool paid, ) = payable(order.seller).call{value: totalCost}("");
+            require(paid, "Payment to seller failed");
+        }
 
         emit TradeOrderExecuted(order.orderId, assetId, msg.sender);
         emit AssetTraded(assetId, order.seller, msg.sender, order.amount);


### PR DESCRIPTION
## Description

In `blockchain/contracts/AssetToken.sol:259`, `executeTradeOrder()` uses `.transfer()` to pay the seller. The `.transfer()` method forwards only 2300 gas, which will revert if the seller is a contract wallet (multisig, smart contract wallet).

**Fix:** Replace with `.call()` pattern that forwards all remaining gas and verifies success.

Closes #4247

GSSoC