### PR TITLE
fix: correct reversed upload status text labels in MyDocumentsScreen

### DIFF
--- a/apps/customer/lib/screens/my_documents_screen.dart
+++ b/apps/customer/lib/screens/my_documents_screen.dart
@@ -179,9 +179,9 @@ class _MyDocumentsScreenState extends State<MyDocumentsScreen> {
                   setSheetState(() {
                     progress += 0.15;
                     if (progress > 0.7) {
-                      statusText = 'Processing document...';
-                    } else if (progress > 0.4) {
                       statusText = 'Uploading to secure storage...';
+                    } else if (progress > 0.4) {
+                      statusText = 'Processing document...';
                     }
                   });
                 } else if (progress >= 0.8 && progress < 1.0) {


### PR DESCRIPTION
## Summary
Corrects the reversed upload status text labels in `MyDocumentsScreen._simulateUpload()`.

## Problem
The status text labels were reversed: "Uploading to secure storage" appeared before "Processing document". This created confusing UX where the status regressed from "Uploading" to "Processing" during upload.

## Fix
Swapped the strings to match the logical order: processing first (0.4+), then uploading (0.7+). This matches the driver version in `documents_screen.dart`.

## Testing
- Customer app compiles successfully
- Upload simulation shows correct status text order

Closes #4559

GSSoC
