### PR TITLE
fix: map GraphQL driver rows

### DIFF
--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -5,6 +5,19 @@ import { gql } from 'graphql-tag';
 import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
 
+function mapDriver(row) {
+    if (!row) return row;
+
+    return {
+        ...row,
+        userId: row.userId ?? row.user_id,
+        truckType: row.truckType ?? row.truck_type,
+        truckNumber: row.truckNumber ?? row.truck_number,
+        currentLocation: row.currentLocation ?? row.current_location,
+        tripsCompleted: row.tripsCompleted ?? row.trips_completed,
+    };
+}
+
 const typeDefs = gql`
     extend type Query {
         driver(id: ID!): Driver
@@ -76,7 +89,7 @@ const resolvers = {
                 .single();
             
             if (error) throw error;
-            return data;
+            return mapDriver(data);
         },
         drivers: async (_, { available, location }) => {
             let query = supabase.from('drivers').select('*');
@@ -95,7 +108,7 @@ const resolvers = {
             
             const { data, error } = await query;
             if (error) throw error;
-            return data;
+            return data.map(mapDriver);
         },
         nearbyDrivers: async (_, { lat, lng, radius = 10 }) => {
             const { data, error } = await supabase
@@ -108,7 +121,7 @@ const resolvers = {
                 .eq('status', 'AVAILABLE');
             
             if (error) throw error;
-            return data;
+            return data.map(mapDriver);
         }
     },
     Mutation: {
@@ -127,7 +140,7 @@ const resolvers = {
                 .single();
             
             if (error) throw error;
-            return data;
+            return mapDriver(data);
         },
         assignDriver: async (_, { orderId, driverId }) => {
             const { data, error } = await supabase
@@ -156,7 +169,7 @@ const resolvers = {
                 .single();
             
             if (error) throw error;
-            return data;
+            return mapDriver(data);
         }
     }
 };


### PR DESCRIPTION
## Summary
- normalize Supabase driver rows before returning them from GraphQL resolvers
- expose camelCase fields expected by the Driver schema
- apply the mapper to driver query and mutation results

Closes #4840

## Validation
- node --check backend/graphql/services/driver.service.js