### PR TITLE
fix: home_screen _loadSubscription used without declaration and _tripSubscription not cancelled in dispose (#5539, #5541)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -144,6 +144,7 @@ class _HomeScreenState extends State<HomeScreen> {
   String? _locationError;
   late final MarketplaceRepository _marketplaceRepo;
   StreamSubscription? _tripSubscription;
+  StreamSubscription? _loadSubscription;
 
   String _hosStatus = 'off_duty';
   int _hosDrivingMinutes = 0;
@@ -293,6 +294,7 @@ class _HomeScreenState extends State<HomeScreen> {
     _batteryService.removeListener(_onBatteryChanged);
     _connectivitySubscription?.cancel();
     _loadSubscription?.cancel();
+    _tripSubscription?.cancel();
     _autoHideTimer?.cancel();
     _mapController.dispose();
     _searchController.dispose();


### PR DESCRIPTION
fix: home_screen _loadSubscription used without declaration (compile error) and _tripSubscription not cancelled in dispose (#5539, #5541)

- Added missing StreamSubscription? _loadSubscription field declaration
- Added _tripSubscription?.cancel() to dispose() to prevent leak

Closes #5539
Closes #5541

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when leaving the home screen by canceling active trip updates.
  * Helps prevent background activity from continuing after the screen is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->