### PR TITLE
fix: mount demand-heatmap route in index.js (#5597)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -42,6 +42,7 @@ import { getRoot, notFound } from './controllers/rootController.js'
 import webhookRoutes from './routes/webhookRoutes.js'
 import auditRoutes from './routes/auditRoutes.js'
 import voiceRoutes from './routes/voiceRoutes.js'
+import demandRoutes from './routes/demandRoutes.js'
 
 // ============================================================================
 // 🆕 MULTI-PROVIDER ORACLE & VERIFICATION ROUTES
@@ -416,6 +417,7 @@ app.use('/api/auth', authLimiter, authRoutes)
 app.use('/api/v1/admin', adminRoutes)
 app.use('/api/v1/admin/audit-logs', auditRoutes)
 app.use('/api/voice', voiceRoutes)
+app.use('/api/demand-heatmap', demandRoutes)
 
 // ============================================================================
 // 🆕 MULTI-PROVIDER ORACLE & VERIFICATION ROUTES


### PR DESCRIPTION
fix: mount demand-heatmap route in index.js (#5597)

demandRoutes.js defines GET /api/demand-heatmap but was never imported or
mounted in index.js, so the driver app's demand-heatmap feature always 404s.
Import demandRoutes and mount it at /api/demand-heatmap.

Closes #5597

GSSOC
