### PR TITLE
fix: send all required features to ML demand forecast in heatmap (#5613)

### DIFF
--- a/backend/api/src/routes/demandRoutes.js
+++ b/backend/api/src/routes/demandRoutes.js
@@ -31,7 +31,10 @@ router.get('/', authenticate, userLimiter, requireRole(['driver', 'admin']), asy
       mlPrediction = await predictDemand({
         hour: new Date().getHours(),
         day_of_week: new Date().getDay(),
-        historical_volume: loads?.length || 0
+        temperature: 25.0,
+        precipitation: 0,
+        historical_volume: loads?.length || 0,
+        nearby_drivers: 0,
       });
     } catch (mlErr) {
       logger.warn('[DemandHeatmap] ML engine prediction failed, falling back to basic data:', mlErr.message);


### PR DESCRIPTION
fix: send all required features to ML demand forecast in heatmap (#5613)

demandRoutes.js sent only 3 of the 6 fields required by DemandForecastInput
(hour, day_of_week, historical_volume), so the ML engine always returned
422 and the route silently fell back to a static 0.5 prediction.

Add the remaining required fields (temperature, precipitation,
nearby_drivers) so the demand-heatmap ML call can actually succeed.

Closes #5613

GSSOC
