### PR TITLE
fix: add buffer-length check in enclave.c

### DIFF
--- a/backend/sgx/enclave/enclave.c
+++ b/backend/sgx/enclave/enclave.c
@@ -37,6 +37,9 @@ void ecall_encrypt_data(
     uint8_t* ciphertext,
     uint32_t* ciphertext_len
 ) {
+    if (plaintext_len == 0 || plaintext_len > sizeof(((secure_data_t*)0)->data)) {
+        return;
+    }
     // In production: use AES-GCM inside enclave
     // For demo: XOR encryption
     uint8_t key[32] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
@@ -54,6 +57,9 @@ void ecall_decrypt_data(
     uint8_t* plaintext,
     uint32_t* plaintext_len
 ) {
+    if (ciphertext_len == 0 || ciphertext_len > sizeof(((secure_data_t*)0)->data)) {
+        return;
+    }
     uint8_t key[32] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
     
     for (uint32_t i = 0; i < ciphertext_len; i++) {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `backend/sgx/enclave/enclave.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `backend/sgx/enclave/enclave.c:42` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-120 |

**Description**: The ecall_encrypt_data and ecall_decrypt_data functions perform memory operations (writing to ciphertext/plaintext buffers) using plaintext_len/ciphertext_len without any bounds checking on the output buffer size. An attacker calling these ECALLs from the untrusted application can provide a large plaintext_len that exceeds the actual allocated size of the ciphertext buffer, causing a buffer overflow within the enclave.

## Evidence

**Exploitation scenario**: An attacker who controls the untrusted application calls ecall_encrypt_data with plaintext_len=10000 but provides a ciphertext buffer of only 256 bytes.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `backend/sgx/enclave/enclave.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for encryption and decryption input lengths.
  * Prevented processing of empty or oversized data, improving reliability and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->