### PR TITLE
fix: add auth and rate-limit middleware to audio cache endpoint

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -37,7 +37,7 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
   }
 });
 
-router.get('/audio/:id', (req, res) => {
+router.get('/audio/:id', authenticate, userLimiter, (req, res) => {
   const buffer = audioCache.get(req.params.id);
   if (!buffer) {
     return res.status(404).json({ error: 'Audio not found' });


### PR DESCRIPTION
## Description

In `backend/api/src/routes/voiceRoutes.js` at lines 40-47, the `GET /audio/:id` endpoint serves cached audio files with zero authentication, authorization, or rate limiting. Any user (including unauthenticated users) who knows or guesses an audio ID can retrieve arbitrary audio content from the in-memory cache. The `POST /query` route at line 11 correctly uses `authenticate` and `userLimiter` middleware, but the audio cache endpoint uses none.

## Fix

Added `authenticate` and `userLimiter` middleware to the `GET /audio/:id` route, matching the authentication pattern used by other routes in the same file.

Closes #5346