### PR TITLE
fix: wire en-route loads to Deadhead Eliminator ML with haversine fal…

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -423,9 +423,30 @@ class _TripsScreenState extends State<TripsScreen> {
     }
 
     try {
+      // Resolve driver's current GPS from the active trip's last known route
+      // point so the ML engine can compute detour distances accurately.
+      double? currentLat;
+      double? currentLng;
+      final activeTrip = _trips.cast<Map<String, dynamic>?>().firstWhere(
+        (t) => t?['status'] == 'active',
+        orElse: () => null,
+      );
+      if (activeTrip != null) {
+        final tripId = activeTrip['trip_display_id']?.toString();
+        final routePoints = tripId != null ? (_routePointsByTripId[tripId] ?? []) : [];
+        if (routePoints.isNotEmpty) {
+          final lastPoint = routePoints.last;
+          currentLat = (lastPoint['latitude'] as num?)?.toDouble();
+          currentLng = (lastPoint['longitude'] as num?)?.toDouble();
+        }
+      }
+
       final results = await Future.wait([
         _marketplaceRepository.fetchLoadOffers(),
-        _marketplaceRepository.fetchEnRouteLoads(),
+        _marketplaceRepository.fetchEnRouteLoads(
+          currentLat: currentLat,
+          currentLng: currentLng,
+        ),
         _marketplaceRepository.fetchDriverBids(),
       ]);
 

--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -75,8 +75,21 @@ class MarketplaceRepository {
     }
   }
 
