### PR TITLE
fix: update Treasury struct state in deposit and withdraw functions

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -84,6 +84,7 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
     address public governanceToken;
     address public treasuryAddress;
     uint256 public totalMembers;
+    Treasury public treasury;
 
     // Events
     event ProposalCreated(uint256 indexed proposalId, address indexed proposer, string title);
@@ -247,7 +248,9 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
 
     function depositTreasury() external payable {
         require(msg.value > 0, "Amount must be > 0");
-        // In production: update treasury state
+        treasury.totalDeposited += msg.value;
+        treasury.balance = address(this).balance;
+        treasury.lastUpdated = block.timestamp;
         emit TreasuryDeposit(msg.sender, msg.value);
     }
 
@@ -258,6 +261,9 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
 
         (bool sent, ) = recipient.call{value: amount}("");
         require(sent, "Transfer failed");
+        treasury.totalWithdrawn += amount;
+        treasury.balance = address(this).balance;
+        treasury.lastUpdated = block.timestamp;
         emit TreasuryWithdraw(msg.sender, amount);
     }
 


### PR DESCRIPTION
Closes #4931

This PR fixes the DAO Treasury where the Treasury struct was defined but never updated by deposit or withdraw functions. Historical treasury accounting (total deposited, total withdrawn, last update time) is now properly tracked on-chain.

Changes:
- blockchain/contracts/DAO.sol — Added Treasury public treasury state variable
- blockchain/contracts/DAO.sol — Updated depositTreasury() to update treasury.totalDeposited, treasury.balance, and treasury.lastUpdated
- blockchain/contracts/DAO.sol — Updated withdrawTreasury() to update treasury.totalWithdrawn, treasury.balance, and treasury.lastUpdated

GSSoC