### PR TITLE
fix: reset order history filter on tab change

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -300,6 +300,12 @@ class _OrdersScreenState extends State<OrdersScreen>
     final controller = TruxifyScope.of(context);
     _controller = controller;
 
+    if (controller.currentTab != 2) {
+      if (_selectedStatusFilter != 'All Trips') {
+        _selectedStatusFilter = 'All Trips';
+      }
+    }
+
     if (_tabController.index != controller.ordersTabIndex &&
         !_tabController.indexIsChanging) {
       _tabController.animateTo(controller.ordersTabIndex);


### PR DESCRIPTION
# Issue #4508

## Description
Fixed a bug in the customer app where the order history filter state would become out of sync with the UI dropdown after navigating to a different tab and coming back. The filter is now reset to 'All Trips' whenever the user navigates away from the Orders tab.

## Changes
- **apps/customer/lib/screens/orders_screen.dart**: Added logic to `didChangeDependencies` to check if `controller.currentTab` is no longer the Orders tab (index 2). If so, it resets `_selectedStatusFilter` to `'All Trips'`.

## Testing
1. Launch the Customer app and go to the Orders tab.
2. Select the "History" sub-tab.
3. Choose a filter (e.g., 'Delivered') from the dropdown.
4. Navigate to the Home tab.
5. Return to the Orders tab -> History sub-tab.
6. Verify that the filter is reset to 'All Trips' and all orders are shown.
