### PR TITLE
fix: include orderId in getTradeOrder return mapping

### DIFF
--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -177,7 +177,8 @@ class TokenizationService {
                 maker: order.maker,
                 price: ethers.formatEther(order.price),
                 amount: ethers.formatEther(order.amount),
-                filled: order.filled
+                filled: order.filled,
+                orderId: order.orderId
             };
         } catch (error) {
             logger.error('Failed to get trade order:', error);


### PR DESCRIPTION
Closes #5028

This PR adds the missing orderId field to the getTradeOrder return mapping in token.service.js. Without it, executeTradeOrder references order.orderId which is always undefined.

Changes:
- backend/tokenization/token.service.js — Added orderId: order.orderId to the getTradeOrder return object

GSSOC