### PR TITLE
Harden weigh station bypass route

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -164,9 +164,23 @@ function parseIntegerQuery(value) {
   return Number.parseInt(value, 10);
 }
 
+function parseCoordinate(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!/^-?(?:\d+|\d*\.\d+)(?:e-?\d+)?$/i.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function hasValidCoordinates(lat, lng) {
-  return Number.isFinite(lat) &&
-    Number.isFinite(lng) &&
+  return lat !== null &&
+    lng !== null &&
     lat >= -90 &&
     lat <= 90 &&
     lng >= -180 &&
@@ -1064,8 +1078,8 @@ router.get('/:driverId/reputation', authenticate, userLimiter, requirePolicy('dr
 router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, async (req, res) => {
   try {
     const driverId = req.user.id;
-    const lat = parseFloat(req.query.lat);
-    const lng = parseFloat(req.query.lng);
+    const lat = parseCoordinate(req.query.lat);
+    const lng = parseCoordinate(req.query.lng);
 
     if (!hasValidCoordinates(lat, lng)) {
       return res.status(400).json({ error: 'lat and lng must be valid coordinates.' });

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -164,6 +164,14 @@ function parseIntegerQuery(value) {
   return Number.parseInt(value, 10);
 }
 
+function hasValidCoordinates(lat, lng) {
+  return Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180;
+}
 
 // ============================================================================
 // 1. GET DRIVER STATS (DRIVER)
@@ -1058,6 +1066,11 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
     const driverId = req.user.id;
     const lat = parseFloat(req.query.lat);
     const lng = parseFloat(req.query.lng);
+
+    if (!hasValidCoordinates(lat, lng)) {
+      return res.status(400).json({ error: 'lat and lng must be valid coordinates.' });
+    }
+
     const status = await checkBypassEligibility(driverId, lat, lng);
     return res.status(200).json(status);
   } catch (err) {


### PR DESCRIPTION
## Summary
- keep the weigh-station bypass route on the existing authenticated driver route stack
- validate latitude and longitude before calling the bypass service
- return a clear 400 response for malformed coordinates

## Validation
- `node --check backend/api/src/routes/driverRoutes.js`

Fixes #4528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for latitude and longitude values when checking weigh-station bypass status.
  * Invalid or out-of-range coordinates now return a clear error instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->