### PR TITLE
 Implement Real-Time WebSockets for Order Trackin…

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -19,6 +19,7 @@ import {
 import { escrowRelease } from '../escrow.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
+import { broadcastOrderMilestone } from '../../sockets/tracker.js';
 
 export class OrderMilestoneService {
   constructor(args = {}) {
@@ -102,6 +103,9 @@ export class OrderMilestoneService {
         });
       }
     }
+
+    // Broadcast milestone update to connected WebSocket clients
+    broadcastOrderMilestone(order.order_display_id, milestone, status);
 
     return { order: updatedOrder, milestone, status };
     });
@@ -238,6 +242,9 @@ export class OrderMilestoneService {
         }
       }
     }
+
+    // Broadcast "Delivered" milestone to connected WebSocket clients
+    broadcastOrderMilestone(order.order_display_id, 'Delivered', 'payment_released');
 
     return { status: 200, body: { message: 'Delivery verified successfully! Payment released to driver.' } };
     });

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1017,6 +1017,28 @@ export async function closeWebSocketServer() {
   });
 }
 
+export function broadcastOrderMilestone(orderDisplayId, milestone, status) {
+  if (!orderDisplayId) return;
+  const broadcastPayload = JSON.stringify({
+    event: 'milestone_update',
+    data: {
+      order_display_id: orderDisplayId,
+      milestone: milestone,
+      status: status,
+      timestamp: new Date()
+    }
+  });
+
+  if (trackingSubscriptions.has(orderDisplayId)) {
+    const clients = trackingSubscriptions.get(orderDisplayId);
+    clients.forEach((client) => {
+      if (client.readyState === 1) { 
+        client.send(broadcastPayload);
+      }
+    });
+  }
+}
+
 export async function handleSubscribe(ws, data) {
   const { order_display_id, driver_id } = data;
   const targetId = order_display_id || driver_id;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Aggressive HTTP polling for order tracking and milestone updates consumes unnecessary bandwidth and server resources, leading to delayed updates for users. Live GPS updates and milestone changes like "En Route" and "Delivered" should be pushed to the client immediately instead of relying on the client to continuously poll the backend for status changes.

**Describe the solution you'd like**
I've implemented real-time WebSocket broadcasting for order milestones in the Node.js backend to push live events to the client only when changes occur. This leverages the existing `ws` WebSocket tracking setup in `tracker.js`. A new `broadcastOrderMilestone` function was created and integrated into `orderMilestoneService.js` to dispatch these events instantly (e.g., when an order updates to "En Route" or is verified as "Delivered").

**Describe alternatives you've considered**
Considered using Firebase Realtime Database to sync state with the clients, but opted for a native WebSocket approach directly in our Node.js backend. This avoids vendor lock-in and keeps our telemetry stream unified with our milestone tracking stream.

**Additional context**
Resolves #4667.