### PR TITLE
Validate WebRTC location updates

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -99,16 +99,21 @@ class WebRTCSignalingServer {
 
     switch (message.type) {
       case 'location-update':
-        peer.location = message.location;
+        if (!this.isValidLocation(message.location)) {
+          logger.warn(`Invalid WebRTC location update dropped for peer ${peerId}`);
+          return;
+        }
+
+        peer.location = this.normalizeLocation(message.location);
         if (this.redis) {
           await this.redis.setex(
             `peer:${peerId}:location`,
             60,
-            JSON.stringify(message.location)
+            JSON.stringify(peer.location)
           );
         }
         // Relay location to nearby peers
-        this.relayLocation(peerId, message.location);
+        this.relayLocation(peerId, peer.location);
         break;
 
       case 'webrtc-offer':

--- a/backend/api/test/unit/webrtcLocationUpdate.test.js
+++ b/backend/api/test/unit/webrtcLocationUpdate.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {},
+  redisClient: null,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const { default: WebRTCSignalingServer } = await import('../../src/services/webrtc/WebRTCSignalingServer.js');
+
+function makeServer() {
+  const server = Object.create(WebRTCSignalingServer.prototype);
+  server.redis = null;
+  server.peers = new Map([
+    ['peer-1', {
+      location: null,
+      meshId: 'mesh-1',
+      ws: { readyState: 1 },
+    }],
+  ]);
+  server.meshes = new Map([['mesh-1', new Set(['peer-1'])]]);
+  server.relayLocation = vi.fn();
+  return server;
+}
+
+describe('WebRTCSignalingServer location-update', () => {
+  it('drops invalid location updates without relaying them', async () => {
+    const server = makeServer();
+
+    await server.handleMessage('peer-1', {
+      type: 'location-update',
+      location: { lat: 120, lng: 75 },
+    });
+
+    expect(server.peers.get('peer-1').location).toBeNull();
+    expect(server.relayLocation).not.toHaveBeenCalled();
+  });
+
+  it('normalizes valid location updates before storing and relaying them', async () => {
+    const server = makeServer();
+
+    await server.handleMessage('peer-1', {
+      type: 'location-update',
+      location: { lat: '21.17', lng: '72.83' },
+    });
+
+    expect(server.peers.get('peer-1').location).toEqual({ lat: 21.17, lng: 72.83 });
+    expect(server.relayLocation).toHaveBeenCalledWith('peer-1', { lat: 21.17, lng: 72.83 });
+  });
+});


### PR DESCRIPTION
## Summary
- validate `location-update` coordinates before storing or relaying them
- normalize valid coordinates to numbers for peer state, Redis cache, and broadcasts
- add unit coverage for invalid and normalized location updates

## Validation
- `npm --prefix backend/api test -- webrtcLocationUpdate.test.js`

Closes #4979
