### PR TITLE
feat: add network error handling

### DIFF
--- a/apps/customer/lib/l10n/app_en.arb
+++ b/apps/customer/lib/l10n/app_en.arb
@@ -808,5 +808,9 @@
   "downloadFailed": "Download failed",
   "@downloadFailed": {
     "description": "Error message when invoice download or generation fails"
+  },
+  "networkError": "Network error. Please check your connection.",
+  "@networkError": {
+    "description": "Error message when network connection fails"
   }
 }

--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -164,11 +164,15 @@ class _LoginScreenState extends State<LoginScreen> {
         onVerificationFailed: (e) {
           if (!mounted) return;
           setState(() => _sendingOtp = false);
+          
+          String errorMsg = e.message ?? AppLocalizations.of(context)!.phoneVerificationFailed;
+          if (e.code == 'network-request-failed') {
+            errorMsg = AppLocalizations.of(context)!.networkError;
+          }
+          
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(
-                e.message ?? AppLocalizations.of(context)!.phoneVerificationFailed,
-              ),
+              content: Text(errorMsg),
             ),
           );
         },
@@ -192,8 +196,14 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _sendingOtp = false);
+      String errorMsg = AppLocalizations.of(context)!.failedToSendOtp;
+      if (e is FirebaseAuthException && e.code == 'network-request-failed') {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      } else if (e.toString().contains('SocketException') || e.toString().contains('network-request-failed')) {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.failedToSendOtp)),
+        SnackBar(content: Text(errorMsg)),
       );
     }
   }
@@ -230,6 +240,7 @@ class _LoginScreenState extends State<LoginScreen> {
       final message = switch (e.code) {
         'invalid-verification-code' => AppLocalizations.of(context)!.invalidVerificationCode,
         'session-expired' => AppLocalizations.of(context)!.otpExpired,
+        'network-request-failed' => AppLocalizations.of(context)!.networkError,
         _ => e.message ?? AppLocalizations.of(context)!.verificationFailed,
       };
       ScaffoldMessenger.of(context).showSnackBar(
@@ -238,8 +249,12 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _verifyingOtp = false);
+      String errorMsg = AppLocalizations.of(context)!.verificationFailed;
+      if (e.toString().contains('SocketException') || e.toString().contains('network-request-failed')) {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.verificationFailed)),
+        SnackBar(content: Text(errorMsg)),
       );
     }
   }

--- a/apps/driver/lib/l10n/app_en.arb
+++ b/apps/driver/lib/l10n/app_en.arb
@@ -841,5 +841,25 @@
   "withdrawalSuccessful": "Withdrawal successful",
   "@withdrawalSuccessful": {
     "description": "Success message after a successful withdrawal"
+  },
+  "networkError": "Network error. Please check your connection.",
+  "@networkError": {
+    "description": "Error message when network connection fails"
+  },
+  "theme": "Theme",
+  "@theme": {
+    "description": "Label for the theme selection setting"
+  },
+  "system": "System",
+  "@system": {
+    "description": "System theme option label"
+  },
+  "light": "Light",
+  "@light": {
+    "description": "Light theme option label"
+  },
+  "dark": "Dark",
+  "@dark": {
+    "description": "Dark theme option label"
   }
 }

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -94,8 +94,14 @@ class _LoginScreenState extends State<LoginScreen> {
         onVerificationFailed: (FirebaseAuthException e) {
           if (!mounted) return;
           setState(() => _loading = false);
+          
+          String errorMsg = e.message ?? AppLocalizations.of(context)!.verificationFailed;
+          if (e.code == 'network-request-failed') {
+            errorMsg = AppLocalizations.of(context)!.networkError;
+          }
+          
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(e.message ?? AppLocalizations.of(context)!.verificationFailed)),
+            SnackBar(content: Text(errorMsg)),
           );
         },
         onAutoVerification: (PhoneAuthCredential credential) async {
@@ -116,8 +122,14 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _loading = false);
+      String errorMsg = AppLocalizations.of(context)!.verificationFailed;
+      if (e is FirebaseAuthException && e.code == 'network-request-failed') {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      } else if (e.toString().contains('SocketException') || e.toString().contains('network-request-failed')) {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.verificationFailed)),
+        SnackBar(content: Text(errorMsg)),
       );
     }
   }

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -74,6 +74,9 @@ class _OtpScreenState extends State<OtpScreen> {
         case 'session-expired':
           message = l10n.codeExpired;
           break;
+        case 'network-request-failed':
+          message = l10n.networkError;
+          break;
         default:
           message = e.message ?? l10n.verificationFailedMsg;
       }
@@ -82,8 +85,12 @@ class _OtpScreenState extends State<OtpScreen> {
       );
     } catch (e) {
       if (!mounted) return;
+      String errorMsg = AppLocalizations.of(context)!.couldNotVerifyOtp;
+      if (e.toString().contains('SocketException') || e.toString().contains('network-request-failed')) {
+        errorMsg = AppLocalizations.of(context)!.networkError;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.couldNotVerifyOtp)),
+        SnackBar(content: Text(errorMsg)),
       );
     } finally {
       if (mounted) {


### PR DESCRIPTION
Close Issue #4505

## Description
Added specific error handling for network-related failures (`network-request-failed` and `SocketException`) during the OTP login process. Previously, a network drop would result in an unhandled exception or an obscure error message. Now, the apps explicitly catch these exceptions and show a localized "Network error. Please check your connection." message via a SnackBar.

## Changes
- **apps/customer/lib/l10n/app_en.arb**: Added `networkError` string.
- **apps/driver/lib/l10n/app_en.arb**: Added `networkError` string.
- **apps/customer/lib/screens/login_screen.dart**: Intercepts `network-request-failed` in `_sendOtp` and `_verifyOtp`.
- **apps/driver/lib/screens/login_screen.dart**: Intercepts `network-request-failed` in `_sendOtp`.
- **apps/driver/lib/screens/otp_screen.dart**: Intercepts `network-request-failed` in `_verifyOtp`.

## Testing
1. Launch the Customer or Driver app.
2. Enter a phone number on the login screen.
3. Disconnect from the network (turn off Wi-Fi/Data).
4. Tap "Send OTP" or "Verify".
5. Verify that a SnackBar displays the network error message instead of crashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OTP login and verification error messages for network-related failures.
  - Added localized network error messaging for both customer and driver applications.
  - Preserved clearer fallback messages for other authentication and verification errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->