### PR TITLE
fix: count only realized revenue in admin dashboard total

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -77,7 +77,7 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
       .from('orders')
       .select('total_amount')
       .gte('created_at', today.toISOString())
-      .in('status', ['delivered', 'payment_released', 'active', 'in_transit']);
+      .in('status', ['delivered', 'payment_released']);
       
     if (revErr) {
       logger.error('Error fetching revenue:', revErr.message);


### PR DESCRIPTION
## Description

Fixes #5636

`total_revenue_today` on the admin dashboard summed `total_amount` for `delivered`, `payment_released`, **and** `active` + `in_transit` orders. The latter two are still held in escrow — not yet earned, and possibly refunded on cancellation — so the dashboard overstated actual revenue.

## Changes
- `backend/api/src/routes/adminRoutes.js`: filter today's revenue to realized statuses only (`delivered`, `payment_released`)

## Testing
- Manual: query verified against Supabase — `active`/`in_transit` orders are excluded from the total.
- Single-line query change, no new dependencies.

GSSOC
