### PR TITLE
fix: replace print with debugPrint in trip_cache to prevent data leaks in release

### DIFF
--- a/apps/driver/lib/services/trip_cache.dart
+++ b/apps/driver/lib/services/trip_cache.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Caches the most recently loaded trip list locally so drivers can still
@@ -35,7 +36,7 @@ class TripCache {
       });
       return sections;
     } catch (e) {
-      print('Error: $e');
+      debugPrint('TripCache decode error: $e');
       return <String, List<Map<String, dynamic>>>{};
     }
   }
@@ -99,7 +100,7 @@ class TripCache {
         savedAt: savedAt,
       );
     } catch (e) {
-      print('Error: $e');
+      debugPrint('TripCache load error: $e');
       return null;
     }
   }


### PR DESCRIPTION
## Summary
Replaces `print()` with `debugPrint()` in `trip_cache.dart` to prevent internal error data from leaking to device logs in release builds. Also adds the missing `flutter/foundation.dart` import.

## Changes
- `apps/driver/lib/services/trip_cache.dart`: Replace `print()` with `debugPrint()` in two catch blocks, add `flutter/foundation.dart` import

## Testing
Verified the fix compiles and both error paths use `debugPrint()`.

Fixes #5185

GSSoC