### PR TITLE
fix: filter truck search using truck_type instead of model name

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -188,7 +188,7 @@ function parseCapacityFilter(value, field) {
  *         description: Number plate already registered
  */
 router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, validateBody(registerTruckSchema), async (req, res) => {
-  const { name, number_plate, max_capacity_tons } = req.body;
+  const { name, truck_type, number_plate, max_capacity_tons } = req.body;
   const normalizedNumberPlate = sanitizeNumberPlate(number_plate);
 
   try {
@@ -209,8 +209,8 @@ router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, val
 
     const { data: truck, error: insertErr } = await supabase
       .from('trucks')
-      .insert({ name, number_plate: normalizedNumberPlate, max_capacity_tons, driver_id: req.user.id })
-      .select('id, name, number_plate, max_capacity_tons, created_at')
+      .insert({ name, truck_type, number_plate: normalizedNumberPlate, max_capacity_tons, driver_id: req.user.id })
+      .select('id, name, truck_type, number_plate, max_capacity_tons, created_at')
       .single();
 
     if (insertErr) {
@@ -587,7 +587,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     const driverIds = drivers.map(d => d.user_id);
 
     const [trucksRes, profilesRes] = await Promise.all([
-      supabase.from('trucks').select('id, name, number_plate, max_capacity_tons').in('id', truckIds),
+      supabase.from('trucks').select('id, name, number_plate, max_capacity_tons, truck_type').in('id', truckIds),
       supabase.from('profiles').select('id, full_name, avatar_url').in('id', driverIds),
     ]);
 
@@ -619,6 +619,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
         truckNumber: truck.number_plate || '',
         capacity: truck.max_capacity_tons ? `${truck.max_capacity_tons} tonnes` : '',
         capacityTons: truck.max_capacity_tons || 0,
+        truckType: truck.truck_type || '',
         price: finalTotalAmount,
         baseFreight: finalBaseFreight,
         tollEstimate: finalTollEstimate,
@@ -636,16 +637,14 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
         return false;
       }
       if (truck_type && truck_type !== '') {
-        const truckNameLower = (truck.truck || '').toLowerCase();
-        const typeLower = truck_type.toLowerCase();
-        if (!truckNameLower.includes(typeLower)) {
+        if (truck.truckType !== truck_type) {
           return false;
         }
       }
       return true;
     });
 
-    const responseResults = filteredResults.map(({ capacityTons, ...rest }) => rest);
+    const responseResults = filteredResults.map(({ capacityTons, truckType, ...rest }) => rest);
 
     res.json(responseResults);
   } catch (err) {

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -241,6 +241,9 @@ export const registerTruckSchema = z.object({
   name: z.string()
     .min(2, 'Truck name must be at least 2 characters')
     .max(100, 'Truck name must be 100 characters or fewer'),
+  truck_type: z.enum(['Open Body', 'Closed Body', 'Container', 'Refrigerated'], {
+    invalid_type_error: 'truck_type must be one of: Open Body, Closed Body, Container, Refrigerated',
+  }),
   number_plate: z.string()
     .transform((v) => v.trim().toUpperCase().replace(/[^A-Z0-9]/g, ''))
     .pipe(

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -140,6 +140,8 @@ create table if not exists trucks (
   id                    uuid primary key default gen_random_uuid(),
   driver_id             uuid not null,                        -- profiles.id
   name                  text not null,                        -- e.g. 'Tata 407'
+  truck_type            text not null default 'Open Body'
+                        check (truck_type in ('Open Body','Closed Body','Container','Refrigerated')),
   number_plate          text not null,                        -- e.g. 'TN 45 AB 1234'
   max_capacity_tons     numeric(6,2) not null default 0,
   cargo_length_ft       numeric(6,2),


### PR DESCRIPTION
## Summary

This PR fixes truck search filtering by introducing and using a dedicated `truck_type` field instead of comparing the selected body type against the truck model name.

### Changes
- Added `truck_type` column to the `trucks` table with valid constraints.
- Added request validation for `truck_type`.
- Stored `truck_type` when registering trucks.
- Updated truck search to filter using `truck_type`.
- Removed reliance on truck model name for body-type filtering.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Truck registration now captures and displays the truck type.
  - Supported types include Open Body, Closed Body, Container, and Refrigerated.
  - Truck search can filter results by exact truck type.

- **Bug Fixes**
  - Search results no longer match truck types against truck names.
  - Internal capacity and type details are excluded from search responses where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->