### PR TITLE
fix: replace impossible ACTIVE state check with timestamp-based check in executeProposal (closes #4271)

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -216,7 +216,6 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
 
     function executeProposal(uint256 proposalId) external nonReentrant {
         Proposal storage proposal = proposals[proposalId];
-        require(proposal.state == ProposalState.ACTIVE, "Proposal not active");
         require(block.timestamp >= proposal.endTime, "Voting not ended");
         require(!proposal.executed, "Already executed");
 


### PR DESCRIPTION
Closes #4271

Removes the `proposal.state == ProposalState.ACTIVE` require that could never be satisfied, since no function sets state to ACTIVE. The timestamp check on line 220 (`block.timestamp >= proposal.endTime`) already ensures voting has ended before execution.