### PR TITLE
Restrict driver document integrity checks

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -5,6 +5,11 @@ import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
+const DOCUMENT_REVIEW_ROLES = new Set(['admin', 'regulator']);
+
+function canCheckDriverDocuments(requestUser, driverId) {
+  return requestUser?.id === driverId || DOCUMENT_REVIEW_ROLES.has(requestUser?.role);
+}
 
 router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
@@ -33,6 +38,14 @@ router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSche
 router.post('/documents/check', authenticate, validateBody(documentCheckSchema), async (req, res) => {
   try {
     const { driverId } = req.body;
+
+    if (!canCheckDriverDocuments(req.user, driverId)) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied: cannot check documents for another driver.',
+      });
+    }
+
     const result = await verificationService.checkDocumentIntegrity(driverId);
 
     res.status(200).json({

--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -1,12 +1,22 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { verificationService } from '../core/container.js';
 import { authenticate } from '../middleware/auth.js';
-import { userLimiter } from '../middleware/rateLimiter.js';
+import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 const DOCUMENT_REVIEW_ROLES = new Set(['admin', 'regulator']);
+const documentCheckLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: safeIpKeyGenerator,
+  store: createStore('rl:document-check:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 900 },
+});
 
 function canCheckDriverDocuments(requestUser, driverId) {
   return requestUser?.id === driverId || DOCUMENT_REVIEW_ROLES.has(requestUser?.role);
@@ -36,7 +46,7 @@ router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSche
   }
 });
 
-router.post('/documents/check', authenticate, userLimiter, validateBody(documentCheckSchema), async (req, res) => {
+router.post('/documents/check', documentCheckLimiter, authenticate, validateBody(documentCheckSchema), async (req, res) => {
   try {
     const { driverId } = req.body;
 

--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { verificationService } from '../core/container.js';
 import { authenticate } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 
@@ -35,7 +36,7 @@ router.get('/order/:orderId', authenticate, validateParams(verifyOrderParamsSche
   }
 });
 
-router.post('/documents/check', authenticate, validateBody(documentCheckSchema), async (req, res) => {
+router.post('/documents/check', authenticate, userLimiter, validateBody(documentCheckSchema), async (req, res) => {
   try {
     const { driverId } = req.body;
 


### PR DESCRIPTION
## Summary
- allow drivers to run document checks only for their own profile
- allow admin and regulator roles to review another driver's documents
- return 403 before exposing document integrity status to unrelated users

## Validation
- `node --check backend/api/src/routes/verificationRoutes.js`

Fixes #4534