### PR TITLE
fix: hide shared FcmService to avoid name collision (closes #4301)

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -112,4 +112,4 @@ class FcmService {
     }
   }
 }
-export 'package:truxify_shared/src/services/fcm_service.dart';
+export 'package:truxify_shared/src/services/fcm_service.dart' hide FcmService;


### PR DESCRIPTION
Closes #4301