### PR TITLE
fix: align predict_eta input shape with LSTM model (#5614)

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -189,12 +189,13 @@ class TrafficPipeline:
     def predict_eta(self, route_data: np.ndarray) -> float:
         """Predict ETA using LSTM model"""
         try:
-            # Reshape for LSTM input: (batch, timesteps, features)
-            if len(route_data.shape) == 2:
-                route_data = route_data.reshape(1, *route_data.shape)
-            elif len(route_data.shape) == 1:
-                route_data = route_data.reshape(1, 1, -1)
-                
+            # Model expects (batch, 60, 5) — trained on 60-step sequences.
+            # Repeat a single feature row to fill the 60-timestep window.
+            if route_data.ndim == 1:
+                route_data = route_data.reshape(1, -1)
+            if route_data.shape[1] == 5:
+                route_data = np.tile(route_data, (1, 60, 1))
+
             prediction = self.model.predict(route_data, verbose=0)
             return float(prediction[0][0])
         except Exception as e:


### PR DESCRIPTION
fix: align predict_eta input shape with LSTM model (#5614)

The LSTM model is built and trained with input_shape=(60, 5) (60-step
sequences, 5 features), but predict_eta reshaped a single feature row to
(1, 1, 5). model.predict raised an input-shape error on every request,
the exception was swallowed, and /eta/predict always returned
eta_seconds: null (or 500).

Repeat the single feature row across the 60-timestep window so the input
matches the trained model shape.

Closes #5614

GSSOC
