### PR TITLE
fix: use safe num cast for WebSocket close code in location_service

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -339,7 +339,7 @@ class LocationService {
           try {
             final parsed = jsonDecode(message.toString());
             if (parsed is Map && parsed['code'] != null) {
-              _lastCloseCode = parsed['code'] as int;
+              _lastCloseCode = (parsed['code'] as num?)?.toInt();
             }
           } catch (_) {}
         },


### PR DESCRIPTION
﻿## Summary
Changes s int cast to safe s num? cast for WebSocket close code in location_service.dart.

## Changes
- parsed['code'] as int → (parsed['code'] as num?)?.toInt()

Dart's jsonDecode returns double for all JSON numbers by default. If the close code arrives as 4001.0 instead of 4001, the s int cast throws TypeError. While inside a try/catch, the error is silently swallowed, leaving _lastCloseCode unset. This prevents the reconnection logic from detecting auth rejection, causing infinite reconnect loops.

## Testing
- [x] Verified no analyzer errors
- [x] Handles both int and double JSON values

Closes #5161

GSSoC
