### PR TITLE
fix: move custom error handlers before generic handler to prevent dead code (#5267)

### DIFF
--- a/backend/api/src/middleware/errorHandler.js
+++ b/backend/api/src/middleware/errorHandler.js
@@ -2,6 +2,28 @@ import logger from './logger.js';
 import { AppError } from '../utils/errors.js';
 
 export function errorHandler(err, req, res, next) {
+  if (err?.type === 'entity.too.large') {
+    logger.warn(
+      { requestId: req.requestId, ip: req.ip, method: req.method, path: req.originalUrl },
+      'Request payload exceeded configured limit'
+    );
+    return res.status(413).json({
+      success: false,
+      error: 'Payload too large'
+    });
+  }
+
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    logger.warn(
+      { requestId: req.requestId, ip: req.ip, method: req.method, path: req.originalUrl },
+      'Malformed JSON payload received'
+    );
+    return res.status(400).json({
+      success: false,
+      error: 'Malformed JSON payload'
+    });
+  }
+
   if (err && err.name === 'MulterError') {
     const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
     return res.status(status).json({


### PR DESCRIPTION
## Description

Custom error handlers for entity.too.large and SyntaxError were registered AFTER the generic errorHandler. Since the generic handler always sends a 500 and never calls next(err), the custom handlers never executed.

## Fix

Moved the custom error handlers to before the sentryErrorHandler and errorHandler, so they run first and can provide proper 413/400 responses instead of generic 500s.

Closes #5267
GSSoC