### PR TITLE
fix: Driver app home_screen.dart missing closing brace in _completeRide

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -839,6 +839,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
     _loadDashboardMetrics();
   }
+}
 
   Future<void> _checkPendingPods() async {
     try {


### PR DESCRIPTION
Fixes #4730