### PR TITLE
fix: allow FCM initialization retry

### DIFF
--- a/packages/truxify_shared/lib/src/services/fcm_service.dart
+++ b/packages/truxify_shared/lib/src/services/fcm_service.dart
@@ -58,8 +58,6 @@ class FcmService {
       debugPrint('[FCM] Already initialized, skipping.');
       return;
     }
-    _initialized = true;
-
     try {
       final messaging = FirebaseMessaging.instance;
 
@@ -95,7 +93,9 @@ class FcmService {
 
       // ── Tap on background notification ──
       FirebaseMessaging.onMessageOpenedApp.listen(_handleNotificationTap);
+      _initialized = true;
     } catch (e) {
+      _initialized = false;
       debugPrint('[FCM] Initialization or registration failed: $e');
     }
   }


### PR DESCRIPTION
## Summary
- stop marking FCM initialization complete before setup succeeds
- set the initialized flag only after listener setup and token registration complete
- reset the flag on setup failure so the next startup can retry

Closes #4842

## Validation
- Not run locally: Dart SDK is not available on PATH in this shell