### PR TITLE
fix(orders): widen order display id randomness and enforce DB uniqueness

### DIFF
--- a/backend/api/src/lib/orderDisplayId.js
+++ b/backend/api/src/lib/orderDisplayId.js
@@ -1,0 +1,36 @@
+import crypto from 'crypto';
+
+// Order display ids look like `#FF<YYYYMMDD><12-char alphanumeric>` so they
+// stay human-friendly while the random suffix is drawn uniformly from a 36
+// char alphabet (A-Z, 0-9) via crypto.randomInt — no modulo bias. That gives
+// 36^12 ≈ 4.7e18 distinct values per calendar day, versus only ~900k for the
+// previous 6-digit format, so collisions are effectively impossible. Callers
+// still re-roll on a DB unique-constraint violation (code 23505) as a safety
+// net (see ORDER_DISPLAY_ID_MAX_RETRIES).
+const DISPLAY_ID_PREFIX = '#FF';
+const DISPLAY_ID_RANDOM_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const DISPLAY_ID_RANDOM_LENGTH = 12;
+
+// Upper bound on how many times a caller will re-roll the display id when an
+// insert fails with a unique-constraint violation (issue #5740).
+export const ORDER_DISPLAY_ID_MAX_RETRIES = 5;
+
+/**
+ * Generate a globally unique order display id of the form
+ * `#FF<YYYYMMDD><12-char alphanumeric>` (e.g. `#FF20260802K9X2Q7Z4M1A3`).
+ *
+ * The display id is the basis for the on-chain escrow booking id
+ * (getEscrowBookingId hashes `escrow:<displayId>`), so uniqueness is required
+ * to keep orders and their escrow bookings 1:1.
+ *
+ * @returns {string} a display id with a ~4.7e18-per-day random space
+ */
+export function generateOrderDisplayId() {
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const random = Array.from(
+    { length: DISPLAY_ID_RANDOM_LENGTH },
+    () => DISPLAY_ID_RANDOM_ALPHABET[crypto.randomInt(DISPLAY_ID_RANDOM_ALPHABET.length)],
+  ).join('');
+  return `${DISPLAY_ID_PREFIX}${dateStr}${random}`;
+}

--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { supabase } from '../../config/db.js';
 import { getRouteEstimate } from '../osrm.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
@@ -7,14 +6,7 @@ import { getLiveTrafficMultiplier } from '../trafficService.js';
 import { DomainError } from './bidAcceptanceService.js';
 import logger from '../../middleware/logger.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
