### PR TITLE
fix: add mounted check after showDatePicker and showTimePicker

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -256,6 +256,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       return;
     }
 
+    if (!mounted) return;
     setState(() {
       _selectedDate = DateUtils.dateOnly(pickedDate);
       _dateController.text = _formatDateLabel(_selectedDate!);
@@ -275,6 +276,7 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       return;
     }
 
+    if (!mounted) return;
     setState(() {
       _selectedTime = pickedTime;
       _timeController.text = _formatTimeLabel(pickedTime);


### PR DESCRIPTION
﻿## Summary
Adds if (!mounted) return; after wait showDatePicker and wait showTimePicker in ind_trucks_screen.dart.

## Changes
- Added mounted check after date picker returns (line 259)
- Added mounted check after time picker returns (line 278)

Both showDatePicker and showTimePicker are async dialogs. If the widget is disposed while either dialog is open (e.g., via back button), the subsequent setState throws setState() called after dispose().

## Testing
- [x] Verified no analyzer errors
- [x] Existing behavior preserved

Closes #5158, Closes #5159

GSSoC
