### PR TITLE
fix: cap completed array at 1000 entries to prevent memory leak

### DIFF
--- a/backend/scheduler/RenderScheduler.js
+++ b/backend/scheduler/RenderScheduler.js
@@ -269,6 +269,9 @@ class RenderScheduler extends EventEmitter {
             
             this.running.delete(task.id);
             this.completed.push(task);
+            if (this.completed.length > 1000) {
+                this.completed = this.completed.slice(-1000);
+            }
             this.stats.completedTasks++;
             
             // Update stats


### PR DESCRIPTION
## Summary
Fixes #4998 — The `completed` array in `RenderScheduler` grew without bound, causing memory leaks in long-running processes.

## Changes
- `RenderScheduler.js`: Added a cap of 1000 entries after each `push()`. When exceeded, the oldest entries are evicted via `slice(-1000)`.

## Test plan
- [ ] `completed` array never exceeds 1000 entries.
- [ ] `getCompletedTasks()` still returns the most recent entries correctly.