### PR TITLE
fix : replace .safe() with .safeInteger() in withdrawSchema (Zod validation)

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -109,7 +109,7 @@ export const withdrawSchema = z.object({
     .number()
     .int({ message: 'Amount must be a whole number (paisa)' })
     .positive({ message: 'Amount must be greater than 0' })
-    .safe({ message: 'Amount is too large' }),
+    .safeInteger({ message: 'Amount must be a safe integer' }),
 }).strict();
 
 export const submitRatingSchema = z.object({


### PR DESCRIPTION
The Zod number schema in withdrawSchema uses .safe() which is not a valid Zod method, causing TypeError at runtime when withdraw requests are validated.

Fix: replace .safe({ message: 'Amount is too large' }) with .safeInteger({ message: 'Amount must be a safe integer' }).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened HTTP security headers.
  * Improved handling of suspicious forwarded IP headers and rate limiting.
  * Restricted request log-level overrides to non-production environments.

* **Bug Fixes**
  * Improved authentication session API documentation.
  * Corrected withdrawal validation messaging for unsafe integer amounts.
  * Streamlined escrow deposit and order confirmation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->