### PR TITLE
fix: race condition in tracker.js - flushMutex released before async insert

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -819,8 +819,6 @@ async function flushTelemetryBuffer() {
   telemetryFlushBuffer = [];
   telemetryWriteBuffer.clear();
 
-  flushMutex = false;
-
   if (recordsToFlush.length === 0) {
     flushMutex = false;
     return;


### PR DESCRIPTION
Fixes #4764