### PR TITLE
fix(core): release escrow reconciliation locks on completion to prevent order deadlock

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -140,8 +140,9 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
           refund_tx_hash: receipt.hash ?? refundTxHash,
           escrow_refunded_at: refundedAt,
           escrow_refund_error: null,
+          reconciled_by: null,
           updated_at: refundedAt,
-        }, [{ op: 'in', column: 'escrow_status', value: ['refund_pending', 'refund_failed'] }], 'id');
+        }, [{ op: 'in', column: 'escrow_status', value: ['refund_pending', 'refund_failed'] }, { op: 'eq', column: 'reconciled_by', value: instanceId }], 'id');
 
         if (updateError) {
           logger.error(
@@ -154,6 +155,7 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         await orderRepository.updateOrder(order.id, {
           escrow_refund_retry_count: newRetryCount,
           escrow_refund_error: err.message,
+          reconciled_by: null,
           updated_at: new Date().toISOString(),
         });
         logger.warn(

--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -104,11 +104,12 @@ export async function reconcilePendingEscrowReleases() {
             escrow_released_at: releasedAt,
             escrow_release_attempts: releaseAttempts,
             escrow_release_last_attempt_at: releaseAttemptedAt,
+            reconciled_by: null,
             updated_at: releasedAt,
           })
           .eq('id', order.id)
-      .in('escrow_status', ['release_failed', 'funded'])
-          .is('reconciled_by', null);
+          .in('escrow_status', ['release_failed', 'funded'])
+          .eq('reconciled_by', instanceId);
 
         if (updateError) {
           logger.error(
@@ -128,6 +129,7 @@ export async function reconcilePendingEscrowReleases() {
             escrow_release_attempts: releaseAttempts,
             escrow_release_last_attempt_at: releaseAttemptedAt,
             escrow_release_error: String(err.message || 'Unknown error').slice(0, 1000),
+            reconciled_by: null,
             updated_at: new Date().toISOString(),
           })
           .eq('id', order.id);


### PR DESCRIPTION
## Summary
Patched a highly critical concurrency flaw in the background escrow reconciliation workers that caused permanently deadlocked orders and prevented driver payouts from being retried.

## Motivation
Closes #5364.

Previously, the `escrowReleaseReconciliation.js` and `escrowRefundReconciliation.js` background workers correctly claimed failed escrow transfers by setting `reconciled_by = instanceId` via an RPC. However, when the workers attempted to update the database after communicating with the blockchain, they incorrectly tried to filter the update with `.is('reconciled_by', null)`. Since the lock was held by the worker, the update silently affected 0 rows. Even worse, the worker never explicitly cleared `reconciled_by`, meaning the order became permanently locked and ignored by all future reconciliation runs. This permanently broke the retry mechanism.

## Changes
- Modified `backend/api/src/services/escrowReleaseReconciliation.js` and `backend/api/src/services/escrowRefundReconciliation.js`:
  - Replaced the erroneous `.is('reconciled_by', null)` filter with `.eq('reconciled_by', instanceId)` in the success block.
  - Added `reconciled_by: null` to the success update payloads so the lock is successfully released.
  - Added `reconciled_by: null` to the error catch-block payloads to guarantee the lock is released if the blockchain transaction fails, allowing the standard `MAX_RETRIES` exponential backoff mechanism to function.

## Acceptance Criteria
- [x] Orders are no longer permanently locked to an `instanceId` after a reconciliation run.
- [x] The success update correctly clears the lock.
- [x] The failure catch block correctly clears the lock.

## Impact & Side Effects
Strict enforcement of database state machine correctness. No negative impact. This ensures drivers get paid and refunds get issued properly when the Polygon RPC endpoints experience transient failures.

## Quality Checklist
- [x] Linter passed
- [x] Types checked
- [x] Unit tests passed (Note: existing CI tests may fail due to unrelated bugs in `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow refund and release reconciliation to prevent updates from being applied to records managed by another processing instance.
  * Escrow records now correctly become available for subsequent processing after successful completion or a failed attempt.
  * Improved retry handling by reliably recording errors and releasing processing ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->