### PR TITLE
fix: convert driver fuel analytics from USD/paisa to INR (#5616)

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -954,9 +954,9 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
           // Summary Cards
           Row(
             children: [
-              Expanded(child: _StatCard(title: 'Total Payout', value: '\$${totalPayout.toStringAsFixed(2)}')),
+              Expanded(child: _StatCard(title: 'Total Payout', value: '₹${totalPayout.toStringAsFixed(2)}')),
               const SizedBox(width: 12),
-              Expanded(child: _StatCard(title: 'Est. Fuel', value: '\$${estFuel.toStringAsFixed(2)}')),
+              Expanded(child: _StatCard(title: 'Est. Fuel', value: '₹${estFuel.toStringAsFixed(2)}')),
             ],
           ),
           const SizedBox(height: 12),

--- a/apps/driver/lib/services/fuel_analytics_service.dart
+++ b/apps/driver/lib/services/fuel_analytics_service.dart
@@ -19,16 +19,14 @@ class FuelAnalyticsService {
         final numericEarnings = double.tryParse(rawEarnings.replaceAll(RegExp(r'[^0-9.]'), '')) ?? 0.0;
         
         totalDistanceKm += numericDistance;
-        totalPayout += numericEarnings;
+        totalPayout += numericEarnings / 100; // earnings are in paisa
       }
 
-      // Convert KM to Miles (1 km = 0.621371 miles)
-      final totalDistanceMiles = totalDistanceKm * 0.621371;
-
-      // Fuel cost calculation (assume constant fuel price for demo e.g. $4.00 per gallon)
-      const fuelPricePerGallon = 4.0;
-      final fuelGallonsUsed = averageMpg > 0 ? (totalDistanceMiles / averageMpg) : 0;
-      final estimatedFuelCost = fuelGallonsUsed * fuelPricePerGallon;
+      // Fuel cost calculation (assume ₹ per litre, km/litre efficiency)
+      const fuelPricePerLitre = 90.0;
+      final kmPerLitre = averageMpg > 0 ? averageMpg * 1.60934 / 3.78541 : 0;
+      final fuelLitresUsed = kmPerLitre > 0 ? (totalDistanceKm / kmPerLitre) : 0;
+      final estimatedFuelCost = fuelLitresUsed * fuelPricePerLitre;
       
       final profitMargin = totalPayout > 0 
           ? ((totalPayout - estimatedFuelCost) / totalPayout) * 100 
@@ -41,12 +39,12 @@ class FuelAnalyticsService {
         final t = trips[i];
         final numDist = double.tryParse(t['distance']?.toString().replaceAll(RegExp(r'[^0-9.]'), '') ?? '0') ?? 0;
         final numEarn = double.tryParse(t['earnings']?.toString().replaceAll(RegExp(r'[^0-9.]'), '') ?? '0') ?? 0;
-        final miles = numDist * 0.621371;
-        final fCost = averageMpg > 0 ? (miles / averageMpg) * fuelPricePerGallon : 0;
+        final litresUsed = kmPerLitre > 0 ? (numDist / kmPerLitre) : 0;
+        final fCost = litresUsed * fuelPricePerLitre;
         
         chartPoints.add({
           'label': t['date'] ?? 'Trip',
-          'payout': numEarn,
+          'payout': numEarn / 100,
           'fuelCost': fCost,
         });
       }


### PR DESCRIPTION
fix: convert driver fuel analytics from USD/paisa to INR (#5616)

fuel_analytics_service.dart summed raw trip earnings (paisa) and rendered
them with a USD prefix, so a ₹2,100 payout displayed as "$210000.00".
Fuel cost was also computed with $4.00/gallon and miles/MPG.

Convert earnings from paisa to INR (/100), use a ₹/L fuel price with
km/litre efficiency, and change the $ prefixes in my_truck_screen.dart to
₹ so the analytics are accurate for an INR-based app.

Closes #5616

GSSOC
