### PR TITLE
fix: replace Redis KEYS with SCAN in sensor fusion stats (#4456)

### DIFF
--- a/backend/ml/multimodal/sensor_fusion.py
+++ b/backend/ml/multimodal/sensor_fusion.py
@@ -216,10 +216,21 @@ class SensorFusion:
     def get_stats(self) -> Dict:
         """Get fusion statistics"""
         raw = self.redis.get('fusion:latest')
+
+        def count_keys(pattern):
+            count = 0
+            cursor = 0
+            while True:
+                cursor, keys = self.redis.scan(cursor=cursor, match=pattern, count=100)
+                count += len(keys)
+                if cursor == 0:
+                    break
+            return count
+
         stats = {
             'last_fusion': json.loads(raw) if raw else None,
-            'vision_count': len(self.redis.keys('vision:*')),
-            'audio_count': len(self.redis.keys('audio:*')),
+            'vision_count': count_keys('vision:*'),
+            'audio_count': count_keys('audio:*'),
             'timestamp': datetime.now().isoformat()
         }
         


### PR DESCRIPTION
Redis KEYS command blocks the server for the entire key space scan. Replace with SCAN cursor-based iteration for counting keys.

Closes #4456

GSSoC