### PR TITLE
fix: use fresh wallet values for escrow deposit in acceptBid

### DIFF
--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -89,11 +89,8 @@ export class BidAcceptanceService {
 
     // Build the escrow deposit transaction
     const amountWei = paisaToMaticWei(bid.bid_amount);
-    const depositTx = await this.buildDepositTxFn(order.order_display_id, driverWallet, amountWei);
+    const depositTx = await this.buildDepositTxFn(order.order_display_id, freshDriverWallet, amountWei);
     const bookingId = depositTx?.bookingId || `escrow:${order.order_display_id}`;
-    const buildResult = await this.buildDepositTxFn(order.order_display_id, driverWallet, amountWei);
-    const depositTx = buildResult;
-    const bookingId = buildResult?.bookingId || `escrow:${order.order_display_id}`;
 
     // Guard against silent escrow disable: if buildDepositTx returned
     // null txData (contract not initialised), reject immediately.


### PR DESCRIPTION
## Fix: `BidAcceptanceService` fetches driver details twice without reusing fresh results

### Problem
In `bidAcceptanceService.js`, the `acceptBid` method fetches driver details twice: once for initial validation (lines 48-51) and once for TOCTOU re-validation (lines 77-80). The fresh values from the re-validation (`freshDriverWallet`, `freshCustomerWallet`) were never used for the actual deposit transaction, making the TOCTOU protection ineffective.

The stale `driverWallet` was used at line 92 for `buildDepositTxFn`, meaning if the driver changed their wallet between the two fetches, the deposit would go to the old address.

### Fix
- Use `freshDriverWallet` for the escrow deposit transaction
- Remove duplicate `buildDepositTxFn` call and variable declarations

### Files Changed
- `backend/api/src/services/order/bidAcceptanceService.js`

Closes #5120