### PR TITLE
fix: use DateTime.tryParse in EarningsStatementModel.fromJson

### DIFF
--- a/apps/driver/lib/models/earnings_statement_model.dart
+++ b/apps/driver/lib/models/earnings_statement_model.dart
@@ -29,8 +29,8 @@ class EarningsStatementModel {
     return EarningsStatementModel(
       driverName: json['driver_name'] as String? ?? 'Driver',
       driverPhone: json['driver_phone'] as String?,
-      startDate: DateTime.parse(json['start_date'] as String),
-      endDate: DateTime.parse(json['end_date'] as String),
+      startDate: DateTime.tryParse(json['start_date'] as String? ?? '') ?? DateTime.now(),
+      endDate: DateTime.tryParse(json['end_date'] as String? ?? '') ?? DateTime.now(),
       totalTrips: (json['total_trips'] as num?)?.toInt() ?? tripsList.length,
       totalEarnings: _parsePaisa(json['total_earnings']),
       platformFees: _parsePaisa(json['platform_fees']),


### PR DESCRIPTION
## Summary
Uses `DateTime.tryParse` in `EarningsStatementModel.fromJson()` to prevent crash on null dates.

## Problem
`DateTime.parse(json['start_date'] as String)` crashes if the field is null or malformed. Meanwhile, `TripEarningRow.fromJson` in the same file correctly uses `DateTime.tryParse`.

## Fix
Changed to `DateTime.tryParse(json['start_date'] as String? ?? '') ?? DateTime.now()` for both fields.

## Testing
- Driver app compiles successfully
- Earnings statement handles null dates gracefully

Closes #4652

GSSoC
