### PR TITLE
fix: include category field in getProductTrace response

### DIFF
--- a/backend/traceability/trace.service.js
+++ b/backend/traceability/trace.service.js
@@ -241,6 +241,7 @@ class TraceabilityService {
                     id: trace[0][0].toString(),
                     name: trace[0][1],
                     description: trace[0][2],
+                    category: trace[0][3],
                     manufacturer: trace[0][4]
                 },
                 events: trace[1].map(e => ({


### PR DESCRIPTION
Closes #5027

This PR adds the missing category field to the getProductTrace response in trace.service.js. The field was being stored on-chain by createProduct but was skipped when reading back.

Changes:
- backend/traceability/trace.service.js — Added category: trace[0][3] to the product mapping

GSSOC