### PR TITLE
feat(devops): replace current auto-assigner with comment-based assignment and tracking labels

### DIFF
--- a/.github/workflows/issue-assigner.yml
+++ b/.github/workflows/issue-assigner.yml
@@ -1,27 +1,102 @@
-name: Issue Auto Assigner
+name: Issue Assignment
 
 on:
-  issues:
-    types: [opened]
+  issue_comment:
+    types: [created]
 
 permissions:
   issues: write
 
 jobs:
   assign:
-    name: Assign Issue to Creator
+    name: Auto-assign contributor
     runs-on: ubuntu-latest
+    
+    # Skip pull request comments (only process real issues)
+    if: github.event.issue.pull_request == null
 
     steps:
-      - name: Assign issue
+      - name: Handle assignment request
+      
         uses: actions/github-script@v7
         with:
+        
           script: |
-            const opener = context.payload.issue.user.login;
+            const comment = context.payload.comment.body.toLowerCase().trim();
+            const KEYWORDS = [
+              "/assign",
+              "assign me",
+              "i'd like to work on this",
+              "i want to work on this",
+              "can i work on this",
+              "please assign me"
+            ];
+
+            // 1. Check if the comment matches any assignment keyword
+            
+            if (!KEYWORDS.some(kw => comment.includes(kw))) return;
+            
+            // Skip automated bot comments
+            
+            if (context.payload.comment.user.type === 'Bot') return;
+
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+
+            // 2. Fetch live issue data from the GitHub API
+            
+            const { data: issue } = await github.rest.issues.get({
+              owner, repo, issue_number: issueNumber,
+            });
+
+            if (issue.state !== 'open') return;
+
+            // 3. Check if the issue is already taken
+            
+            if (issue.assignees && issue.assignees.length > 0) {
+              const assignees = issue.assignees.map(a => a.login);
+              
+              if (assignees.includes(commenter)) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issueNumber,
+                  body: `@${commenter} You are already assigned to this issue! Please link your upcoming Pull Request to this ticket.`,
+                });
+                
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issueNumber,
+                  body: `@${commenter} This issue is already claimed by @${assignees.join(', @')}. Keep an eye out for other open tasks!`,
+                });
+                
+              }
+              return;
+            }
+
+            // 4. Assign the contributor
             
             await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              assignees: [opener]
+              owner, repo, issue_number: issueNumber,
+              assignees: [commenter],
             });
+
+            // 5. add an "assigned" label to track status
+            
+            const currentLabels = issue.labels.map(l => l.name);
+            if (!currentLabels.includes('assigned')) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issueNumber,
+                labels: ['assigned'],
+              });
+              
+            }
+
+            // 6. Post confirmation comment
+            
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              
+              body: `Assigned to @${commenter}! Please open a Pull Request linking to this issue once ready.`,
+            });
+
+            

--- a/.github/workflows/issue-assigner.yml
+++ b/.github/workflows/issue-assigner.yml
@@ -11,6 +11,11 @@ jobs:
   assign:
     name: Auto-assign contributor
     runs-on: ubuntu-latest
+
+    # Serialize runs for the same issue to prevent race conditions
+    concurrency:
+      group: issue-assign-${{ github.event.issue.number }}
+      cancel-in-progress: false
     
     # Skip pull request comments (only process real issues)
     if: github.event.issue.pull_request == null
@@ -80,18 +85,32 @@ jobs:
               assignees: [commenter],
             });
 
-            // 5. add an "assigned" label to track status
+            // 5. Verify GitHub successfully added the assignee (handles non-collaborator silent drops)
             
-            const currentLabels = issue.labels.map(l => l.name);
+            const { data: updatedIssue } = await github.rest.issues.get({
+              owner, repo, issue_number: issueNumber,
+            });
+
+            const currentAssignees = updatedIssue.assignees.map(a => a.login);
+            if (!currentAssignees.includes(commenter)) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${commenter} Unable to assign you automatically. A repository administrator may need to assign you manually.`,
+              });
+              return;
+            }
+
+            // 6. Add an "assigned" label to track status
+            
+            const currentLabels = updatedIssue.labels.map(l => l.name);
             if (!currentLabels.includes('assigned')) {
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: issueNumber,
                 labels: ['assigned'],
               });
-              
             }
 
-            // 6. Post confirmation comment
+            // 7. Post confirmation comment
             
             await github.rest.issues.createComment({
               owner, repo, issue_number: issueNumber,


### PR DESCRIPTION

###  Description
- Replaces the automatic issue opener assignment workflow with an interactive comment-triggered assigner (`/assign`, "can i work on this").
-  Also add tracking labels like assigned.
- Also take care of situation like same or different person asking for assignment

###  Changes Made
- Updated trigger from `issues: [opened]` to `issue_comment: [created]`.
- Added phrase detection for `/assign`, `assign me`, `can i work on this`, etc.
- Added duplicate assignment prevention and bot filter checks.
- Added automatic `assigned` label application to track claimed tasks on the project board.
- Posts helpful confirmation comments to guide contributors.

###  Related Issue
Closes #5785 @KanishJebaMathewM 

###  Checklists
- [x] Tested workflow logic against GitHub REST API methods.
- [x] Configured permissions (`issues: write`).
- [x] Ensured PR comments are explicitly filtered out (`if: github.event.issue.pull_request == null`).<img width="802" height="820" alt="image" src="[link removed for security]" />

GSSoC'26


> ⚠️ **Security Notice:** Links posted by non-contributors have been automatically removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic issue assignment when eligible commenters request assignment using recognized phrases.
  * Added confirmation messages and an `assigned` label when assignments are completed.
  * Reports when an issue is already assigned.

* **Bug Fixes**
  * Excludes pull request comments, bot comments, and closed issues from automatic assignment.
  * Removed automatic assignment of issue creators when issues are opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->