### PR TITLE
fix: remove unused dart:convert import from order_service (closes #4317)

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../core/api_client.dart';
 


### PR DESCRIPTION
Closes #4317