### PR TITLE
Fix customer home data result mapping

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -69,14 +69,12 @@ class _HomeScreenState extends State<HomeScreen> {
       final profile = results[0] is Map<String, dynamic> ? results[0] as Map<String, dynamic> : <String, dynamic>{};
       final orders = results[1] is List ? List<Map<String, dynamic>>.from(results[1] as List) : <Map<String, dynamic>>[];
       final stats = results[2] is Map<String, dynamic> ? results[2] as Map<String, dynamic> : null;
+      final history = results[3] is List ? List<Map<String, dynamic>>.from(results[3] as List) : <Map<String, dynamic>>[];
+
       setState(() {
         _customerName = (profile['full_name']?.toString() ?? profile['name']?.toString() ?? '').trim();
         _activeOrders = orders;
         _customerStats = stats;
-      final history = results[2] is List ? List<Map<String, dynamic>>.from(results[2] as List) : <Map<String, dynamic>>[];
-      setState(() {
-        _customerName = (profile['full_name']?.toString() ?? profile['name']?.toString() ?? '').trim();
-        _activeOrders = orders;
         _usualRoutes = _computeUsualRoutes(history);
         _isLoading = false;
       });


### PR DESCRIPTION
## Summary
- map customer order history from the fourth async result
- preserve customer stats from the stats result
- collapse the home loader into one complete state update

## Validation
- `git diff --check`

Fixes #4424