### PR TITLE
fix(delivery): persist escrow release outcome before complete_trip_tx to avoid deadlock

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -57,7 +57,7 @@ export class DeliveryVerificationService {
       });
     }
 
-    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, drop_lat, drop_lng, toll_estimate, base_freight, platform_fee, total_amount');
+    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, release_tx_hash, drop_lat, drop_lng, toll_estimate, base_freight, platform_fee, total_amount');
 
     if (orderErr || !order) {
       throw new DomainError(404, { error: 'Order not found.' });
@@ -270,6 +270,26 @@ export class DeliveryVerificationService {
           retryable: true,
         });
       }
+
+      // Persist the confirmed release outcome immediately so a later
+      // complete_trip_tx failure is recoverable: escrow_status becomes
+      // 'released' before the RPC runs, so the SQL gate no longer blocks
+      // retries with a NULL release hash.
+      if (releaseTxHash || escrowAlreadyReleased) {
+        const { error: persistReleaseErr } = await this.orderRepository.updateOrder(orderId, {
+          escrow_status: 'released',
+          escrow_release_error: null,
+          escrow_released_at: new Date().toISOString(),
+          release_tx_hash: releaseTxHash,
+        });
+
+        if (persistReleaseErr) {
+          logger.error('[escrow] Release confirmed but persistence failed:', persistReleaseErr.message);
+        }
+      }
+    } else if (order.escrow_status === 'released') {
+      // Release was confirmed in a previous attempt — reuse the persisted hash.
+      releaseTxHash = order.release_tx_hash || null;
     } else {
       logger.info(`[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`);
     }


### PR DESCRIPTION
## Fix: Persist the Escrow Release Outcome Before complete_trip_tx (#5704)

### Problem
`verifyDelivery` released the escrow on-chain and then called `complete_trip_tx`. If that RPC failed transiently, `escrow_status` remained `funded`/`release_failed` with no `release_tx_hash` persisted — and the SQL gate (`RAISE EXCEPTION ... p_release_tx_hash IS NULL`) deadlocked every retry, blocking the order from ever completing.

### Changes
- `backend/api/src/services/order/deliveryVerificationService.js` `verifyDelivery`
  - Added `release_tx_hash` to the order select.
  - After a successful on-chain release (or when already released), persists `escrow_status: 'released'`, `release_tx_hash`, `escrow_release_error: null`, and `escrow_released_at` **before** calling `complete_trip_tx`.
  - The `escrow_status === 'released'` branch reuses the persisted hash instead of discarding it.
- Verified: `escrow.test.js` + `deliveryVerificationGeofence.test.js` pass 43/43.

### Impact
A transient RPC failure after release is now retryable — the released state and hash are already persisted, so the order can finish without deadlocking against the SQL gate.

Closes #5704
