### PR TITLE
fix: use dependency injection for OrderTimelineService in DeliveryVerificationService

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -20,13 +20,12 @@ import { escrowRelease as defaultEscrowRelease } from '../escrow.js';
 import logger from '../../middleware/logger.js';
 import { OrderTimelineService } from './orderTimelineService.js';
 
-const orderTimelineService = new OrderTimelineService(supabase);
-
 const DELIVERY_OTP_READY_STATUSES = new Set(['arriving']);
 
 export class DeliveryVerificationService {
   constructor(orderRepository, deps = {}) {
     this.orderRepository = orderRepository;
+    this.orderTimelineService = deps.orderTimelineService || new OrderTimelineService(supabase);
     this.notificationService = deps.notificationService || {
       sendDeliveryOtpNotification,
       storeDeliveryOtp,


### PR DESCRIPTION
## Fix: `DeliveryVerificationService` creates its own `OrderTimelineService` bypassing DI

### Problem
In `deliveryVerificationService.js:23`, a new `OrderTimelineService` is instantiated at module level using the raw `supabase` client, bypassing the repository layer and any custom dependencies or mock overrides that should be passed via the constructor.

### Fix
- Remove module-level `OrderTimelineService` instantiation
- Accept `OrderTimelineService` via the `deps` constructor parameter
- Fall back to creating a new instance if not provided

### Files Changed
- `backend/api/src/services/order/deliveryVerificationService.js`

Closes #5118