### PR TITLE
fix: clear profiles.fcm_token in unregisterAllDeviceTokens (#4450)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -200,6 +200,21 @@ export async function unregisterAllDeviceTokens(userId) {
     logger.error('[DeviceController] Failed to unregister device tokens:', error.message);
     throw error;
   }
+
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({
+      fcm_token: null,
+      fcm_token_updated_at: new Date().toISOString(),
+    })
+    .eq('id', userId);
+
+  if (profileError) {
+    logger.error(
+      '[DeviceController] Device tokens removed but failed to clear profiles.fcm_token:',
+      profileError.message
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
unregisterAllDeviceTokens deleted user_devices rows but did not clear profiles.fcm_token, leaving stale tokens that could still receive push notifications after logout/account deletion.

Add profile clearing to match the single-device unregisterDeviceToken behavior.

Closes #4450

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device sign-out cleanup by clearing saved notification tokens when all registered devices are removed.
  * Prevented stale notification credentials from remaining after device token unregistration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->