### PR TITLE
fix: safely convert currentStop id to String in _completeRide

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -813,7 +813,7 @@ class _HomeScreenState extends State<HomeScreen> {
       final stops = await _tripService.fetchTripStops(_activeTripId!);
       final currentStop = stops.where((s) => s['is_current'] == true).firstOrNull;
       if (currentStop != null) {
-        await _tripService.markStopCompleted(currentStop['id'], _activeTripId!);
+        await _tripService.markStopCompleted(currentStop['id'].toString(), _activeTripId!);
       }
     } catch (e) {
       if (mounted) {


### PR DESCRIPTION
## Summary
Safely converts `currentStop['id']` to String in `_completeRide`.

## Problem
`currentStop['id']` was passed as `dynamic` to `markStopCompleted` which expects `String`. If the value was null or a non-string type, this would crash.

## Fix
Added `.toString()` for safe conversion.

## Testing
- Driver app compiles successfully

Closes #4910

GSSoC
