### PR TITLE
fix: replace unsafe castWithType with safe map conversion in order_service searchTrucks

### DIFF
--- a/apps/customer/lib/services/order_service.dart
+++ b/apps/customer/lib/services/order_service.dart
@@ -246,7 +246,9 @@ class OrderService {
         throw StateError('Unexpected truck search response type');
       }
       final listBody = body;
-      return listBody.cast<Map<String, dynamic>>();
+      return listBody
+          .map((e) => e is Map ? Map<String, dynamic>.from(e) : <String, dynamic>{})
+          .toList(growable: false);
     } on ApiException catch (e) {
       throw StateError(e.message);
     } catch (e) {


### PR DESCRIPTION
## Summary
Replaces the unsafe `.cast<Map<String, dynamic>>()` call with a safe `.map().toList()` pattern in `searchTrucks()`. The previous code would throw a `TypeError` if any API response element had a type mismatch. The new pattern gracefully converts valid elements and provides an empty fallback for invalid ones, consistent with other methods in the same service.

## Changes
- `apps/customer/lib/services/order_service.dart`: Replace `.cast()` with safe `.map().from()` conversion

## Testing
Verified the fix compiles and handles type mismatches gracefully.

Fixes #5368

GSSoC