### PR TITLE
fix: remove duplicate const declarations in GraphQL order service

### DIFF
--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -18,19 +18,6 @@ function isAdmin(user) {
     return ADMIN_ROLES.has(user?.role);
 }
 
-const ADMIN_ROLES = new Set(['ADMIN', 'admin']);
-
-function requireUser(user) {
-    if (!user?.id) {
-        throw new Error('Authentication required');
-    }
-    return user;
-}
-
-function isAdmin(user) {
-    return ADMIN_ROLES.has(user?.role);
-}
-
 function mapOrder(row) {
     if (!row) return row;
 


### PR DESCRIPTION
Closes #4932

This PR fixes a SyntaxError in the GraphQL order service caused by duplicate const declarations. The file had ADMIN_ROLES, requireUser(), and isAdmin() declared twice, which is a parse-time error in ES modules.

Changes:
- backend/graphql/services/order.service.js — Removed duplicate declarations at lines 21-32

GSSoC