### PR TITLE
fix(escrow): add onlyOwner resolveDispute for disputed bookings

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -37,6 +37,9 @@ const ESCROW_ABI = [
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
   'function cancelWithPenalty(uint256 bookingId, uint256 driverFee) external',
+  'function raiseDispute(uint256 bookingId) external',
+  'function resolveDispute(uint256 bookingId, uint256 driverAmount) external',
+  'function resolveDisputeTimeout(uint256 bookingId) external',
   'function bookings(uint256 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, uint256 createdAt)'
 ]
 
@@ -509,4 +512,116 @@ export async function releaseEscrowFunds (orderDisplayId) {
 
 export async function escrowRefund (orderDisplayId) {
   return submitEscrowRefund(orderDisplayId)
+}
+
+/**
+ * Submit an escrow dispute raise and return its hash before confirmation.
+ * Only the relayer (owner) may call raiseDispute on-chain.
+ */
+export async function submitEscrowRaiseDispute (orderDisplayId) {
+  return measureExecution('EscrowService.submitEscrowRaiseDispute', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping raiseDispute.')
+      return { txHash: null, bookingId }
+    }
+
+    let tx
+    try {
+      tx = await escrowContract.raiseDispute(bookingId)
+      logger.info(`[escrow] raiseDispute tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+    } catch (err) {
+      logger.error(`[escrow] raiseDispute failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+    return {
+      txHash: tx.hash,
+      bookingId,
+      waitForConfirmation: async () => {
+        const receipt = await tx.wait(1)
+        if (!receipt || receipt.status === 0) {
+          throw new Error('Escrow raiseDispute transaction reverted or was not found.')
+        }
+        logger.info(`[escrow] raiseDispute confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
+        return receipt
+      }
+    }
+  })
+}
+
+/**
+ * Submit a dispute resolution that splits the escrowed funds. driverAmountWei
+ * is awarded to the driver; the remainder is refunded to the customer.
+ * Only the relayer (owner) may call resolveDispute on-chain.
+ *
+ * @param {string} orderDisplayId
+ * @param {string|bigint} driverAmountWei — wei awarded to the driver
+ */
+export async function submitEscrowResolveDispute (orderDisplayId, driverAmountWei) {
+  return measureExecution('EscrowService.submitEscrowResolveDispute', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping resolveDispute.')
+      return { txHash: null, bookingId }
+    }
+
+    let tx
+    try {
+      tx = await escrowContract.resolveDispute(bookingId, driverAmountWei)
+      logger.info(`[escrow] resolveDispute tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+    } catch (err) {
+      logger.error(`[escrow] resolveDispute failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+    return {
+      txHash: tx.hash,
+      bookingId,
+      waitForConfirmation: async () => {
+        const receipt = await tx.wait(1)
+        if (!receipt || receipt.status === 0) {
+          throw new Error('Escrow resolveDispute transaction reverted or was not found.')
+        }
+        logger.info(`[escrow] resolveDispute confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
+        return receipt
+      }
+    }
+  })
+}
+
+/**
+ * Submit a dispute-timeout resolution that refunds the customer in full.
+ * Only the relayer (owner) may call resolveDisputeTimeout on-chain.
+ */
+export async function submitEscrowResolveDisputeTimeout (orderDisplayId) {
+  return measureExecution('EscrowService.submitEscrowResolveDisputeTimeout', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping resolveDisputeTimeout.')
+      return { txHash: null, bookingId }
+    }
+
+    let tx
+    try {
+      tx = await escrowContract.resolveDisputeTimeout(bookingId)
+      logger.info(`[escrow] resolveDisputeTimeout tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+    } catch (err) {
+      logger.error(`[escrow] resolveDisputeTimeout failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+    return {
+      txHash: tx.hash,
+      bookingId,
+      waitForConfirmation: async () => {
+        const receipt = await tx.wait(1)
+        if (!receipt || receipt.status === 0) {
+          throw new Error('Escrow resolveDisputeTimeout transaction reverted or was not found.')
+        }
+        logger.info(`[escrow] resolveDisputeTimeout confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
+        return receipt
+      }
+    }
+  })
 }

--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -21,7 +21,10 @@ import {
   ESCROW_MATIC_PER_PAISA,
   paisaToMaticWei,
   validateEscrowSetup,
-  isEscrowEnabled
+  isEscrowEnabled,
+  submitEscrowRaiseDispute,
+  submitEscrowResolveDispute,
+  submitEscrowResolveDisputeTimeout
 } from '../../src/services/escrow.js'
 
 describe('escrow service — getEscrowBookingId', () => {
@@ -286,6 +289,51 @@ describe('escrow service \u2014 submitEscrowRefund (contract unconfigured)', () 
   it('returns the same bookingId as getEscrowBookingId', async () => {
     const result = await submitEscrowRefund('#FF20260530')
     const expected = getEscrowBookingId('#FF20260530')
+    expect(result.bookingId).toBe(expected)
+  })
+})
+
+describe('escrow service \u2014 submitEscrowRaiseDispute (contract unconfigured)', () => {
+  it('returns txHash: null and a valid bookingId when contract is not initialised', async () => {
+    const result = await submitEscrowRaiseDispute('#FF20260601')
+    expect(result.txHash).toBeNull()
+    expect(typeof result.bookingId).toBe('string')
+    expect(result.bookingId.startsWith('0x')).toBe(true)
+  })
+
+  it('returns the same bookingId as getEscrowBookingId', async () => {
+    const result = await submitEscrowRaiseDispute('#FF20260602')
+    const expected = getEscrowBookingId('#FF20260602')
+    expect(result.bookingId).toBe(expected)
+  })
+})
+
+describe('escrow service \u2014 submitEscrowResolveDispute (contract unconfigured)', () => {
+  it('returns txHash: null and a valid bookingId when contract is not initialised', async () => {
+    const result = await submitEscrowResolveDispute('#FF20260603', '600000000000000000')
+    expect(result.txHash).toBeNull()
+    expect(typeof result.bookingId).toBe('string')
+    expect(result.bookingId.startsWith('0x')).toBe(true)
+  })
+
+  it('returns the same bookingId as getEscrowBookingId', async () => {
+    const result = await submitEscrowResolveDispute('#FF20260604', 0)
+    const expected = getEscrowBookingId('#FF20260604')
+    expect(result.bookingId).toBe(expected)
+  })
+})
+
+describe('escrow service \u2014 submitEscrowResolveDisputeTimeout (contract unconfigured)', () => {
+  it('returns txHash: null and a valid bookingId when contract is not initialised', async () => {
+    const result = await submitEscrowResolveDisputeTimeout('#FF20260605')
+    expect(result.txHash).toBeNull()
+    expect(typeof result.bookingId).toBe('string')
+    expect(result.bookingId.startsWith('0x')).toBe(true)
+  })
+
+  it('returns the same bookingId as getEscrowBookingId', async () => {
+    const result = await submitEscrowResolveDisputeTimeout('#FF20260606')
+    const expected = getEscrowBookingId('#FF20260606')
     expect(result.bookingId).toBe(expected)
   })
 })

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -26,7 +26,8 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         Active,       // Payment locked, trip in progress
         Delivered,    // GPS + OTP confirmed, payment released to driver
         Cancelled,    // Cancelled before driver started — full refund
-        Disputed      // Under dispute resolution via n8n automation
+        Disputed,     // Under dispute resolution via n8n automation
+        Resolved      // Dispute settled by owner — funds split per resolution
     }
 
     // ─── Structs ─────────────────────────────────────────────────────────────
@@ -82,6 +83,14 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     event BookingDisputed(
         uint256 indexed bookingId,
         address indexed raisedBy
+    );
+
+    event DisputeResolved(
+        uint256 indexed bookingId,
+        address indexed driver,
+        uint256 driverAmount,
+        address indexed customer,
+        uint256 refundAmount
     );
 
     event WithdrawalReady(
@@ -317,11 +326,76 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     }
 
     /**
+     * @dev Resolve a disputed booking by splitting the escrowed funds between
+     *      the driver and the customer. Restricted to onlyOwner (backend) so
+     *      disputes are settled through the backend's resolution pipeline
+     *      (n8n automation) — no third party can force an outcome.
+     *
+     *      Pass driverAmount == booking.amount to pay the driver in full,
+     *      or 0 to refund the customer in full. Any partial amount is split
+     *      between both parties. Sets a terminal Resolved state and routes
+     *      each party's share to their pending-withdrawal bucket.
+     *
+     * @param bookingId   The disputed booking to resolve
+     * @param driverAmount The portion of the escrow awarded to the driver
+     */
+    function resolveDispute(uint256 bookingId, uint256 driverAmount)
+        external
+        onlyOwner
+        nonReentrant
+        whenNotPaused
+    {
+        Booking storage booking = bookings[bookingId];
+
+        require(
+            booking.status == BookingStatus.Disputed,
+            "TruxifyEscrow: Booking not disputed"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(booking.amount > 0, "TruxifyEscrow: Nothing to resolve");
+        require(driverAmount <= booking.amount, "TruxifyEscrow: Award exceeds escrow");
+
+        uint256 escrowAmount   = booking.amount;
+        uint256 customerRefund = escrowAmount - driverAmount;
+        address payable driver = booking.driver;
+        address payable customer = booking.customer;
+
+        booking.amount = 0;
+        booking.paid = true;
+        booking.status = BookingStatus.Resolved;
+
+        uint256 newDeadline = block.timestamp + WITHDRAWAL_TIMEOUT;
+        if (driverAmount > 0) {
+            pendingWithdrawals[driver] += driverAmount;
+            if (releaseTimestamps[driver] == 0 || newDeadline > releaseTimestamps[driver]) {
+                releaseTimestamps[driver] = newDeadline;
+            }
+            emit WithdrawalReady(bookingId, driver, driverAmount);
+        }
+        if (customerRefund > 0) {
+            pendingWithdrawals[customer] += customerRefund;
+            if (releaseTimestamps[customer] == 0 || newDeadline > releaseTimestamps[customer]) {
+                releaseTimestamps[customer] = newDeadline;
+            }
+            emit WithdrawalReady(bookingId, customer, customerRefund);
+        }
+
+        emit DisputeResolved(bookingId, driver, driverAmount, customer, customerRefund);
+    }
+
+    /**
      * @dev Resolve a stale dispute that has been inactive for DISPUTE_TIMEOUT.
      *      Defaults to refunding the customer in full to prevent locked funds.
+     *      Restricted to onlyOwner (backend) so an arbitrary third party cannot
+     *      front-run a pending resolution and force a full customer refund.
      * @param bookingId The booking to resolve
      */
-    function resolveDisputeTimeout(uint256 bookingId) external nonReentrant whenNotPaused {
+    function resolveDisputeTimeout(uint256 bookingId)
+        external
+        onlyOwner
+        nonReentrant
+        whenNotPaused
+    {
         Booking storage booking = bookings[bookingId];
 
         require(

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -1058,23 +1058,23 @@ describe("TruxifyEscrow", function () {
     });
   });
 
-  // "?"?"? resolveDisputeTimeout "?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?"?
+  // ─── resolveDisputeTimeout ───────────────────────────────────────────────
   describe("resolveDisputeTimeout", function () {
     it("resolves dispute by refunding customer after timeout", async function () {
-      const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
+      const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
       await escrow.connect(customer).createBooking(2, driver.address, { value: amount });
 
-      // Raise dispute
-      await escrow.connect(customer).raiseDispute(2);
+      // Raise dispute (owner-only)
+      await escrow.connect(owner).raiseDispute(2);
 
       // Fast forward time by 8 days (7 days timeout)
       await hre.network.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
       await hre.network.provider.send("evm_mine");
 
       // Resolve dispute
-      await escrow.resolveDisputeTimeout(2);
+      await escrow.connect(owner).resolveDisputeTimeout(2);
 
       // Check that customer got the pending withdrawal
       const pendingRefund = await escrow.pendingWithdrawals(customer.address);
@@ -1086,18 +1086,111 @@ describe("TruxifyEscrow", function () {
     });
 
     it("reverts if timeout has not been reached", async function () {
-      const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
+      const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
       await escrow.connect(customer).createBooking(3, driver.address, { value: amount });
 
-      // Raise dispute
-      await escrow.connect(customer).raiseDispute(3);
+      // Raise dispute (owner-only)
+      await escrow.connect(owner).raiseDispute(3);
 
       // Try to resolve immediately
       await expect(
-        escrow.resolveDisputeTimeout(3)
+        escrow.connect(owner).resolveDisputeTimeout(3)
       ).to.be.revertedWith("TruxifyEscrow: Dispute timeout not reached");
+    });
+
+    it("reverts if called by a non-owner before timeout expires", async function () {
+      const { escrow, owner, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
+
+      await escrow.connect(customer).createBooking(4, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(owner).raiseDispute(4);
+
+      await hre.network.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);
+      await hre.network.provider.send("evm_mine");
+
+      await expect(
+        escrow.connect(attacker).resolveDisputeTimeout(4)
+      ).to.be.revertedWithCustomError(escrow, "OwnableUnauthorizedAccount")
+       .withArgs(attacker.address);
+    });
+  });
+
+  // ─── resolveDispute ──────────────────────────────────────────────────────
+  describe("resolveDispute", function () {
+    async function deployDisputedBookingFixture() {
+      const { escrow, owner, customer, driver, attacker } = await loadFixture(deployWithBookingFixture);
+      await escrow.connect(owner).raiseDispute(1);
+      return { escrow, owner, customer, driver, attacker, bookingId: 1, amount: ethers.parseEther("1.0") };
+    }
+
+    it("splits a disputed booking between driver and customer", async function () {
+      const { escrow, owner, customer, driver, bookingId, amount } = await loadFixture(deployDisputedBookingFixture);
+      const driverAward = ethers.parseEther("0.6");
+
+      await expect(escrow.connect(owner).resolveDispute(bookingId, driverAward))
+        .to.emit(escrow, "DisputeResolved")
+        .withArgs(bookingId, driver.address, driverAward, customer.address, amount - driverAward);
+
+      const booking = await escrow.getBooking(bookingId);
+      expect(booking.status).to.equal(4); // Resolved
+      expect(booking.paid).to.be.true;
+      expect(booking.amount).to.equal(0);
+      expect(await escrow.pendingWithdrawals(driver.address)).to.equal(driverAward);
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount - driverAward);
+    });
+
+    it("pays the driver in full when award equals the escrow amount", async function () {
+      const { escrow, owner, customer, driver, bookingId, amount } = await loadFixture(deployDisputedBookingFixture);
+
+      await escrow.connect(owner).resolveDispute(bookingId, amount);
+
+      expect(await escrow.pendingWithdrawals(driver.address)).to.equal(amount);
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(0);
+    });
+
+    it("refunds the customer in full when the driver award is zero", async function () {
+      const { escrow, owner, customer, driver, bookingId, amount } = await loadFixture(deployDisputedBookingFixture);
+
+      await escrow.connect(owner).resolveDispute(bookingId, 0);
+
+      expect(await escrow.pendingWithdrawals(driver.address)).to.equal(0);
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount);
+    });
+
+    it("reverts if called by a non-owner", async function () {
+      const { escrow, attacker, bookingId } = await loadFixture(deployDisputedBookingFixture);
+
+      await expect(
+        escrow.connect(attacker).resolveDispute(bookingId, 0)
+      ).to.be.revertedWithCustomError(escrow, "OwnableUnauthorizedAccount")
+       .withArgs(attacker.address);
+    });
+
+    it("reverts if the driver award exceeds the escrow amount", async function () {
+      const { escrow, owner, bookingId, amount } = await loadFixture(deployDisputedBookingFixture);
+
+      await expect(
+        escrow.connect(owner).resolveDispute(bookingId, amount + 1n)
+      ).to.be.revertedWith("TruxifyEscrow: Award exceeds escrow");
+    });
+
+    it("reverts for a booking that is not disputed", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await expect(
+        escrow.connect(owner).resolveDispute(bookingId, 0)
+      ).to.be.revertedWith("TruxifyEscrow: Booking not disputed");
+    });
+
+    it("reverts when the contract is paused", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployDisputedBookingFixture);
+
+      await escrow.connect(owner).pause();
+
+      await expect(
+        escrow.connect(owner).resolveDispute(bookingId, 0)
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
     });
   });
 });

--- a/scripts/check-escrow-abi.sh
+++ b/scripts/check-escrow-abi.sh
@@ -26,10 +26,14 @@ echo "🔍 Checking escrow ABI compatibility..."
 # Expected selectors (from backend/api/src/services/escrow.js)
 # These are keccak256(first 4 bytes) of the function signatures
 declare -A EXPECTED_SELECTORS
-EXPECTED_SELECTORS["createBooking(uint256,address)"]="cf5ba53f"
-EXPECTED_SELECTORS["releasePayment(uint256)"]="2d8e4a0b"
-EXPECTED_SELECTORS["cancelBooking(uint256)"]="66b71f1c"
-EXPECTED_SELECTORS["bookings(uint256)"]="dc97d7d3"
+EXPECTED_SELECTORS["createBooking(uint256,address)"]="490a3b30"
+EXPECTED_SELECTORS["releasePayment(uint256)"]="88685cd9"
+EXPECTED_SELECTORS["cancelBooking(uint256)"]="0dca825e"
+EXPECTED_SELECTORS["cancelWithPenalty(uint256,uint256)"]="ca9a63b1"
+EXPECTED_SELECTORS["raiseDispute(uint256)"]="a5c1674e"
+EXPECTED_SELECTORS["resolveDispute(uint256,uint256)"]="bdc84ac3"
+EXPECTED_SELECTORS["resolveDisputeTimeout(uint256)"]="333edf12"
+EXPECTED_SELECTORS["bookings(uint256)"]="1dab301e"
 
 # Check if cast (foundry) is available for selector computation
 HAS_CAST=false


### PR DESCRIPTION
## bug: Escrow Dispute Lifecycle Dead-Ends — a Disputed Driver Can Never Be Paid

Closes #5738

### Summary
Once a booking is `Disputed`, `releasePayment` and `cancelBooking` both hard-require
`Active` status, so the driver could never be paid. The only on-chain resolution,
`resolveDisputeTimeout`, was `external` without `onlyOwner` — any address could
front-run a pending backend resolution after 7 days and force a 100% customer
refund.

### Changes
- **`resolveDispute(bookingId, driverAmount)`** — `onlyOwner`, splits escrowed
  funds between driver and customer per the backend's resolution outcome, sets a
  terminal `Resolved` state, and routes both shares to the pending-withdrawal
  buckets (`pull-based`, `CEI`, `nonReentrant`, `whenNotPaused`)
- Added `DisputeResolved` event
- **`resolveDisputeTimeout` restricted to `onlyOwner`** — an arbitrary third party
  can no longer front-run a pending resolution; the backend keeps it as the 7-day
  fallback path
- `escrow.js`: exposes `submitEscrowRaiseDispute`, `submitEscrowResolveDispute`,
  `submitEscrowResolveDisputeTimeout` (relayer-signed, with unconfigured-fallback)
  and extends `ESCROW_ABI` with the three dispute selectors
- `check-escrow-abi.sh`: corrects stale pre-existing selectors and adds the new
  dispute selectors

### Testing
- Contract suite: `resolveDispute` owner-only raise, split/full-pay/full-refund,
  unauthorized revert, paused revert; `resolveDisputeTimeout` access control
- Backend suite: unconfigured-fallback unit tests for the new `submitEscrow*`
  functions