### PR TITLE
fix: pass supabase as orderRepository to OrderTimelineService

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -20,7 +20,7 @@ import { escrowRelease as defaultEscrowRelease } from '../escrow.js';
 import logger from '../../middleware/logger.js';
 import { OrderTimelineService } from './orderTimelineService.js';
 
-const orderTimelineService = new OrderTimelineService({ supabase, logger });
+const orderTimelineService = new OrderTimelineService(supabase);
 
 const DELIVERY_OTP_READY_STATUSES = new Set(['arriving']);
 


### PR DESCRIPTION
## Summary
Fixes #4999 — `OrderTimelineService` was instantiated with `{ supabase, logger }` instead of a proper repository object, causing `TypeError` when timeline methods were called.

## Changes
- `deliveryVerificationService.js`: Changed constructor argument from `{ supabase, logger }` to `supabase` to match the expected `orderRepository` parameter type.

## Test plan
- [ ] Timeline operations no longer throw `TypeError` at runtime.