### PR TITLE
fix: secure voice audio endpoint with auth and rate limiting

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -37,7 +37,7 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
   }
 });
 
-router.get('/audio/:id', (req, res) => {
+router.get('/audio/:id', authenticate, userLimiter, (req, res) => {
   const buffer = audioCache.get(req.params.id);
   if (!buffer) {
     return res.status(404).json({ error: 'Audio not found' });


### PR DESCRIPTION
## Summary

This PR secures the `GET /audio/:id` endpoint by applying the same authentication and rate-limiting middleware already used by the `POST /query` endpoint.

Previously, the endpoint was publicly accessible, allowing any user who knew or guessed an audio ID to retrieve cached audio files. This change ensures that only authenticated users can access cached audio responses while also protecting the endpoint against abuse through rate limiting.

## Related Issue

Closes #<Issue_Number>

## Changes Made

- Added the `authenticate` middleware to the `GET /audio/:id` endpoint.
- Added the `userLimiter` middleware to prevent excessive requests and enumeration attacks.
- Aligned the security of the audio retrieval endpoint with the existing protected voice query endpoint.
- Preserved the existing functionality for serving cached audio files.

## Notes

This change improves the security of the Voice API by preventing unauthorized access to cached audio content without altering the endpoint's existing behavior for authorized users.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5346