-
-function generateOrderDisplayId() {
-  const prefix = '#FF';
-  const now = new Date();
-  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
-  const random = crypto.randomInt(100000, 999999).toString();
-  return `${prefix}${dateStr}${random}`;
-}
+import { generateOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } from '../../lib/orderDisplayId.js';
 
 export async function createOrder({ orderData, userId, user }) {
   return measureExecution('OrderCreationService.createOrder', async () => {
@@ -73,7 +65,7 @@ export async function createOrder({ orderData, userId, user }) {
     logger.warn({ err: mlErr.message }, 'Price prediction unavailable, falling back to base pricing');
   }
 
-  const MAX_ID_RETRIES = 3;
+  const MAX_ID_RETRIES = ORDER_DISPLAY_ID_MAX_RETRIES;
   let order = null;
   let orderErr = null;
   let orderDisplayId = null;

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { DomainError } from './domainError.js';
 import { DeliveryVerificationService } from './deliveryVerificationService.js';
 import { expireDeliveryOtps, sendPushNotification } from '../notificationService.js';
@@ -21,16 +20,9 @@ import { getLiveTrafficMultiplier } from '../trafficService.js';
 import { eventBus } from '../../core/events/index.js';
 import logger from '../../middleware/logger.js';
 import { supabaseAdmin } from '../../config/db.js';
+import { generateOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } from '../../lib/orderDisplayId.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function generateOrderDisplayId() {
-  const prefix = '#FF';
-  const now = new Date();
-  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
-  const random = crypto.randomInt(100000, 999999).toString();
-  return `${prefix}${dateStr}${random}`;
-}
 
 export class OrderLifecycleService {
   constructor({ orderRepository, orderTimelineService, bidAcceptanceService, deliveryVerificationService }) {
@@ -102,7 +94,7 @@ export class OrderLifecycleService {
       logger.warn({ err: mlErr.message }, 'Price prediction unavailable, falling back to base pricing');
     }
 
-    const MAX_ID_RETRIES = 3;
+    const MAX_ID_RETRIES = ORDER_DISPLAY_ID_MAX_RETRIES;
     let order = null;
     let orderErr = null;
     let orderDisplayId = null;

--- a/backend/api/test/unit/lib/orderDisplayId.test.js
+++ b/backend/api/test/unit/lib/orderDisplayId.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for backend/api/src/lib/orderDisplayId.js
+ *
+ * Coverage:
+ *   - format: `#FF<YYYYMMDD><12-char alphanumeric>`
+ *   - character set: only A-Z and 0-9 in the random suffix
+ *   - uniqueness across a large batch (no collisions)
+ *   - ORDER_DISPLAY_ID_MAX_RETRIES is a positive bounded retry cap
+ *
+ * Run with:  npm test -- test/unit/lib/orderDisplayId.test.js
+ */
+import { describe, it, expect } from 'vitest'
+import { generateOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } from '../../../src/lib/orderDisplayId.js'
+
+const ID_RE = /^#FF\d{8}[A-Z0-9]{12}$/
+
+describe('orderDisplayId — generateOrderDisplayId', () => {
+  it('returns ids matching `#FF<YYYYMMDD><12-char alphanumeric>`', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateOrderDisplayId()).toMatch(ID_RE)
+    }
+  })
+
+  it('produces a random suffix drawn only from A-Z and 0-9', () => {
+    const suffix = generateOrderDisplayId().slice(11)
+    expect(suffix).toMatch(/^[A-Z0-9]{12}$/)
+    expect(suffix).not.toMatch(/[a-z]/)
+    expect(suffix).not.toMatch(/[^A-Z0-9]/)
+  })
+
+  it('does not reuse a previous 6-digit numeric suffix', () => {
+    // The issue (#5740) is that the old `#FF<date><6 digits>` format only had
+    // ~900k values/day. Assert the suffix is at least 10 chars of A-Z0-9.
+    const suffix = generateOrderDisplayId().slice(11)
+    expect(suffix.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('produces unique ids across a large batch', () => {
+    const ids = new Set()
+    for (let i = 0; i < 10000; i++) {
+      ids.add(generateOrderDisplayId())
+    }
+    expect(ids.size).toBe(10000)
+  })
+
+  it('uses a bounded retry cap for callers', () => {
+    expect(ORDER_DISPLAY_ID_MAX_RETRIES).toBeGreaterThanOrEqual(1)
+    expect(Number.isInteger(ORDER_DISPLAY_ID_MAX_RETRIES)).toBe(true)
+  })
+})

--- a/supabase/migrations/20260802050000_unique_order_display_id.sql
+++ b/supabase/migrations/20260802050000_unique_order_display_id.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- Migration: Enforce a unique constraint on orders.order_display_id (Issue #5740)
+-- =============================================================================
+-- Problem:
+--   generateOrderDisplayId() previously returned `#FF` + YYYYMMDD + a 6-digit
+--   random suffix — only ~900k values per calendar day. With the birthday
+--   paradox, ~950 orders/day yields a >50% daily collision probability. There
+--   is no explicit migration guaranteeing uniqueness of order_display_id, so
+--   two orders can share the same display id, which:
+--     - makes findOrderByDisplayId return the first match (tracking/timeline
+--       show the wrong order), and
+--     - derives the same on-chain escrow booking id via getEscrowBookingId,
+--       so the second order's deposit reverts on-chain ("Booking already
+--       exists") or the idempotency checks in recordDepositTx accept a booking
+--       created for the wrong order, permanently breaking funding/payout.
+--
+-- Fix:
+--   1. The backend generator now draws a 12-char alphanumeric suffix from a
+--      36-char alphabet (36^12 ≈ 4.7e18 values/day) and re-rolls on a
+--      unique-constraint violation (see src/lib/orderDisplayId.js).
+--   2. This migration guarantees a UNIQUE constraint on
+--      orders.order_display_id as a database-level safety net. It is a no-op
+--      when the constraint already exists (the canonical schema in
+--      docs/supabase_setup.sql declares `order_display_id text unique not
+--      null`), and it refuses to run when duplicate display ids exist so an
+--      operator can resolve the data instead of shipping with collisions.
+--
+-- Backward compatibility:
+--   - Idempotent: skips when orders_order_display_id_key already exists.
+--   - Fails loudly (rather than partially enforcing) if duplicate display ids
+--     are present, so existing corrupt data is surfaced before deployment.
+--   - The FK ratings.order_display_id -> orders.order_display_id (added in
+--     20260802030000) already required a unique constraint on the referenced
+--     column, so production schemas following the canonical DDL already pass.
+-- =============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'orders_order_display_id_key'
+      AND conrelid = 'public.orders'::regclass
+  ) THEN
+    -- Guard against adding the constraint on data that already contains
+    -- duplicate display ids: uniqueness cannot be enforced retroactively
+    -- without resolving those rows first.
+    IF EXISTS (
+      SELECT order_display_id
+      FROM public.orders
+      WHERE order_display_id IS NOT NULL
+      GROUP BY order_display_id
+      HAVING COUNT(*) > 1
+    ) THEN
+      RAISE EXCEPTION
+        'Cannot add unique constraint orders_order_display_id_key: duplicate order_display_id values exist. Resolve duplicates before running this migration.';
+    END IF;
+
+    ALTER TABLE public.orders
+      ADD CONSTRAINT orders_order_display_id_key UNIQUE (order_display_id);
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## bug: Order Display ID Collision Risk from 6-Digit Randomness

Closes #5740

### Summary
`order_display_id` was generated per-service with 6-digit randomness
(~7200 candidates/day), producing frequent collisions that required retry loops
(MAX_ID_RETRIES=3). The generators were also duplicated in
`orderCreationService.js` and `orderLifecycleService.js`, and no database-level
uniqueness guaranteed the display ID column.

### Changes
- **New shared `backend/api/src/lib/orderDisplayId.js`** with
  `generateOrderDisplayId()` → `#FF<YYYYMMDD><12-char A-Z0-9>` using
  `crypto.randomInt` (36^12 ≈ 4.7e18 candidates per day, no modulo bias) and
  `ORDER_DISPLAY_ID_MAX_RETRIES = 5`
- `orderCreationService.js` and `orderLifecycleService.js` now import the shared
  module; local duplicate generators and `crypto` imports removed; retry count
  now uses the shared constant (5)
- **New idempotent migration** `supabase/migrations/20260802050000_unique_order_display_id.sql`:
  adds `orders_order_display_id_key` UNIQUE constraint; no-op if already present;
  `RAISE EXCEPTION` if duplicate display IDs exist
- Added `backend/api/test/unit/lib/orderDisplayId.test.js`

### Testing
- `orderDisplayId.test.js` — 5/5 pass
- `escrow.test.js` — 32/32 pass
- Existing pre-generated display IDs: the format/prefix is unchanged for
  migration of current data; uniqueness is enforced going forward