### PR TITLE
Surface tracking token validation errors

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -37,6 +37,10 @@ router.get(
 
       const validation = await trackingTokenService.validateToken(token);
 
+      if (validation.reason === 'validation_error') {
+        return res.status(500).json({ error: 'Failed to validate tracking link' });
+      }
+
       if (!validation.valid) {
         const statusMessages = {
           not_found: { status: 404, message: 'Tracking link not found or invalid' },
@@ -125,6 +129,10 @@ router.get(
       }
 
       const validation = await trackingTokenService.validateToken(token);
+
+      if (validation.reason === 'validation_error') {
+        return res.status(500).json({ error: 'Failed to validate tracking link' });
+      }
 
       if (!validation.valid) {
         return res.status(404).json({ error: 'Tracking link not found or invalid' });

--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -55,9 +55,14 @@ export class TrackingTokenService {
       .from('tracking_tokens')
       .select('id, order_display_id, expires_at, revoked, revoked_at')
       .eq('token_hash', tokenHash)
-      .single();
+      .maybeSingle();
 
-    if (error || !token) {
+    if (error) {
+      this._logger.error({ error }, 'Failed to validate tracking token');
+      return { valid: false, reason: 'validation_error' };
+    }
+
+    if (!token) {
       return { valid: false, reason: 'not_found' };
     }
 


### PR DESCRIPTION
## Summary
- distinguish tracking token query failures from missing tokens
- log validation query errors in the token service
- return 500 from public tracking endpoints when token validation fails unexpectedly

## Validation
- `node --check backend/api/src/services/trackingTokenService.js`
- `node --check backend/api/src/routes/publicTrackingRoutes.js`

Fixes #4531