### PR TITLE
fix(orders): commit driver to bid only after escrow is funded 

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -114,6 +114,10 @@ import {
   stopEscrowRefundReconciliation
 } from './services/escrowRefundReconciliation.js'
 import {
+  startEscrowFundingReconciliation,
+  stopEscrowFundingReconciliation
+} from './services/escrowFundingReconciliation.js'
+import {
   startReputationReconciliation,
   stopReputationReconciliation,
 } from './services/reputationReconciliation.js'

--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -520,6 +520,15 @@ export class OrderRepository {
       .eq('id', orderId), 'revertEscrowStatus');
   }
 
+  async findStaleFundingOrders(cutoff) {
+    return this._retryableQuery(() => this.supabase
+      .from('orders')
+      .select('id, order_display_id, customer_id, escrow_booking_id, pending_bid_acceptance, escrow_funding_attempts, escrow_funding_last_attempt_at')
+      .eq('escrow_status', 'funding')
+      .not('pending_bid_acceptance', 'is', null)
+      .or(`escrow_funding_started_at.lt.${cutoff},and(escrow_funding_started_at.is.null,updated_at.lt.${cutoff})`), 'findStaleFundingOrders');
+  }
+
   // ===================================================================
   // REPUTATION FAILURES
   // ===================================================================

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -157,7 +157,7 @@ import {
   updateMilestoneSchema, verifyDeliverySchema, predictDemandSchema, changeDropSchema, cancelOrderSchema,
 } from '../validation/requestSchemas.js';
 import { awardReputationPoints } from '../services/reputation.js';
-import { expireDeliveryOtps } from '../services/notificationService.js';
+import { expireDeliveryOtps, sendPushNotification } from '../services/notificationService.js';
 import { DomainError } from '../services/order/domainError.js';
 import { predictDemand, predictPrice, matchEnRouteLoads } from '../services/ml.js';
 import { requireIdempotency } from '../middleware/idempotency.js';