-  Future<List<LoadOffer>> fetchEnRouteLoads() async {
-    final path = '/api/orders/load-offers/en-route';
+  Future<List<LoadOffer>> fetchEnRouteLoads({
+    double? currentLat,
+    double? currentLng,
+    double maxDetourKm = 50,
+  }) async {
+    final queryParams = <String, String>{};
+    if (currentLat != null && currentLng != null) {
+      queryParams['current_lat'] = currentLat.toStringAsFixed(6);
+      queryParams['current_lng'] = currentLng.toStringAsFixed(6);
+      queryParams['max_detour_km'] = maxDetourKm.toStringAsFixed(1);
+    }
+    final query = queryParams.isNotEmpty
+        ? '?${queryParams.entries.map((e) => '${e.key}=${e.value}').join('&')}'
+        : '';
+    final path = '/api/orders/load-offers/en-route$query';
     try {
       final decoded = await _apiClient.get(path);
       if (decoded is! List) throw StateError('Unexpected response type');

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -167,7 +167,7 @@ import {
 import { awardReputationPoints } from '../services/reputation.js';
 import { expireDeliveryOtps } from '../services/notificationService.js';
 import { DomainError } from '../services/order/domainError.js';
-import { predictDemand, predictPrice } from '../services/ml.js';
+import { predictDemand, predictPrice, matchEnRouteLoads } from '../services/ml.js';
 import { requireIdempotency } from '../middleware/idempotency.js';
 import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
@@ -399,27 +399,74 @@ router.get('/load-offers', authenticate, userLimiter, async (req, res) => {
  *         description: En-route offers
  */
 router.get('/load-offers/en-route', authenticate, userLimiter, async (req, res) => {
-  const page = Math.max(1, parseInt(req.query.page) || 1);
-  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 20));
-  const cacheKey = `load-offers:en-route:${page}:${limit}`;
+  // Optional driver GPS — used to score loads by detour distance
+  const currentLat = parseFloat(req.query.current_lat);
+  const currentLng = parseFloat(req.query.current_lng);
+  const maxDetourKm = parseFloat(req.query.max_detour_km) || 50;
+
+  const hasGps = Number.isFinite(currentLat) && Number.isFinite(currentLng);
+
+  // Cache key includes GPS bucket (0.1° resolution ≈ 11 km) so nearby drivers
+  // share a cache entry without stale results.
+  const latBucket = hasGps ? (Math.round(currentLat * 10) / 10).toFixed(1) : 'x';
+  const lngBucket = hasGps ? (Math.round(currentLng * 10) / 10).toFixed(1) : 'x';
+  const cacheKey = `load-offers:en-route:${latBucket}:${lngBucket}:${maxDetourKm}`;
+
   try {
     const cachedOffers = await readLoadOfferCache(cacheKey);
     if (cachedOffers) {
       return res.json(cachedOffers);
     }
 
-    const { data: offers, error } = await orderRepository.findLoadOffers(
-      { is_en_route: true },
-      { pagination: { page, limit } }
+    // Fetch ALL available offers (not pre-filtered by is_en_route flag which may
+    // not be populated) so the ML model can rank by detour from the driver.
+    const { data: rawOffers, error } = await orderRepository.findLoadOffers(
+      { status: 'available' },
+      { pagination: { page: 1, limit: 100 } }
     );
 
-    if (error) return res.status(500).json({ error: 'Failed to fetch en-route loads.', details: error.message });
+    if (error) {
+      return res.status(500).json({ error: 'Failed to fetch load offers.', details: error.message });
+    }
 
-    await writeLoadOfferCache(cacheKey, offers);
+    let enriched;
+    let mlUnavailable = false;
 
-    res.json(offers);
+    if (hasGps && rawOffers && rawOffers.length > 0) {
+      try {
+        enriched = await matchEnRouteLoads({
+          currentLat,
+          currentLng,
+          offers: rawOffers,
+          maxDetourKm,
+        });
+      } catch (mlErr) {
+        // matchEnRouteLoads already handles its own fallback internally;
+        // this outer catch is a last-resort safety net.
+        logger.error('[orderRoutes] matchEnRouteLoads threw unexpectedly:', mlErr.message);
+        enriched = rawOffers;
+        mlUnavailable = true;
+      }
+    } else {
+      // No GPS provided — return all available offers unscored
+      enriched = (rawOffers || []).map(o => ({
+        ...o,
+        detour_km: null,
+        extra_earnings: o.freight_value || 0,
+        match_score: null,
+        ml_used: false,
+      }));
+    }
+
+    if (mlUnavailable) {
+      // Still return the data — just tell the client ML was not available
+      res.set('X-ML-Status', 'unavailable');
+    }
+
+    await writeLoadOfferCache(cacheKey, enriched);
+    res.json(enriched);
   } catch (err) {
-    logger.error("[orderRoutes] Failed to fetch en-route loads:", err.message);
+    logger.error('[orderRoutes] Failed to fetch en-route loads:', err.message);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });

--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -522,7 +522,134 @@ export async function listModels() {
   return handleResponse(response);
 }
 
+/**
+ * Finds en-route load opportunities for an active driver using the Deadhead
+ * Eliminator ML model. When the ML engine is unavailable (no ML_API_KEY,
+ * network error, etc.) it falls back to a pure haversine-distance ranking so
+ * the endpoint never returns an empty list when offers exist in the DB.
+ *
+ * @param {object} params
+ * @param {number}   params.currentLat       - Driver's current latitude
+ * @param {number}   params.currentLng       - Driver's current longitude
+ * @param {Array}    params.offers           - Raw load_offer rows from DB
+ * @param {object}   [params.truckSpecs]     - Truck capacity; defaults to generous values
+ * @param {number}   [params.maxDetourKm=50] - Max acceptable detour in km
+ * @returns {Promise<Array>} - offers enriched with detour_km, extra_earnings, match_score
+ */
+export async function matchEnRouteLoads({
+  currentLat,
+  currentLng,
+  offers,
+  truckSpecs,
+  maxDetourKm = 50,
+}) {
+  if (!offers || offers.length === 0) return [];
+
+  // Build the available_loads list the ML model expects
+  const availableLoads = offers
+    .filter(o => o.origin_lat && o.origin_lng && o.dest_lat && o.dest_lng && o.weight_kg)
+    .map(o => ({
+      load_id: o.id,
+      origin_lat: Number(o.origin_lat),
+      origin_lng: Number(o.origin_lng),
+      dest_lat: Number(o.dest_lat),
+      dest_lng: Number(o.dest_lng),
+      weight_kg: Number(o.weight_kg),
+      length_m: Number(o.length_m || 1),
+      width_m: Number(o.width_m || 1),
+      height_m: Number(o.height_m || 1),
+      pickup_deadline: new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString(),
+      payment_inr: Number(o.payment_inr || o.freight_value || 0),
+    }));
+
+  const specs = truckSpecs || {
+    max_weight_kg: 25000,
+    max_length_m: 12,
+    max_width_m: 2.5,
+    max_height_m: 4,
+  };
+
+  let recommendations = [];
+  let mlUsed = false;
+
+  // Try the FastAPI ML engine first
+  if (availableLoads.length > 0) {
+    try {
+      const result = await matchDeadhead({
+        driverDestination: { lat: currentLat, lng: currentLng },
+        truckSpecs: specs,
+        arrivalTime: new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString(),
+        availableLoads,
+      });
+      recommendations = result.recommendations || [];
+      mlUsed = true;
+    } catch (err) {
+      logger.warn('[ML] matchEnRouteLoads: falling back to haversine. Reason: ' + err.message);
+    }
+  }
+
+  // Haversine fallback — score by distance to pickup
+  if (!mlUsed) {
+    recommendations = offers
+      .filter(o => o.origin_lat && o.origin_lng)
+      .map(o => {
+        const dtKm = _haversineKm(currentLat, currentLng, Number(o.origin_lat), Number(o.origin_lng));
+        return {
+          load_id: o.id,
+          detour_km: dtKm,
+          distance_to_pickup_km: dtKm,
+          match_score: Math.max(0, 1 - dtKm / maxDetourKm),
+          estimated_earnings: Number(o.payment_inr || o.freight_value || 0),
+          _fallback: true,
+        };
+      })
+      .filter(r => r.detour_km <= maxDetourKm)
+      .sort((a, b) => b.match_score - a.match_score);
+  }
+
+  // Build a lookup map of ML results keyed by load_id
+  const recMap = new Map(recommendations.map(r => [r.load_id, r]));
+
+  // Merge ML/haversine annotations back onto the original offer rows
+  const enriched = offers
+    .map(o => {
+      const rec = recMap.get(o.id);
+      if (!rec) return null; // not recommended by ML — exclude
+      return {
+        ...o,
+        detour_km: rec.detour_km ?? rec.distance_to_pickup_km ?? 0,
+        extra_earnings: rec.estimated_earnings
+          ? Math.round(rec.estimated_earnings * 100) // convert to paisa for consistency
+          : (o.freight_value || 0),
+        match_score: rec.match_score ?? 0,
+        extra_distance_km: rec.detour_km ?? 0,
+        ml_used: mlUsed,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.match_score - a.match_score);
+
+  return enriched;
+}
+
+/**
+ * Haversine great-circle distance in km between two lat/lng points.
+ * @private
+ */
+function _haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
 export const __testing = {
   demandCache,
-  priceCache
+  priceCache,
+  _haversineKm,
 };


### PR DESCRIPTION
## Bug: En-Route Loads screen spinning / empty

### Root Cause
`GET /api/orders/load-offers/en-route` was querying `is_en_route = true` — a
column never populated in production. No connection to ML engine.

### Fix
- Added `matchEnRouteLoads()` in `ml.js` — calls FastAPI Deadhead Eliminator,
  falls back to haversine scoring when ML is unavailable
- Rewrote the route handler to accept `?current_lat&current_lng` GPS params and
  return ML-enriched results (`detour_km`, `match_score`, `extra_earnings`)
- Flutter `marketplace_repository.dart` now sends driver GPS in the request
- `trips_screen.dart` extracts active trip's last route point as GPS source

The screen now always shows ranked results, even without FastAPI running.
