### PR TITLE
fix: make WebRTC connection handler async to fix await syntax error

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -17,7 +17,7 @@ class WebRTCSignalingServer {
   }
 
   setupWebSocket() {
-    this.wss.on('connection', (ws, req) => {
+    this.wss.on('connection', async (ws, req) => {
       const url = new URL(req.url, `http://${req.headers.host}`);
 
       // Authenticate via token query parameter or Authorization header


### PR DESCRIPTION
## Description

Fixes #5665

`WebRTCSignalingServer.js` used `await verifyAuthToken(token)` inside a `ws.on('connection', ...)` callback that was **not** declared `async`. That is a parse-time `SyntaxError` in ES modules, so the module could not be imported — and since `index.js:79` statically imports `sockets/webrtc.js` → `WebRTCSignalingServer.js`, **the entire API server failed to boot**.

Verified before/after:
- Before: `node --input-type=module -e "await import(...)"` → `Unexpected reserved word`
- After: module parses cleanly (`node --check` passes)

## Changes
- `backend/api/src/services/webrtc/WebRTCSignalingServer.js`: declare the `connection` handler `async`

## Testing
- `node --check src/services/webrtc/WebRTCSignalingServer.js` → passes
- No new dependencies.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection authentication by ensuring token verification completes before the connection proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->