### PR TITLE
fix: ml.js 4 functions bypass getBaseUrl() producing inconsistent ML engine URL resolution (#5543)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -459,7 +459,7 @@ export async function matchDeadhead({ driverDestination, truckSpecs, arrivalTime
  */
 export async function optimiseMidTrip(routeData) {
   guardMlApiKey();
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/optimise/mid-trip`;
   const response = await fetch(url, {
     method: 'POST',
@@ -477,7 +477,7 @@ export async function optimiseMidTrip(routeData) {
  */
 export async function trainDemandModel(force = false) {
   guardMlApiKey();
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/demand`;
   const response = await fetch(url, {
     method: 'POST',
@@ -495,7 +495,7 @@ export async function trainDemandModel(force = false) {
  */
 export async function trainPriceModel(force = false) {
   guardMlApiKey();
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/train/price`;
   const response = await fetch(url, {
     method: 'POST',
@@ -512,7 +512,7 @@ export async function trainPriceModel(force = false) {
  */
 export async function listModels() {
   guardMlApiKey();
-  const baseUrl = process.env.ML_ENGINE_URL || DEFAULT_ML_ENGINE_URL;
+  const baseUrl = getBaseUrl();
   const url = `${baseUrl}/models`;
   const response = await fetch(url, {
     method: 'GET',


### PR DESCRIPTION
fix: ml.js 4 functions bypass getBaseUrl() producing inconsistent ML engine URL resolution (#5543)

Functions optimiseMidTrip, trainDemandModel, trainPriceModel, and
listModels used process.env.ML_ENGINE_URL directly instead of
getBaseUrl(), ignoring ML_SERVICE_URL env var. Now all use
getBaseUrl() for consistent resolution.

Closes #5543

GSSOC
