### PR TITLE
fix: stop reporting PoD submission without upload

### DIFF
--- a/apps/driver/lib/services/ocr_scanner_service.dart
+++ b/apps/driver/lib/services/ocr_scanner_service.dart
@@ -31,8 +31,8 @@ class OcrScannerService {
 
   /// Submits the processed digital PoD to the blockchain ledger for immutable storage
   Future<bool> submitDigitalPoD(PodDocument document) async {
-    // Simulate network upload
-    await Future.delayed(const Duration(seconds: 1));
-    return true; // Success
+    throw UnsupportedError(
+      'Digital PoD submission is not configured. Connect the backend or ledger submission endpoint before reporting success.',
+    );
   }
 }


### PR DESCRIPTION
## Summary
- remove the simulated PoD upload delay
- stop returning success without a backend or ledger side effect
- throw a clear configuration error until real submission is implemented

Fixes #5650

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.