### PR TITLE
fix: remove duplicate repository parameter in customer NotificationsScreen

### DIFF
--- a/apps/customer/lib/screens/notifications_screen.dart
+++ b/apps/customer/lib/screens/notifications_screen.dart
@@ -27,7 +27,6 @@ class NotificationsScreen extends StatelessWidget {
         final route = shared.NotificationRouter.resolve(payload);
         shared.NotificationRouter.executeNavigation(context, route);
       },
-      repository: NotificationRepository(client),
       onItemTap: onItemTap,
     );
   }


### PR DESCRIPTION
## Summary
Removes the duplicate `repository` named parameter in the customer `NotificationsScreen` constructor call.

## Problem
`shared.NotificationsScreen(...)` was called with the `repository` parameter twice (lines 20 and 30). Dart does not allow duplicate named parameters — this is a compile-time error. Line 30 also used `NotificationRepository` without the `shared.` prefix, which is not in scope.

## Fix
Removed the duplicate `repository: NotificationRepository(client),` line. The single `repository: shared.NotificationRepository(client),` on line 20 is sufficient.

## Testing
- Customer app compiles successfully
- Notifications screen loads correctly with the repository

Closes #4548

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tapping a notification now correctly resolves its destination and navigates to the appropriate screen.
  * Improved notification repository integration for the notifications screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->