### PR TITLE
Surface public tracking order lookup failures

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -158,9 +158,14 @@ export class TrackingTokenService {
         created_at
       `)
       .eq('order_display_id', orderDisplayId)
-      .single();
+      .maybeSingle();
 
-    if (orderError || !order) {
+    if (orderError) {
+      this._logger.error({ error: orderError, orderDisplayId }, 'Failed to fetch public tracking order');
+      throw new Error('Failed to fetch public tracking order');
+    }
+
+    if (!order) {
       return null;
     }
 


### PR DESCRIPTION
## Summary
- use `maybeSingle()` for public tracking order lookup
- keep missing orders as a null result for the route-level 404
- log and throw unexpected lookup failures so the route returns 500

## Validation
- `node --check backend/api/src/services/trackingTokenService.js`

Fixes #4532