### PR TITLE
fix: add length check before wallet address substring to prevent RangeError

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -1012,9 +1012,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     ),
                   ),
                   subtitle: Text(
-                    _walletAddress.isNotEmpty
+                    _walletAddress.length >= 16
                         ? '${_walletAddress.substring(0, 10)}...${_walletAddress.substring(_walletAddress.length - 6)}'
-                        : AppLocalizations.of(context)!.notSet,
+                        : _walletAddress.isNotEmpty
+                            ? _walletAddress
+                            : AppLocalizations.of(context)!.notSet,
                     style: GoogleFonts.dmSans(
                       fontSize: 12,
                       color: TruxifyColors.adaptiveSecondaryText(context),


### PR DESCRIPTION
## Summary
Adds a length check before `substring` operations on the wallet address display. The previous guard only checked `isNotEmpty`, which is insufficient — addresses shorter than 16 characters would throw a `RangeError`. Now short addresses are displayed in full without truncation, matching the customer-side implementation.

## Changes
- `apps/driver/lib/screens/profile_screen.dart`: Check `_walletAddress.length >= 16` before truncating, display full address if shorter

## Testing
Verified the fix compiles and handles addresses of all lengths correctly.

Fixes #5208

GSSoC