### PR TITLE
fix: replace Object.defineProperty with direct assignment in validateParams (#4459)

### DIFF
--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -47,12 +47,7 @@ export function validateParams(schema) {
       });
     }
 
-    Object.defineProperty(req, 'params', {
-      value: result.data,
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
+    req.params = result.data;
     return next();
   };
 }


### PR DESCRIPTION
Object.defineProperty on req.params can throw in environments where the property descriptor is non-configurable, and is unnecessary since Express req.params is always a plain writable object. Use direct assignment instead.

Closes #4459

GSSoC