### PR TITLE
Mount API feature route modules

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -9,6 +9,8 @@ import tripRoutes from './routes/tripRoutes.js'
 import deviceRoutes from './routes/deviceRoutes.js'
 import documentRoutes from './routes/documentRoutes.js'
 import maintenancePhotoRoutes from './routes/maintenancePhotoRoutes.js'
+import iotRoutes from './routes/iotRoutes.js'
+import demandRoutes from './routes/demandRoutes.js'
 
 import { closeDbConnections, waitForMongoDb, validateConfig } from './config/db.js'
 import { orderRepository } from './core/container.js'
@@ -364,6 +366,9 @@ app.use('/api/profile', profileRoutes)
 app.use('/api/devices', deviceRoutes)
 app.use('/api/driver/documents', documentRoutes)
 app.use('/api/maintenance', maintenancePhotoRoutes)
+app.use('/api/iot', iotRoutes)
+app.use('/api/demand-heatmap', demandRoutes)
+app.use('/api/webhooks', webhookRoutes)
 app.use('/api/trucks', truckRoutes)
 app.use('/api/v1', lookupRoutes)
 app.use('/api/public', publicTrackingRoutes)


### PR DESCRIPTION
## Summary
- mount IoT routes at `/api/iot`
- mount demand heatmap routes at `/api/demand-heatmap`
- mount webhook routes at `/api/webhooks`

## Validation
- `node --check backend/api/src/index.js`
- `node --check backend/api/src/routes/iotRoutes.js`
- `node --check backend/api/src/routes/demandRoutes.js`
- `node --check backend/api/src/routes/webhookRoutes.js`

Fixes #4421