### PR TITLE
fix: add challenge period enforcement in closeChannel and settleChannel functions (#5272)

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -50,6 +50,7 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
     mapping(uint256 => Dispute) public disputes;
     mapping(address => uint256[]) public userChannels;
     mapping(uint256 => mapping(address => uint256)) public pendingWithdrawals;
+    mapping(uint256 => uint256) public channelClosesAt;
 
     uint256 public channelCounter;
     uint256 public constant CHALLENGE_PERIOD = 1 days;
@@ -129,7 +130,7 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
         bytes memory signatureB
     ) external whenNotPaused {
         Channel storage channel = channels[channelId];
-        require(channel.isOpen, "Channel not open");
+        require(channel.isOpen || (!channel.isSettled && block.timestamp <= channelClosesAt[channelId]), "Channel not open or challenge period expired");
         require(!channel.isSettled, "Channel settled");
         require(nonce > channel.nonce, "Invalid nonce");
 
@@ -189,6 +190,7 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
 
         channel.isOpen = false;
         channel.lastUpdated = block.timestamp;
+        channelClosesAt[channelId] = block.timestamp + CHALLENGE_PERIOD;
 
         // Capture final balances before settlement
         uint256 finalBalanceA = channel.balanceA;
@@ -196,8 +198,16 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
 
         // Emit event before zeroing balances
         emit ChannelClosed(channelId, finalBalanceA, finalBalanceB);
+    }
 
-        // Settle balances
+    function settleChannel(uint256 channelId) external whenNotPaused {
+        Channel storage channel = channels[channelId];
+        require(!channel.isOpen, "Channel still open");
+        require(!channel.isSettled, "Already settled");
+        require(channelClosesAt[channelId] > 0, "Channel not closed");
+        require(block.timestamp > channelClosesAt[channelId], "Challenge period not elapsed");
+        require(msg.sender == channel.participantA || msg.sender == channel.participantB, "Not participant");
+
         _settleChannel(channelId);
     }
 


### PR DESCRIPTION
## Description

closeChannel immediately settled balances without a challenge period, allowing one participant to close with an outdated state. The CHALLENGE_PERIOD constant was defined but never used.

## Fix

1. closeChannel now records a challenge deadline instead of immediately settling
2. Added settleChannel function that finalizes after the challenge period
3. updateState can still be called during the challenge period to submit a more recent state
4. Added channelClosesAt mapping to track challenge deadlines

Closes #5272
GSSoC