### PR TITLE
fix: replace hardcoded auth with real JWT verification in gateway (#4453)

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -3,6 +3,7 @@ import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
 import logger from '../../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
 
 class GraphQLGateway {
     constructor() {
@@ -327,8 +328,20 @@ class GraphQLGateway {
     }
 
     async getUserFromToken(token) {
-        // In production: decode JWT and fetch user
-        return { id: 'user-123', role: 'CUSTOMER' };
+        if (!token) return null;
+
+        try {
+            const stripped = token.startsWith('Bearer ') ? token.slice(7) : token;
+            const { data: { user }, error } = await supabase.auth.getUser(stripped);
+            if (error || !user) {
+                logger.warn('[GraphQL Gateway] Invalid auth token:', error?.message || 'no user');
+                return null;
+            }
+            return { id: user.id, role: user.user_metadata?.role || 'CUSTOMER' };
+        } catch (err) {
+            logger.warn('[GraphQL Gateway] Token verification failed:', err.message);
+            return null;
+        }
     }
 
     async stop() {


### PR DESCRIPTION
The getUserFromToken method returned a hardcoded user regardless of the provided token. This allows any request to act as user-123 with CUSTOMER role.

Fix validates the token via supabase.auth.getUser and returns null for missing or invalid tokens.

Closes #4453

GSSoC