### PR TITLE
fix: use computed proposal state in onlyActiveProposal modifier

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -103,7 +103,7 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
     }
 
     modifier onlyActiveProposal(uint256 proposalId) {
-        require(proposals[proposalId].state == ProposalState.ACTIVE, "Proposal not active");
+        require(getProposalState(proposalId) == ProposalState.ACTIVE, "Proposal not active");
         _;
     }
 
@@ -196,7 +196,7 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
         uint256 votingPower = members[msg.sender].votingPower;
         require(votingPower > 0, "No voting power");
         require(!hasVoted[proposalId][msg.sender], "Already voted");
-        require(proposals[proposalId].state == ProposalState.ACTIVE, "Proposal not active");
+        require(getProposalState(proposalId) == ProposalState.ACTIVE, "Proposal not active");
 
         Proposal storage proposal = proposals[proposalId];
 


### PR DESCRIPTION
Closes #4922

This PR fixes the DAO governance system where proposals could never reach ACTIVE state. The onlyActiveProposal modifier and castVote function were checking the stored state field (permanently stuck at PENDING) instead of the dynamically computed state from getProposalState().

Changes:
- lockchain/contracts/DAO.sol:106 — Changed onlyActiveProposal to use getProposalState(proposalId) instead of proposals[proposalId].state
- lockchain/contracts/DAO.sol:199 — Changed explicit check in castVote to use getProposalState(proposalId)

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proposal activity checks when casting votes and executing actions.
  * Ensured proposal state is evaluated consistently through the standard state-checking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->