### PR TITLE
fix: driver shell_screen FCM callbacks not cleared in dispose causing memory leak (#5377)

### DIFF
--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -196,6 +196,8 @@ class _ShellScreenState extends State<ShellScreen> {
   @override
   void dispose() {
     _weighStationSub?.cancel();
+    FcmService.clearForegroundCallback();
+    FcmService.clearTapCallback();
     ForegroundNotificationHandler.dispose();
     _currentIndex.dispose();
     super.dispose();


### PR DESCRIPTION
GSSOC
