### PR TITLE
fix: booking_confirmation_screen shows generic error message with no actionable details on booking failure (#5380)

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -143,7 +143,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       if (!mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to create booking')),
+        SnackBar(content: Text('Failed to create booking: $e')),
       );
     } finally {
       if (mounted) {


### PR DESCRIPTION
GSSOC
