### PR TITLE
fix: check speed between points instead of total distance for impossible travel

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -234,16 +234,21 @@ class FraudDetectionService {
     // 2. Check location anomalies
     if (patterns.locationHistory.length > 10) {
       const locations = patterns.locationHistory;
-      let distanceTraveled = 0;
+      let hasImpossibleSpeed = false;
       for (let i = 1; i < locations.length; i++) {
-        distanceTraveled += this.calculateDistance(
+        const distance = this.calculateDistance(
           locations[i-1].lat, locations[i-1].lng,
           locations[i].lat, locations[i].lng
         );
+        const timeDiffHours = (locations[i].timestamp - locations[i-1].timestamp) / 3600000;
+        if (timeDiffHours > 0 && (distance / timeDiffHours) > 150) {
+          hasImpossibleSpeed = true;
+          break;
+        }
       }
       
-      // Impossible travel distance in short time
-      if (distanceTraveled > 100) { // 100km in short time
+      // Impossible travel speed (>150 km/h for a truck)
+      if (hasImpossibleSpeed) {
         riskScore += 0.3;
       }
     }


### PR DESCRIPTION
Closes #4925

This PR fixes the impossible travel fraud detection which was summing total distance across all location history points instead of checking speed between consecutive points. Legitimate long-distance truck drivers were being flagged as fraudulent.

Changes:
- backend/api/src/services/fraud/FraudDetectionService.js — Changed from cumulative distance check (>100km) to instantaneous speed check (>150 km/h between consecutive points)

GSSoC