### PR TITLE
fix: stop returning fixed predictive ETA delays

### DIFF
--- a/apps/driver/lib/services/eta_ml_engine.dart
+++ b/apps/driver/lib/services/eta_ml_engine.dart
@@ -1,48 +1,15 @@
-import 'dart:async';
 import '../models/predictive_eta_model.dart';
 
 class EtaMlEngine {
-  /// Simulates querying an ML model that predicts a highly accurate ETA
-  /// based on Hours of Service, historical wait times, and weather.
+  /// Calculates a predictive ETA from load, HoS, facility, weather, and traffic
+  /// inputs.
   Future<PredictiveEta> calculatePredictiveEta({
     required String loadId,
     required double remainingDriveTimeHours,
     required String destinationFacilityId,
   }) async {
-    // Simulate ML model inference delay
-    await Future.delayed(const Duration(seconds: 2));
-
-    // Base mock calculation
-    final now = DateTime.now();
-    final standardEta = now.add(const Duration(hours: 4)); // e.g. 240 miles at 60mph
-    
-    // Simulate ML factors
-    Map<String, int> factors = {};
-    int totalDelayMinutes = 0;
-
-    // Driver needs a mandatory 30-minute rest break
-    if (remainingDriveTimeHours < 4.0) {
-      factors['Mandatory HoS Rest Break'] = 30;
-      totalDelayMinutes += 30;
-    }
-
-    // Historical wait time at this specific warehouse (e.g. Walmart DC usually takes 45 mins to get a door)
-    factors['Historical Dock Dwell Time'] = 45;
-    totalDelayMinutes += 45;
-
-    // Simulate a weather delay overlay
-    factors['Heavy Rain / Traffic (I-95)'] = 20;
-    totalDelayMinutes += 20;
-
-    final mlPredictedEta = standardEta.add(Duration(minutes: totalDelayMinutes));
-
-    return PredictiveEta(
-      loadId: loadId,
-      baseDistanceMiles: 240.0,
-      standardEta: standardEta,
-      mlPredictedEta: mlPredictedEta,
-      addedDelayMinutes: totalDelayMinutes,
-      delayFactors: factors,
+    throw UnsupportedError(
+      'Predictive ETA is not configured. Connect the ETA model endpoint before displaying ML ETA results.',
     );
   }
 }


### PR DESCRIPTION
## Summary
- remove fixed ETA, distance, and delay factor calculations
- stop ignoring load and destination inputs while presenting an ML result
- throw a clear configuration error until the ETA model endpoint is connected

Fixes #5652

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.