### PR TITLE
Fix reconciliationRunning guard getting stuck true when Redis is used

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -23,7 +23,6 @@ export async function reconcileFailedReputationUpdates() {
         return;
       }
       lockAcquired = true;
-      reconciliationRunning = true;
       leaseExtender = setInterval(async () => {
         try {
           await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);


### PR DESCRIPTION
reconciliationRunning is the in-process fallback guard meant only for the no-Redis path (it is only reset back to false when !lockAcquired in the finally block). The Redis-locked branch was also setting it to true, so once a reconciliation run happened with Redis available, the flag stayed true forever and any later run that fell back to the in-process guard (e.g. after a Redis outage) would see it already true and skip immediately, silently stopping reputation-update retries. Removed the erroneous assignment, matching the sibling reconciliation services (escrowReleaseReconciliation.js, documentExpiryService.js).