### PR TITLE
fix: use refreshed order state after lock in cancelOrder

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -685,14 +685,14 @@ export class OrderLifecycleService {
           if (refundTxHash) {
             receipt = await confirmEscrowRefund(refundTxHash);
           } else {
-            const submitted = await submitEscrowRefund(order.order_display_id);
+            const submitted = await submitEscrowRefund(workingOrder.order_display_id);
             refundTxHash = submitted.txHash;
             if (!refundTxHash || !submitted.waitForConfirmation) {
               throw new Error('Escrow refund transaction was not submitted.');
             }
 
             const submittedAt = new Date().toISOString();
-            await this.orderRepository.updateOrder(order.id, {
+            await this.orderRepository.updateOrder(currentOrder.id, {
               refund_tx_hash: refundTxHash,
               escrow_refund_submitted_at: submittedAt,
               updated_at: submittedAt,
@@ -703,7 +703,7 @@ export class OrderLifecycleService {
 
           const refundedAt = new Date().toISOString();
           const { data: updatedOrder, error: updateErr } = await this.orderRepository.updateOrderWithFilter(
-            order.id,
+            currentOrder.id,
             {
               status: 'cancelled',
               cancellation_reason: reason ?? workingOrder.cancellation_reason,
@@ -730,8 +730,8 @@ export class OrderLifecycleService {
             };
           }
 
-          await this.orderTimelineService.insertCancelEvent(order.order_display_id);
-          await expireDeliveryOtps(order.id);
+          await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
+          await expireDeliveryOtps(currentOrder.id);
 
           return {
             status: 200,
@@ -745,7 +745,7 @@ export class OrderLifecycleService {
           logger.error('[escrow] Refund failed for order', orderId, ':', refundErr.message);
           const failedAt = new Date().toISOString();
           const nextEscrowStatus = refundTxHash ? 'refund_pending' : 'refund_failed';
-          await this.orderRepository.updateOrder(order.id, {
+          await this.orderRepository.updateOrder(currentOrder.id, {
             status: 'cancelled',
             escrow_status: nextEscrowStatus,
             refund_tx_hash: refundTxHash,
@@ -764,8 +764,8 @@ export class OrderLifecycleService {
             },
           };
         }
-      } else if (order.escrow_booking_id) {
-        logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) - skipping on-chain refund.`);
+      } else if (currentOrder.escrow_booking_id) {
+        logger.info(`[escrow] Escrow not funded (status: ${currentOrder.escrow_status}) - skipping on-chain refund.`);
       }
 
       const updatePayload = {
@@ -775,7 +775,7 @@ export class OrderLifecycleService {
       };
 
       const { data: updatedOrder, error: updateErr } = await this.orderRepository.updateOrderGuardStatus(
-        order.id,
+        currentOrder.id,
         updatePayload,
         ['delivered', 'payment_released', 'cancelled']
       );
@@ -789,8 +789,8 @@ export class OrderLifecycleService {
 
       const cancellationFee = updatedOrder?.cancellation_fee ?? 0;
 
-      await this.orderTimelineService.insertCancelEvent(order.order_display_id);
-      await expireDeliveryOtps(order.id);
+      await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
+      await expireDeliveryOtps(currentOrder.id);
 
       return {
         status: 200,


### PR DESCRIPTION
## Fix: `cancelOrder` uses stale `order` variable after lock acquisition

### Problem
In `orderLifecycleService.js`, the `cancelOrder` method uses the original `order` variable (fetched before acquiring the lock) instead of the refreshed `workingOrder`/`currentOrder` (re-fetched after lock acquisition at line 628) for refund submission and database updates.

This could cause:
- Submitting refund for a stale `order_display_id` if the order was modified by another process
- Updating the wrong order record if IDs changed due to concurrent modifications

### Fix
Replace all stale `order` references after lock acquisition with the refreshed `workingOrder` or `currentOrder`:
- `submitEscrowRefund(workingOrder.order_display_id)` instead of `order.order_display_id`
- `updateOrder(currentOrder.id, ...)` instead of `order.id`
- `insertCancelEvent(currentOrder.order_display_id)` instead of `order.order_display_id`
- `expireDeliveryOtps(currentOrder.id)` instead of `order.id`
- `currentOrder.escrow_booking_id` / `currentOrder.escrow_status` in the else branch

### Files Changed
- `backend/api/src/services/order/orderLifecycleService.js`

Closes #5116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order cancellation and refund processing by consistently using the latest order state.
  - Ensured cancellation statuses, refund reconciliation, timeline updates, and OTP expiration are applied to the correct order record.
  - Improved handling of cancellations when escrow bookings are not funded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->