### PR TITLE
fix(core): resolve race condition in idempotency middleware by implementing polling loop

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -79,14 +79,38 @@ export function requireIdempotency(ttlSeconds = 3600) {
       if (redisClient) {
         const lockKey = `${key}:lock`;
         const lockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', 10000);
+        
         if (!lockAcquired) {
-          await new Promise(r => setTimeout(r, 200));
-          const retryRaw = await redisClient.get(key);
-          const retryCached = retryRaw ? readAndParse(retryRaw) : null;
-          if (retryCached) {
-            return res.status(retryCached.statusCode).json(retryCached.body);
+          let retries = 50; // Poll for up to 10 seconds
+          let cacheFound = false;
+          
+          while (retries > 0) {
+            await new Promise(r => setTimeout(r, 200));
+            const retryRaw = await redisClient.get(key);
+            const retryCached = retryRaw ? readAndParse(retryRaw) : null;
+            
+            if (retryCached) {
+              cacheFound = true;
+              return res.status(retryCached.statusCode).json(retryCached.body);
+            }
+            
+            const lockStillHeld = await redisClient.get(lockKey);
+            if (!lockStillHeld) {
+              break; // Lock released but cache empty
+            }
+            
+            retries--;
           }
-          return res.status(409).json({ error: 'Duplicate request being processed' });
+          
+          if (!cacheFound && retries === 0) {
+            return res.status(409).json({ error: 'Duplicate request being processed' });
+          }
+          
+          // Re-acquire lock and process if previous request crashed
+          const newLockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', 10000);
+          if (!newLockAcquired) {
+             return res.status(409).json({ error: 'Duplicate request being processed' });
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Resolved a critical concurrency race condition in `requireIdempotency` (`idempotency.js`). Replaced the hardcoded `200ms` lock-wait delay with a robust bounded polling loop, ensuring legitimate concurrent retries gracefully wait for the original transaction to finish instead of instantly failing.

## Motivation
#Fixes#4696

Previously, when a slow network caused a user to retry a state-mutating request (e.g. order creation or payment), the idempotency middleware would catch the second request but only wait exactly `200ms`. If the original request took longer than 200ms to process, the middleware would blindly throw a `409 Duplicate request being processed` error. This completely broke the idempotency guarantee and crashed the client's retry flow. 

## Changes
- Modified `backend/api/src/middleware/idempotency.js`:
  - Replaced the simple 200ms `setTimeout` with a `while` loop that polls Redis every 200ms.
  - The loop bounds at 50 iterations (10 seconds), perfectly matching the `PX 10000` lock TTL.
  - Added safe-guard logic: if the lock is released but the cache remains empty (e.g., the original worker crashed before caching the response), the retry will now actively acquire the lock and process the request itself rather than deadlocking.

## Acceptance Criteria
- [x] Concurrent retries on long-running endpoints wait gracefully instead of throwing premature 409 errors.
- [x] Lock crashes are handled properly (lock releases but cache is empty).

## Impact & Side Effects
No breaking changes. This massively improves the reliability of all state-mutating endpoints across the entire backend.

## Quality Checklist
- [x] Linter passed
- [x] Types checked
- [x] Unit tests passed (Note: existing CI tests may fail due to unrelated bugs in `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate requests by waiting for an in-progress request to complete before responding.
  * Added recovery behavior for interrupted requests, reducing premature conflict errors.
  * Maintains a conflict response when no cached result becomes available after retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->