### PR TITLE
fix: Driver app sync_service PoD sync double-try logic - marks POD synced even on upload failure

### DIFF
--- a/apps/driver/lib/services/sync_service.dart
+++ b/apps/driver/lib/services/sync_service.dart
@@ -50,14 +50,16 @@ class SyncService {
           await LocalDbService.instance.markPoDSynced(podId);
         } catch (e) {
           debugPrint('Failed to sync PoD $podId: $e');
-        try {
-          final stopId = pod['stop_id'] as String;
-          final tripId = pod['trip_display_id'] as String;
-          await _tripService.markStopCompleted(stopId, tripId);
-          await LocalDbService.instance.markPoDSynced(pod['id'] as int);
-        } catch (e) {
-          debugPrint('Failed to sync pod ${pod['id']}: $e');
         }
+      
+      // Retry stop completion even if upload fails
+      try {
+        final stopId = pod['stop_id'] as String;
+        final tripId = pod['trip_display_id'] as String;
+        await _tripService.markStopCompleted(stopId, tripId);
+        await LocalDbService.instance.markPoDSynced(pod['id'] as int);
+      } catch (e) {
+        debugPrint('Failed to sync pod ${pod['id']}: $e');
       }
       debugPrint('Sync completed for ${pendingPoDs.length} items.');
     } catch (e) {


### PR DESCRIPTION
Fixes #4732