### PR TITLE
fix(otp): block resend/regenerate during lockout, stop clearing lockout

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -117,6 +117,12 @@ export class DeliveryVerificationService {
 
   async ensureDeliveryOtp({ orderId }) {
     return measureExecution('DeliveryVerificationService.ensureDeliveryOtp', async () => {
+    if (await checkOtpLockout(orderId)) {
+      throw new DomainError(429, {
+        error: `Too many failed OTP attempts. Delivery OTP is locked for ${OTP_LOCKOUT_MINUTES} minutes.`,
+      });
+    }
+
     const activeOtp = await this.notificationService.getActiveDeliveryOtp(orderId);
     if (activeOtp) {
       logger.warn(`[DeliveryVerificationService] Driver attempted OTP regeneration for order ${orderId}`);
@@ -135,6 +141,12 @@ export class DeliveryVerificationService {
 
   async resendDeliveryOtp({ orderId, customerId, orderDisplayId, orderStatus }) {
     return measureExecution('DeliveryVerificationService.resendDeliveryOtp', async () => {
+    if (await checkOtpLockout(orderId)) {
+      throw new DomainError(429, {
+        error: `Too many failed OTP attempts. Delivery OTP is locked for ${OTP_LOCKOUT_MINUTES} minutes.`,
+      });
+    }
+
     const terminalStatuses = ['delivered', 'cancelled', 'payment_released'];
     if (terminalStatuses.includes(orderStatus)) {
       throw new DomainError(400, { error: 'Cannot resend OTP for a completed or cancelled order.' });
@@ -143,12 +155,18 @@ export class DeliveryVerificationService {
       throw new DomainError(409, { error: 'Delivery OTP can only be sent after the shipment reaches the delivery location.' });
     }
 
+    const activeOtp = await this.notificationService.getActiveDeliveryOtp(orderId);
     const otp = crypto.randomInt(100000, 1000000).toString();
     const stored = await this.notificationService.storeDeliveryOtp(orderId, otp, OTP_TTL_MINUTES);
     if (!stored) {
       throw new Error('Failed to generate delivery OTP.');
     }
-    await clearOtpState(orderId);
+    // Only a fresh issuance after the previous OTP expired may reset the
+    // failure counter; an active-OTP resend keeps it so repeated resends
+    // cannot zero out the brute-force budget.
+    if (!activeOtp) {
+      await clearOtpState(orderId);
+    }
 
     const notifResult = await this.notificationService.sendDeliveryOtpNotification(customerId, orderDisplayId, otp);
     if (!notifResult.success) {

--- a/backend/api/src/services/order/orderNotificationService.js
+++ b/backend/api/src/services/order/orderNotificationService.js
@@ -72,11 +72,21 @@ export async function clearOtpState(orderId) {
   if (redisClient) {
     try {
       const countKey = `otp_failed_count:${orderId}`;
-      const lockKey = `otp_lockout:${orderId}`;
-      await redisClient.del(countKey, lockKey);
+      // Never delete otp_lockout — the lockout key self-expires via its own
+      // TTL, and clearing it here would let resend/regenerate paths reset the
+      // anti-brute-force guard on demand.
+      await redisClient.del(countKey);
       return;
     } catch (err) {
       logger.error('[OTP] Redis error in clearOtpState, falling back to memory:', err.message);
+    }
+  }
+  const record = inMemoryOtpFailedAttempts.get(orderId);
+  if (record) {
+    record.count = 0;
+    if (record.lockedUntil) {
+      // Respect the lockout window; the record is dropped when it expires.
+      return;
     }
   }
   inMemoryOtpFailedAttempts.delete(orderId);
@@ -98,8 +108,13 @@ export class OrderNotificationService {
    * @returns {Promise<{otp: string|null, notified: boolean}>}
    */
   async sendOrderNotification({ type, orderId, orderDisplayId, customerId }) {
+    if (await checkOtpLockout(orderId)) {
+      logger.warn(`[OTP] Rejected OTP issuance for locked order ${orderId}`);
+      return { otp: null, notified: false };
+    }
+
+    const activeOtp = await getActiveDeliveryOtp(orderId);
     if (type === 'delivery_otp_in_transit') {
-      const activeOtp = await getActiveDeliveryOtp(orderId);
       if (activeOtp) {
         logger.warn(`[OTP] Driver attempted OTP regeneration for order ${orderId}`);
         return { otp: null, notified: false };
@@ -110,7 +125,10 @@ export class OrderNotificationService {
     const stored = await storeDeliveryOtp(orderId, otp, OTP_TTL_MINUTES);
     if (!stored) return { otp: null, notified: false };
 
-    await clearOtpState(orderId);
+    // Only a fresh issuance after the previous OTP expired may reset the
+    // failure counter; an active-OTP resend keeps it so repeated resends
+    // cannot zero out the brute-force budget.
+    if (!activeOtp) await clearOtpState(orderId);
 
     const notifResult = await sendDeliveryOtpNotification(customerId, orderDisplayId, otp);
 


### PR DESCRIPTION
## Fix: Block Resend/Regenerate During OTP Lockout, Stop Clearing the Lockout (#5706)

### Problem
`clearOtpState` deleted **both** `otp_failed_count` **and** `otp_lockout`, and `resendDeliveryOtp`/`ensureDeliveryOtp`/`sendOrderNotification` called it unconditionally. Any caller could generate a fresh OTP and zero out the entire anti-brute-force state on demand — unlimited 5-guess bursts, so the lockout guard defeated itself through its own reset helper.

### Changes
- `backend/api/src/services/order/orderNotificationService.js`
  - `clearOtpState` now only clears the failure counter; it **never** deletes `otp_lockout` (the lockout key self-expires via TTL, and the in-memory record keeps `lockedUntil`).
  - `sendOrderNotification` rejects issuance (`{ otp: null, notified: false }`) while the lockout is active, and only resets the counter when the previous OTP expired (no active OTP) — an active-OTP resend keeps the counter.
- `backend/api/src/services/order/deliveryVerificationService.js`
  - `ensureDeliveryOtp` and `resendDeliveryOtp` call `checkOtpLockout` first and throw `DomainError(429)` while locked.
  - `resendDeliveryOtp` only resets the counter after the previous OTP expired, so repeated resends cannot zero out the brute-force budget.
  - `resendOtpFn` (orderLifecycleService) delegates to `resendDeliveryOtp`, so it inherits the 429 guard.

### Impact
After 5 failed guesses the order is locked for the full window — resend and regenerate paths reject with 429 and cannot reset the counter or the lockout.

Closes #5706