### PR TITLE
fix: add Clone derive to DriverData struct in lib.rs

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -21,7 +21,7 @@ pub struct RouteResponse {
 }
 
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DriverData {
     pub driver_id: String,
     pub lat: f64,


### PR DESCRIPTION
Fixes #5241

## GSSoC 2026