### PR TITLE
Fix stale order worker scheduling

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -3,9 +3,16 @@ import logger from '../middleware/logger.js';
 import { supabase } from '../config/db.js';
 import { sendPushNotification } from '../services/notificationService.js';
 
+let staleOrderWorkerTask = null;
+
 export const startStaleOrderWorker = () => {
+  if (staleOrderWorkerTask) {
+    logger.info('[StaleOrderWorker] Stale order cleanup cron job already scheduled.');
+    return staleOrderWorkerTask;
+  }
+
   // Run every hour at minute 0
-  cron.schedule('0 * * * *', async () => {
+  staleOrderWorkerTask = cron.schedule('0 * * * *', async () => {
     logger.info('[StaleOrderWorker] Starting cleanup of stale pending orders...');
     try {
       const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
@@ -63,4 +70,13 @@ export const startStaleOrderWorker = () => {
   });
 
   logger.info('[StaleOrderWorker] Stale order cleanup cron job scheduled (runs every hour).');
+  return staleOrderWorkerTask;
+};
+
+export const stopStaleOrderWorker = () => {
+  if (!staleOrderWorkerTask) return;
+
+  staleOrderWorkerTask.stop();
+  staleOrderWorkerTask = null;
+  logger.info('[StaleOrderWorker] Stale order cleanup cron job stopped.');
 };

--- a/backend/api/test/unit/staleOrderWorker.test.js
+++ b/backend/api/test/unit/staleOrderWorker.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scheduleMock = vi.fn();
+const stopMock = vi.fn();
+
+vi.mock('node-cron', () => ({
+  default: {
+    schedule: scheduleMock,
+  },
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {},
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe('staleOrderWorker', () => {
+  beforeEach(async () => {
+    scheduleMock.mockReset();
+    scheduleMock.mockReturnValue({ stop: stopMock });
+
+    const { stopStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
+    stopStaleOrderWorker();
+    stopMock.mockReset();
+  });
+
+  it('schedules only one cron task across repeated starts', async () => {
+    const { startStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
+
+    const firstTask = startStaleOrderWorker();
+    const secondTask = startStaleOrderWorker();
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(secondTask).toBe(firstTask);
+  });
+
+  it('stops the active cron task', async () => {
+    const { startStaleOrderWorker, stopStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
+
+    startStaleOrderWorker();
+    stopStaleOrderWorker();
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- make the stale order cleanup worker reuse the existing cron task across repeated starts
- return the active task and add a stop helper for teardown
- cover repeated start and stop behavior with a focused unit test

## Validation
- `npm --prefix backend/api test -- staleOrderWorker.test.js`

Closes #4975


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate stale-order cleanup jobs from being scheduled.
  * Added the ability to stop an active stale-order cleanup job safely.

* **Tests**
  * Added coverage to verify job reuse, scheduling behavior, and clean shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->