### PR TITLE
fix: remove redundant burn override inherited from ERC20Burnable (closes #4292)

### DIFF
--- a/blockchain/contracts/DAOToken.sol
+++ b/blockchain/contracts/DAOToken.sol
@@ -17,8 +17,4 @@ contract DAOToken is ERC20, ERC20Burnable, Ownable {
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
     }
-
-    function burn(uint256 amount) external override {
-        super.burn(amount);
-    }
 }


### PR DESCRIPTION
Closes #4292