### PR TITLE
fix: import requireRole in loadRoutes.js to prevent boot crash

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -51,7 +51,7 @@
 
 import express from 'express';
 import { supabase } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
## Description

Fixes #5666

`requireRole(['customer'])` is used in the `POST /api/loads` route chain (`loadRoutes.js:311`) but was never imported. Because `index.js:37` statically imports `loadRoutes`, evaluating the route chain threw `ReferenceError: requireRole is not defined` at boot — **the whole server failed to start**.

## Changes
- `backend/api/src/routes/loadRoutes.js`: add `requireRole` to the existing `auth.js` import

## Testing
- `node --check src/routes/loadRoutes.js` → passes
- `requireRole` export confirmed present at `middleware/auth.js:349`

GSSOC
