### PR TITLE
fix: add mounted check before setState after async API call in ProfileScreen

### DIFF
--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -245,6 +245,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             'wallet_address': address,
                           },
                         );
+                        if (!mounted) return;
                         setState(() {
                           _walletAddress = address;
                         });


### PR DESCRIPTION
## Summary
Adds missing `mounted` check before `setState` after async API call in ProfileScreen.

## Problem
After `await apiClient.put(...)`, `setState` was called without a `mounted` guard. If the widget unmounted during the API call, this threw a Flutter error.

## Fix
Added `if (!mounted) return;` before `setState`.

## Testing
- Customer app compiles successfully

Closes #4878

GSSoC
