### PR TITLE
fix: use int.tryParse in TruckResultsScreen._price to prevent FormatException

### DIFF
--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -131,9 +131,9 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
   }
 
   int _price(String price) {
-    return int.parse(
+    return int.tryParse(
       price.replaceAll('₹', '').replaceAll(',', '').trim(),
-    );
+    ) ?? 0;
   }
 
   double _eta(String eta) {


### PR DESCRIPTION
## Summary
Uses `int.tryParse` instead of `int.parse` in `TruckResultsScreen._price()` to prevent `FormatException`.

## Problem
`_price()` used `int.parse()` which throws `FormatException` if the cleaned price string is not a valid integer. This method is called from `sortedTrucks` when the user selects "Cheapest" sort, crashing the screen on unexpected API data.

## Fix
Changed to `int.tryParse(... ) ?? 0` to gracefully handle non-numeric price strings.

## Testing
- Customer app compiles successfully
- Sort by Cheapest works correctly even on unexpected price strings

Closes #4562

GSSoC
