### PR TITLE
fix : added logging when response.text() fails in osrm.js error handlers

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -6,7 +6,7 @@ import { measureExecution } from '../core/performanceMetrics.js';
 export const osrmBreaker = new CircuitBreaker(async (url, options) => {
   const response = await fetch(url, options);
   if (response.status >= 500) {
-    await response.text().catch(() => {});
+    await response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message));
     throw new Error(`[OSRM] Request failed (${response.status})`);
   }
   return response;
@@ -98,7 +98,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
 
       if (!response.ok) {
         clearTimeout(timeout);
-        await response.text().catch(() => {});
+        await response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message));
         if (response.status >= 500 && attempt < maxRetries - 1) {
           logger.warn({ status: response.status, attempt: attempt + 1, maxRetries }, 'Server error. Retrying...');
           await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
@@ -197,7 +197,7 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
       { signal: controller.signal },
     );
     if (!response.ok) {
-      await response.text().catch(() => {});
+      await response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message));
       return null;
     }
 


### PR DESCRIPTION
Closes #4703.

Summary of What Has Been Done:
Replaced three silent .catch(() => {}) patterns in osrm.js with .catch(err => logger.warn(...)). These were in error-handling paths where the response body was being discarded — any errors from the discard operation were silently swallowed. Now errors from reading error response bodies are logged with the OSRM service context.

Changes Made:
- backend/api/src/services/osrm.js: replaced 3 instances of response.text().catch(() => {}) with response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message))

Impact it Made:
- OSRM error response reading failures are now logged for production diagnostics
- No functional change to the routing behavior — only error visibility improves
- Backend unit tests pass (22 pre-existing failures on upstream main unchanged)

Note: This PR is submitted as part of GSSOC.