### PR TITLE
Isolate stale order notification failures

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -45,15 +45,18 @@ export const startStaleOrderWorker = () => {
         }
 
         // Send a notification to the customer
-        await sendPushNotification(
-          order.customer_id,
-          'Order Cancelled',
-          'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
-          'ORDER_CANCELLED',
-          { orderId: order.id }
-        );
-
-        logger.info(`[StaleOrderWorker] Cancelled order ${order.id} and notified customer ${order.customer_id}.`);
+        try {
+          await sendPushNotification(
+            order.customer_id,
+            'Order Cancelled',
+            'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
+            'ORDER_CANCELLED',
+            { orderId: order.id }
+          );
+          logger.info(`[StaleOrderWorker] Cancelled order ${order.id} and notified customer ${order.customer_id}.`);
+        } catch (notifyErr) {
+          logger.warn(`[StaleOrderWorker] Cancelled order ${order.id}, but failed to notify customer ${order.customer_id}: ${notifyErr.message}`);
+        }
       }
       
       logger.info('[StaleOrderWorker] Cleanup of stale pending orders completed.');

--- a/backend/api/test/unit/staleOrderWorkerNotifications.test.js
+++ b/backend/api/test/unit/staleOrderWorkerNotifications.test.js
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let scheduledHandler;
+const scheduleMock = vi.fn((expression, handler) => {
+  scheduledHandler = handler;
+  return { stop: vi.fn() };
+});
+const sendPushNotificationMock = vi.fn();
+const loggerWarnMock = vi.fn();
+const updateCalls = [];
+
+vi.mock('node-cron', () => ({
+  default: {
+    schedule: scheduleMock,
+  },
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: sendPushNotificationMock,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+  },
+}));
+
+function makeBuilder(table) {
+  const builder = {
+    _mode: 'select',
+    _payload: null,
+    select() { return this; },
+    eq() { return this; },
+    lt() { return this; },
+    update(payload) {
+      this._mode = 'update';
+      this._payload = payload;
+      return this;
+    },
+    then(resolve) {
+      if (table === 'orders' && this._mode === 'select') {
+        return resolve({
+          data: [
+            { id: 'order-1', customer_id: 'customer-1' },
+            { id: 'order-2', customer_id: 'customer-2' },
+          ],
+          error: null,
+        });
+      }
+
+      if (table === 'orders' && this._mode === 'update') {
+        updateCalls.push(this._payload);
+        return resolve({ data: null, error: null });
+      }
+
+      return resolve({ data: null, error: null });
+    },
+  };
+
+  return builder;
+}
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {
+    from: vi.fn(makeBuilder),
+  },
+}));
+
+describe('staleOrderWorker notifications', () => {
+  beforeEach(async () => {
+    scheduledHandler = null;
+    updateCalls.length = 0;
+    scheduleMock.mockClear();
+    sendPushNotificationMock.mockReset();
+    loggerWarnMock.mockClear();
+    vi.resetModules();
+  });
+
+  it('continues cancelling stale orders when one notification fails', async () => {
+    sendPushNotificationMock
+      .mockRejectedValueOnce(new Error('push unavailable'))
+      .mockResolvedValueOnce();
+
+    const { startStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
+    startStaleOrderWorker();
+
+    await scheduledHandler();
+
+    expect(updateCalls).toHaveLength(2);
+    expect(sendPushNotificationMock).toHaveBeenCalledTimes(2);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('failed to notify customer customer-1')
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep stale order cancellation moving when a push notification fails
- log notification failures per order instead of aborting the entire cleanup loop
- add a regression test covering a failed first notification and continued processing

## Validation
- `npm --prefix backend/api test -- staleOrderWorkerNotifications.test.js`

Closes #4976
