### PR TITLE
fix: trace.service.js calls getTotalProducts/getTotalShipments - methods not in contract ABI

### DIFF
--- a/backend/traceability/trace.service.js
+++ b/backend/traceability/trace.service.js
@@ -44,7 +44,7 @@ class TraceabilityService {
             );
             const receipt = await tx.wait();
 
-            const productId = await this.contract.getTotalProducts();
+            const productId = await this.contract.getProductCount();
 
             await this.storeProduct({
                 ...productData,
@@ -77,7 +77,7 @@ class TraceabilityService {
             );
             const receipt = await tx.wait();
 
-            const shipmentId = await this.contract.getTotalShipments();
+            const shipmentId = await this.contract.getShipmentCount();
 
             await this.storeShipment({
                 productId,


### PR DESCRIPTION
Fixes #4741