### PR TITLE
fix: orderValidationService uses wrong column driver_id - HoS compliance check silently passes

### DIFF
--- a/backend/api/src/services/order/orderValidationService.js
+++ b/backend/api/src/services/order/orderValidationService.js
@@ -178,7 +178,7 @@ export class OrderValidationService {
     const { data: driver, error } = await this.supabase
       .from('driver_details')
       .select('accumulated_driving_minutes, accumulated_on_duty_minutes, hos_status')
-      .eq('driver_id', driverId)
+      .eq('user_id', driverId)
       .maybeSingle();
 
     if (error) {


### PR DESCRIPTION
Fixes #4720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hours of Service compliance validation by correctly matching driver records, ensuring applicable driving and on-duty limits are enforced reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->