### PR TITLE
fix(core): mitigate duplicate webhook execution via optimistic concurrency control (fixes #4575)

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -64,6 +64,7 @@ export const dlqService = {
         .from('webhook_failures')
         .update({ status: 'processing', updated_at: now })
         .in('id', eventIds)
+        .eq('status', 'pending')
         .select();
 
       if (claimErr) {


### PR DESCRIPTION
## 📌 Summary

This PR fixes a critical race condition in the Dead Letter Queue (DLQ) processing workflow by introducing optimistic concurrency control (OCC) when claiming pending webhook events.

Previously, `processQueue` fetched pending webhook events and claimed them using an `.in('id', eventIds)` update without verifying that each event was still in the `pending` state. When multiple worker instances polled the queue simultaneously, they could retrieve the same event IDs and both successfully update them to `processing`, resulting in duplicate webhook execution.

This change adds a status check to the claim operation, ensuring that only events still marked as `pending` can be transitioned to `processing`. As a result, only one worker can successfully claim and process a webhook, preserving exactly-once processing across the cluster.

---

## 🎯 Motivation

Closes #4575

The previous implementation was vulnerable to race conditions during concurrent queue polling, which could lead to:

- Duplicate webhook deliveries.
- Inconsistent downstream system state.
- Duplicate billing, notifications, or external API calls.
- Loss of exactly-once delivery guarantees in distributed deployments.

By implementing optimistic concurrency control at the database level, this PR improves the reliability and correctness of distributed webhook processing.

---

## 🛠️ Changes

### Modified

- `backend/api/src/services/webhook/dlqService.js`

### Implementation

- Updated the webhook claim query to include `.eq('status', 'pending')` alongside the existing ID filter.
- Ensured that only records still in the `pending` state can be claimed.
- Allowed competing workers to safely receive zero updated rows when another worker has already claimed the event.
- Preserved the existing queue processing logic while eliminating duplicate claims.

---

## ✅ Acceptance Criteria

- [x] Only one worker can claim a pending webhook event.
- [x] Concurrent workers cannot process the same webhook simultaneously.
- [x] Unclaimed events remain available for subsequent polling cycles.
- [x] Existing queue processing behavior is preserved.

---

## ⚠️ Impact & Side Effects

### Reliability

- Prevents duplicate webhook execution in distributed environments.
- Guarantees atomic event claiming through optimistic concurrency control.
- Improves consistency and fault tolerance of the DLQ processing pipeline.

### Breaking Changes

- None.

---

## 🧪 How to Test

1. Start two or more backend worker instances connected to the same database.
2. Insert a pending webhook event into the DLQ.
3. Pause both workers immediately before the claim (`.update()`) operation.
4. Resume both workers simultaneously.
5. Verify that only one worker successfully updates the event from `pending` to `processing`.
6. Confirm that only the successful worker executes the webhook handler and that the competing worker receives no claimed records.

---

## 📝 Quality Checklist

- [x] Code follows the project's style guidelines.
- [x] Self-reviewed.
- [x] Existing functionality preserved.
- [x] No breaking API changes.
- [x] Improves concurrency safety and exactly-once webhook processing.
- [x] No new warnings introduced.
- [x] Backward compatible.