### PR TITLE
fix: handle notification update failures

### DIFF
--- a/packages/truxify_shared/lib/src/repositories/notification_repository.dart
+++ b/packages/truxify_shared/lib/src/repositories/notification_repository.dart
@@ -2,6 +2,15 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/notification_item.dart';
 
+class NotificationRepositoryException implements Exception {
+  NotificationRepositoryException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'NotificationRepositoryException: $message';
+}
+
 class NotificationRepository {
   NotificationRepository(this._client);
 
@@ -26,11 +35,19 @@ class NotificationRepository {
   }
 
   Future<void> markNotificationRead(String id, String userId) async {
-    await _client
+    final response = await _client
         .from('notifications')
         .update({'is_read': true})
         .eq('id', id)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select();
+
+    if (response is! List || response.isEmpty) {
+      throw NotificationRepositoryException(
+        'Failed to mark notification $id as read for user $userId: '
+        'no matching writable row was found or the update was rejected.',
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Improves error handling in `NotificationRepository.markNotificationRead()` by validating the Supabase update result and throwing a repository exception when the update fails or no writable row is found.

## Problem

`markNotificationRead()` awaited the Supabase update request but never verified whether the operation actually succeeded. As a result, the UI could assume a notification was marked as read even when the update was rejected or no row matched the provided `id` and `user_id` filters.

## Fix

- Added a custom `NotificationRepositoryException` for repository-level update failures.
- Updated `markNotificationRead()` to request the updated row using `.select()`.
- Added validation to ensure the update returned at least one row.
- Throw a descriptive `NotificationRepositoryException` when no matching writable row is found or the update is rejected.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/3766

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification read-status updates by confirming the change was successfully applied.
  * Added clearer error handling when a notification cannot be marked as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->