### PR TITLE
fix: import missing startDlqWorker in index.js 

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -16,6 +16,7 @@ import { closeWebSocketServer, initWebSocketServer } from './sockets/tracker.js'
 import { initLocationServer, closeLocationServer } from './sockets/locationServer.js'
 import { startEscrowReleaseReconciliation, stopEscrowReleaseReconciliation } from './services/escrowReleaseReconciliation.js'
 import { validateEscrowSetup } from './services/escrow.js'
+import { startDlqWorker } from './workers/dlqWorker.js'
 
 // Load REST routes
 import orderRoutes from './routes/orderRoutes.js'


### PR DESCRIPTION
## Description

The DLQ (Dead Letter Queue) worker is defined in `workers/dlqWorker.js` with a `startDlqWorker` function, but it is never imported or called in `index.js`. The worker silently never starts, causing failed webhook events to accumulate in the DLQ without being retried.

## Fix

Added the missing import for `startDlqWorker` from `./workers/dlqWorker.js` in the main `index.js` file where it is already called during server startup.

## Changes

- `backend/api/src/index.js`: Added `import { startDlqWorker } from './workers/dlqWorker.js'`

## Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally
- [x] My commits follow the Conventional Commits format
- [x] I have starred the repo

Closes #4396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Added startup support for the dead-letter queue worker to improve background message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->