### PR TITLE
fix: catch latest image tags in OPA policy

### DIFF
--- a/k8s/opa/policies/security.rego
+++ b/k8s/opa/policies/security.rego
@@ -3,8 +3,17 @@ package security
 
 # Deny if image tag is latest
 deny[msg] {
-    input.review.object.spec.containers[_].image == "latest"
+    image := input.review.object.spec.containers[_].image
+    image_uses_latest_tag(image)
     msg = "Image tag 'latest' is not allowed. Use specific version tags."
+}
+
+image_uses_latest_tag(image) {
+    image == "latest"
+}
+
+image_uses_latest_tag(image) {
+    endswith(image, ":latest")
 }
 
 # Deny if privileged container


### PR DESCRIPTION
## Summary
- update the security policy to detect images tagged with :latest
- keep the existing bare latest check for completeness
- centralize latest-tag detection in a helper rule for future policy tests

Closes #4844

## Validation
- Reviewed diff locally
- Not run locally: OPA CLI is not available on PATH in this shell