### PR TITLE
fix(core): eliminate node.js socket leaks in osrm circuit breaker (fixes #4573)

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -6,6 +6,7 @@ import { measureExecution } from '../core/performanceMetrics.js';
 export const osrmBreaker = new CircuitBreaker(async (url, options) => {
   const response = await fetch(url, options);
   if (response.status >= 500) {
+    await response.text().catch(() => {});
     throw new Error(`[OSRM] Request failed (${response.status})`);
   }
   return response;
@@ -97,6 +98,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
 
       if (!response.ok) {
         clearTimeout(timeout);
+        await response.text().catch(() => {});
         if (response.status >= 500 && attempt < maxRetries - 1) {
           logger.warn({ status: response.status, attempt: attempt + 1, maxRetries }, 'Server error. Retrying...');
           await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
@@ -194,7 +196,10 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
       buildGeometryUrl({ originLat, originLng, destLat, destLng }),
       { signal: controller.signal },
     );
-    if (!response.ok) return null;
+    if (!response.ok) {
+      await response.text().catch(() => {});
+      return null;
+    }
 
     const payload = await response.json();
     const route = Array.isArray(payload?.routes) ? payload.routes[0] : null;


### PR DESCRIPTION
## 📌 Summary

This PR resolves a critical resource management issue in the OSRM service by ensuring HTTP response bodies are always consumed when requests return non-successful (4xx/5xx) status codes.

Previously, `osrmBreaker`, `getRouteEstimate`, and `getRouteGeometry` exited early on failed responses without consuming or cancelling the response body. In Node.js, leaving response streams unread prevents the underlying TCP connection from being returned to the connection pool, causing socket leaks that can eventually exhaust available file descriptors under sustained traffic.

This change explicitly drains failed response bodies before returning or throwing, ensuring proper connection reuse and improving the overall reliability of outbound HTTP communication.

---

## 🎯 Motivation

Closes #4573

The previous implementation leaked sockets whenever the OSRM service returned a non-2xx response. Over time, this could result in:

- Gradual exhaustion of available file descriptors (`EMFILE`).
- Connection pool depletion due to unreleased sockets.
- Increased latency and degraded throughput.
- Failure of outbound HTTP requests across the application under sustained load.

By consuming failed response bodies before exiting, this PR prevents socket leaks and improves the resilience of the backend service.

---

## 🛠️ Changes

### Modified

- `backend/api/src/services/osrm.js`

### Implementation

- Added `await response.text().catch(() => {})` before throwing errors inside `osrmBreaker`.
- Added `await response.text().catch(() => {})` inside the `if (!response.ok)` block of `getRouteEstimate`.
- Added `await response.text().catch(() => {})` inside the `if (!response.ok)` block of `getRouteGeometry`.
- Preserved the existing retry logic and fallback behavior while ensuring all failed response bodies are properly drained.

---

## ✅ Acceptance Criteria

- [x] Non-2xx OSRM responses no longer leak sockets.
- [x] Failed response bodies are explicitly consumed before returning or throwing.
- [x] Existing retry and fallback logic continues to function correctly.
- [x] No changes to the public API or expected application behavior.

---

## ⚠️ Impact & Side Effects

### Performance & Reliability

- Prevents socket leaks caused by unconsumed HTTP response bodies.
- Improves connection pool health and socket reuse.
- Reduces the risk of file descriptor exhaustion (`EMFILE`) under heavy traffic.
- Increases overall stability of outbound HTTP communication.

### Breaking Changes

- None.

---

## 🧪 How to Test

1. Start the backend service.
2. Trigger OSRM requests that intentionally return 4xx or 5xx responses.
3. Monitor active TCP connections using tools such as `lsof`, `netstat`, or similar.
4. Verify that failed requests do not leave sockets in an `ESTABLISHED` state after completion.
5. Confirm that `getRouteEstimate` and `getRouteGeometry` continue returning their expected fallback values and that retries behave as before.

---

## 📝 Quality Checklist

- [x] Code follows the project's style guidelines.
- [x] Self-reviewed.
- [x] Existing functionality preserved.
- [x] No breaking API changes.
- [x] Improves resource management and connection reuse.
- [x] No new warnings introduced.
- [x] Backward compatible.