### PR TITLE
fix: remove duplicate GET /telemetry/:id route in iotRoutes.js

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -108,14 +108,10 @@ function canReadTelemetry(user, load) {
   }
 });
 
-// =====================================================================// 2. GET TELEMETRY DATA
+// =====================================================================
+// 2. GET TELEMETRY DATA
 // GET /api/iot/telemetry/:id
-// =====================================================================router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validateParams(paramIdSchema), async (req, res) => {
-  try {
-    const loadId = req.params.id;
-    const { data: load, error: loadErr } = await supabase
-      .from('load_offers')
-      .select('id, customer_id, driver_id')
+// =====================================================================
 router.get('/telemetry/:id', authenticate, validateParams(paramIdSchema), async (req, res) => {
   const loadId = req.params.id;
 


### PR DESCRIPTION
## Summary

Removed the duplicate incomplete `router.get('/telemetry/:id')` definition that overlapped with the complete one, fixing the SyntaxError that prevented the file from parsing.

Fixes #5216

## GSSoC 2026

This PR is submitted under GSSoC 2026.