### PR TITLE
fix(atomicswap): restrict executeSwap and executeCrossChainSwap to counterparty only

### DIFF
--- a/blockchain/contracts/AtomicSwap.sol
+++ b/blockchain/contracts/AtomicSwap.sol
@@ -118,6 +118,7 @@ contract AtomicSwap is Ownable, ReentrancyGuard, Pausable {
     function executeSwap(uint256 swapId, bytes32 secret) external nonReentrant whenNotPaused {
         Swap storage swap = swaps[swapId];
         require(swap.initiator != address(0), "Swap not found");
+        require(msg.sender == swap.counterparty, "Only counterparty can execute");
         require(!swap.executed, "Already executed");
         require(!swap.refunded, "Already refunded");
         require(block.timestamp <= swap.timelock, "Swap expired");
@@ -212,6 +213,7 @@ contract AtomicSwap is Ownable, ReentrancyGuard, Pausable {
     ) external nonReentrant whenNotPaused {
         CrossChainSwap storage swap = crossChainSwaps[swapId];
         require(swap.initiator != address(0), "Swap not found");
+        require(msg.sender == swap.counterparty, "Only counterparty can execute");
         require(!swap.executed, "Already executed");
         require(!swap.refunded, "Already refunded");
         require(block.timestamp <= swap.timelock, "Swap expired");


### PR DESCRIPTION
## Summary

Closes #5149

`executeSwap` and `executeCrossChainSwap` in `AtomicSwap.sol` had no `msg.sender` check, allowing **any address** that knows the secret preimage to execute the swap and force funds to the counterparty. This is inconsistent with `refundSwap` and `refundCrossChainSwap`, which both correctly enforce `require(msg.sender == swap.initiator, ...)`.

## Root Cause

```solidity
// Before (vulnerable)
function executeSwap(uint256 swapId, bytes32 secret) external nonReentrant whenNotPaused {
    Swap storage swap = swaps[swapId];
    require(swap.initiator != address(0), "Swap not found");
    // ❌ No msg.sender check — anyone can execute
```

## Fix

Added `require(msg.sender == swap.counterparty, "Only counterparty can execute")` immediately after the swap existence check in both functions:

```solidity
// After (fixed)
function executeSwap(uint256 swapId, bytes32 secret) external nonReentrant whenNotPaused {
    Swap storage swap = swaps[swapId];
    require(swap.initiator != address(0), "Swap not found");
    require(msg.sender == swap.counterparty, "Only counterparty can execute"); // ✅
```

This ensures only the designated counterparty can reveal the secret and claim the funds — matching the semantics of a standard HTLC atomic swap where the recipient must actively claim.

## Impact Mitigated

| Attack Vector | Status |
|---|---|
| Forced acceptance by third party | ✅ Blocked |
| Cross-chain secret replay by observer | ✅ Blocked |
| Gas griefing via contract counterparty | ✅ Blocked |

## Files Changed

- `blockchain/contracts/AtomicSwap.sol` — added `require(msg.sender == swap.counterparty)` to `executeSwap` (line 121) and `executeCrossChainSwap` (line 216)

## PR Checklist

- [x] Code builds successfully
- [x] No unnecessary files included
- [x] Changes are minimal and focused on the issue
- [x] PR linked to active issue #5149
