### PR TITLE
fix : added logger.warn for silent .catch in osrm.js response body handling

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -6,7 +6,7 @@ import { measureExecution } from '../core/performanceMetrics.js';
 export const osrmBreaker = new CircuitBreaker(async (url, options) => {
   const response = await fetch(url, options);
   if (response.status >= 500) {
-    await response.text().catch(() => {});
+    await response.text().catch((err) => { logger.warn("[osrm] Failed to consume response body", err); });
     throw new Error(`[OSRM] Request failed (${response.status})`);
   }
   return response;
@@ -98,7 +98,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
 
       if (!response.ok) {
         clearTimeout(timeout);
-        await response.text().catch(() => {});
+        await response.text().catch((err) => { logger.warn("[osrm] Failed to consume response body", err); });
         if (response.status >= 500 && attempt < maxRetries - 1) {
           logger.warn({ status: response.status, attempt: attempt + 1, maxRetries }, 'Server error. Retrying...');
           await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
@@ -197,7 +197,7 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
       { signal: controller.signal },
     );
     if (!response.ok) {
-      await response.text().catch(() => {});
+      await response.text().catch((err) => { logger.warn("[osrm] Failed to consume response body", err); });
       return null;
     }
 


### PR DESCRIPTION
Closing this PR. The fix has been incorporated into PR #4894 which contains all ESLint and test fixes consolidated.