### PR TITLE
fix: use RELAYER_WALLET_PRIVATE_KEY in state channel service (#4823)

### DIFF
--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -5,7 +5,7 @@ import { supabase } from '../../api/src/config/db.js';
 class StateChannelService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
-        this.wallet = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider);
+        this.wallet = new ethers.Wallet(process.env.RELAYER_WALLET_PRIVATE_KEY, this.provider);
         this.channelAddress = process.env.STATE_CHANNEL_ADDRESS;
 
         this.channelABI = [


### PR DESCRIPTION
The state channel service referenced process.env.PRIVATE_KEY which is never set. The rest of the codebase uses RELAYER_WALLET_PRIVATE_KEY. This caused ethers.Wallet to throw on construction, crashing the state channel service.

Closes #4823

GSSoC