### PR TITLE
Fix broken imports in eventsourcing routes

### DIFF
--- a/backend/eventsourcing/routes.js
+++ b/backend/eventsourcing/routes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import eventStore from './event-store.js';
-import logger from '../../api/src/middleware/logger.js';
+import { supabase } from '../api/src/config/db.js';
+import logger from '../api/src/middleware/logger.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Two bugs in the same file: the logger import used a relative path two directories too shallow (../../api/... resolves outside the repo instead of into backend/api/...), so simply loading this router threw a module-not-found error. Separately, the /eventsourcing/rebuild handler referenced supabase without ever importing it, so any request to that endpoint threw ReferenceError: supabase is not defined. Fixed the logger path and added the missing supabase import.