### PR TITLE
fix : treat 0.0 ETA as valid in traffic_pipeline.py predict_eta()

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -269,7 +269,7 @@ class TrafficPipeline:
                 # Predict ETA
                 eta_seconds = self.predict_eta(features)
                 
-                if eta_seconds:
+                if eta_seconds is not None:
                     eta_minutes = eta_seconds / 60
                     eta_string = str(timedelta(seconds=int(eta_seconds)))
                     


### PR DESCRIPTION
Closes #4944.

Summary of What Has Been Done:
The predict_eta() call result was checked with `if eta_seconds:` which treats 0.0 (valid ETA for very short distances or when driver is at destination) as falsy like None. Changed to explicit `if eta_seconds is not None:`.

Changes Made:
- backend/ml/services/traffic_pipeline.py: changed falsy check to explicit None check.

Impact it Made:
- Customers near destination now receive valid ETA instead of no ETA
- Fixes silent data loss for short-distance orders
- Correct behavior for edge case where driver is already at pickup

Note: This PR is submitted as part of GSSOC contribution to the Truxify project.