### PR TITLE
fix: add getTradeOrder to token ABI definition

### DIFF
--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -15,6 +15,7 @@ class TokenizationService {
             'function createTradeOrder(uint256 assetId, uint256 amount, uint256 price, string memory orderType) external',
             'function executeTradeOrder(uint256 assetId, uint256 orderIndex) external payable',
             'function cancelTradeOrder(uint256 assetId, uint256 orderIndex) external',
+            'function getTradeOrder(uint256 assetId, uint256 orderIndex) external view returns (tuple(address,uint256,uint256,uint256,bool))',
             'function getAsset(uint256 assetId) external view returns (tuple(uint256,string,string,string,uint256,uint256,uint256,uint256,address,bool,string,uint256,uint256))',
             'function getFractionalOwnership(uint256 assetId, address owner) external view returns (tuple(address,uint256,uint256,uint256))',
             'function getTotalAssets() external view returns (uint256)',


### PR DESCRIPTION
Closes #5032

This PR adds the missing getTradeOrder function to the token ABI definition. The ABI was missing this function, causing every call to getTradeOrder to fail with a contract interaction error.

Changes:
- backend/tokenization/token.service.js — Added getTradeOrder(uint256,uint256) to the tokenABI array

GSSOC