### PR TITLE
fix: add mounted check before setState in pod_scanner_screen _simulateCameraScan

### DIFF
--- a/apps/driver/lib/screens/pod_scanner_screen.dart
+++ b/apps/driver/lib/screens/pod_scanner_screen.dart
@@ -23,6 +23,7 @@ class _PodScannerScreenState extends State<PodScannerScreen> {
     // Simulated image path from camera
     final doc = await _ocrService.scanDocument('/local/cache/image_capture.jpg');
 
+    if (!mounted) return;
     setState(() {
       _isScanning = false;
       _scannedDocument = doc;


### PR DESCRIPTION
## Summary
Adds a `if (!mounted) return;` guard before `setState` after `await _ocrService.scanDocument()` in `_simulateCameraScan()`. Prevents crash when user navigates away during the scan delay.

## Changes
- `apps/driver/lib/screens/pod_scanner_screen.dart`: Add mounted check before setState

## Testing
Verified the fix compiles and the guard protects against disposed widget.

Fixes #5369

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scanning results from updating the screen after it has been closed, avoiding potential errors during document scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->