### PR TITLE
fix: add authorization checks to WebRTC GPS offline data endpoints

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -211,6 +211,12 @@ class WebRTCSignalingServer {
       return;
     }
 
+    const peer = this.peers.get(peerId);
+    if (!peer) {
+      logger.warn(`[WebRTC] GPS data from unknown peer ${peerId}`);
+      return;
+    }
+
     const normalizedData = {
       ...data,
       location: this.normalizeLocation(data.location)
@@ -383,7 +389,11 @@ class WebRTCSignalingServer {
     return Boolean(peer && peer.userId === user?.id);
   }
 
-  async getOfflineGPSData(peerId, since) {
+  async getOfflineGPSData(peerId, since, requestingUser) {
+    if (!requestingUser || !this.canUserAccessPeer(peerId, requestingUser)) {
+      logger.warn(`[WebRTC] Unauthorized offline GPS data access attempt for peer ${peerId}`);
+      return [];
+    }
     const { data } = await supabase
       .from('gps_offline_data')
       .select('*')
@@ -394,7 +404,11 @@ class WebRTCSignalingServer {
     return data || [];
   }
 
-  async syncOfflineData(peerId) {
+  async syncOfflineData(peerId, requestingUser) {
+    if (!requestingUser || !this.canUserAccessPeer(peerId, requestingUser)) {
+      logger.warn(`[WebRTC] Unauthorized sync offline data attempt for peer ${peerId}`);
+      return;
+    }
     // Mark data as synced for this peer
     await supabase
       .from('gps_offline_data')


### PR DESCRIPTION
## fix: add authorization checks to WebRTC GPS offline data endpoints

### Problem
`getOfflineGPSData` and `syncOfflineData` queried/mutated GPS tracking data keyed only by `peerId` with zero access control. The existing `canUserAccessPeer` method was never called in the offline data flow.

### Changes
- `getOfflineGPSData` now requires `requestingUser` and calls `canUserAccessPeer` before returning data
- `syncOfflineData` now requires `requestingUser` and calls `canUserAccessPeer` before mutating data
- `handleGPSData` verifies peer exists in the peers map before storing GPS data

Closes #5529