### PR TITLE
fix: resilient_websocket catch(_) silently swallows connection errors with no logging (#5432)

### DIFF
--- a/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
+++ b/apps/customer/lib/core/offline/websocket/resilient_websocket.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 class ResilientWebSocket {
@@ -51,7 +52,8 @@ class ResilientWebSocket {
       _attempt = 0;
       _startHeartbeat();
       onConnect?.call();
-    } catch (_) {
+    } catch (e, st) {
+      debugPrint('[ResilientWebSocket] Connection failed: $e\n$st');
       _scheduleReconnect();
     }
   }


### PR DESCRIPTION
GSSOC
