### PR TITLE
fix: add missing closing brace and retry file upload in sync_service

### DIFF
--- a/apps/driver/lib/services/sync_service.dart
+++ b/apps/driver/lib/services/sync_service.dart
@@ -50,16 +50,16 @@ class SyncService {
           await LocalDbService.instance.markPoDSynced(podId);
         } catch (e) {
           debugPrint('Failed to sync PoD $podId: $e');
+          try {
+            if (orderId != null && (photoPath != null || signaturePath != null)) {
+              await _uploadPodFiles(orderId, photoPath: photoPath, signaturePath: signaturePath);
+            }
+            await _tripService.markStopCompleted(stopId, tripId);
+            await LocalDbService.instance.markPoDSynced(podId);
+          } catch (retryErr) {
+            debugPrint('Retry also failed for pod $podId: $retryErr');
+          }
         }
-      
-      // Retry stop completion even if upload fails
-      try {
-        final stopId = pod['stop_id'] as String;
-        final tripId = pod['trip_display_id'] as String;
-        await _tripService.markStopCompleted(stopId, tripId);
-        await LocalDbService.instance.markPoDSynced(pod['id'] as int);
-      } catch (e) {
-        debugPrint('Failed to sync pod ${pod['id']}: $e');
       }
       debugPrint('Sync completed for ${pendingPoDs.length} items.');
     } catch (e) {


### PR DESCRIPTION
Closes #4923

This PR fixes the PoD sync retry logic in sync_service.dart where:
1. The or loop was missing its closing brace, causing a Dart syntax error
2. The retry logic was outside the loop and only ran once after the entire loop finished
3. The retry logic only called markStopCompleted but never retried the file upload (_uploadPodFiles), silently losing proof-of-delivery files

Changes:
- Added missing closing brace for the or loop
- Moved retry logic inside the loop for each pod
- Added file upload retry to the catch block
- Used same variables instead of re-declaring (fixing variable shadowing)

GSSoC