### PR TITLE
fix: add type safety in WalletTransactionModel.fromMap

### DIFF
--- a/apps/driver/lib/models/wallet_transaction_model.dart
+++ b/apps/driver/lib/models/wallet_transaction_model.dart
@@ -40,13 +40,13 @@ class WalletTransactionModel {
 
   factory WalletTransactionModel.fromMap(Map<String, dynamic> map) {
     return WalletTransactionModel(
-      id: map['id'],
-      tripDisplayId: map['trip_display_id'],
+      id: map['id'].toString(),
+      tripDisplayId: map['trip_display_id']?.toString(),
       amount: (map['amount'] ?? 0) / 100.0,
       txnType: map['txn_type'] ?? '',
       status: map['status'] ?? '',
       description: map['description'] ?? '',
-      createdAt: DateTime.parse(map['created_at']),
+      createdAt: DateTime.tryParse(map['created_at']?.toString() ?? '') ?? DateTime.now(),
     );
   }
 }


### PR DESCRIPTION
## Summary
Adds type safety in `WalletTransactionModel.fromMap()` for `id` and `created_at` fields.

## Problem
1. `id: map['id']` had no cast to String — if the database returns an int, downstream code expecting String would fail
2. `DateTime.parse(map['created_at'])` crashes on null or malformed dates

## Fix
- Added `.toString()` cast for `id` and `tripDisplayId`
- Changed to `DateTime.tryParse` with fallback to `DateTime.now()`

## Testing
- Driver app compiles successfully
- Wallet screen handles null/malformed data gracefully

Closes #4644

GSSoC
