### PR TITLE
fix: use order's own cargo details in rebook instead of hardcoded values

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -594,11 +594,11 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                   pickup: pickup,
                   drop: drop,
                   dateLabel: _currentOrder.date,
-                  goodsType: 'Textile',
-                  weightTonnes: '3',
-                  dimensions: '12 × 6 × 6',
-                  stacked: true,
-                  fragile: false,
+                  goodsType: _currentOrder.goodsType ?? 'General',
+                  weightTonnes: _currentOrder.weightTonnes ?? '0',
+                  dimensions: _currentOrder.dimensions ?? '',
+                  stacked: _currentOrder.isStackable ?? true,
+                  fragile: _currentOrder.isFragile ?? false,
                   requirements: _currentOrder.specialRequirements != null && _currentOrder.specialRequirements!.isNotEmpty
           ? [_currentOrder.specialRequirements!]
           : const [],


### PR DESCRIPTION
## Summary
Replaces hardcoded cargo details in "Rebook This Route" with the order's actual values.

## Problem
The rebook button pre-filled goodsType as "Textile", weight as "3", dimensions as "12 × 6 × 6" regardless of the original order. Rebooking a "Electronics" order would incorrectly search for Textile trucks.

## Fix
Uses `_currentOrder.goodsType`, `weightTonnes`, `dimensions`, `isStackable`, and `isFragile` with sensible defaults.

## Testing
- Customer app compiles successfully

Closes #4868

GSSoC
