### PR TITLE
fix : import getEscrowBookingId in orderRoutes.js to prevent ReferenceError

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -185,6 +185,7 @@ import {
   confirmEscrowRefund,
   escrowRefund,
 } from '../core/container.js';
+import { getEscrowBookingId } from '../services/escrow.js';
 import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 import { getEscrowBookingId } from '../services/escrow.js';


### PR DESCRIPTION
The function getEscrowBookingId is called at line ~1172 of orderRoutes.js but is never imported, causing ReferenceError at runtime when order.escrow_booking_id is falsy.

Fix: add getEscrowBookingId to the imports from ../services/escrow.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow booking handling when an order lacks a booking reference.
  * Corrected withdrawal validation messaging for amounts that are not safe integers.
  * Improved request logging behavior when dynamic log levels are provided.

* **Documentation**
  * Updated session endpoint documentation to use the shared session response schema.

* **Tests**
  * Updated escrow test setup and mock filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->