### PR TITLE
fix: interpolate fields in GpsCompressionStats.summary

### DIFF
--- a/apps/customer/lib/core/offline/gps/gps_delta_compressor.dart
+++ b/apps/customer/lib/core/offline/gps/gps_delta_compressor.dart
@@ -116,5 +116,5 @@ class GpsCompressionStats {
 
   void recordSkip() { originalPoints++; }
 
-  String get summary => 'compressionRatio:F1 pointsSaved points saved';
+  String get summary => 'compressionRatio: ${compressionRatio.toStringAsFixed(1)}%, $pointsSaved points saved';
 }


### PR DESCRIPTION
## Summary
Fixes broken string interpolation in `GpsCompressionStats.summary`.

## Problem
`summary` returned a literal string `'compressionRatio:F1 pointsSaved points saved'` with no interpolation. The fields `:F1` and `pointsSaved` were never interpolated, so the getter always returned the same static text.

## Fix
Replaced with properly interpolated string:
```dart
String get summary => 'compressionRatio: ${compressionRatio.toStringAsFixed(1)}%, $pointsSaved points saved';
```

## Testing
- Customer app compiles successfully
- Summary now shows actual compression stats

Closes #4561

GSSoC
