### PR TITLE
fix: home_screen _loadSubscription used without declaration causes compile error (#5539)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -144,6 +144,7 @@ class _HomeScreenState extends State<HomeScreen> {
   String? _locationError;
   late final MarketplaceRepository _marketplaceRepo;
   StreamSubscription? _tripSubscription;
+  StreamSubscription? _loadSubscription;
 
   String _hosStatus = 'off_duty';
   int _hosDrivingMinutes = 0;


### PR DESCRIPTION
fix: home_screen _loadSubscription used without declaration causes compile error (#5539)

Closes #5539

GSSOC
