### PR TITLE
perf(telemetry): add compound index to eliminate full collection scans (fixes #5691)

### DIFF
--- a/backend/api/src/config/db.js
+++ b/backend/api/src/config/db.js
@@ -146,6 +146,10 @@ export async function waitForMongoDb() {
       ).catch(err => logger.error({ err }, 'Failed to create TTL index on telemetry'));
 
       mongoDb.collection('telemetry').createIndex(
+        { driver_id: 1, order_id: 1, timestamp: -1 }
+      ).catch(err => logger.error({ err }, 'Failed to create compound index on telemetry'));
+
+      mongoDb.collection('telemetry').createIndex(
         { location: '2dsphere' }
       ).catch(err => logger.error({ err }, 'Failed to create 2dsphere index on telemetry'));
       if (_mongoDbResolve) _mongoDbResolve();


### PR DESCRIPTION
### Summary
Closes #5691

This pull request resolves a critical performance bottleneck in the live tracking feature (`GET /api/orders/:id/driver-location`). Previously, querying the `telemetry` collection without a compound index resulted in full collection scans (O(N)), which degraded database performance.

### Changes
- Modified `backend/api/src/config/db.js`:
  - Added a compound index `{ driver_id: 1, order_id: 1, timestamp: -1 }` on the `telemetry` collection to optimize the location queries.

### Acceptance Criteria
- [x] O(N) full collection scan is eliminated.
- [x] Database queries use the new compound index.

### Impact & Side Effects
- Performance optimization for live tracking endpoints. No breaking changes or side effects.

### How to Test
1. Start the backend.
2. Verify that MongoDB creates the compound index on startup by checking the `telemetry` collection's indexes.

### Quality Checklist
- [x] I have tested my changes locally.
- [x] I have added/updated tests if applicable.
- [x] Linting and tests pass locally.
