### PR TITLE
fix: clamp traffic surge multiplier to documented 2.5 cap (#5600)

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -29,7 +29,7 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
     if (isRushHour) {
       // Create a deterministic pseudo-random multiplier based on coordinates
       const geoHash = Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng));
-      const surgeMultiplier = 1.2 + (geoHash * 1.3); // between 1.2 and 2.5
+      const surgeMultiplier = Math.min(2.5, 1.2 + (geoHash * 1.3)); // between 1.2 and 2.5
       logger.info(`[TrafficService] Live traffic surge detected at ${pickupLat},${pickupLng}: x${surgeMultiplier.toFixed(2)}`);
       return Number(surgeMultiplier.toFixed(2));
     }


### PR DESCRIPTION
fix: clamp traffic surge multiplier to documented 2.5 cap (#5600)

geoHash = |sin(lat) + cos(lng)| can reach ~2, making surgeMultiplier climb
to ~3.8, far above the documented 1.2-2.5 range. Clamp it with Math.min so
rush-hour quotes never exceed the intended price cap.

Closes #5600

GSSOC
