### PR TITLE
fix : added firebaseUid string guard to isValidCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -66,6 +66,9 @@ function getRedisClient() {
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedProfile(firebaseUid, cachedProfile) {
+  if (typeof firebaseUid !== 'string' || !firebaseUid) {
+    return false;
+  }
   if (!cachedProfile || typeof cachedProfile !== 'object' || Array.isArray(cachedProfile)) {
     return false;
   }


### PR DESCRIPTION
Closes #5067.

Summary of What Has Been Done:
Added a guard at the start of isValidCachedProfile() to return false if firebaseUid is not a non-empty string, preventing type coercion bugs when non-string values are passed as the UID argument.

Changes Made:
- backend/api/src/lib/profileCache.js: Added typeof firebaseUid !== 'string' || !firebaseUid guard before the cachedProfile null check.

Impact it Made:
- Prevents type coercion bugs where non-string values produce unexpected loose-equality comparisons with cachedProfile.uid.
- Hardens the cache layer against malformed inputs.
- All 38 existing profileCache unit tests continue to pass.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile cache validation by rejecting invalid or empty profile identifiers.
  * Preserved existing handling for inactive and otherwise invalid cached profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->