### PR TITLE
fix: wrap _loadAllData in try/finally to prevent permanent loading spinner

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -54,15 +54,17 @@ class _EarningsScreenState extends State<EarningsScreen> {
   Future<void> _loadAllData() async {
     setState(() => _isLoading = true);
 
-    await Future.wait([
-      _loadMonthlyEarnings(),
-      _loadSelectedDayTrips(),
-      _loadTransactions(),
-      _loadWalletSummary(),
-    ]);
-
-    if (mounted) {
-      setState(() => _isLoading = false);
+    try {
+      await Future.wait([
+        _loadMonthlyEarnings(),
+        _loadSelectedDayTrips(),
+        _loadTransactions(),
+        _loadWalletSummary(),
+      ]);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Wraps `_loadAllData()` in try/finally so the loading state is always cleared, even if an inner data load throws.

## Problem
`_loadAllData()` calls `Future.wait` on 4 loading methods without try/catch or try/finally. If any inner method throws before entering its own try block (e.g., `setState` throws if the widget is disposed mid-flight), the `Future.wait` rejects and `_isLoading = false` is never reached. The user sees a permanent loading spinner with no way to recover.

## Fix
Wrapped in try/finally:
```dart
try {
  await Future.wait([...]);
} finally {
  if (mounted) setState(() => _isLoading = false);
}
```

## Testing
- Driver app compiles successfully
- Loading spinner always resolves, even if a data load fails

Closes #4261

GSSoC
