### PR TITLE
fix: Driver app home_screen.dart unsafe cast on lastStop['drop_location'] - runtime crash

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -652,7 +652,7 @@ class _HomeScreenState extends State<HomeScreen> {
         
         if (stops.isNotEmpty) {
           final lastStop = stops.last;
-          final address = lastStop['drop_location'] as String;
+          final address = lastStop['drop_location'] as String? ?? '';
           await prefs.setString('cached_address', address);
           
           final dropPoint = await GeocodeService.resolvePlace(address);


### PR DESCRIPTION
Fixes #4733