### PR TITLE
fix: extract shipment ID from transaction receipt events

### DIFF
--- a/backend/traceability/trace.service.js
+++ b/backend/traceability/trace.service.js
@@ -77,7 +77,21 @@ class TraceabilityService {
             );
             const receipt = await tx.wait();
 
-            const shipmentId = await this.contract.getShipmentCount();
+            let shipmentId;
+            for (const log of receipt.logs) {
+                try {
+                    const parsed = this.contract.interface.parseLog(log);
+                    if (parsed && parsed.name === 'ShipmentCreated') {
+                        shipmentId = parsed.args.shipmentId;
+                        break;
+                    }
+                } catch (e) {
+                    // Not a matching event, continue
+                }
+            }
+            if (!shipmentId) {
+                shipmentId = await this.contract.getShipmentCount();
+            }
 
             await this.storeShipment({
                 productId,


### PR DESCRIPTION
Closes #5033

This PR fixes the shipment ID extraction in createShipment to use transaction receipt events instead of getShipmentCount(). The previous approach returned the total count, not the ID of the newly created shipment, which could cause race conditions.

Changes:
- backend/traceability/trace.service.js — Parse ShipmentCreated event from receipt logs to extract the correct shipment ID, with fallback to getShipmentCount()

GSSOC