### PR TITLE
fix: allow geolocation, camera, and microphone on the origin itself

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -20,7 +20,7 @@ export default function securityHeaders(req, res, next) {
   if (!res.getHeader('Permissions-Policy')) {
     res.setHeader(
       'Permissions-Policy',
-      'camera=(), microphone=(), geolocation=()'
+      'geolocation=(self), camera=(self), microphone=(self)'
     );
   }
 


### PR DESCRIPTION
## Description

The `Permissions-Policy` header is set to `camera=(), microphone=(),
geolocation=()` which blocks all origins, including the app itself.
This breaks GPS tracking for logistics, WebRTC video calling, and
voice AI features.

## Changes

- Change policy from `camera=(), microphone=(), geolocation=()`
  to `geolocation=(self), camera=(self), microphone=(self)`
- Core features (GPS, WebRTC, voice) now function on the origin

Closes #5588