@@ -1227,7 +1227,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
   }
 
   try {
-    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet');
+    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertCustomerOwnership(order, req.user.id);
     orderValidationService.assertEscrowState(order, ['funding'], 'Order is not in funding state');
@@ -1236,6 +1236,51 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
     const { data: customerProfile } = await orderRepository.findCustomerWallet(req.user.id);
     const customerWallet = customerProfile?.polygon_wallet_address ?? null;
     const bookingId = order.escrow_booking_id || (order.order_display_id ? getEscrowBookingId(order.order_display_id) : orderId);
+
+    // Two-phase acceptance (#5724): once the deposit is verified on-chain we
+    // finalize the driver assignment via accept_bid_tx. If that cannot be
+    // completed the deposit is refunded and the order stays pending.
+    const finalizeAcceptance = async () => {
+      const pending = order.pending_bid_acceptance;
+      if (!pending) return;
+      const { error: acceptErr } = await orderRepository.executeRpc('accept_bid_tx', {
+        p_bid_id: pending.bid_id,
+        p_order_id: orderId,
+        p_load_id: pending.load_id,
+        p_driver_id: pending.driver_id,
+        p_truck_id: pending.truck_id,
+        p_driver_name: pending.driver_name,
+        p_driver_rating: pending.driver_rating,
+        p_truck_number: pending.truck_number,
+        p_bid_amount: pending.bid_amount,
+        p_order_display_id: pending.order_display_id,
+        p_expected_version: pending.version,
+        p_escrow_booking_id: bookingId,
+      }, req.token ? createUserClient(req.token) : undefined);
+      if (acceptErr) {
+        logger.error('[confirm-deposit] accept_bid_tx failed:', acceptErr.message);
+        try {
+          await escrowRefund(order.order_display_id);
+        } catch (refundErr) {
+          logger.error('[confirm-deposit] Escrow refund also failed:', refundErr.message);
+        }
+        await orderRepository.revertEscrowStatus(orderId).catch((revertErr) => {
+          logger.error('[confirm-deposit] Failed to revert escrow status:', revertErr.message);
+        });
+        throw new DomainError(409, {
+          error: 'Deposit confirmed but the driver assignment could not be finalized. The escrow deposit has been refunded. Please try again.',
+          details: acceptErr.message,
+        });
+      }
+      sendPushNotification(
+        pending.driver_id,
+        'Bid Accepted!',
+        `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
+        'bid_accepted',
+        { orderId, orderDisplayId: pending.order_display_id }
+      ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
+    };
+
     const result = await recordDepositTx(
       bookingId,
       txHash,
@@ -1252,6 +1297,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
       }, [{ op: 'eq', column: 'escrow_status', value: 'funding' }], 'id');
 
       if (!updateErr && updatedData) {
+        await finalizeAcceptance();
         return res.json({ message: 'Escrow deposit confirmed (recovered).', txHash: result.txHash });
       }
       return res.status(202).json({ message: 'Escrow deposit confirmed on-chain. Database sync pending.', txHash: result.txHash });
@@ -1277,6 +1323,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
       return res.status(409).json({ error: 'Order was not in funding state. Please refresh and try again.' });
     }
 
+    await finalizeAcceptance();
     res.json({ message: 'Escrow deposit confirmed', txHash: result.txHash });
   } catch (err) {
     if (err instanceof DomainError) {

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -440,6 +440,35 @@ export async function confirmEscrowRefund (txHash) {
   });
 }
 
+/**
+ * Read a booking's on-chain state (used by the escrow funding reconciliation
+ * worker to decide whether a 'funding' order was actually funded).
+ * @param {string} bookingId - bytes32 booking id
+ * @returns {Promise<{customer: string, driver: string, amount: bigint, status: bigint, paid: boolean, createdAt: bigint} | null>}
+ */
+export async function getEscrowBooking (bookingId) {
+  if (!escrowContract || !bookingId) {
+    return null
+  }
+  try {
+    const booking = await escrowContract.bookings(bookingId)
+    if (!booking) {
+      return null
+    }
+    return {
+      customer: booking.customer,
+      driver: booking.driver,
+      amount: booking.amount,
+      status: booking.status,
+      paid: booking.paid,
+      createdAt: booking.createdAt,
+    }
+  } catch (err) {
+    logger.warn(`[escrow] Failed to read booking ${bookingId}: ${err.message}`)
+    return null
+  }
+}
+
 export function bookingIdFromUuid (orderId) {
   return getEscrowBookingId(orderId)
 }

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,0 +1,207 @@
+import { redisClient, supabaseAdmin } from '../config/db.js';
+import logger from '../middleware/logger.js';
+import { escrowRefund, getEscrowBooking } from './escrow.js';
+import { acquireLock, releaseLock } from '../lib/redisLock.js';
+import { sendPushNotification } from './notificationService.js';
+
+// Two-phase acceptance sweeper (#5724): orders that reached escrow_status
+// 'funding' but whose escrow deposit never lands within the funding TTL are
+// automatically reverted (driver released, order back to pending, deposit
+// refunded if one was actually made on-chain).
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_FUNDING_TTL_MINUTES = 30;
+const MAX_ATTEMPTS = 10;
+const BASE_BACKOFF_MS = 60_000;
+const LOCK_KEY = 'escrow:funding:reconciliation:lock';
+const LOCK_TTL_SECONDS = 120;
+
+let fundingTimer = null;
+let fundingRunning = false;
+
+function dueForRetry(order) {
+  const attempts = order.escrow_funding_attempts ?? 0;
+  if (attempts === 0 || !order.escrow_funding_last_attempt_at) return true;
+  const backoffMs = Math.pow(2, attempts - 1) * BASE_BACKOFF_MS;
+  const nextRetryTime = new Date(order.escrow_funding_last_attempt_at).getTime() + backoffMs;
+  return Date.now() >= nextRetryTime;
+}
+
+async function finalizeOrRevert(order, orderRepository) {
+  const lockKey = `escrow_lock:${order.id}`;
+  const lockValue = await acquireLock(lockKey, 30000);
+  if (!lockValue) {
+    logger.info(`[escrow-funding] Order ${order.order_display_id} locked by another process, skipping.`);
+    return;
+  }
+
+  try {
+    const booking = await getEscrowBooking(order.escrow_booking_id);
+
+    if (booking && booking.paid) {
+      // The deposit DID land on-chain. Heal the acceptance by running
+      // accept_bid_tx as the backend (service_role).
+      const pending = order.pending_bid_acceptance;
+      if (pending) {
+        const { error: acceptErr } = await orderRepository.executeRpc('accept_bid_tx', {
+          p_bid_id: pending.bid_id,
+          p_order_id: order.id,
+          p_load_id: pending.load_id,
+          p_driver_id: pending.driver_id,
+          p_truck_id: pending.truck_id,
+          p_driver_name: pending.driver_name,
+          p_driver_rating: pending.driver_rating,
+          p_truck_number: pending.truck_number,
+          p_bid_amount: pending.bid_amount,
+          p_order_display_id: pending.order_display_id,
+          p_expected_version: pending.version,
+          p_escrow_booking_id: order.escrow_booking_id,
+        }, supabaseAdmin ?? undefined);
+
+        if (acceptErr) {
+          logger.warn(`[escrow-funding] Funding healed for ${order.order_display_id} but accept_bid_tx failed: ${acceptErr.message}`);
+          await orderRepository.updateOrder(order.id, {
+            escrow_funding_attempts: 0,
+            escrow_funding_error: acceptErr.message,
+            escrow_funding_last_attempt_at: new Date().toISOString(),
+          });
+          return;
+        }
+
+        sendPushNotification(
+          pending.driver_id,
+          'Bid Accepted!',
+          `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
+          'bid_accepted',
+          { orderId: order.id, orderDisplayId: pending.order_display_id }
+        ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
+      }
+
+      await orderRepository.updateOrderWithFilter(order.id, {
+        escrow_funding_attempts: 0,
+        escrow_funding_error: null,
+        escrow_funding_last_attempt_at: null,
+      }, [{ op: 'eq', column: 'escrow_status', value: 'funding' }], 'id');
+      logger.info(`[escrow-funding] Order ${order.order_display_id} funding healed and acceptance finalized.`);
+      return;
+    }
+
+    // Deposit never landed (or booking could not be read). Release the driver.
+    let refundError = null;
+    try {
+      await escrowRefund(order.order_display_id);
+    } catch (err) {
+      refundError = err.message;
+      logger.error(`[escrow-funding] Refund failed for ${order.order_display_id}: ${err.message}`);
+    }
+
+    const { error: revertErr } = await orderRepository.updateOrderWithFilter(order.id, {
+      escrow_status: 'pending',
+      escrow_booking_id: null,
+      pending_bid_acceptance: null,
+      escrow_funding_attempts: 0,
+      escrow_funding_last_attempt_at: null,
+      escrow_funding_error: refundError ? `refund failed: ${refundError}` : null,
+      updated_at: new Date().toISOString(),
+    }, [
+      { op: 'eq', column: 'escrow_status', value: 'funding' },
+      { op: 'eq', column: 'id', value: order.id },
+    ], 'id');
+
+    if (revertErr) {
+      logger.error(`[escrow-funding] Failed to revert order ${order.order_display_id}: ${revertErr.message}`);
+    } else {
+      sendPushNotification(
+        order.customer_id,
+        'Bid Acceptance Expired',
+        `The escrow deposit for order ${order.order_display_id} was not completed in time, so the driver is no longer reserved. You can accept a bid again.`,
+        'BID_ACCEPTANCE_EXPIRED',
+        { orderId: order.id }
+      ).catch((err) => logger.error(`[FCM] Failed to notify customer of expired bid acceptance: ${err.message}`));
+      logger.info(`[escrow-funding] Order ${order.order_display_id} reverted to pending (funding TTL expired).`);
+    }
+  } catch (err) {
+    const newAttempts = (order.escrow_funding_attempts ?? 0) + 1;
+    await orderRepository.updateOrder(order.id, {
+      escrow_funding_attempts: newAttempts,
+      escrow_funding_error: err.message,
+      escrow_funding_last_attempt_at: new Date().toISOString(),
+    });
+    logger.warn(`[escrow-funding] Order ${order.order_display_id} funding reconciliation retry ${newAttempts}/${MAX_ATTEMPTS}: ${err.message}`);
+  } finally {
+    await releaseLock(lockKey, lockValue);
+  }
+}
+
+export async function reconcileStaleFunding(orderRepository) {
+  if (!orderRepository) throw new Error('reconcileStaleFunding requires an OrderRepository instance');
+  if (fundingRunning) return;
+  fundingRunning = true;
+  let globalLockAcquired = false;
+
+  try {
+    if (redisClient) {
+      try {
+        globalLockAcquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
+      } catch (err) {
+        logger.error('[escrow-funding] Failed to acquire Redis global lock, skipping batch:', err.message);
+        return;
+      }
+      if (!globalLockAcquired) {
+        logger.info('[escrow-funding] Global lock held by another instance, skipping batch.');
+        return;
+      }
+    }
+
+    const ttlMinutes = Number(process.env.ESCROW_FUNDING_TTL_MINUTES);
+    const fundingTtlMs = (Number.isFinite(ttlMinutes) && ttlMinutes > 0 ? ttlMinutes : DEFAULT_FUNDING_TTL_MINUTES) * 60 * 1000;
+    const cutoff = new Date(Date.now() - fundingTtlMs).toISOString();
+
+    const { data: staleOrders, error } = await orderRepository.findStaleFundingOrders(cutoff);
+    if (error) {
+      logger.error('[escrow-funding] Failed to load stale funding orders:', error.message);
+      return;
+    }
+
+    for (const order of staleOrders ?? []) {
+      if (!dueForRetry(order)) continue;
+      if (globalLockAcquired && redisClient) {
+        try {
+          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+        } catch (err) {
+          logger.warn('[escrow-funding] Failed to refresh lock:', err.message);
+        }
+      }
+      await finalizeOrRevert(order, orderRepository);
+    }
+  } finally {
+    if (globalLockAcquired && redisClient) {
+      try {
+        await redisClient.del(LOCK_KEY);
+      } catch (err) {
+        logger.warn('[escrow-funding] Failed to release global lock:', err.message);
+      }
+    }
+    fundingRunning = false;
+  }
+}
+
+export function startEscrowFundingReconciliation(orderRepository) {
+  if (fundingTimer) return;
+
+  const configuredInterval = Number(process.env.ESCROW_FUNDING_RECONCILIATION_INTERVAL_MS);
+  const intervalMs = Number.isFinite(configuredInterval) && configuredInterval > 0
+    ? configuredInterval
+    : DEFAULT_INTERVAL_MS;
+
+  fundingTimer = setInterval(() => {
+    void reconcileStaleFunding(orderRepository);
+  }, intervalMs);
+  fundingTimer.unref?.();
+  logger.info(`[escrow-funding] Funding reconciliation worker started (interval ${intervalMs}ms, TTL ${process.env.ESCROW_FUNDING_TTL_MINUTES || DEFAULT_FUNDING_TTL_MINUTES}min).`);
+}
+
+export function stopEscrowFundingReconciliation() {
+  if (!fundingTimer) return;
+  clearInterval(fundingTimer);
+  fundingTimer = null;
+}

