### PR TITLE
Fix recommendLoads never calling fetch

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -347,6 +347,13 @@ export async function recommendLoads({ userId, bookingHistory = [], ratedDrivers
     top_n: topN,
   };
 
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  });
+
   return handleResponse(response);
 }
 


### PR DESCRIPTION
recommendLoads built the request url and payload but never called fetch, then passed an undefined response variable straight into handleResponse, throwing ReferenceError: response is not defined on every call. Added the missing fetch call, matching the identical pattern used by recommendTrucks right below it.