### PR TITLE
fix: change releaseTimestamps comparison to keep latest deadline instead of earliest (#5226)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -184,7 +184,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         pendingWithdrawals[driver] += paymentAmount;
 
         uint256 newDeadline = block.timestamp + WITHDRAWAL_TIMEOUT;
-        if (releaseTimestamps[driver] == 0 || newDeadline < releaseTimestamps[driver]) {
+        if (releaseTimestamps[driver] == 0 || newDeadline > releaseTimestamps[driver]) {
             releaseTimestamps[driver] = newDeadline;
         }
 
@@ -229,7 +229,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         pendingWithdrawals[customer] += refundAmount;
 
         uint256 newDeadline = block.timestamp + WITHDRAWAL_TIMEOUT;
-        if (releaseTimestamps[customer] == 0 || newDeadline < releaseTimestamps[customer]) {
+        if (releaseTimestamps[customer] == 0 || newDeadline > releaseTimestamps[customer]) {
             releaseTimestamps[customer] = newDeadline;
         }
 


### PR DESCRIPTION
## Description

The releaseTimestamps mapping used < comparison which caused the withdrawal deadline to shrink — when multiple bookings were released to the same driver, the earliest deadline was kept instead of the latest.

## Fix

Changed < to > in both releasePayment() and cancelBooking() so the withdrawal deadline always extends to the latest booking's expiry, giving drivers the full 30-day window for all released funds.

Closes #5226
GSSoC