### PR TITLE
fix: add missing connectivity_plus import to trip_service.dart (#5478)

### DIFF
--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -1,3 +1,4 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'api_client.dart';


### PR DESCRIPTION
Closes #5478

GSSOC