### PR TITLE
fix: remove duplicate onTap in shared NotificationsScreen ListTile

### DIFF
--- a/packages/truxify_shared/lib/src/screens/notifications_screen.dart
+++ b/packages/truxify_shared/lib/src/screens/notifications_screen.dart
@@ -214,7 +214,11 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                           final item = _items[index];
                           final relativeTime = _formatRelativeTime(item.createdAt);
                           return ListTile(
-                            onTap: () => _onTileTap(item),
+                            onTap: () async {
+                              if (!item.isRead) await _markRead(item);
+                              widget.onNotificationTap?.call(item);
+                              widget.onItemTap?.call(item);
+                            },
                             tileColor: item.isRead ? null : Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.25),
                             leading: Icon(Icons.notifications_rounded, color: item.isRead ? null : Theme.of(context).colorScheme.primary),
                             title: Text(item.title),
@@ -225,10 +229,6 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                               ].join('\n'),
                             ),
                             isThreeLine: true,
-                            onTap: () {
-                              if (!item.isRead) _markRead(item);
-                              widget.onNotificationTap?.call(item);
-                            },
                             trailing: item.isRead
                                 ? const Icon(Icons.done_rounded)
                                 : TextButton(


### PR DESCRIPTION
## Summary
Removes duplicate `onTap` in shared `NotificationsScreen` ListTile and consolidates into a single handler.

## Problem
The ListTile specified `onTap` twice (lines 217 and 228). In Dart, the last value silently wins, making `_onTileTap` dead code and `widget.onItemTap` never invoked. The driver app's `onItemTap` callback was silently dropped on every notification tap.

## Fix
Consolidated both handlers into a single `onTap` that calls both `onNotificationTap` and `onItemTap`.

## Testing
- Shared package compiles successfully
- Both notification tap callbacks are now invoked correctly

Closes #4656

GSSoC
