### PR TITLE
fix: use driver_id instead of non-existent owner_id in truckRoutes

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -209,7 +209,7 @@ router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, val
 
     const { data: truck, error: insertErr } = await supabase
       .from('trucks')
-      .insert({ name, number_plate: normalizedNumberPlate, max_capacity_tons, owner_id: req.user.id })
+      .insert({ name, number_plate: normalizedNumberPlate, max_capacity_tons, driver_id: req.user.id })
       .select('id, name, number_plate, max_capacity_tons, created_at')
       .single();
 
@@ -289,7 +289,7 @@ router.get('/', authenticate, requirePolicy('truck:list-own'), userLimiter, asyn
     let query = supabase
       .from('trucks')
       .select('id, name, number_plate, max_capacity_tons, created_at')
-      .eq('owner_id', req.user.id);
+      .eq('driver_id', req.user.id);
 
     if (name && typeof name === 'string') {
       const cleanName = name.trim();
@@ -337,7 +337,7 @@ function isLongitude(value) {
 }
 
 async function canViewTruckNumber(user, truck) {
-  if (user.role === 'admin' || truck.owner_id === user.id) {
+  if (user.role === 'admin' || truck.driver_id === user.id) {
     return { allowed: true };
   }
 
@@ -684,7 +684,7 @@ router.get('/:id/number', authenticate, userLimiter, validateParams(uuidParamSch
   try {
     const { data: truck, error } = await supabase
       .from('trucks')
-      .select('id, owner_id, number_plate')
+      .select('id, driver_id, number_plate')
       .eq('id', req.params.id)
       .maybeSingle();
 


### PR DESCRIPTION
## Description

Fixes #5668

The `trucks` table uses `driver_id` (see `docs/supabase_setup.sql:139-156` and the RLS policies in `supabase/migrations/20240101000000_rls.sql`), but `truckRoutes.js` referenced a non-existent `owner_id` column in four places:
- register truck INSERT
- "list my trucks" `.eq()` filter
- ownership check in `canViewTruckNumber`
- number-plate SELECT

Every truck operation failed with `column "owner_id" does not exist` → 500.

## Changes
- `backend/api/src/routes/truckRoutes.js`: replace all four `owner_id` references with `driver_id`

## Testing
- `node --check src/routes/truckRoutes.js` → passes
- `owner_id` no longer appears anywhere in the file; column matches the schema + RLS

GSSOC
