### PR TITLE
fix: change void _sendOtp to Future<void> in driver login_screen

### DIFF
--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -43,7 +43,7 @@ class _LoginScreenState extends State<LoginScreen> {
     super.dispose();
   }
 
-  void _sendOtp() async {
+  Future<void> _sendOtp() async {
     final phone = _phoneController.text.replaceAll(' ', '').trim();
 
     if (phone.isEmpty) {


### PR DESCRIPTION
﻿## Summary
Changes oid _sendOtp() async to Future<void> _sendOtp() async in the driver login screen.

## Changes
- Changed return type from oid to Future<void> at line 46

sync void functions silently swallow any exceptions that escape the inner 	ry/catch block. These errors won't be reported to Crashlytics or any error tracking service, making production debugging harder. The Dart analyzer also flags this as a warning (void_void_async).

## Testing
- [x] Verified no analyzer errors
- [x] Behavior unchanged — function still works identically

Closes #5129

GSSoC
