### PR TITLE
fix: replace print with debugPrint in route_service to prevent error data leaks in release

### DIFF
--- a/apps/driver/lib/services/route_service.dart
+++ b/apps/driver/lib/services/route_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import '../core/config.dart';
 import 'package:latlong2/latlong.dart';
@@ -46,7 +47,7 @@ class RouteService {
       }
       return out;
     } catch (e) {
-      print('Error: $e');
+      debugPrint('RouteService error: $e');
       return [];
     }
   }


### PR DESCRIPTION
## Summary
Replaces `print()` with `debugPrint()` in `route_service.dart` to prevent error details (including OSRM URLs) from leaking to device logs in release builds. Also adds the missing `flutter/foundation.dart` import.

## Changes
- `apps/driver/lib/services/route_service.dart`: Replace `print()` with `debugPrint()` in catch block, add `flutter/foundation.dart` import

## Testing
Verified the fix compiles and the error path uses `debugPrint()`.

Fixes #5186

GSSoC