### PR TITLE
fix: add missing mounted check in MyTruckScreen null truck branch

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -45,6 +45,7 @@ class _MyTruckScreenState extends State<MyTruckScreen> {
 
       final truck = await _truckRepository.fetchTruckForDriver(driverId);
       if (truck == null) {
+        if (!mounted) return;
         setState(() {
           _errorMessage = 'No truck assigned to this driver';
           _isLoading = false;


### PR DESCRIPTION
## Summary
Adds missing `mounted` check in `MyTruckScreen._loadData()` null truck branch.

## Problem
After `await _truckRepository.fetchTruckForDriver(driverId)`, the null-truck branch called `setState` without checking `mounted`. If the user navigated away during the network call, this would call `setState` on an unmounted widget, throwing a Flutter error.

## Fix
Added `if (!mounted) return;` before the `setState` call in the null truck branch.

## Testing
- Driver app compiles successfully
- No crash on fast navigation away from truck screen during data loading

Closes #4560

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an error when loading truck information after leaving the screen.
  * Improved stability when no truck is assigned and the screen is closed during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->