### PR TITLE
fix: use DateTime.tryParse in EarningsDailyModel.fromMap to prevent crash

### DIFF
--- a/apps/driver/lib/models/earnings_daily_model.dart
+++ b/apps/driver/lib/models/earnings_daily_model.dart
@@ -13,7 +13,7 @@ class EarningsDailyModel {
 
   factory EarningsDailyModel.fromMap(Map<String, dynamic> map) {
     return EarningsDailyModel(
-      dayDate: DateTime.parse(map['day_date']),
+      dayDate: DateTime.tryParse(map['day_date']?.toString() ?? '') ?? DateTime.now(),
       amount: ((map['amount'] ?? 0) / 100.0),
       tripCount: map['trip_count'] ?? 0,
       hoursDriven: double.tryParse(map['hours_driven'].toString()) ?? 0.0,


### PR DESCRIPTION
## Summary
Uses `DateTime.tryParse` in `EarningsDailyModel.fromMap()` to prevent crash on null or malformed dates.

## Problem
`DateTime.parse(map['day_date'])` crashes with `FormatException` if the value is null or not a valid ISO8601 string from the database.

## Fix
Changed to `DateTime.tryParse(map['day_date']?.toString() ?? '') ?? DateTime.now()` for graceful handling.

## Testing
- Driver app compiles successfully
- Earnings screen handles null/malformed dates gracefully

Closes #4643

GSSoC
