### PR TITLE
fix: use correct column name user_id in hos_service fetchCurrentStatus

### DIFF
--- a/apps/driver/lib/services/hos_service.dart
+++ b/apps/driver/lib/services/hos_service.dart
@@ -47,7 +47,7 @@ class HosService {
       final response = await Supabase.instance.client
           .from('driver_details')
           .select('hos_status, accumulated_driving_minutes, accumulated_on_duty_minutes, shift_start_time')
-          .eq('driver_id', driverId)
+          .eq('user_id', driverId)
           .maybeSingle();
       
       return response;


### PR DESCRIPTION
Closes #5025

This PR fixes the wrong column name in hos_service.dart where .eq('driver_id', driverId) was used instead of .eq('user_id', driverId). The database schema defines the column as user_id, causing the query to fail silently.

Changes:
- apps/driver/lib/services/hos_service.dart — Changed .eq('driver_id', driverId) to .eq('user_id', driverId)

GSSOC