### PR TITLE
fix: add mounted check before setState in saved_addresses_screen

### DIFF
--- a/apps/customer/lib/screens/saved_addresses_screen.dart
+++ b/apps/customer/lib/screens/saved_addresses_screen.dart
@@ -26,6 +26,7 @@ class _SavedAddressesScreenState extends State<SavedAddressesScreen> {
   }
 
   Future<void> _load() async {
+    if (!mounted) return;
     setState(() {
       _loading = true;
       _error = null;


### PR DESCRIPTION
﻿## Summary
Adds if (!mounted) return; guard at the start of _load() in saved_addresses_screen.dart.

## Changes
- Added if (!mounted) return; before the first setState in _load()

_load() is called after wait in _setDefault (line 47), _delete (line 58), and _showAddDialog (line 75). If the user navigates away during any of those awaits, the initial setState in _load() crashes with setState() called after dispose().

The fix is identical to the pattern already used in other screens (e.g., chat_screen.dart, home_screen.dart).

## Testing
- [x] Verified no analyzer errors
- [x] Existing behavior preserved

Closes #5056

GSSoC
