### PR TITLE
feat(api): add GET /api/driver/trips/:tripDisplayId endpoint to fetch single trip details (fixes #4698)

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -579,6 +579,56 @@ router.get('/trips', authenticate, userLimiter, requirePolicy('driver:view-trips
 });
 
 // ============================================================================
+// 5b. FETCH SINGLE TRIP DETAILS (DRIVER)
+// ============================================================================
+/**
+ * @openapi
+ * /api/driver/trips/{tripDisplayId}:
+ *   get:
+ *     tags: [Driver]
+ *     summary: Get single trip details
+ *     description: Returns parent details for a specific trip. Driver must own the trip.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: tripDisplayId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Trip display ID
+ *     responses:
+ *       200:
+ *         description: Single trip object
+ *       404:
+ *         description: Trip not found or Access denied
+ */
+router.get('/trips/:tripDisplayId', authenticate, userLimiter, requirePolicy('driver:view-trips'), async (req, res) => {
+  const { tripDisplayId } = req.params;
+
+  try {
+    const { data: trip, error } = await supabase
+      .from('trips')
+      .select('*')
+      .eq('trip_display_id', tripDisplayId)
+      .eq('driver_id', req.user.id)
+      .maybeSingle();
+
+    if (error) {
+      return res.status(500).json({ error: 'Failed to fetch trip details.', details: error.message });
+    }
+    if (!trip) {
+      return res.status(404).json({ error: 'Trip not found or Access Denied.' });
+    }
+
+    res.json(trip);
+  } catch (err) {
+    logger.error('Driver single trip fetch error:', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
 // 6. FETCH TRIP ITEMS (DRIVER)
 // ============================================================================
 /**


### PR DESCRIPTION
## Summary
Added a missing RESTful API endpoint (`GET /api/driver/trips/:tripDisplayId`) to allow drivers (and the mobile client) to fetch the parent details of a specific trip without needing to inefficiently paginate through their entire trip history.

## Motivation
Fixes #4698. 
Currently, the mobile app lacks an efficient way to fetch a single trip's parent data (status, total freight, origin/destination timestamps) if the driver deep-links into the app via a specific push notification. Adding this dedicated endpoint resolves the gap in the API surface, making it directly queryable by ID just like its sub-resources (`/items` and `/stops`).

## Changes
- Modified `backend/api/src/routes/driverRoutes.js`:
  - Added the new `GET /trips/:tripDisplayId` endpoint.
  - Included full JSDoc OpenAPI specifications for Swagger generation.
  - Implemented strict Supabase queries to ensure the `req.user.id` matches the trip's `driver_id`, preventing unauthorized access.
  - Added robust `404` and `500` error handling.

## Acceptance Criteria
- [x] A single trip's details can be fetched directly by its display ID.
- [x] Authorization guards ensure a driver can only fetch their own assigned trips.

## Impact & Side Effects
No breaking changes. This is a purely additive feature to the API surface.

## Quality Checklist
- [x] Linter passed
- [x] Types checked
- [x] Unit tests passed (Note: existing CI tests may fail due to unrelated bugs in `main`)
