### PR TITLE
fix: destination_picker_screen catch(_) silently swallows reverse-geocoding errors with no logging (#5439)

### DIFF
--- a/apps/driver/lib/screens/destination_picker_screen.dart
+++ b/apps/driver/lib/screens/destination_picker_screen.dart
@@ -155,7 +155,8 @@ class _DestinationPickerScreenState extends State<DestinationPickerScreen> {
                 ? 'Pinned location (${point.latitude.toStringAsFixed(5)}, ${point.longitude.toStringAsFixed(5)})'
                 : displayName;
       });
-    } catch (_) {
+    } catch (e) {
+      debugPrint('destination_picker_screen: GeocodeService.resolvePlace error: $e');
       if (!mounted) {
         return;
       }

--- a/trux_issue_body.txt
+++ b/trux_issue_body.txt
@@ -1,0 +1,25 @@
+## Summary
+The DigiLocker document verification feature sends a hardcoded mock authentication code `"mock_digilocker_auth_code_98765"` instead of capturing the real OAuth redirect code. Every user who tries to link their DigiLocker account receives a failure.
+
+## Location
+`apps/driver/lib/screens/documents_screen.dart:265-273`
+```dart
+final response = await http.post(
+    Uri.parse('$_apiBaseUrl/api/documents/verify-digilocker'),
+    headers: {
+      'Content-Type': 'application/json',
+      if (token.isNotEmpty) 'Authorization': 'Bearer $token',
+    },
+    body: jsonEncode({
+      'code': 'mock_digilocker_auth_code_98765',  // HARDCODED MOCK
+    }),
+);
+```
+
+## Impact
+Every user who attempts to link their DigiLocker account hits this code path. Since the auth code is a hardcoded mock string, the backend API always rejects it. The DigiLocker document verification feature is completely non-functional for all users.
+
+## Expected
+Implement the actual DigiLocker OAuth redirect flow to capture the real authorization code, then remove the hardcoded mock value.
+
+GSSOC

--- a/trux_pr_body.txt
+++ b/trux_pr_body.txt
@@ -1,0 +1,10 @@
+The DigiLocker document verification feature was sending a hardcoded mock auth code `"mock_digilocker_auth_code_98765"` instead of capturing the real OAuth authorization code. Every user who tried to link their DigiLocker account received a failure.
+
+Fix:
+1. Opens the DigiLocker authorization URL in the device browser via `url_launcher`
+2. Shows a dialog for the user to paste the authorization code from the browser redirect URL
+3. Sends the real code to the backend instead of the hardcoded mock
+
+Closes #5504
+
+GSSOC


### PR DESCRIPTION
GSSOC
