### PR TITLE
fix: cancel Timer.periodic on modal bottom sheet dismiss in DocumentsScreen

### DIFF
--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -178,6 +178,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
     double progress = 0.0;
     String statusText = 'Reading file contents...';
     bool isDone = false;
+    Timer? uploadTimer;
 
     await showModalBottomSheet<void>(
       context: context,
@@ -191,7 +192,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         return StatefulBuilder(
           builder: (context, setSheetState) {
             if (progress == 0.0) {
-              Timer.periodic(const Duration(milliseconds: 300), (timer) {
+              uploadTimer?.cancel();
+              uploadTimer = Timer.periodic(const Duration(milliseconds: 300), (timer) {
                 if (!context.mounted) {
                   timer.cancel();
                   return;
@@ -310,7 +312,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
           },
         );
       },
-    );
+    ).then((_) => uploadTimer?.cancel());
   }
 
   Future<void> _showUploadSheet(BuildContext context) async {


### PR DESCRIPTION
## Summary
Stores the `Timer.periodic` reference and cancels it when the modal bottom sheet is dismissed in `DocumentsScreen`.

## Problem
A `Timer.periodic` was created inside the `StatefulBuilder` builder for upload simulation but was never tracked or canceled on sheet dismiss. If the user dismissed the sheet before the timer completed, it continued running and called `setSheetState` on a defunct `StatefulBuilder`.

## Fix
Stored the timer in a local variable `uploadTimer` and added `.then((_) => uploadTimer?.cancel())` on the `showModalBottomSheet` future to ensure cleanup on dismiss.

## Testing
- Driver app compiles successfully
- Upload simulation works correctly
- Timer is properly canceled when the sheet is dismissed

Closes #4551

GSSoC
