### PR TITLE
Refactor bin packing logic and improve validation

### DIFF
--- a/backend/ml/app/models/bin_packing.py
+++ b/backend/ml/app/models/bin_packing.py
@@ -62,6 +62,14 @@ class _Shelf:
         return None
 
     def _fit(self, l: float, w: float, h: float, rotated: bool) -> dict | None:
+        # An item taller than the shelf's remaining vertical clearance can
+        # never be placed here, regardless of how it fits in x/y — checking
+        # this first prevents placements that would overflow the truck's
+        # ceiling (or the shelf above) once shelf_height grows past
+        # max_height.
+        if h > self.max_height:
+            return None
+
         # Does it fit in the remaining row?
         if self.cursor_x + l <= self.max_length and self.cursor_y + w <= self.max_width:
             pos = {"x": self.cursor_x, "y": self.cursor_y, "z": self.z_bottom}
@@ -150,7 +158,7 @@ def _pack_packages(
         if not placed:
             # Open a new shelf
             z_offset = sum(s.shelf_height for s in shelves)
-            if z_offset + ph > truck_h:
+            if z_offset + pkg_height > truck_h:
                 arrangements[idx] = {
                     "package_index": idx,
                     "position": {"x": 0.0, "y": 0.0, "z": 0.0},
@@ -161,7 +169,7 @@ def _pack_packages(
                 continue
 
             new_shelf = _Shelf(z_offset, truck_l, truck_w, truck_h - z_offset)
-            pos = new_shelf.try_place(pl, pw, ph)
+            pos = new_shelf.try_place(pkg_length, pkg_width, pkg_height)
             if pos is not None:
                 arrangements[idx] = {
                     "package_index": idx,
@@ -267,6 +275,10 @@ def optimise_packing(
             "utilization_pct": 0.0,
         }
 
+    if not delivery_addresses and packages:
+        raise ValueError(
+            "delivery_addresses must contain at least one address when packages are provided"
+        )
     if len(delivery_addresses) < len(packages):
         logger.warning(
             "Fewer delivery addresses (%d) than packages (%d); "


### PR DESCRIPTION
### Problem
`_Shelf._fit()` stored `max_height` but never checked an item's height
against it. Only the *first* item on a shelf was height-checked (in
`_pack_packages`, when the shelf is created); every later item placed on the
same shelf via `try_place()` skipped that check entirely.

### Fix
Added a guard at the top of `_Shelf._fit()`:
```python
if h > self.max_height:
    return None
```
This rejects any item taller than the shelf's remaining vertical clearance
before attempting row/column placement, so `shelf_height` can never grow
past `max_height`, and downstream `z_offset` calculations for later shelves
stay correct.

### Impact
Prevents `optimise_packing()` from returning packing plans where an item's
`z` position + height physically overflows the truck bed, and keeps
`utilization_pct` accurate.

### Testing
- Verified a shelf with `max_height=1.5` now rejects a 2.0m-tall item via
  `try_place()`, correctly falling through to a new shelf.
- Existing packing scenarios (uniform-height items) are unaffected since
  `h <= max_height` was already implicitly true for the first item on every
  shelf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D package packing to prevent items from exceeding available shelf height.
  * Corrected package dimension handling during shelf creation for more reliable placement.
  * Added validation requiring delivery addresses when packages are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->