### PR TITLE
fix: add try-catch to DriverEarningsService.fetchCompletedTripsForDay

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -184,15 +184,19 @@ class DriverEarningsService {
 
     final day = date.toIso8601String().split('T').first;
 
-    final response = await _client
-        .from('trips')
-        .select()
-        .eq('driver_id', driverId!)
-        .eq('status', 'completed')
-        .eq('trip_date', day)
-        .order('created_at', ascending: false);
+    try {
+      final response = await _client
+          .from('trips')
+          .select()
+          .eq('driver_id', driverId!)
+          .eq('status', 'completed')
+          .eq('trip_date', day)
+          .order('created_at', ascending: false);
 
-    return _mapResponseRows(response, 'completed trips');
+      return _mapResponseRows(response, 'completed trips');
+    } catch (e) {
+      throw Exception('Failed to fetch completed trips: $e');
+    }
   }
 
   /// Fetches today's earnings summary (amount, hours driven, trip count).


### PR DESCRIPTION
## Summary
Adds try-catch to `DriverEarningsService.fetchCompletedTripsForDay`.

## Problem
Unlike every other async method in the class (`fetchEarningsSummary`, `fetchTodayEarningsSummary`, `fetchDriverStats`), `fetchCompletedTripsForDay` had no error handling. Supabase query failures propagated unhandled.

## Fix
Added try-catch with a descriptive exception, consistent with the other methods.

## Testing
- Driver app compiles successfully

Closes #4957

GSSoC
