### PR TITLE
sec(voice): add file size limit and validation to prevent DoS (fixes #5693)

### DIFF
--- a/backend/api/src/routes/voice.routes.js
+++ b/backend/api/src/routes/voice.routes.js
@@ -6,8 +6,17 @@ import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
-const upload = multer({ dest: 'uploads/voice/' }); // Temporary storage for incoming audio
-
+const upload = multer({
+  dest: 'uploads/voice/', // Temporary storage for incoming audio
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB limit
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith('audio/')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Invalid file type. Only audio is allowed.'));
+    }
+  }
+});
 /**
  * @swagger
  * /api/v1/voice/assistant:


### PR DESCRIPTION
### Summary
Closes #5693

This pull request mitigates a Denial of Service (DoS) vulnerability in the Voice AI Assistant endpoint (`POST /api/v1/voice/assistant`). Previously, the `multer` middleware was configured without any file size limits, allowing malicious actors to upload arbitrarily large files and exhaust server disk space instantly.

### Changes
- Modified `backend/api/src/routes/voice.routes.js`:
  - Added `limits: { fileSize: 10 * 1024 * 1024 }` (10MB) to the `multer` configuration.
  - Added a `fileFilter` to strictly allow only MIME types starting with `audio/`, rejecting invalid formats before they are fully written to disk.

### Acceptance Criteria
- [x] File uploads over 10MB are rejected automatically.
- [x] Non-audio files are rejected.
- [x] The backend disk space is protected from Unrestricted File Upload attacks on this endpoint.

### Impact & Side Effects
- Security hardening for Voice AI endpoints.
- Valid audio clips are typically < 1MB, so the 10MB limit will not affect normal user functionality.

### How to Test
1. Start the backend server locally.
2. Attempt to upload a 20MB file or a non-audio file (e.g., a `.txt` file) to `/api/v1/voice/assistant`.
3. Verify that the server rejects the request with an error and does not save the file to `uploads/voice/`.

### Quality Checklist
- [x] I have tested my changes locally.
- [x] I have added/updated tests if applicable.
- [x] Linting and tests pass locally.
