### PR TITLE
fix: delete temp CSV file after sharing in EarningsExportService

### DIFF
--- a/apps/driver/lib/services/earnings_export_service.dart
+++ b/apps/driver/lib/services/earnings_export_service.dart
@@ -14,7 +14,11 @@ class EarningsExportService {
     final tempDir = Directory.systemTemp;
     final file = File('${tempDir.path}/$filename');
     await file.writeAsString(csvContent);
-    await Share.shareXFiles([XFile(file.path)], text: 'Earnings Statement');
+    try {
+      await Share.shareXFiles([XFile(file.path)], text: 'Earnings Statement');
+    } finally {
+      await file.delete().catchError((_) {});
+    }
   }
 
   Future<String> saveCsv(String csvContent, String filename) async {


### PR DESCRIPTION
## Summary
Deletes the temp CSV file after sharing in `EarningsExportService.shareCsv()`.

## Problem
`shareCsv` wrote a temp file to `Directory.systemTemp` but never cleaned it up after `Share.shareXFiles`. Each call created an orphaned temp file, accumulating storage consumption over time.

## Fix
Wrapped `Share.shareXFiles` in try/finally to delete the temp file after sharing completes (or fails).

## Testing
- Driver app compiles successfully
- CSV export works correctly and temp files are cleaned up

Closes #4550

GSSoC
