### PR TITLE
Enforce order access on oracle routes

### DIFF
--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -1,13 +1,23 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { oracleService } from '../core/container.js';
 import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
-import { userLimiter } from '../middleware/rateLimiter.js';
+import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateBody } from '../middleware/validate.js';
 import { oracleConfirmSchema, oracleVerifyCrosschainSchema } from '../validation/requestSchemas.js';
 import { PolicyError, policy } from '../security/policyEngine.js';
 
 const router = express.Router();
+const oracleVerificationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: safeIpKeyGenerator,
+  store: createStore('rl:oracle-verification:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 900 },
+});
 
 async function authorizeOrderAccess(req, orderId) {
   const { data: order, error } = await supabase
@@ -49,7 +59,7 @@ router.get('/status', authenticate, async (req, res) => {
   }
 });
 
-router.post('/confirm', authenticate, userLimiter, validateBody(oracleConfirmSchema), async (req, res) => {
+router.post('/confirm', oracleVerificationLimiter, authenticate, validateBody(oracleConfirmSchema), async (req, res) => {
   try {
     const { orderId, otp, gpsCoordinates } = req.body;
     await authorizeOrderAccess(req, orderId);
@@ -79,7 +89,7 @@ router.post('/confirm', authenticate, userLimiter, validateBody(oracleConfirmSch
   }
 });
 
-router.post('/verify-crosschain', authenticate, userLimiter, validateBody(oracleVerifyCrosschainSchema), async (req, res) => {
+router.post('/verify-crosschain', oracleVerificationLimiter, authenticate, validateBody(oracleVerifyCrosschainSchema), async (req, res) => {
   try {
     const { orderId, blockchainHash } = req.body;
     await authorizeOrderAccess(req, orderId);

--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { oracleService } from '../core/container.js';
 import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateBody } from '../middleware/validate.js';
 import { oracleConfirmSchema, oracleVerifyCrosschainSchema } from '../validation/requestSchemas.js';
 import { PolicyError, policy } from '../security/policyEngine.js';
@@ -48,7 +49,7 @@ router.get('/status', authenticate, async (req, res) => {
   }
 });
 
-router.post('/confirm', authenticate, validateBody(oracleConfirmSchema), async (req, res) => {
+router.post('/confirm', authenticate, userLimiter, validateBody(oracleConfirmSchema), async (req, res) => {
   try {
     const { orderId, otp, gpsCoordinates } = req.body;
     await authorizeOrderAccess(req, orderId);
@@ -78,7 +79,7 @@ router.post('/confirm', authenticate, validateBody(oracleConfirmSchema), async (
   }
 });
 
-router.post('/verify-crosschain', authenticate, validateBody(oracleVerifyCrosschainSchema), async (req, res) => {
+router.post('/verify-crosschain', authenticate, userLimiter, validateBody(oracleVerifyCrosschainSchema), async (req, res) => {
   try {
     const { orderId, blockchainHash } = req.body;
     await authorizeOrderAccess(req, orderId);

--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -1,10 +1,34 @@
 import express from 'express';
 import { oracleService } from '../core/container.js';
+import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
 import { oracleConfirmSchema, oracleVerifyCrosschainSchema } from '../validation/requestSchemas.js';
+import { PolicyError, policy } from '../security/policyEngine.js';
 
 const router = express.Router();
+
+async function authorizeOrderAccess(req, orderId) {
+  const { data: order, error } = await supabase
+    .from('orders')
+    .select('id, customer_id, driver_id')
+    .eq('id', orderId)
+    .maybeSingle();
+
+  if (error) {
+    const err = new Error('Failed to verify order access');
+    err.status = 500;
+    throw err;
+  }
+
+  if (!order) {
+    const err = new Error('Order not found');
+    err.status = 404;
+    throw err;
+  }
+
+  policy.authorize(req.user, 'order:view', { order });
+}
 
 router.get('/status', authenticate, async (req, res) => {
   try {
@@ -27,6 +51,8 @@ router.get('/status', authenticate, async (req, res) => {
 router.post('/confirm', authenticate, validateBody(oracleConfirmSchema), async (req, res) => {
   try {
     const { orderId, otp, gpsCoordinates } = req.body;
+    await authorizeOrderAccess(req, orderId);
+
     const result = await oracleService.confirmDelivery({
       orderId,
       otp,
@@ -38,6 +64,13 @@ router.post('/confirm', authenticate, validateBody(oracleConfirmSchema), async (
       data: result
     });
   } catch (error) {
+    if (error instanceof PolicyError || error.status) {
+      return res.status(error.status || 403).json({
+        success: false,
+        error: error.message
+      });
+    }
+
     res.status(500).json({
       success: false,
       error: error.message
@@ -48,6 +81,8 @@ router.post('/confirm', authenticate, validateBody(oracleConfirmSchema), async (
 router.post('/verify-crosschain', authenticate, validateBody(oracleVerifyCrosschainSchema), async (req, res) => {
   try {
     const { orderId, blockchainHash } = req.body;
+    await authorizeOrderAccess(req, orderId);
+
     const result = await oracleService.verifyCrossChain(orderId, blockchainHash);
 
     res.status(200).json({
@@ -55,6 +90,13 @@ router.post('/verify-crosschain', authenticate, validateBody(oracleVerifyCrossch
       data: result
     });
   } catch (error) {
+    if (error instanceof PolicyError || error.status) {
+      return res.status(error.status || 403).json({
+        success: false,
+        error: error.message
+      });
+    }
+
     res.status(500).json({
       success: false,
       error: error.message


### PR DESCRIPTION
## Summary
- verify order ownership before oracle confirmation work
- verify order ownership before cross-chain verification work
- return clear 404, 403, or 500 responses before provider calls run

## Validation
- `node --check backend/api/src/routes/oracleRoutes.js`

Fixes #4535