### PR TITLE
Handle public tracking route lookup errors

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -132,11 +132,16 @@ router.get(
 
       const { orderDisplayId } = validation;
 
-      const { data: order } = await supabase
+      const { data: order, error: orderError } = await supabase
         .from('orders')
         .select('pickup_lat, pickup_lng, drop_lat, drop_lng, driver_id')
         .eq('order_display_id', orderDisplayId)
-        .single();
+        .maybeSingle();
+
+      if (orderError) {
+        logger.error({ err: orderError, orderDisplayId }, 'Failed to fetch public route order');
+        return res.status(500).json({ error: 'Failed to load route information' });
+      }
 
       if (!order) {
         return res.status(404).json({ error: 'Order not found' });


### PR DESCRIPTION
## Summary
- capture Supabase lookup errors in the public tracking route endpoint
- return 500 only for real lookup failures
- keep 404 responses for valid tokens with no matching order

## Validation
- `node --check backend/api/src/routes/publicTrackingRoutes.js`

Fixes #4425