### PR TITLE
fix: add -- prefix to liquibase rollbackCount argument

### DIFF
--- a/database/liquibase/liquibase.service.js
+++ b/database/liquibase/liquibase.service.js
@@ -71,8 +71,7 @@ class LiquibaseService {
                 `--changeLogFile=${this.liquibasePath}/changelog-master.xml`,
                 `--url=${this.dbUrl}`,
                 `--username=${this.username}`,
-                `rollbackCount`,
-                `${rollbackCount}`,
+                `--rollbackCount=${rollbackCount}`,
             ];
 
             const { stdout, stderr } = await runLiquibase(args, this.password);


### PR DESCRIPTION
## Summary

Replaced bare `rollbackCount` and `${rollbackCount}` arguments with `--rollbackCount=${rollbackCount}`. Liquibase CLI requires the `--` prefix for arguments; without it the rollback command is broken.

Fixes #5232

## GSSoC 2026