### PR TITLE
fix: add mounted check before _loadOrders in realtime callback to prevent setState after dispose

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -324,6 +324,7 @@ class _OrdersScreenState extends State<OrdersScreen>
           ),
           callback: (payload) {
             debugPrint('Realtime customer orders list update: ${payload.newRecord}');
+            if (!mounted) return;
             _loadOrders();
           },
         )


### PR DESCRIPTION
## Summary
Adds `if (!mounted) return;` guard before `_loadOrders()` in the Realtime subscription callback in `orders_screen.dart`. Prevents a `setState` crash when a Realtime notification arrives during widget disposal.

## Changes
- `apps/customer/lib/screens/orders_screen.dart`: Add mounted check in Realtime callback

## Testing
Verified the fix compiles.

Fixes #5376

GSSoC