### PR TITLE
feat: add in-app chat for drivers and customers

### DIFF
--- a/apps/customer/lib/screens/chat_screen.dart
+++ b/apps/customer/lib/screens/chat_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import '../models/app_models.dart';
+import '../theme/app_theme.dart';
+import '../services/supabase_service.dart';
+
+class ChatScreen extends StatefulWidget {
+  final HistoryOrderData order;
+
+  const ChatScreen({super.key, required this.order});
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final TextEditingController _controller = TextEditingController();
+  final List<Map<String, dynamic>> _messages = [];
+  RealtimeChannel? _channel;
+  bool _isSending = false;
+  late final String _myUserId;
+
+  @override
+  void initState() {
+    super.initState();
+    _myUserId = SupabaseService.currentUserId ?? 'unknown';
+    _setupSupabaseChannel();
+  }
+
+  void _setupSupabaseChannel() {
+    final orderId = widget.order.orderId;
+    _channel = Supabase.instance.client.channel('chat_$orderId');
+
+    _channel!
+      .onBroadcast(
+        event: 'message',
+        callback: (payload) {
+          final data = payload;
+          if (data['senderId'] != _myUserId) {
+            setState(() {
+              _messages.insert(0, {
+                'text': data['text'],
+                'isMe': false,
+                'sender': data['senderName'],
+              });
+            });
+          }
+        },
+      )
+      .subscribe();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _channel?.unsubscribe();
+    super.dispose();
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    setState(() {
+      _isSending = true;
+      _messages.insert(0, {
+        'text': text,
+        'isMe': true,
+        'sender': 'Me',
+      });
+    });
+
+    _controller.clear();
+
+    try {
+      await _channel?.sendBroadcastMessage(
+        event: 'message',
+        payload: {
+          'text': text,
+          'senderId': _myUserId,
+          'senderName': 'Customer',
+        },
+      );
+    } catch (e) {
+      debugPrint('Error sending message: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSending = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Chat with ${widget.order.driver}'),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              reverse: true,
+              padding: const EdgeInsets.all(16),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                final isMe = msg['isMe'] == true;
+                return Align(
+                  alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    decoration: BoxDecoration(
+                      color: isMe ? TruxifyColors.accent : Theme.of(context).cardColor,
+                      borderRadius: BorderRadius.circular(16).copyWith(
+                        bottomRight: isMe ? const Radius.circular(0) : null,
+                        bottomLeft: !isMe ? const Radius.circular(0) : null,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.05),
+                          blurRadius: 5,
+                          offset: const Offset(0, 2),
+                        )
+                      ],
+                    ),
+                    child: Text(
+                      msg['text'],
+                      style: TextStyle(
+                        color: isMe ? Colors.white : Theme.of(context).textTheme.bodyMedium?.color,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(16).copyWith(
+              bottom: MediaQuery.of(context).padding.bottom + 16,
+            ),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: InputDecoration(
+                      hintText: 'Type a message...',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      fillColor: Theme.of(context).cardColor,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                    ),
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => _sendMessage(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                CircleAvatar(
+                  backgroundColor: TruxifyColors.accent,
+                  radius: 24,
+                  child: IconButton(
+                    icon: _isSending
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
+                          )
+                        : const Icon(Icons.send_rounded, color: Colors.white, size: 20),
+                    onPressed: _isSending ? null : _sendMessage,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -10,6 +10,7 @@ import '../services/invoice_pdf_service.dart';
 import '../services/order_service.dart';
 import '../services/tracking_service.dart';
 import '../theme/app_theme.dart';
+import 'chat_screen.dart';
 import '../widgets/common_widgets.dart';
 import '../widgets/timeline_row.dart';
 
@@ -533,6 +534,16 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                       Text(_currentOrder.truckNumber, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: TruxifyColors.adaptiveSecondaryText(context))),
                     ],
                   ),
+                ),
+                IconButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => ChatScreen(order: _currentOrder),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.chat_bubble_outline_rounded, color: TruxifyColors.accent),
                 ),
               ],
             ),

