### PR TITLE
fix: wrap SQLAlchemy sessions in try/finally to prevent connection leaks

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -204,8 +204,10 @@ class TrafficPipeline:
     def train_model(self, epochs=50, batch_size=32):
         """Train LSTM model on historical data"""
         session = self.Session()
-        data = session.query(TrafficData).all()
-        session.close()
+        try:
+            data = session.query(TrafficData).all()
+        finally:
+            session.close()
         
         if len(data) < 100:
             logger.warning("Not enough data for training")
@@ -313,10 +315,12 @@ class TrafficPipeline:
         """Get traffic forecast for next N hours"""
         # Get historical data for this route
         session = self.Session()
-        data = session.query(TrafficData).filter(
-            TrafficData.route_id == route_id
-        ).order_by(TrafficData.timestamp.desc()).limit(24).all()
-        session.close()
+        try:
+            data = session.query(TrafficData).filter(
+                TrafficData.route_id == route_id
+            ).order_by(TrafficData.timestamp.desc()).limit(24).all()
+        finally:
+            session.close()
         
         if len(data) < 10:
             return {'forecast': None, 'confidence': 'low'}


### PR DESCRIPTION
Closes #4927

This PR fixes SQLAlchemy session leaks in the traffic pipeline where database sessions were not properly closed when queries threw exceptions, leading to connection pool exhaustion over time.

Changes:
- backend/ml/services/traffic_pipeline.py — Wrapped 	rain_model() and get_traffic_forecast() sessions in try/finally blocks to guarantee cleanup

GSSoC