### PR TITLE
fix(api): mount hppProtection, responseSanitizer, and suspiciousRequests middleware

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -23,6 +23,8 @@ import {
   requestIdMiddleware,
   requestLogger,
   securityHeaders,
+  suspiciousRequests,
+  responseSanitizer,
 } from "./middleware/index.js";
 
 // Load REST routes
@@ -322,6 +324,9 @@ app.use((req, res, next) => {
 app.use(requestIdMiddleware)
 app.use(requestLogger)
 
+app.use(hppProtection)
+app.use(suspiciousRequests)
+
 // Enforce a known request content-type on mutating requests (POST/PUT/PATCH).
 // `requireJsonContent` only rejects unrecognized media types; the three
 // allowed types match the parsers registered above.
@@ -499,6 +504,8 @@ app.get('/', (req, res) => {
   const wsPort = process.env.PORT || 5000
   res.send(`<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://${wsHost}:${wsPort}/ws/tracking</code></p>`)
 })
+
+app.use(responseSanitizer)
 
 // Handling 404 Route Not Found
 app.use((req, res) => {

--- a/backend/api/test/unit/responseSanitizer.test.js
+++ b/backend/api/test/unit/responseSanitizer.test.js
@@ -1,1 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import responseSanitizer from '../../src/middleware/responseSanitizer.js';
 
+function makeResMock() {
+  const res = {
+    _data: null,
+  };
+  res.json = vi.fn(function (body) {
+    res._data = body;
+    return res;
+  });
+  return res;
+}
+
+describe('responseSanitizer', () => {
+  it('calls next() and wraps res.json', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('strips _internal field from response body', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json({ id: '1', name: 'test', _internal: 'secret' });
+
+    expect(res._data).toEqual({ id: '1', name: 'test' });
+    expect(res._data._internal).toBeUndefined();
+  });
+
+  it('strips __v field from response body', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json({ id: '1', __v: 3 });
+
+    expect(res._data).toEqual({ id: '1' });
+    expect(res._data.__v).toBeUndefined();
+  });
+
+  it('strips _debug, _metadata, and _private fields', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json({ id: '2', _debug: true, _metadata: {}, _private: 'x' });
+
+    expect(res._data).toEqual({ id: '2' });
+  });
+
+  it('handles arrays of objects by sanitizing each element', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json([
+      { id: '1', _internal: 'a' },
+      { id: '2', __v: 5 },
+    ]);
+
+    expect(res._data).toEqual([{ id: '1' }, { id: '2' }]);
+  });
+
+  it('passes through primitive values unchanged', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json('hello');
+
+    expect(res._data).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5150

## Changes

- **ackend/api/src/index.js**:
  - Added suspiciousRequests and esponseSanitizer to the named imports from ./middleware/index.js
  - Mounted pp.use(hppProtection) and pp.use(suspiciousRequests) in the global middleware chain (after request logging, before route handlers)
  - Mounted pp.use(responseSanitizer) after all route handlers and before the 404/error handlers

- **ackend/api/test/unit/responseSanitizer.test.js**:
  - Filled in 6 unit tests covering: stripping of _internal, __v, _debug, _metadata, _private fields, array sanitization, and primitive passthrough

## Middleware Order

`
requestLogger
hppProtection       ← blocks HTTP Parameter Pollution
suspiciousRequests  ← blocks suspicious patterns
...routes...
responseSanitizer   ← strips internal fields from outbound JSON
404 handler
error handler
`

## Tests

All three relevant test suites pass:
- 	est/unit/hppProtection.test.js — 6/6 ✅
- 	est/unit/suspiciousRequests.test.js — (existing)
- 	est/unit/responseSanitizer.test.js — 6/6 ✅ (newly populated)