### PR TITLE
feat: add DemandHeatmapScreen with FastAPI stub endpoint

### DIFF
--- a/apps/driver/lib/screens/demand_heatmap_screen.dart
+++ b/apps/driver/lib/screens/demand_heatmap_screen.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:http/http.dart' as http;
+
+class HeatZone {
+  final double lat;
+  final double lng;
+  final double intensity;
+  final String label;
+
+  HeatZone({
+    required this.lat,
+    required this.lng,
+    required this.intensity,
+    required this.label,
+  });
+
+  factory HeatZone.fromJson(Map<String, dynamic> json) => HeatZone(
+        lat: json['lat'],
+        lng: json['lng'],
+        intensity: json['intensity'],
+        label: json['label'],
+      );
+}
+
+class DemandHeatmapScreen extends StatefulWidget {
+  const DemandHeatmapScreen({super.key});
+
+  @override
+  State<DemandHeatmapScreen> createState() => _DemandHeatmapScreenState();
+}
+
+class _DemandHeatmapScreenState extends State<DemandHeatmapScreen> {
+  List<HeatZone> _zones = [];
+  bool _isLoading = true;
+  String? _error;
+
+  // TODO: Replace with your actual backend URL / ApiService
+  static const String _baseUrl = 'http://localhost:8000';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHeatmapData();
+  }
+
+  Future<void> _loadHeatmapData() async {
+    setState(() { _isLoading = true; _error = null; });
+    try {
+      final response = await http.get(
+        Uri.parse('$_baseUrl/ml/demand-heatmap?hours=48'),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        final zones = (data['zones'] as List)
+            .map((z) => HeatZone.fromJson(z))
+            .toList();
+        setState(() { _zones = zones; _isLoading = false; });
+      } else {
+        setState(() { _error = 'Failed to load data'; _isLoading = false; });
+      }
+    } catch (e) {
+      setState(() { _error = 'Network error: $e'; _isLoading = false; });
+    }
+  }
+
+  Color _intensityColor(double intensity) {
+    if (intensity >= 0.75) return Colors.red.withOpacity(0.7);
+    if (intensity >= 0.5) return Colors.orange.withOpacity(0.7);
+    return Colors.green.withOpacity(0.7);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Demand Heatmap — Next 48 hrs'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadHeatmapData,
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(_error!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadHeatmapData,
+                        child: const Text('Retry'),
+                      ),
+                    ],
+                  ),
+                )
+              : Column(
+                  children: [
+                    _buildLegend(),
+                    Expanded(child: _buildMap()),
+                  ],
+                ),
+    );
+  }
+
+  Widget _buildLegend() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _legendItem(Colors.green, 'Low demand'),
+          _legendItem(Colors.orange, 'Medium demand'),
+          _legendItem(Colors.red, 'High demand'),
+        ],
+      ),
+    );
+  }
+
+  Widget _legendItem(Color color, String label) {
+    return Row(children: [
+      Container(width: 12, height: 12, decoration: BoxDecoration(color: color, shape: BoxShape.circle)),
+      const SizedBox(width: 4),
+      Text(label, style: const TextStyle(fontSize: 12)),
+    ]);
+  }
+
+  Widget _buildMap() {
+    return FlutterMap(
+      options: const MapOptions(
+        initialCenter: LatLng(20.5937, 78.9629),
+        initialZoom: 5,
+      ),
+      children: [
+        TileLayer(
+          urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+          userAgentPackageName: 'com.truxify.driver',
+        ),
+        CircleLayer(
+          circles: _zones.map((zone) => CircleMarker(
+            point: LatLng(zone.lat, zone.lng),
+            radius: 40 + (zone.intensity * 40),
+            color: _intensityColor(zone.intensity),
+            borderColor: _intensityColor(zone.intensity).withOpacity(0.9),
+            borderStrokeWidth: 2,
+          )).toList(),
+        ),
+        MarkerLayer(
+          markers: _zones.map((zone) => Marker(
+            point: LatLng(zone.lat, zone.lng),
+            width: 80,
+            height: 30,
+            child: Text(
+              zone.label,
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+                shadows: [Shadow(blurRadius: 2, color: Colors.black)],
+              ),
+              textAlign: TextAlign.center,
+            ),
+          )).toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -27,6 +27,8 @@ import '../widgets/earnings_shimmer.dart';
 import '../widgets/map_markers.dart';
 import 'destination_picker_screen.dart';
 import '../widgets/pulsing_location_dot.dart';
+// NEW IMPORT for the demand heatmap screen
+import '../screens/demand_heatmap_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   HomeScreen({
@@ -1308,6 +1310,26 @@ class _HomeScreenState extends State<HomeScreen> {
             _buildErrorMetrics()
           else
             _buildMetricsRow(),
+          // ---------- NEW: Demand Heatmap Card ----------
+          const SizedBox(height: 16),
+          GestureDetector(
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const DemandHeatmapScreen()),
+            ),
+            child: Card(
+              margin: EdgeInsets.zero,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: ListTile(
+                leading: const Icon(Icons.thermostat, color: Colors.orange),
+                title: const Text('Demand Heatmap'),
+                subtitle: const Text('View high-demand freight zones — next 48 hrs'),
+                trailing: const Icon(Icons.arrow_forward_ios, size: 14),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -23,9 +23,9 @@ dependencies:
   web_socket_channel: ^3.0.0
 
   google_fonts: ^8.1.0
-  flutter_map: ^8.1.1
+  flutter_map: ^6.1.0
   latlong2: ^0.9.1
-  http: ^1.6.0
+  http: ^1.2.0
   shared_preferences: ^2.5.5
   intl: ^0.20.2
   url_launcher: ^6.3.2

--- a/backend/ml/app/main.py
+++ b/backend/ml/app/main.py
@@ -7,6 +7,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from .models.eta_prediction import eta_predictor
+from ml.routes.demand_heatmap import router as heatmap_router
+app.include_router(heatmap_router)
 
 from .models.demand_forecast import (
     predict_demand,

--- a/backend/ml/app/routes/demand_heatmap.py
+++ b/backend/ml/app/routes/demand_heatmap.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter
+from typing import List
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/ml", tags=["ML"])
+
+class DemandZone(BaseModel):
+    lat: float
+    lng: float
+    intensity: float  # 0.0 (low) to 1.0 (high)
+    label: str
+
+class DemandHeatmapResponse(BaseModel):
+    zones: List[DemandZone]
+    forecast_hours: int
+
+@router.get("/demand-heatmap", response_model=DemandHeatmapResponse)
+async def get_demand_heatmap(hours: int = 48):
+    """
+    Returns mock demand heatmap data for the next N hours.
+    TODO: Replace with real ML model inference (Model #9).
+    """
+    mock_zones = [
+        {"lat": 19.0760, "lng": 72.8777, "intensity": 0.9, "label": "Mumbai"},
+        {"lat": 28.6139, "lng": 77.2090, "intensity": 0.8, "label": "Delhi"},
+        {"lat": 12.9716, "lng": 77.5946, "intensity": 0.7, "label": "Bengaluru"},
+        {"lat": 17.3850, "lng": 78.4867, "intensity": 0.6, "label": "Hyderabad"},
+        {"lat": 22.5726, "lng": 88.3639, "intensity": 0.5, "label": "Kolkata"},
+        {"lat": 13.0827, "lng": 80.2707, "intensity": 0.75, "label": "Chennai"},
+        {"lat": 23.0225, "lng": 72.5714, "intensity": 0.4, "label": "Ahmedabad"},
+    ]
+    return {"zones": mock_zones, "forecast_hours": hours}


### PR DESCRIPTION
Fixes #4864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a demand heatmap view showing forecast demand zones for the next 48 hours.
  - Added interactive map markers with intensity-based colors, labels, and a low-to-high legend.
  - Added navigation to the heatmap from the driver dashboard.
  - Added backend support for retrieving demand heatmap forecast data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->