### PR TITLE
feat: implement driver earnings analytics dashboard and backend endpoint

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -6,6 +6,7 @@ import 'package:truxify_driver/models/earnings_statement_model.dart';
 import 'package:truxify_driver/services/driver_earnings_service.dart';
 import 'package:truxify_driver/services/earnings_export_service.dart';
 import 'package:truxify_shared/truxify_shared.dart';
+import 'package:fl_chart/fl_chart.dart';
 import '../theme/app_theme.dart';
 import '../widgets/earnings/withdraw_bottom_sheet.dart';
 import '../widgets/earnings_shimmer.dart';
@@ -37,6 +38,10 @@ class _EarningsScreenState extends State<EarningsScreen> {
   double _confirmedEarnings = 0.0;
   double _pendingEarnings = 0.0;
   double _totalEarnings = 0.0;
+  bool _showAnalyticsTab = false;
+  bool _isAnalyticsLoading = false;
+  Map<String, dynamic>? _analyticsData;
+  String _selectedPeriod = 'week';
 
   @override
   void initState() {
@@ -456,12 +461,463 @@ class _EarningsScreenState extends State<EarningsScreen> {
     }
   }
 
+  Future<void> _loadAnalyticsData() async {
+    setState(() => _isAnalyticsLoading = true);
+    try {
+      final data = await _earningsService.fetchEarningsAnalytics(
+        period: _selectedPeriod,
+      );
+      setState(() {
+        _analyticsData = data;
+        _isAnalyticsLoading = false;
+      });
+    } catch (e) {
+      debugPrint('Failed to load analytics: $e');
+      setState(() => _isAnalyticsLoading = false);
+      _showSnackBar('Failed to load analytics: $e', TruxifyColors.error);
+    }
+  }
+
+  Widget _buildPeriodToggle() {
+    final periods = ['day', 'week', 'month'];
+    final labels = {'day': 'Today', 'week': 'This Week', 'month': 'This Month'};
+    
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.outlineVariant.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: periods.map((p) {
+            final isSel = _selectedPeriod == p;
+            return Expanded(
+              child: GestureDetector(
+                onTap: () {
+                  setState(() => _selectedPeriod = p);
+                  _loadAnalyticsData();
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  decoration: BoxDecoration(
+                    color: isSel ? TruxifyColors.accent.withValues(alpha: 0.1) : Colors.transparent,
+                    borderRadius: BorderRadius.circular(8),
+                    border: isSel ? Border.all(color: TruxifyColors.accent, width: 1.5) : null,
+                  ),
+                  child: Center(
+                    child: Text(
+                      labels[p]!,
+                      style: GoogleFonts.dmSans(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 13,
+                        color: isSel ? TruxifyColors.accent : TruxifyColors.adaptiveSecondaryText(context),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBarChartCard() {
+    if (_analyticsData == null) return const SizedBox.shrink();
+    final chartData = _analyticsData!['weekly_chart'] as List?;
+    if (chartData == null || chartData.isEmpty) return const SizedBox.shrink();
+
+    List<BarChartGroupData> barGroups = [];
+    double maxVal = 1000.0;
+
+    for (int i = 0; i < chartData.length; i++) {
+      final item = chartData[i] as Map;
+      final earningsVal = ((item['earnings'] ?? 0) / 100.0).toDouble();
+      if (earningsVal > maxVal) maxVal = earningsVal;
+
+      barGroups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: earningsVal,
+              color: TruxifyColors.accent,
+              width: 14,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(4),
+                topRight: Radius.circular(4),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardTheme.color,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Daily Earnings Breakdown',
+            style: GoogleFonts.dmSans(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            height: 180,
+            child: BarChart(
+              BarChartData(
+                alignment: BarChartAlignment.spaceAround,
+                maxY: maxVal * 1.1,
+                barTouchData: BarTouchData(
+                  touchTooltipData: BarTouchTooltipData(
+                    getTooltipColor: (_) => TruxifyColors.accentDark,
+                    getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                      final item = chartData[group.x] as Map;
+                      return BarTooltipItem(
+                        '${item['day']}\n₹${rod.toY.toStringAsFixed(0)}',
+                        const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                      );
+                    },
+                  ),
+                ),
+                titlesData: FlTitlesData(
+                  show: true,
+                  bottomTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      getTitlesWidget: (value, meta) {
+                        final index = value.toInt();
+                        if (index < 0 || index >= chartData.length) return const SizedBox.shrink();
+                        final item = chartData[index] as Map;
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(
+                            item['day'].toString(),
+                            style: GoogleFonts.dmSans(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w600,
+                              color: TruxifyColors.adaptiveSecondaryText(context),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  leftTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 45,
+                      getTitlesWidget: (value, meta) {
+                        return Text(
+                          '₹${value.toStringAsFixed(0)}',
+                          style: GoogleFonts.dmSans(
+                            fontSize: 9,
+                            color: TruxifyColors.adaptiveSecondaryText(context),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                ),
+                gridData: const FlGridData(show: false),
+                borderData: FlBorderData(show: false),
+                barGroups: barGroups,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCumulativeStatsCard() {
+    if (_analyticsData == null) return const SizedBox.shrink();
+    final stats = _analyticsData!['cumulative_stats'] as Map?;
+    final deadheadCount = _analyticsData!['deadhead_trips_saved'] ?? 0;
+    if (stats == null) return const SizedBox.shrink();
+
+    final totalKm = stats['total_km'] ?? 0;
+    final avgEarning = stats['avg_earning_per_km'] ?? 0.0;
+    final lifetimeTrips = stats['lifetime_trips'] ?? 0;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardTheme.color,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Performance Metrics',
+            style: GoogleFonts.dmSans(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              _buildCumulativeMetricTile(
+                icon: Icons.map_outlined,
+                color: Colors.blue,
+                label: 'Total Distance',
+                value: '$totalKm km',
+              ),
+              _buildCumulativeMetricTile(
+                icon: Icons.trending_up_rounded,
+                color: Colors.green,
+                label: 'Avg Earning/km',
+                value: '₹${(avgEarning as double).toStringAsFixed(1)}',
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              _buildCumulativeMetricTile(
+                icon: Icons.local_shipping_outlined,
+                color: TruxifyColors.accent,
+                label: 'Lifetime Trips',
+                value: '$lifetimeTrips',
+              ),
+              _buildCumulativeMetricTile(
+                icon: Icons.eco_outlined,
+                color: Colors.teal,
+                label: 'Deadhead Saved',
+                value: '$deadheadCount',
+                subtitle: 'ML Deadhead Eliminator',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCumulativeMetricTile({
+    required IconData icon,
+    required Color color,
+    required String label,
+    required String value,
+    String? subtitle,
+  }) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.outlineVariant.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.1),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, color: color, size: 20),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    value,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    label,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
+                      color: TruxifyColors.adaptiveSecondaryText(context),
+                    ),
+                  ),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: GoogleFonts.dmSans(
+                        fontSize: 8,
+                        color: color,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTripsListCard() {
+    if (_analyticsData == null) return const SizedBox.shrink();
+    final trips = _analyticsData!['trips'] as List?;
+    
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardTheme.color,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Trip History Analysis',
+            style: GoogleFonts.dmSans(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (trips == null || trips.isEmpty)
+            _buildEmptyMessage('No completed trips found in this period.')
+          else
+            ...trips.map((item) {
+              final trip = item as Map;
+              final route = trip['route_label'] ?? 'Route Unavailable';
+              final gross = (trip['gross_earnings'] ?? 0) / 100.0;
+              final fuel = (trip['estimated_fuel_cost'] ?? 0) / 100.0;
+              final net = (trip['net_earnings'] ?? 0) / 100.0;
+              final receiptLink = trip['receipt_link'];
+              final displayId = trip['trip_display_id'] ?? '';
+
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.local_shipping, size: 16, color: TruxifyColors.accent),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            route,
+                            style: GoogleFonts.dmSans(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                        Text(
+                          displayId,
+                          style: GoogleFonts.dmSans(
+                            fontSize: 11,
+                            color: TruxifyColors.adaptiveSecondaryText(context),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _buildTripValueColumn('Gross Payment', '₹${gross.toStringAsFixed(0)}'),
+                        _buildTripValueColumn('Fuel Cost', '₹${fuel.toStringAsFixed(0)}', color: Colors.orange),
+                        _buildTripValueColumn('Net Earnings', '₹${net.toStringAsFixed(0)}', color: Colors.green, isBold: true),
+                      ],
+                    ),
+                    if (receiptLink != null) ...[
+                      const SizedBox(height: 6),
+                      GestureDetector(
+                        onTap: () async {
+                          final uri = Uri.parse(receiptLink.toString());
+                          _showSnackBar('Receipt link: $receiptLink', TruxifyColors.accent);
+                        },
+                        child: Row(
+                          children: [
+                            const Icon(Icons.link, size: 12, color: Colors.blue),
+                            const SizedBox(width: 4),
+                            Text(
+                              'On-Chain Receipt',
+                              style: GoogleFonts.dmSans(
+                                fontSize: 11,
+                                color: Colors.blue,
+                                fontWeight: FontWeight.w600,
+                                decoration: TextDecoration.underline,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                    Divider(color: Theme.of(context).colorScheme.outlineVariant),
+                  ],
+                ),
+              );
+            }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTripValueColumn(String label, String value, {Color? color, bool isBold = false}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: GoogleFonts.dmSans(
+            fontSize: 10,
+            color: TruxifyColors.adaptiveSecondaryText(context),
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: GoogleFonts.dmSans(
+            fontSize: 13,
+            fontWeight: isBold ? FontWeight.bold : FontWeight.w600,
+            color: color ?? Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         body: RefreshIndicator(
-          onRefresh: _loadAllData,
+          onRefresh: _showAnalyticsTab ? _loadAnalyticsData : _loadAllData,
           child: CustomScrollView(
             slivers: [
               SliverAppBar(
@@ -511,42 +967,126 @@ class _EarningsScreenState extends State<EarningsScreen> {
                   padding: const EdgeInsets.symmetric(vertical: 20),
                   child: Column(
                     children: [
-                      if (!_isLoading && _isMonthLoading) const LinearProgressIndicator(),
-                      AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 300),
-                        child: _isLoading
-                            ? const SummaryCardsShimmer(key: ValueKey('summary_shimmer'))
-                            : _buildOverallSummaryCards(key: const ValueKey('summary_content')),
+                      // Sliding Segmented Tab Control
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.outlineVariant.withValues(alpha: 0.3),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: GestureDetector(
+                                  onTap: () => setState(() => _showAnalyticsTab = false),
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(vertical: 12),
+                                    decoration: BoxDecoration(
+                                      color: !_showAnalyticsTab ? TruxifyColors.accent : Colors.transparent,
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: Center(
+                                      child: Text(
+                                        'Wallet & Calendar',
+                                        style: GoogleFonts.dmSans(
+                                          fontWeight: FontWeight.bold,
+                                          fontSize: 14,
+                                          color: !_showAnalyticsTab ? Colors.white : TruxifyColors.adaptiveSecondaryText(context),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Expanded(
+                                child: GestureDetector(
+                                  onTap: () {
+                                    setState(() => _showAnalyticsTab = true);
+                                    _loadAnalyticsData();
+                                  },
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(vertical: 12),
+                                    decoration: BoxDecoration(
+                                      color: _showAnalyticsTab ? TruxifyColors.accent : Colors.transparent,
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: Center(
+                                      child: Text(
+                                        'Analytics & Profits',
+                                        style: GoogleFonts.dmSans(
+                                          fontWeight: FontWeight.bold,
+                                          fontSize: 14,
+                                          color: _showAnalyticsTab ? Colors.white : TruxifyColors.adaptiveSecondaryText(context),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
-                      if (!_isLoading && _confirmedEarnings > 0) ...[
-                        const SizedBox(height: 16),
-                        _buildWithdrawButton(),
+                      const SizedBox(height: 16),
+
+                      if (_showAnalyticsTab) ...[
+                        if (_isAnalyticsLoading)
+                          const Center(
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(vertical: 40),
+                              child: CircularProgressIndicator(),
+                            ),
+                          )
+                        else ...[
+                          _buildPeriodToggle(),
+                          const SizedBox(height: 24),
+                          if (_selectedPeriod == 'week' || _selectedPeriod == 'month') ...[
+                            _buildBarChartCard(),
+                            const SizedBox(height: 24),
+                          ],
+                          _buildCumulativeStatsCard(),
+                          const SizedBox(height: 24),
+                          _buildTripsListCard(),
+                        ],
+                      ] else ...[
+                        if (!_isLoading && _isMonthLoading) const LinearProgressIndicator(),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: _isLoading
+                              ? const SummaryCardsShimmer(key: ValueKey('summary_shimmer'))
+                              : _buildOverallSummaryCards(key: const ValueKey('summary_content')),
+                        ),
+                        if (!_isLoading && _confirmedEarnings > 0) ...[
+                          const SizedBox(height: 16),
+                          _buildWithdrawButton(),
+                        ],
+                        const SizedBox(height: 24),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: _isLoading
+                              ? HeatmapCalendarShimmer(
+                                  key: const ValueKey('calendar_shimmer'),
+                                  currentYear: _currentYear,
+                                  currentMonth: _currentMonth,
+                                )
+                              : _buildHeatmapCalendarCard(key: const ValueKey('calendar_content')),
+                        ),
+                        const SizedBox(height: 24),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: _isLoading
+                              ? const SelectedDateDetailsShimmer(key: ValueKey('details_shimmer'))
+                              : _buildSelectedDateDetailsCard(key: const ValueKey('details_content')),
+                        ),
+                        const SizedBox(height: 24),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: _isLoading
+                              ? const PendingPaymentsShimmer(key: ValueKey('payments_shimmer'))
+                              : _buildTransactionHistoryCard(key: const ValueKey('payments_content')),
+                        ),
                       ],
-                      const SizedBox(height: 24),
-                      AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 300),
-                        child: _isLoading
-                            ? HeatmapCalendarShimmer(
-                                key: const ValueKey('calendar_shimmer'),
-                                currentYear: _currentYear,
-                                currentMonth: _currentMonth,
-                              )
-                            : _buildHeatmapCalendarCard(key: const ValueKey('calendar_content')),
-                      ),
-                      const SizedBox(height: 24),
-                      AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 300),
-                        child: _isLoading
-                            ? const SelectedDateDetailsShimmer(key: ValueKey('details_shimmer'))
-                            : _buildSelectedDateDetailsCard(key: const ValueKey('details_content')),
-                      ),
-                      const SizedBox(height: 24),
-                      AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 300),
-                        child: _isLoading
-                            ? const PendingPaymentsShimmer(key: ValueKey('payments_shimmer'))
-                            : _buildTransactionHistoryCard(key: const ValueKey('payments_content')),
-                      ),
                       const SizedBox(height: 40),
                     ],
                   ),

--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -344,6 +344,27 @@ class DriverEarningsService {
     }
   }
 
+  Future<Map<String, dynamic>> fetchEarningsAnalytics({
+    required String period,
+  }) async {
+    if (driverId == null) return {};
+
+    final path = '/api/driver/$driverId/earnings?period=$period';
+
+    try {
+      final decoded = await _apiClient.get(path);
+      if (decoded is! Map) {
+        throw StateError('Unexpected earnings analytics response format');
+      }
+      return Map<String, dynamic>.from(decoded);
+    } catch (e) {
+      if (e is ApiException) {
+        throw Exception(e.message.isNotEmpty ? e.message : 'Failed to load earnings analytics.');
+      }
+      throw Exception('Network error: Failed to fetch earnings analytics.');
+    }
+  }
+
   void dispose() {
     _apiClient.dispose();
   }

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   web_socket_channel: ^3.0.0
 
   google_fonts: ^8.1.0
+  fl_chart: ^0.66.0
   flutter_riverpod: ^2.5.1
   flutter_map: ^8.1.1
   latlong2: ^0.10.1

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1424,6 +1424,147 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requireDriverRole, 
   }
 });
 
+// ============================================================================
+// GET DRIVER ANALYTICS & EARNINGS
+// ============================================================================
+router.get('/:id/earnings', authenticate, userLimiter, requirePolicy('driver:view-earnings'), validateParams(paramIdSchema), async (req, res) => {
+  const { id } = req.params;
+  const period = req.query.period || 'week';
+
+  if (req.user.role !== 'admin' && req.user.id !== id) {
+    return res.status(403).json({ error: 'Access denied. You can only view your own earnings.' });
+  }
+
+  try {
+    let cutoff = new Date();
+    if (period === 'day') {
+      cutoff.setHours(0, 0, 0, 0);
+    } else if (period === 'week') {
+      cutoff.setDate(cutoff.getDate() - 7);
+    } else if (period === 'month') {
+      cutoff.setDate(cutoff.getDate() - 30);
+    } else {
+      return res.status(400).json({ error: 'Invalid period. Must be day, week, or month.' });
+    }
+
+    const { data: trips, error: tripsError } = await supabase
+      .from('trips')
+      .select('*')
+      .eq('driver_id', id)
+      .eq('status', 'completed')
+      .gte('trip_date', cutoff.toISOString().split('T')[0])
+      .order('trip_date', { ascending: false });
+
+    if (tripsError) {
+      return res.status(500).json({ error: 'Failed to fetch trips.', details: tripsError.message });
+    }
+
+    const { count: lifetimeTrips, error: countError } = await supabase
+      .from('trips')
+      .select('*', { count: 'exact', head: true })
+      .eq('driver_id', id)
+      .eq('status', 'completed');
+
+    if (countError) {
+      logger.warn('Failed to fetch lifetime trips count:', countError.message);
+    }
+
+    // Weekly Chart Aggregation (always shows past 7 days)
+    const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const weeklyChartMap = {};
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      const dayLabel = daysOfWeek[d.getDay()];
+      weeklyChartMap[dayLabel] = 0;
+    }
+
+    trips.forEach(trip => {
+      const tripDate = new Date(trip.trip_date);
+      const dayLabel = daysOfWeek[tripDate.getDay()];
+      if (weeklyChartMap[dayLabel] !== undefined) {
+        weeklyChartMap[dayLabel] += trip.total_earnings;
+      }
+    });
+
+    const weeklyChart = Object.entries(weeklyChartMap).map(([day, earnings]) => ({
+      day,
+      earnings
+    }));
+
+    let totalKm = 0;
+    trips.forEach(trip => {
+      if (trip.distance) {
+        const distanceNum = parseInt(trip.distance.replace(/[^0-9]/g, '')) || 0;
+        totalKm += distanceNum;
+      }
+    });
+
+    // Deadhead Trips Saved logic
+    const { data: allCompletedTrips, error: allTripsError } = await supabase
+      .from('trips')
+      .select('route_label, trip_date')
+      .eq('driver_id', id)
+      .eq('status', 'completed')
+      .order('trip_date', { ascending: true });
+
+    let deadheadTripsSaved = 0;
+    if (allCompletedTrips && allCompletedTrips.length > 1) {
+      for (let i = 1; i < allCompletedTrips.length; i++) {
+        const prevTrip = allCompletedTrips[i - 1];
+        const currTrip = allCompletedTrips[i];
+        
+        const prevRoute = prevTrip.route_label.split(' → ');
+        const currRoute = currTrip.route_label.split(' → ');
+        
+        if (prevRoute.length === 2 && currRoute.length === 2) {
+          const prevDrop = prevRoute[1].trim().toLowerCase();
+          const currPickup = currRoute[0].trim().toLowerCase();
+          
+          if (prevDrop === currPickup) {
+            const prevDate = new Date(prevTrip.trip_date);
+            const currDate = new Date(currTrip.trip_date);
+            const diffDays = Math.abs(currDate - prevDate) / (1000 * 60 * 60 * 24);
+            if (diffDays <= 3) {
+              deadheadTripsSaved++;
+            }
+          }
+        }
+      }
+    }
+
+    const totalNetEarnings = trips.reduce((sum, t) => sum + t.net_earnings, 0);
+
+    res.json({
+      period,
+      gross_earnings: trips.reduce((sum, t) => sum + t.total_earnings, 0),
+      net_earnings: totalNetEarnings,
+      trips_completed: trips.length,
+      weekly_chart: weeklyChart,
+      trips: trips.map(t => ({
+        trip_display_id: t.trip_display_id,
+        route_label: t.route_label,
+        gross_earnings: t.total_earnings,
+        estimated_fuel_cost: t.fuel_deducted,
+        net_earnings: t.net_earnings,
+        blockchain_hash: t.blockchain_hash,
+        receipt_link: t.blockchain_hash ? `https://polygonscan.com/tx/${t.blockchain_hash}` : null,
+        trip_date: t.trip_date
+      })),
+      cumulative_stats: {
+        total_km: totalKm,
+        avg_earning_per_km: totalKm > 0 ? (totalNetEarnings / 100.0) / totalKm : 0,
+        lifetime_trips: lifetimeTrips || 0
+      },
+      deadhead_trips_saved: deadheadTripsSaved
+    });
+
+  } catch (err) {
+    logger.error('Driver analytics fetch error:', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
 export default router;
 
 // Resolves #2051: Composite indexes added for 2dsphere queries


### PR DESCRIPTION
# Description

This PR implements the Driver Earnings Analytics screen in the Flutter Driver App and its corresponding secure backend endpoint.

---

## Proposed Changes

### 1. Backend API (`backend/api/`)
- **`driverRoutes.js`**: Added the `GET /api/driver/:id/earnings` endpoint. Computes gross and net earnings, completed trips, daily breakdowns, and dynamic return trips saved (Deadhead Eliminator matching) with strict user/admin access controls.

### 2. Flutter Driver App (`apps/driver/`)
- **`pubspec.yaml`**: Added the `fl_chart: ^0.66.0` dependency.
- **`driver_earnings_service.dart`**: Implemented the client API caller.
- **`earnings_screen.dart`**: Added a sliding tab toggle to switch between Wallet and Analytics views, containing Today/Week/Month toggles, daily bar charts, cumulative stats (distance, avg earnings, deadhead count), and trip analysis lists with receipt links.
