### PR TITLE
Stop selecting order delivery OTP in verification

### DIFF
--- a/backend/api/src/services/verification/VerificationService.js
+++ b/backend/api/src/services/verification/VerificationService.js
@@ -26,7 +26,6 @@ class VerificationService {
       const [oracleResult, crossChainResult, documentIntegrity, driverVerification] = await Promise.all([
         this.oracleService.confirmDelivery({
           orderId,
-          otp: order.delivery_otp,
           gpsCoordinates: null,
         }),
         order.blockchain_tx_hash
@@ -72,7 +71,7 @@ class VerificationService {
     if (this.orderRepository) {
       const { data, error } = await this.orderRepository.findOrderById(
         orderId,
-        'id, order_display_id, status, customer_id, driver_id, truck_id, delivery_otp, otp_verified, blockchain_tx_hash, escrow_status'
+        'id, order_display_id, status, customer_id, driver_id, truck_id, otp_verified, blockchain_tx_hash, escrow_status'
       );
       if (error) throw error;
       return data;
@@ -80,7 +79,7 @@ class VerificationService {
 
     const { data, error } = await this.supabase
       .from('orders')
-      .select('id, order_display_id, status, customer_id, driver_id, truck_id, delivery_otp, otp_verified, blockchain_tx_hash, escrow_status')
+      .select('id, order_display_id, status, customer_id, driver_id, truck_id, otp_verified, blockchain_tx_hash, escrow_status')
       .eq('id', orderId)
       .maybeSingle();
 


### PR DESCRIPTION
## Summary
- stop selecting `delivery_otp` from the orders table during verification
- stop passing an order-level OTP into oracle delivery confirmation
- rely on the existing delivery OTP verification source used by the oracle flow

## Validation
- `node --check backend/api/src/services/verification/VerificationService.js`

Fixes #4423