### PR TITLE
fix(repo): remove duplicate findOrderById and findOrderByDisplayId definitions

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -21,7 +21,6 @@
     "@sentry/node": "^10.62.0",
     "@supabase/supabase-js": "^2.109.0",
     "axios": "^1.6.0",
-    "circuit-breaker-js": "^1.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "ethers": "6.17.0",

--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -116,21 +116,6 @@ export class OrderRepository {
       .eq('id', id)
       .maybeSingle(), 'findOrderForTimeline');
   } 
-  async findOrderById(id, columns = '*') {
-    return this._retryableQuery(() => this.supabase
-      .from('orders')
-      .select(columns)
-      .eq('id', id)
-      .maybeSingle(), 'findOrderById');
-  }
-
-  async findOrderByDisplayId(displayId, columns = '*') {
-    return this._retryableQuery(() => this.supabase
-      .from('orders')
-      .select(columns)
-      .eq('order_display_id', displayId)
-      .maybeSingle(), 'findOrderByDisplayId');
-  }
 
   async updateOrder(id, updates) {
     return this._retryableQuery(() => this.supabase


### PR DESCRIPTION
## Description

Fixes #4403 — Duplicate `findOrderById` and `findOrderByDisplayId` method definitions in `orderRepository.js` where the second definitions silently overwrote the first in the prototype chain.

## Changes

### Core Fix — `orderRepository.js`
- Removed the duplicate set of definitions for `findOrderById` and `findOrderByDisplayId` (lines 119–133).
- The first definitions (lines 59–73) and the `findOrderByAnyId` dispatcher remain fully untouched.

### Dependency Corrections — `package.json`
- Cleaned up invalid `circuit-breaker-js` package reference in `backend/api/package.json` to allow clean install and verification.

## Testing

```
 ✓ test/unit/escrowRefundReconciliation.test.js (11 tests)
 ✓ test/unit/services/orderTimelineService.test.js (13 tests)

 Test Files  2 passed (2)
      Tests  24 passed (24)
```

## Related Issues
- Closes #4403
