### PR TITLE
fix: return 422 when escrow deposit exceeds safety cap

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -70,11 +70,11 @@ RELAYER_WALLET_PRIVATE_KEY=your_private_key
 
 # ── Escrow ────────────────────────────────
 # MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
-# Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004
-# Defaults to 0.01 if unset.
-ESCROW_MATIC_PER_PAISA=0.01
-# Safety cap: reject deposits exceeding this many MATIC
-MAX_ESCROW_MATIC=5
+# Realistic value: if 1 INR = 0.00040 MATIC, then 1 paisa = 0.000004 MATIC,
+# i.e. ESCROW_MATIC_PER_PAISA=0.000004. Defaults to 0.000004 if unset.
+ESCROW_MATIC_PER_PAISA=0.000004
+# Safety cap: reject deposits exceeding this many MATIC. Defaults to 100 if unset.
+MAX_ESCROW_MATIC=100
 # Poll interval for confirmed refunds that still need a Supabase state update.
 ESCROW_RECONCILIATION_INTERVAL_MS=60000
 

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -50,8 +50,8 @@ function parseEnvFloat(raw, defaultVal, name) {
   return val;
 }
 
-export const ESCROW_MATIC_PER_PAISA = parseEnvFloat(process.env.ESCROW_MATIC_PER_PAISA, '0.01', 'ESCROW_MATIC_PER_PAISA');
-const MAX_ESCROW_MATIC = parseEnvFloat(process.env.MAX_ESCROW_MATIC, '5', 'MAX_ESCROW_MATIC');
+export const ESCROW_MATIC_PER_PAISA = parseEnvFloat(process.env.ESCROW_MATIC_PER_PAISA, '0.000004', 'ESCROW_MATIC_PER_PAISA');
+const MAX_ESCROW_MATIC = parseEnvFloat(process.env.MAX_ESCROW_MATIC, '100', 'MAX_ESCROW_MATIC');
 
 /** @type {ethers.Contract | null} */
 let escrowContract = null

--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -88,7 +88,16 @@ export class BidAcceptanceService {
     }
 
     // Build the escrow deposit transaction
-    const amountWei = paisaToMaticWei(bid.bid_amount);
+    let amountWei;
+    try {
+      amountWei = paisaToMaticWei(bid.bid_amount);
+    } catch (err) {
+      throw new DomainError(422, {
+        error: 'Deposit amount exceeds the escrow safety cap.',
+        details: err.message,
+        recovery: 'Configure ESCROW_MATIC_PER_PAISA / MAX_ESCROW_MATIC or contact support for a larger escrow limit.',
+      });
+    }
     const depositTx = await this.buildDepositTxFn(order.order_display_id, freshDriverWallet, amountWei);
     const bookingId = depositTx?.bookingId || `escrow:${order.order_display_id}`;
 

--- a/backend/api/test/setup.js
+++ b/backend/api/test/setup.js
@@ -12,7 +12,7 @@
 process.env.BYPASS_AUTH = 'true';
 process.env.DEV_ACCESS_TOKEN = 'test-dev-token-123';
 process.env.MONGODB_SHUTDOWN_WAIT_MS = '0';
-process.env.ESCROW_MATIC_PER_PAISA = '0.01';
+process.env.ESCROW_MATIC_PER_PAISA = '0.000004';
 process.env.MAX_ESCROW_MATIC = '10000';
 process.env.DRIVER_LOGIN_OTP = '1234';
 

--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -51,17 +51,17 @@ describe('escrow service — getEscrowBookingId', () => {
   })
 
   it('ESCROW_MATIC_PER_PAISA parses the configured env var correctly', () => {
-    // process.env.ESCROW_MATIC_PER_PAISA is set to '0.01' in setup.js
-    expect(ESCROW_MATIC_PER_PAISA).toBe(0.01)
+    // process.env.ESCROW_MATIC_PER_PAISA is set to '0.000004' in setup.js
+    expect(ESCROW_MATIC_PER_PAISA).toBe(0.000004)
   })
 
