### PR TITLE
fix: add mounted check before setState in route_optimization_screen _runOptimization

### DIFF
--- a/apps/driver/lib/screens/route_optimization_screen.dart
+++ b/apps/driver/lib/screens/route_optimization_screen.dart
@@ -37,6 +37,7 @@ class _RouteOptimizationScreenState extends State<RouteOptimizationScreen> {
     // Simulate current driver GPS location
     final optimized = await _optimizationService.optimizeRoute(_stops, 34.00, -118.15);
 
+    if (!mounted) return;
     setState(() {
       _stops = optimized;
       _isOptimizing = false;


### PR DESCRIPTION
## Summary
Adds a `if (!mounted) return;` guard before `setState` after `await _optimizationService.optimizeRoute()` in `_runOptimization()`. Prevents crash when user navigates away during the optimization delay.

## Changes
- `apps/driver/lib/screens/route_optimization_screen.dart`: Add mounted check before setState

## Testing
Verified the fix compiles and the guard protects against disposed widget.

Fixes #5367

GSSoC