### PR TITLE
fix: add mounted check in chat screen broadcast callback

### DIFF
--- a/apps/customer/lib/screens/chat_screen.dart
+++ b/apps/customer/lib/screens/chat_screen.dart
@@ -37,7 +37,7 @@ class _ChatScreenState extends State<ChatScreen> {
         event: 'message',
         callback: (payload) {
           final data = payload;
-          if (data['senderId'] != _myUserId) {
+          if (data['senderId'] != _myUserId && mounted) {
             setState(() {
               _messages.insert(0, {
                 'text': data['text'],


### PR DESCRIPTION
## Summary
Adds `mounted` check in chat screen broadcast callback.

## Problem
The Supabase broadcast callback called `setState` without checking `mounted`. If the user navigated away while the channel was still subscribed, the callback fired on a disposed widget.

## Fix
Added `&& mounted` to the callback condition.

## Testing
- Customer app compiles successfully

Closes #4909

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat stability by preventing updates to the chat screen after it has been closed.
  * Reduced the risk of errors when incoming messages arrive during screen transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->