### PR TITLE
fix: correct OSRM trip waypoint_index mapping in optimizeWaypoints

### DIFF
--- a/backend/api/src/services/routingService.js
+++ b/backend/api/src/services/routingService.js
@@ -42,14 +42,15 @@ export async function optimizeWaypoints(start, end, waypoints) {
     // Index 0 is the start, Index N is the end.
     
     const optimizedWaypoints = new Array(waypoints.length);
-    
-    // Original array order: [Start, WP1, WP2, ..., End]
-    for (let i = 0; i < waypointsResult.length; i++) {
+
+    // waypointsResult is in input order: [Start, WP1, WP2, ..., End].
+    // Each waypoint's `waypoint_index` is its position in the optimized trip
+    // (0 = start, waypoints.length + 1 = end), so subtract 1 for the middle stops.
+    for (let i = 1; i <= waypoints.length; i++) {
       const osrmWp = waypointsResult[i];
-      const originalIndex = osrmWp.waypoint_index - 1;
-      const optimizedIndex = i;
-      if (originalIndex >= 0 && originalIndex < waypoints.length) {
-        optimizedWaypoints[optimizedIndex] = waypoints[originalIndex];
+      const optimizedIndex = osrmWp.waypoint_index - 1;
+      if (optimizedIndex >= 0 && optimizedIndex < waypoints.length) {
+        optimizedWaypoints[optimizedIndex] = waypoints[i - 1];
       }
     }
 

--- a/backend/api/test/unit/routingService.test.js
+++ b/backend/api/test/unit/routingService.test.js
@@ -45,6 +45,7 @@ describe('routingService - getHaversineDistance', () => {
 describe('routingService - optimizeWaypoints', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAxiosGet.mockReset();
   });
 
   it('returns empty array when waypoints is empty', async () => {
@@ -84,7 +85,10 @@ describe('routingService - optimizeWaypoints', () => {
   it('falls back to original order when waypointsResult is empty', async () => {
     mockAxiosGet.mockResolvedValueOnce({ data: { code: 'Ok', waypoints: [] } });
 
-    const wp = [{ lat: 13, lng: 77, address: 'A' }];
+    const wp = [
+      { lat: 13, lng: 77, address: 'A' },
+      { lat: 14, lng: 78, address: 'B' },
+    ];
     const result = await optimizeWaypoints(
       { lat: 0, lng: 0, address: 'Start' },
       { lat: 20, lng: 90, address: 'End' },
@@ -109,35 +113,38 @@ describe('routingService - optimizeWaypoints', () => {
   });
 
   it('reorders waypoints based on OSRM waypoint_index values', async () => {
-    // OSRM returns waypoints in trip order with waypoint_index indicating
-    // the input coordinate position.
-    // Input coords: [start(0), WP_B(1), WP_A(2), end(3)]
-    // Trip order: WP_A, WP_B, start, end
-    // waypoint_indices in trip order: 2 (WP_A), 1 (WP_B), 0 (start), 3 (end)
+    // OSRM Trip API returns waypoints in INPUT order; each waypoint's
+    // `waypoint_index` is its position in the optimized trip.
+    // Input coords: [start(0), WP1(1), WP2(2), WP3(3), end(4)]
+    // Trip order: start, WP3, WP1, WP2, end
+    // waypoint_indices in input order: 0 (start), 2 (WP1), 3 (WP2), 1 (WP3), 4 (end)
     mockAxiosGet.mockResolvedValueOnce({
       data: {
         code: 'Ok',
         waypoints: [
-          { waypoint_index: 2 },
-          { waypoint_index: 1 },
           { waypoint_index: 0 },
+          { waypoint_index: 2 },
           { waypoint_index: 3 },
+          { waypoint_index: 1 },
+          { waypoint_index: 4 },
         ],
       },
     });
 
-    const wpA = { lat: 14, lng: 78, address: 'A' };
-    const wpB = { lat: 13, lng: 77, address: 'B' };
-    const wp = [wpA, wpB]; // input order
+    const wp1 = { lat: 14, lng: 78, address: 'WP1' };
+    const wp2 = { lat: 15, lng: 79, address: 'WP2' };
+    const wp3 = { lat: 16, lng: 80, address: 'WP3' };
+    const wp = [wp1, wp2, wp3]; // input order
 
     const result = await optimizeWaypoints(
       { lat: 0, lng: 0, address: 'Start' },
       { lat: 20, lng: 90, address: 'End' },
       wp
     );
-    // Trip order: WP_A (index 2), WP_B (index 1)
-    // Expected: [wpA, wpB] since WP_A comes first in trip
-    expect(result).toEqual([wpA, wpB]);
+    // Trip order of the middle stops: WP3, WP1, WP2
+    expect(result).toEqual([wp3, wp1, wp2]);
+    expect(result).toHaveLength(wp.length);
+    expect(result.every(waypoint => waypoint !== undefined)).toBe(true);
   });
 
   it('calls OSRM Trip API with correct coordinates', async () => {
@@ -145,9 +152,9 @@ describe('routingService - optimizeWaypoints', () => {
       data: {
         code: 'Ok',
         waypoints: [
+          { waypoint_index: 0 },
           { waypoint_index: 2 },
           { waypoint_index: 1 },
-          { waypoint_index: 0 },
           { waypoint_index: 3 },
         ],
       },


### PR DESCRIPTION
## Summary

Fixes the inverted `waypoint_index` mapping in `optimizeWaypoints` that caused every multi-stop order to persist a scrambled waypoint list (length `N+1`, a `null` hole at index 0 via `JSON.stringify`).

## Root cause

OSRM Trip API returns `waypoints` **in input order**; each entry's `waypoint_index` is its position in the optimized trip. The code iterated with `optimizedIndex = i` (treating the array as trip-ordered) and read `waypoints[waypoint_index - 1]` (treating `waypoint_index` as the input position) — the exact inverse.

## Changes

- `backend/api/src/services/routingService.js` — reconstruct from the input-order array: `optimizedWaypoints[waypoint_index - 1] = waypoints[i - 1]` for `i = 1..waypoints.length`, keeping the bounds guard. Result now has no holes and reflects the optimized stop order.
- `backend/api/test/unit/routingService.test.js`:
  - Rewrote the "reorders" mock to OSRM input-order semantics (the old mock contradicted itself and masked the bug).
  - `mockAxiosGet.mockReset()` in `beforeEach` so queued once-values from earlier tests cannot leak (previously the empty-waypoints test used a single waypoint, never called axios, and left a stale mock that made the reorder test pass by fallback).
  - Empty-waypoints fallback test now uses two waypoints so it genuinely exercises the axios path.

## Verification

The rewritten test fails against the old mapping (reproducing `[undefined, ...]`) and passes with the fix; full `test/unit` suite shows zero new failures vs. the pre-existing baseline.

Closes #5623
