### PR TITLE
fix: remove unused hardcoded _apiBaseUrl from FcmService (closes #4319)

### DIFF
--- a/apps/driver/lib/services/fcm_service.dart
+++ b/apps/driver/lib/services/fcm_service.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart' as http;
 import 'api_client.dart';
 
 class FcmService {
-  static final String _apiBaseUrl = 'http://localhost:5000';
   static final ApiClient apiClient = ApiClient();
   static Future<void> initializeAndRegister() async {
     try {

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -145,7 +145,7 @@ import rateLimit from 'express-rate-limit';
 
 import { bidLimiter, userLimiter, userKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateBody, validateParams } from '../middleware/validate.js';
 import { z } from 'zod';


### PR DESCRIPTION
Closes #4319