### PR TITLE
fix: remove unnecessary async from initializePools in ShardManager (#4829)

### DIFF
--- a/backend/api/src/services/sharding/ShardManager.js
+++ b/backend/api/src/services/sharding/ShardManager.js
@@ -66,7 +66,7 @@ class ShardManager {
     this.initializePools();
   }
 
-  async initializePools() {
+  initializePools() {
     for (const [name, config] of this.shards) {
       try {
         config.pool = new Pool({


### PR DESCRIPTION
initializePools was declared async but called without await from initializeShards (called from the non-async constructor). The returned Promise was silently dropped, meaning errors inside the function were swallowed. Pool() is synchronous so async is unnecessary.

Closes #4829

GSSoC