### PR TITLE
fix : add status filter to admin dashboard revenue query

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -76,7 +76,8 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
     const { data: todayOrders, error: revErr } = await supabase
       .from('orders')
       .select('total_amount')
-      .gte('created_at', today.toISOString());
+      .gte('created_at', today.toISOString())
+      .in('status', ['delivered', 'payment_released', 'active', 'in_transit']);
       
     if (revErr) {
       logger.error('Error fetching revenue:', revErr.message);


### PR DESCRIPTION
Closes #4945.

Summary of What Has Been Done:
The admin dashboard revenue query in adminRoutes.js summed total_amount from ALL orders regardless of status, inflating revenue with cancelled, pending, and refunded orders. Added .in('status', ['delivered', 'payment_released', 'active', 'in_transit']) to only include revenue-generating order states.

Changes Made:
- backend/api/src/routes/adminRoutes.js: added status filter to the revenue query.

Impact it Made:
- Accurate revenue figures on admin dashboard
- Prevents misleading business decisions from inflated numbers

Note: This PR is submitted as part of GSSOC contribution to the Truxify project.