### PR TITLE
Fix WidgetPlugin constructor shadowing the render() prototype method

### DIFF
--- a/backend/plugins/PluginManager.js
+++ b/backend/plugins/PluginManager.js
@@ -7,7 +7,7 @@ class WidgetPlugin {
         this.version = config.version || '1.0.0';
         this.description = config.description || '';
         this.author = config.author || '';
-        this.render = config.render || null;
+        this.renderFn = config.render || null;
         this.metadata = config.metadata || {};
         this.props = config.props || {};
         this.hooks = config.hooks || {};
@@ -38,8 +38,8 @@ class WidgetPlugin {
     }
     
     render(props = {}) {
-        if (this.render) {
-            return this.render({ ...this.props, ...props });
+        if (this.renderFn) {
+            return this.renderFn({ ...this.props, ...props });
         }
         return null;
     }


### PR DESCRIPTION
The constructor assigned this.render = config.render, an own property with the same name as the class's render(props) prototype method. The own property always wins, so the prototype method (which merges default props with call-time props) could never run - plugin.render() resolved straight to the raw config.render function and default props declared via config.props were silently dropped. Renamed the stored callback to renderFn so the prototype method is reachable again.