### PR TITLE
fix: clear FCM callbacks in driver shell_screen dispose to prevent memory leak

### DIFF
--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -197,6 +197,8 @@ class _ShellScreenState extends State<ShellScreen> {
   void dispose() {
     _weighStationSub?.cancel();
     ForegroundNotificationHandler.dispose();
+    FcmService.clearForegroundCallback();
+    FcmService.clearTapCallback();
     _currentIndex.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
Adds `FcmService.clearForegroundCallback()` and `FcmService.clearTapCallback()` calls to the driver `ShellScreen`'s `dispose()` method. Previously the FCM callbacks retained a reference to the disposed state instance, causing a memory leak.

## Changes
- `apps/driver/lib/screens/shell_screen.dart`: Clear FCM static callbacks in dispose

## Testing
Verified the fix compiles and cleanup methods exist on FcmService.

Fixes #5377

GSSoC