### PR TITLE
fix: guard _eventController.add with isClosed check to prevent StateError on dispose race

### DIFF
--- a/apps/driver/lib/services/weigh_station_service.dart
+++ b/apps/driver/lib/services/weigh_station_service.dart
@@ -111,7 +111,9 @@ class WeighStationService {
         stationId: response['stationId'] ?? stationKey,
       );
 
-      _eventController.add(event);
+      if (!_eventController.isClosed) {
+        _eventController.add(event);
+      }
     } catch (e) {
       debugPrint('[WeighStationService] Error checking bypass status: $e');
     }


### PR DESCRIPTION
## Summary
Guards `_eventController.add(event)` with `!isClosed` check in `_triggerBypassCheck()` to prevent `StateError` when the service is disposed mid-request.

## Changes
- `apps/driver/lib/services/weigh_station_service.dart`: Wrap `_eventController.add` with `isClosed` guard

## Testing
Verified the fix compiles and handles the race condition gracefully.

Fixes #5366

GSSoC