### PR TITLE
fix(api): export broadcastOrderMilestone to fix ESM boot failure 

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1061,6 +1061,29 @@ export async function closeWebSocketServer() {
   });
 }
 
+export function broadcastOrderMilestone(orderDisplayId, milestone, status) {
+  if (!orderDisplayId || !trackingSubscriptions.has(orderDisplayId)) {
+    return;
+  }
+
+  const payload = JSON.stringify({
+    event: 'milestone_update',
+    data: {
+      order_display_id: orderDisplayId,
+      milestone,
+      status,
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  const clients = trackingSubscriptions.get(orderDisplayId);
+  clients.forEach((client) => {
+    if (client.readyState === 1) {
+      client.send(payload);
+    }
+  });
+}
+
 export async function handleSubscribe(ws, data) {
   const { order_display_id, driver_id } = data;
   const targetId = order_display_id || driver_id;


### PR DESCRIPTION
## Fix: Export broadcastOrderMilestone to Fix the API Boot ESM Error (#5702)

### Problem
The backend API crashed at boot with an ESM link error: `backend/api/src/core/container.js:10` imports `orderMilestoneService`, which imports `broadcastOrderMilestone` from `sockets/tracker.js` — but `tracker.js` never exported it, so module resolution failed and the whole server failed to start.

### Changes
- `backend/api/src/sockets/tracker.js`: added the missing exported `broadcastOrderMilestone(orderDisplayId, milestone, status)`, which sends `{ event: 'milestone_update', data: { order_display_id, milestone, status, timestamp } }` to clients subscribed in `trackingSubscriptions` — following the existing broadcast pattern used by `handleLocationPing`.
- Verified the module loads (`import(...)` → "MODULE LOADED OK") and lint is clean.

### Impact
The API server boots successfully; milestone updates broadcast to subscribed tracking clients.

Closes #5702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time order milestone updates for active subscribers.
  * Updates are delivered only through open connections and are skipped when no active subscribers are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->