### PR TITLE
fix: filter cancelled orders from admin dashboard revenue

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -76,7 +76,8 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
     const { data: todayOrders, error: revErr } = await supabase
       .from('orders')
       .select('total_amount')
-      .gte('created_at', today.toISOString());
+      .gte('created_at', today.toISOString())
+      .in('status', ['delivered', 'payment_released', 'active', 'in_transit']);
       
     if (revErr) {
       logger.error('Error fetching revenue:', revErr.message);


### PR DESCRIPTION
Closes #4924

This PR fixes the admin dashboard revenue calculation which was including cancelled, refunded, and failed orders in the daily revenue total.

Changes:
- backend/api/src/routes/adminRoutes.js — Added status filter to exclude cancelled/refunded/failed orders

GSSoC