### PR TITLE
fix: use correct column name sync_status in OfflineDbStats.collect

### DIFF
--- a/apps/customer/lib/core/offline/db/offline_event_db.dart
+++ b/apps/customer/lib/core/offline/db/offline_event_db.dart
@@ -12,7 +12,7 @@ class OfflineDbStats {
 
   static Future<OfflineDbStats> collect(Database db) async {
     final total = Sqflite.firstIntValue(await db.rawQuery('SELECT COUNT(*) FROM trip_events')) ?? 0;
-    final pending = Sqflite.firstIntValue(await db.rawQuery("SELECT COUNT(*) FROM trip_events WHERE synced = 0")) ?? 0;
+    final pending = Sqflite.firstIntValue(await db.rawQuery("SELECT COUNT(*) FROM trip_events WHERE sync_status = 'pending'")) ?? 0;
     return OfflineDbStats()
       ..totalEvents = total
       ..pendingEvents = pending


### PR DESCRIPTION
## Summary
Fixes the wrong column name in `OfflineDbStats.collect()` — queries `sync_status` instead of the nonexistent `synced` column.

## Problem
`OfflineDbStats.collect()` queried `WHERE synced = 0`, but the table schema defines the column as `sync_status TEXT NOT NULL`. Every other query in the file correctly uses `sync_status`. The column `synced` does not exist and would throw a `SqliteException` at runtime.

## Fix
Changed `WHERE synced = 0` to `WHERE sync_status = 'pending'` to match the actual schema and string-based status values.

## Testing
- Customer app compiles successfully
- `OfflineDbStats.collect()` now correctly counts pending events

Closes #4263

GSSoC
