### PR TITLE
fix: reset saving state on error in PaymentMethodsScreen._submit

### DIFF
--- a/apps/customer/lib/screens/payment_methods_screen.dart
+++ b/apps/customer/lib/screens/payment_methods_screen.dart
@@ -353,17 +353,21 @@ class _AddPaymentSheetState extends State<_AddPaymentSheet> {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _saving = true);
 
-    final method = PaymentMethod(
-      id: '',
-      userId: SupabaseService.requireUserId(),
-      methodType: _selectedType,
-      displayLabel: _labelCtrl.text.trim(),
-      provider:
-          _providerCtrl.text.trim().isEmpty ? null : _providerCtrl.text.trim(),
-      isDefault: _setAsDefault,
-    );
+    try {
+      final method = PaymentMethod(
+        id: '',
+        userId: SupabaseService.requireUserId(),
+        methodType: _selectedType,
+        displayLabel: _labelCtrl.text.trim(),
+        provider:
+            _providerCtrl.text.trim().isEmpty ? null : _providerCtrl.text.trim(),
+        isDefault: _setAsDefault,
+      );
 
-    Navigator.of(context).pop(method);
+      Navigator.of(context).pop(method);
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
Resets the "Saving..." button state when `requireUserId()` throws an error.

## Problem
`_submit()` sets `_saving = true` then calls `SupabaseService.requireUserId()`. If that throws (e.g. expired session, signed out user), the bottom sheet stays open with the button permanently disabled on "Saving...".

## Fix
Wrapped the `PaymentMethod` construction and `Navigator.pop` in `try/catch`. On failure, `_saving` is reset to `false`.

## Testing
- Customer app compiles successfully

Closes #4869

GSSoC
