### PR TITLE
fix: forward actual error message to MetricsErrorCard

### DIFF
--- a/apps/driver/lib/widgets/home/driver_status_sheet.dart
+++ b/apps/driver/lib/widgets/home/driver_status_sheet.dart
@@ -117,7 +117,7 @@ class DriverStatusSheet extends StatelessWidget {
           if (isLoadingMetrics)
             const SummaryCardsShimmer()
           else if (metricsError != null)
-            const MetricsErrorCard()
+            MetricsErrorCard(errorMessage: metricsError)
           else
             ShiftMetricsRow(
               payValue: payValue,

--- a/apps/driver/lib/widgets/home/metrics_error_card.dart
+++ b/apps/driver/lib/widgets/home/metrics_error_card.dart
@@ -3,7 +3,9 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../theme/app_theme.dart';
 
 class MetricsErrorCard extends StatelessWidget {
-  const MetricsErrorCard({super.key});
+  const MetricsErrorCard({super.key, this.errorMessage});
+
+  final String? errorMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +25,7 @@ class MetricsErrorCard extends StatelessWidget {
               size: 14, color: TruxifyColors.errorRed),
           const SizedBox(width: 6),
           Text(
-            'Metrics unavailable',
+            errorMessage ?? 'Metrics unavailable',
             style: GoogleFonts.dmSans(
               fontSize: 11,
               color: TruxifyColors.errorRed,


### PR DESCRIPTION
## Summary
Forwards the actual error message to `MetricsErrorCard` instead of showing a generic "Metrics unavailable" message.

## Problem
`MetricsErrorCard` hardcoded "Metrics unavailable" and had no parameter to accept the actual error message. The parent `DriverStatusSheet` had a `metricsError` string with the real error (network timeout, auth failure, etc.) but it was silently discarded.

## Fix
- Added optional `String? errorMessage` parameter to `MetricsErrorCard`
- Passed `metricsError` from the parent widget
- Falls back to "Metrics unavailable" when no message is provided

## Testing
- Driver app compiles successfully
- Metrics card now shows the actual error message

Closes #4645

GSSoC
