### PR TITLE
feat: Add dispute timeout logic to escrow contract (#5008)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -38,6 +38,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         BookingStatus status;       // Current booking lifecycle status
         bool paid;                  // True after payment has been released
         uint256 createdAt;          // Block timestamp at booking creation
+        uint256 disputedAt;         // Block timestamp when dispute was raised
     }
 
     // ─── State ───────────────────────────────────────────────────────────────
@@ -47,6 +48,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;
     uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
+    uint256 public constant DISPUTE_TIMEOUT = 7 days;
 
     // ─── Events ──────────────────────────────────────────────────────────────
 
@@ -115,7 +117,8 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             amount:    msg.value,
             status:    BookingStatus.Active,
             paid:      false,
-            createdAt: block.timestamp
+            createdAt: block.timestamp,
+            disputedAt: 0
         });
 
         bookingCount++;
@@ -225,8 +228,43 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         );
 
         booking.status = BookingStatus.Disputed;
+        booking.disputedAt = block.timestamp;
 
         emit BookingDisputed(bookingId, msg.sender);
+    }
+
+    /**
+     * @dev Resolve a stale dispute that has been inactive for DISPUTE_TIMEOUT.
+     *      Defaults to refunding the customer in full to prevent locked funds.
+     * @param bookingId The booking to resolve
+     */
+    function resolveDisputeTimeout(uint256 bookingId) external nonReentrant whenNotPaused {
+        Booking storage booking = bookings[bookingId];
+
+        require(
+            booking.status == BookingStatus.Disputed,
+            "TruxifyEscrow: Booking not disputed"
+        );
+        require(
+            block.timestamp > booking.disputedAt + DISPUTE_TIMEOUT,
+            "TruxifyEscrow: Dispute timeout not reached"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+
+        // ── EFFECTS: Default to refunding customer ──────────────────────────
+        uint256 refundAmount = booking.amount;
+        address payable customer = booking.customer;
+
+        booking.amount = 0;
+        booking.paid = true;
+        booking.status = BookingStatus.Cancelled;
+
+        // ── INTERACTIONS ──────────────────────────────────────────────────
+        pendingWithdrawals[customer] += refundAmount;
+        releaseTimestamps[customer] = block.timestamp + WITHDRAWAL_TIMEOUT;
+
+        emit WithdrawalReady(bookingId, customer, refundAmount);
+        emit BookingCancelled(bookingId, customer, refundAmount);
     }
 
     /**

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -159,4 +159,47 @@ describe("TruxifyEscrow", function () {
       expect(booking.amount).to.equal(0);
     });
   });
+
+  // "?"?"? resolveDisputeTimeout "?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?
+  describe("resolveDisputeTimeout", function () {
+    it("resolves dispute by refunding customer after timeout", async function () {
+      const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
+
+      const amount = ethers.parseEther("1.0");
+      await escrow.connect(customer).createBooking(2, driver.address, { value: amount });
+
+      // Raise dispute
+      await escrow.connect(customer).raiseDispute(2);
+
+      // Fast forward time by 8 days (7 days timeout)
+      await hre.network.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+      await hre.network.provider.send("evm_mine");
+
+      // Resolve dispute
+      await escrow.resolveDisputeTimeout(2);
+
+      // Check that customer got the pending withdrawal
+      const pendingRefund = await escrow.pendingWithdrawals(customer.address);
+      expect(pendingRefund).to.equal(amount);
+
+      const booking = await escrow.getBooking(2);
+      expect(booking.status).to.equal(2); // Cancelled
+      expect(booking.amount).to.equal(0);
+    });
+
+    it("reverts if timeout has not been reached", async function () {
+      const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
+
+      const amount = ethers.parseEther("1.0");
+      await escrow.connect(customer).createBooking(3, driver.address, { value: amount });
+
+      // Raise dispute
+      await escrow.connect(customer).raiseDispute(3);
+
+      // Try to resolve immediately
+      await expect(
+        escrow.resolveDisputeTimeout(3)
+      ).to.be.revertedWith("TruxifyEscrow: Dispute timeout not reached");
+    });
+  });
 });


### PR DESCRIPTION
## Fixes Issue #5008

### Description
Prevents a scenario where funds are permanently locked in the Polygon escrow contract if a dispute is raised but the resolution pipeline fails or both parties go unresponsive.

### Changes Included
* **`TruxifyEscrow.sol`:** Added a 7-day `DISPUTE_TIMEOUT` time-lock modifier. If a dispute sits idle for 7 days, `resolveDisputeTimeout()` can be called to default to a customer refund.
* **`TruxifyEscrow.test.js`:** Added time-manipulation tests using Hardhat network helpers to fast-forward the EVM and verify both successful timeout triggers and pre-timeout reverts.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Re-entrancy guards and Checks-Effects-Interactions (CEI) patterns are strictly maintained in the new resolution function.