### PR TITLE
fix: ZKP service generates invalid hex via Uint8Array.toString('hex')

### DIFF
--- a/backend/zkp/zkp.service.js
+++ b/backend/zkp/zkp.service.js
@@ -110,8 +110,8 @@ class ZKPService {
 
             return {
                 success: true,
-                proof: `0x${proof.toString('hex')}`,
-                publicInputs: `0x${publicInputs.toString('hex')}`,
+                proof: `0x${ethers.hexlify(proof)}`,
+                publicInputs: `0x${ethers.hexlify(publicInputs)}`,
                 timestamp: new Date().toISOString()
             };
         } catch (error) {


### PR DESCRIPTION
Fixes #4742