### PR TITLE
fix : extended buffer warn threshold to cover 50-80% in tracker.js

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -706,7 +706,7 @@ export async function handleLocationPing(ws, data, req) {
   const usagePct = (telemetryWriteBuffer.length / MAX_BUFFER_SIZE) * 100;
   if (usagePct >= 80) {
     logger.warn(`[TRUXIFY BUFFER CRITICAL] Buffer at ${usagePct.toFixed(0)}% capacity (${telemetryWriteBuffer.length}/${MAX_BUFFER_SIZE})`);
-  } else if (usagePct >= 50 && usagePct < 60) {
+  } else if (usagePct >= 50 && usagePct < 80) {
     logger.warn(`[TRUXIFY BUFFER WARN] Buffer at ${usagePct.toFixed(0)}% capacity (${telemetryWriteBuffer.length}/${MAX_BUFFER_SIZE})`);
   }
 


### PR DESCRIPTION
Closes #5014.

Summary of What Has Been Done:
The telemetry buffer usage warning in tracker.js was configured to fire only when the buffer usage percentage was between 50 and 60, leaving a dead zone where the warning would not fire between 60% and the critical threshold at 80%. This change extends the warn range to 50-80%, covering the full intended warning band.

Changes Made:
- backend/api/src/sockets/tracker.js — changed buffer warn condition from `usagePct >= 50 && usagePct < 60` to `usagePct >= 50 && usagePct < 80`.

Impact it Made:
- Buffer warnings now fire continuously from 50% capacity up to the critical threshold at 80%.
- No behavioral change at critical threshold (already handled by separate condition).

Note: Please assign this PR to the `tmdeveloper007` account. This PR is made as part of GSSOC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry buffer monitoring by expanding warnings to cover usage from 50% to below 80%.
  * Preserved separate critical alerts for buffer usage at 80% or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->