### PR TITLE
fix: add mounted check in chat broadcast callback

### DIFF
--- a/apps/driver/lib/screens/chat_screen.dart
+++ b/apps/driver/lib/screens/chat_screen.dart
@@ -37,7 +37,7 @@ class _ChatScreenState extends State<ChatScreen> {
         event: 'message',
         callback: (payload) {
           final data = payload;
-          if (data['senderId'] != _myUserId) {
+          if (data['senderId'] != _myUserId && mounted) {
             setState(() {
               _messages.insert(0, {
                 'text': data['text'],


### PR DESCRIPTION
﻿## Summary
Adds mounted check before setState in the Supabase broadcast callback in chat_screen.dart.

## Changes
- Added && mounted guard to the broadcast callback condition at line 40

The broadcast callback fires asynchronously when a message arrives from Supabase Realtime. If the user navigates away while a message is in transit, the callback fires after the widget is disposed, causing setState() called after dispose(). The same file already uses if (mounted) correctly for _sendMessage — only the broadcast callback was missing the guard.

## Testing
- [x] Verified no analyzer errors

Closes #5127

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat stability by preventing message updates after leaving or closing the chat screen.
  * Preserved existing behavior that filters out messages sent by the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->