-  it('ESCROW_MATIC_PER_PAISA defaults to 0.01 when env var is absent', async () => {
+  it('ESCROW_MATIC_PER_PAISA defaults to 0.000004 when env var is absent', async () => {
     const originalEnv = process.env.ESCROW_MATIC_PER_PAISA
     delete process.env.ESCROW_MATIC_PER_PAISA
 
     vi.resetModules()
     const { ESCROW_MATIC_PER_PAISA: defaultVal } = await import('../../src/services/escrow.js')
-    expect(defaultVal).toBe(0.01)
+    expect(defaultVal).toBe(0.000004)
 
     if (originalEnv !== undefined) {
       process.env.ESCROW_MATIC_PER_PAISA = originalEnv
@@ -87,22 +87,22 @@ describe('escrow service — getEscrowBookingId', () => {
 })
 
 describe('escrow service — paisaToMaticWei', () => {
-  it('converts paisa to wei using the default rate (0.01 MATIC/paisa)', () => {
-    // 100 paisa × 0.01 = 1 MATIC = 10^18 wei
+  it('converts paisa to wei using the configured rate (0.000004 MATIC/paisa)', () => {
+    // 100 paisa × 0.000004 = 0.0004 MATIC = 4 × 10^14 wei
     const wei = paisaToMaticWei(100);
-    expect(wei).toBe(1_000_000_000_000_000_000n);
+    expect(wei).toBe(400_000_000_000_000n);
   });
 
-  it('converts 1 paisa to 0.01 MATIC (10^16 wei)', () => {
+  it('converts 1 paisa to 0.000004 MATIC (4 × 10^12 wei)', () => {
     const wei = paisaToMaticWei(1);
     expect(typeof wei).toBe('bigint');
-    expect(wei).toBe(10_000_000_000_000_000n);
+    expect(wei).toBe(4_000_000_000_000n);
   });
 
-  it('converts 250000 paisa (₹2500) to 2500 MATIC', () => {
-    // 250000 × 0.01 = 2500 MATIC
+  it('converts 250000 paisa (₹2500) to 1 MATIC', () => {
+    // 250000 × 0.000004 = 1 MATIC
     const wei = paisaToMaticWei(250_000);
-    expect(wei).toBe(ethers.parseEther('2500'));
+    expect(wei).toBe(ethers.parseEther('1'));
   });
 
   it('returns 0n for 0 paisa', () => {
@@ -128,7 +128,29 @@ describe('escrow service — paisaToMaticWei', () => {
 
   it('handles string input for paisa', () => {
     const wei = paisaToMaticWei('100');
-    expect(wei).toBe(1_000_000_000_000_000_000n);
+    expect(wei).toBe(400_000_000_000_000n);
+  });
+
+  it('enforces the default 100 MATIC safety cap when env vars are absent', async () => {
+    const rateEnv = process.env.ESCROW_MATIC_PER_PAISA;
+    const capEnv = process.env.MAX_ESCROW_MATIC;
+    delete process.env.ESCROW_MATIC_PER_PAISA;
+    delete process.env.MAX_ESCROW_MATIC;
+
+    vi.resetModules();
+    const { paisaToMaticWei: defaultRateWei } = await import('../../src/services/escrow.js');
+
+    // 10,000,000 paisa (₹100k) × 0.000004 = 40 MATIC — a realistic large
+    // order that is now well under the default 100 MATIC cap, no RangeError.
+    expect(defaultRateWei(10_000_000)).toBe(ethers.parseEther('40'));
+    // An order far beyond the cap is rejected with a handled RangeError.
+    expect(() => defaultRateWei(100_000_000_000)).toThrow(RangeError);
+
+    if (rateEnv !== undefined) process.env.ESCROW_MATIC_PER_PAISA = rateEnv;
+    else delete process.env.ESCROW_MATIC_PER_PAISA;
+    if (capEnv !== undefined) process.env.MAX_ESCROW_MATIC = capEnv;
+    else delete process.env.MAX_ESCROW_MATIC;
+    vi.resetModules();
   });
 
   it('converts using a custom rate when env var is overridden', async () => {


### PR DESCRIPTION
## Summary

Fixes two related problems: the escrow safety cap was effectively useless because of an incorrect paisa→MATIC rate, and a deposit that exceeded the cap crashed with an unhandled `RangeError` (HTTP 500) instead of a clean client error.

## Changes

- `backend/api/src/services/escrow.js` — corrected defaults: `ESCROW_MATIC_PER_PAISA` `'0.01'` → `'0.000004'`, `MAX_ESCROW_MATIC` `'5'` → `'100'`.
- `backend/api/src/services/order/bidAcceptanceService.js` — `paisaToMaticWei(bid.bid_amount)` wrapped in try/catch; overflow now surfaces as a `DomainError` 422 `'Deposit amount exceeds the escrow safety cap.'` with `details`/`recovery`, instead of an unhandled `RangeError`.
- `.env.example` — rate/cap updated to `0.000004` / `100`.
- `backend/api/test/setup.js` + `backend/api/test/unit/escrow.test.js` — updated expected wei values and added a default-cap test.

All 32 `escrow` unit tests pass.

Closes #5625
