### PR TITLE
fix: orders_screen realtime callback missing mounted check causes setState after dispose crash (#5376)

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -324,6 +324,7 @@ class _OrdersScreenState extends State<OrdersScreen>
           ),
           callback: (payload) {
             debugPrint('Realtime customer orders list update: ${payload.newRecord}');
+            if (!mounted) return;
             _loadOrders();
           },
         )


### PR DESCRIPTION
GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented order updates from triggering refreshes after the Orders screen has been closed, improving stability and avoiding potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->