### PR TITLE
fix: replace double bang assertions in TruxifyScope.of with proper null checks

### DIFF
--- a/apps/driver/lib/controllers/app_controller.dart
+++ b/apps/driver/lib/controllers/app_controller.dart
@@ -64,7 +64,13 @@ class TruxifyScope extends InheritedNotifier<TruxifyController> {
 
   static TruxifyController of(BuildContext context) {
     final scope = context.dependOnInheritedWidgetOfExactType<TruxifyScope>();
-    assert(scope != null, 'TruxifyScope not found in widget tree.');
-    return scope!.notifier!;
+    if (scope == null) {
+      throw FlutterError('TruxifyScope not found in widget tree.');
+    }
+    final controller = scope.notifier;
+    if (controller == null) {
+      throw FlutterError('TruxifyScope.notifier is null.');
+    }
+    return controller;
   }
 }


### PR DESCRIPTION
## Summary
Replaces the double non-null assertions in `TruxifyScope.of()` with proper null checks that throw `FlutterError` in both debug and release mode. Previously, `assert` only guarded in debug mode, leaving release builds vulnerable to crash from missing `TruxifyScope` ancestor.

## Changes
- `apps/driver/lib/controllers/app_controller.dart`: Replace `scope!.notifier!` with explicit null checks

## Testing
Verified the fix compiles.

Fixes #5389

GSSoC