### PR TITLE
feat: implement stale order cleanup cron job (Fixes #4669)

### DIFF
--- a/backend/api/package-lock.json
+++ b/backend/api/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/node": "^10.62.0",
         "@supabase/supabase-js": "^2.109.0",
         "axios": "^1.6.0",
+        "circuit-breaker-js": "0.0.1",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "ethers": "6.17.0",
@@ -28,6 +29,7 @@
         "mongoose": "^9.7.4",
         "multer": "^2.2.0",
         "mysql2": "^3.6.5",
+        "node-cron": "^4.6.0",
         "opossum": "^10.0.0",
         "pg": "^8.22.0",
         "pino": "^10.3.1",
@@ -36,13 +38,8 @@
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "ws": "^8.21.0",
-        "zod": "^4.4.3",
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
-        }
+        "ws": "^8.21.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3158,6 +3155,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/circuit-breaker-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/circuit-breaker-js/-/circuit-breaker-js-0.0.1.tgz",
+      "integrity": "sha512-5Mq1ZmGK8k15CxIblQXSOiICqZFhz6ioP8W7PuzFWAMmFG5Wot1Ar1ZQFB/rb3Ogj3d3sAQowHpk3xIhX4BGYQ==",
+      "license": "MIT"
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -4356,6 +4359,27 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -7794,6 +7818,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -8163,13 +8196,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/opossum": {
       "version": "10.0.0",
@@ -11077,9 +11103,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -31,11 +31,14 @@
     "helmet": "^8.2.0",
     "i18next": "^26.3.4",
     "i18next-http-middleware": "^3.9.7",
+    "ioredis": "^5.3.2",
     "ipfs-http-client": "^60.0.0",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^7.4.0",
     "mongoose": "^9.7.4",
     "multer": "^2.2.0",
+    "mysql2": "^3.6.5",
+    "node-cron": "^4.6.0",
     "opossum": "^10.0.0",
     "pg": "^8.22.0",
     "pino": "^10.3.1",
@@ -45,9 +48,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.21.1",
-    "zod": "^4.4.3",
-    "mysql2": "^3.6.5",
-    "ioredis": "^5.3.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -110,6 +110,7 @@ import {
   startDlqWorker,
   stopDlqWorker,
 } from './workers/dlqWorker.js'
+import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -594,6 +595,7 @@ server.listen(PORT, () => {
   startEscrowRefundReconciliation(orderRepository)
   startReputationReconciliation(orderRepository)
   startDlqWorker()
+  startStaleOrderWorker()
   startDocumentExpiryWorker()
 })
 

--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -1,0 +1,66 @@
+import cron from 'node-cron';
+import logger from '../middleware/logger.js';
+import { supabase } from '../config/db.js';
+import { sendPushNotification } from '../services/notificationService.js';
+
+export const startStaleOrderWorker = () => {
+  // Run every hour at minute 0
+  cron.schedule('0 * * * *', async () => {
+    logger.info('[StaleOrderWorker] Starting cleanup of stale pending orders...');
+    try {
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+      // Find all pending orders created more than 24 hours ago
+      const { data: staleOrders, error: fetchError } = await supabase
+        .from('orders')
+        .select('id, customer_id')
+        .eq('status', 'pending')
+        .lt('created_at', twentyFourHoursAgo);
+
+      if (fetchError) {
+        logger.error(`[StaleOrderWorker] Error fetching stale orders: ${fetchError.message}`);
+        return;
+      }
+
+      if (!staleOrders || staleOrders.length === 0) {
+        logger.info('[StaleOrderWorker] No stale orders found.');
+        return;
+      }
+
+      logger.info(`[StaleOrderWorker] Found ${staleOrders.length} stale pending orders. Cancelling...`);
+
+      for (const order of staleOrders) {
+        // Update status to cancelled
+        const { error: updateError } = await supabase
+          .from('orders')
+          .update({
+            status: 'cancelled',
+            updated_at: new Date().toISOString()
+          })
+          .eq('id', order.id);
+
+        if (updateError) {
+          logger.error(`[StaleOrderWorker] Failed to cancel order ${order.id}: ${updateError.message}`);
+          continue;
+        }
+
+        // Send a notification to the customer
+        await sendPushNotification(
+          order.customer_id,
+          'Order Cancelled',
+          'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
+          'ORDER_CANCELLED',
+          { orderId: order.id }
+        );
+
+        logger.info(`[StaleOrderWorker] Cancelled order ${order.id} and notified customer ${order.customer_id}.`);
+      }
+      
+      logger.info('[StaleOrderWorker] Cleanup of stale pending orders completed.');
+    } catch (err) {
+      logger.error(`[StaleOrderWorker] Unexpected error during cleanup: ${err.message}`);
+    }
+  });
+
+  logger.info('[StaleOrderWorker] Stale order cleanup cron job scheduled (runs every hour).');
+};


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Orders posted by customers that never receive a bid stay in the `pending` state indefinitely, cluttering up the database and the driver's job marketplace.

**Describe the solution you'd like**
Implemented a background cron job using `node-cron` (`src/workers/staleOrderWorker.js`) that runs hourly to automatically cancel and clean up orders that have been pending without accepted bids for over 24 hours. The worker also integrates with the notification service (`sendPushNotification`) to send a notification to the customer instructing them to try posting again. 

**Describe alternatives you've considered**
Considered hiding them from the UI after 24 hours without changing the DB state, but officially changing the status to `cancelled` is cleaner for analytics and refunds.

**Additional context**
Resolves #4669.