### PR TITLE
Fix duplicate entries in userAssets on repeat purchases

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -159,6 +159,7 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         asset.availableTokens -= amount;
 
         // Update fractional ownership
+        bool isNewHolder = fractionalOwnership[assetId][msg.sender].amount == 0;
         fractionalOwnership[assetId][msg.sender].owner = msg.sender;
         fractionalOwnership[assetId][msg.sender].tokenId = assetId;
         fractionalOwnership[assetId][msg.sender].amount += amount;
@@ -173,7 +174,9 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
             require(refunded, "Refund failed");
         }
 
-        userAssets[msg.sender].push(assetId);
+        if (isNewHolder) {
+            userAssets[msg.sender].push(assetId);
+        }
 
         emit FractionalPurchase(assetId, msg.sender, amount);
     }


### PR DESCRIPTION
purchaseFraction pushed assetId onto userAssets[msg.sender] on every purchase, with no check for an existing entry. Buying the same asset twice left two identical entries. _removeUserAsset only removes the first match and breaks, so after a full sellFraction divestment a stale duplicate assetId remained, causing getUserAssets to keep reporting an asset the user no longer holds any tokens of. Now only pushes on the user's first purchase of that asset.