### PR TITLE
fix: remove extra brace breaking compilation of validateRegistrationNumber in validators

### DIFF
--- a/apps/driver/lib/utils/validators.dart
+++ b/apps/driver/lib/utils/validators.dart
@@ -21,9 +21,8 @@ String? validateRegistrationNumber(String? value) {
   final RegExp regex = RegExp(r'^[A-Z]{2}\d{2}[A-Z]{1,2}\d{4}$');
   final trimmedValue = value.trim();
 
-if (!regex.hasMatch(trimmedValue)) {
-  return 'Enter a valid RTO number (e.g., DL01AA1234)';
-}
+  if (!regex.hasMatch(trimmedValue)) {
+    return 'Enter a valid RTO number (e.g., DL01AA1234)';
   }
 
   return null;


### PR DESCRIPTION
## Summary
Removes an extra closing brace in `validateRegistrationNumber()` that prematurely closed the function body, leaving `return null;` as a dangling top-level statement. The file would not compile.

## Changes
- `apps/driver/lib/utils/validators.dart`: Remove extra brace, fix indentation

## Testing
Verified the file now has proper brace structure.

Fixes #5386

GSSoC