### PR TITLE
fix: missing fetch in recommendLoads, CJS in ESM, null supabase in FraudDetection

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -33,6 +33,7 @@ class FraudDetectionService {
   // ============ Behavioral Fingerprinting ============
   async trackBehavior(userId, eventData) {
     try {
+      if (!supabase) return null;
       const profile = await this.getOrCreateProfile(userId);
       
       // Update behavioral metrics
@@ -99,6 +100,7 @@ class FraudDetectionService {
   }
 
   async getOrCreateProfile(userId) {
+    if (!supabase) return null;
     // Check Redis cache
     const cached = this.redis ? await this.redis.get(`behavior:${userId}`) : null;
     if (cached) {
@@ -278,6 +280,7 @@ class FraudDetectionService {
   }
 
   async getUserConnections(userId) {
+    if (!supabase) return [];
     // Get all connections (orders, trips, shared routes)
     const { data: orders, error } = await supabase
       .from('orders')
@@ -507,6 +510,7 @@ class FraudDetectionService {
 
   async storeRiskScore(userId, score, components) {
     try {
+      if (!supabase) return;
       await supabase
         .from('fraud_risk_scores')
         .insert([{
@@ -540,6 +544,7 @@ class FraudDetectionService {
   // ============ Auto-Review Queue ============
   async addToReviewQueue(userId, reason, riskScore) {
     try {
+      if (!supabase) return null;
       const { data } = await supabase
         .from('fraud_review_queue')
         .insert([{
@@ -561,6 +566,7 @@ class FraudDetectionService {
   }
 
   async getReviewQueue(limit = 50) {
+    if (!supabase) return [];
     const { data } = await supabase
       .from('fraud_review_queue')
       .select('*')
@@ -572,6 +578,7 @@ class FraudDetectionService {
   }
 
   async resolveReview(reviewId, action, notes) {
+    if (!supabase) return null;
     const { data } = await supabase
       .from('fraud_review_queue')
       .update({
@@ -601,6 +608,7 @@ class FraudDetectionService {
   }
 
   async getFraudStats() {
+    if (!supabase) return { total: 0, highRisk: 0, mediumRisk: 0, lowRisk: 0, avgScore: 0 };
     const { data: scores } = await supabase
       .from('fraud_risk_scores')
       .select('risk_score, created_at')

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -347,6 +347,13 @@ export async function recommendLoads({ userId, bookingHistory = [], ratedDrivers
     top_n: topN,
   };
 
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  });
+
   return handleResponse(response);
 }
 

--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -22,6 +22,4 @@ const checkBypassEligibility = async (driverId, lat, lng) => {
   };
 };
 
-module.exports = {
-  checkBypassEligibility
-};
+export { checkBypassEligibility };


### PR DESCRIPTION
Real fixes:
1. ml.js: recommendLoads has no fetch() call - response is undefined, throws ReferenceError
2. weighStationService.js: module.exports used in ESM package - throws ReferenceError: module is not defined
3. FraudDetectionService.js: 8 methods access supabase without null guard - throws TypeError when supabase not configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fraud detection storage is unavailable by returning safe fallback results.
  * Added a five-second timeout for machine-learning load recommendations to prevent requests from hanging.
* **Refactor**
  * Updated weigh station service exports for improved module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->