### PR TITLE
fix: add mounted check before _loadTrips after Navigator returns

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -256,7 +256,8 @@ class _TripsScreenState extends State<TripsScreen> {
         },
       ),
     ));
-    
+
+    if (!mounted) return;
     await _loadTrips();
   }
 


### PR DESCRIPTION
﻿## Summary
Adds if (!mounted) return; after Navigator.push returns and before calling _loadTrips() in _completeCurrentStop.

## Changes
- Added if (!mounted) return; at line 260 before _loadTrips()

_loadTrips() immediately calls setState without a mounted check. If the user navigates away from the trips screen while the ProofOfDeliveryScreen is showing, the widget may be disposed by the time Navigator.push returns, causing setState() called after dispose().

## Testing
- [x] Verified no analyzer errors
- [x] Existing behavior preserved

Closes #5131

GSSoC
