### PR TITLE
fix: guard _nextMonth to prevent navigation to future months

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -155,6 +155,9 @@ class _EarningsScreenState extends State<EarningsScreen> {
   }
 
   void _nextMonth() {
+    final now = DateTime.now();
+    if (_currentYear >= now.year && _currentMonth >= now.month) return;
+
     setState(() {
       _currentMonth++;
 


### PR DESCRIPTION
## Summary
Adds a guard to `_nextMonth()` in `EarningsScreen` to prevent navigation to future months.

## Problem
`_nextMonth()` had no guard, allowing users to navigate to future months (e.g., August 2026). This renders empty calendar grids and triggers wasted API calls. Additionally, `_loadMonthlyEarnings()` computes `daysSinceMonthStart` which can go negative for future months, causing incorrect `days` query parameters.

## Fix
Added guard at the start of `_nextMonth()`:
```dart
final now = DateTime.now();
if (_currentYear >= now.year && _currentMonth >= now.month) return;
```

## Testing
- Driver app compiles successfully
- Right arrow is disabled when viewing the current month

Closes #4262

GSSoC
