### PR TITLE
Enforce access on order verification

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -1,14 +1,38 @@
 import express from 'express';
 import { verificationService } from '../core/container.js';
+import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
+import { PolicyError, policy } from '../security/policyEngine.js';
 
 const router = express.Router();
 
 router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
+    const { data: order, error: orderError } = await supabase
+      .from('orders')
+      .select('id, customer_id, driver_id')
+      .eq('id', orderId)
+      .maybeSingle();
+
+    if (orderError) {
+      return res.status(500).json({
+        success: false,
+        error: 'Failed to verify order access',
+      });
+    }
+
+    if (!order) {
+      return res.status(404).json({
+        success: false,
+        error: 'Order not found',
+      });
+    }
+
+    policy.authorize(req.user, 'order:view', { order });
+
     const result = await verificationService.verifyOrder(orderId);
 
     if (result.error && !result.orderId) {
@@ -23,6 +47,13 @@ router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSche
       data: result
     });
   } catch (error) {
+    if (error instanceof PolicyError) {
+      return res.status(error.status).json({
+        success: false,
+        error: error.message,
+      });
+    }
+
     res.status(500).json({
       success: false,
       error: error.message

--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -2,13 +2,14 @@ import express from 'express';
 import { verificationService } from '../core/container.js';
 import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 import { PolicyError, policy } from '../security/policyEngine.js';
 
 const router = express.Router();
 
-router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
+router.get('/order/:orderId', authenticate, userLimiter, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
     const { data: order, error: orderError } = await supabase

--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -1,15 +1,25 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { verificationService } from '../core/container.js';
 import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
-import { userLimiter } from '../middleware/rateLimiter.js';
+import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 import { PolicyError, policy } from '../security/policyEngine.js';
 
 const router = express.Router();
+const orderVerificationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: safeIpKeyGenerator,
+  store: createStore('rl:order-verification:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 900 },
+});
 
-router.get('/order/:orderId', authenticate, userLimiter, validateParams(verifyOrderParamsSchema), async (req, res) => {
+router.get('/order/:orderId', orderVerificationLimiter, authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
     const { data: order, error: orderError } = await supabase


### PR DESCRIPTION
## Summary
- load order ownership before running verification
- reuse the existing order view policy for customer, driver, and admin access
- return 404 for missing orders and 403 for unrelated users

## Validation
- `node --check backend/api/src/routes/verificationRoutes.js`

Fixes #4533