### PR TITLE
fix: Earnings label uses wrong text color on gradient card in TripDetailScreen

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -475,10 +475,7 @@ Widget _cargoBadge({
                             Text(
                               'Earnings',
                               style: GoogleFonts.dmSans(
-                                color:Theme.of(context)
-                                              .colorScheme
-                                              .onSurface
-                                              .withValues(alpha: 0.6),
+                                color: Colors.white.withValues(alpha: 0.5),
                                 fontSize: 10,
                               ),
                             ),


### PR DESCRIPTION
## Summary
Fixes the "Earnings" label text color on the gradient hero card in `TripDetailScreen` to match sibling labels.

## Problem
The "Earnings" label used `Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)` — a dark color that is invisible against the dark gradient background. The sibling labels "Distance" and "Duration" correctly use `Colors.white.withValues(alpha: 0.5)`.

## Fix
Changed to `Colors.white.withValues(alpha: 0.5)` to match the other labels on the same gradient card.

## Testing
- Driver app compiles successfully
- All three labels (Distance, Duration, Earnings) now use consistent white text on the gradient card

Closes #4259

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Earnings” label styling for improved contrast and visual consistency in trip details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->