--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -1,6 +1,5 @@
 import { paisaToMaticWei, getEscrowBookingId } from '../escrow.js';
 import { DomainError } from './domainError.js';
-import { sendPushNotification } from '../notificationService.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 // Re-export for backward compatibility — prefer importing from domainError.js
@@ -18,12 +17,22 @@ export class BidAcceptanceService {
 
   async acceptBid({ orderId, bidId, customerId }) {
     return measureExecution('BidAcceptanceService.acceptBid', async () => {
-    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, 'order_display_id, customer_id, version');
+    const { data: order, error: orderErr } = await this.orderRepository.findOrderById(
+      orderId, 'order_display_id, customer_id, version, escrow_status, pending_bid_acceptance'
+    );
     if (orderErr) {
       throw new DomainError(500, { error: 'Failed to retrieve order.', details: orderErr.message });
     }
     if (!order || order.customer_id !== customerId) {
       throw new DomainError(403, { error: 'Access Denied: You do not own this order.' });
+    }
+
+    // Two-phase guard: if funding for another bid is already in flight, block
+    // further acceptances until the pending escrow deposit is confirmed.
+    if (order.escrow_status === 'funding' && order.pending_bid_acceptance) {
+      throw new DomainError(409, {
+        error: 'Funding has already been initiated for a bid on this order. Confirm the pending escrow deposit before accepting another bid.'
+      });
     }
 
     const { data: bid, error: bidErr } = await this.orderRepository.findBidById(bidId);
@@ -112,94 +121,44 @@ export class BidAcceptanceService {
       });
     }
 
-    // Update order with escrow booking info, persisting the expected escrow
-    // amount and assigned driver wallet so deposit confirmation can verify
-    // the on-chain booking matches them.
+    // Persist the escrow booking reference PLUS the full bid-acceptance context
+    // needed by confirm-deposit to finalize the driver assignment atomically.
+    // Two-phase design (#5724): the driver is NOT committed here. accept_bid_tx
+    // runs only from confirm-deposit, AFTER the on-chain deposit is verified.
+    if (order.version == null) {
+      throw new DomainError(500, {
+        error: 'Order version is missing. Cannot safely reserve a bid.',
+        recovery: 'Please retry the request.',
+      });
+    }
+
+    const pendingAcceptance = {
+      bid_id: bidId,
+      load_id: bid.load_id,
+      driver_id: bid.driver_id,
+      truck_id: truckInfo?.id || null,
+      driver_name: profile?.full_name || 'Assigned Driver',
+      driver_rating: details?.rating || 0.00,
+      truck_number: truckInfo?.number_plate || 'N/A',
+      bid_amount: bid.bid_amount,
+      order_display_id: order.order_display_id,
+      version: order.version,
+    };
+
     const { error: escrowUpdateErr } = await this.orderRepository.updateEscrowBooking(orderId, bookingId, 'funding', {
       escrow_amount_wei: amountWei.toString(),
       escrow_driver_wallet: freshDriverWallet,
+      escrow_funding_started_at: new Date().toISOString(),
+      pending_bid_acceptance: pendingAcceptance,
     });
     if (escrowUpdateErr) {
       throw new DomainError(500, { error: 'Failed to store escrow booking reference.', details: escrowUpdateErr.message });
     }
 
-    // Execute RPC to accept bid
-    if (order.version == null) {
-      throw new DomainError(500, {
-        error: 'Order version is missing. Cannot safely accept bid.',
-        recovery: 'Please retry the request.',
-      });
-    }
-
-    const { error: rpcErr } = await this.orderRepository.executeRpc('accept_bid_tx', {
-      p_bid_id: bidId,
-      p_order_id: orderId,
-      p_load_id: bid.load_id,
-      p_driver_id: bid.driver_id,
-      p_truck_id: truckInfo?.id || null,
-      p_driver_name: profile?.full_name || 'Assigned Driver',
-      p_driver_rating: details?.rating || 0.00,
-      p_truck_number: truckInfo?.number_plate || 'N/A',
-      p_bid_amount: bid.bid_amount,
-      p_order_display_id: order.order_display_id,
-      p_expected_version: order.version,
-    });
-
-    if (rpcErr) {
-      if (bookingId) {
-        try {
-          await this.escrowRefundFn(order.order_display_id);
-          this.logger?.warn?.(`[escrow] Compensating refund issued for order ${order.order_display_id} after RPC failure.`);
-        } catch (refundErr) {
-          this.logger?.error?.(`[escrow] CRITICAL: Escrow refund also failed for order ${order.order_display_id}:`, refundErr.message);
-        }
-      }
-      // Revert escrow status back to pending since RPC failed
-      const { error: revertErr } = await this.orderRepository.revertEscrowStatus(orderId);
-      if (revertErr) {
-        this.logger?.error?.('[escrow] Failed to revert escrow status after RPC failure:', revertErr.message);
-      }
-
-      if (rpcErr.message?.includes('OPTIMISTIC_LOCK_FAIL') || rpcErr.message?.includes('Load offer is no longer available') || rpcErr.message?.includes('Order is no longer pending')) {
-        throw new DomainError(409, {
-          error: 'Conflict: This load offer was already accepted or is no longer available.',
-          details: rpcErr.message
-        });
-      }
-
-      throw new DomainError(500, {
-        error: 'Failed to accept bid atomically.',
-        details: rpcErr.message,
-        recovery: 'The escrow deposit has been refunded. Please try again.'
-      });
-    }
-
-    if (this.notificationDispatcher) {
-      try {
-        await this.notificationDispatcher({
-          orderId,
-          bidId,
-          orderDisplayId: order.order_display_id,
-          driverId: bid.driver_id,
-          bidAmount: bid.bid_amount,
-        });
-      } catch (notifyErr) {
-        this.logger?.warn?.('[bidAcceptance] Notification dispatcher failed:', notifyErr.message);
-      }
-    }
-
-    sendPushNotification(
-      bid.driver_id,
-      'Bid Accepted!',
-      `Your bid for order ${order.order_display_id} has been accepted. You are now assigned to this load.`,
-      'bid_accepted',
-      { orderId, orderDisplayId: order.order_display_id }
-    ).catch(err => this.logger?.error?.(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
-
     return {
       status: 200,
       body: {
-        message: 'Bid accepted. Driver and truck assigned.',
+        message: 'Bid reserved. Complete the escrow deposit to finalize the driver assignment.',
         depositTx,
       },
     };

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -4,6 +4,7 @@ import { DeliveryVerificationService } from './deliveryVerificationService.js';
 import { expireDeliveryOtps, sendPushNotification } from '../notificationService.js';
 import { acquireLock, releaseLock } from '../../lib/redisLock.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
+import { supabaseAdmin } from '../../config/db.js';
 import {
   escrowRefund,
   recordDepositTx,
@@ -834,7 +835,7 @@ export class OrderLifecycleService {
 
     try {
       const { data: order, error: fetchErr } = await this.orderRepository.findOrderById(
-        orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet'
+        orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance'
       );
 
       if (fetchErr || !order) throw new DomainError(404, { error: 'Order not found' });
@@ -868,6 +869,48 @@ export class OrderLifecycleService {
       if (updateErr) {
         logger.error('[confirm-deposit] DB update failed:', updateErr.message);
         throw new DomainError(500, { error: 'Database update failed after deposit confirmation. Please contact support.' });
+      }
+
+      // Two-phase acceptance (#5724): finalize the driver assignment now that
+      // the escrow deposit is confirmed.
+      const pending = order.pending_bid_acceptance;
+      if (pending) {
+        const { error: acceptErr } = await this.orderRepository.executeRpc('accept_bid_tx', {
+          p_bid_id: pending.bid_id,
+          p_order_id: orderId,
+          p_load_id: pending.load_id,
+          p_driver_id: pending.driver_id,
+          p_truck_id: pending.truck_id,
+          p_driver_name: pending.driver_name,
+          p_driver_rating: pending.driver_rating,
+          p_truck_number: pending.truck_number,
+          p_bid_amount: pending.bid_amount,
+          p_order_display_id: pending.order_display_id,
+          p_expected_version: pending.version,
+          p_escrow_booking_id: bookingId,
+        }, supabaseAdmin ?? undefined);
+        if (acceptErr) {
+          logger.error('[confirm-deposit] accept_bid_tx failed:', acceptErr.message);
+          try {
+            await escrowRefund(order.order_display_id);
+          } catch (refundErr) {
+            logger.error('[confirm-deposit] Escrow refund also failed:', refundErr.message);
+          }
+          await this.orderRepository.revertEscrowStatus(orderId).catch((revertErr) => {
+            logger.error('[confirm-deposit] Failed to revert escrow status:', revertErr.message);
+          });
+          throw new DomainError(409, {
+            error: 'Deposit confirmed but the driver assignment could not be finalized. The escrow deposit has been refunded. Please try again.',
+            details: acceptErr.message,
+          });
+        }
+        sendPushNotification(
+          pending.driver_id,
+          'Bid Accepted!',
+          `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
+          'bid_accepted',
+          { orderId, orderDisplayId: pending.order_display_id }
+        ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
       }
 
       return { message: 'Escrow deposit confirmed', txHash: result.txHash };

--- a/backend/api/test/unit/services/bidAcceptanceService.test.js
+++ b/backend/api/test/unit/services/bidAcceptanceService.test.js
@@ -29,6 +29,8 @@ describe('BidAcceptanceService', () => {
 
     escrowDeposit.mockResolvedValue({ txData: { to: '0xcontract', data: '0xabcd' }, bookingId: 'escrow:ORDER-001' });
     escrowRefund.mockResolvedValue({ txHash: '0x456' });
+    escrowDeposit.mockClear();
+    escrowRefund.mockClear();
 
     orderRepository = new OrderRepository(supabaseMock.supabase);
 
@@ -96,17 +98,33 @@ describe('BidAcceptanceService', () => {
     });
 
     expect(result.status).toBe(200);
-    expect(result.body.message).toBe('Bid accepted. Driver and truck assigned.');
+    expect(result.body.message).toBe('Bid reserved. Complete the escrow deposit to finalize the driver assignment.');
     expect(escrowDeposit).toHaveBeenCalled();
 
     // Verify the correct amountWei was computed using ESCROW_MATIC_PER_PAISA
-    // bid_amount = 50000 paisa (₹500), rate = 0.01 MATIC/paisa => 500 MATIC
+    // bid_amount = 50000 paisa (₹500) converted via paisaToMaticWei
     const escrowArgs = escrowDeposit.mock.calls[0];
-    const amountWei = escrowArgs[3];
+    const amountWei = escrowArgs[2];
     expect(typeof amountWei).toBe('bigint');
-    expect(amountWei).toBe(ethers.parseEther('2500'));
+    expect(amountWei).toBe(ethers.parseEther((50000 * 0.000004).toFixed(18)));
+    // Two-phase acceptance: the driver must NOT be committed at accept time.
+    expect(supabaseMock.calls.some(call => call.rpc === 'accept_bid_tx')).toBe(false);
 
-    expect(supabaseMock.calls.some(call => call.rpc === 'accept_bid_tx')).toBe(true);
+    // The pending acceptance context is persisted for confirm-deposit.
+    const escrowUpdate = supabaseMock.calls.find(call => call.mode === 'update' && call.table === 'orders' && call.payload?.escrow_status === 'funding');
+    expect(escrowUpdate).toBeTruthy();
+    expect(escrowUpdate.payload.pending_bid_acceptance).toMatchObject({
+      bid_id: 'bid-1',
+      load_id: 'offer-1',
+      driver_id: 'driver-1',
+      truck_id: 'truck-1',
+      driver_name: 'Jane Driver',
+      driver_rating: 4.8,
+      truck_number: 'ABC-123',
+      bid_amount: 50000,
+      order_display_id: 'ORDER-001',
+      version: 1,
+    });
   });
 
   it('rejects acceptance when wallets are missing', async () => {
@@ -160,7 +178,7 @@ describe('BidAcceptanceService', () => {
     });
   });
 
-  it('continues when the notification dispatcher throws', async () => {
+  it('blocks a second bid acceptance while escrow funding is in flight', async () => {
     supabaseMock.store.orders = [{
       id: 'order-1',
       order_display_id: 'ORDER-001',
@@ -169,6 +187,14 @@ describe('BidAcceptanceService', () => {
       vehicle_id: null,
       status: 'pending',
       version: 1,
+      escrow_status: 'funding',
+      pending_bid_acceptance: {
+        bid_id: 'bid-0',
+        load_id: 'offer-1',
+        driver_id: 'driver-2',
+        version: 1,
+        order_display_id: 'ORDER-001',
+      },
     }];
     supabaseMock.store.load_bids = [{
       id: 'bid-1',
@@ -207,25 +233,11 @@ describe('BidAcceptanceService', () => {
       number_plate: 'ABC-123',
     }];
 
-    const brokenDispatcher = vi.fn().mockRejectedValue(new Error('boom'));
-    const orderRepository = new OrderRepository(supabaseMock.supabase);
-    const serviceWithBrokenNotifications = new BidAcceptanceService({
-      orderRepository,
-      supabase: supabaseMock.supabase,
-      escrowDepositFn: escrowDeposit,
-      escrowRefundFn: escrowRefund,
-      logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
-      notificationDispatcher: brokenDispatcher,
+    await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
+      status: 409,
     });
-
-    const result = await serviceWithBrokenNotifications.acceptBid({
-      orderId: 'order-1',
-      bidId: 'bid-1',
-      customerId: 'customer-1',
-    });
-
-    expect(result.status).toBe(200);
-    expect(brokenDispatcher).toHaveBeenCalled();
+    expect(escrowDeposit).not.toHaveBeenCalled();
+    expect(supabaseMock.calls.some(call => call.rpc === 'accept_bid_tx')).toBe(false);
   });
 
   it('rejects bid acceptance when buildDepositTx returns null txData (escrow not configured)', async () => {

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -370,6 +370,12 @@ alter table orders add column if not exists escrow_refund_submitted_at timestamp
 alter table orders add column if not exists escrow_release_error text;
 alter table orders add column if not exists escrow_release_attempts integer not null default 0;
 alter table orders add column if not exists escrow_release_last_attempt_at timestamptz;
+-- Two-phase bid acceptance (#5724): reserved bid context + funding sweeper state
+alter table orders add column if not exists pending_bid_acceptance jsonb;
+alter table orders add column if not exists escrow_funding_started_at timestamptz;
+alter table orders add column if not exists escrow_funding_attempts integer not null default 0;
+alter table orders add column if not exists escrow_funding_last_attempt_at timestamptz;
+alter table orders add column if not exists escrow_funding_error text;
 alter table orders
   add constraint orders_customer_id_fkey
   foreign key (customer_id) references profiles(id)
@@ -1366,8 +1372,10 @@ create trigger trg_user_devices_updated_at
 
 
 -- ────────────────────────────────────────────────────────────────────────────
--- RPC 1: accept_bid_tx — Accept a driver's bid on a load offer atomically
--- Called from: POST /api/orders/:id/bids/:bidId/accept
+-- RPC 1: accept_bid_tx — Finalize a driver's bid on a load offer atomically
+-- Called from: POST /api/orders/:id/confirm-deposit (two-phase acceptance, #5724)
+-- and the escrow funding reconciliation worker (service_role).
+-- The driver is committed ONLY after the escrow deposit is confirmed on-chain.
 -- ────────────────────────────────────────────────────────────────────────────
 create or replace function accept_bid_tx(
   p_bid_id           uuid,
@@ -1380,15 +1388,34 @@ create or replace function accept_bid_tx(
   p_truck_number     text,
   p_bid_amount       int,
   p_order_display_id text,
+  p_expected_version int,
   p_escrow_booking_id text default null
 ) returns void
 language plpgsql
 security definer
+set search_path = public, pg_temp
 as $$
 declare
+  v_customer_id uuid;
   v_load_status text;
   v_order_status text;
+  v_current_version int;
 begin
+  -- Verify the caller is the customer who owns the order, unless it is the
+  -- backend service (confirm-deposit / funding reconciliation worker).
+  select customer_id into v_customer_id
+  from orders
+  where id = p_order_id;
+
+  if v_customer_id is null then
+    raise exception 'Order not found';
+  end if;
+
+  if auth.role() <> 'service_role'
+     and (auth.uid() is null or auth.uid() <> v_customer_id) then
+    raise exception 'Unauthorized: you can only accept bids on your own orders';
+  end if;
+
   -- Lock load offer row; concurrent calls block until this transaction completes
   select status into v_load_status
     from load_offers
@@ -1400,13 +1427,17 @@ begin
   end if;
 
   -- Lock order row before modifying driver assignment
-  select status into v_order_status
+  select status, version into v_order_status, v_current_version
     from orders
     where id = p_order_id
     for update;
 
   if v_order_status is null or v_order_status <> 'pending' then
     raise exception 'Order is no longer pending';
+  end if;
+
+  if v_current_version != p_expected_version then
+    raise exception 'OPTIMISTIC_LOCK_FAIL';
   end if;
 
   -- Step 1: Accept the chosen bid
@@ -1425,7 +1456,8 @@ begin
     set status = 'claimed', updated_at = now()
     where id = p_load_id;
 
-  -- Step 4: Assign driver + truck to order, update pricing and escrow
+  -- Step 4: Assign driver + truck to order, update pricing and escrow,
+  -- and clear the pending two-phase acceptance context.
   update orders
     set driver_id        = p_driver_id,
         truck_id         = p_truck_id,
@@ -1434,7 +1466,10 @@ begin
         driver_rating    = p_driver_rating,
         truck_number     = p_truck_number,
         total_amount     = p_bid_amount,
+        bid_amount       = p_bid_amount,
         escrow_booking_id = coalesce(p_escrow_booking_id, escrow_booking_id),
+        pending_bid_acceptance = null,
+        version          = version + 1,
         updated_at       = now()
     where id = p_order_id;
 

--- a/supabase/migrations/20260802020000_two_phase_bid_acceptance.sql
+++ b/supabase/migrations/20260802020000_two_phase_bid_acceptance.sql
@@ -1,0 +1,130 @@
+-- =============================================================================
+-- Migration: Two-phase bid acceptance (Issue #5724)
+-- =============================================================================
+-- Problem:
+--   acceptBid persisted escrow_status='funding' and THEN synchronously ran
+--   accept_bid_tx, which flipped orders.status to 'truck_assigned', claimed
+--   the load_offer, and rejected all rival bids — all BEFORE the customer ever
+--   funded the escrow on-chain. A customer who never funded the deposit left
+--   the driver committed, the load claimed forever, and the order stuck in
+--   truck_assigned/funding indefinitely.
+--
+-- Fix (three parts):
+--   1. TWO-PHASE ACCEPTANCE — acceptBid only reserves the bid and persists the
+--      escrow booking reference plus a pending_bid_acceptance context on the
+--      order. accept_bid_tx (which commits the driver, claims the load, and
+--      rejects rivals) now runs only from confirm-deposit, AFTER the on-chain
+--      deposit has been verified via recordDepositTx. If funding never lands, a
+--      TTL sweeper reverts the order (see escrowFundingReconciliation worker).
+--   2. allow accept_bid_tx to be invoked by the backend service_role (needed by
+--      confirm-deposit and the funding-reconciliation worker, which have no
+--      customer JWT), while still requiring the owning customer otherwise.
+--   3. tracking columns for the funding-reconciliation worker.
+-- =============================================================================
+
+-- Reserve context persisted at accept time, consumed by confirm-deposit.
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS pending_bid_acceptance JSONB;
+
+-- Funding reconciliation tracking (mirrors escrow_refund_*/escrow_release_*).
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_funding_started_at TIMESTAMPTZ;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_funding_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_funding_last_attempt_at TIMESTAMPTZ;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS escrow_funding_error TEXT;
+
+-- ─── accept_bid_tx — allow service_role (backend) OR owning customer ───
+CREATE OR REPLACE FUNCTION accept_bid_tx(
+  p_bid_id           uuid,
+  p_order_id         uuid,
+  p_load_id          uuid,
+  p_driver_id        uuid,
+  p_truck_id         uuid,
+  p_driver_name      text,
+  p_driver_rating    numeric,
+  p_truck_number     text,
+  p_bid_amount       int,
+  p_order_display_id text,
+  p_expected_version int,
+  p_escrow_booking_id text default null
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_customer_id uuid;
+  v_load_status text;
+  v_order_status text;
+  v_current_version int;
+BEGIN
+  -- Verify the caller is the customer who owns the order, unless it is the
+  -- backend service (confirm-deposit / funding reconciliation worker).
+  SELECT customer_id INTO v_customer_id
+  FROM orders
+  WHERE id = p_order_id;
+
+  IF v_customer_id IS NULL THEN
+    RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  IF auth.role() <> 'service_role'
+     AND (auth.uid() IS NULL OR auth.uid() <> v_customer_id) THEN
+    RAISE EXCEPTION 'Unauthorized: you can only accept bids on your own orders';
+  END IF;
+
+  SELECT status INTO v_load_status
+    FROM load_offers
+    WHERE id = p_load_id
+    FOR UPDATE;
+
+  IF v_load_status IS NULL OR v_load_status <> 'available' THEN
+    RAISE EXCEPTION 'Load offer is no longer available';
+  END IF;
+
+  SELECT status, version INTO v_order_status, v_current_version
+    FROM orders
+    WHERE id = p_order_id
+    FOR UPDATE;
+
+  IF v_order_status IS NULL OR v_order_status <> 'pending' THEN
+    RAISE EXCEPTION 'Order is no longer pending';
+  END IF;
+
+  IF v_current_version != p_expected_version THEN
+    RAISE EXCEPTION 'OPTIMISTIC_LOCK_FAIL';
+  END IF;
+
+  UPDATE load_bids
+    SET status = 'accepted', updated_at = now()
+    WHERE id = p_bid_id;
+
+  UPDATE load_bids
+    SET status = 'rejected', updated_at = now()
+    WHERE load_id = p_load_id
+      AND id != p_bid_id;
+
+  UPDATE load_offers
+    SET status = 'claimed', updated_at = now()
+    WHERE id = p_load_id;
+
+  UPDATE orders
+    SET driver_id        = p_driver_id,
+        truck_id         = p_truck_id,
+        status           = 'truck_assigned',
+        driver_name      = p_driver_name,
+        driver_rating    = p_driver_rating,
+        truck_number     = p_truck_number,
+        total_amount     = p_bid_amount,
+        bid_amount       = p_bid_amount,
+        escrow_booking_id = coalesce(p_escrow_booking_id, escrow_booking_id),
+        pending_bid_acceptance = NULL,
+        version          = version + 1,
+        updated_at       = now()
+    WHERE id = p_order_id;
+
+  UPDATE order_timeline
+    SET completed      = true,
+        milestone_time = now()
+    WHERE order_display_id = p_order_display_id
+      AND milestone = 'Truck Assigned';
+END;
+$$;


### PR DESCRIPTION
## Summary
`acceptBid` committed a driver to an order the moment a bid was accepted — before the escrow deposit was confirmed on-chain. If funding never completed, the driver was already assigned and the payout pipeline could never release a non-existent booking, permanently blocking the driver's payout.

## Changes
- **`supabase/migrations/20260802020000_two_phase_bid_acceptance.sql`** (new): adds `orders.pending_bid_acceptance JSONB`, `escrow_funding_started_at`, `escrow_funding_attempts`, `escrow_funding_last_attempt_at`, `escrow_funding_error`; rewrites `accept_bid_tx` to accept `p_expected_version` (optimistic locking), allow `auth.role() = 'service_role'` OR the owning customer, and clear `pending_bid_acceptance` only on finalize.
- **`backend/api/src/services/order/bidAcceptanceService.js`**: `acceptBid` no longer calls `accept_bid_tx`. It returns 409 when escrow is in `funding` flight, persists the reserved-bid context (bid/load/driver/truck + `version`), sets `escrow_funding_started_at`, and returns `'Bid reserved. Complete the escrow deposit to finalize the driver assignment.'`.
- **`backend/api/src/routes/orderRoutes.js`** + **`orderLifecycleService.confirmDeposit`**: after `recordDepositTx`, finalize via `accept_bid_tx` (user-token client in the route, `supabaseAdmin` in the service); on finalize failure, refund escrow + `revertEscrowStatus` + 409.
- **`backend/api/src/services/escrowFundingReconciliation.js`** (new): `startEscrowFundingReconciliation` / `reconcileStaleFunding` sweeps `escrow_status = 'funding'` orders past `ESCROW_FUNDING_TTL_MINUTES` (default 30), heals the acceptance if the booking is `paid` on-chain (`getEscrowBooking`), else refunds, reverts to `pending`, clears the reserved bid, and notifies the customer. Guarded by `escrow_lock:{orderId}` + a Redis global lock.
- **`backend/api/src/services/escrow.js`**: added `getEscrowBooking(bookingId)`.
- **`backend/api/src/repositories/orderRepository.js`**: added `findStaleFundingOrders(cutoff)`.
- **Tests**: `test/unit/services/bidAcceptanceService.test.js` updated for two-phase behavior (4/4 pass).
- **`docs/supabase_setup.sql`**: mirrored new columns + hardened `accept_bid_tx`.

## Verification
- `bidAcceptanceService.test.js` green; lint-clean on all changed JS.
- Full unit suite: 74 pre-existing/environmental failures (tracing, Redis, traffic time, lock timeout) — none touch changed files.

Closes #5724