### PR TITLE
fix: add error logging to documents_screen _formatDate catch block to surface upstream date issues

### DIFF
--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -97,7 +97,8 @@ class DriverDocument {
       return '${dt.day.toString().padLeft(2, '0')}/'
           '${dt.month.toString().padLeft(2, '0')}/'
           '${dt.year}';
-    } catch (_) {
+    } catch (e) {
+      debugPrint('DocumentsScreen: failed to parse date "$raw": $e');
       return raw;
     }
   }


### PR DESCRIPTION
## Summary
Adds error logging to the `catch (_)` block in `_formatDate()` in `documents_screen.dart` so that unparseable date strings from the backend are logged instead of silently returning the raw string.

## Changes
- `apps/driver/lib/screens/documents_screen.dart`: Replace `catch (_)` with `catch (e)` and add `debugPrint`

## Testing
Verified the fix compiles and logs date parse failures.

Fixes #5379

GSSoC