### PR TITLE
fix: prevent race condition in PodStorageService database initialization

### DIFF
--- a/apps/driver/lib/services/pod_storage_service.dart
+++ b/apps/driver/lib/services/pod_storage_service.dart
@@ -44,11 +44,13 @@ class PodRecord {
 
 class PodStorageService {
   static Database? _database;
+  static Future<Database>? _pendingInit;
   static const String tableName = 'pods';
 
   Future<Database> get database async {
     if (_database != null) return _database!;
-    _database = await _initDB('pods_cache.db');
+    _pendingInit ??= _initDB('pods_cache.db');
+    _database = await _pendingInit;
     return _database!;
   }
 


### PR DESCRIPTION
## Summary
Prevents race condition in `PodStorageService` database initialization.

## Problem
Same race condition as `LocalDbService`. Concurrent callers could both see `_database == null` and both call `_initDB`, causing sqflite double-open errors.

## Fix
Added `_pendingInit` to ensure only one initialization runs; concurrent callers await the same future.

## Testing
- Driver app compiles successfully

Closes #4959

GSSoC
