### PR TITLE
fix: replace undefined hybrid_key with self.classical_key.public_key() (#4826)

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -44,7 +44,7 @@ class HybridCrypto:
         # Combine keys
         hybrid_keys = {
             'classical': {
-                'public': hybrid_key['classical']['public'],
+                'public': self.classical_key.public_key(),
                 'private': self.classical_key
             },
             'quantum': self.quantum_key,


### PR DESCRIPTION
generate_hybrid_keypair referenced undefined variable hybrid_key when building the classical public key entry. This caused NameError on every call. Replace with self.classical_key.public_key().

Closes #4826

GSSoC