### PR TITLE
fix: add clear isInFlight and pendingCount to bid_submission_guard for stale entry management

### DIFF
--- a/apps/driver/lib/services/bid_submission_guard.dart
+++ b/apps/driver/lib/services/bid_submission_guard.dart
@@ -16,4 +16,10 @@ class BidSubmissionGuard {
       _inFlight.remove(loadId);
     }
   }
+
+  bool isInFlight(String loadId) => _inFlight.contains(loadId);
+
+  int get pendingCount => _inFlight.length;
+
+  void clear() => _inFlight.clear();
 }


### PR DESCRIPTION
## Summary
Adds `clear()`, `isInFlight()`, and `pendingCount` to `BidSubmissionGuard`. Previous implementation had no way for callers to manage stale entries — if a future never completes (e.g., app lifecycle interruption), the set entry persists and blocks future submissions for that load ID indefinitely.

## Changes
- `apps/driver/lib/services/bid_submission_guard.dart`: Add `clear()`, `isInFlight()`, `pendingCount`

## Testing
Verified the fix compiles.

Fixes #5390

GSSoC