### PR TITLE
fix(dao): restrict executeProposal to owner

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -213,7 +213,7 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
         emit VoteCast(proposalId, msg.sender, support, votingPower);
     }
 
-    function executeProposal(uint256 proposalId) external nonReentrant {
+    function executeProposal(uint256 proposalId) external onlyOwner nonReentrant {
         Proposal storage proposal = proposals[proposalId];
         require(block.timestamp >= proposal.endTime, "Voting not ended");
         require(!proposal.executed, "Already executed");


### PR DESCRIPTION
## Summary

Closes #5152

`executeProposal` in `DAO.sol` had no access control — any address could call it for any proposal that had passed its voting period and met quorum. This function performs an arbitrary `target.call{value: proposal.value}(proposal.callData)`, meaning an attacker could trigger arbitrary contract calls drawing from the DAO's ETH balance.

## Root Cause

```solidity
// Before (vulnerable)
function executeProposal(uint256 proposalId) external nonReentrant {
    // ❌ No msg.sender check — anyone can execute
```

Compare with `cancelProposal` which correctly restricts access:

```solidity
function cancelProposal(uint256 proposalId) external onlyOwner {
    // ✅ Owner-only
```

The inconsistency allowed anyone who monitored the blockchain to front-run legitimate executors or force execution of proposals the DAO owner had not yet reviewed.

## Fix

Added the `onlyOwner` modifier to `executeProposal`, matching the access control pattern already established by `cancelProposal` and `withdrawTreasury`:

```solidity
// After (fixed)
function executeProposal(uint256 proposalId) external onlyOwner nonReentrant {
```

## Impact Mitigated

| Attack Vector | Status |
|---|---|
| Unauthorized execution of arbitrary `target.call` | ✅ Blocked |
| Front-running legitimate executor | ✅ Blocked |
| ETH drain / selfdestruct via malicious proposal calldata | ✅ Blocked |

## Files Changed

- `blockchain/contracts/DAO.sol` — added `onlyOwner` modifier to `executeProposal` (line 216)

## PR Checklist

- [x] Code builds successfully
- [x] Change is minimal and focused on the issue
- [x] Consistent with existing access control patterns (`cancelProposal`, `withdrawTreasury`)
- [x] No unnecessary files included
- [x] PR linked to active issue #5152
