### PR TITLE
fix: show last 5 trips in fuel analytics chart instead of first 5

### DIFF
--- a/apps/driver/lib/services/fuel_analytics_service.dart
+++ b/apps/driver/lib/services/fuel_analytics_service.dart
@@ -36,7 +36,8 @@ class FuelAnalyticsService {
 
       // Provide sample points for a chart (last 5 trips)
       final chartPoints = <Map<String, dynamic>>[];
-      for (int i = 0; i < trips.length && i < 5; i++) {
+      final startIndex = trips.length > 5 ? trips.length - 5 : 0;
+      for (int i = startIndex; i < trips.length; i++) {
         final t = trips[i];
         final numDist = double.tryParse(t['distance']?.toString().replaceAll(RegExp(r'[^0-9.]'), '') ?? '0') ?? 0;
         final numEarn = double.tryParse(t['earnings']?.toString().replaceAll(RegExp(r'[^0-9.]'), '') ?? '0') ?? 0;


### PR DESCRIPTION
## Summary
Shows last 5 trips in fuel analytics chart instead of first 5.

## Problem
The chart loop iterated from index 0, displaying the 5 oldest trips instead of the 5 most recent. The comment said "last 5 trips" but the code took the first 5.

## Fix
Start the loop from `trips.length - 5` when there are more than 5 trips.

## Testing
- Driver app compiles successfully

Closes #4880

GSSoC
