### PR TITLE
fix: replace Mongoose with Supabase and add auth to fcm-token endpoint (#5275)

### DIFF
--- a/backend/api/routes/users.js
+++ b/backend/api/routes/users.js
@@ -1,15 +1,22 @@
 import express from 'express';
-import { Driver } from '../models/Driver.js'; // adjust to your actual model
+import { authenticate } from '../src/middleware/auth.js';
+import { supabase } from '../src/config/db.js';
+
 const router = express.Router();
 
 // POST /api/users/fcm-token — update FCM token on login
-router.post('/fcm-token', async (req, res) => {
+router.post('/fcm-token', authenticate, async (req, res) => {
   try {
-    const { userId, fcmToken, userType } = req.body; // userType: 'driver' | 'manufacturer'
+    const { fcmToken } = req.body;
     if (!fcmToken) return res.status(400).json({ error: 'fcmToken required' });
-    
-    // Update token in DB (adapt to your schema)
-    await Driver.findByIdAndUpdate(userId, { fcmToken });
+
+    // Update token in Supabase for the authenticated user
+    const { error } = await supabase
+      .from('profiles')
+      .update({ fcm_token: fcmToken })
+      .eq('id', req.user.id);
+
+    if (error) throw error;
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });


### PR DESCRIPTION
## Description

The fcm-token endpoint had two critical issues:
1. Used Mongoose findByIdAndUpdate in a Supabase backend — non-functional
2. No authentication — attacker could hijack any user's notifications

## Fix

Replaced the Mongoose call with a Supabase update query. Added the authenticate middleware to use the session user's ID instead of an arbitrary userId from the request body.

Closes #5275
GSSoC