### PR TITLE
fix: apply traffic multiplier to quoted price in predictPrice (#5615)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -107,7 +107,7 @@ export async function predictPrice({
 } = {}) {
   guardMlApiKey();
   
-  const cacheKey = JSON.stringify({ distanceKm, cargoWeightKg, truckType, routeOrigin, routeDestination });
+  const cacheKey = JSON.stringify({ distanceKm, cargoWeightKg, truckType, routeOrigin, routeDestination, trafficMultiplier });
   const cached = priceCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
@@ -148,8 +148,8 @@ export async function predictPrice({
 
   const result = {
       ...validated.validated,
-      estimatedPricePaisa: convertToPaisa(validated.validated.estimated_price),
-      estimatedPriceInr: validated.validated.estimated_price,
+      estimatedPricePaisa: convertToPaisa(validated.validated.estimated_price * trafficMultiplier),
+      estimatedPriceInr: validated.validated.estimated_price * trafficMultiplier,
   };
   priceCache.set(cacheKey, result);
   return result;


### PR DESCRIPTION
fix: apply traffic multiplier to quoted price in predictPrice (#5615)

ml.js sent traffic_multiplier to /predict/price, but PricePredictInput has
no such field, so Pydantic silently dropped it and surge pricing never
affected any quoted price.

Apply the multiplier to the validated ML price server-side (before paisa
conversion) so rush-hour quotes actually reflect the surge. Include
trafficMultiplier in the cache key so a surge quote is not served from a
cached base price.

Closes #5615

GSSOC
