### PR TITLE
fix: use explicit None check for ETA prediction result

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -269,7 +269,7 @@ class TrafficPipeline:
                 # Predict ETA
                 eta_seconds = self.predict_eta(features)
                 
-                if eta_seconds:
+                if eta_seconds is not None:
                     eta_minutes = eta_seconds / 60
                     eta_string = str(timedelta(seconds=int(eta_seconds)))
                     


### PR DESCRIPTION
Closes #4926

This PR fixes the traffic pipeline ETA prediction where a valid zero-second ETA (for very short distances) was treated as a prediction failure because Python's truthiness check treats 0.0 as falsy.

Changes:
- backend/ml/services/traffic_pipeline.py — Changed if eta_seconds: to if eta_seconds is not None: to correctly handle zero-second predictions

GSSoC