### PR TITLE
fix: use safe num cast for double values in fuel analytics chart

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -940,9 +940,9 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
       return Center(child: Text(_error!, style: const TextStyle(color: TruxifyColors.error)));
     }
 
-    final totalPayout = _data!['totalPayout'] as double;
-    final estFuel = _data!['estimatedFuelCost'] as double;
-    final margin = _data!['profitMargin'] as double;
+    final totalPayout = (_data!['totalPayout'] as num?)?.toDouble() ?? 0.0;
+    final estFuel = (_data!['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
+    final margin = (_data!['profitMargin'] as num?)?.toDouble() ?? 0.0;
     final chartPoints = _data!['chartPoints'] as List<Map<String, dynamic>>;
 
     return RefreshIndicator(


### PR DESCRIPTION
﻿## Summary
Changes s double casts to safe s num? casts with .toDouble() fallback in the fuel analytics chart.

## Changes
- 	otalPayout: _data!['totalPayout'] as double → (_data!['totalPayout'] as num?)?.toDouble() ?? 0.0
- estFuel: same pattern
- margin: same pattern

Dart's s double cast is strict — if the server returns an int (e.g.,  instead of .0), it throws TypeError. Using s num? safely handles both int and double values.

## Testing
- [x] Verified no analyzer errors

Closes #5157

GSSoC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fuel analytics reliability when payout, estimated fuel cost, or profit margin data is missing or provided as whole numbers.
  * Prevented potential runtime errors and ensured unavailable values display as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->