### PR TITLE
fix: store splash_screen timer as field and cancel in dispose to prevent resource leak

### DIFF
--- a/apps/driver/lib/screens/splash_screen.dart
+++ b/apps/driver/lib/screens/splash_screen.dart
@@ -16,10 +16,12 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  Timer? _navigationTimer;
+
   @override
   void initState() {
     super.initState();
-    Timer(const Duration(seconds: 2), () {
+    _navigationTimer = Timer(const Duration(seconds: 2), () {
       if (!mounted) {
         return;
       }
@@ -30,6 +32,12 @@ class _SplashScreenState extends State<SplashScreen> {
         Navigator.of(context).pushReplacementNamed(AppRoutes.login);
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _navigationTimer?.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
## Summary
Stores the navigation timer as a field and adds `dispose()` to cancel it in the driver `SplashScreen`. Previously the timer was created anonymously with no way to cancel it if the widget was removed from the tree.

## Changes
- `apps/driver/lib/screens/splash_screen.dart`: Add `_navigationTimer` field, `dispose()` override with cancel

## Testing
Verified the fix compiles.

Fixes #5388

GSSoC