### PR TITLE
fix: use RELAYER_WALLET_PRIVATE_KEY in ZKP service constructor (#4822)

### DIFF
--- a/backend/zkp/zkp.service.js
+++ b/backend/zkp/zkp.service.js
@@ -7,7 +7,7 @@ import { supabase } from '../../api/src/config/db.js';
 class ZKPService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
-        this.wallet = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider);
+        this.wallet = new ethers.Wallet(process.env.RELAYER_WALLET_PRIVATE_KEY, this.provider);
         this.zkpAddress = process.env.ZKP_CONTRACT_ADDRESS;
 
         this.zkpABI = [


### PR DESCRIPTION
The ZKP service referenced process.env.PRIVATE_KEY which is never set. The rest of the codebase uses RELAYER_WALLET_PRIVATE_KEY (defined in .env.example, used in escrow.js and reputation.js). This caused ethers.Wallet to throw on construction, crashing the ZKP service.

Closes #4822

GSSoC