### PR TITLE
fix: clamp traffic surge multiplier to documented range

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -27,9 +27,9 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
     const isRushHour = (hour >= 7 && hour <= 10) || (hour >= 16 && hour <= 19);
 
     if (isRushHour) {
-      // Create a deterministic pseudo-random multiplier based on coordinates
-      const geoHash = Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng));
-      const surgeMultiplier = 1.2 + (geoHash * 1.3); // between 1.2 and 2.5
+      // sin(x) + cos(y) ranges over [-2, 2], so after Math.abs it's [0, 2] — normalize to [0, 1] before scaling
+      const geoHash = Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng)) / 2;
+      const surgeMultiplier = Math.min(2.5, Math.max(1.2, 1.2 + (geoHash * 1.3))); // clamped to 1.2–2.5
       logger.info(`[TrafficService] Live traffic surge detected at ${pickupLat},${pickupLng}: x${surgeMultiplier.toFixed(2)}`);
       return Number(surgeMultiplier.toFixed(2));
     }


### PR DESCRIPTION
## Description

This PR fixes the traffic surge multiplier calculation to ensure it always stays within the documented **1.2–2.5** range during rush hours.

### Problem

`getLiveTrafficMultiplier()` in `backend/api/src/services/trafficService.js` computes a rush-hour surge multiplier from a coordinate-based hash. The hash was assumed to range over roughly **[0, 1.414]**, but `sin(lat) + cos(lng)` actually ranges over **[-2, 2]**, so `Math.abs(...)` produces values up to **2**, not **~1.414**. This pushed the resulting multiplier as high as **~3.04**, exceeding the documented **1.2–2.5** range.

### Changes

- Normalized the coordinate-based hash by dividing `Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng))` by `2` to correctly map it to the **[0, 1]** range before scaling.
- Added explicit clamping using `Math.min(2.5, Math.max(1.2, ...))` to ensure the multiplier always remains within the documented **1.2–2.5** range.
- Preserved the existing mock traffic simulation and rush-hour logic. This PR only fixes the multiplier range and does not change the mock implementation.

### Result

- Ensures rush-hour pricing always stays within the intended **1.2–2.5** surge range.
- Prevents inflated quotes caused by out-of-range surge multipliers.
- Improves consistency for downstream pricing calculations such as orders, bids, and escrow amounts.
- Leaves non-rush-hour behavior unchanged (multiplier remains **1.0**).
- Retains the current mock implementation until a real traffic provider (e.g., TomTom or Google Maps Distance Matrix) is integrated.

### File Changed

- `backend/api/src/services/trafficService.js` — `getLiveTrafficMultiplier()`

Closes #5600