### PR TITLE
Normalize truck number plates

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -189,13 +189,14 @@ function parseCapacityFilter(value, field) {
  */
 router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, validateBody(registerTruckSchema), async (req, res) => {
   const { name, number_plate, max_capacity_tons } = req.body;
+  const normalizedNumberPlate = sanitizeNumberPlate(number_plate);
 
   try {
     // Check for duplicate number plate
     const { data: existing, error: checkErr } = await supabase
       .from('trucks')
       .select('id')
-      .eq('number_plate', number_plate)
+      .eq('number_plate', normalizedNumberPlate)
       .maybeSingle();
 
     if (checkErr) {
@@ -208,7 +209,7 @@ router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, val
 
     const { data: truck, error: insertErr } = await supabase
       .from('trucks')
-      .insert({ name, number_plate, max_capacity_tons, owner_id: req.user.id })
+      .insert({ name, number_plate: normalizedNumberPlate, max_capacity_tons, owner_id: req.user.id })
       .select('id, name, number_plate, max_capacity_tons, created_at')
       .single();
 

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -241,7 +241,7 @@ export const registerTruckSchema = z.object({
     .min(2, 'Truck name must be at least 2 characters')
     .max(100, 'Truck name must be 100 characters or fewer'),
   number_plate: z.string()
-    .transform((v) => v.trim().toUpperCase())
+    .transform((v) => v.trim().toUpperCase().replace(/[^A-Z0-9]/g, ''))
     .pipe(
       z.string().regex(numberPlateRegex, 'Invalid number plate format (e.g. MH12AB1234)')
     ),

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -148,6 +148,19 @@ describe('Truck Routes', () => {
       const insertCall = m.calls.find(c => c.table === 'trucks' && c.mode === 'insert');
       expect(insertCall.payload.number_plate).toBe('MH12AB1234');
     });
+
+    it('normalises separators before duplicate lookup', async () => {
+      m.store.trucks.push({ id: 'truck-existing', number_plate: 'MH12AB1234', owner_id: 'other-driver' });
+
+      const res = await request(buildApp())
+        .post('/api/trucks')
+        .set(DRIVER_HEADERS)
+        .send({ name: 'Duplicate', number_plate: 'MH 12 AB 1234', max_capacity_tons: 5 });
+
+      expect(res.status).toBe(409);
+      const checkCall = m.calls.find(c => c.table === 'trucks' && c.mode === 'select');
+      expect(checkCall.filters).toContainEqual({ col: 'number_plate', op: 'eq', val: 'MH12AB1234' });
+    });
   });
 
   describe('GET /api/trucks', () => {


### PR DESCRIPTION
## Summary
- normalize number plate separators during request validation
- use the normalized plate for duplicate checks and inserts
- add integration coverage for duplicate lookup with formatted plate input

## Validation
- `npm --prefix backend/api test -- truckRoutes.test.js`

Closes #4983
