### PR TITLE
fix: home_screen _tripSubscription not cancelled in dispose causing memory leak (#5541)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -293,6 +293,7 @@ class _HomeScreenState extends State<HomeScreen> {
     _batteryService.removeListener(_onBatteryChanged);
     _connectivitySubscription?.cancel();
     _loadSubscription?.cancel();
+    _tripSubscription?.cancel();
     _autoHideTimer?.cancel();
     _mapController.dispose();
     _searchController.dispose();


### PR DESCRIPTION
fix: home_screen _tripSubscription not cancelled in dispose causing memory leak (#5541)

Closes #5541

GSSOC
