### PR TITLE
fix(#5723): reject non-positive withdraw amounts and harden driver wallet

### DIFF
--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -94,8 +94,8 @@ create table if not exists driver_details (
   total_trips       int not null default 0,
   completion_rate   numeric(5,2) not null default 100.00,     -- percentage
   is_online         boolean not null default false,
-  wallet_confirmed  int not null default 0,                   -- paisa
-  wallet_pending    int not null default 0,
+  wallet_confirmed  int not null default 0 check (wallet_confirmed >= 0),   -- paisa
+  wallet_pending    int not null default 0 check (wallet_pending >= 0),
   wallet_total      int not null default 0,
   created_at        timestamptz not null default now(),
   updated_at        timestamptz not null default now()
@@ -923,6 +923,11 @@ create policy "Drivers access own driver_details"
   using (user_id = get_profile_id())
   with check (user_id = get_profile_id());
 
+-- Only the backend (service_role) may write wallet balance columns (Issue #5723).
+-- Blocks direct PATCH /rest/v1/driver_details with wallet_* fields.
+revoke update (wallet_confirmed, wallet_pending, wallet_total)
+  on driver_details from anon, authenticated;
+
 
 -- 3. CUSTOMER STATS
 create policy "Service role full access on customer_stats"
@@ -1458,11 +1463,38 @@ create or replace function withdraw_funds_tx(
 ) returns void
 language plpgsql
 security definer
+set search_path = public, pg_temp
 as $$
 declare
   v_confirmed int;
   v_pending   int;
+  v_day_total int;
+  v_daily_cap constant int := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
 begin
+  -- Verify the caller IS the driver
+  if auth.uid() <> p_driver_id then
+    raise exception 'Unauthorized: you can only withdraw your own funds';
+  end if;
+
+  -- Reject non-positive amounts: a negative p_amount would otherwise mint
+  -- wallet_confirmed via wallet_confirmed = v_confirmed - p_amount.
+  if p_amount is null or p_amount <= 0 then
+    raise exception 'Withdrawal amount must be a positive whole number of paisa';
+  end if;
+
+  -- Enforce the per-driver per-day withdrawal cap.
+  select coalesce(sum(amount), 0)
+    into v_day_total
+    from wallet_transactions
+   where driver_id  = p_driver_id
+     and txn_type   = 'withdrawal'
+     and created_at >= date_trunc('day', now());
+
+  if v_day_total + p_amount > v_daily_cap then
+    raise exception 'Daily withdrawal cap exceeded: % of % used',
+      v_day_total + p_amount, v_daily_cap;
+  end if;
+
   -- Lock the row to prevent concurrent withdrawals
   select wallet_confirmed, wallet_pending
     into v_confirmed, v_pending
@@ -1470,9 +1502,9 @@ begin
     where user_id = p_driver_id
     for update;
 
-  if v_confirmed < p_amount then
+  if v_confirmed is null or v_confirmed < p_amount then
     raise exception 'Insufficient balance: available %, requested %',
-      v_confirmed, p_amount;
+      coalesce(v_confirmed, 0), p_amount;
   end if;
 
   -- Move funds from confirmed → pending

--- a/supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql
+++ b/supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql
@@ -1,0 +1,107 @@
+-- =============================================================================
+-- Migration: Reject non-positive withdraw amounts + harden wallet (Issue #5723)
+-- =============================================================================
+-- Problem:
+--   withdraw_funds_tx only guards `v_confirmed < p_amount`. With a negative
+--   p_amount (e.g. -100000) the balance check always passes and
+--   `wallet_confirmed = v_confirmed - p_amount` ADDS |p_amount| to the
+--   confirmed balance while driving wallet_pending negative. wallet_* columns
+--   have no CHECK constraints, so the negative wallet_pending never errors and
+--   a driver can mint unlimited wallet_confirmed via direct REST RPC calls.
+--
+-- Fix:
+--   1. Reject NULL / non-positive amounts at the top of the RPC.
+--   2. Enforce a per-driver per-day withdrawal cap inside the RPC.
+--   3. Add CHECK (wallet_confirmed >= 0) and CHECK (wallet_pending >= 0) so a
+--      minted/negative balance is impossible at the database level.
+--   4. Revoke UPDATE on wallet_* columns from anon/authenticated so clients
+--      cannot PATCH driver_details.wallet_confirmed directly.
+-- =============================================================================
+
+-- 1. Wallet balance columns must never go negative.
+--    NOT VALID + VALIDATE avoids failing if legacy data already violates it.
+ALTER TABLE driver_details
+  ADD CONSTRAINT driver_details_wallet_confirmed_nonnegative
+  CHECK (wallet_confirmed >= 0) NOT VALID;
+
+ALTER TABLE driver_details
+  ADD CONSTRAINT driver_details_wallet_pending_nonnegative
+  CHECK (wallet_pending >= 0) NOT VALID;
+
+ALTER TABLE driver_details
+  VALIDATE CONSTRAINT driver_details_wallet_confirmed_nonnegative;
+
+ALTER TABLE driver_details
+  VALIDATE CONSTRAINT driver_details_wallet_pending_nonnegative;
+
+-- 2. Harden withdraw_funds_tx: positive-amount guard + daily withdrawal cap.
+CREATE OR REPLACE FUNCTION withdraw_funds_tx(
+  p_driver_id   UUID,
+  p_amount      INT
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_confirmed  INT;
+  v_pending    INT;
+  v_day_total  INT;
+  v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
+BEGIN
+  -- Verify the caller IS the driver
+  IF auth.uid() <> p_driver_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only withdraw your own funds';
+  END IF;
+
+  -- Reject non-positive amounts: a negative p_amount would otherwise mint
+  -- wallet_confirmed via wallet_confirmed = v_confirmed - p_amount.
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'Withdrawal amount must be a positive whole number of paisa';
+  END IF;
+
+  -- Enforce the per-driver per-day withdrawal cap.
+  SELECT COALESCE(SUM(amount), 0)
+    INTO v_day_total
+    FROM wallet_transactions
+   WHERE driver_id  = p_driver_id
+     AND txn_type   = 'withdrawal'
+     AND created_at >= date_trunc('day', now());
+
+  IF v_day_total + p_amount > v_daily_cap THEN
+    RAISE EXCEPTION 'Daily withdrawal cap exceeded: % of % used',
+      v_day_total + p_amount, v_daily_cap;
+  END IF;
+
+  -- Lock the wallet row to prevent concurrent withdrawals.
+  SELECT wallet_confirmed, wallet_pending
+    INTO v_confirmed, v_pending
+    FROM driver_details
+   WHERE user_id = p_driver_id
+     FOR UPDATE;
+
+  IF v_confirmed IS NULL OR v_confirmed < p_amount THEN
+    RAISE EXCEPTION 'Insufficient balance: available %, requested %',
+      COALESCE(v_confirmed, 0), p_amount;
+  END IF;
+
+  -- Move funds from confirmed → pending.
+  UPDATE driver_details
+     SET wallet_confirmed = v_confirmed - p_amount,
+         wallet_pending   = v_pending   + p_amount,
+         updated_at       = now()
+   WHERE user_id = p_driver_id;
+
+  -- Log the withdrawal transaction.
+  INSERT INTO wallet_transactions
+    (driver_id, amount, txn_type, status, description)
+  VALUES
+    (p_driver_id, p_amount, 'withdrawal', 'pending',
+     'Withdrawal to registered bank account');
+END;
+$$;
+
+-- 3. Only the backend (service_role) may write wallet balance columns.
+--    This blocks direct PATCH /rest/v1/driver_details with wallet_* fields.
+REVOKE UPDATE (wallet_confirmed, wallet_pending, wallet_total)
+  ON driver_details FROM anon, authenticated;


### PR DESCRIPTION
## Summary
`withdraw_funds_tx` only guarded `v_confirmed < p_amount`. A negative `p_amount` (e.g. `-100000`) passed the balance check and `wallet_confirmed = v_confirmed - p_amount` ADDED |p_amount| to the confirmed balance while driving `wallet_pending` negative. The wallet columns had no CHECK constraints, so a driver could mint unlimited `wallet_confirmed` via direct REST RPC calls.

## Changes
- **`supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql`** (new):
  1. Reject `NULL` / non-positive `p_amount` at the top of `withdraw_funds_tx`.
  2. Enforce a per-driver per-day withdrawal cap (`10000000` paisa ≈ ₹1,00,000) inside the RPC.
  3. Add `CHECK (wallet_confirmed >= 0)` and `CHECK (wallet_pending >= 0)` (`NOT VALID` + `VALIDATE` so legacy data doesn't fail the migration).
  4. `REVOKE UPDATE (wallet_confirmed, wallet_pending, wallet_total) ON driver_details FROM anon, authenticated` so clients cannot `PATCH` balances directly.
- **`docs/supabase_setup.sql`**: mirrored the hardened RPC, CHECK constraints, and REVOKE for parity.

## Verification
- SQL-only change; logic mirrors repo conventions (`SECURITY DEFINER`, `SET search_path = public, pg_temp`, `auth.uid()`, `NOT VALID` + `VALIDATE`).

Closes #5723