### PR TITLE
fix: use deque for bounded anomaly_history to prevent memory leak (#4461)

### DIFF
--- a/backend/ml/anomaly/detector.py
+++ b/backend/ml/anomaly/detector.py
@@ -3,6 +3,7 @@ import pandas as pd
 import redis
 import json
 import logging
+from collections import deque
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 from models import LSTMAutoencoder
@@ -37,7 +38,7 @@ class AnomalyDetector:
         for name, model in self.models.items():
             model.build_model()
         
-        self.anomaly_history = []
+        self.anomaly_history = deque(maxlen=self.max_history)
         self.max_history = 1000
         
         logger.info("✅ Anomaly Detector initialized")
@@ -114,8 +115,6 @@ class AnomalyDetector:
             # Store anomaly history
             if result['is_anomaly']:
                 self.anomaly_history.append(result)
-                if len(self.anomaly_history) > self.max_history:
-                    self.anomaly_history = self.anomaly_history[-self.max_history:]
                 
                 # Store in Redis
                 self.redis.setex(
@@ -242,7 +241,7 @@ class AnomalyDetector:
         """Get anomaly detection history"""
         if data_type:
             return [h for h in self.anomaly_history if h.get('data_type') == data_type]
-        return self.anomaly_history
+        return list(self.anomaly_history)
     
     def get_alerts(self, severity: Optional[str] = None) -> List[Dict]:
         """Get recent alerts"""


### PR DESCRIPTION
The anomaly_history list used periodic O(n) slicing to cap size, creating a new list copy each time it exceeded max_history. This causes memory fragmentation and unbounded growth between trimmings.

Replace with collections.deque(maxlen=...) for automatic O(1) bounded eviction.

Closes #4461

GSSoC