### PR TITLE
feat: add push notifications for new trips

### DIFF
--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -155,6 +155,32 @@ export async function createOrder({ orderData, userId, user }) {
     throw new DomainError(500, { error: 'Failed to create load offer.', details: offerErr.message });
   }
 
+  try {
+    const { sendFcmNotification } = await import('../notificationService.js');
+    const { data: drivers } = await supabase
+      .from('profiles')
+      .select('id, fcm_token')
+      .eq('role', 'driver')
+      .not('fcm_token', 'is', null);
+
+    if (drivers && drivers.length > 0) {
+      const notification = {
+        title: 'New Trip Available',
+        body: `A new trip from ${pickup_address.split(',')[0]} to ${drop_address.split(',')[0]} is available.`,
+      };
+      const payload = {
+        type: 'new_trip',
+        orderId: orderDisplayId,
+      };
+      // Fire and forget notifications
+      Promise.all(drivers.map(driver => sendFcmNotification(driver.id, notification, payload))).catch(e => {
+        logger.error('Error in batch push notification:', e.message);
+      });
+    }
+  } catch (pushErr) {
+    logger.error('Failed to send push notifications to drivers:', pushErr.message);
+  }
+
   return { message: 'Order created successfully and broadcasted to loads board.', order };
   });
 }

--- a/packages/truxify_shared/lib/src/services/notification_router.dart
+++ b/packages/truxify_shared/lib/src/services/notification_router.dart
@@ -183,6 +183,7 @@ class NotificationRouter {
       case 'payment':
       case 'payment_released':
         return NotificationTarget.earnings;
+      case 'new_trip':
       case 'load_offer':
         return NotificationTarget.loadDetail;
       case 'system':


### PR DESCRIPTION
# Issue #4507

## Description
Implemented push notifications via Firebase Cloud Messaging (FCM) to instantly alert drivers when a new trip request is placed. This prevents drivers from missing new load offers when the app is minimized.

## Changes
- **backend/api/src/services/order/orderCreationService.js**: Integrated `notificationService` to query all users with the `driver` role who have an active FCM token. It now loops through the results and asynchronously pushes a "New Trip Available" payload.
- **packages/truxify_shared/lib/src/services/notification_router.dart**: Added `new_trip` to the `NotificationTarget` resolution logic, directing it to `loadDetail`.
- **apps/driver/lib/screens/shell_screen.dart**: Uses the existing routing to parse `loadDetail` and switch the app to the Marketplace (Home tab) when the notification is tapped.

## Testing
1. Use the Customer app to create a new trip (or trigger order creation in the backend).
2. The Driver app, even when backgrounded, should receive an FCM push notification.
3. Tapping the notification should open the app and redirect the driver to the Home tab (Marketplace) where the new trip is displayed.
