### PR TITLE
fix: remove duplicate shutdown comments and fix numbering 

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -628,15 +628,11 @@ async function shutdown (signal) {
     await closeWebRTCSignaling()
     logger.info('[shutdown] WebRTC signaling server closed.')
 
-    // 5. Close database/cache connections
-
-
     // 5. Close OpenTelemetry tracing
     await tracing.shutdown()
     logger.info('[shutdown] OpenTelemetry tracing shut down.')
 
     // 6. Close database/cache connections
-
     await closeDbConnections()
 
     logger.info('[shutdown] Clean exit.')


### PR DESCRIPTION
## Description

The shutdown sequence in `index.js` has duplicate comment blocks for database connection closure and incorrect step numbering. Step 5 appears twice with different descriptions, causing confusion during debugging and maintenance.

## Fix

Removed the duplicate comment blocks and corrected the step numbering to maintain a clean, sequential shutdown process.

## Changes

- `backend/api/src/index.js`: Removed duplicate "Close database/cache connections" comments, fixed step numbering (5→OpenTelemetry, 6→database)

## Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally
- [x] My commits follow the Conventional Commits format
- [x] I have starred the repo

Closes #4399