### PR TITLE
fix: protect GraphQL order mutations

### DIFF
--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -5,6 +5,19 @@ import { gql } from 'graphql-tag';
 import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
 
+const ADMIN_ROLES = new Set(['ADMIN', 'admin']);
+
+function requireUser(user) {
+    if (!user?.id) {
+        throw new Error('Authentication required');
+    }
+    return user;
+}
+
+function isAdmin(user) {
+    return ADMIN_ROLES.has(user?.role);
+}
+
 const typeDefs = gql`
     extend type Query {
         order(id: ID!): Order
@@ -132,10 +145,13 @@ const resolvers = {
     },
     Mutation: {
         createOrder: async (_, { input }, { user }) => {
+            const currentUser = requireUser(user);
+            const customerId = isAdmin(currentUser) ? input.customerId : currentUser.id;
+
             const { data, error } = await supabase
                 .from('orders')
                 .insert([{
-                    customer_id: input.customerId,
+                    customer_id: customerId,
                     pickup: input.pickup,
                     dropoff: input.dropoff,
                     weight: input.weight,
@@ -152,33 +168,48 @@ const resolvers = {
             return data;
         },
         updateOrder: async (_, { id, input }, { user }) => {
-            const { data, error } = await supabase
+            const currentUser = requireUser(user);
+            const updates = {
+                status: input.status,
+                pickup: input.pickup || undefined,
+                dropoff: input.dropoff || undefined,
+                updated_at: new Date().toISOString()
+            };
+
+            if (isAdmin(currentUser)) {
+                updates.driver_id = input.driverId || undefined;
+            }
+
+            let query = supabase
                 .from('orders')
-                .update({
-                    status: input.status,
-                    pickup: input.pickup || undefined,
-                    dropoff: input.dropoff || undefined,
-                    driver_id: input.driverId || undefined,
-                    updated_at: new Date().toISOString()
-                })
-                .eq('id', id)
-                .select()
-                .single();
+                .update(updates)
+                .eq('id', id);
+
+            if (!isAdmin(currentUser)) {
+                query = query.eq('customer_id', currentUser.id);
+            }
+
+            const { data, error } = await query.select().single();
             
             if (error) throw error;
             return data;
         },
         cancelOrder: async (_, { id, reason }, { user }) => {
-            const { data, error } = await supabase
+            const currentUser = requireUser(user);
+            let query = supabase
                 .from('orders')
                 .update({
                     status: 'CANCELLED',
                     cancellation_reason: reason,
                     updated_at: new Date().toISOString()
                 })
-                .eq('id', id)
-                .select()
-                .single();
+                .eq('id', id);
+
+            if (!isAdmin(currentUser)) {
+                query = query.eq('customer_id', currentUser.id);
+            }
+
+            const { data, error } = await query.select().single();
             
             if (error) throw error;
             return data;


### PR DESCRIPTION
## Summary
- require authenticated context for order mutations
- derive customer ownership from the current user for customer order creation
- scope update and cancel mutations to the owner, with driver assignment limited to admins

Closes #4836

## Validation
- node --check backend/graphql/services/order.service.js