### PR TITLE
fix: replace .transfer() with .call{value} pattern in withdrawTreasury (closes #4283)

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -259,7 +259,8 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
         require(recipient != address(0), "Invalid recipient");
         require(address(this).balance >= amount, "Insufficient balance");
 
-        payable(recipient).transfer(amount);
+        (bool sent, ) = recipient.call{value: amount}("");
+        require(sent, "Transfer failed");
         emit TreasuryWithdraw(msg.sender, amount);
     }
 


### PR DESCRIPTION
Closes #4283