### PR TITLE
Restrict ZKP verification to owned users

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -12,7 +12,7 @@ function canVerifyUser(requestUser, targetUserId) {
 }
 
 // Verify driver KYC using ZK-SNARK
-router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
+router.post('/zkp/verify', userLimiter, authenticate, async (req, res) => {
   try {
     const { userId, name, licenseNumber, rcNumber, insuranceNumber, issueDate, expiryDate } = req.body;
     

--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -1,18 +1,28 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import zkpService from '../services/zkp/zkp.service.js';
 import logger from '../middleware/logger.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
-import { userLimiter } from '../middleware/rateLimiter.js';
+import { userLimiter, safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 const PRIVILEGED_VERIFICATION_ROLES = new Set(['admin', 'regulator']);
+const zkpVerifyLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: safeIpKeyGenerator,
+  store: createStore('rl:zkp-verify:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 900 },
+});
 
 function canVerifyUser(requestUser, targetUserId) {
   return requestUser?.id === targetUserId || PRIVILEGED_VERIFICATION_ROLES.has(requestUser?.role);
 }
 
 // Verify driver KYC using ZK-SNARK
-router.post('/zkp/verify', userLimiter, authenticate, async (req, res) => {
+router.post('/zkp/verify', zkpVerifyLimiter, authenticate, async (req, res) => {
   try {
     const { userId, name, licenseNumber, rcNumber, insuranceNumber, issueDate, expiryDate } = req.body;
     

--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -5,6 +5,11 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
+const PRIVILEGED_VERIFICATION_ROLES = new Set(['admin', 'regulator']);
+
+function canVerifyUser(requestUser, targetUserId) {
+  return requestUser?.id === targetUserId || PRIVILEGED_VERIFICATION_ROLES.has(requestUser?.role);
+}
 
 // Verify driver KYC using ZK-SNARK
 router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
@@ -15,6 +20,13 @@ router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
       return res.status(400).json({
         success: false,
         error: 'Missing required fields: userId, name, licenseNumber'
+      });
+    }
+
+    if (!canVerifyUser(req.user, userId)) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied: cannot verify another user.'
       });
     }
     


### PR DESCRIPTION
## Summary
- prevent normal users from submitting ZKP verification for another account
- allow privileged operator roles to verify another user when needed
- return a clear 403 response before running verification work

## Validation
- `node --check backend/api/src/routes/zkp.routes.js`

Fixes #4530