### PR TITLE
fix: deliver the actual delivery OTP to the customer

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -222,7 +222,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
       .insert({
         user_id: customerId,
         title,
-        body: `Your delivery verification OTP has been sent for order ${orderDisplayId}.`,
+        body: `Your delivery verification OTP for order ${orderDisplayId} is ${otp}.`,
         notif_type: 'order_update',
         metadata: { order_display_id: orderDisplayId, delivery_otp_hash: otpHash },
       });
@@ -240,8 +240,8 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
   let fcmResult;
   try { fcmResult = await sendFcmNotification(
       customerId,
-    { title: 'Delivery Verification OTP', body: `Your delivery verification OTP has been sent for order ${orderDisplayId}.` },
-    { orderDisplayId, notifType: 'delivery_otp' }
+    { title: 'Delivery Verification OTP', body: `Your delivery verification OTP for order ${orderDisplayId} is ${otp}.` },
+    { orderDisplayId, notifType: 'delivery_otp', deliveryOtp: String(otp) }
   ); } catch (err) { logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error'); }
 
   if (process.env.TWILIO_AUTH_TOKEN) {


### PR DESCRIPTION
## Description

Fixes #5633

The delivery OTP was generated and stored as a SHA-256 hash, but the plaintext digits were never delivered anywhere:
- FCM notification body said "OTP has been sent" without the code
- DB notification stored only `delivery_otp_hash`
- SMS path was a logging-only stub

So neither customer nor driver could learn the OTP, making `arriving` orders unverifiable and locking escrow.

## Changes
- `backend/api/src/services/notificationService.js`:
  - DB notification body now includes the actual OTP digits
  - FCM notification body now includes the actual OTP digits
  - FCM data payload now carries `deliveryOtp` for the app

## Testing
- Manual: `sendDeliveryOtpNotification(...)` with a fake FCM setup → body/data contain the digits; DB row body shows them.
- Hash-only storage for verification is unchanged.

GSSOC
