### PR TITLE
fix: reject unauthenticated requests on critical endpoints in fraud middleware (#4460)

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -4,7 +4,23 @@ import logger from './logger.js';
 export const fraudDetectionMiddleware = async (req, res, next) => {
   try {
     const userId = req.user?.id;
+
+    const criticalEndpoints = [
+      '/api/orders',
+      '/api/payments',
+      '/api/escrow',
+      '/api/trips'
+    ];
+
+    const isCritical = criticalEndpoints.some(endpoint => req.path.startsWith(endpoint));
+
     if (!userId) {
+      if (isCritical) {
+        logger.warn('[Fraud] Blocking unauthenticated request to critical endpoint');
+        return res.status(401).json({
+          error: 'Authentication required for this endpoint',
+        });
+      }
       logger.warn('[Fraud] Skipping fraud check — no userId on request');
       return next();
     }
@@ -21,14 +37,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
     await fraudDetection.trackBehavior(userId, behaviorData);
 
     // Get real-time risk for critical endpoints
-    const criticalEndpoints = [
-      '/api/orders',
-      '/api/payments',
-      '/api/escrow',
-      '/api/trips'
-    ];
-
-    if (criticalEndpoints.some(endpoint => req.path.startsWith(endpoint))) {
+    if (isCritical) {
       const risk = await fraudDetection.getRealTimeRisk(userId, {
         amount: req.body?.amount || 0,
         frequency: 1,


### PR DESCRIPTION
The fraud middleware silently skipped fraud checks when userId was missing, allowing unauthenticated requests to bypass fraud detection on critical endpoints like payments and escrow.

Now returns 401 for unauthenticated requests to critical endpoints.

Closes #4460

GSSoC