### PR TITLE
fix: uncomment iotRoutes POST /telemetry/:id route handler

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -27,9 +27,11 @@ function canReadTelemetry(user, load) {
   return user?.role === 'admin' || load.customer_id === user?.id || load.driver_id === user?.id;
 }
 
-// =====================================================================// 1. POST TELEMETRY DATA (IoT)
+// =====================================================================
+// 1. POST TELEMETRY DATA (IoT)
 // POST /api/iot/telemetry/:id
-// =====================================================================router.post('/telemetry/:id', authenticate, validateParams(paramIdSchema), async (req, res) => {
+// =====================================================================
+router.post('/telemetry/:id', authenticate, validateParams(paramIdSchema), async (req, res) => {
   try {
     const parseResult = telemetrySchema.safeParse(req.body);
     if (!parseResult.success) {


### PR DESCRIPTION
## Summary

Fixes the commented-out `router.post('/telemetry/:id')` call in `iotRoutes.js`. The `//` was on the same line as `router.post()`, commenting out the entire route registration. The handler code below ran as top-level module code where `req`/`res` were undefined, causing `ReferenceError` at import.

## Change

Split the section header comment from the `router.post()` call so the route is properly registered.

Fixes #5215

## GSSoC 2026

This PR is submitted under GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formatting and readability of internal route documentation.
  * No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->