### PR TITLE
feat(api): implement reverse-geocoding utility using Nominatim (OSM)

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -1,0 +1,76 @@
+import { redisClient } from '../config/db.js';
+import logger from '../middleware/logger.js';
+
+const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/**
+ * Reverse geocodes a latitude and longitude to a human-readable address
+ * using the OpenStreetMap Nominatim API. Implements aggressive Redis caching.
+ *
+ * @param {number|string} lat - Latitude
+ * @param {number|string} lon - Longitude
+ * @returns {Promise<string|null>} Formatted location string or null if failed
+ */
+export async function reverseGeocode(lat, lon) {
+  if (!lat || !lon) return null;
+
+  // Round coordinates to ~100m precision (3 decimal places) to maximize cache hits
+  const roundedLat = Number(lat).toFixed(3);
+  const roundedLon = Number(lon).toFixed(3);
+  const cacheKey = `geocode:${roundedLat},${roundedLon}`;
+
+  try {
+    // 1. Check Redis Cache
+    if (redisClient) {
+      const cached = await redisClient.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+
+    // 2. Fetch from OpenStreetMap Nominatim
+    // Note: Nominatim requires a valid User-Agent to avoid being blocked
+    const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${roundedLat}&lon=${roundedLon}&zoom=14`;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Truxify-Node-Backend/1.0',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    });
+
+    if (!response.ok) {
+      logger.error({ status: response.status }, '[ReverseGeocode] Nominatim API error');
+      return null;
+    }
+
+    const data = await response.json();
+    let formattedAddress = null;
+
+    if (data && data.address) {
+      // Build a clean, readable location string (e.g., "NH-48, Jaipur")
+      const { road, suburb, city, town, village, state } = data.address;
+      
+      const localArea = road || suburb || village;
+      const mainArea = city || town || state;
+
+      if (localArea && mainArea) {
+        formattedAddress = `${localArea}, ${mainArea}`;
+      } else if (mainArea) {
+        formattedAddress = mainArea;
+      } else if (data.display_name) {
+        // Fallback to the full display string, truncated if too long
+        formattedAddress = data.display_name.split(',').slice(0, 2).join(',');
+      }
+    }
+
+    // 3. Save to Redis Cache if valid
+    if (formattedAddress && redisClient) {
+      await redisClient.set(cacheKey, formattedAddress, 'EX', CACHE_TTL_SECONDS);
+    }
+
+    return formattedAddress;
+  } catch (err) {
+    logger.error({ err, lat, lon }, '[ReverseGeocode] Error reverse geocoding coordinates');
+    return null;
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves #5557 by adding a robust, cached reverse-geocoding utility that converts raw GPS coordinates into human-readable locations without relying on paid Google APIs.

## Changes Made
* **Created `reverseGeocode.js`**: Added the new utility inside `backend/api/src/lib/`.
* **Nominatim Integration**: Successfully implemented REST calls to OpenStreetMap's Nominatim API with proper `User-Agent` headers to comply with their usage policies.
* **Aggressive Redis Caching**: 
  * Coordinates are rounded to 3 decimal places (approx ~100m precision) to generate a high-hit-rate cache key (`geocode:lat,lon`).
  * Hooked into the existing `redisClient` to check the cache *before* making HTTP requests.
  * Successful API responses are cached in Redis for 7 days.
* **Response Parsing**: Built logic to cleanly extract and format `road`, `suburb`, `village`, `city`, and `state` fields into a concise location string suitable for the driver app UI.

## Related Issue
Closes #5557

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 📝 Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have kept the commit history clean (single commit)