### PR TITLE
fix: use RemoteGraphQLDataSource in gateway buildService (#4452)

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -1,4 +1,5 @@
-import { ApolloGateway } from '@apollo/gateway';
+import { ApolloGateway, IntrospectAndCompose } from '@apollo/gateway';
+import { RemoteGraphQLDataSource } from '@apollo/gateway';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
@@ -33,18 +34,12 @@ class GraphQLGateway {
                 ttl: 300 // 5 minutes
             }),
             buildService({ name, url }) {
-                return {
-                    name,
+                return new RemoteGraphQLDataSource({
                     url,
-                    requestDidStart() {
-                        return {
-                            willSendResponse({ response }) {
-                                // Log response
-                                logger.debug(`GraphQL ${name} response sent`);
-                            }
-                        };
-                    }
-                };
+                    willSendRequest({ request }) {
+                        logger.debug(`GraphQL ${name} request sent`);
+                    },
+                });
             }
         });
     }


### PR DESCRIPTION
The buildService method returned a plain object instead of extending RemoteGraphQLDataSource. Apollo Gateway requires services to be instances of RemoteGraphQLDataSource to properly forward requests.

Closes #4452

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved handling of requests sent between the GraphQL gateway and connected services.
  - Added clearer request activity logging to support better monitoring and troubleshooting.
  - No changes were made to the public API or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->