### PR TITLE
fix: reject placeholder OCR scan results

### DIFF
--- a/apps/driver/lib/services/ocr_scanner_service.dart
+++ b/apps/driver/lib/services/ocr_scanner_service.dart
@@ -1,31 +1,21 @@
-import 'dart:math';
+import 'dart:io';
+
 import '../models/pod_document_model.dart';
 
 class OcrScannerService {
-  /// Simulates scanning an image file using an OCR engine (like Google ML Kit)
-  /// and extracting key Bill of Lading (BoL) data.
+  /// Scans an image file and extracts key Bill of Lading data.
   Future<PodDocument> scanDocument(String imagePath) async {
-    // Simulate processing delay for OCR engine
-    await Future.delayed(const Duration(seconds: 3));
+    final file = File(imagePath);
+    if (!await file.exists()) {
+      throw ArgumentError.value(
+        imagePath,
+        'imagePath',
+        'Document image does not exist.',
+      );
+    }
 
-    final randomId = Random().nextInt(10000).toString().padLeft(4, '0');
-    
-    // Simulated extracted text block
-    const mockExtractedText = '''
-    BILL OF LADING
-    Load Ref: TRK-992-AZ
-    Receiver: Acme Warehouse Corp
-    Date: 2026-07-27
-    Signature: [VERIFIED]
-    ''';
-
-    return PodDocument(
-      documentId: 'DOC-$randomId',
-      loadReferenceNumber: 'TRK-992-AZ',
-      receiverName: 'Acme Warehouse Corp',
-      scanTimestamp: DateTime.now(),
-      hasSignature: true,
-      rawExtractedText: mockExtractedText,
+    throw UnsupportedError(
+      'OCR scanning is not configured. Connect an OCR provider before accepting scanned PoD data.',
     );
   }
 


### PR DESCRIPTION
## Summary
- validate that the supplied document image path exists
- remove hardcoded Bill of Lading extraction data
- throw a clear unsupported error until a real OCR provider is connected

Fixes #5649

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.