### PR TITLE
fix: forward GraphQL auth context

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -37,7 +37,17 @@ class GraphQLGateway {
             buildService({ name, url }) {
                 return new RemoteGraphQLDataSource({
                     url,
-                    willSendRequest({ request }) {
+                    willSendRequest({ request, context }) {
+                        const authorization = context?.headers?.authorization;
+                        if (authorization) {
+                            request.http.headers.set('authorization', authorization);
+                        }
+
+                        if (context?.user?.id) {
+                            request.http.headers.set('x-user-id', context.user.id);
+                            request.http.headers.set('x-user-role', context.user.role || 'CUSTOMER');
+                        }
+
                         logger.debug(`GraphQL ${name} request sent`);
                     },
                 });


### PR DESCRIPTION
## Summary
- forward incoming authorization headers from the gateway to subgraphs
- attach verified user id and role headers when token verification succeeds
- keep the existing request logging behavior intact

Closes #4838

## Validation
- node --check backend/graphql/gateway/index.js