### PR TITLE
Use notification schema for IoT alerts

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -72,8 +72,14 @@ router.post('/telemetry/:id', validateParams(paramIdSchema), async (req, res) =>
       await supabase.from('notifications').insert({
         user_id: load.customer_id,
         title: 'Temperature Alert',
-        message: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
-        type: 'alert'
+        body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
+        notif_type: 'cold_chain_alert',
+        metadata: {
+          load_id: loadId,
+          temperature,
+          target_temperature_min: load.target_temperature_min,
+          target_temperature_max: load.target_temperature_max
+        }
       }).catch(err => logger.error('Failed to send notification:', err));
     }
 


### PR DESCRIPTION
## Summary
- write IoT temperature alerts with `body` and `notif_type`
- include alert details in notification metadata
- keep the existing customer alert behavior intact

## Validation
- `node --check backend/api/src/routes/iotRoutes.js`

Fixes #4427