### PR TITLE
fix: documents_screen _formatDate silently swallows parse errors with catch(_) hiding upstream date issues (#5379)

### DIFF
--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -97,7 +97,8 @@ class DriverDocument {
       return '${dt.day.toString().padLeft(2, '0')}/'
           '${dt.month.toString().padLeft(2, '0')}/'
           '${dt.year}';
-    } catch (_) {
+    } catch (e) {
+      debugPrint('DocumentsScreen: failed to parse date "$raw": $e');
       return raw;
     }
   }


### PR DESCRIPTION
GSSOC
