### PR TITLE
fix: dispose OrderService after estimatePriceRange in FindTrucksScreen

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -765,30 +765,34 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
 
     try {
       final service = OrderService();
-      final result = await service.estimatePriceRange(
-        pickupLat: _pickupPoint!.latitude,
-        pickupLng: _pickupPoint!.longitude,
-        dropLat: _dropPoint!.latitude,
-        dropLng: _dropPoint!.longitude,
-        weightTonnes: weight,
-        isFragile: _fragile,
-        isStackable: _stacked,
-      );
+      try {
+        final result = await service.estimatePriceRange(
+          pickupLat: _pickupPoint!.latitude,
+          pickupLng: _pickupPoint!.longitude,
+          dropLat: _dropPoint!.latitude,
+          dropLng: _dropPoint!.longitude,
+          weightTonnes: weight,
+          isFragile: _fragile,
+          isStackable: _stacked,
+        );
 
-      if (!mounted) return;
+        if (!mounted) return;
 
-      setState(() {
-        _estimateLoading = false;
-        if (result != null) {
-          _estimateMinPrice = result['minPrice'] as int?;
-          _estimateMaxPrice = result['maxPrice'] as int?;
-          _estimateError = null;
-        } else {
-          _estimateError = 'Estimate unavailable';
-          _estimateMinPrice = null;
-          _estimateMaxPrice = null;
-        }
-      });
+        setState(() {
+          _estimateLoading = false;
+          if (result != null) {
+            _estimateMinPrice = result['minPrice'] as int?;
+            _estimateMaxPrice = result['maxPrice'] as int?;
+            _estimateError = null;
+          } else {
+            _estimateError = 'Estimate unavailable';
+            _estimateMinPrice = null;
+            _estimateMaxPrice = null;
+          }
+        });
+      } finally {
+        service.dispose();
+      }
     } catch (e) {
       if (mounted) {
         setState(() {


### PR DESCRIPTION
## Summary
Disposes `OrderService` after each `estimatePriceRange` call in `FindTrucksScreen._estimatePrice()`.

## Problem
`_estimatePrice()` created a new `OrderService()` on every call (line 767) without disposing it. This method is called frequently — every time the user changes pickup/drop locations, weight, or toggles stackable/fragile flags. Each call leaked an `OrderService` instance with its HTTP client.

## Fix
Added a nested try/finally block to dispose the service after each call:
```dart
final service = OrderService();
try {
  final result = await service.estimatePriceRange(...);
  // ...
} finally {
  service.dispose();
}
```

## Testing
- Customer app compiles successfully
- Price estimation works correctly
- OrderService instances are properly cleaned up

Closes #4552

GSSoC
