### PR TITLE
fix: safe .replace() call on trip.distance in driverRoutes

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1495,7 +1495,7 @@ router.get('/:id/earnings', authenticate, userLimiter, requirePolicy('driver:vie
     let totalKm = 0;
     trips.forEach(trip => {
       if (trip.distance) {
-        const distanceNum = parseInt(trip.distance.replace(/[^0-9]/g, '')) || 0;
+        const distanceNum = parseInt(String(trip.distance).replace(/[^0-9]/g, '')) || 0;
         totalKm += distanceNum;
       }
     });


### PR DESCRIPTION
## Summary

`trip.distance` may be returned as a number by Supabase. Calling `.replace()` on a number throws `TypeError`. Convert to `String()` first.

Fixes #5217

## GSSoC 2026