### PR TITLE
fix: remove double JSON.parse on in-memory idempotency cache result (#5501)

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -138,7 +138,7 @@ export function requireIdempotency(ttlSeconds = 3600) {
           // After waiting, check if the result is now cached
           const cachedAfterWait = getFromMemory(key);
           if (cachedAfterWait) {
-            return res.status(JSON.parse(cachedAfterWait).statusCode).json(JSON.parse(cachedAfterWait).body);
+            return res.status(cachedAfterWait.statusCode).json(cachedAfterWait.body);
           }
           if (retries === 0) {
             return res.status(409).json({ error: 'Duplicate request being processed' });


### PR DESCRIPTION
`getFromMemory()` already calls `JSON.parse` internally and returns a parsed object. The subsequent `JSON.parse(cachedAfterWait)` called `.toString()` on it, yielding `"[object Object]"` -- invalid JSON. This caused a SyntaxError crash on every idempotency retry in memory-only mode.

Closes #5501

GSSOC
