### PR TITLE
fix: OBD telemetry model defaults sensor readings to 0.0 masking sensor failures (#5542)

### DIFF
--- a/apps/driver/lib/models/obd_telemetry_model.dart
+++ b/apps/driver/lib/models/obd_telemetry_model.dart
@@ -1,24 +1,34 @@
+import 'package:flutter/foundation.dart';
+
 class ObdTelemetry {
-  final double engineTemperature;
-  final double oilLevel;
-  final double tirePressureAvg;
-  final double predictiveHealthScore;
+  final double? engineTemperature;
+  final double? oilLevel;
+  final double? tirePressureAvg;
+  final double? predictiveHealthScore;
   final List<String> warnings;
 
   ObdTelemetry({
-    required this.engineTemperature,
-    required this.oilLevel,
-    required this.tirePressureAvg,
-    required this.predictiveHealthScore,
+    this.engineTemperature,
+    this.oilLevel,
+    this.tirePressureAvg,
+    this.predictiveHealthScore,
     required this.warnings,
   });
 
   factory ObdTelemetry.fromJson(Map<String, dynamic> json) {
+    final et = json['engineTemperature']?.toDouble();
+    final ol = json['oilLevel']?.toDouble();
+    final tp = json['tirePressureAvg']?.toDouble();
+    final ph = json['predictiveHealthScore']?.toDouble();
+    if (et == null) debugPrint('ObdTelemetry: engineTemperature missing or null');
+    if (ol == null) debugPrint('ObdTelemetry: oilLevel missing or null');
+    if (tp == null) debugPrint('ObdTelemetry: tirePressureAvg missing or null');
+    if (ph == null) debugPrint('ObdTelemetry: predictiveHealthScore missing or null');
     return ObdTelemetry(
-      engineTemperature: json['engineTemperature']?.toDouble() ?? 0.0,
-      oilLevel: json['oilLevel']?.toDouble() ?? 0.0,
-      tirePressureAvg: json['tirePressureAvg']?.toDouble() ?? 0.0,
-      predictiveHealthScore: json['predictiveHealthScore']?.toDouble() ?? 0.0,
+      engineTemperature: et,
+      oilLevel: ol,
+      tirePressureAvg: tp,
+      predictiveHealthScore: ph,
       warnings: List<String>.from(json['warnings'] ?? []),
     );
   }

--- a/apps/driver/lib/screens/vehicle_health_screen.dart
+++ b/apps/driver/lib/screens/vehicle_health_screen.dart
@@ -33,23 +33,23 @@ class _VehicleHealthScreenState extends State<VehicleHealthScreen> {
           }
 
           final data = snapshot.data!;
-          final isHealthy = data.predictiveHealthScore > 80;
+          final isHealthy = (data.predictiveHealthScore ?? 0) > 80;
 
           return Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _buildHealthScoreCard(data.predictiveHealthScore, isHealthy),
+                _buildHealthScoreCard(data.predictiveHealthScore ?? 0, isHealthy),
                 const SizedBox(height: 20),
                 const Text(
                   'Live OBD-II Telemetry',
                   style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 10),
-                _buildTelemetryRow('Engine Temp', '${data.engineTemperature.toStringAsFixed(1)} °F', data.engineTemperature > 205 ? Colors.red : Colors.green),
-                _buildTelemetryRow('Oil Level', '${data.oilLevel.toStringAsFixed(1)} %', Colors.blue),
-                _buildTelemetryRow('Tire Pressure', '${data.tirePressureAvg.toStringAsFixed(1)} PSI', Colors.green),
+                _buildTelemetryRow('Engine Temp', data.engineTemperature != null ? '${data.engineTemperature!.toStringAsFixed(1)} °F' : 'N/A', (data.engineTemperature ?? 0) > 205 ? Colors.red : Colors.green),
+                _buildTelemetryRow('Oil Level', data.oilLevel != null ? '${data.oilLevel!.toStringAsFixed(1)} %' : 'N/A', Colors.blue),
+                _buildTelemetryRow('Tire Pressure', data.tirePressureAvg != null ? '${data.tirePressureAvg!.toStringAsFixed(1)} PSI' : 'N/A', Colors.green),
                 const SizedBox(height: 20),
                 if (data.warnings.isNotEmpty) ...[
                   const Text(


### PR DESCRIPTION
fix: OBD telemetry model defaults sensor readings to 0.0 masking sensor failures (#5542)

Changed ObdTelemetry fields from double to double? and fromJson
logs when sensor values are missing instead of silently defaulting
to 0.0. Updated vehicle_health_screen to display 'N/A' for null
readings.

Closes #5542

GSSOC
