### PR TITLE
fix: add bounds checking in waypoint optimization loop

### DIFF
--- a/backend/api/src/services/routingService.js
+++ b/backend/api/src/services/routingService.js
@@ -47,7 +47,10 @@ export async function optimizeWaypoints(start, end, waypoints) {
     for (let i = 0; i < waypointsResult.length; i++) {
       const osrmWp = waypointsResult[i];
       const originalIndex = osrmWp.waypoint_index - 1;
-      optimizedWaypoints[i] = waypoints[originalIndex];
+      const optimizedIndex = i;
+      if (originalIndex >= 0 && originalIndex < waypoints.length) {
+        optimizedWaypoints[optimizedIndex] = waypoints[originalIndex];
+      }
     }
 
     return optimizedWaypoints;


### PR DESCRIPTION
Closes #5024

This PR adds bounds checking to the waypoint optimization loop in routingService.js to prevent undefined values when OSRM returns unexpected waypoint indices.

Changes:
- backend/api/src/services/routingService.js — Added bounds check for originalIndex before accessing waypoints array

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route optimization reliability by safely handling invalid waypoint indexes returned during routing.
  * Prevented potential errors when mapping optimized routes back to the original waypoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->