### PR TITLE
sec(zkp): enforce IDOR authorization checks on kyc endpoints (fixes #5692)

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -21,6 +21,13 @@ router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
   try {
     const { userId, name, licenseNumber, rcNumber, insuranceNumber, issueDate, expiryDate } = req.body;
     
+    if (userId !== req.user.id && req.user.role !== 'admin' && req.user.role !== 'regulator') {
+      return res.status(403).json({
+        success: false,
+        error: 'Access Denied: You can only verify your own account.'
+      });
+    }
+
     if (!userId || !name || !licenseNumber) {
       return res.status(400).json({
         success: false,
@@ -65,6 +72,14 @@ router.post('/zkp/verify', authenticate, userLimiter, async (req, res) => {
 router.get('/zkp/status/:userId', authenticate, userLimiter, async (req, res) => {
   try {
     const { userId } = req.params;
+
+    if (userId !== req.user.id && req.user.role !== 'admin' && req.user.role !== 'regulator') {
+      return res.status(403).json({
+        success: false,
+        error: 'Access Denied: You can only view your own status.'
+      });
+    }
+
     const verified = await zkpService.isVerified(userId);
     
     res.json({


### PR DESCRIPTION
### Summary
Closes #5692

This pull request resolves a critical IDOR vulnerability in the Zero-Knowledge Proof (ZKP) KYC endpoints. Previously, any authenticated user could verify or view the status of arbitrary accounts by modifying the `userId` in the payload or URL parameters. This PR adds authorization checks to ensure the `userId` matches the authenticated `req.user.id` or that the requester holds the `admin`/`regulator` role.

### Changes
- Modified `backend/api/src/routes/zkp.routes.js`:
  - `POST /zkp/verify`: Added explicit check `userId === req.user.id || req.user.role === 'admin' || req.user.role === 'regulator'` returning `403 Forbidden` if violated.
  - `GET /zkp/status/:userId`: Added explicit check `userId === req.user.id || req.user.role === 'admin' || req.user.role === 'regulator'` returning `403 Forbidden` if violated.

### Acceptance Criteria
- [x] Users can only verify their own account unless they are an admin.
- [x] Users can only view their own status unless they are an admin.

### Impact & Side Effects
- Resolves IDOR vulnerability (Security Hardening).
- Standard users attempting to access cross-tenant data will receive a `403 Forbidden` response.

### How to Test
1. Start the backend server locally.
2. Login as a standard driver and attempt to verify KYC for another driver's `userId`.
3. Verify that the server returns a `403` error instead of processing the verification.

### Quality Checklist
- [x] I have tested my changes locally.
- [x] I have added/updated tests if applicable.
- [x] Linting and tests pass locally.
