### PR TITLE
fix: add error logging to destination_picker_screen catch block replacing silent catch(_)

### DIFF
--- a/apps/driver/lib/screens/destination_picker_screen.dart
+++ b/apps/driver/lib/screens/destination_picker_screen.dart
@@ -155,7 +155,8 @@ class _DestinationPickerScreenState extends State<DestinationPickerScreen> {
                 ? 'Pinned location (${point.latitude.toStringAsFixed(5)}, ${point.longitude.toStringAsFixed(5)})'
                 : displayName;
       });
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[DestinationPickerScreen] Reverse geocode failed: $e');
       if (!mounted) {
         return;
       }


### PR DESCRIPTION
## Summary
Replaces `catch (_)` with `catch (e)` + `debugPrint` in `destination_picker_screen.dart`. When reverse geocoding fails (network error, API timeout), the error is now logged before falling back to raw coordinates.

## Changes
- `apps/driver/lib/screens/destination_picker_screen.dart`: Add debugPrint to silent catch block

## Testing
Verified the file compiles.

Fixes #5439

GSSoC