### PR TITLE
ci: setup GitHub Actions for Flutter Apps (#5450)

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,0 +1,40 @@
+name: Flutter CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_and_test:
+    name: Flutter Lint & Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        app: [apps/customer, apps/driver]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.x' # Assuming 3.22.x based on pubspec sdk constraint >=3.3.0
+          channel: 'stable'
+
+      - name: Install Dependencies
+        working-directory: ${{ matrix.app }}
+        run: flutter pub get
+
+      - name: Analyze Code
+        working-directory: ${{ matrix.app }}
+        run: flutter analyze
+
+      - name: Run Tests
+        working-directory: ${{ matrix.app }}
+        run: flutter test

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     name: Flutter Lint & Test


### PR DESCRIPTION
Closes #5450

## Description
This PR addresses issue #5450 by adding a robust GitHub Actions Continuous Integration (CI) pipeline for both of Truxify's Flutter applications (Customer and Driver).

This ensures that no broken code, failing tests, or unlinted files ever get merged into the `main` branch.

## Changes Made
- Created a new GitHub Actions workflow file at `.github/workflows/flutter_ci.yml`.
- Configured the workflow to automatically trigger on any `push` or `pull_request` against the `main` branch.
- Utilized a build matrix strategy (`matrix: app: [apps/customer, apps/driver]`) to run parallel independent CI jobs for both Flutter apps simultaneously, cutting build times in half.
- Configured `subosito/flutter-action@v2` to provision the correct stable Flutter SDK.
- The pipeline securely executes `flutter pub get`, `flutter analyze` (for strict linting), and `flutter test` (for widget/unit tests).

## How to Test
1. Check out this branch: `git checkout feat/flutter-ci`
2. Push any arbitrary commit to this branch (e.g. adding a comment to `apps/customer/lib/main.dart`).
3. Navigate to the **Actions** tab on your GitHub repository.
4. Verify that the "Flutter CI" workflow triggered successfully.
5. Watch the matrix spawn two parallel jobs ("Flutter Lint & Test (apps/customer)" and "Flutter Lint & Test (apps/driver)").
6. Confirm both jobs pass all steps (Setup, Install, Analyze, Test) and turn green.