### PR TITLE
fix: remove broken relative imports and unused variables in startup_event (#4821)

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -92,10 +92,6 @@ app.add_middleware(
 @app.on_event("startup")
 async def startup_event():
     from app.models.base import preload_all_models
-    import sys
-    from .models.base import load_model, preload_all_models
-    from .models.demand_forecast import MODEL_NAME as DEMAND_MODEL_NAME
-    from .models.price_prediction import MODEL_NAME as PRICE_MODEL_NAME
     
     logger.info("ML Engine starting, pre-loading models...")
     persisted_models = await preload_all_models()


### PR DESCRIPTION
startup_event mixed absolute and relative imports. Relative imports (from .models.base) raise ImportError when main.py is run as a top-level module. Also removed unused imports and duplicate preload_all_models.

Closes #4821

GSSoC