### PR TITLE
fix: show error when profile is null in EditProfileScreen

### DIFF
--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -52,7 +52,10 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           _isLoading = false;
         });
       } else if (mounted) {
-        setState(() => _isLoading = false);
+        setState(() {
+          _isLoading = false;
+          _loadError = 'Profile not found';
+        });
       }
     } catch (e) {
       if (mounted) {


### PR DESCRIPTION
## Summary
Shows error message when profile data is null in `EditProfileScreen._loadProfile()`.

## Problem
When `profile` was null and the widget was mounted, `_isLoading` was set to false but `_loadError` stayed null. The screen showed an empty editable form with no indication that profile loading failed.

## Fix
Set `_loadError = 'Profile not found'` when profile data is null.

## Testing
- Customer app compiles successfully
- Edit profile screen shows error message when profile data is unavailable

Closes #4655

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile loading error handling when a profile cannot be found.
  * The screen now displays a clear “Profile not found” message instead of remaining without a specific error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->