### PR TITLE
fix: use supabaseAdmin in reputationReconciliation to bypass RLS

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -1,4 +1,4 @@
-import { supabase, redisClient } from '../config/db.js';
+import { supabaseAdmin, redisClient } from '../config/db.js';
 import { awardReputationPoints } from './reputation.js';
 import logger from '../middleware/logger.js';
 import os from 'os';
@@ -12,6 +12,11 @@ let reconciliationTimer = null;
 let reconciliationRunning = false;
 
 export async function reconcileFailedReputationUpdates() {
+  if (!supabaseAdmin) {
+    logger.warn('[reputation-reconciliation] supabaseAdmin not available — skipping cycle');
+    return;
+  }
+
   let lockAcquired = false;
   let leaseExtender = null;
 
@@ -45,7 +50,7 @@ export async function reconcileFailedReputationUpdates() {
 
   try {
     const instanceId = process.env.HOSTNAME || os.hostname();
-    const { data: failedReputations, error } = await supabase
+    const { data: failedReputations, error } = await supabaseAdmin
       .from('reputation_failures')
       .select('*')
       .lt('retry_count', MAX_RETRIES)
@@ -73,14 +78,14 @@ export async function reconcileFailedReputationUpdates() {
 
       try {
         await awardReputationPoints(row.driver_wallet, row.stars);
-        const { error: deleteError } = await supabase.from('reputation_failures').delete().eq('id', row.id);
+        const { error: deleteError } = await supabaseAdmin.from('reputation_failures').delete().eq('id', row.id);
         if (deleteError) {
           throw new Error(`Award succeeded but failed to delete reconciled reputation failure ${row.id}: ${deleteError.message}`);
         }
         logger.info(`[reputation-reconciliation] Successfully retried reputation update for ${row.driver_wallet}`);
       } catch (err) {
         const newRetryCount = (row.retry_count ?? 0) + 1;
-        await supabase.from('reputation_failures').update({
+        await supabaseAdmin.from('reputation_failures').update({
           retry_count: newRetryCount,
           last_error: err.message,
           last_attempt_at: new Date().toISOString(),


### PR DESCRIPTION
## Fix: Use supabaseAdmin in reputationReconciliation to bypass RLS

### Problem
`reputationReconciliation.js` imported the regular `supabase` client instead of `supabaseAdmin`. Background reconciliation queries against `reputation_failures` and `orders` tables require admin access to bypass Row Level Security. Using the non-admin client caused all queries to return empty results when no authenticated user context exists.

### Fix
Change the import from `supabase` to `supabaseAdmin` and update all query references. Add a null guard at the function entry.

Closes #4514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of reputation update reconciliation.
  * Reconciliation now safely skips processing when the required administrative database access is unavailable.
  * Retry cleanup and bookkeeping are handled consistently during failed update recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->