### PR TITLE
fix: make ML engine URL configurable in Flutter dashboard (#4458)

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -11,6 +11,11 @@ class _MLDashboardState extends State<MLDashboard> {
   Map<String, dynamic>? metrics;
   bool isLoading = true;
 
+  static const String _baseUrl = String.fromEnvironment(
+    'ML_ENGINE_URL',
+    defaultValue: 'http://localhost:8000',
+  );
+
   @override
   void initState() {
     super.initState();
@@ -20,7 +25,7 @@ class _MLDashboardState extends State<MLDashboard> {
   Future<void> fetchMetrics() async {
     try {
       final response = await http.get(
-        Uri.parse('http://ml-engine:8000/ab-testing/status'),
+        Uri.parse('$_baseUrl/ab-testing/status'),
       );
       if (response.statusCode == 200) {
         setState(() {


### PR DESCRIPTION
The dashboard hardcoded Docker hostname 'ml-engine' which is unreachable outside Docker. Make the URL configurable via compile-time environment variable with localhost fallback for local development.

Closes #4458

GSSoC