### PR TITLE
Validate support ticket update ids

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -571,7 +571,7 @@ router.get('/tickets/:id', authenticate, userLimiter, validateParams(uuidParamSc
  *       404:
  *         description: Ticket not found
  */
-router.patch('/tickets/:id', authenticate, userLimiter, validateBody(updateTicketSchema), async (req, res) => {
+router.patch('/tickets/:id', authenticate, userLimiter, validateParams(uuidParamSchema), validateBody(updateTicketSchema), async (req, res) => {
   const ticketId = req.params.id;
   const { subject, description, category, status } = req.body;
 


### PR DESCRIPTION
## Summary
- adds UUID param validation to the support ticket update route
- keeps the patch route consistent with ticket read and comment routes
- rejects malformed ticket ids before querying Supabase

## Validation
- node --check backend/api/src/routes/supportRoutes.js

Closes #4624