### PR TITLE
Wire driver HoS status endpoint

### DIFF
--- a/apps/driver/lib/services/hos_service.dart
+++ b/apps/driver/lib/services/hos_service.dart
@@ -16,7 +16,7 @@ class HosService {
       final token = session?.accessToken;
       if (token == null) return false;
 
-      final url = Uri.parse('$_defaultApiBaseUrl/api/drivers/hos/status');
+      final url = Uri.parse('$_defaultApiBaseUrl/api/driver/hos/status');
       final response = await http.put(
         url,
         headers: {

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -140,6 +140,9 @@ import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';
 const router = express.Router();
+const hosStatusSchema = z.object({
+  status: z.enum(['off_duty', 'on_duty', 'driving', 'resting'])
+});
 
 // Driver role authorization guard middleware
 function requireDriverRole(req, res, next) {
@@ -272,6 +275,43 @@ router.put('/online', authenticate, userLimiter, requirePolicy('driver:toggle-on
 
   } catch (err) {
     logger.error('Driver online status update error:', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 2b. UPDATE HOURS-OF-SERVICE STATUS (DRIVER)
+// ============================================================================
+router.put('/hos/status', authenticate, userLimiter, requirePolicy('driver:update-hos'), validateBody(hosStatusSchema), async (req, res) => {
+  const { status } = req.body;
+
+  try {
+    const { data: details, error } = await supabase
+      .from('driver_details')
+      .update({
+        hos_status: status,
+        updated_at: new Date().toISOString()
+      })
+      .eq('user_id', req.user.id)
+      .select('hos_status, accumulated_driving_minutes, accumulated_on_duty_minutes, shift_start_time')
+      .maybeSingle();
+
+    if (error) {
+      return res.status(500).json({ error: 'Failed to update HoS status.', details: error.message });
+    }
+    if (!details) {
+      return res.status(404).json({ error: 'Driver profile not found.' });
+    }
+
+    res.json({
+      message: `HoS status marked as ${details.hos_status}.`,
+      status: details.hos_status,
+      accumulated_driving_minutes: details.accumulated_driving_minutes,
+      accumulated_on_duty_minutes: details.accumulated_on_duty_minutes,
+      shift_start_time: details.shift_start_time
+    });
+  } catch (err) {
+    logger.error('Driver HoS status update error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -52,6 +52,7 @@ const POLICIES = {
   'driver:view-stats':         { roles: [ROLES.DRIVER] },
   'document:upload':           { roles: [ROLES.DRIVER] },
   'driver:toggle-online':      { roles: [ROLES.DRIVER] },
+  'driver:update-hos':         { roles: [ROLES.DRIVER] },
   'driver:view-wallet':        { roles: [ROLES.DRIVER] },
   'driver:view-earnings':      { roles: [ROLES.DRIVER] },
   'driver:view-trips':         { roles: [ROLES.DRIVER] },


### PR DESCRIPTION
## Summary
- add an authenticated driver HoS status update endpoint
- add a driver policy for HoS status updates
- update the driver app service to call the mounted `/api/driver/hos/status` route

## Validation
- `node --check backend/api/src/routes/driverRoutes.js`
- `node --check backend/api/src/security/policyEngine.js`
- `git diff --check`

Fixes #4422