### PR TITLE
fix: normalize profile shape to always use userId instead of user_id 

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -113,6 +113,10 @@ class FraudDetectionService {
       .single();
 
     if (data) {
+      // Normalize: DB returns user_id, code expects userId
+      if (data.user_id && !data.userId) {
+        data.userId = data.user_id;
+      }
       return data;
     }
 


### PR DESCRIPTION
## Description

The `getOrCreateProfile` method returns inconsistent profile shapes depending on the source. Database records use `user_id` (snake_case from PostgreSQL), while newly created profiles use `userId` (camelCase). Code throughout the service expects `userId`, causing undefined reference errors when processing database-sourced profiles.

## Fix

Added normalization logic to convert `user_id` to `userId` when returning profiles from the database, ensuring consistent shape across all code paths.

## Changes

- `backend/api/src/services/fraud/FraudDetectionService.js`: Added `userId` normalization in `getOrCreateProfile()` when profile comes from database

## Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally
- [x] My commits follow the Conventional Commits format
- [x] I have starred the repo

Closes #4400