### PR TITLE
fix(worker): close staleOrderWorker TOCTOU race and refund funded escrow

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -2,10 +2,13 @@ import cron from 'node-cron';
 import logger from '../middleware/logger.js';
 import { supabase } from '../config/db.js';
 import { sendPushNotification } from '../services/notificationService.js';
+import { submitEscrowRefund, confirmEscrowRefund } from '../services/escrow.js';
 import { WorkerTracer } from '../core/telemetry/WorkerTracer.js';
 import spanFactory from '../core/telemetry/SpanFactory.js';
 
 let staleOrderWorkerTask = null;
+
+const STALE_ORDER_CANCELLATION_REASON = 'Stale order: no accepted bid within 24 hours.';
 
 export const startStaleOrderWorker = () => {
   if (staleOrderWorkerTask) {
@@ -42,41 +45,9 @@ export const startStaleOrderWorker = () => {
       });
 
       for (const order of staleOrders) {
-        // Update status to cancelled
-        const { error: updateError } = await supabase
-          .from('orders')
-          .update({
-            status: 'cancelled',
-            updated_at: new Date().toISOString()
-          })
-          .eq('id', order.id);
-
-        if (updateError) {
-          logger.error(`[StaleOrderWorker] Failed to cancel order ${order.id}: ${updateError.message}`);
-          continue;
-        }
-
-        // Cancel associated load offers
-        await supabase
-          .from('load_offers')
-          .update({ status: 'cancelled' })
-          .eq('order_display_id', order.order_display_id);
-
-        // Send a notification to the customer
-        try {
-          await sendPushNotification(
-            order.customer_id,
-            'Order Cancelled',
-            'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
-            'ORDER_CANCELLED',
-            { orderId: order.id }
-          );
-          logger.info(`[StaleOrderWorker] Cancelled order ${order.id} and notified customer ${order.customer_id}.`);
-        } catch (notifyErr) {
-          logger.warn(`[StaleOrderWorker] Cancelled order ${order.id}, but failed to notify customer ${order.customer_id}: ${notifyErr.message}`);
-        }
+        await cancelStaleOrder(order);
       }
-      
+
       logger.info('[StaleOrderWorker] Cleanup of stale pending orders completed.');
     } catch (err) {
       logger.error(`[StaleOrderWorker] Unexpected error during cleanup: ${err.message}`);
@@ -89,6 +60,223 @@ export const startStaleOrderWorker = () => {
   logger.info('[StaleOrderWorker] Stale order cleanup cron job scheduled (runs every hour).');
   return staleOrderWorkerTask;
 };
+
+/**
+ * Cancel a single stale order without racing concurrent bid acceptance.
+ *
+ * TOCTOU fix (issue #5741): bidAcceptanceService.acceptBid persists the escrow
+ * booking reference (escrow_status='funding') while the order is still
+ * 'pending', and only later flips it to 'truck_assigned'. A naive
+ * status-overwrite could therefore cancel an order that was just accepted and
+ * strand on-chain escrow funds. We therefore:
+ *   1. Re-fetch the order inside the loop with a status='pending' filter to
+ *      close the window between the batch SELECT and the per-order UPDATE.
+ *   2. Skip orders whose escrow_status is 'funding' — those belong to the
+ *      escrow-funding reconciliation worker.
+ *   3. Run every cancellation UPDATE guarded by status='pending' (and the
+ *      current escrow_status), so it can never overwrite a concurrently
+ *      accepted order.
+ *   4. When escrow is funded, route the refund through the same escrow refund
+ *      pipeline used by orderLifecycleService.cancelOrder before finalising
+ *      the cancellation.
+ *
+ * @param {{id: string, customer_id: string, order_display_id: string}} staleOrder
+ * @returns {Promise<void>}
+ */
+async function cancelStaleOrder(staleOrder) {
+  try {
+    // Re-fetch the order inside the loop with a status filter to close the
+    // window between the batch SELECT and the per-order UPDATE.
+    const { data: current, error: refetchErr } = await supabase
+      .from('orders')
+      .select('id, customer_id, order_display_id, escrow_status, refund_tx_hash, escrow_refund_attempts')
+      .eq('id', staleOrder.id)
+      .eq('status', 'pending')
+      .maybeSingle();
+
+    if (refetchErr) {
+      logger.error(`[StaleOrderWorker] Failed to re-fetch order ${staleOrder.id}: ${refetchErr.message}`);
+      return;
+    }
+
+    if (!current) {
+      logger.info(`[StaleOrderWorker] Order ${staleOrder.id} is no longer pending (accepted or cancelled concurrently), skipping.`);
+      return;
+    }
+
+    const escrowStatus = current.escrow_status ?? 'pending';
+
+    // An order that entered the two-phase acceptance flow (escrow_status
+    // 'funding' is persisted BEFORE status moves to 'truck_assigned') must
+    // never be cancelled here — the escrow-funding reconciliation worker owns
+    // the funding → healed/reverted transition.
+    if (escrowStatus === 'funding') {
+      logger.info(`[StaleOrderWorker] Order ${current.order_display_id} has escrow funding in flight, skipping.`);
+      return;
+    }
+
+    const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(escrowStatus);
+
+    const cancelled = requiresRefund
+      ? await cancelWithRefund(current, escrowStatus)
+      : await cancelPlain(current);
+
+    if (!cancelled) {
+      logger.info(`[StaleOrderWorker] Order ${current.order_display_id} was not cancelled (state changed concurrently), skipping side effects.`);
+      return;
+    }
+
+    // Cancel associated load offers (guarded on nothing — the order is now
+    // cancelled, so its offers can never be fulfilled).
+    await supabase
+      .from('load_offers')
+      .update({ status: 'cancelled' })
+      .eq('order_display_id', current.order_display_id);
+
+    // Send a notification to the customer
+    try {
+      await sendPushNotification(
+        current.customer_id,
+        'Order Cancelled',
+        requiresRefund
+          ? `Your order ${current.order_display_id} was cancelled because it was not completed in time. Any escrowed funds are being refunded.`
+          : 'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
+        'ORDER_CANCELLED',
+        { orderId: current.id, orderDisplayId: current.order_display_id }
+      );
+      logger.info(`[StaleOrderWorker] Cancelled order ${current.order_display_id} and notified customer ${current.customer_id}.`);
+    } catch (notifyErr) {
+      logger.warn(`[StaleOrderWorker] Cancelled order ${current.order_display_id}, but failed to notify customer ${current.customer_id}: ${notifyErr.message}`);
+    }
+  } catch (err) {
+    logger.error(`[StaleOrderWorker] Error processing stale order ${staleOrder.id}: ${err.message}`);
+  }
+}
+
+/**
+ * Cancel an order that has no escrow involvement (escrow_status NULL or
+ * 'pending'). The UPDATE is guarded on status='pending' AND escrow_status
+ * NULL/'pending', so a concurrently accepted order is never overwritten.
+ *
+ * @returns {Promise<boolean>} true when the order was actually cancelled
+ */
+async function cancelPlain(current) {
+  const { data: cancelled, error: updateErr } = await supabase
+    .from('orders')
+    .update({
+      status: 'cancelled',
+      cancellation_reason: STALE_ORDER_CANCELLATION_REASON,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', current.id)
+    .eq('status', 'pending')
+    .or('escrow_status.is.null,escrow_status.eq.pending')
+    .select('id');
+
+  if (updateErr) {
+    logger.error(`[StaleOrderWorker] Failed to cancel order ${current.id}: ${updateErr.message}`);
+    return false;
+  }
+
+  return Boolean(cancelled && cancelled.length > 0);
+}
+
+/**
+ * Cancel an order whose escrow is (or was) funded, routing the refund through
+ * the same pipeline used by orderLifecycleService.cancelOrder: first place the
+ * order into 'refund_pending' with a guarded update, then submit/confirm the
+ * refund, then finalise to 'refunded'. Any failure lands the order in
+ * 'refund_pending'/'refund_failed' so the escrow-refund reconciliation worker
+ * retries it.
+ *
+ * @returns {Promise<boolean>} true when the order was actually cancelled
+ */
+async function cancelWithRefund(current, escrowStatus) {
+  const attemptAt = new Date().toISOString();
+
+  // Guarded transition: only an order that is STILL pending AND in the exact
+  // escrow state we observed may enter refund reconciliation. This is the
+  // serialisation point that prevents two workers from double-refunding.
+  const { data: pendingOrder, error: pendingErr } = await supabase
+    .from('orders')
+    .update({
+      status: 'cancelled',
+      cancellation_reason: STALE_ORDER_CANCELLATION_REASON,
+      escrow_status: 'refund_pending',
+      escrow_refund_error: null,
+      escrow_refund_attempts: (current.escrow_refund_attempts ?? 0) + 1,
+      escrow_refund_last_attempt_at: attemptAt,
+      updated_at: attemptAt,
+    })
+    .eq('id', current.id)
+    .eq('status', 'pending')
+    .eq('escrow_status', escrowStatus)
+    .select('id');
+
+  if (pendingErr) {
+    logger.error(`[StaleOrderWorker] Failed to place order ${current.order_display_id} into refund reconciliation: ${pendingErr.message}`);
+    return false;
+  }
+
+  if (!pendingOrder || pendingOrder.length === 0) {
+    return false;
+  }
+
+  let refundTxHash = current.refund_tx_hash ?? null;
+  try {
+    if (refundTxHash) {
+      await confirmEscrowRefund(refundTxHash);
+    } else {
+      const submitted = await submitEscrowRefund(current.order_display_id);
+      if (submitted.waitForConfirmation) {
+        const receipt = await submitted.waitForConfirmation();
+        refundTxHash = receipt.hash ?? submitted.txHash;
+      } else {
+        // Escrow contract may not be initialised — record the tx hash and let
+        // the escrow-refund reconciliation worker finalise confirmation.
+        refundTxHash = submitted.txHash;
+      }
+    }
+
+    const refundedAt = new Date().toISOString();
+    const { error: finalErr } = await supabase
+      .from('orders')
+      .update({
+        status: 'cancelled',
+        escrow_status: 'refunded',
+        refund_tx_hash: refundTxHash,
+        escrow_refunded_at: refundedAt,
+        escrow_refund_error: null,
+        updated_at: refundedAt,
+      })
+      .eq('id', current.id)
+      .in('escrow_status', ['refund_pending', 'refund_failed'])
+      .select('id');
+
+    if (finalErr) {
+      logger.error(`[StaleOrderWorker] Refund confirmed for ${current.order_display_id} but final order update failed: ${finalErr.message}`);
+    }
+
+    return true;
+  } catch (refundErr) {
+    const failedAt = new Date().toISOString();
+    const nextEscrowStatus = refundTxHash ? 'refund_pending' : 'refund_failed';
+    await supabase
+      .from('orders')
+      .update({
+        status: 'cancelled',
+        escrow_status: nextEscrowStatus,
+        refund_tx_hash: refundTxHash,
+        escrow_refund_error: String(refundErr.message || refundErr).slice(0, 1000),
+        escrow_refund_last_attempt_at: failedAt,
+        updated_at: failedAt,
+      })
+      .eq('id', current.id)
+      .in('escrow_status', ['refund_pending', 'refund_failed']);
+    logger.error(`[StaleOrderWorker] Refund failed for order ${current.order_display_id}: ${refundErr.message}`);
+    return true;
+  }
+}
 
 export const stopStaleOrderWorker = () => {
   if (!staleOrderWorkerTask) return;

--- a/backend/api/test/unit/staleOrderWorkerNotifications.test.js
+++ b/backend/api/test/unit/staleOrderWorkerNotifications.test.js
@@ -53,15 +53,39 @@ function makeBuilder(table) {
   const builder = {
     _mode: 'select',
     _payload: null,
+    _id: null,
     select() { return this; },
-    eq() { return this; },
+    eq(column, value) {
+      if (column === 'id') this._id = value;
+      return this;
+    },
     lt() { return this; },
+    or() { return this; },
+    in() { return this; },
+    maybeSingle() { return this; },
     update(payload) {
       this._mode = 'update';
       this._payload = payload;
       return this;
     },
     then(resolve) {
+      // Per-order re-fetch (inside the loop): the worker re-reads the order
+      // with a status='pending' filter before touching it, so a single,
+      // still-pending order is returned.
+      if (table === 'orders' && this._mode === 'select' && this._id) {
+        const single = {
+          id: this._id,
+          customer_id: this._id === 'order-1' ? 'customer-1' : 'customer-2',
+          order_display_id: this._id === 'order-1' ? 'disp-1' : 'disp-2',
+          escrow_status: 'pending',
+          escrow_amount_wei: null,
+          refund_tx_hash: null,
+          escrow_refund_attempts: 0,
+        };
+        return resolve({ data: single, error: null });
+      }
+
+      // Batch SELECT of stale orders
       if (table === 'orders' && this._mode === 'select') {
         return resolve({
           data: [
@@ -74,7 +98,7 @@ function makeBuilder(table) {
 
       if (table === 'orders' && this._mode === 'update') {
         updateCalls.push(this._payload);
-        return resolve({ data: null, error: null });
+        return resolve({ data: [{ id: this._id }], error: null });
       }
 
       return resolve({ data: null, error: null });

--- a/backend/api/test/unit/staleOrderWorkerRace.test.js
+++ b/backend/api/test/unit/staleOrderWorkerRace.test.js
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let scheduledHandler;
+const scheduleMock = vi.fn((expression, handler) => {
+  scheduledHandler = handler;
+  return { stop: vi.fn() };
+});
+const sendPushNotificationMock = vi.fn();
+const submitEscrowRefundMock = vi.fn();
+const confirmEscrowRefundMock = vi.fn();
+const ordersUpdateCalls = [];
+let scriptedResponses = [];
+
+function makeBuilder(table) {
+  const builder = {
+    _mode: 'select',
+    _payload: null,
+    _filters: [],
+    select() { return this; },
+    eq(column, value) {
+      this._filters.push({ op: 'eq', column, value });
+      return this;
+    },
+    lt() { return this; },
+    or(filter) {
+      this._filters.push({ op: 'or', filter });
+      return this;
+    },
+    in() { return this; },
+    maybeSingle() { return this; },
+    update(payload) {
+      this._mode = 'update';
+      this._payload = payload;
+      return this;
+    },
+    then(resolve) {
+      const scripted = scriptedResponses.shift();
+      const result = scripted ?? { data: null, error: null };
+      if (table === 'orders' && this._mode === 'update') {
+        ordersUpdateCalls.push({ payload: this._payload, filters: this._filters, result });
+      }
+      return resolve(result);
+    },
+  };
+
+  return builder;
+}
+
+vi.mock('node-cron', () => ({
+  default: {
+    schedule: scheduleMock,
+  },
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: sendPushNotificationMock,
+}));
+
+vi.mock('../../src/services/escrow.js', () => ({
+  submitEscrowRefund: submitEscrowRefundMock,
+  confirmEscrowRefund: confirmEscrowRefundMock,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/core/telemetry/WorkerTracer.js', () => ({
+  WorkerTracer: {
+    wrapCronJob: vi.fn((_name, handler) => handler),
+    wrapIntervalWorker: vi.fn((_name, handler) => handler),
+  },
+}));
+
+vi.mock('../../src/core/telemetry/SpanFactory.js', () => ({
+  default: {
+    getActiveSpan: vi.fn(() => ({ setAttributes: vi.fn() })),
+    startWorkerSpan: vi.fn(() => ({ setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() })),
+  },
+  STANDARD_ATTRIBUTES: {},
+  SPAN_NAMES: {},
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {
+    from: vi.fn(makeBuilder),
+  },
+}));
+
+describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
+  beforeEach(async () => {
+    scheduledHandler = null;
+    scriptedResponses = [];
+    ordersUpdateCalls.length = 0;
+    scheduleMock.mockClear();
+    sendPushNotificationMock.mockReset();
+    submitEscrowRefundMock.mockReset();
+    confirmEscrowRefundMock.mockReset();
+    vi.resetModules();
+    const { startStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
+    startStaleOrderWorker();
+  });
+
+  const staleOrder = { id: 'order-1', customer_id: 'customer-1', order_display_id: 'disp-1' };
+
+  function stillPending(overrides = {}) {
+    return {
+      id: 'order-1',
+      customer_id: 'customer-1',
+      order_display_id: 'disp-1',
+      escrow_status: 'pending',
+      escrow_amount_wei: null,
+      refund_tx_hash: null,
+      escrow_refund_attempts: 0,
+      ...overrides,
+    };
+  }
+
+  it('skips an order that is no longer pending when re-fetched (TOCTOU window closed)', async () => {
+    scriptedResponses = [
+      { data: [staleOrder], error: null },
+      { data: null, error: null }, // re-fetch: not pending anymore
+    ];
+
+    await scheduledHandler();
+
+    expect(ordersUpdateCalls).toHaveLength(0);
+    expect(sendPushNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('never cancels an order whose escrow funding is in flight', async () => {
+    scriptedResponses = [
+      { data: [staleOrder], error: null },
+      { data: stillPending({ escrow_status: 'funding' }), error: null },
+    ];
+
+    await scheduledHandler();
+
+    expect(ordersUpdateCalls).toHaveLength(0);
+    expect(submitEscrowRefundMock).not.toHaveBeenCalled();
+    expect(sendPushNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('guards the plain cancellation update on status=pending AND escrow_status pending/null', async () => {
+    scriptedResponses = [
+      { data: [staleOrder], error: null },
+      { data: stillPending(), error: null },
+      { data: [{ id: 'order-1' }], error: null }, // guarded cancel succeeds
+    ];
+
+    await scheduledHandler();
+
+    expect(ordersUpdateCalls).toHaveLength(1);
+    const { payload, filters } = ordersUpdateCalls[0];
+    expect(payload.status).toBe('cancelled');
+    expect(filters).toEqual(expect.arrayContaining([
+      { op: 'eq', column: 'id', value: 'order-1' },
+      { op: 'eq', column: 'status', value: 'pending' },
+      { op: 'or', filter: 'escrow_status.is.null,escrow_status.eq.pending' },
+    ]));
+    expect(sendPushNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes funded escrow through submitEscrowRefund before finalising the cancellation', async () => {
+    submitEscrowRefundMock.mockResolvedValue({
+      txHash: '0xrefund',
+      bookingId: '0xbooking',
+      waitForConfirmation: async () => ({ hash: '0xrefund' }),
+    });
+
+    scriptedResponses = [
+      { data: [staleOrder], error: null },
+      { data: stillPending({ escrow_status: 'funded' }), error: null },
+      { data: [{ id: 'order-1' }], error: null }, // → refund_pending
+      { data: [{ id: 'order-1' }], error: null }, // → refunded
+    ];
+
+    await scheduledHandler();
+
+    expect(submitEscrowRefundMock).toHaveBeenCalledWith('disp-1');
+
+    const refundPending = ordersUpdateCalls.find(c => c.payload.escrow_status === 'refund_pending');
+    expect(refundPending).toBeDefined();
+    expect(refundPending.filters).toEqual(expect.arrayContaining([
+      { op: 'eq', column: 'status', value: 'pending' },
+      { op: 'eq', column: 'escrow_status', value: 'funded' },
+    ]));
+
+    const refunded = ordersUpdateCalls.find(c => c.payload.escrow_status === 'refunded');
+    expect(refunded).toBeDefined();
+    expect(refunded.payload.refund_tx_hash).toBe('0xrefund');
+    expect(sendPushNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the order for refund reconciliation when the refund submit fails', async () => {
+    submitEscrowRefundMock.mockRejectedValue(new Error('cancelBooking reverted'));
+
+    scriptedResponses = [
+      { data: [staleOrder], error: null },
+      { data: stillPending({ escrow_status: 'funded' }), error: null },
+      { data: [{ id: 'order-1' }], error: null }, // → refund_pending
+    ];
+
+    await scheduledHandler();
+
+    const failed = ordersUpdateCalls.find(c => c.payload.escrow_status === 'refund_failed');
+    expect(failed).toBeDefined();
+    expect(failed.payload.escrow_refund_error).toContain('cancelBooking reverted');
+    expect(sendPushNotificationMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## bug: Stale Order Worker TOCTOU Race and Stranded Escrow Funds

Closes #5741

### Summary
`staleOrderWorker` could cancel an order that was concurrently being accepted:
the batch `SELECT` returned a `pending` order, the customer accepted it
(flipping `escrow_status` to `funding` then `status` to `truck_assigned`), and
the worker's unguarded `UPDATE` still cancelled it. Funded orders also had no
refund path — the worker marked them cancelled without returning on-chain funds.

### Changes
- **Re-fetch inside the loop**: each stale order is re-read with
  `.eq('status','pending').maybeSingle()` before any mutation, closing the window
  between the batch SELECT and the per-order UPDATE
- **Guarded cancellations**: every update is now atomic on
  `status='pending'` **and** the current `escrow_status` —
  - plain cancel: `.or('escrow_status.is.null,escrow_status.eq.pending')`
  - refunded cancel: `.eq('escrow_status', <observed>)`
  A concurrently accepted order (escrow_status `funding` is persisted before
  `status` flips) can never be overwritten
- **`funding` orders are skipped** and left to the escrow-funding reconciliation
  worker (TTL sweep) which owns that transition
- **Escrow refunds wired in**: funded / `refund_pending` / `refund_failed` orders
  route through `submitEscrowRefund` + `confirmEscrowRefund` (mirroring
  `orderLifecycleService.cancelOrder`), landing in `refunded`, or
  `refund_pending`/`refund_failed` with `escrow_refund_error` for the refund
  reconciliation worker to retry — no more stranded customer funds
- Side effects (load-offer cancel, push notification) now fire only when the
  guarded UPDATE actually affected a row

### Testing
- **New `staleOrderWorkerRace.test.js`** — 5 tests: skip when re-fetch not
  pending, skip `funding` in flight, guarded plain-cancel filter, funded path
  calls `submitEscrowRefund` then finalizes `refunded`, refund failure →
  `refund_failed` with error recorded
- Updated `staleOrderWorkerNotifications.test.js` mock to the guarded-update
  contract
- All worker suites pass: 3 files, 8 tests