### PR TITLE
fix: use defined requireDriverRole instead of nonexistent requireDriver (closes #4295)

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1010,7 +1010,7 @@ router.get('/:driverId/reputation', authenticate, userLimiter, requirePolicy('dr
 });
 
 
-router.get('/weigh-stations/bypass-status', requireAuth, requireDriver, async (req, res) => {
+router.get('/weigh-stations/bypass-status', requireAuth, requireDriverRole, async (req, res) => {
   try {
     const driverId = req.user.id;
     const lat = parseFloat(req.query.lat);


### PR DESCRIPTION
Closes #4295

Replaces `requireDriver` with `requireDriverRole` on the weigh-stations endpoint so the defined middleware is actually used.