### PR TITLE
Validate public tracking route coordinates

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -10,6 +10,13 @@ const router = express.Router();
 
 const trackingTokenService = new TrackingTokenService({ supabase, logger });
 
+function parseFiniteCoordinate(value) {
+  if (value === null || value === undefined || value === '') return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 // Rate limiter — generous for public consumers, strict per IP
 const publicLimiter = rateLimit({
   windowMs: 1 * 60 * 1000,
@@ -155,11 +162,20 @@ router.get(
         return res.status(404).json({ error: 'Order not found' });
       }
 
+      const pickupLat = parseFiniteCoordinate(order.pickup_lat);
+      const pickupLng = parseFiniteCoordinate(order.pickup_lng);
+      const dropLat = parseFiniteCoordinate(order.drop_lat);
+      const dropLng = parseFiniteCoordinate(order.drop_lng);
+
+      if ([pickupLat, pickupLng, dropLat, dropLng].some((value) => value === null)) {
+        return res.status(422).json({ error: 'Route coordinates are not available for this order' });
+      }
+
       // Return simple pickup-to-drop route for public view
       // Full OSRM route is only available to authenticated users
       const coordinates = [
-        [order.pickup_lng, order.pickup_lat],
-        [order.drop_lng, order.drop_lat],
+        [pickupLng, pickupLat],
+        [dropLng, dropLat],
       ];
 
       return res.json({

--- a/backend/api/test/integration/publicTracking.test.js
+++ b/backend/api/test/integration/publicTracking.test.js
@@ -294,6 +294,21 @@ describe('Tracking Routes', () => {
       expect(res.body.geometry.coordinates).toHaveLength(2);
       expect(res.body.properties.fallback).toBe(true);
     });
+
+    it('should reject route geometry when order coordinates are missing', async () => {
+      const shareRes = await request(app)
+        .post('/api/orders/%23FF20241205/share-tracking')
+        .set('x-user-id', 'customer-uuid-123')
+        .send({});
+
+      mockStore.orders[0].drop_lng = null;
+
+      const res = await request(app)
+        .get(`/api/public/tracking/${shareRes.body.token}/route`);
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe('Route coordinates are not available for this order');
+    });
   });
 
   describe('Security: No auth required for public endpoint', () => {


### PR DESCRIPTION
## Summary
- validate route coordinates before building public tracking GeoJSON
- return a clear 422 response when pickup or drop coordinates are unavailable
- add integration coverage for missing coordinate data

## Validation
- `npm --prefix backend/api test -- publicTracking.test.js`

Closes #4984
