### PR TITLE
Authorize WebRTC offline sync

### DIFF
--- a/backend/api/src/routes/webrtcRoutes.js
+++ b/backend/api/src/routes/webrtcRoutes.js
@@ -131,6 +131,13 @@ router.post('/webrtc/sync/:peerId', authenticate, userLimiter, requirePolicy('we
       });
     }
 
+    if (!signaling.canUserAccessPeer(peerId, req.user)) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied for requested peer'
+      });
+    }
+
     await signaling.syncOfflineData(peerId);
     res.json({
       success: true,

--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -371,6 +371,13 @@ class WebRTCSignalingServer {
     };
   }
 
+  canUserAccessPeer(peerId, user) {
+    if (user?.role === 'admin') return true;
+
+    const peer = this.peers.get(peerId);
+    return Boolean(peer && peer.userId === user?.id);
+  }
+
   async getOfflineGPSData(peerId, since) {
     const { data } = await supabase
       .from('gps_offline_data')

--- a/backend/api/test/integration/webrtcOfflineSync.test.js
+++ b/backend/api/test/integration/webrtcOfflineSync.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const signalingMock = {
+  canUserAccessPeer: vi.fn(),
+  getOfflineGPSData: vi.fn(),
+  syncOfflineData: vi.fn(),
+};
+
+vi.mock('../../src/sockets/webrtc.js', () => ({
+  getWebRTCSignaling: () => signalingMock,
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => {
+    req.user = { id: 'user-1', role: 'driver' };
+    next();
+  },
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (req, res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (req, res, next) => next(),
+}));
+
+const { default: webrtcRoutes } = await import('../../src/routes/webrtcRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', webrtcRoutes);
+  return app;
+}
+
+describe('WebRTC offline sync route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks offline sync for peers the user cannot access', async () => {
+    signalingMock.canUserAccessPeer.mockReturnValue(false);
+
+    const res = await request(buildApp()).post('/api/webrtc/sync/peer-2');
+
+    expect(res.status).toBe(403);
+    expect(signalingMock.syncOfflineData).not.toHaveBeenCalled();
+  });
+
+  it('syncs offline data for an accessible peer', async () => {
+    signalingMock.canUserAccessPeer.mockReturnValue(true);
+    signalingMock.syncOfflineData.mockResolvedValue();
+
+    const res = await request(buildApp()).post('/api/webrtc/sync/peer-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(signalingMock.syncOfflineData).toHaveBeenCalledWith('peer-1');
+  });
+});


### PR DESCRIPTION
## Summary
- add a peer ownership check before marking offline GPS rows as synced
- keep admin access while blocking unrelated peer ids for normal users
- add integration coverage for denied and allowed offline sync requests

## Validation
- `npm --prefix backend/api test -- webrtcOfflineSync.test.js`

Closes #4982
