### PR TITLE
fix: add Redis-based per-order lock to prevent double escrow release

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -213,6 +213,13 @@ export class DeliveryVerificationService {
     await this.completeDeliveryOtp({ otpRecordId: otpRecord.id, orderId });
 
     if (verifiedOrder.escrow_status === 'funded' || verifiedOrder.escrow_status === 'release_failed') {
+      const releaseLockKey = `escrow:release:${orderId}`;
+      const releaseLockAcquired = await redisClient?.set(releaseLockKey, '1', 'NX', 'EX', 60);
+      if (!releaseLockAcquired) {
+        logger.info(`[escrow] Release already in-progress for order ${orderId}, skipping`);
+        return { escrowUpdateFailed: false };
+      }
+
       try {
         const releaseResult = await this.escrowReleaseFn(order.order_display_id);
         if (releaseResult.txHash) {
@@ -228,6 +235,8 @@ export class DeliveryVerificationService {
           error: 'Blockchain escrow release failed. Payment cannot be processed. Please retry.',
           retryable: true,
         });
+      } finally {
+        await redisClient?.del(releaseLockKey);
       }
     } else {
       logger.info(`[escrow] Escrow not funded (status: ${verifiedOrder.escrow_status}) — skipping on-chain release.`);


### PR DESCRIPTION
## Fix: Add Redis-based per-order lock to prevent double escrow release

### Problem
Under concurrent conditions or slow RPC commits, `escrowReleaseFn` could be called twice for the same order, resulting in duplicate blockchain transactions and incorrect wallet crediting. There was no idempotency guard around the on-chain release call.

### Fix
Add a Redis NX lock (`escrow:release:{orderId}`) with 60s TTL before the release call. If the lock cannot be acquired, skip the release. Release the lock in a `finally` block.

Closes #4516