### PR TITLE
fix: validate and sanitize websocket telemetry payloads

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -327,7 +327,8 @@ export function initWebSocketServer(server, orderRepository) {
   }
 
   _orderRepository = orderRepository;
-  const wss = new WebSocketServer({ noServer: true });
+  const MAX_WS_PAYLOAD_BYTES = parseInt(process.env.WS_MAX_PAYLOAD_BYTES, 10) || 4096;
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_WS_PAYLOAD_BYTES });
   wsServer = wss;
 
   server.on('upgrade', async (request, socket, head) => {
@@ -610,16 +611,22 @@ export async function handleLocationPing(ws, data, req) {
   const lat = data.lat !== undefined ? data.lat : data.latitude;
   const lng = data.lng !== undefined ? data.lng : data.longitude;
 
-  // Fix 3: Coordinate validation — proper null/undefined, type, and range validation
-  if (lat === null || lat === undefined || typeof lat !== 'number' || !Number.isFinite(lat) ||
-      lng === null || lng === undefined || typeof lng !== 'number' || !Number.isFinite(lng)) {
-    return ws.send(JSON.stringify({ error: 'Missing mandatory tracking parameters (lat, lng).' }));
+  // Fix 3 + dead-code fix: run the payload through the schema validator/
+  const normalizedForValidation = {
+    lat,
+    lng,
+    driverId: driver_id,
+    timestamp: device_timestamp ? Date.parse(device_timestamp) || Date.now() : Date.now(),
+    speed: typeof speed === 'number' ? speed : undefined,
+    heading: typeof bearing === 'number' ? bearing : undefined,
+  };
+
+  const validationErrors = validateTelemetryPayload(normalizedForValidation);
+  if (validationErrors) {
+    return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: validationErrors }));
   }
 
-  // Range validation
-  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
-    return ws.send(JSON.stringify({ error: 'Coordinates out of valid range' }));
-  }
+  const sanitized = sanitizeTelemetryData(normalizedForValidation);
 
   // Parse device timestamp for analytics and clock skew check only (Fix 1)
   let deviceTime = null;
@@ -731,17 +738,17 @@ export async function handleLocationPing(ws, data, req) {
     telemetryOverflowDropped++;
   }
   await telemetryWriteBuffer.push({
-    driver_id,
-    order_id: orderUUID || null,
-    order_display_id: orderDisplayId || null,
-    lat,
-    lng,
-    location: {
-      type: 'Point',
-      coordinates: [parseFloat(lng), parseFloat(lat)]
-    },
-    speed_kmh: speed || 0,
-    bearing_deg: bearing || 0,
+  driver_id,
+  order_id: orderUUID || null,
+  order_display_id: orderDisplayId || null,
+  lat: sanitized.lat,
+  lng: sanitized.lng,
+  location: {
+    type: 'Point',
+    coordinates: [sanitized.lng, sanitized.lat]
+  },
+  speed_kmh: sanitized.speed ?? 0,
+  bearing_deg: sanitized.heading ?? 0,
     timestamp: deviceTime || new Date(),
     pinged_at: deviceTime || new Date(),
     buffered_at: new Date(),
@@ -761,7 +768,7 @@ export async function handleLocationPing(ws, data, req) {
       const redisKey = `driver:location:${driver_id}`;
       await redisClient.set(
         redisKey,
-        JSON.stringify({ latitude: lat, longitude: lng, speed: speed || 0, bearing: bearing || 0, updated_at: new Date(serverNow) }),
+        JSON.stringify({ latitude: sanitized.lat, longitude: sanitized.lng, speed: sanitized.speed ?? 0, bearing: sanitized.heading ?? 0, updated_at: new Date(serverNow) }),
         'EX',
         120
       );
@@ -775,10 +782,10 @@ export async function handleLocationPing(ws, data, req) {
     data: {
       driver_id,
       order_display_id: orderDisplayId,
-      latitude: lat,
-      longitude: lng,
-      speed: speed || 0,
-      bearing: bearing || 0,
+      latitude: sanitized.lat,
+      longitude: sanitized.lng,
+      speed: sanitized.speed ?? 0,
+      bearing: sanitized.heading ?? 0,
       timestamp: new Date(serverNow)
     }
   });
@@ -822,8 +829,8 @@ export async function handleLocationPing(ws, data, req) {
       payload: {
         orderId: orderUUID,
         driverId: driver_id,
-        lat,
-        lng,
+        lat: sanitized.lat,
+        lng: sanitized.lng,
         timestamp: new Date(serverNow).toISOString()
       }
     }).catch((err) => {


### PR DESCRIPTION
## Summary

This PR improves the security and robustness of the WebSocket telemetry pipeline by enforcing payload size limits, validating incoming telemetry data, and ensuring only sanitized values are used throughout processing.

Previously, telemetry payloads were accepted using the default WebSocket payload limit, and although validation/sanitization helpers existed, they were not fully integrated into the processing flow. This could allow oversized or malformed telemetry payloads to consume unnecessary resources or propagate invalid data.

## Changes

- Added a configurable `maxPayload` limit to the WebSocket server to reject oversized frames.
- Integrated `validateTelemetryPayload()` into the telemetry processing flow.
- Applied `sanitizeTelemetryData()` before storing, caching, and broadcasting telemetry.
- Enforced latitude and longitude validation through the telemetry schema.
- Updated MongoDB telemetry storage to use sanitized values.
- Updated Redis location cache to use sanitized values.
- Updated WebSocket broadcasts to use sanitized values.
- Updated Supabase Realtime broadcasts to use sanitized values.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5758