### PR TITLE
fix: resolve undefined accessToken in marketplace_repository _authHeaders

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -56,10 +56,11 @@ class MarketplaceRepository {
   }
 
   Future<Map<String, String>> _authHeaders() async {
+    final token = _supabaseAccessToken() ?? await _firebaseAccessToken();
     return <String, String>{
       'Content-Type': 'application/json',
-      if (accessToken != null && accessToken.isNotEmpty)
-        'Authorization': 'Bearer $accessToken',
+      if (token != null && token.isNotEmpty)
+        'Authorization': 'Bearer $token',
     };
   }
 


### PR DESCRIPTION
## Summary
Fixes `_authHeaders()` in `marketplace_repository.dart` which references an undefined variable `accessToken`. The method now properly calls `_supabaseAccessToken()` (falling back to `_firebaseAccessToken()`) to obtain the auth token.

## Changes
- `apps/driver/lib/services/marketplace_repository.dart`: Replace undefined `accessToken` with actual token method calls

## Testing
Verified the fix compiles and the token methods return the expected values.

Fixes #5183

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved marketplace authentication by supporting a fallback access token when the primary authentication token is unavailable.
  - Prevented empty authorization headers from being sent with marketplace requests.
  - Marketplace requests now authenticate more reliably across supported sign-in methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->