### PR TITLE
fix: add try-catch to bid_copilot_screen _fetchPricingInsight to prevent infinite loading

### DIFF
--- a/apps/driver/lib/screens/bid_copilot_screen.dart
+++ b/apps/driver/lib/screens/bid_copilot_screen.dart
@@ -33,19 +33,27 @@ class _BidCopilotScreenState extends State<BidCopilotScreen> {
   }
 
   Future<void> _fetchPricingInsight() async {
-    final result = await _pricingEngine.analyzeLoadPricing(
-      loadId: widget.loadId,
-      origin: widget.origin,
-      destination: widget.destination,
-      totalMiles: widget.totalMiles,
-    );
+    try {
+      final result = await _pricingEngine.analyzeLoadPricing(
+        loadId: widget.loadId,
+        origin: widget.origin,
+        destination: widget.destination,
+        totalMiles: widget.totalMiles,
+      );
 
-    if (mounted) {
-      setState(() {
-        _insight = result;
-        _isLoading = false;
-        _userBid = result.suggestedBid;
-      });
+      if (mounted) {
+        setState(() {
+          _insight = result;
+          _isLoading = false;
+          _userBid = result.suggestedBid;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Wraps the `_fetchPricingInsight()` async call in a try-catch so that if `_pricingEngine.analyzeLoadPricing()` throws, `_isLoading` is set to `false` instead of leaving the user with an infinite loading spinner.

## Changes
- `apps/driver/lib/screens/bid_copilot_screen.dart`: Add try-catch around async pricing fetch, set `_isLoading = false` on error

## Testing
Verified the fix compiles and the error path properly clears the loading state.

Fixes #5207

GSSoC