### PR TITLE
fix: increase escrow lock TTL from 30s to 120s for blockchain operations

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -445,7 +445,7 @@ export class OrderLifecycleService {
   async verifyDeliveryFn(orderId, driverId, otp) {
     return measureExecution('OrderLifecycleService.verifyDeliveryFn', async () => {
       const lockKey = `escrow_lock:${orderId}`;
-      const lockValue = await acquireLock(lockKey, 30000);
+      const lockValue = await acquireLock(lockKey, 120000);
       if (!lockValue) {
         throw new DomainError(409, { error: 'Delivery verification is currently being processed. Please try again later.' });
       }


### PR DESCRIPTION
Closes #5030

This PR increases the distributed lock TTL for delivery verification from 30 seconds to 120 seconds. The previous TTL was too short for blockchain escrow release operations which can take longer due to network confirmation times.

Changes:
- backend/api/src/services/order/orderLifecycleService.js — Changed acquireLock TTL from 30000 to 120000ms

GSSOC