### PR TITLE
fix: remove dangling ETA refs that crash ML engine boot (#5612)

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -85,8 +85,6 @@ async def startup_event():
     loaded_models.update(persisted_models)
     if eta_predictor.model is not None:
         loaded_models.add("eta_prediction")
-    if traffic_pipeline.model is not None:
-        loaded_models.add("traffic_eta")
     logger.info("ML Engine startup complete — loaded: %s", sorted(loaded_models))
 
 
@@ -376,7 +374,6 @@ async def health():
         "trust_scorer": model_exists("trust_scorer"),
         "collaborative_filter": model_exists("collaborative_filter"),
         "eta_predictor": eta_predictor.model is not None,
-        "traffic_eta": traffic_pipeline.model is not None,
     }
     non_optional = {k: v for k, v in models.items() if k != 'eta_predictor'}
     all_ready = all(non_optional.values())
@@ -438,26 +435,6 @@ async def predict_price_endpoint(input: PricePredictInput, _auth=Depends(verify_
     except Exception as e:
         logger.error("Price prediction failed: %s", e)
         raise HTTPException(status_code=500, detail="Price prediction failed")
-
-
-# ETA endpoints are served via routes/eta_routes.py under /eta prefix
-
-@app.post("/predict/eta", response_model=ETAPredictOutput)
-async def predict_eta_endpoint(input: ETAPredictInput, _auth=Depends(verify_api_key)):
-    try:
-        result = eta_predictor.predict(
-            distance=input.route_distance,
-            time_of_day=input.time_of_day,
-            day_of_week=input.day_of_week,
-            route_type=input.route_type,
-            historical_speed=input.historical_speed,
-        )
-        return ETAPredictOutput(**result)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e))
-    except Exception as e:
-        logger.error("ETA prediction failed: %s", e)
-        raise HTTPException(status_code=500, detail="ETA prediction failed")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fix: remove dangling ETA refs that crash ML engine boot (#5612)

main.py references traffic_pipeline and ETAPredictInput/ETAPredictOutput
that were deleted by commit 1c7078d5 ("fix: remove duplicate ETA
endpoints"). The references cause an import-time NameError, so the entire
ML engine fails to start.

Remove the dangling references: the duplicate /predict/eta endpoint
(ETA is served via routes/eta_routes.py under /eta) and the
traffic_pipeline model checks in the startup event and health endpoint.

Closes #5612

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete ETA prediction endpoint and legacy model status reporting.
  * ETA functionality remains available through the current route structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->