### PR TITLE
fix: implement exponential backoff for escrow refund retries (Fixes #…

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -536,7 +536,7 @@ export class OrderRepository {
   async findPendingEscrowRefunds() {
     return this._retryableQuery(() => this.supabase
       .from('orders')
-      .select('id, order_display_id, refund_tx_hash, escrow_status, escrow_refund_retry_count')
+      .select('id, order_display_id, refund_tx_hash, escrow_status, escrow_refund_retry_count, updated_at')
       .in('escrow_status', ['refund_pending', 'refund_failed'])
       .limit(50), 'findPendingEscrowRefunds');
   }

--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -31,6 +31,7 @@ const LOCK_KEY = 'escrow:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;
 const LEASE_EXTENSION_INTERVAL_MS = (LOCK_TTL_SECONDS * 1000) / 2;
 const MAX_RETRIES = 10;
+const BASE_BACKOFF_MS = 60_000; // Base backoff for exponential retries (1 minute)
 let reconciliationTimer = null;
 let reconciliationRunning = false;
 
@@ -65,6 +66,20 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
     }
 
     for (const order of pendingOrders ?? []) {
+      const retryCount = order.escrow_refund_retry_count ?? 0;
+
+      // Exponential backoff logic based on updated_at
+      if (retryCount > 0 && order.updated_at) {
+        const updatedAtTime = new Date(order.updated_at).getTime();
+        const backoffMs = Math.pow(2, retryCount - 1) * BASE_BACKOFF_MS;
+        const nextRetryTime = updatedAtTime + backoffMs;
+
+        if (Date.now() < nextRetryTime) {
+          logger.info(`[escrow-reconciliation] Order ${order.order_display_id} in backoff period (retry ${retryCount}), skipping until ${new Date(nextRetryTime).toISOString()}`);
+          continue;
+        }
+      }
+
       if (globalLockAcquired && redisClient) {
         try {
           await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);

--- a/backend/api/test/unit/escrowRefundReconciliation.test.js
+++ b/backend/api/test/unit/escrowRefundReconciliation.test.js
@@ -105,6 +105,26 @@ describe('reconcilePendingEscrowRefunds', () => {
     expect(mocks.redisDel).toHaveBeenCalledTimes(1);
   });
 
+  it('skips order if it is still within the exponential backoff window', async () => {
+    mocks.redisSet.mockReturnValueOnce('OK'); // global lock
+    const now = Date.now();
+    // retryCount = 2, so backoff = 2^(2-1) * 60000 = 120000ms.
+    // updated_at is only 30000ms ago, so it should skip!
+    const recentUpdate = new Date(now - 30000).toISOString();
+    configureBuilder([{
+      id: 'oB',
+      order_display_id: 'OB',
+      escrow_refund_retry_count: 2,
+      updated_at: recentUpdate
+    }]);
+
+    await reconcilePendingEscrowRefunds(orderRepository);
+
+    // Global lock acquired and released. No per-order lock because it skipped.
+    expect(mocks.redisSet).toHaveBeenCalledTimes(1);
+    expect(mocks.redisDel).toHaveBeenCalledTimes(1);
+  });
+
   it('skips order when per-order redisClient.set returns null', async () => {
     // Global lock OK (truthy); per-order lock fails (returns null)
     mocks.redisSet.mockReturnValueOnce('OK').mockReturnValueOnce(null);


### PR DESCRIPTION
### What does this PR do?
Resolves #4666 by implementing proper exponential backoff (`2^(retry-1) * 1 min`) for the escrow refund reconciliation background worker. Previously, transactions failing due to Polygon network congestion were retried immediately every minute regardless of their failure count, potentially exacerbating issues and wasting compute.

### Key Changes
- **Updated `findPendingEscrowRefunds`:** The `orderRepository` now includes `updated_at` in its payload.
- **Implemented Backoff Math:** Added a `BASE_BACKOFF_MS` of 1 minute. Retries now exponentially scale back before running again based on the `escrow_refund_retry_count` and `updated_at` time.
- **Improved Logging:** Standardized skip logging logic when an order is still in its backoff grace period.
- **Unit Tests:** Added Vitest unit test coverage to guarantee orders bypass the worker process if they are still within the exponential backoff window.

### Quality Assurance
- [x] Tested locally: `npx vitest run test/unit/escrowRefundReconciliation.test.js` passes perfectly.
- [x] Branched cleanly from `upstream/main` to ensure zero merge conflicts.
- [x] Prepared as one single, clean atomic commit!

### Related Issues
- Resolves https://github.com/KanishJebaMathewM/Truxify/issues/4666