### PR TITLE
fix: add end anchor to withdrawal amount input filter regex

### DIFF
--- a/apps/driver/lib/widgets/earnings/withdraw_bottom_sheet.dart
+++ b/apps/driver/lib/widgets/earnings/withdraw_bottom_sheet.dart
@@ -283,7 +283,7 @@ class _WithdrawBottomSheetState extends State<WithdrawBottomSheet> {
       focusNode: _amountFocusNode,
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
       inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'^\d*\.?\d{0,2}')),
+        FilteringTextInputFormatter.allow(RegExp(r'^\d*\.?\d{0,2}$')),
       ],
       onChanged: (_) => setState(() {
         _serverError = null;


### PR DESCRIPTION
## Summary
Adds `$` end anchor to the withdrawal amount input filter regex.

## Problem
The regex `^\d*\.?\d{0,2}` had no `$` anchor, so `FilteringTextInputFormatter.allow` permitted trailing non-numeric characters (e.g., `"12abc"` matched because the prefix `"12"` was valid).

## Fix
Added `$` end anchor: `^\d*\.?\d{0,2}$`

## Testing
- Driver app compiles successfully
- Only valid numeric strings are accepted in the withdrawal amount field

Closes #4866

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal amount validation to accept only valid numeric values with up to two decimal places.
  * Prevented additional trailing characters from being entered in the withdrawal amount field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->