### PR TITLE
fix: store and manage 3 FCM StreamSubscriptions to prevent leaks and duplicates

### DIFF
--- a/packages/truxify_shared/lib/src/services/fcm_service.dart
+++ b/packages/truxify_shared/lib/src/services/fcm_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -28,6 +30,9 @@ class FcmService {
   static bool _initialized = false;
   static ForegroundMessageCallback? _foregroundCallback;
   static NotificationTapCallback? _tapCallback;
+  static StreamSubscription<String>? _tokenRefreshSubscription;
+  static StreamSubscription<RemoteMessage>? _foregroundSubscription;
+  static StreamSubscription<RemoteMessage>? _tapSubscription;
 
   /// Registers a callback for foreground messages.
   static void setForegroundCallback(ForegroundMessageCallback callback) {
@@ -45,6 +50,18 @@ class FcmService {
 
   static void clearTapCallback() {
     _tapCallback = null;
+  }
+
+  /// Cancels all FCM stream subscriptions. Should be called on sign-out or
+  /// when FCM listeners need to be reset to prevent duplicate handlers.
+  static void unregisterAll() {
+    _tokenRefreshSubscription?.cancel();
+    _tokenRefreshSubscription = null;
+    _foregroundSubscription?.cancel();
+    _foregroundSubscription = null;
+    _tapSubscription?.cancel();
+    _tapSubscription = null;
+    _initialized = false;
   }
 
   /// Must be called once during app startup.
@@ -81,7 +98,7 @@ class FcmService {
           await _sendTokenToBackend(token, apiClient: apiClient);
         }
 
-        messaging.onTokenRefresh.listen((newToken) async {
+        _tokenRefreshSubscription = messaging.onTokenRefresh.listen((newToken) async {
           await _sendTokenToBackend(newToken, apiClient: apiClient);
         });
       } else {
@@ -89,10 +106,10 @@ class FcmService {
       }
 
       // ── Foreground messages ──────────────────────────────────────
-      FirebaseMessaging.onMessage.listen(_handleForegroundMessage);
+      _foregroundSubscription = FirebaseMessaging.onMessage.listen(_handleForegroundMessage);
 
       // ── Tap on background notification ──
-      FirebaseMessaging.onMessageOpenedApp.listen(_handleNotificationTap);
+      _tapSubscription = FirebaseMessaging.onMessageOpenedApp.listen(_handleNotificationTap);
       _initialized = true;
     } catch (e) {
       _initialized = false;


### PR DESCRIPTION
## Summary
`FcmService.initializeAndRegister()` creates 3 `StreamSubscription` objects (onTokenRefresh, onMessage, onMessageOpenedApp) that were never stored or cancellable. This caused:
1. Resource leaks — subscriptions persist even after sign-out
2. Duplicate handler risk — calling `resetInitialized()` + `initializeAndRegister()` creates duplicate listeners

## Changes
- Added `_tokenRefreshSubscription`, `_foregroundSubscription`, `_tapSubscription` static fields
- Stored returned subscriptions from `.listen()` calls
- Added `unregisterAll()` method to cancel all subscriptions and reset initialized flag

## Testing
Verified the file compiles.

Fixes #5434

GSSoC