### PR TITLE
fix: load available loads from repository

### DIFF
--- a/apps/driver/lib/screens/available_loads_screen.dart
+++ b/apps/driver/lib/screens/available_loads_screen.dart
@@ -1,7 +1,44 @@
 import 'package:flutter/material.dart';
 
-class AvailableLoadsScreen extends StatelessWidget {
-  const AvailableLoadsScreen({super.key});
+import '../models/app_models.dart';
+import '../services/marketplace_repository.dart';
+
+class AvailableLoadsScreen extends StatefulWidget {
+  const AvailableLoadsScreen({
+    super.key,
+    MarketplaceRepository? repository,
+  }) : _repository = repository;
+
+  final MarketplaceRepository? _repository;
+
+  @override
+  State<AvailableLoadsScreen> createState() => _AvailableLoadsScreenState();
+}
+
+class _AvailableLoadsScreenState extends State<AvailableLoadsScreen> {
+  late final MarketplaceRepository _repository =
+      widget._repository ?? MarketplaceRepository();
+  late Future<List<LoadOffer>> _loadsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadsFuture = _repository.fetchLoadOffers();
+  }
+
+  @override
+  void dispose() {
+    if (widget._repository == null) {
+      _repository.dispose();
+    }
+    super.dispose();
+  }
+
+  void _refreshLoads() {
+    setState(() {
+      _loadsFuture = _repository.fetchLoadOffers();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +49,6 @@ class AvailableLoadsScreen extends StatelessWidget {
       ),
       body: Column(
         children: [
-          // Filtering UI (Placeholder)
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: SingleChildScrollView(
@@ -40,14 +76,45 @@ class AvailableLoadsScreen extends StatelessWidget {
               ),
             ),
           ),
-          
-          // Loads List
           Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              itemCount: 10, // Dummy count
-              itemBuilder: (context, index) {
-                return _buildLoadCard(context, index);
+            child: FutureBuilder<List<LoadOffer>>(
+              future: _loadsFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if (snapshot.hasError) {
+                  return _MessageState(
+                    icon: Icons.error_outline,
+                    title: 'Could not load available loads',
+                    message: snapshot.error.toString(),
+                    actionLabel: 'Retry',
+                    onAction: _refreshLoads,
+                  );
+                }
+
+                final loads = snapshot.data ?? const <LoadOffer>[];
+                if (loads.isEmpty) {
+                  return _MessageState(
+                    icon: Icons.inventory_2_outlined,
+                    title: 'No loads available',
+                    message: 'New load offers will appear here as they become available.',
+                    actionLabel: 'Refresh',
+                    onAction: _refreshLoads,
+                  );
+                }
+
+                return RefreshIndicator(
+                  onRefresh: () async => _refreshLoads(),
+                  child: ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    itemCount: loads.length,
+                    itemBuilder: (context, index) {
+                      return _buildLoadCard(context, loads[index]);
+                    },
+                  ),
+                );
               },
             ),
           ),
@@ -56,14 +123,7 @@ class AvailableLoadsScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildLoadCard(BuildContext context, int index) {
-    // Dummy data generation based on index
-    final origin = index % 2 == 0 ? "Mumbai, MH" : "Delhi, DL";
-    final destination = index % 2 == 0 ? "Pune, MH" : "Jaipur, RJ";
-    final distance = 150 + (index * 45); // km
-    final weight = 5.0 + index; // tons
-    final profitMargin = 2500 + (index * 500); // INR estimated profit
-
+  Widget _buildLoadCard(BuildContext context, LoadOffer load) {
     return Card(
       elevation: 2,
       margin: const EdgeInsets.only(bottom: 16.0),
@@ -73,7 +133,6 @@ class AvailableLoadsScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Locations Row
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -82,66 +141,51 @@ class AvailableLoadsScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Origin',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
+                        'Route',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.copyWith(color: Colors.grey),
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        origin,
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                        load.route,
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
                       ),
                     ],
                   ),
                 ),
-                const Icon(Icons.arrow_forward_outlined, color: Colors.blueAccent),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text(
-                        'Destination',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        destination,
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
-                ),
+                const SizedBox(width: 12),
+                Chip(label: Text(load.badgeLabel)),
               ],
             ),
-            
             const Divider(height: 32),
-            
-            // Stats Row
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                _buildStatColumn(context, Icons.route, '$distance km'),
-                _buildStatColumn(context, Icons.scale, '$weight Tons'),
+                _buildStatColumn(context, Icons.route, load.routeDistance),
+                _buildStatColumn(context, Icons.scale, load.weight),
                 _buildStatColumn(
-                  context, 
-                  Icons.account_balance_wallet, 
-                  '₹$profitMargin', 
-                  isHighlight: true
+                  context,
+                  Icons.account_balance_wallet,
+                  load.estimatedProfit,
+                  isHighlight: true,
                 ),
               ],
             ),
-            
             const SizedBox(height: 16),
-            
-            // Action Button
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: () {
-                  // TODO: Navigate to load details or accept load
-                },
+                onPressed: () {},
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 12),
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
                 child: const Text('View Details'),
               ),
@@ -152,7 +196,12 @@ class AvailableLoadsScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildStatColumn(BuildContext context, IconData icon, String value, {bool isHighlight = false}) {
+  Widget _buildStatColumn(
+    BuildContext context,
+    IconData icon,
+    String value, {
+    bool isHighlight = false,
+  }) {
     return Column(
       children: [
         Icon(icon, size: 20, color: isHighlight ? Colors.green : Colors.grey[600]),
@@ -160,11 +209,59 @@ class AvailableLoadsScreen extends StatelessWidget {
         Text(
           value,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            fontWeight: isHighlight ? FontWeight.bold : FontWeight.normal,
-            color: isHighlight ? Colors.green[700] : null,
-          ),
+                fontWeight: isHighlight ? FontWeight.bold : FontWeight.normal,
+                color: isHighlight ? Colors.green[700] : null,
+              ),
         ),
       ],
+    );
+  }
+}
+
+class _MessageState extends StatelessWidget {
+  const _MessageState({
+    required this.icon,
+    required this.title,
+    required this.message,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final String actionLabel;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: Colors.grey[600]),
+            const SizedBox(height: 12),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onAction,
+              child: Text(actionLabel),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace generated available-load rows with MarketplaceRepository data
- add loading, error, empty, retry, and pull-to-refresh states
- keep the card layout backed by LoadOffer fields instead of index-derived values

Fixes #5646

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.