### PR TITLE
fix: use double.tryParse instead of double.parse in truck results _eta

### DIFF
--- a/apps/customer/lib/screens/truck_results_screen.dart
+++ b/apps/customer/lib/screens/truck_results_screen.dart
@@ -138,10 +138,10 @@ class _TruckResultsScreenState extends State<TruckResultsScreen> {
 
   double _eta(String eta) {
     if (eta.contains('mins')) {
-      return double.parse(eta.replaceAll('mins', '').trim());
+      return double.tryParse(eta.replaceAll('mins', '').trim()) ?? double.infinity;
     }
     if (eta.contains('hrs')) {
-      return double.parse(eta.replaceAll('hrs', '').trim()) * 60;
+      return (double.tryParse(eta.replaceAll('hrs', '').trim()) ?? 0) * 60;
     }
     return double.infinity;
   }


### PR DESCRIPTION
## Summary
Uses `double.tryParse` instead of `double.parse` in truck results `_eta`.

## Problem
`double.parse` threw `FormatException` on unexpected ETA format (empty string, stray whitespace). The `_price` method already used `int.tryParse` safely.

## Fix
Changed to `double.tryParse` with `double.infinity` fallback.

## Testing
- Customer app compiles successfully

Closes #4911

GSSoC
