### PR TITLE
fix: replace unsafe as double cast with safe num conversion in earnings_screen

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -652,7 +652,7 @@ class _EarningsScreenState extends State<EarningsScreen> {
     if (stats == null) return const SizedBox.shrink();
 
     final totalKm = stats['total_km'] ?? 0;
-    final avgEarning = stats['avg_earning_per_km'] ?? 0.0;
+    final avgEarning = (stats['avg_earning_per_km'] as num?)?.toDouble() ?? 0.0;
     final lifetimeTrips = stats['lifetime_trips'] ?? 0;
 
     return Container(
@@ -687,7 +687,7 @@ class _EarningsScreenState extends State<EarningsScreen> {
                 icon: Icons.trending_up_rounded,
                 color: Colors.green,
                 label: 'Avg Earning/km',
-                value: '₹${(avgEarning as double).toStringAsFixed(1)}',
+                value: '₹${avgEarning.toStringAsFixed(1)}',
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
Replaces the unsafe `as double` cast on `avg_earning_per_km` with a safe `num?` conversion that handles both `int` and `double` JSON values. Also removes the redundant `as double` cast at the usage site.

## Changes
- `apps/driver/lib/screens/earnings_screen.dart`: Use `(stats['avg_earning_per_km'] as num?)?.toDouble() ?? 0.0` instead of dynamic fallback + unsafe cast

## Testing
Verified the fix compiles and handles both int and double JSON values correctly.

Fixes #5206

GSSoC