### PR TITLE
fix: guard HOS API base URL in release

### DIFF
--- a/apps/driver/lib/services/hos_service.dart
+++ b/apps/driver/lib/services/hos_service.dart
@@ -3,11 +3,10 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'api_client.dart';
+
 class HosService {
-  static const String _defaultApiBaseUrl = String.fromEnvironment(
-    'TRUXIFY_API_BASE_URL',
-    defaultValue: 'http://localhost:5000',
-  );
+  static String get _defaultApiBaseUrl => ApiClient.defaultBaseUrl;
 
   /// Statuses: 'off_duty', 'on_duty', 'driving', 'resting'
   static Future<bool> updateStatus(String status) async {


### PR DESCRIPTION
## Summary
- remove the HOS service's standalone localhost default
- use the shared ApiClient.defaultBaseUrl configuration guard
- fail fast in release builds when TRUXIFY_API_BASE_URL is missing

Fixes #5653

## Testing
- Not run: Dart/Flutter tooling is not installed in this environment.