### PR TITLE
fix: include release_tx_hash in escrow reconciliation SELECT query

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -39,7 +39,7 @@ export async function reconcilePendingEscrowReleases() {
     const instanceId = process.env.HOSTNAME || os.hostname();
     const { data: failedOrders, error } = await supabaseAdmin
       .from('orders')
-      .select('id, order_display_id, escrow_release_attempts')
+      .select('id, order_display_id, escrow_release_attempts, release_tx_hash')
       .eq('escrow_status', 'release_failed')
       .lt('escrow_release_attempts', MAX_RETRIES)
       .limit(50);


### PR DESCRIPTION
## Fix: Include release_tx_hash in escrow reconciliation SELECT query

### Problem
The reconciliation function reads `order.release_tx_hash` to detect already-released orders, but the SELECT clause omitted it. This caused the duplicate-release guard to never fire, potentially re-submitting orders to the blockchain and wasting gas.

### Fix
Add `release_tx_hash` to the SELECT clause: `.select('id, order_display_id, escrow_release_attempts, release_tx_hash')`

Closes #4515