### PR TITLE
fix: always refresh Redis TTL after INCR to prevent leaked keys

### DIFF
--- a/backend/api/src/services/order/orderNotificationService.js
+++ b/backend/api/src/services/order/orderNotificationService.js
@@ -41,7 +41,7 @@ export async function recordOtpFailure(orderId) {
       const lockKey = `otp_lockout:${orderId}`;
 
       const count = await redisClient.incr(countKey);
-      if (count === 1) await redisClient.expire(countKey, OTP_LOCKOUT_MINUTES * 60);
+      await redisClient.expire(countKey, OTP_LOCKOUT_MINUTES * 60);
       if (count >= OTP_MAX_FAILED_ATTEMPTS) {
         await redisClient.set(lockKey, '1', 'EX', OTP_LOCKOUT_MINUTES * 60);
       }


### PR DESCRIPTION
Closes #4928

This PR fixes a Redis key leak in the OTP notification service where INCR and EXPIRE were not atomic. If the process crashed between the two commands, the key would persist forever without a TTL. Now the TTL is refreshed on every increment attempt.

Changes:
- backend/api/src/services/order/orderNotificationService.js — Changed if (count === 1) await redisClient.expire(...) to always call edisClient.expire(...) after INCR

GSSoC