### PR TITLE
fix: prevent double-awarding on-chain reputation on retry

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -126,10 +126,16 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
     return;
   }
   try {
+    // Submit the transaction ONCE — retrying submission would re-award the
+    // points if a previous tx was already mined but its confirmation wait timed
+    // out. Only the confirmation wait is retried below.
+    const tx = await reputationContract.increaseReputation(driverWalletAddress, stars);
+    logger.info(`[reputation] increaseReputation tx submitted: ${tx.hash}`);
     await retryWithBackoff(async () => {
-      const tx = await reputationContract.increaseReputation(driverWalletAddress, stars);
-      logger.info(`[reputation] increaseReputation tx submitted: ${tx.hash}`);
-      await tx.wait(1);
+      const receipt = await reputationContract.runner.provider.waitForTransaction(tx.hash, 1, 60_000);
+      if (!receipt || receipt.status === 0) {
+        throw new Error(`increaseReputation transaction ${tx.hash} reverted or was not found on chain.`);
+      }
       logger.info(`[reputation] increaseReputation confirmed for driver ${driverWalletAddress} (+${stars} pts).`);
     }, REPUTATION_RETRY_MAX, REPUTATION_RETRY_DELAY_MS);
   } catch (err) {


### PR DESCRIPTION
## Description

Fixes #5635

`awardReputationPoints` wrapped the entire `increaseReputation` **submission** + confirmation wait inside `retryWithBackoff`. If `tx.wait(1)` timed out after the tx was already mined, the retry submitted a **second** `increaseReputation` tx — silently double-crediting the driver (e.g. 10 points instead of 5), with no audit trail.

## Changes
- `backend/api/src/services/reputation.js`:
  - Submit the transaction **once** outside the retry loop
  - Retry only the confirmation wait using `provider.waitForTransaction(tx.hash, 1, 60s)`, which resolves immediately for an already-mined tx
  - Reject a `status === 0` (reverted) receipt instead of treating it as success

## Testing
- Manual: with a mock contract, `awardReputationPoints` calls `increaseReputation` exactly once even when the wait is flaky and retried; reverted receipts are reported as errors.
- Same pattern as `confirmEscrowRefund` already used in the codebase.

GSSOC
