### PR TITLE
Share escrow webhook processing with DLQ

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import crypto from 'crypto';
 import logger from '../middleware/logger.js';
 import { dlqService } from '../services/webhook/dlqService.js';
+import { processEscrowWebhookEvent } from '../services/webhook/escrowWebhookProcessor.js';
 
 const router = express.Router();
 
@@ -58,13 +59,7 @@ router.post('/escrow', verifyWebhookSignature, async (req, res) => {
 
   try {
     logger.info(`[Webhook] Received Escrow event: ${eventType} for order ${orderId}`);
-    
-    // Simulate some processing that might fail
-    if (req.body.simulateFailure === true) {
-      throw new Error('Simulated database lock or processing failure');
-    }
-
-    // Processing success
+    await processEscrowWebhookEvent(eventType, req.body);
     return res.status(200).json({ received: true });
   } catch (error) {
     logger.error(`[Webhook] Failed to process escrow webhook for order ${orderId}: ${error.message}`);

--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -1,0 +1,16 @@
+import logger from '../../middleware/logger.js';
+
+export async function processEscrowWebhookEvent(eventType, payload = {}) {
+  if (!eventType) {
+    throw new Error('Missing escrow webhook event type');
+  }
+
+  const orderId = payload.orderId || 'unknown';
+  logger.info(`[Webhook] Processing escrow event ${eventType} for order ${orderId}`);
+
+  if (payload.simulateFailure === true) {
+    throw new Error('Simulated database lock or processing failure');
+  }
+
+  return { received: true };
+}

--- a/backend/api/src/workers/dlqWorker.js
+++ b/backend/api/src/workers/dlqWorker.js
@@ -1,19 +1,9 @@
 import { dlqService } from '../services/webhook/dlqService.js';
 import logger from '../middleware/logger.js';
+import { processEscrowWebhookEvent } from '../services/webhook/escrowWebhookProcessor.js';
 
-// Import our handlers
-// Currently we only have a placeholder for escrow, but we map it here
 const processFnMap = {
-  'escrow': async (eventType, payload) => {
-    logger.info(`[DLQ Worker] Processing escrow event ${eventType}...`);
-    // Placeholder logic for retrying an escrow webhook event
-    if (eventType === 'EscrowRefunded') {
-      // Simulate processing
-      logger.info(`[DLQ Worker] Simulating EscrowRefunded processing for order: ${payload.orderId}`);
-    } else {
-      throw new Error(`Unhandled escrow event type in DLQ worker: ${eventType}`);
-    }
-  }
+  escrow: processEscrowWebhookEvent,
 };
 
 let intervalId = null;

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const { processEscrowWebhookEvent } = await import('../../src/services/webhook/escrowWebhookProcessor.js');
+
+describe('processEscrowWebhookEvent', () => {
+  it('processes supported escrow events without limiting retries to refunds', async () => {
+    await expect(
+      processEscrowWebhookEvent('EscrowDeposited', { orderId: 'order-1' })
+    ).resolves.toEqual({ received: true });
+  });
+
+  it('keeps processor failures visible to the DLQ retry loop', async () => {
+    await expect(
+      processEscrowWebhookEvent('EscrowDeposited', {
+        orderId: 'order-1',
+        simulateFailure: true,
+      })
+    ).rejects.toThrow('Simulated database lock or processing failure');
+  });
+});


### PR DESCRIPTION
## Summary
- move escrow webhook handling into a shared processor
- use the same processor from the live webhook route and the DLQ retry worker
- add coverage for retrying a non-refund escrow event and preserving failure propagation

## Validation
- `npm --prefix backend/api test -- escrowWebhookProcessor.test.js webhookRoutes.test.js`

Closes #4978
