### PR TITLE
fix: sanitize CSV values to prevent formula injection in profile export

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -566,11 +566,18 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
 
     if (format === 'csv') {
       // Optimize memory: construct CSV string directly using string builder/loop
+      const sanitizeCsvValue = (val) => {
+        const str = String(val);
+        if (/^[=+\-@\t\r]/.test(str)) {
+          return `"'"${str.replace(/"/g, '""')}"`;
+        }
+        return `"${str.replace(/"/g, '""')}"`;
+      };
       const headers = ['ID', 'Order Display ID', 'Pickup Address', 'Drop Address', 'Pickup Date', 'Base Freight', 'Platform Fee', 'Toll Estimate', 'Net Earnings', 'Status'];
-      let csvString = headers.map(val => `"${String(val).replace(/"/g, '""')}"`).join(',') + '\n';
+      let csvString = headers.map(val => sanitizeCsvValue(val)).join(',') + '\n';
       for (const t of tripsList) {
         const row = [t.id, t.order_display_id, t.pickup_address, t.drop_address, t.pickup_date, t.base_freight, t.platform_fee, t.toll_estimate, t.net_earnings, t.status];
-        csvString += row.map(val => `"${String(val).replace(/"/g, '""')}"`).join(',') + '\n';
+        csvString += row.map(val => sanitizeCsvValue(val)).join(',') + '\n';
       }
       res.setHeader('Content-Type', 'text/csv');
       return res.send(csvString.trimEnd());


### PR DESCRIPTION
Closes #5029

This PR adds CSV value sanitization to prevent formula injection in the profile trip export. Previously, values starting with =, +, -, or @ could be interpreted as formulas when opened in Excel.

Changes:
- backend/api/src/routes/profileRoutes.js — Added sanitizeCsvValue() helper that prefixes dangerous characters with a single quote to neutralize formula execution

GSSOC