### PR TITLE
fix: use same shared secret derivation in decapsulate as encapsulate (#4827)

### DIFF
--- a/backend/pqc/kyber.py
+++ b/backend/pqc/kyber.py
@@ -140,7 +140,7 @@ class KyberKEM:
         
         # Derive shared secret
         shared_secret = hashlib.sha256(
-            np.concatenate([u.flatten(), v.flatten(), result.flatten()]).tobytes()
+            np.concatenate([u.flatten(), v.flatten()]).tobytes()
         ).digest()
         
         return shared_secret


### PR DESCRIPTION
encapsulate derived the shared secret from SHA-256(u || v) while decapsulate used SHA-256(u || v || result). The different input lengths meant the KEM always produced mismatched keys. Align decapsulate with the standard spec.

Closes #4827

GSSoC