### PR TITLE
fix: replace JWT_SECRET verification with Firebase/Supabase auth in W…

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -11,6 +11,78 @@ import logger from './logger.js';
  * In production, development auth headers (x-user-id, x-user-role, x-user-name)
  * are unconditionally stripped to prevent any possibility of bypass.
  */
+export async function verifyAuthToken(token) {
+  let userProfile = null;
+  let firebaseUid = null;
+  let supabaseUserId = null;
+
+  let decoded;
+  try {
+    decoded = jwt.decode(token);
+  } catch (err) {
+  }
+
+  const isSupabaseToken = decoded && typeof decoded.iss === 'string' && (decoded.iss.includes('supabase') || decoded.iss.includes('supabase.co'));
+
+  if (isSupabaseToken) {
+    if (!supabase) {
+      throw new Error('Supabase client is not configured on this server.');
+    }
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      throw new Error(authError?.message || 'Invalid or expired Supabase authentication token.');
+    }
+    supabaseUserId = user.id;
+
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('id, firebase_uid, role, full_name, phone')
+      .eq('id', user.id)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error('Database query failed verification: ' + error.message);
+    }
+    userProfile = profile;
+  } else {
+    if (!firebaseAdmin) {
+      throw new Error('Firebase Auth verification is not configured on this server.');
+    }
+    const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
+    firebaseUid = decodedToken.uid;
+
+    if (!supabase) {
+      throw new Error('Supabase client is not configured on this server.');
+    }
+
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('id, firebase_uid, role, full_name, phone')
+      .eq('firebase_uid', firebaseUid)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error('Database query failed verification: ' + error.message);
+    }
+    userProfile = profile;
+  }
+
+  if (!userProfile) {
+    throw new Error('User profile not found or inactive.');
+  }
+
+  return {
+    id: userProfile.id,
+    uid: userProfile.firebase_uid,
+    role: userProfile.role,
+    fullName: userProfile.full_name,
+    phone: userProfile.phone,
+    isActive: true
+  };
+}
+
 export async function authenticate(req, res, next) {
   // ── Production header sanitization (defense in depth) ──────────────
   // Strip dev-only authentication headers before any logic runs.

--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -1,5 +1,5 @@
 import { WebSocketServer } from 'ws';
-import jwt from 'jsonwebtoken';
+import { verifyAuthToken } from '../../middleware/auth.js';
 import logger from '../../middleware/logger.js';
 import { supabase, redisClient } from '../../config/db.js';
 
@@ -32,9 +32,9 @@ class WebRTCSignalingServer {
 
       let decoded;
       try {
-        decoded = jwt.verify(token, process.env.JWT_SECRET);
+        decoded = await verifyAuthToken(token);
       } catch (err) {
-        logger.warn(`WebRTC connection rejected: invalid token — ${err.message}`);
+        logger.warn(`WebRTC connection rejected: ${err.message}`);
         ws.close(4001, 'Invalid token');
         return;
       }
@@ -45,7 +45,7 @@ class WebRTCSignalingServer {
       // Store peer with authenticated user info
       this.peers.set(peerId, {
         ws,
-        userId: decoded.sub,
+        userId: decoded.id,
         role: decoded.role,
         location: null,
         meshId,


### PR DESCRIPTION
## Description

The WebRTC signaling server verifies tokens using `JWT_SECRET` with
`jwt.verify()`, but the REST API already uses Firebase Auth (with
Supabase fallback). This creates two parallel auth schemes where the
same user may be verified differently depending on the channel.

## Changes

- Extract shared `verifyAuthToken()` function in `auth.js` that
  tries Firebase first, then falls back to Supabase
- Import and use `verifyAuthToken` in `WebRTCSignalingServer.js`
  instead of direct `jwt.verify` with `JWT_SECRET`
- WebRTC now accepts the same tokens as the REST API middleware

Closes #5587