### PR TITLE
fix: evict expired cache entries before lookup in GeocodeService

### DIFF
--- a/apps/driver/lib/services/geocode_service.dart
+++ b/apps/driver/lib/services/geocode_service.dart
@@ -39,9 +39,9 @@ class GeocodeService {
   static Future<LatLng?> resolvePlace(String query) async {
     final key = query.trim().toLowerCase();
     if (key.isEmpty) return null;
+    _evictExpired();
     final cached = _cache[key];
     if (cached != null) return cached.value;
-    _evictExpired();
 
     final uri = Uri.https(
       'nominatim.openstreetmap.org',
@@ -89,9 +89,9 @@ class GeocodeService {
   /// Reverse geocode coordinates to an address string.
   static Future<String?> reverseGeocode(LatLng point) async {
     final key = '${point.latitude},${point.longitude}';
+    _evictExpired();
     final cached = _reverseCache[key];
     if (cached != null) return cached.value;
-    _evictExpired();
 
     final uri = Uri.https(
       'nominatim.openstreetmap.org',


### PR DESCRIPTION
## Summary
Moves `_evictExpired()` before cache lookup in `GeocodeService` to prevent serving stale entries.

## Problem
`_evictExpired()` was called AFTER the cache lookup in both `resolvePlace` and `reverseGeocode`. This meant expired entries were returned as valid results before being evicted.

## Fix
Moved the eviction call before the cache lookup in both methods.

## Testing
- Driver app compiles successfully
- Geocode cache properly evicts expired entries before lookup

Closes #4654

GSSoC
