### PR TITLE
fix(escrow): reject reverted releasePayment receipts before crediting driver

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -372,6 +372,10 @@ export async function escrowRelease (orderDisplayId) {
     const tx = await escrowContract.releasePayment(bookingId)
     logger.info(`[escrow] releasePayment tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
     const receipt = await tx.wait(1)
+    if (!receipt || receipt.status === 0) {
+      logger.error(`[escrow] releasePayment reverted or not found for booking ${orderDisplayId}`)
+      return { txHash: null, bookingId, error: 'release reverted' }
+    }
     logger.info(`[escrow] releaseFunds confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
     return { txHash: receipt.hash, bookingId }
   } catch (err) {


### PR DESCRIPTION
## Fix: Reject Reverted Escrow Releases Before Crediting the Driver (#5703)

### Problem
`escrowRelease` awaited `tx.wait(1)` but never inspected the transaction receipt. A reverted release (`receipt.status === 0`) was treated as success, and the caller proceeded to credit the driver wallet for an on-chain release that never happened.

### Changes
- `backend/api/src/services/escrow.js` `escrowRelease`: after `tx.wait(1)`, added `if (!receipt || receipt.status === 0) return { txHash: null, bookingId, error: 'release reverted' }` — mirroring the status checks already present in `recordDepositTx`, `submitEscrowRefund`, and `confirmEscrowRefund`.

### Impact
A reverted release can no longer produce a phantom `txHash` or a driver wallet credit; the caller sees `release reverted`.

Closes #5703