### PR TITLE
Fix device token validation flow

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -42,14 +42,13 @@ export async function registerDeviceToken(req, res, next) {
     }
 
     const tokenErr = validateFcmToken(fcmToken);
-    return res.status(400).json(
-      errorResponse(
-        'VALIDATION_ERROR',
-        tokenErr
-      )
-    );
     if (tokenErr) {
-      return next(new ValidationError(tokenErr));
+      return res.status(400).json(
+        errorResponse(
+          'VALIDATION_ERROR',
+          tokenErr
+        )
+      );
     }
 
     const platErr = validatePlatform(platform);

--- a/backend/api/test/unit/deviceController.test.js
+++ b/backend/api/test/unit/deviceController.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSupabaseMock } from '../helpers/supabaseMock.js';
+
+const supabaseMock = createSupabaseMock();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: supabaseMock.supabase,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const { registerDeviceToken } = await import('../../src/controllers/deviceController.js');
+
+function makeResponse() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  };
+}
+
+describe('registerDeviceToken', () => {
+  beforeEach(() => {
+    supabaseMock.reset();
+  });
+
+  it('continues to upsert when the FCM token is valid', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        fcmToken: 'valid_token_12345',
+        platform: 'android',
+      },
+    };
+    const res = makeResponse();
+    const next = vi.fn();
+
+    await registerDeviceToken(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+    expect(supabaseMock.calls.some((call) => call.table === 'user_devices' && call.mode === 'upsert')).toBe(true);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Device token registered',
+    });
+  });
+
+  it('returns a validation response when the FCM token is invalid', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      body: { fcmToken: 'bad token with spaces' },
+    };
+    const res = makeResponse();
+    const next = vi.fn();
+
+    await registerDeviceToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+    expect(supabaseMock.calls.some((call) => call.table === 'user_devices')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fixes the unreachable validation branch in device token registration
- lets valid FCM tokens continue to the existing device upsert and profile sync flow
- adds focused controller coverage for valid and invalid token paths

## Validation
- node --check backend/api/src/controllers/deviceController.js
- node --check backend/api/test/unit/deviceController.test.js

The focused Vitest command could not run locally because this checkout does not currently install the backend test runner successfully; npm dependency installation stops on the existing repo setup conflict.

Closes #4619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid device notification tokens now return a clear validation error with HTTP 400.
  * Prevented duplicate error handling and unnecessary database operations for invalid tokens.

* **Tests**
  * Added coverage for successful device token registration and invalid-token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->