### PR TITLE
fix: make stuck-escrow retry path reachable in verifyDelivery (#5599)

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -169,18 +169,22 @@ export class DeliveryVerificationService {
     return measureExecution('DeliveryVerificationService.verifyDelivery', async () => {
     const { order, otpRecord } = await this.validateDeliveryOtp({ orderId, driverId, otp });
 
-    const guardResult = await this.orderRepository.updateOrderGuardStatus(
-      orderId,
-      { updated_at: new Date().toISOString() },
-      ['cancelled', 'payment_released']
-    );
+    const isRetryForStuckEscrow = order.status === 'payment_released' && ['funded', 'release_failed'].includes(order.escrow_status);
 
-    if (guardResult.error) {
-      const pgCode = guardResult.error.code;
-      if (pgCode === 'PGRST116') {
-        throw new DomainError(409, { error: 'Order was already cancelled or payment released.' });
+    if (!isRetryForStuckEscrow) {
+      const guardResult = await this.orderRepository.updateOrderGuardStatus(
+        orderId,
+        { updated_at: new Date().toISOString() },
+        ['cancelled', 'payment_released']
+      );
+
+      if (guardResult.error) {
+        const pgCode = guardResult.error.code;
+        if (pgCode === 'PGRST116') {
+          throw new DomainError(409, { error: 'Order was already cancelled or payment released.' });
+        }
+        throw new DomainError(500, { error: 'Failed to verify OTP.', details: guardResult.error.message });
       }
-      throw new DomainError(500, { error: 'Failed to verify OTP.', details: guardResult.error.message });
     }
 
     let releaseTxHash = null;
@@ -209,7 +213,6 @@ export class DeliveryVerificationService {
     }
 
     // 2. Execute Postgres RPC to complete the trip AFTER blockchain success
-    const isRetryForStuckEscrow = order.status === 'payment_released' && ['funded', 'release_failed'].includes(order.escrow_status);
 
     let verifiedOrder;
     let tripData = null;


### PR DESCRIPTION
fix: make stuck-escrow retry path reachable in verifyDelivery (#5599)

verifyDelivery ran an unconditional status guard excluding 'payment_released'
before checking isRetryForStuckEscrow. A stuck-escrow order (status
payment_released, escrow funded/release_failed) would always hit PGRST116
and throw 409, making the retry branch dead code, leaving escrow_status and
escrow_release_error stale forever.

Compute isRetryForStuckEscrow up front and skip the guard for retry orders so
the branch is actually reachable.

Closes #5599

GSSOC
