### PR TITLE
fix: replace hardcoded customer rating with N/A in LoadDetailScreen

### DIFF
--- a/apps/driver/lib/screens/load_detail_screen.dart
+++ b/apps/driver/lib/screens/load_detail_screen.dart
@@ -111,7 +111,7 @@ class LoadDetailScreen extends StatelessWidget {
                   icon: Icons.star_rounded,
                   iconColor: Colors.amber,
                   label: 'Customer rating',
-                  value: '4.9  (28 orders)',
+                  value: 'N/A',
                 ),
                 _DetailRow(
                   icon: Icons.people_rounded,


### PR DESCRIPTION
## Summary
Replaces the hardcoded customer rating `'4.9  (28 orders)'` with `'N/A'` in `LoadDetailScreen`.

## Problem
The customer rating and order count were hardcoded as `'4.9  (28 orders)'` (line 114). Every customer appeared to have exactly a 4.9 rating with 28 orders, regardless of their actual history. This misled drivers into making bidding decisions based on fake reputation data.

## Fix
Replaced with `'N/A'` since the `LoadOffer` model does not have rating fields. Dynamic rating can be added when the backend provides it.

## Testing
- Driver app compiles successfully
- Load detail screen shows "N/A" for customer rating instead of fake data

Closes #4549

GSSoC
