### PR TITLE
fix: add mounted check before setState in voice_ai_screen _stopRecording

### DIFF
--- a/apps/customer/lib/screens/voice_ai_screen.dart
+++ b/apps/customer/lib/screens/voice_ai_screen.dart
@@ -108,6 +108,7 @@ class _VoiceAiScreenState extends State<VoiceAiScreen> with SingleTickerProvider
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
+        if (!mounted) return;
         setState(() {
           _transcript = data['transcript']?.toString();
           _responseText = data['response_text']?.toString();
@@ -122,6 +123,7 @@ class _VoiceAiScreenState extends State<VoiceAiScreen> with SingleTickerProvider
         throw Exception('Server returned status: ${response.statusCode}');
       }
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         _isProcessing = false;
         _responseText = 'Failed to process voice query: $e';


### PR DESCRIPTION
## Summary
Adds `if (!mounted) return;` guards before both `setState` calls in `_stopRecording()` to prevent calling `setState` on a disposed widget after the async HTTP request.

## Changes
- `apps/customer/lib/screens/voice_ai_screen.dart`: Add mounted check before setState in success and error paths

## Testing
Verified the fix compiles and both setState calls are properly guarded.

Fixes #5205

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Voice AI recording stability by preventing updates after the screen has been closed.
  * Reduced the risk of errors when voice responses finish processing after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->