### PR TITLE
fix: stop returning mock commercial routes

### DIFF
--- a/apps/driver/lib/services/commercial_navigation_service.dart
+++ b/apps/driver/lib/services/commercial_navigation_service.dart
@@ -1,38 +1,11 @@
-import 'dart:async';
 import '../models/truck_profile_model.dart';
 
 class CommercialNavigationService {
-  /// Simulates querying a commercial routing API (like HERE Maps) that factors
-  /// in truck dimensions and hazmat status to generate a safe route.
+  /// Calculates a commercial route that factors in truck dimensions and hazmat
+  /// status.
   Future<NavigationRoute> calculateSafeRoute(String origin, String destination, TruckProfile profile) async {
-    // Simulate API latency
-    await Future.delayed(const Duration(seconds: 2));
-
-    List<String> hazardsAvoided = [];
-
-    // Simulate routing logic
-    if (profile.heightFeet > 13.0) {
-      hazardsAvoided.add('Low Clearance Bridge (11ft 8in) on Main St');
-    }
-    
-    if (profile.grossWeightLbs > 60000) {
-      hazardsAvoided.add('Weight Restricted County Road (10 Tons)');
-    }
-
-    if (profile.hazmatClass != 'NONE') {
-      hazardsAvoided.add('Downtown Tunnel (Hazmat Restricted)');
-    }
-
-    // A mock standard route would be 50 miles, but commercial routing might be longer
-    // to avoid hazards.
-    final penaltyMiles = hazardsAvoided.length * 5.5;
-
-    return NavigationRoute(
-      routeId: 'RTE-${DateTime.now().millisecondsSinceEpoch}',
-      polylineEncoded: 'mock_polyline_data_here',
-      distanceMiles: 45.0 + penaltyMiles,
-      estimatedTimeMinutes: 55.0 + (penaltyMiles * 1.5),
-      avoidedHazards: hazardsAvoided,
+    throw UnsupportedError(
+      'Commercial navigation is not configured. Connect a truck-routing provider before displaying safe-route guidance.',
     );
   }
 }


### PR DESCRIPTION
## Summary
- remove synthetic hazard and distance calculations from commercial navigation
- stop returning the placeholder polyline value
- throw a clear configuration error until a truck-routing provider is connected

Fixes #5651

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.