### PR TITLE
fix: use injected deliveryVerificationService in OrderLifecycleService constructor

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -33,7 +33,7 @@ export class OrderLifecycleService {
     this.orderRepository = orderRepository;
     this.orderTimelineService = orderTimelineService;
     this.bidAcceptanceService = bidAcceptanceService;
-    this.deliveryVerification = deps.deliveryVerificationService ?? new DeliveryVerificationService(orderRepository);
+    this.deliveryVerification = deliveryVerificationService || new DeliveryVerificationService(orderRepository);
   }
 
   async createOrder(customerId, customerName, body) {


### PR DESCRIPTION
## Fix: `OrderLifecycleService` ignores injected `deliveryVerificationService`

### Problem
In `orderLifecycleService.js:36`, the constructor references `deps.deliveryVerificationService` but `deps` does not exist in the constructor scope (parameters are destructured as `{ orderRepository, orderTimelineService, bidAcceptanceService, deliveryVerificationService }`). This causes a `ReferenceError` at runtime, meaning the injected service is always bypassed and a new instance is always created.

### Fix
- Change `deps.deliveryVerificationService` to the destructured `deliveryVerificationService` parameter
- Fall back to creating a new `DeliveryVerificationService` if not provided

### Files Changed
- `backend/api/src/services/order/orderLifecycleService.js`

Closes #5119