### PR TITLE
fix: return null instead of 0,0 when coordinates fail to parse in public_tracking_screen

### DIFF
--- a/apps/customer/lib/screens/public_tracking_screen.dart
+++ b/apps/customer/lib/screens/public_tracking_screen.dart
@@ -137,21 +137,30 @@ class _PublicTrackingScreenState extends State<PublicTrackingScreen> {
     final lat = _order?['pickup_lat'];
     final lng = _order?['pickup_lng'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   LatLng? _getDropLatLng() {
     final lat = _order?['drop_lat'];
     final lng = _order?['drop_lng'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   LatLng? _getDriverLatLng() {
     final lat = _driverLocation?['latitude'];
     final lng = _driverLocation?['longitude'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   @override


### PR DESCRIPTION
## Summary
Changes the three coordinate-accessor methods in `public_tracking_screen.dart` to return `null` instead of `LatLng(0.0, 0.0)` when `double.tryParse` fails. Previously, unparseable coordinates placed map markers at Null Island (lat 0, lng 0 in the Atlantic Ocean) instead of hiding them.

## Changes
- `apps/customer/lib/screens/public_tracking_screen.dart`: Return null on parse failure in `_getPickupLatLng`, `_getDropLatLng`, `_getDriverLatLng`

## Testing
Verified the fix compiles and returns null on invalid coordinates.

Fixes #5378

GSSoC