### PR TITLE
fix: replace undefined page variable with cursor in getOrderHistory call (#5500)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -493,7 +493,7 @@ router.get('/history', authenticate, userLimiter, requirePolicy('order:view-hist
       return res.status(400).json({ error: 'limit must be between 1 and 100' });
     }
 
-    const result = await orderLifecycleService.getOrderHistory(req.user.id, page, limit);
+    const result = await orderLifecycleService.getOrderHistory(req.user.id, cursor, limit);
     res.json(result);
   } catch (err) {
     if (err instanceof DomainError) {


### PR DESCRIPTION
The variable \page\ on line 496 was never declared, causing an unhandled ReferenceError on every request to \GET /api/orders/history\. The \cursor\ query parameter was already being read (line 488) but never passed to the service. Replaced \page\ with \cursor\.\n\nCloses #5500\n\nGSSOC