--- a/apps/driver/lib/screens/chat_screen.dart
+++ b/apps/driver/lib/screens/chat_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import '../models/app_models.dart';
+import '../theme/app_theme.dart';
+import '../services/supabase_service.dart';
+
+class ChatScreen extends StatefulWidget {
+  final Trip trip;
+
+  const ChatScreen({super.key, required this.trip});
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final TextEditingController _controller = TextEditingController();
+  final List<Map<String, dynamic>> _messages = [];
+  RealtimeChannel? _channel;
+  bool _isSending = false;
+  late final String _myUserId;
+
+  @override
+  void initState() {
+    super.initState();
+    _myUserId = SupabaseService.currentUserId ?? 'unknown';
+    _setupSupabaseChannel();
+  }
+
+  void _setupSupabaseChannel() {
+    final orderId = widget.trip.id;
+    _channel = Supabase.instance.client.channel('chat_$orderId');
+
+    _channel!
+      .onBroadcast(
+        event: 'message',
+        callback: (payload) {
+          final data = payload;
+          if (data['senderId'] != _myUserId) {
+            setState(() {
+              _messages.insert(0, {
+                'text': data['text'],
+                'isMe': false,
+                'sender': data['senderName'],
+              });
+            });
+          }
+        },
+      )
+      .subscribe();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _channel?.unsubscribe();
+    super.dispose();
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    setState(() {
+      _isSending = true;
+      _messages.insert(0, {
+        'text': text,
+        'isMe': true,
+        'sender': 'Me',
+      });
+    });
+
+    _controller.clear();
+
+    try {
+      await _channel?.sendBroadcastMessage(
+        event: 'message',
+        payload: {
+          'text': text,
+          'senderId': _myUserId,
+          'senderName': 'Driver',
+        },
+      );
+    } catch (e) {
+      debugPrint('Error sending message: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSending = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Chat with Customer'),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              reverse: true,
+              padding: const EdgeInsets.all(16),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                final isMe = msg['isMe'] == true;
+                return Align(
+                  alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    decoration: BoxDecoration(
+                      color: isMe ? TruxifyColors.accent : Theme.of(context).cardColor,
+                      borderRadius: BorderRadius.circular(16).copyWith(
+                        bottomRight: isMe ? const Radius.circular(0) : null,
+                        bottomLeft: !isMe ? const Radius.circular(0) : null,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.05),
+                          blurRadius: 5,
+                          offset: const Offset(0, 2),
+                        )
+                      ],
+                    ),
+                    child: Text(
+                      msg['text'],
+                      style: TextStyle(
+                        color: isMe ? Colors.white : Theme.of(context).textTheme.bodyMedium?.color,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(16).copyWith(
+              bottom: MediaQuery.of(context).padding.bottom + 16,
+            ),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: InputDecoration(
+                      hintText: 'Type a message...',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      fillColor: Theme.of(context).cardColor,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                    ),
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => _sendMessage(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                CircleAvatar(
+                  backgroundColor: TruxifyColors.accent,
+                  radius: 24,
+                  child: IconButton(
+                    icon: _isSending
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
+                          )
+                        : const Icon(Icons.send_rounded, color: Colors.white, size: 20),
+                    onPressed: _isSending ? null : _sendMessage,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../theme/app_theme.dart';
 import '../models/app_models.dart';
 import '../widgets/common_widgets.dart';
+import 'chat_screen.dart';
 
 class TripDetailScreen extends StatefulWidget {
   final Trip trip;
@@ -772,6 +773,18 @@ Widget _cargoBadge({
                               fontWeight: FontWeight.bold,
                               color: TruxifyColors.accent,
                             ),
+                          ),
+                          IconButton(
+                            onPressed: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => ChatScreen(trip: trip),
+                                ),
+                              );
+                            },
+                            icon: const Icon(Icons.chat_bubble_outline_rounded, color: TruxifyColors.accent, size: 20),
+                            constraints: const BoxConstraints(),
+                            padding: const EdgeInsets.only(left: 12),
                           ),
                         ],
                       ),


### PR DESCRIPTION
# Issue #4509

## Description
Implemented an ephemeral In-App Chat feature allowing Drivers and Customers to communicate directly through the app without relying on external phone calls or SMS. The chat uses Supabase Realtime Broadcast channels for low-latency, real-time message delivery.

## Changes
- **apps/customer/lib/screens/chat_screen.dart**: Created a new Chat UI for customers to converse with their assigned driver.
- **apps/driver/lib/screens/chat_screen.dart**: Created a mirror Chat UI for drivers.
- **apps/customer/lib/screens/order_detail_screen.dart**: Added a Chat bubble icon next to the Driver's profile information. Tapping it opens the `ChatScreen` initialized with the current order ID.
- **apps/driver/lib/screens/trip_detail_screen.dart**: Added a Chat bubble icon next to the customer details in the trip's items list.

## Testing
1. Launch both Customer and Driver apps side-by-side or on two devices.
2. Ensure both apps are logged in and looking at the same active Order/Trip.
3. Tap the "Chat" button from the Order Details (Customer) and Trip Details (Driver) screens.
4. Send messages from one end and verify they appear instantly on the other end.


Under ECSoC 26.