### PR TITLE
fix(order): use injected deliveryVerificationService

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -33,7 +33,7 @@ export class OrderLifecycleService {
     this.orderRepository = orderRepository;
     this.orderTimelineService = orderTimelineService;
     this.bidAcceptanceService = bidAcceptanceService;
-    this.deliveryVerification = new DeliveryVerificationService(orderRepository);
+    this.deliveryVerification = deps.deliveryVerificationService ?? new DeliveryVerificationService(orderRepository);
   }
 
   async createOrder(customerId, customerName, body) {


### PR DESCRIPTION
## Summary
Fixes #4995 — `orderLifecycleService` was not using the injected `deliveryVerificationService` from `deps`, creating a new default instance and bypassing any test or runtime overrides.

## Changes
- `orderLifecycleService.js`: Use `deps.deliveryVerificationService ?? new DeliveryVerificationService(orderRepository)` instead of always creating a new default instance.

## Test plan
- [ ] Service correctly uses the injected dependency when provided.
- [ ] Falls back to default when no injection is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved service configuration by allowing delivery verification handling to be supplied externally, while preserving the existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->