### PR TITLE
fix: extract hardcoded 8400 heatmap threshold to named constant

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -18,6 +18,8 @@ class EarningsScreen extends StatefulWidget {
 }
 
 class _EarningsScreenState extends State<EarningsScreen> {
+  static const double _heatmapMaxDailyEarnings = 8400.0;
+
   final DriverEarningsService _earningsService = DriverEarningsService();
   final EarningsExportService _exportService = EarningsExportService();
 
@@ -823,7 +825,7 @@ class _EarningsScreenState extends State<EarningsScreen> {
               FontWeight textWeight = FontWeight.normal;
 
               if (earnings > 0) {
-                final double scale = (earnings / 8400.0).clamp(0.0, 1.0);
+                final double scale = (earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0);
                 final double opacity = 0.15 + (scale * 0.75);
                 cellBgColor = TruxifyColors.accent.withValues(alpha: opacity);
 
@@ -876,7 +878,7 @@ class _EarningsScreenState extends State<EarningsScreen> {
                         fontWeight: isSelected ? FontWeight.bold : textWeight,
                         color: isSelected
                             ? (earnings > 0 &&
-                                    (0.15 + (earnings / 8400.0) * 0.75) > 0.6
+                                    (0.15 + (earnings / _heatmapMaxDailyEarnings) * 0.75) > 0.6
                                 ? Colors.white
                                 : TruxifyColors.accent)
                             : textColor,


### PR DESCRIPTION
## Summary
Extracts hardcoded `8400.0` heatmap threshold to a named constant.

## Problem
The daily earnings heatmap used a magic number `8400.0` in two separate locations for color intensity scaling. If the expected max daily earnings changes, both must be manually updated.

## Fix
Extracted to `_heatmapMaxDailyEarnings` constant at the top of `_EarningsScreenState`.

## Testing
- Driver app compiles successfully

Closes #4876

GSSoC
