### PR TITLE
fix: use pg-compatible executeQuery in shard orders route

### DIFF
--- a/backend/api/src/routes/shardRoutes.js
+++ b/backend/api/src/routes/shardRoutes.js
@@ -89,9 +89,10 @@ router.get('/shards/location', authenticate, userLimiter, requirePolicy('shard:v
 router.get('/shards/:shardName/orders', authenticate, userLimiter, requirePolicy('shard:query-orders'), shardMiddleware, async (req, res) => {
   try {
     const { shardName } = req.params;
-    const connection = await shardManager.getShardConnection(shardName);
-    const [rows] = await connection.execute(
-      'SELECT * FROM orders ORDER BY created_at DESC LIMIT 100'
+    const rows = await shardManager.executeQuery(
+      'SELECT * FROM orders ORDER BY created_at DESC LIMIT 100',
+      [],
+      shardName
     );
     res.json({
       success: true,


### PR DESCRIPTION
## Description

Fixes #5667

`GET /shards/:shardName/orders` called `connection.execute(...)` on a **node-postgres `pg` Pool**, which exposes `.query()` (not mysql2's `.execute()`), and destructured the result as a `[rows, fields]` tuple though `.query()` resolves to `{ rows, rowCount, ... }`. Every request threw `TypeError: connection.execute is not a function` → always HTTP 500, endpoint dead.

`ShardManager.executeQuery` already exists and handles pg's `.query()` correctly (`ShardManager.js:165-183`).

## Changes
- `backend/api/src/routes/shardRoutes.js`: replace the `getShardConnection` + `.execute()` block with `shardManager.executeQuery(query, [], shardName)`, which returns `result.rows`

## Testing
- `node --check src/routes/shardRoutes.js` → passes
- Path now matches the documented pg API used elsewhere in the repo

GSSOC
