### PR TITLE
Destroy WebRTC signaling on close

### DIFF
--- a/backend/api/src/sockets/webrtc.js
+++ b/backend/api/src/sockets/webrtc.js
@@ -15,7 +15,7 @@ export function getWebRTCSignaling() {
 
 export function closeWebRTCSignaling() {
   if (signalingServer) {
-    signalingServer.wss.close();
+    signalingServer.destroy();
     signalingServer = null;
   }
 }

--- a/backend/api/test/unit/webrtcSocketLifecycle.test.js
+++ b/backend/api/test/unit/webrtcSocketLifecycle.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const destroyMock = vi.fn();
+const closeMock = vi.fn();
+
+vi.mock('../../src/services/webrtc/WebRTCSignalingServer.js', () => ({
+  default: vi.fn().mockImplementation(function WebRTCSignalingServerMock() {
+    this.destroy = destroyMock;
+    this.wss = {
+      close: closeMock,
+    };
+  }),
+}));
+
+const { closeWebRTCSignaling, initWebRTCSignaling } = await import('../../src/sockets/webrtc.js');
+
+describe('WebRTC signaling socket lifecycle', () => {
+  beforeEach(() => {
+    destroyMock.mockClear();
+    closeMock.mockClear();
+    closeWebRTCSignaling();
+    destroyMock.mockClear();
+  });
+
+  it('uses full signaling teardown when closing the singleton', () => {
+    initWebRTCSignaling({});
+    closeWebRTCSignaling();
+
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- route WebRTC signaling shutdown through the server `destroy()` method
- ensure the close helper clears timers and peer state through the existing teardown path
- add lifecycle coverage for closing the singleton

## Validation
- `npm --prefix backend/api test -- webrtcSocketLifecycle.test.js`

Closes #4980
