### PR TITLE
fix: strip timezone from pickup_deadline to fix naive/aware datetime comparison

### DIFF
--- a/backend/ml/app/models/deadhead_eliminator.py
+++ b/backend/ml/app/models/deadhead_eliminator.py
@@ -118,7 +118,8 @@ def find_return_loads(
 
             # --- Time feasibility ---
             try:
-                deadline_dt = datetime.fromisoformat(load.get("pickup_deadline", ""))
+                deadline_dt_raw = datetime.fromisoformat(load.get("pickup_deadline", ""))
+                deadline_dt = deadline_dt_raw.replace(tzinfo=None)
             except (ValueError, TypeError):
                 # Skip loads with unparseable deadlines
                 continue


### PR DESCRIPTION
## Summary
Fixes a silent failure in `backend/ml/app/models/deadhead_eliminator.py` where a naive/aware datetime comparison caused all loads with timezone-aware deadlines to be skipped from return-load recommendations.

## Bug
`arrival_dt` (and `estimated_arrival`) are timezone-naive (from `datetime.now()` or a naive ISO string). `deadline_dt` parsed from `pickup_deadline` is timezone-aware when the string contains a UTC offset (e.g. `...+05:30` or `...Z`).

Comparing naive with aware raises:
```
TypeError: can't compare offset-naive and offset-aware datetimes
```
This was silently caught by the per-load `try/except Exception` block, causing every load with a timezone-aware deadline to be excluded from recommendations with only a generic warning logged.

## Fix
Strip timezone from `deadline_dt` via `.replace(tzinfo=None)` so both sides of the comparison are naive. This matches the naive nature of `arrival_dt` and `estimated_arrival`.

## Impact
Drivers with timezone-aware load deadlines (all loads with explicit UTC offsets in the database) were being silently excluded from return-load matches. This fix restores those matches.

Closes #4589