### PR TITLE
fix : added unreachable code fix in registerDeviceToken deviceController

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -42,14 +42,13 @@ export async function registerDeviceToken(req, res, next) {
     }
 
     const tokenErr = validateFcmToken(fcmToken);
-    return res.status(400).json(
-      errorResponse(
-        'VALIDATION_ERROR',
-        tokenErr
-      )
-    );
     if (tokenErr) {
-      return next(new ValidationError(tokenErr));
+      return res.status(400).json(
+        errorResponse(
+          'VALIDATION_ERROR',
+          tokenErr
+        )
+      );
     }
 
     const platErr = validatePlatform(platform);


### PR DESCRIPTION
Closes #4702.

Summary of What Has Been Done:
In registerDeviceToken(), the validateFcmToken() result was checked for errors AFTER a return statement, making the if (tokenErr) block unreachable. This caused every token registration attempt — even with valid tokens — to return HTTP 400. The fix moves the 400 response inside the error-checking block so it is only returned when the token is actually invalid.

Changes Made:
- backend/api/src/controllers/deviceController.js: moved the tokenErr check before the return statement; the 400 response now only triggers for invalid tokens.

Impact it Made:
- Fixes broken FCM device registration so push notifications can be delivered to registered devices
- Valid tokens now proceed to the database upsert path correctly
- Backend unit tests pass (22 pre-existing failures on upstream main unchanged)

Note: This PR is submitted as part of GSSOC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device registration error handling by returning a clear HTTP 400 validation response when an invalid notification token is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->