### PR TITLE
fix: correct escrow MATIC rate default to match documented value

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -71,8 +71,8 @@ RELAYER_WALLET_PRIVATE_KEY=your_private_key
 # ── Escrow ────────────────────────────────
 # MATIC equivalent of 1 paisa. bid_amount is stored in paisa (1 INR = 100 paisa).
 # Example: if 1 INR = 0.00040 MATIC, set ESCROW_MATIC_PER_PAISA=0.000004
-# Defaults to 0.01 if unset.
-ESCROW_MATIC_PER_PAISA=0.01
+# Defaults to 0.000004 if unset.
+ESCROW_MATIC_PER_PAISA=0.000004
 # Safety cap: reject deposits exceeding this many MATIC
 MAX_ESCROW_MATIC=5
 # Poll interval for confirmed refunds that still need a Supabase state update.

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -50,7 +50,7 @@ function parseEnvFloat(raw, defaultVal, name) {
   return val;
 }
 
-export const ESCROW_MATIC_PER_PAISA = parseEnvFloat(process.env.ESCROW_MATIC_PER_PAISA, '0.01', 'ESCROW_MATIC_PER_PAISA');
+export const ESCROW_MATIC_PER_PAISA = parseEnvFloat(process.env.ESCROW_MATIC_PER_PAISA, '0.000004', 'ESCROW_MATIC_PER_PAISA');
 const MAX_ESCROW_MATIC = parseEnvFloat(process.env.MAX_ESCROW_MATIC, '5', 'MAX_ESCROW_MATIC');
 
 /** @type {ethers.Contract | null} */


### PR DESCRIPTION
## Description

Fixes #5632

`ESCROW_MATIC_PER_PAISA` defaulted to `0.01` (~2500× the value documented in `.env.example`). With `MAX_ESCROW_MATIC = 5`, any deposit above **500 paisa (₹5)** threw `RangeError`, so escrow-protected orders could not be created with the default config.

## Changes
- `backend/api/src/services/escrow.js`: default `ESCROW_MATIC_PER_PAISA` `0.01` → `0.000004` (matches the documented "1 INR = 0.00040 MATIC" example)
- `backend/api/.env.example`: value + inline "defaults to" comment updated to match

## Testing
- Manual: `ESCROW_MATIC_PER_PAISA` unset → `paisaToMaticWei(5000)` = 0.02 MATIC (under cap); previously it threw.
- No new dependencies.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default MATIC-to-paisa conversion rate for escrow transactions.
  * Improved the default configuration to reflect the correct conversion value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->