### PR TITLE
fix(location): verify bookings against real orders table

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -29,21 +29,7 @@ async function getBookingContext(bookingId) {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const isUuid = uuidRegex.test(bookingId);
 
-  // Try bookings table first
-  try {
-    let query = supabase.from('bookings').select('*');
-    if (isUuid) {
-      query = query.eq('id', bookingId);
-    } else {
-      query = query.eq('booking_display_id', bookingId);
-    }
-    const { data: booking } = await query.maybeSingle();
-    if (booking) return booking;
-  } catch (err) {
-    logger.warn('Bookings table check failed in voiceService:', err.message);
-  }
-
-  // Fallback to orders table
+  // Orders table is the real order model (there is no bookings table).
   try {
     let orderQuery = supabase.from('orders').select('*');
     if (isUuid) {

--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -290,12 +290,16 @@ async function verifyCustomerToken(socket, next) {
  */
 async function verifyDriverAssignment(driverId, bookingId) {
   try {
-    const { data, error } = await supabase
-      .from("bookings")
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUuid = uuidRegex.test(bookingId);
+
+    let query = supabase
+      .from("orders")
       .select("id")
-      .eq("id", bookingId)
-      .eq("driver_id", driverId)
-      .single();
+      .eq("driver_id", driverId);
+    query = isUuid ? query.eq("id", bookingId) : query.eq("order_display_id", bookingId);
+
+    const { data, error } = await query.maybeSingle();
 
     if (error || !data) return false;
     return true;
@@ -311,14 +315,16 @@ async function verifyDriverAssignment(driverId, bookingId) {
  */
 async function verifyBookingOwnership(customerId, bookingId) {
   try {
-    // Use Supabase client from existing db module
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUuid = uuidRegex.test(bookingId);
 
-    const { data, error } = await supabase
-      .from("bookings")
+    let query = supabase
+      .from("orders")
       .select("id")
-      .eq("id", bookingId)
-      .eq("customer_id", customerId)
-      .single();
+      .eq("customer_id", customerId);
+    query = isUuid ? query.eq("id", bookingId) : query.eq("order_display_id", bookingId);
+
+    const { data, error } = await query.maybeSingle();
 
     if (error || !data) return false;
     return true;


### PR DESCRIPTION
## Fix: Point Location-Server and Voice Helpers at the Real Orders Table (#5705)

### Problem
`verifyDriverAssignment` and `verifyBookingOwnership` in `backend/api/src/sockets/locationServer.js`, plus `getBookingContext` in `backend/api/src/services/voiceService.js`, queried `supabase.from('bookings')` — a table that does not exist anywhere in the schema (the real model is `orders`). Every driver/customer socket connection was rejected with "Forbidden" and voice lookups failed.

### Changes
- `backend/api/src/sockets/locationServer.js`: both verify helpers now query `supabase.from('orders')`, matching by `id` (when the booking id is a UUID) or `order_display_id`, combined with `.eq('driver_id', driverId)` / `.eq('customer_id', customerId)`.
- `backend/api/src/services/voiceService.js`: `getBookingContext` queries `orders` directly (`id` or `order_display_id`), dropping the non-existent `bookings` branch.

### Impact
Driver/customer socket connections verify against the real order model, and voice OTP context lookups resolve correctly.

Closes #5705