### PR TITLE
feat: build Admin Dashboard Panel scaffold (Flutter Web) (Fixes #4668)

### DIFF
--- a/apps/admin/lib/main.dart
+++ b/apps/admin/lib/main.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+void main() {
+  runApp(const AdminDashboardApp());
+}
+
+class AdminDashboardApp extends StatelessWidget {
+  const AdminDashboardApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Truxify Admin Dashboard',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey),
+        useMaterial3: true,
+      ),
+      home: const DashboardShell(),
+    );
+  }
+}
+
+class DashboardShell extends StatefulWidget {
+  const DashboardShell({super.key});
+
+  @override
+  State<DashboardShell> createState() => _DashboardShellState();
+}
+
+class _DashboardShellState extends State<DashboardShell> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _pages = const [
+    UsersView(),
+    TrucksView(),
+    SupportTicketsView(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Truxify Admin Panel'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (int index) {
+              setState(() {
+                _selectedIndex = index;
+              });
+            },
+            labelType: NavigationRailLabelType.all,
+            destinations: const [
+              NavigationRailDestination(
+                icon: Icon(Icons.people_outline),
+                selectedIcon: Icon(Icons.people),
+                label: Text('Users'),
+              ),
+              NavigationRailDestination(
+                icon: Icon(Icons.local_shipping_outlined),
+                selectedIcon: Icon(Icons.local_shipping),
+                label: Text('Trucks'),
+              ),
+              NavigationRailDestination(
+                icon: Icon(Icons.support_agent_outlined),
+                selectedIcon: Icon(Icons.support_agent),
+                label: Text('Tickets'),
+              ),
+            ],
+          ),
+          const VerticalDivider(thickness: 1, width: 1),
+          Expanded(
+            child: _pages[_selectedIndex],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class UsersView extends StatelessWidget {
+  const UsersView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('User Management View (Coming Soon)'),
+    );
+  }
+}
+
+class TrucksView extends StatelessWidget {
+  const TrucksView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Truck Verification View (Coming Soon)'),
+    );
+  }
+}
+
+class SupportTicketsView extends StatefulWidget {
+  const SupportTicketsView({super.key});
+
+  @override
+  State<SupportTicketsView> createState() => _SupportTicketsViewState();
+}
+
+class _SupportTicketsViewState extends State<SupportTicketsView> {
+  List<dynamic> _tickets = [];
+  bool _isLoading = true;
+  String _error = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchTickets();
+  }
+
+  Future<void> _fetchTickets() async {
+    try {
+      // Connecting directly to the existing /api/support/admin/tickets endpoint
+      final response = await http.get(Uri.parse('/api/support/admin/tickets'));
+      if (response.statusCode == 200) {
+        setState(() {
+          _tickets = json.decode(response.body);
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load tickets: ${response.statusCode}';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error connecting to backend: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error.isNotEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, color: Colors.red, size: 48),
+            const SizedBox(height: 16),
+            Text(_error, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _fetchTickets,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_tickets.isEmpty) {
+      return const Center(child: Text('No active support tickets.'));
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        DataTable(
+          columns: const [
+            DataColumn(label: Text('ID')),
+            DataColumn(label: Text('User')),
+            DataColumn(label: Text('Issue')),
+            DataColumn(label: Text('Status')),
+            DataColumn(label: Text('Actions')),
+          ],
+          rows: _tickets.map((ticket) {
+            return DataRow(cells: [
+              DataCell(Text(ticket['id'].toString())),
+              DataCell(Text(ticket['user_id'].toString())),
+              DataCell(Text(ticket['subject'] ?? 'N/A')),
+              DataCell(Text(ticket['status'] ?? 'Open')),
+              DataCell(
+                TextButton(
+                  onPressed: () {
+                    // Placeholder for resolution action
+                  },
+                  child: const Text('Resolve'),
+                ),
+              ),
+            ]);
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/admin/pubspec.yaml
+++ b/apps/admin/pubspec.yaml
@@ -1,0 +1,23 @@
+name: admin_dashboard
+description: Truxify Admin Dashboard Panel (Flutter Web).
+publish_to: none
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  http: ^1.2.2
+
+dev_dependencies:
+  flutter_lints: ^6.0.0
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/apps/admin/web/index.html
+++ b/apps/admin/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="A new Flutter project.">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="admin_dashboard">
+  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+  <link rel="icon" type="image/png" href="favicon.png"/>
+  <title>admin_dashboard</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Backend routes exist for administrators, but the support team has no UI to manage users, verify trucks, or resolve support tickets. Developers currently have to run manual DB queries to perform administrative tasks.

**Describe the solution you'd like**
I've built the foundational scaffolding for a dedicated Flutter Web application (`apps/admin`) serving as the Admin Dashboard Panel. It features a responsive navigation sidebar and a basic tab structure for Users, Trucks, and Tickets. The Support Tickets module is wired up to connect directly to the existing `/api/support/admin/tickets` endpoint to fetch real-time ticket data.

**Describe alternatives you've considered**
Considered building a React.js admin panel, but since the mobile apps are already built in Flutter, reusing Flutter for the web panel ensures better code sharing and a unified architectural approach across the monorepo.

**Additional context**
Resolves #4668.