### PR TITLE
fix: add error logging to resilient_websocket catch block replacing silent catch(_)

### DIFF
--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 class ResilientWebSocket {
@@ -51,7 +52,8 @@ class ResilientWebSocket {
       _attempt = 0;
       _startHeartbeat();
       onConnect?.call();
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[ResilientWebSocket] Connection failed: $e');
       _scheduleReconnect();
     }
   }


### PR DESCRIPTION
## Summary
Replaces `catch (_)` with `catch (e)` + `debugPrint` in `ResilientWebSocket._connectOnce()`. WebSocket connection failures (DNS, network, HTTP) were silently discarded with no diagnostic output.

## Changes
- `apps/customer/lib/core/offline/websocket/resilient_websocket.dart`: Add `import 'package:flutter/foundation.dart'`, add error logging to catch block

## Testing
Verified the file compiles.

Fixes #5432

GSSoC