### PR TITLE
fix: cutomer_app ml_dashboard shows infinite loading spinner on non-200 API responses

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -32,6 +32,10 @@ class _MLDashboardState extends State<MLDashboard> {
           metrics = json.decode(response.body);
           isLoading = false;
         });
+      } else {
+        setState(() {
+          isLoading = false;
+        });
       }
     } catch (e) {
       setState(() {


### PR DESCRIPTION
Fixes #4754