### PR TITLE
fix: add mounted check before setState in pod_capture_screen

### DIFF
--- a/apps/driver/lib/screens/pod_capture_screen.dart
+++ b/apps/driver/lib/screens/pod_capture_screen.dart
@@ -84,14 +84,16 @@ class _PodCaptureScreenState extends State<PodCaptureScreen> {
 
       final List<ConnectivityResult> connectivityResult = await Connectivity().checkConnectivity();
       if (connectivityResult.contains(ConnectivityResult.none)) {
-        setState(() => _uploadStatus = 'Saved offline. Will sync when online.');
         if (mounted) {
+          setState(() => _uploadStatus = 'Saved offline. Will sync when online.');
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Saved offline. Will sync when online.')),
           );
         }
       } else {
-        setState(() => _uploadStatus = 'Uploading...');
+        if (mounted) {
+          setState(() => _uploadStatus = 'Uploading...');
+        }
         try {
           await SyncService.instance.uploadPodFiles(
             orderId: widget.orderId,


### PR DESCRIPTION
﻿## Summary
Adds if (mounted) checks before setState calls in pod_capture_screen.dart that occur after async gaps.

## Changes
- Line 87: Wrapped setState for offline status in if (mounted) block
- Line 94: Wrapped setState for uploading status in if (mounted) block

Both setState calls happen after wait Connectivity().checkConnectivity(). Without the mounted guard, navigating away during the await causes a setState() called after dispose() framework error.

The same file already correctly uses if (mounted) for ScaffoldMessenger calls at lines 88 and 103 — only the setState calls were missing the guard.

## Testing
- [x] Verified no analyzer errors
- [x] Existing behavior preserved — status text still updates correctly

Closes #5055

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod capture reliability by preventing status updates after the screen has been closed.
  * Avoided potential errors during offline and online save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->