### PR TITLE
fix: prevent race condition in LocalDbService database initialization

### DIFF
--- a/apps/driver/lib/services/local_db_service.dart
+++ b/apps/driver/lib/services/local_db_service.dart
@@ -6,12 +6,14 @@ import 'package:path_provider/path_provider.dart';
 class LocalDbService {
   static final LocalDbService instance = LocalDbService._init();
   static Database? _database;
+  static Future<Database>? _pendingInit;
 
   LocalDbService._init();
 
   Future<Database> get database async {
     if (_database != null) return _database!;
-    _database = await _initDB('truxify_driver.db');
+    _pendingInit ??= _initDB('truxify_driver.db');
+    _database = await _pendingInit;
     return _database!;
   }
 


### PR DESCRIPTION
## Summary
Prevents race condition in `LocalDbService` database initialization.

## Problem
Concurrent callers could both see `_database == null` and both call `_initDB`, causing sqflite "database is already open" errors.

## Fix
Added `_pendingInit` to ensure only one initialization runs; concurrent callers await the same future.

## Testing
- Driver app compiles successfully

Closes #4958

GSSoC
