### PR TITLE
fix(core): resolve distributed lock leak in escrow refund reconciliation (fixes #4572)

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -40,9 +40,9 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
   }
   if (reconciliationRunning) return;
   reconciliationRunning = true;
+  let globalLockAcquired = false;
 
   try {
-    let globalLockAcquired = false;
     if (redisClient) {
       try {
         globalLockAcquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
@@ -149,7 +149,7 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         await releaseLock(lockKey, lockValue);
       }
     }
-
+  } finally {
     if (globalLockAcquired && redisClient) {
       try {
         await redisClient.del(LOCK_KEY);
@@ -157,7 +157,6 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         logger.warn('[escrow-reconciliation] Failed to release global lock:', err.message);
       }
     }
-  } finally {
     reconciliationRunning = false;
   }
 }


### PR DESCRIPTION
## 📌 Summary

This PR fixes a critical concurrency issue in the escrow refund reconciliation worker by ensuring the Redis distributed lock is always released, even when unexpected errors occur during reconciliation.

Previously, the lock release (`redisClient.del(LOCK_KEY)`) was placed inside the `try` block. If an exception occurred while processing pending escrow refunds, the function exited before releasing the lock, leaving it active until its 120-second TTL expired. During this period, all other cluster nodes were prevented from executing the reconciliation job.

The lock cleanup has been moved to the `finally` block, guaranteeing that it is released regardless of whether the reconciliation succeeds or fails.

---

## 🎯 Motivation

Closes #4572

The previous implementation could leak the distributed Redis lock whenever a database or runtime error interrupted reconciliation. This resulted in:

- Cluster-wide reconciliation being blocked until the lock TTL expired.
- Delayed escrow refund processing.
- Reduced fault tolerance during transient failures.
- Unnecessary downtime for the scheduled reconciliation worker.

This change improves the reliability of the distributed locking mechanism and ensures uninterrupted reconciliation across all backend instances.

---

## 🛠️ Changes

### Modified

- `backend/api/src/services/escrowRefundReconciliation.js`

### Implementation

- Moved `redisClient.del(LOCK_KEY)` from the `try` block into the `finally` block.
- Promoted the lock acquisition state (`globalLockAcquired`) to the outer scope so it can be referenced during cleanup.
- Ensured the Redis lock is released regardless of success, failure, or early returns.
- Preserved the existing reconciliation logic and API behavior.

---

## ✅ Acceptance Criteria

- [x] Redis distributed lock is always released after reconciliation completes.
- [x] Lock is released even when database queries or other reconciliation steps throw exceptions.
- [x] No execution path bypasses lock cleanup.
- [x] Existing reconciliation behavior remains unchanged.

---

## ⚠️ Impact & Side Effects

### Reliability

- Prevents Redis lock leaks during reconciliation failures.
- Improves fault tolerance for distributed workers.
- Eliminates unnecessary delays caused by expired lock TTLs.

### Breaking Changes

- None.

---

## 🧪 How to Test

1. Start the backend service and monitor the escrow reconciliation logs.
2. Simulate a failure in `findPendingEscrowRefunds()` (or another database operation within the reconciliation process).
3. Verify that the reconciliation exits with an error.
4. Check Redis to confirm the distributed lock is removed immediately instead of remaining until TTL expiration.
5. Trigger another reconciliation cycle and verify that another worker can successfully acquire the lock.

---

## 📝 Quality Checklist

- [x] Code follows the project's style guidelines.
- [x] Self-reviewed.
- [x] Existing functionality preserved.
- [x] No breaking API changes.
- [x] Improves distributed locking reliability.
- [x] No new warnings introduced.
- [x] Backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow refund reconciliation reliability by ensuring distributed processing locks are consistently released, including when early exits or batch-loading failures occur.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->