### PR TITLE
Authorize WebRTC offline peer reads

### DIFF
--- a/backend/api/src/routes/webrtcRoutes.js
+++ b/backend/api/src/routes/webrtcRoutes.js
@@ -105,6 +105,13 @@ router.get('/webrtc/offline/:peerId', authenticate, userLimiter, requirePolicy('
       });
     }
 
+    if (!signaling.canUserAccessPeer(peerId, req.user)) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied for requested peer'
+      });
+    }
+
     const data = await signaling.getOfflineGPSData(peerId, since);
     res.json({
       success: true,

--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -371,6 +371,13 @@ class WebRTCSignalingServer {
     };
   }
 
+  canUserAccessPeer(peerId, user) {
+    if (user?.role === 'admin') return true;
+
+    const peer = this.peers.get(peerId);
+    return Boolean(peer && peer.userId === user?.id);
+  }
+
   async getOfflineGPSData(peerId, since) {
     const { data } = await supabase
       .from('gps_offline_data')

--- a/backend/api/test/integration/webrtcOfflineRoutes.test.js
+++ b/backend/api/test/integration/webrtcOfflineRoutes.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const signalingMock = {
+  canUserAccessPeer: vi.fn(),
+  getOfflineGPSData: vi.fn(),
+  syncOfflineData: vi.fn(),
+};
+
+vi.mock('../../src/sockets/webrtc.js', () => ({
+  getWebRTCSignaling: () => signalingMock,
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => {
+    req.user = { id: 'user-1', role: 'driver' };
+    next();
+  },
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (req, res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (req, res, next) => next(),
+}));
+
+const { default: webrtcRoutes } = await import('../../src/routes/webrtcRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', webrtcRoutes);
+  return app;
+}
+
+describe('WebRTC offline routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks offline GPS reads for peers the user cannot access', async () => {
+    signalingMock.canUserAccessPeer.mockReturnValue(false);
+
+    const res = await request(buildApp()).get('/api/webrtc/offline/peer-2');
+
+    expect(res.status).toBe(403);
+    expect(signalingMock.getOfflineGPSData).not.toHaveBeenCalled();
+  });
+
+  it('returns offline GPS data for an accessible peer', async () => {
+    signalingMock.canUserAccessPeer.mockReturnValue(true);
+    signalingMock.getOfflineGPSData.mockResolvedValue([{ peerId: 'peer-1' }]);
+
+    const res = await request(buildApp()).get('/api/webrtc/offline/peer-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([{ peerId: 'peer-1' }]);
+    expect(signalingMock.getOfflineGPSData).toHaveBeenCalledWith('peer-1', undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- add a signaling-level peer access check for authenticated users
- block offline GPS reads when the requested peer is not owned by the caller
- add integration coverage for denied and allowed offline GPS reads

## Validation
- `npm --prefix backend/api test -- webrtcOfflineRoutes.test.js webrtcLocationUpdate.test.js`

Closes #4981
