### PR TITLE
fix: change void _verifyOtp to Future<void> in customer login_screen

### DIFF
--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -209,7 +209,7 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
-  void _verifyOtp() async {
+  Future<void> _verifyOtp() async {
     final otp = _otpControllers.map((controller) => controller.text).join();
 
     if (otp.length != 6 || !RegExp(r'^\d{6}$').hasMatch(otp)) {


### PR DESCRIPTION
﻿## Summary
Changes oid _verifyOtp() async to Future<void> _verifyOtp() async in the customer login screen.

## Changes
- Changed return type from oid to Future<void> at line 212

sync void functions silently swallow any exceptions that escape the inner 	ry/catch block. These errors won't be reported to Crashlytics or any error tracking service, making production debugging harder. The Dart analyzer also flags this as a warning (void_void_async).

## Testing
- [x] Verified no analyzer errors
- [x] Behavior unchanged — function still works identically

Closes #5130

GSSoC
