### PR TITLE
fix: add close() method for resource cleanup in TrafficPipeline (#5270)

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -61,6 +61,11 @@ class TrafficPipeline:
         else:
             logger.info("Creating new LSTM model")
             return self._create_lstm_model()
+
+    def close(self):
+        """Dispose database connections and close Redis connection."""
+        self.engine.dispose()
+        self.redis.close()
     
     def _create_lstm_model(self):
         """Create LSTM model for ETA prediction"""


### PR DESCRIPTION
## Description

The TrafficPipeline class creates a SQLAlchemy engine and Redis connection in __init__ but has no cleanup method. On service restart, these resources are leaked.

## Fix

Added a close() method that calls self.engine.dispose() and self.redis.close(). This allows callers to cleanly release resources on shutdown.

Closes #5270
GSSoC