### PR TITLE
fix: use backtick template literal in root endpoint so WebSocket URL is interpolated (#5503)

### DIFF
--- a/backend/api/src/controllers/rootController.js
+++ b/backend/api/src/controllers/rootController.js
@@ -1,7 +1,7 @@
 export const getRoot = (req, res) => {
   const wsHost = req.hostname || 'localhost';
   const wsPort = process.env.PORT || 5000;
-  res.send("<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://${wsHost}:${wsPort}/ws/tracking</code></p>");
+  res.send(`<h1>Truxify Backend API is running.</h1><p>Use WebSockets at <code>ws://${wsHost}:${wsPort}/ws/tracking</code></p>`);
 };
 
 export const notFound = (req, res) => {


### PR DESCRIPTION
Switches single quotes to backticks in rootController.js so \\\ and \\\ are properly interpolated. Currently the raw template syntax is rendered literally.\n\nCloses #5503\n\nGSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the root page message so it displays the actual WebSocket connection address instead of unreplaced placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->