### PR TITLE
fix: add resource cleanup for TrafficPipeline

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -44,6 +44,38 @@ class TrafficPipeline:
         self.model = self._load_or_create_model()
         self.gmaps_api_key = os.getenv('GOOGLE_MAPS_API_KEY', '')
         self.osrm_url = os.getenv('OSRM_URL', 'http://localhost:5000')
+        self._closed = False
+
+    def close(self):
+        """Dispose DB connection pool and close Redis connection.
+
+        Safe to call multiple times.
+        """
+        if self._closed:
+            return
+        try:
+            self.engine.dispose()
+        except Exception as e:
+            logger.error(f"Error disposing SQLAlchemy engine: {e}")
+        try:
+            self.redis.close()
+        except Exception as e:
+            logger.error(f"Error closing Redis connection: {e}")
+        self._closed = True
+        logger.info("TrafficPipeline resources released")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self):
+        try:
+            if not getattr(self, '_closed', True):
+                self.close()
+        except Exception:
+            pass
         
     def _load_or_create_model(self):
         """Load existing LSTM model or create new"""


### PR DESCRIPTION
## Summary

This PR resolves the resource cleanup issue in the `TrafficPipeline` class by adding explicit lifecycle management for database and Redis connections.

Previously, the class created SQLAlchemy and Redis connections without providing a cleanup mechanism, which could lead to connection leaks during service restarts or when pipeline instances were destroyed.

## Changes Made

- Added a `close()` method to explicitly release resources.
- Disposed the SQLAlchemy connection pool using `engine.dispose()`.
- Closed the Redis client using `redis.close()`.
- Added an internal `_closed` flag to prevent multiple cleanup attempts.
- Implemented `__enter__()` and `__exit__()` to support context manager usage.
- Added a defensive `__del__()` method as a best-effort fallback for resource cleanup.

## Notes

This change improves resource management and helps prevent database connection pool exhaustion and Redis connection leaks during service restarts or repeated pipeline initialization.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved traffic pipeline resource management by reliably releasing database and cache connections.
  * Added automatic cleanup when pipeline processing completes or encounters an error.
  * Made cleanup safe to call repeatedly and during object disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->