### PR TITLE
fix: convert freight_value (paisa) to INR in matchEnRouteLoads (#5598)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -559,7 +559,7 @@ export async function matchEnRouteLoads({
       width_m: Number(o.width_m || 1),
       height_m: Number(o.height_m || 1),
       pickup_deadline: new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString(),
-      payment_inr: Number(o.payment_inr || o.freight_value || 0),
+      payment_inr: Number(o.payment_inr || (o.freight_value ? o.freight_value / 100 : 0)),
     }));
 
   const specs = truckSpecs || {
@@ -599,7 +599,7 @@ export async function matchEnRouteLoads({
           detour_km: dtKm,
           distance_to_pickup_km: dtKm,
           match_score: Math.max(0, 1 - dtKm / maxDetourKm),
-          estimated_earnings: Number(o.payment_inr || o.freight_value || 0),
+          estimated_earnings: Number(o.payment_inr || (o.freight_value ? o.freight_value / 100 : 0)),
           _fallback: true,
         };
       })


### PR DESCRIPTION
fix: convert freight_value (paisa) to INR in matchEnRouteLoads (#5598)

freight_value is stored in paisa (loadRoutes.js maps min_price Rupees to
freight_value paisa via *100), but matchEnRouteLoads fed it straight into
payment_inr/estimated_earnings as if it were INR, then the merge multiplied
by 100 again, inflating extra_earnings by 100x (or ~10,000x in the ML path).

Convert freight_value to INR (/100) before it is used as payment_inr, so the
existing *100-to-paisa conversion produces correct earnings.

Closes #5598

GSSOC
