### PR TITLE
fix: disable submit button during upload to prevent double-submit

### DIFF
--- a/apps/driver/lib/screens/pod_screen.dart
+++ b/apps/driver/lib/screens/pod_screen.dart
@@ -234,7 +234,7 @@ class _ProofOfDeliveryScreenState extends State<ProofOfDeliveryScreen> {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: _submit,
+                      onPressed: _isProcessing ? null : _submit,
                       style: ElevatedButton.styleFrom(
                         backgroundColor: TruxifyColors.primary,
                         padding: const EdgeInsets.symmetric(vertical: 16),


### PR DESCRIPTION
﻿## Summary
Disables the "Complete Delivery" button while an upload is in progress to prevent double-submit race condition.

## Changes
- Changed onPressed: _submit to onPressed: _isProcessing ? null : _submit

The _isProcessing flag already exists (set to 	rue at line 98 during upload) but wasn't wired to the button's onPressed. A user could tap the button multiple times rapidly, triggering multiple concurrent uploads and potentially creating duplicate delivery records.

## Testing
- [x] Verified no analyzer errors
- [x] Button correctly disables during upload, re-enables on completion/error

Closes #5057

GSSoC
