### PR TITLE
fix: use sliding window for event frequency fraud detection

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -262,11 +262,12 @@ class FraudDetectionService {
 
     // 4. Check event frequency
     if (profile.events.length > 50) {
-      const timeSpan = Date.now() - profile.events[0].timestamp;
-      const eventsPerMinute = (profile.events.length / (timeSpan / 60000));
+      const recentWindow = 60000; // 1 minute
+      const cutoff = Date.now() - recentWindow;
+      const recentCount = profile.events.filter(e => e.timestamp > cutoff).length;
       
       // Too many events = bot
-      if (eventsPerMinute > 60) {
+      if (recentCount > 60) {
         riskScore += 0.3;
       }
     }


### PR DESCRIPTION
Closes #4930

This PR fixes the event frequency fraud detection which was using the full buffer time span instead of a sliding window. Recent burst events were invisible if older events diluted the rate.

Changes:
- backend/api/src/services/fraud/FraudDetectionService.js — Changed from full history rate calculation to 1-minute sliding window count for burst detection

GSSoC