### PR TITLE
fix: handle null drop_location in HomeScreen _loadActiveTrip

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -652,25 +652,26 @@ class _HomeScreenState extends State<HomeScreen> {
         
         if (stops.isNotEmpty) {
           final lastStop = stops.last;
-          final address = lastStop['drop_location'] as String;
-          await prefs.setString('cached_address', address);
+          final address = (lastStop['drop_location'] as String?) ?? '';
+          if (address.isNotEmpty) {
+            await prefs.setString('cached_address', address);
           
-          final dropPoint = await GeocodeService.resolvePlace(address);
-          if (dropPoint != null) {
-            await prefs.setDouble('cached_drop_lat', dropPoint.latitude);
-            await prefs.setDouble('cached_drop_lng', dropPoint.longitude);
-          }
+            final dropPoint = await GeocodeService.resolvePlace(address);
+            if (dropPoint != null) {
+              await prefs.setDouble('cached_drop_lat', dropPoint.latitude);
+              await prefs.setDouble('cached_drop_lng', dropPoint.longitude);
+            }
           
-          if (dropPoint != null && mounted) {
-            setState(() {
-              _destination = DestinationPickResult(address: address, point: dropPoint);
-              final routePoints = <ll.LatLng>[_currentLocation ?? dropPoint, dropPoint];
-              _routeFuture = RouteService.fetchRouteGeoJson(routePoints).onError(
-                (_, __) => routePoints,
-              );
-            });
+            if (dropPoint != null && mounted) {
+              setState(() {
+                _destination = DestinationPickResult(address: address, point: dropPoint);
+                final routePoints = <ll.LatLng>[_currentLocation ?? dropPoint, dropPoint];
+                _routeFuture = RouteService.fetchRouteGeoJson(routePoints).onError(
+                  (_, __) => routePoints,
+                );
+              });
+            }
           }
-        }
       } else {
         final prefs = await SharedPreferences.getInstance();
         await prefs.remove('cached_trip_id');


### PR DESCRIPTION
## Summary
Handles null `drop_location` in `HomeScreen._loadActiveTrip()` to prevent active trip disappearing.

## Problem
`lastStop['drop_location'] as String` threw `TypeError` when the value was null. The outer `try/catch` silently caught this, aborting `_loadActiveTrip` — the driver saw no active trip even though one existed.

## Fix
Changed to `(lastStop['drop_location'] as String?) ?? ''` with an `isNotEmpty` guard.

## Testing
- Driver app compiles successfully
- Active trip displays correctly even when a stop has null drop_location

Closes #4867

GSSoC
