### PR TITLE
fix: fail closed when webhook secret is missing

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -174,6 +174,18 @@ if (!process.env.DRIVER_LOGIN_OTP) {
 }
 
 // ============================================================================
+// 🆕 WEBHOOK VALIDATION
+// ============================================================================
+if (!process.env.WEBHOOK_SECRET) {
+  if (process.env.NODE_ENV === 'production') {
+    logger.fatal('WEBHOOK_SECRET is not set. POST /api/webhooks/escrow would fail closed and reject all incoming webhooks. Set WEBHOOK_SECRET and restart.')
+    process.exit(1)
+  } else {
+    logger.warn('⚠️ WEBHOOK_SECRET is not set. Webhook requests will be rejected (fail-closed) until it is configured.')
+  }
+}
+
+// ============================================================================
 // 🆕 OTEL VALIDATION
 // ============================================================================
 if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {

--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -14,8 +14,9 @@ const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
  */
 function verifyWebhookSignature(req, res, next) {
   if (!WEBHOOK_SECRET) {
-    logger.warn('[Webhook] WEBHOOK_SECRET not set — skipping signature verification');
-    return next();
+    // Fail closed: an unset secret must never mean "accept everything".
+    logger.error('[Webhook] WEBHOOK_SECRET not set — rejecting webhook request');
+    return res.status(500).json({ error: 'Webhook processing is not configured' });
   }
 
   const signature = req.headers['x-webhook-signature'];
@@ -24,6 +25,11 @@ function verifyWebhookSignature(req, res, next) {
   }
 
   const rawBody = req.rawBody;
+  if (!rawBody) {
+    logger.error('[Webhook] rawBody missing — cannot verify signature, rejecting request');
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+
   const expectedSignature = crypto
     .createHmac('sha256', WEBHOOK_SECRET)
     .update(rawBody)


### PR DESCRIPTION
## Summary

This PR fixes a security issue in the webhook authentication flow by changing the webhook signature verification from a **fail-open** to a **fail-closed** approach when `WEBHOOK_SECRET` is not configured.

Previously, if `WEBHOOK_SECRET` was unset, the middleware skipped signature verification and allowed unauthenticated webhook requests to reach the escrow webhook handler. This could allow forged webhook events to trigger webhook processing and enqueue invalid entries into the Dead Letter Queue (DLQ).

## Changes

- Updated `verifyWebhookSignature` to reject requests when `WEBHOOK_SECRET` is not configured instead of bypassing verification.
- Added startup validation for `WEBHOOK_SECRET`.
- In production, the application now logs a fatal error and exits if `WEBHOOK_SECRET` is missing.
- In non-production environments, a warning is logged to indicate that webhook requests will be rejected until the secret is configured.
- Preserved existing HMAC signature verification logic for properly configured deployments.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5757