### PR TITLE
fix: add dispose for TextEditingController fields in HelpCenterScreen

### DIFF
--- a/packages/truxify_shared/lib/src/screens/help_center_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/help_center_screen.dart
@@ -40,6 +40,13 @@ class _HelpCenterScreenState extends State<HelpCenterScreen> {
     _loadFaqs();
   }
 
+  @override
+  void dispose() {
+    _subjectController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
   Future<void> _loadFaqs() async {
     try {
       final faqs = await widget.faqRepository.fetchFaqs(widget.appType);


### PR DESCRIPTION
## Summary
Adds `dispose()` override to `HelpCenterScreen` to clean up `TextEditingController` fields.

## Problem
`_HelpCenterScreenState` created two `TextEditingController` instances (lines 29-30) but never overrode `dispose()`. Every navigation to/from the screen leaked the controllers.

## Fix
Added `dispose()` override:
```dart
@override
void dispose() {
  _subjectController.dispose();
  _descriptionController.dispose();
  super.dispose();
}
```

## Testing
- Shared package compiles successfully
- Help center screen works correctly with proper controller cleanup

Closes #4558

GSSoC
