### PR TITLE
fix: use raw body buffer for webhook HMAC verification instead of JSON.stringify (#5502)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -332,6 +332,9 @@ app.use(
   express.json({
     limit: jsonBodyLimit,
     strict: true,
+    verify: (req, _res, buf) => {
+      req.rawBody = buf.toString('utf8');
+    },
   })
 );
 

--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -23,9 +23,7 @@ function verifyWebhookSignature(req, res, next) {
     return res.status(401).json({ error: 'Missing X-Webhook-Signature header' });
   }
 
-  const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
-  // TODO: Register the webhook route with express.raw({ type: '*/*' }) middleware
-  // to receive raw body for HMAC verification instead of relying on JSON.stringify
+  const rawBody = req.rawBody;
   const expectedSignature = crypto
     .createHmac('sha256', WEBHOOK_SECRET)
     .update(rawBody)


### PR DESCRIPTION
JSON.stringify(req.body) is non-deterministic because object key ordering can vary between V8 versions and payload shapes. This caused every webhook with a non-trivial JSON body to fail HMAC verification.\n\nFix: Added a erify callback to express.json() that captures the raw body buffer via eq.rawBody. The webhook middleware now uses eq.rawBody for HMAC computation, matching exactly what the sender signed.\n\nCloses #5502\n\nGSSOC