### PR TITLE
fix: use fresh wallet address for escrow deposit in acceptBid

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -89,11 +89,8 @@ export class BidAcceptanceService {
 
     // Build the escrow deposit transaction
     const amountWei = paisaToMaticWei(bid.bid_amount);
-    const depositTx = await this.buildDepositTxFn(order.order_display_id, driverWallet, amountWei);
+    const depositTx = await this.buildDepositTxFn(order.order_display_id, freshDriverWallet, amountWei);
     const bookingId = depositTx?.bookingId || `escrow:${order.order_display_id}`;
-    const buildResult = await this.buildDepositTxFn(order.order_display_id, driverWallet, amountWei);
-    const depositTx = buildResult;
-    const bookingId = buildResult?.bookingId || `escrow:${order.order_display_id}`;
 
     // Guard against silent escrow disable: if buildDepositTx returned
     // null txData (contract not initialised), reject immediately.


### PR DESCRIPTION
## Fix: `acceptBid` uses stale wallet address for escrow deposit

### Problem
In `bidAcceptanceService.js:92`, the `acceptBid` method uses the stale `driverWallet` (fetched at line 53) for the escrow deposit transaction, instead of the `freshDriverWallet` validated during the TOCTOU re-validation at lines 77-81. This defeats the purpose of the TOCTOU protection - if the driver changed their wallet between the initial fetch and re-validation, the deposit would be sent to the old wallet.

Additionally, there were duplicate `const` declarations for `depositTx` and `bookingId` (lines 92-96), which would cause a JavaScript syntax error.

### Fix
- Use `freshDriverWallet` instead of `driverWallet` for `buildDepositTxFn`
- Remove duplicate variable declarations

### Files Changed
- `backend/api/src/services/order/bidAcceptanceService.js`

Closes #5117