### PR TITLE
fix : normalized tripRoutes 200/202 responses to use {error} key

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -206,7 +206,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
 
   if (events.length === 0) {
     // Flutter expects 200 or 202 for success.
-    return res.status(200).json({ message: 'Empty batch received, nothing to process.' });
+    return res.status(200).json({ error: 'Empty batch received, nothing to process.' });
   }
 
   try {
@@ -222,7 +222,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
     if (existingBatch) {
       logger.info('[SyncEngine] Ignored duplicate batch:', idempotencyKey);
       // Return 202 Accepted so the Flutter app marks them as synced locally
-      return res.status(202).json({ message: 'Batch already processed.' });
+      return res.status(202).json({ error: 'Batch already processed.' });
     }
 
     // 2. Validate per-event-type payloads and strip sensitive fields


### PR DESCRIPTION
Closes #4704.

Summary of What Has Been Done:
In tripRoutes.js, two success responses used {message: ...} key instead of {error: ...}. The rest of the file already uses {error: ...} for all other HTTP responses. This inconsistency could break frontend error parsing for these two endpoints.

Changes Made:
- backend/api/src/routes/tripRoutes.js line 209: changed {message: ...} to {error: ...}
- backend/api/src/routes/tripRoutes.js line 225: changed {message: ...} to {error: ...}

Impact it Made:
- Consistent response format across all tripRoutes.js endpoints
- Frontend error parsing works uniformly for all trip route responses
- Backend unit tests pass (22 pre-existing failures on upstream main unchanged)

Note: This PR is submitted as part of GSSOC.