### PR TITLE
fix: replace broken _withRetry with proper retry loop

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -160,7 +160,6 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isLoadingMetrics = true;
   String? _metricsError;
   String? _networkError;
-  int _retryCount = 0;
 
   final BatteryService _batteryService = BatteryService.instance;
   int _batteryLevel = 100;
@@ -181,17 +180,18 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _withRetry(Future<void> Function() fn) async {
-    try {
-      _retryCount = 0;
-      await fn();
-    } catch (e) {
-      _retryCount++;
-      if (_retryCount <= 3) {
-        await Future.delayed(Duration(seconds: _retryCount));
+    for (int i = 0; i < 3; i++) {
+      try {
         await fn();
-      } else {
-        setState(() => _networkError = 'Operation failed after $_retryCount retries');
+        return;
+      } catch (e) {
+        if (i < 2) {
+          await Future.delayed(Duration(seconds: i + 1));
+        }
       }
+    }
+    if (mounted) {
+      setState(() => _networkError = 'Network error. Please check your connection and try again.');
     }
   }
 


### PR DESCRIPTION
﻿## Summary
Replaces the broken _withRetry method with a proper retry loop that actually retries up to 3 times.

## Changes
- Replaced try/catch with a or loop that retries up to 3 times
- Added if (mounted) check before the final setState call
- Removed unused _retryCount member variable

The old implementation had multiple issues:
1. The else branch (showing error message) was unreachable — _retryCount could only be 1 after the first catch
2. The second wait fn() was not wrapped in try/catch, so failures propagated unhandled
3. No actual loop — it only ever made one retry attempt

## Testing
- [x] Verified no analyzer errors
- [x] Retry now works correctly: tries 3 times with exponential backoff (1s, 2s delays)
- [x] Error message shown to user after all retries exhausted

Closes #5058

GSSoC
