### PR TITLE
Handle truck search enrichment failures

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -552,6 +552,16 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
       supabase.from('profiles').select('id, full_name, avatar_url').in('id', driverIds),
     ]);
 
+    if (trucksRes.error) {
+      logger.error('Truck enrichment lookup error:', trucksRes.error.message);
+      return res.status(500).json({ error: 'Failed to search trucks. Please try again later.' });
+    }
+
+    if (profilesRes.error) {
+      logger.error('Driver profile enrichment lookup error:', profilesRes.error.message);
+      return res.status(500).json({ error: 'Failed to search trucks. Please try again later.' });
+    }
+
     const truckMap = Object.fromEntries((trucksRes.data || []).map(t => [t.id, t]));
     const profileMap = Object.fromEntries((profilesRes.data || []).map(p => [p.id, p]));
 


### PR DESCRIPTION
## Summary
- check truck enrichment lookup failures before mapping search results
- check driver profile lookup failures before mapping search results
- return a clear backend error instead of incomplete truck search rows

## Validation
- `node --check backend/api/src/routes/truckRoutes.js`

Fixes #4537