### PR TITLE
fix: use cached values in getChannelStats and filter nulls (#4824)

### DIFF
--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -283,8 +283,8 @@ class StateChannelService {
 
     async getChannelStats() {
         const channels = [];
-        for (const [id, _] of this.channelCache) {
-            channels.push(await this.getChannel(id));
+        for (const [id, cached] of this.channelCache) {
+            if (cached) channels.push(cached);
         }
 
         return {


### PR DESCRIPTION
getChannelStats called this.getChannel(id) for entries already in the cache, which can return null when on-chain queries fail. The null values caused TypeError on property access. Use cached values directly and filter out null entries.

Closes #4824

GSSoC