### PR TITLE
fix: set _isDisposed flag in TripService.dispose()

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -222,6 +222,7 @@ class TripService {
   }
 
   void dispose() {
+    _isDisposed = true;
     _apiClient.dispose();
   }
 }


### PR DESCRIPTION
## Summary
Sets `_isDisposed` flag in `TripService.dispose()` to complete the implementation.

## Problem
`_isDisposed` was declared on line 26 but never set to `true` in `dispose()`. The flag was dead code, suggesting an incomplete dispose implementation.

## Fix
Added `_isDisposed = true` in `dispose()` before calling `_apiClient.dispose()`.

## Testing
- Driver app compiles successfully
- TripService dispose lifecycle is now complete

Closes #4646

GSSoC
