### PR TITLE
fix: clean up associated load offers when cancelling stale orders

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -13,7 +13,7 @@ export const startStaleOrderWorker = () => {
       // Find all pending orders created more than 24 hours ago
       const { data: staleOrders, error: fetchError } = await supabase
         .from('orders')
-        .select('id, customer_id')
+        .select('id, customer_id, order_display_id')
         .eq('status', 'pending')
         .lt('created_at', twentyFourHoursAgo);
 
@@ -43,6 +43,12 @@ export const startStaleOrderWorker = () => {
           logger.error(`[StaleOrderWorker] Failed to cancel order ${order.id}: ${updateError.message}`);
           continue;
         }
+
+        // Cancel associated load offers
+        await supabase
+          .from('load_offers')
+          .update({ status: 'cancelled' })
+          .eq('order_display_id', order.order_display_id);
 
         // Send a notification to the customer
         await sendPushNotification(


### PR DESCRIPTION
Closes #5031

This PR adds load_offers cleanup to the stale order worker. Previously, when stale pending orders were cancelled, associated load_offers remained in pending status, appearing as available bids in the marketplace.

Changes:
- backend/api/src/workers/staleOrderWorker.js — Added order_display_id to select query and load_offers status update to 'cancelled' after order cancellation

GSSOC