### PR TITLE
fix: check in-memory behavioralProfiles in getOrCreateProfile

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -126,6 +126,10 @@ class FraudDetectionService {
       return JSON.parse(cached);
     }
 
+    // Check in-memory cache (written by trackBehavior during Redis outages)
+    const inMemory = this.behavioralProfiles.get(userId);
+    if (inMemory) return inMemory;
+
     // Check database
     const { data } = await supabase
       .from('behavioral_profiles')


### PR DESCRIPTION
## Summary
Fixes #4997 — `getOrCreateProfile` only checked Redis and the database but never the in-memory `behavioralProfiles` Map. Profiles written by `trackBehavior` during Redis outages were effectively write-only.

## Changes
- `FraudDetectionService.js`: Added `this.behavioralProfiles.get(userId)` check between Redis cache and database lookup.

## Test plan
- [ ] During Redis outage, profiles written by `trackBehavior` are retrievable by `getOrCreateProfile`.
- [ ] Normal flow (Redis available) is unaffected.