### PR TITLE
fix: dispose MarketplaceRepository in finally block in ProfitEstimateCard

### DIFF
--- a/apps/driver/lib/widgets/profit_estimate_card.dart
+++ b/apps/driver/lib/widgets/profit_estimate_card.dart
@@ -43,14 +43,17 @@ class _ProfitEstimateCardState extends State<ProfitEstimateCard> {
 
     try {
       final repo = MarketplaceRepository();
-      final prediction = await repo.predictLoadProfit(
-        load: widget.load,
-        truckMileageKmL: widget.truckMileageKmL,
-        fuelPricePerLitre: widget.fuelPricePerLitre,
-        tripDurationHours: duration,
-      );
-      repo.dispose();
-      if (mounted) setState(() { _prediction = prediction; _isLoading = false; });
+      try {
+        final prediction = await repo.predictLoadProfit(
+          load: widget.load,
+          truckMileageKmL: widget.truckMileageKmL,
+          fuelPricePerLitre: widget.fuelPricePerLitre,
+          tripDurationHours: duration,
+        );
+        if (mounted) setState(() { _prediction = prediction; _isLoading = false; });
+      } finally {
+        repo.dispose();
+      }
     } catch (_) {
       if (mounted) setState(() { _isLoading = false; _error = 'Prediction unavailable'; });
     }


### PR DESCRIPTION
## Summary
Wraps `MarketplaceRepository` usage in `try/finally` in `ProfitEstimateCard` to prevent resource leak.

## Problem
`repo.dispose()` was not in a `finally` block. If `predictLoadProfit` threw an exception, the repository's internal `ApiClient` was never disposed.

## Fix
Wrapped in nested try/finally to ensure `repo.dispose()` is always called.

## Testing
- Driver app compiles successfully
- Profit estimate card handles prediction failures without leaking resources

Closes #4653

GSSoC
