### PR TITLE
fix: reject POD upload when no valid proof file was uploaded

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1555,6 +1555,8 @@ router.post('/:id/pod', authenticate, requireRole(['driver']), podUpload.fields(
     let photoHash = order.pod_photo_hash || null;
     const files = req.files || {};
 
+    let uploadedAny = false;
+
     if (files.signature && files.signature[0]) {
       const file = files.signature[0];
       try {
@@ -1573,6 +1575,7 @@ router.post('/:id/pod', authenticate, requireRole(['driver']), podUpload.fields(
       }
       signatureUrl = storagePath;
       signatureHash = computeFileHash(file.buffer);
+      uploadedAny = true;
     }
 
     if (files.photo && files.photo[0]) {
@@ -1593,6 +1596,11 @@ router.post('/:id/pod', authenticate, requireRole(['driver']), podUpload.fields(
       }
       photoUrl = storagePath;
       photoHash = computeFileHash(file.buffer);
+      uploadedAny = true;
+    }
+
+    if (!uploadedAny) {
+      return res.status(400).json({ error: 'At least one valid proof file (signature or photo) is required' });
     }
 
     const updates = {


### PR DESCRIPTION
## Description

Fixes #5634

The PoD upload endpoint returned **HTTP 200 "Proof of Delivery uploaded successfully" even when no valid file was uploaded**. The multer `fileFilter` silently dropped disallowed types (`cb(null, false)`), and both `signature` and `photo` fields were optional — so a request with no accepted files stored nothing but still reported success.

## Changes
- `backend/api/src/routes/orderRoutes.js`:
  - Track `uploadedAny` flag when an accepted file is actually stored
  - Return **400** when neither a signature nor a photo was uploaded

## Testing
- Manual: POST `/api/orders/:id/pod` with only a disallowed type (e.g. HEIC) → 400 with clear error; with a valid PNG → 200 as before.
- No new dependencies.

GSSOC
