### PR TITLE
perf: Add PostGIS GIST indexes and benchmark script (#5009)

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint . --max-warnings=0",
     "verify-db": "node scripts/verify-db-schema.js",
-    "seed:dev": "node scripts/seed-dev-profile.js"
+    "seed:dev": "node scripts/seed-dev-profile.js",
+    "benchmark:postgis": "node scripts/benchmark-postgis.js"
   },
   "dependencies": {
     "@sentry/node": "^10.62.0",

--- a/backend/api/scripts/benchmark-postgis.js
+++ b/backend/api/scripts/benchmark-postgis.js
@@ -1,0 +1,78 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function runBenchmark() {
+  console.log('--- PostGIS GIST Index Benchmark ---');
+  
+  // Define search parameters
+  const targetLat = 19.0760;
+  const targetLng = 72.8777;
+  const radiusMeters = 50000; // 50km
+  
+  // Note: To properly run this benchmark locally, you would:
+  // 1. Seed the driver_locations table with 10,000 mock rows scattered around India
+  // 2. Drop the GIST index and measure the execution time
+  // 3. Re-create the GIST index and measure the execution time
+  
+  console.log(`\nQuerying for trucks within ${radiusMeters/1000}km of (${targetLat}, ${targetLng})...`);
+  
+  const start = performance.now();
+  
+  // Using PostGIS ST_DWithin via Supabase RPC (since direct PostGIS filters aren't natively supported 
+  // via PostgREST without an RPC function in standard Supabase setup)
+  const { data, error } = await supabase.rpc('get_nearby_drivers', {
+    search_lat: targetLat,
+    search_lng: targetLng,
+    radius_meters: radiusMeters
+  });
+  
+  const end = performance.now();
+  
+  if (error) {
+    if (error.code === 'PGRST202') {
+      console.log('RPC get_nearby_drivers not found. Ensure you have created it.');
+      console.log('\nExample RPC creation:');
+      console.log(`
+CREATE OR REPLACE FUNCTION get_nearby_drivers(search_lat float, search_lng float, radius_meters float)
+RETURNS SETOF driver_locations AS $$
+BEGIN
+  RETURN QUERY
+  SELECT *
+  FROM driver_locations
+  WHERE ST_DWithin(
+    location,
+    ST_SetSRID(ST_MakePoint(search_lng, search_lat), 4326)::geography,
+    radius_meters
+  );
+END;
+$$ LANGUAGE plpgsql;`);
+    } else {
+      console.error('Error querying nearby drivers:', error);
+    }
+    process.exit(1);
+  }
+  
+  const executionTimeMs = (end - start).toFixed(2);
+  console.log(`Query completed in ${executionTimeMs} ms. Found ${data?.length || 0} drivers.`);
+  console.log('\nExpectations:');
+  console.log('- Without GIST Index (10k rows): ~15-25ms (Sequential Scan)');
+  console.log('- With GIST Index (10k rows): ~1-3ms (Index Scan)');
+}
+
+runBenchmark().catch(console.error);

--- a/supabase/migrations/20260727120000_add_postgis_geospatial_indexes.sql
+++ b/supabase/migrations/20260727120000_add_postgis_geospatial_indexes.sql
@@ -1,0 +1,30 @@
+-- Enable PostGIS extension for geospatial queries
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- 1. Add geography column to driver_locations
+ALTER TABLE driver_locations 
+ADD COLUMN IF NOT EXISTS location GEOGRAPHY(Point, 4326);
+
+-- 2. Backfill existing data
+UPDATE driver_locations 
+SET location = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography
+WHERE latitude IS NOT NULL AND longitude IS NOT NULL AND location IS NULL;
+
+-- 3. Create the GIST index on the new geography column
+CREATE INDEX IF NOT EXISTS idx_driver_locations_location ON driver_locations USING GIST(location);
+
+-- 4. Create trigger to automatically maintain the location column
+CREATE OR REPLACE FUNCTION trg_update_driver_location()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.latitude IS NOT NULL AND NEW.longitude IS NOT NULL THEN
+        NEW.location = ST_SetSRID(ST_MakePoint(NEW.longitude, NEW.latitude), 4326)::geography;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_update_driver_location ON driver_locations;
+CREATE TRIGGER trigger_update_driver_location
+BEFORE INSERT OR UPDATE OF latitude, longitude ON driver_locations
+FOR EACH ROW EXECUTE FUNCTION trg_update_driver_location();


### PR DESCRIPTION
## Fixes Issue #5009

### Description
As the number of active drivers grows, querying for nearby trucks using standard numeric comparisons or sequential PostGIS scans becomes a significant bottleneck. This PR introduces proper geospatial indexing.

### Changes Included
* **Database Migration:** Adds a PostGIS `GEOGRAPHY` column to `driver_locations`, backfills data, and applies a `GIST` index for rapid spatial queries.
* **Auto-Sync Trigger:** Ensures that the backend can continue updating the standard `latitude`/`longitude` numeric columns, while Postgres automatically maintains the `GEOGRAPHY` column under the hood.
* **Benchmarking Script:** Added `npm run benchmark:postgis` to test the execution speed of `ST_DWithin` queries via RPC.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* The migration is fully non-destructive and backwards compatible with existing code.