### PR TITLE
feat: setup automated database migrations check in CI/CD

### DIFF
--- a/.github/workflows/supabase-ci.yml
+++ b/.github/workflows/supabase-ci.yml
@@ -1,0 +1,27 @@
+name: Supabase CI
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/**'
+      - '.github/workflows/supabase-ci.yml'
+
+jobs:
+  db-check:
+    name: Database Migration Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase locally and run migrations
+        run: supabase start
+
+      - name: Lint database schema
+        run: supabase db lint


### PR DESCRIPTION
**Describe the bug / feature**
Database migrations live in `supabase/migrations`, but there was no CI check to ensure that a newly pushed migration is valid or doesn't conflict with existing schemas. This risks breaking the production database if a faulty migration is accidentally merged.

**To Reproduce**
N/A

**Expected behavior**
- Created a new GitHub Action workflow `.github/workflows/supabase-ci.yml` targeting Supabase migrations.
- Uses `supabase/setup-cli@v1` to run locally on PRs.
- Automatically spins up a fresh container (`supabase start`) to ensure migrations apply cleanly.
- Runs `supabase db lint` to verify that the SQL syntax is valid and doesn't introduce vulnerabilities before allowing the PR to be merged.

**Screenshots**
N/A

**Environment**
- CI: GitHub Actions
- Database: Supabase / PostgreSQL

**Additional context**
Closes #4428