### PR TITLE
fix: ML services use deprecated sqlalchemy.ext.declarative - breaks with SQLAlchemy 2.x

### DIFF
--- a/backend/ml/services/ab_testing.py
+++ b/backend/ml/services/ab_testing.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime
 from typing import Dict, Any, Optional
 from sqlalchemy import create_engine, Column, String, Float, DateTime, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 import pandas as pd
 import json

--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 from sqlalchemy import create_engine, Column, String, Float, DateTime, Integer, Boolean
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 import tensorflow as tf
 from tensorflow import keras


### PR DESCRIPTION
Fixes #4727