### PR TITLE
fix: dispose MarketplaceRepository in finally block in ProfitEstimateCard

### DIFF
--- a/apps/driver/lib/widgets/profit_estimate_card.dart
+++ b/apps/driver/lib/widgets/profit_estimate_card.dart
@@ -43,14 +43,17 @@ class _ProfitEstimateCardState extends State<ProfitEstimateCard> {
 
     try {
       final repo = MarketplaceRepository();
-      final prediction = await repo.predictLoadProfit(
-        load: widget.load,
-        truckMileageKmL: widget.truckMileageKmL,
-        fuelPricePerLitre: widget.fuelPricePerLitre,
-        tripDurationHours: duration,
-      );
-      repo.dispose();
-      if (mounted) setState(() { _prediction = prediction; _isLoading = false; });
+      try {
+        final prediction = await repo.predictLoadProfit(
+          load: widget.load,
+          truckMileageKmL: widget.truckMileageKmL,
+          fuelPricePerLitre: widget.fuelPricePerLitre,
+          tripDurationHours: duration,
+        );
+        if (mounted) setState(() { _prediction = prediction; _isLoading = false; });
+      } finally {
+        repo.dispose();
+      }
     } catch (_) {
       if (mounted) setState(() { _isLoading = false; _error = 'Prediction unavailable'; });
     }


### PR DESCRIPTION
## Summary
Disposes `MarketplaceRepository` in a `finally` block in `ProfitEstimateCard`.

## Problem
`repo.dispose()` was only called on the success path. If `predictLoadProfit` threw, the repository's HTTP client leaked.

## Fix
Moved `dispose()` to a `finally` block so it runs even when the prediction throws.

## Testing
- Driver app compiles successfully

Closes #4955

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading profit predictions by ensuring resources are cleaned up whether the prediction succeeds or fails.
  * Preserved the existing error message and loading-state behavior when predictions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->