### PR TITLE
fix: clean up subscriptions on auth rejection in LocationService

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -347,7 +347,7 @@ class LocationService {
           debugPrint('[LocationService] WebSocket closed (code: $_lastCloseCode)');
           if (_lastCloseCode == 4001 || _lastCloseCode == 4003) {
             debugPrint('[LocationService] Auth rejected (code $_lastCloseCode) — not reconnecting');
-            _isTracking = false;
+            stopTracking();
             return;
           }
           _scheduleReconnect();


### PR DESCRIPTION
## Summary
Cleans up subscriptions on auth rejection in LocationService.

## Problem
When WebSocket closed with auth rejection codes 4001/4003, only `_isTracking` was set to `false`. Position subscription, timers, and heartbeat were left running, wasting resources.

## Fix
Changed to call `stopTracking()` for proper cleanup.

## Testing
- Driver app compiles successfully

Closes #4912

GSSoC
