### PR TITLE
fix: public_tracking_screen coordinate fallback to 0,0 places map markers at Null Island on parse failure (#5378)

### DIFF
--- a/apps/customer/lib/screens/public_tracking_screen.dart
+++ b/apps/customer/lib/screens/public_tracking_screen.dart
@@ -137,21 +137,30 @@ class _PublicTrackingScreenState extends State<PublicTrackingScreen> {
     final lat = _order?['pickup_lat'];
     final lng = _order?['pickup_lng'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   LatLng? _getDropLatLng() {
     final lat = _order?['drop_lat'];
     final lng = _order?['drop_lng'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   LatLng? _getDriverLatLng() {
     final lat = _driverLocation?['latitude'];
     final lng = _driverLocation?['longitude'];
     if (lat == null || lng == null) return null;
-    return LatLng(double.tryParse(lat.toString()) ?? 0.0, double.tryParse(lng.toString()) ?? 0.0);
+    final parsedLat = double.tryParse(lat.toString());
+    final parsedLng = double.tryParse(lng.toString());
+    if (parsedLat == null || parsedLng == null) return null;
+    return LatLng(parsedLat, parsedLng);
   }
 
   @override


### PR DESCRIPTION
GSSOC
