### PR TITLE
fix: enforce delivery geofence before escrow release

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -68,6 +68,14 @@ REPUTATION_CONTRACT_ADDRESS=0x...
 DELIVERY_RECEIPTS_CONTRACT_ADDRESS=0x...
 RELAYER_WALLET_PRIVATE_KEY=your_private_key
 
+# ── Delivery Verification (Geofence) ───────
+# Radius (km) within which the driver's latest telemetry must be from the
+# drop-off location before escrow can be released. Defaults to 0.5 if unset.
+DELIVERY_GEOFENCE_RADIUS_KM=0.5
+# Maximum age (ms) of the latest telemetry point accepted for geofence
+# verification. Defaults to 300000 (5 minutes) if unset.
+DELIVERY_GEOFENCE_MAX_AGE_MS=300000
+
 # ── Escrow ────────────────────────────────
 # MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
 # Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -1,7 +1,8 @@
 import crypto from 'crypto';
-import { supabase, redisClient } from '../../config/db.js';
+import { supabase, redisClient, mongoDb } from '../../config/db.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
+import { haversineKm } from '../../lib/pricing.js';
 import {
   sendDeliveryOtpNotification,
   storeDeliveryOtp,
@@ -21,6 +22,19 @@ import logger from '../../middleware/logger.js';
 import { OrderTimelineService } from './orderTimelineService.js';
 
 const DELIVERY_OTP_READY_STATUSES = new Set(['arriving']);
+
+const DELIVERY_GEOFENCE_RADIUS_KM = Number(process.env.DELIVERY_GEOFENCE_RADIUS_KM) || 0.5;
+const DELIVERY_GEOFENCE_MAX_AGE_MS = Number(process.env.DELIVERY_GEOFENCE_MAX_AGE_MS) || 5 * 60 * 1000;
+
+function toEpochMs(value) {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const time = Date.parse(value);
+    return Number.isNaN(time) ? null : time;
+  }
+  return null;
+}
 
 export class DeliveryVerificationService {
   constructor(orderRepository, deps = {}) {
@@ -43,7 +57,7 @@ export class DeliveryVerificationService {
       });
     }
 
-    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, toll_estimate, base_freight, platform_fee, total_amount');
+    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, drop_lat, drop_lng, toll_estimate, base_freight, platform_fee, total_amount');
 
     if (orderErr || !order) {
       throw new DomainError(404, { error: 'Order not found.' });
@@ -165,9 +179,75 @@ export class DeliveryVerificationService {
     });
   }
 
