### PR TITLE
fix: cancel stream subscription in fleet_maintenance_screen dispose to prevent memory leak

### DIFF
--- a/apps/driver/lib/screens/maintenance/fleet_maintenance_screen.dart
+++ b/apps/driver/lib/screens/maintenance/fleet_maintenance_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:truxify_driver/models/obd_telemetry_model.dart';
 import 'package:truxify_driver/services/obd_maintenance_service.dart';
@@ -13,6 +14,7 @@ class _FleetMaintenanceScreenState extends State<FleetMaintenanceScreen> {
   final ObdMaintenanceService _obdService = ObdMaintenanceService();
   ObdTelemetryModel? _currentTelemetry;
   String? _alertMessage;
+  StreamSubscription<ObdTelemetryModel>? _telemetrySub;
   
   @override
   void initState() {
@@ -20,8 +22,14 @@ class _FleetMaintenanceScreenState extends State<FleetMaintenanceScreen> {
     _startTelemetryStream();
   }
 
+  @override
+  void dispose() {
+    _telemetrySub?.cancel();
+    super.dispose();
+  }
+
   void _startTelemetryStream() {
-    _obdService.streamTelemetryData().listen((data) async {
+    _telemetrySub = _obdService.streamTelemetryData().listen((data) async {
       final prediction = await _obdService.predictFailure(data);
       if (mounted) {
         setState(() {


### PR DESCRIPTION
## Summary
Stores the `StreamSubscription` from `_obdService.streamTelemetryData()` in a field and cancels it in `dispose()`. Previously the subscription was never cancelled, causing a memory leak and duplicate listeners on repeated navigation.

## Changes
- `apps/driver/lib/screens/maintenance/fleet_maintenance_screen.dart`: Add `_telemetrySub` field, cancel in `dispose()`, assign in `_startTelemetryStream()`, add `dart:async` import

## Testing
Verified the fix compiles and properly cleans up the subscription on dispose.

Fixes #5370

GSSoC