### PR TITLE
fix(osrm): remove unused RECOVERABLE_ERRORS and withRetry helper (fixes #1282)

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -16,26 +16,6 @@ export const osrmBreaker = new CircuitBreaker(async (url, options) => {
   resetTimeout: 30000
 });
 
-
-const RECOVERABLE_ERRORS = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'FETCH_ERR'];
-
-async function withRetry(fn, options = {}) {
-  const { retries = 2, baseDelay = 300, label = 'operation' } = options;
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt < retries && RECOVERABLE_ERRORS.some(e => err.code === e || err.message?.includes(e))) {
-        const delay = baseDelay * Math.pow(2, attempt);
-        logger.warn(`[osrm] ${label} failed (attempt ${attempt + 1}/${retries + 1}), retrying in ${delay}ms`);
-        await new Promise(r => setTimeout(r, delay));
-      } else {
-        throw err;
-      }
-    }
-  }
-}
-
 const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
 const DEFAULT_TIMEOUT_MS = 1500;
 const DEFAULT_MAX_RETRIES = 3;


### PR DESCRIPTION
Closes #1282


### Summary
Removed unused `RECOVERABLE_ERRORS` constant and `withRetry` helper function from `backend/api/src/services/osrm.js` .

### Code Audit & Note for Maintainers
Upon auditing `backend/api/src/services/osrm.js`:
1. `CACHE_TTL_SECONDS` (86400) and `ROUTE_CACHE_TTL_SECONDS` (30) are actively used on lines 124 and 225 for Redis cache expiration (`EX`).
2. `MAX_RETRIES` and `RETRY_DELAYS_MS` are no longer present in the module.
3. `RECOVERABLE_ERRORS` and `withRetry` were unused dead code cluttering the module.

### How to Test
Run the OSRM unit tests locally:
```bash
npx vitest run test/unit/osrm.test.js
```
All 23 unit tests pass cleanly.

Label Request: GSSoC'26 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal retry-handling logic from the routing service.
  * No changes to end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->