+  async assertDriverAtDropoff(order) {
+    const rawDropLat = order.drop_lat;
+    const rawDropLng = order.drop_lng;
+    if (rawDropLat === null || rawDropLat === undefined || rawDropLat === '' ||
+        rawDropLng === null || rawDropLng === undefined || rawDropLng === '') {
+      throw new DomainError(400, {
+        error: 'Order is missing drop-off coordinates. Delivery cannot be confirmed.',
+      });
+    }
+    const dropLat = Number(rawDropLat);
+    const dropLng = Number(rawDropLng);
+    if (!Number.isFinite(dropLat) || !Number.isFinite(dropLng)) {
+      throw new DomainError(400, {
+        error: 'Order has invalid drop-off coordinates. Delivery cannot be confirmed.',
+      });
+    }
+
+    if (!mongoDb) {
+      throw new DomainError(503, {
+        error: 'Driver location service is unavailable. Please retry shortly.',
+        retryable: true,
+      });
+    }
+
+    const latestTelemetry = await mongoDb
+      .collection('telemetry')
+      .find({ driver_id: order.driver_id, order_id: order.id })
+      .sort({ timestamp: -1 })
+      .limit(1)
+      .toArray();
+
+    const telemetry = latestTelemetry && latestTelemetry[0];
+    if (!telemetry) {
+      throw new DomainError(409, {
+        error: 'Driver location is not available. Delivery can only be confirmed when the driver is at the drop-off location.',
+      });
+    }
+
+    const lat = Number(telemetry.lat);
+    const lng = Number(telemetry.lng);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      throw new DomainError(409, { error: 'Driver location is invalid. Delivery cannot be confirmed.' });
+    }
+
+    const telemetryTime = telemetry.server_received_at || telemetry.buffered_at || telemetry.timestamp;
+    const timestampMs = toEpochMs(telemetryTime);
+    if (timestampMs === null || Date.now() - timestampMs > DELIVERY_GEOFENCE_MAX_AGE_MS) {
+      throw new DomainError(409, {
+        error: 'Driver location is stale. Delivery can only be confirmed when the driver is at the drop-off location.',
+      });
+    }
+
+    const distanceKm = haversineKm(lat, lng, dropLat, dropLng);
+    if (distanceKm > DELIVERY_GEOFENCE_RADIUS_KM) {
+      throw new DomainError(409, {
+        error: `Driver is ${distanceKm.toFixed(2)} km from the drop-off location. Delivery can only be confirmed within ${DELIVERY_GEOFENCE_RADIUS_KM} km of the drop-off.`,
+      });
+    }
+  }
+
   async verifyDelivery({ orderId, driverId, otp }) {
     return measureExecution('DeliveryVerificationService.verifyDelivery', async () => {
     const { order, otpRecord } = await this.validateDeliveryOtp({ orderId, driverId, otp });
+
+    const isRetryForStuckEscrow = order.status === 'payment_released' && ['funded', 'release_failed'].includes(order.escrow_status);
+
+    if (!isRetryForStuckEscrow) {
+      await this.assertDriverAtDropoff(order);
+    }
 
     let releaseTxHash = null;
     let escrowAlreadyReleased = false;
@@ -195,8 +275,6 @@ export class DeliveryVerificationService {
     }
 
     // 2. Execute Postgres RPC to complete the trip AFTER blockchain success
-    const isRetryForStuckEscrow = order.status === 'payment_released' && ['funded', 'release_failed'].includes(order.escrow_status);
-
     let verifiedOrder;
     let tripData = null;
 

--- a/backend/api/test/contracts/delivery.contract.test.js
+++ b/backend/api/test/contracts/delivery.contract.test.js
@@ -7,6 +7,7 @@ const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js
 const m = createSupabaseMock();
 
 let mockRedis = null;
+let mockMongoDb = null;
 let completeTripRpcError = null;
 
 const originalRpc = m.supabase.rpc;
@@ -49,7 +50,7 @@ vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
   firebaseAdmin: null,
   get redisClient() { return mockRedis; },
-  mongoDb: null,
+  get mongoDb() { return mockMongoDb; },
 }));
 
 vi.mock('../../src/sockets/tracker.js', () => ({
@@ -88,6 +89,44 @@ const CUSTOMER = {
   'x-user-role': 'customer',
 };
 
+const DROP_LAT = 28.6139;
+const DROP_LNG = 77.209;
+
+function makeMongoDbMock(records) {
+  return {
+    collection: () => ({
+      find: () => ({
+        sort: () => ({
+          limit: () => ({
+            toArray: async () => records,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+function seedDriverAtDropOff(orderId, driverId, lat = DROP_LAT, lng = DROP_LNG) {
+  mockMongoDb = makeMongoDbMock([{
+    driver_id: driverId,
+    order_id: orderId,
+    lat,
+    lng,
+    server_received_at: new Date(),
+  }]);
+}
+
+function makeOtpRecord(id, orderId) {
+  return {
+    id,
+    order_id: orderId,
+    otp_hash: crypto.createHash('sha256').update('123456').digest('hex'),
+    expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    verified: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
 describe('POST /api/orders/:id/verify-delivery — delivery verification contract', () => {
   beforeEach(() => {
     m.store.orders = [];
@@ -97,6 +136,7 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
     completeTripRpcError = null;
     escrowReleaseMock.mockReset();
     mockRedis = null;
+    mockMongoDb = makeMongoDbMock([]);
   });
 
   it('200: returns success message on valid delivery verification', async () => {
@@ -105,15 +145,11 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
       driver_id: DRIVER['x-user-id'],
       order_display_id: 'ORD-DV',
       status: 'arriving',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
     });
-    m.store.delivery_otps.push({
-      id: 'otp-dv-1',
-      order_id: 'order-dv-1',
-      otp_hash: crypto.createHash('sha256').update('123456').digest('hex'),
-      expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      verified: false,
-      created_at: new Date().toISOString(),
-    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-1', 'order-dv-1'));
+    seedDriverAtDropOff('order-dv-1', DRIVER['x-user-id']);
     m.store.order_timeline.push({
       order_display_id: 'ORD-DV',
       milestone: 'Delivered',
@@ -140,15 +176,11 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
       status: 'arriving',
       total_amount: 125000,
       escrow_status: 'funded',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
     });
-    m.store.delivery_otps.push({
-      id: 'otp-dv-2',
-      order_id: 'order-dv-2',
-      otp_hash: crypto.createHash('sha256').update('123456').digest('hex'),
-      expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      verified: false,
-      created_at: new Date().toISOString(),
-    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-2', 'order-dv-2'));
+    seedDriverAtDropOff('order-dv-2', DRIVER['x-user-id']);
     m.store.order_timeline.push({
       order_display_id: 'ORD-DV-202',
       milestone: 'Delivered',
@@ -244,15 +276,11 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
       status: 'arriving',
       total_amount: 125000,
       escrow_status: 'funded',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
     });
-    m.store.delivery_otps.push({
-      id: 'otp-dv-5',
-      order_id: 'order-dv-5',
-      otp_hash: crypto.createHash('sha256').update('123456').digest('hex'),
-      expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      verified: false,
-      created_at: new Date().toISOString(),
-    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-5', 'order-dv-5'));
+    seedDriverAtDropOff('order-dv-5', DRIVER['x-user-id']);
 
     const res = await request(buildApp())
       .post('/api/orders/order-dv-5/verify-delivery')
@@ -271,15 +299,11 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
       driver_id: DRIVER['x-user-id'],
       order_display_id: 'ORD-RPC-FAIL',
       status: 'arriving',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
     });
-    m.store.delivery_otps.push({
-      id: 'otp-dv-6',
-      order_id: 'order-dv-6',
-      otp_hash: crypto.createHash('sha256').update('123456').digest('hex'),
-      expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      verified: false,
-      created_at: new Date().toISOString(),
-    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-6', 'order-dv-6'));
+    seedDriverAtDropOff('order-dv-6', DRIVER['x-user-id']);
 
     completeTripRpcError = { message: 'Database temporary failure' };
 
@@ -290,6 +314,89 @@ describe('POST /api/orders/:id/verify-delivery — delivery verification contrac
       .send({ otp: '123456' });
 
     expectServerError(res);
+  });
+
+  it('409: rejects escrow release when the driver is outside the geofence', async () => {
+    escrowReleaseMock.mockResolvedValue({ txHash: '0xrelease' });
+
+    m.store.orders.push({
+      id: 'order-dv-7',
+      driver_id: DRIVER['x-user-id'],
+      order_display_id: 'ORD-OUTSIDE-GEOFENCE',
+      status: 'arriving',
+      total_amount: 125000,
+      escrow_status: 'funded',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
+    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-7', 'order-dv-7'));
+    seedDriverAtDropOff('order-dv-7', DRIVER['x-user-id'], DROP_LAT, 77.218);
+
+    const res = await request(buildApp())
+      .post('/api/orders/order-dv-7/verify-delivery')
+      .set('X-Idempotency-Key', 'dv-test-8')
+      .set(DRIVER)
+      .send({ otp: '123456' });
+
+    expectErrorContract(res, 409);
+    expect(res.body.error).toMatch(/km from the drop-off/i);
+    expect(escrowReleaseMock).not.toHaveBeenCalled();
+    expect(m.calls.find(c => c.rpc === 'complete_trip_tx')).toBeFalsy();
+  });
+
+  it('409: rejects when no driver telemetry exists for the order', async () => {
+    escrowReleaseMock.mockResolvedValue({ txHash: '0xrelease' });
+
+    m.store.orders.push({
+      id: 'order-dv-8',
+      driver_id: DRIVER['x-user-id'],
+      order_display_id: 'ORD-NO-TELEMETRY',
+      status: 'arriving',
+      total_amount: 125000,
+      escrow_status: 'funded',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
+    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-8', 'order-dv-8'));
+
+    const res = await request(buildApp())
+      .post('/api/orders/order-dv-8/verify-delivery')
+      .set('X-Idempotency-Key', 'dv-test-9')
+      .set(DRIVER)
+      .send({ otp: '123456' });
+
+    expectErrorContract(res, 409);
+    expect(res.body.error).toMatch(/location is not available/i);
+    expect(escrowReleaseMock).not.toHaveBeenCalled();
+    expect(m.calls.find(c => c.rpc === 'complete_trip_tx')).toBeFalsy();
+  });
+
+  it('503: rejects when the driver location service is unavailable', async () => {
+    escrowReleaseMock.mockResolvedValue({ txHash: '0xrelease' });
+    mockMongoDb = null;
+
+    m.store.orders.push({
+      id: 'order-dv-9',
+      driver_id: DRIVER['x-user-id'],
+      order_display_id: 'ORD-LOC-DOWN',
+      status: 'arriving',
+      total_amount: 125000,
+      escrow_status: 'funded',
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
+    });
+    m.store.delivery_otps.push(makeOtpRecord('otp-dv-9', 'order-dv-9'));
+
+    const res = await request(buildApp())
+      .post('/api/orders/order-dv-9/verify-delivery')
+      .set('X-Idempotency-Key', 'dv-test-10')
+      .set(DRIVER)
+      .send({ otp: '123456' });
+
+    expectErrorContract(res, 503);
+    expect(res.body.retryable).toBe(true);
+    expect(escrowReleaseMock).not.toHaveBeenCalled();
+    expect(m.calls.find(c => c.rpc === 'complete_trip_tx')).toBeFalsy();
   });
 });
 

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -61,14 +61,39 @@ m.supabase.rpc = vi.fn().mockImplementation(async (fnName, args) => {
   return originalRpc(fnName, args);
 });
 let mockRedis = null;
+let mockMongoDb = null;
 afterEach(() => { mockRedis = null; });
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
   firebaseAdmin: null,
   get redisClient() { return mockRedis; },
-  mongoDb: null,
+  get mongoDb() { return mockMongoDb; },
 }));
+
+function makeMongoDbMock(records) {
+  return {
+    collection: () => ({
+      find: () => ({
+        sort: () => ({
+          limit: () => ({
+            toArray: async () => records,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+function seedDriverAtDropOff(orderId, driverId) {
+  mockMongoDb = makeMongoDbMock([{
+    driver_id: driverId,
+    order_id: orderId,
+    lat: 28.6139,
+    lng: 77.209,
+    server_received_at: new Date(),
+  }]);
+}
 
 vi.mock('../../src/sockets/tracker.js', () => ({
   initWebSocketServer: () => ({}),
@@ -998,6 +1023,7 @@ describe('Delivery OTP Verification and Milestones', () => {
     m.calls.length = 0;
     completeTripRpcError = null;
     escrowReleaseMock.mockReset();
+    mockMongoDb = makeMongoDbMock([]);
   });
 
   it('blocks direct transition to Delivered milestone with descriptive message', async () => {
@@ -1144,7 +1170,9 @@ describe('Delivery OTP Verification and Milestones', () => {
       id: 'order-1',
       driver_id: 'driver-123',
       order_display_id: 'ORD001',
-      status: 'arriving'
+      status: 'arriving',
+      drop_lat: 28.6139,
+      drop_lng: 77.209
     }];
     m.store.delivery_otps = [{
       id: 'otp-1',
@@ -1154,6 +1182,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString()
     }];
+    seedDriverAtDropOff('order-1', 'driver-123');
     m.store.order_timeline = [{
       order_display_id: 'ORD001',
       milestone: 'Delivered',
@@ -1198,7 +1227,9 @@ describe('Delivery OTP Verification and Milestones', () => {
       id: 'order-retry',
       driver_id: 'driver-123',
       order_display_id: 'ORD-RETRY',
-      status: 'arriving'
+      status: 'arriving',
+      drop_lat: 28.6139,
+      drop_lng: 77.209
     }];
     m.store.delivery_otps = [{
       id: 'otp-retry',
@@ -1208,6 +1239,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString()
     }];
+    seedDriverAtDropOff('order-retry', 'driver-123');
 
     completeTripRpcError = { message: 'temporary database failure' };
 
@@ -1250,6 +1282,8 @@ describe('Delivery OTP Verification and Milestones', () => {
       status: 'arriving',
       total_amount: 125000,
       escrow_status: 'funded',
+      drop_lat: 28.6139,
+      drop_lng: 77.209,
     }];
     m.store.delivery_otps = [{
       id: 'otp-2',
@@ -1259,6 +1293,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString(),
     }];
+    seedDriverAtDropOff('order-2', 'driver-456');
     m.store.order_timeline = [{
       order_display_id: 'ORD002',
       milestone: 'Delivered',
@@ -1305,6 +1340,8 @@ describe('Delivery OTP Verification and Milestones', () => {
       total_amount: 125000,
       escrow_status: 'funded',
       escrow_release_attempts: 0,
+      drop_lat: 28.6139,
+      drop_lng: 77.209,
     }];
     m.store.delivery_otps = [{
       id: 'otp-release-failed',
@@ -1314,6 +1351,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString(),
     }];
+    seedDriverAtDropOff('order-release-failed', 'driver-456');
 
     const app = buildApp();
     const res = await request(app)
@@ -1356,6 +1394,8 @@ describe('Delivery OTP Verification and Milestones', () => {
       total_amount: 125000,
       escrow_status: 'funded',
       escrow_release_attempts: 2,
+      drop_lat: 28.6139,
+      drop_lng: 77.209,
     }];
     m.store.delivery_otps = [{
       id: 'otp-no-release-hash',
@@ -1365,6 +1405,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString(),
     }];
+    seedDriverAtDropOff('order-no-release-hash', 'driver-456');
 
     const app = buildApp();
     const res = await request(app)
@@ -1424,7 +1465,9 @@ describe('Delivery OTP Verification and Milestones', () => {
       id: orderId,
       driver_id: 'driver-123',
       order_display_id: 'ORD-LOCK',
-      status: 'arriving'
+      status: 'arriving',
+      drop_lat: 28.6139,
+      drop_lng: 77.209,
     }];
     m.store.delivery_otps = [{
       id: 'otp-lockout',
@@ -1434,6 +1477,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString()
     }];
+    seedDriverAtDropOff(orderId, 'driver-123');
 
     const app = buildApp();
 
@@ -1481,6 +1525,8 @@ describe('Delivery OTP Verification and Milestones', () => {
 
     // Update expires_at so the OTP itself isn't expired after lockout bypass
     m.store.delivery_otps[0].expires_at = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    // Re-seed telemetry so it stays fresh after the 31-minute time advance
+    seedDriverAtDropOff(orderId, 'driver-123');
 
     try {
       // Correct OTP should now succeed
@@ -1505,7 +1551,9 @@ describe('Delivery OTP Verification and Milestones', () => {
       id: orderId,
       driver_id: 'driver-123',
       order_display_id: 'ORD-CLEAR',
-      status: 'arriving'
+      status: 'arriving',
+      drop_lat: 28.6139,
+      drop_lng: 77.209,
     }];
     m.store.delivery_otps = [{
       id: 'otp-clear-state',
@@ -1515,6 +1563,7 @@ describe('Delivery OTP Verification and Milestones', () => {
       verified: false,
       created_at: new Date().toISOString()
     }];
+    seedDriverAtDropOff(orderId, 'driver-123');
 
     const app = buildApp();
 

--- a/backend/api/test/unit/deliveryVerificationGeofence.test.js
+++ b/backend/api/test/unit/deliveryVerificationGeofence.test.js
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for the delivery geofence check (issue #5624).
+ *
+ * Locks in the contract invariant that escrow is only released after the
+ * driver's latest telemetry point is confirmed to be within the geofence
+ * radius of the order's drop-off location, and that the check is skipped on
+ * the stuck-escrow retry path.
+ *
+ * Run with:  npx vitest run test/unit/deliveryVerificationGeofence.test.js
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeliveryVerificationService } from '../../src/services/order/deliveryVerificationService.js';
+import { DomainError } from '../../src/services/order/domainError.js';
+import crypto from 'crypto';
+
+const h = vi.hoisted(() => ({
+  mockMongoDb: null,
+}));
+
+let mockTelemetryRecords = [];
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: vi.fn() },
+  firebaseAdmin: null,
+  redisClient: null,
+  get mongoDb() {
+    return h.mockMongoDb;
+  },
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendDeliveryOtpNotification: vi.fn(),
+  storeDeliveryOtp: vi.fn(),
+  getActiveDeliveryOtp: vi.fn(),
+  verifyDeliveryOtp: vi.fn(),
+}));
+
+const DROP_LAT = 28.6139;
+const DROP_LNG = 77.209;
+const OTP_HASH = crypto.createHash('sha256').update('123456').digest('hex');
+
+function makeMongoMock() {
+  return {
+    collection: () => ({
+      find: () => ({
+        sort: () => ({
+          limit: () => ({
+            toArray: async () => mockTelemetryRecords,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+function makeOrder(overrides = {}) {
+  return {
+    id: 'order-geo-1',
+    order_display_id: 'ORD-GEO',
+    driver_id: 'driver-1',
+    customer_id: 'customer-1',
+    status: 'arriving',
+    escrow_status: 'funded',
+    escrow_release_attempts: 0,
+    drop_lat: DROP_LAT,
+    drop_lng: DROP_LNG,
+    ...overrides,
+  };
+}
+
+function makeTelemetry(lat, lng, ageMs = 1000, overrides = {}) {
+  return {
+    driver_id: 'driver-1',
+    order_id: 'order-geo-1',
+    lat,
+    lng,
+    server_received_at: new Date(Date.now() - ageMs),
+    ...overrides,
+  };
+}
+
+function makeOtpRecord() {
+  return {
+    id: 'otp-geo-1',
+    order_id: 'order-geo-1',
+    otp_hash: OTP_HASH,
+    verified: false,
+    expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+  };
+}
+
+function makeService({ repoOverrides = {}, escrowReleaseFn } = {}) {
+  const repo = {
+    findOrderById: vi.fn()
+      .mockResolvedValueOnce({ data: makeOrder(), error: null })
+      .mockResolvedValueOnce({ data: { status: 'payment_released', escrow_status: 'released', escrow_release_attempts: 0 }, error: null }),
+    updateOrderGuardStatus: vi.fn().mockResolvedValue({ data: null, error: null }),
+    executeRpc: vi.fn().mockResolvedValue({ data: { driver_id: 'driver-1', order_display_id: 'ORD-GEO' }, error: null }),
+    updateOrder: vi.fn().mockResolvedValue({ data: null, error: null }),
+    updateWalletTransaction: vi.fn().mockResolvedValue({ data: null, error: null }),
+    ...repoOverrides,
+  };
+  const notificationService = {
+    getActiveDeliveryOtp: vi.fn().mockResolvedValue(makeOtpRecord()),
+    verifyDeliveryOtp: vi.fn().mockResolvedValue(true),
+  };
+  const service = new DeliveryVerificationService(repo, {
+    notificationService,
+    orderTimelineService: {},
+    escrowReleaseFn: escrowReleaseFn || vi.fn().mockResolvedValue({ txHash: '0xrelease' }),
+  });
+  return { service, repo, notificationService };
+}
+
+function captureDomainError(promise) {
+  return promise.then(
+    () => null,
+    (err) => err
+  );
+}
+
+beforeEach(() => {
+  mockTelemetryRecords = [];
+  h.mockMongoDb = makeMongoMock();
+});
+
+afterEach(() => {
+  h.mockMongoDb = null;
+  mockTelemetryRecords = [];
+  vi.clearAllMocks();
+});
+
+describe('DeliveryVerificationService.assertDriverAtDropoff', () => {
+  it('rejects when the order is missing drop-off coordinates', async () => {
+    const { service } = makeService();
+    const err = await captureDomainError(
+      service.assertDriverAtDropoff(makeOrder({ drop_lat: null, drop_lng: null }))
+    );
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(400);
+    expect(err.payload.error).toMatch(/missing drop-off coordinates/i);
+  });
+
+  it('rejects with 503 when the location store is unavailable', async () => {
+    h.mockMongoDb = null;
+    const { service } = makeService();
+    const err = await captureDomainError(service.assertDriverAtDropoff(makeOrder()));
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(503);
+    expect(err.payload.retryable).toBe(true);
+  });
+
+  it('rejects when no telemetry exists for the driver on this order', async () => {
+    const { service } = makeService();
+    const err = await captureDomainError(service.assertDriverAtDropoff(makeOrder()));
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(err.payload.error).toMatch(/location is not available/i);
+  });
+
+  it('rejects when telemetry coordinates are invalid', async () => {
+    mockTelemetryRecords = [makeTelemetry('NaN', DROP_LNG)];
+    const { service } = makeService();
+    const err = await captureDomainError(service.assertDriverAtDropoff(makeOrder()));
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(err.payload.error).toMatch(/location is invalid/i);
+  });
+
+  it('rejects when the latest telemetry is stale', async () => {
+    mockTelemetryRecords = [makeTelemetry(DROP_LAT, DROP_LNG, 6 * 60 * 1000)];
+    const { service } = makeService();
+    const err = await captureDomainError(service.assertDriverAtDropoff(makeOrder()));
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(err.payload.error).toMatch(/stale/i);
+  });
+
+  it('rejects when the driver is outside the geofence radius', async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.218)];
+    const { service } = makeService();
+    const err = await captureDomainError(service.assertDriverAtDropoff(makeOrder()));
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(err.payload.error).toMatch(/km from the drop-off/i);
+  });
+
+  it('passes when the driver is exactly at the drop-off location', async () => {
+    mockTelemetryRecords = [makeTelemetry(DROP_LAT, DROP_LNG)];
+    const { service } = makeService();
+    await expect(service.assertDriverAtDropoff(makeOrder())).resolves.toBeUndefined();
+  });
+
+  it('passes when the driver is just inside the geofence radius', async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.2135)];
+    const { service } = makeService();
+    await expect(service.assertDriverAtDropoff(makeOrder())).resolves.toBeUndefined();
+  });
+});
+
+describe('DeliveryVerificationService.verifyDelivery geofence gating', () => {
+  it('releases escrow only after the geofence check passes', async () => {
+    mockTelemetryRecords = [makeTelemetry(DROP_LAT, DROP_LNG)];
+    const escrowReleaseFn = vi.fn().mockResolvedValue({ txHash: '0xrelease' });
+    const { service, repo } = makeService({ escrowReleaseFn });
+    const result = await service.verifyDelivery({ orderId: 'order-geo-1', driverId: 'driver-1', otp: '123456' });
+    expect(escrowReleaseFn).toHaveBeenCalledWith('ORD-GEO');
+    expect(repo.executeRpc).toHaveBeenCalled();
+    expect(result.escrowUpdateFailed).toBe(false);
+  });
+
+  it('aborts before escrow release when the driver is outside the geofence', async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.218)];
+    const escrowReleaseFn = vi.fn().mockResolvedValue({ txHash: '0xrelease' });
+    const { service, repo } = makeService({ escrowReleaseFn });
+    const err = await captureDomainError(
+      service.verifyDelivery({ orderId: 'order-geo-1', driverId: 'driver-1', otp: '123456' })
+    );
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(escrowReleaseFn).not.toHaveBeenCalled();
+    expect(repo.executeRpc).not.toHaveBeenCalled();
+  });
+
+  it('skips the geofence check on the stuck-escrow retry path', async () => {
+    h.mockMongoDb = null;
+    const escrowReleaseFn = vi.fn().mockResolvedValue({ txHash: '0xrelease' });
+    const { service, repo } = makeService({
+      escrowReleaseFn,
+      repoOverrides: {
+        findOrderById: vi.fn().mockResolvedValueOnce({
+          data: makeOrder({ status: 'payment_released', escrow_status: 'funded' }),
+          error: null,
+        }),
+      },
+    });
+    const result = await service.verifyDelivery({ orderId: 'order-geo-1', driverId: 'driver-1', otp: '123456' });
+    expect(escrowReleaseFn).toHaveBeenCalledWith('ORD-GEO');
+    expect(repo.executeRpc).not.toHaveBeenCalled();
+    expect(repo.updateOrder).toHaveBeenCalled();
+    expect(result.escrowUpdateFailed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a GPS geofence check to `/verify-delivery` so escrow release only proceeds when the driver's latest telemetry is within a configurable radius of the drop-off location — mirroring the on-chain geofence requirement of `TruxifyEscrow`.

## Changes

- `backend/api/src/services/order/deliveryVerificationService.js`:
  - New `assertDriverAtDropoff(order)` — reads the latest telemetry record for `{ driver_id, order_id }`, rejects with a `DomainError` when: drop coordinates are missing/non-finite (400), location service is unavailable (503, `retryable: true`), no telemetry exists (409), telemetry is stale beyond `DELIVERY_GEOFENCE_MAX_AGE_MS` (409), or distance from drop-off exceeds `DELIVERY_GEOFENCE_RADIUS_KM` (409).
  - `verifyDelivery` calls it after OTP validation and immediately before escrow release; skipped on the stuck-escrow retry path (`status === 'payment_released'` with `escrow_status` `funded`/`release_failed`) so a previously paid order can still be released.
- `.env.example` — `DELIVERY_GEOFENCE_RADIUS_KM=0.5`, `DELIVERY_GEOFENCE_MAX_AGE_MS=300000` (code defaults match).

## Tests

- New `backend/api/test/unit/deliveryVerificationGeofence.test.js` (11 tests, all pass).
- `delivery.contract.test.js` — seeded drop coordinates + telemetry in success paths; added 409-outside-radius, 409-no-telemetry, and 503-location-down cases asserting escrow release is not called.
- `orders.test.js` — seeded drop coords + telemetry for the verify-delivery path.

Full `test/unit` suite: zero new failures vs. the pre-existing baseline.

Closes #5624
