### PR TITLE
fix: align POST /api/loads insert with load_offers schema

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -310,7 +310,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
 // ============================================================================
 router.post('/', authenticate, userLimiter, requireRole(['customer']), async (req, res) => {
   try {
-    const { origin, destination, weight_tons, truck_type_required, expected_price, material_type } = req.body;
+    const { origin, destination, weight_tons, expected_price, material_type } = req.body;
 
     if (!origin || !origin.lat || !origin.lng) {
       return res.status(400).json({ error: 'Origin with lat/lng is required' });
@@ -319,20 +319,30 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), async (re
       return res.status(400).json({ error: 'Destination with lat/lng is required' });
     }
 
-    // Convert to PostGIS Geography POINT format
-    const pickupGeom = `POINT(${origin.lng} ${origin.lat})`;
-    const dropGeom = `POINT(${destination.lng} ${destination.lat})`;
+    if (weight_tons === undefined || weight_tons === null || Number.isNaN(Number(weight_tons))) {
+      return res.status(400).json({ error: 'Valid weight_tons is required' });
+    }
+    if (expected_price === undefined || expected_price === null || Number.isNaN(Number(expected_price))) {
+      return res.status(400).json({ error: 'Valid expected_price is required' });
+    }
+
+    const pickupAddress = origin.address || 'Unknown Origin';
+    const dropAddress = destination.address || 'Unknown Destination';
+    const routeLabel = `${pickupAddress.split(',')[0]} \u2192 ${dropAddress.split(',')[0]}`;
 
     const { data, error } = await supabase
       .from('load_offers')
       .insert({
         customer_id: req.user.id,
-        pickup_address: origin.address || 'Unknown Origin',
-        drop_address: destination.address || 'Unknown Destination',
-        pickup_geom: pickupGeom,
-        drop_geom: dropGeom,
-        weight_tons: parseFloat(weight_tons),
-        truck_type_required: truck_type_required,
+        customer_name: req.user.fullName || 'Customer',
+        pickup_address: pickupAddress,
+        drop_address: dropAddress,
+        pickup_lat: origin.lat,
+        pickup_lng: origin.lng,
+        drop_lat: destination.lat,
+        drop_lng: destination.lng,
+        route_label: routeLabel,
+        weight: `${weight_tons} tonnes`,
         freight_value: Math.round(parseFloat(expected_price) * 100), // Assuming paisa representation
         goods_type: material_type || 'General',
         status: 'available'


### PR DESCRIPTION
## Description

Fixes #5669

`POST /api/loads` inserted into `load_offers` using columns that **don't exist** in the schema and omitted several **NOT NULL** columns, so every load posting failed:
- Non-existent: `pickup_geom`, `drop_geom`, `weight_tons`, `truck_type_required`
- Omitted NOT NULL: `customer_name`, `route_label`, `weight`

Actual schema (`docs/supabase_setup.sql:404-461`) uses `pickup_lat/pickup_lng`/`drop_lat/drop_lng`, `weight` (text), and requires `customer_name`, `route_label`.

## Changes
- `backend/api/src/routes/loadRoutes.js`:
  - Map origin/destination to `pickup_lat/lng`, `drop_lat/lng`
  - Set `weight` as text (`"${weight_tons} tonnes"`)
  - Build `route_label` from addresses, `customer_name` from the authenticated profile
  - Drop the 4 non-existent columns
  - Add up-front validation for `weight_tons` and `expected_price` (replaces the silent `NaN` values)

## Testing
- `node --check src/routes/loadRoutes.js` → passes
- Insert fields now match every column in the `load_offers` DDL

GSSOC
