### PR TITLE
fix: pass event and filter params to onPostgresChanges in subscribeToChannel

### DIFF
--- a/apps/customer/lib/services/supabase_service.dart
+++ b/apps/customer/lib/services/supabase_service.dart
@@ -81,11 +81,21 @@ class SupabaseService {
     String? filterColumn,
     dynamic filterValue,
   }) {
-    var filter = RealtimeListenTypes.postgresChanges;
     var channel = client.channel('$table-changes');
     channel.onPostgresChanges(
       table: table,
       schema: 'public',
+      event: PostgresChangeEvent.values.firstWhere(
+        (e) => e.name == event,
+        orElse: () => PostgresChangeEvent.all,
+      ),
+      filter: filterColumn != null && filterValue != null
+          ? PostgresChangeFilter(
+              type: PostgresChangeFilterType.eq,
+              column: filterColumn,
+              value: filterValue,
+            )
+          : null,
       callback: (payload) => onEvent(payload.newRecord),
     );
     channel.subscribe();


### PR DESCRIPTION
## Summary
Passes `event` and `filter` parameters to `onPostgresChanges` in `SupabaseService.subscribeToChannel()`.

## Problem
`subscribeToChannel()` declared `required String event` but never passed it to `onPostgresChanges`. The `event`, `filterColumn`, and `filterValue` parameters were all silently ignored, meaning ALL postgres change events were received regardless of what the caller requested.

## Fix
- Maps the event string to `PostgresChangeEvent` enum and passes it to `onPostgresChanges`
- Applies `PostgresChangeFilter` when `filterColumn` is provided
- Removed unused dead code variable

## Testing
- Customer app compiles successfully
- Realtime subscriptions now correctly filter by event type

Closes #4642

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time update subscriptions by correctly handling event types.
  * Added optional equality filtering to receive only matching database changes.
  * Added a safe fallback for unrecognized event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->