### PR TITLE
fix: show error details in booking_confirmation_screen SnackBar for actionable feedback

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -143,7 +143,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       if (!mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to create booking')),
+        SnackBar(content: Text('Failed to create booking: $e')),
       );
     } finally {
       if (mounted) {


### PR DESCRIPTION
## Summary
Includes the actual error details in the SnackBar message on booking failure instead of showing a generic "Failed to create booking" message. This gives the user actionable information about what went wrong.

## Changes
- `apps/customer/lib/screens/booking_confirmation_screen.dart`: Show error context in SnackBar

## Testing
Verified the fix compiles.

Fixes #5380

GSSoC