### PR TITLE
fix: track cross-chain swaps in userSwaps mapping (#5269)

### DIFF
--- a/blockchain/contracts/AtomicSwap.sol
+++ b/blockchain/contracts/AtomicSwap.sol
@@ -201,6 +201,7 @@ contract AtomicSwap is Ownable, ReentrancyGuard, Pausable {
         });
 
         usedHashLocks[hashLock] = true;
+        userSwaps[msg.sender].push(swapId);
 
         emit CrossChainSwapCreated(swapId, block.chainid, destChainId);
         return swapId;


### PR DESCRIPTION
## Description

The \createCrossChainSwap\ function was not pushing the swap ID to \userSwaps[msg.sender]\, making cross-chain swaps invisible to the \getUserSwaps\ view function.

## Fix

Added \userSwaps[msg.sender].push(swapId)\ after the swap is created, matching the behavior of \createSwap\.

Closes #5269
GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-chain swaps now appear in the creator’s swap history, alongside regular swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->