### PR TITLE
fix: share encryption key between federated server and client (#4825)

### DIFF
--- a/backend/ml/federated/federated_client.py
+++ b/backend/ml/federated/federated_client.py
@@ -52,16 +52,10 @@ class FederatedClient:
         """Register client with server"""
         self.redis.sadd('federated:clients', self.client_id)
         
-        # Set encryption key if not exists
-        if not self.redis.exists(f'federated:key:{self.client_id}'):
-            key = Fernet.generate_key()
-            self.redis.setex(
-                f'federated:key:{self.client_id}',
-                86400 * 7,  # 7 days
-                key
-            )
-        
-        self.encryption_key = self.redis.get(f'federated:key:{self.client_id}')
+        self.encryption_key = self.redis.get('federated:encryption_key')
+        if not self.encryption_key:
+            logger.warning('No server encryption key found in Redis; federated weight exchange will fail')
+            return
         self.cipher = Fernet(self.encryption_key)
     
     def _subscribe_updates(self):

--- a/backend/ml/federated/federated_server.py
+++ b/backend/ml/federated/federated_server.py
@@ -25,6 +25,7 @@ class FederatedServer:
         self.clients_per_round = 5
         self.encryption_key = Fernet.generate_key()
         self.cipher = Fernet(self.encryption_key)
+        self.redis.setex('federated:encryption_key', 86400, self.encryption_key)
         
         # Differential Privacy settings
         self.dp_noise_scale = 0.01


### PR DESCRIPTION
The server and client each generated independent Fernet keys. When the server encrypted model weights, the client could not decrypt them (and vice versa). Server now stores its key in Redis and the client retrieves it.

Closes #4825

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Federated learning clients now use a shared server-managed encryption key for secure communication.
  * Encryption keys are securely stored for up to 24 hours to support client connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->