### PR TITLE
fix(security): harden JSON parsing against malformed payloads

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -284,8 +284,20 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // Payload parsers
-app.use(express.json({ limit: '1mb' })) // Added payload limit for security
-app.use(express.urlencoded({ extended: true, limit: '1mb' }))
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || '1mb';
+
+app.use(
+  express.json({
+    limit: jsonBodyLimit,
+    strict: true,
+  })
+);
+app.use(
+  express.urlencoded({
+    extended: true,
+    limit: jsonBodyLimit,
+  })
+);
 
 // ============================================================================
 // 🆕 OPENTELEMETRY TRACING MIDDLEWARE
@@ -660,3 +672,43 @@ process.on('unhandledRejection', async (reason) => {
 
 process.on('SIGTERM', () => shutdown('SIGTERM')) // Docker / Kubernetes stop
 process.on('SIGINT', () => shutdown('SIGINT')) // Ctrl+C in dev
+
+app.use((err, req, res, next) => {
+  if (err?.type === 'entity.too.large') {
+    logger.warn(
+      {
+        requestId: req.requestId,
+        ip: req.ip,
+        method: req.method,
+        path: req.originalUrl,
+      },
+      'Request payload exceeded configured limit'
+    );
+
+    return res.status(413).json({
+      error: 'Payload too large',
+    });
+  }
+
+  if (
+    err instanceof SyntaxError &&
+    err.status === 400 &&
+    'body' in err
+  ) {
+    logger.warn(
+      {
+        requestId: req.requestId,
+        ip: req.ip,
+        method: req.method,
+        path: req.originalUrl,
+      },
+      'Malformed JSON payload received'
+    );
+
+    return res.status(400).json({
+      error: 'Malformed JSON payload',
+    });
+  }
+
+  next(err);
+});


### PR DESCRIPTION
## Summary

This PR enhances request body parsing security by improving JSON parser configuration and centralized error handling for malformed and oversized payloads.

### Changes

* Made JSON and URL-encoded body size limits configurable through an environment variable.
* Enabled strict JSON parsing to reject invalid payload formats.
* Added centralized handling for malformed JSON payloads with structured logging.
* Added graceful handling and logging for oversized request payloads (`413 Payload Too Large`).
* Preserved backward compatibility for existing API endpoints.

### Why

The application already enforced request size limits, but malformed JSON and oversized payloads could be handled more consistently. This enhancement improves observability, provides clearer client responses, and makes payload limits configurable across deployments.

### Testing

* Verified malformed JSON requests return **400 Bad Request**.
* Verified oversized payloads return **413 Payload Too Large**.
* Verified warning logs are generated for parsing failures.
* Confirmed valid requests continue to be processed normally.

Related Issue: #4113
