### PR TITLE
fix: decode proof parameter and update balances in resolveDispute (#5271)

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -255,13 +255,29 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
         require(!dispute.resolved, "Already resolved");
         require(block.timestamp >= dispute.startedAt + SETTLEMENT_PERIOD, "Settlement period not elapsed");
 
-        // Verify proof and resolve
-        // In production: verify state proof
+        Channel storage channel = channels[channelId];
+
+        // Decode proof: (balanceA, balanceB, signatureA, signatureB)
+        (uint256 proofBalanceA, uint256 proofBalanceB, bytes memory sigA, bytes memory sigB) =
+            abi.decode(proof, (uint256, uint256, bytes, bytes));
+
+        // Verify that balances sum to the channel's total
+        uint256 totalBalance = channel.balanceA + channel.balanceB;
+        require(proofBalanceA + proofBalanceB == totalBalance, "Invalid proof balances");
+
+        // Verify that the proof is signed by the challenger (the party who raised the dispute)
+        bytes32 stateHash = keccak256(abi.encodePacked(
+            channelId, proofBalanceA, proofBalanceB, dispute.challenger
+        ));
+        require(_verifySignature(stateHash, sigA, dispute.challenger), "Invalid challenger signature");
+
         dispute.resolved = true;
 
-        // Reopen channel with disputed state
-        Channel storage channel = channels[channelId];
-        channel.isOpen = true;
+        // Update to disputed state and settle
+        channel.balanceA = proofBalanceA;
+        channel.balanceB = proofBalanceB;
+
+        _settleChannel(channelId);
 
         emit DisputeResolved(channelId, true);
     }


### PR DESCRIPTION
## Description

The resolveDispute function accepted a proof parameter but ignored it. It simply reopened the channel with stale balances without resolving the disputed state.

## Fix

Decoded the proof to extract disputed balances and challenger signatures. The function now:
1. Decodes (balanceA, balanceB, signatureA, signatureB) from the proof
2. Verifies total balance sum matches the channel
3. Verifies the challenger's signature on the proof
4. Updates channel balances to the disputed state
5. Settles the channel with corrected balances

Closes #5271
GSSoC