### PR TITLE
fix: require X-API-Key auth on all ML routers and stop host-exposing the ML engine port

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -1,11 +1,10 @@
 import asyncio
-import hmac
 import logging
 import os
 import time
 import numpy as np
 from datetime import datetime, timedelta
-from fastapi import FastAPI, HTTPException, Header, Depends, Query
+from fastapi import FastAPI, HTTPException, Depends, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
@@ -27,7 +26,7 @@ from app.models.mid_trip_reoptimiser import find_mid_trip_loads
 from app.models.base import model_exists
 from app.models.demand_forecast import MODEL_NAME as DEMAND_MODEL_NAME
 from app.models.price_prediction import MODEL_NAME as PRICE_MODEL_NAME
-from routes import register_ml_routers
+from routes import register_ml_routers, verify_api_key
 
 logging.basicConfig(
     level=logging.INFO,
@@ -38,21 +37,13 @@ logger = logging.getLogger(__name__)
 # Track loaded models for health reporting
 loaded_models: set[str] = set()
 
-async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
-    ml_api_key = os.environ.get("ML_API_KEY")
-    if not ml_api_key:
-        logger.warning("ML_API_KEY not set - ML engine is unavailable (503)")
-        raise HTTPException(status_code=503, detail="ML engine not configured: missing ML_API_KEY")
-    if not x_api_key or not hmac.compare_digest(x_api_key, ml_api_key):
-        raise HTTPException(status_code=401, detail="Unauthorized")
-
-
 app = FastAPI(
     title="Truxify ML Engine",
     description="ML prediction service for load matching, pricing, ETA, and route optimization",
     version="1.0.0",
-    docs_url="/docs",      # Swagger UI at /docs
-    redoc_url="/redoc", 
+    # Swagger/ReDoc interactive docs are disabled in production.
+    docs_url=None if os.environ.get("ENVIRONMENT") == "production" else "/docs",
+    redoc_url=None if os.environ.get("ENVIRONMENT") == "production" else "/redoc",
 )
 
 

--- a/backend/ml/routes/__init__.py
+++ b/backend/ml/routes/__init__.py
@@ -1,11 +1,25 @@
+import hmac
 import importlib
 import logging
+import os
 from typing import TYPE_CHECKING
+
+from fastapi import Depends, Header, HTTPException
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
+
+
+async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
+    """Shared auth dependency applied to every ML route (incl. dynamic routers)."""
+    ml_api_key = os.environ.get("ML_API_KEY")
+    if not ml_api_key:
+        logger.warning("ML_API_KEY not set - ML engine is unavailable (503)")
+        raise HTTPException(status_code=503, detail="ML engine not configured: missing ML_API_KEY")
+    if not x_api_key or not hmac.compare_digest(x_api_key, ml_api_key):
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 # ---------------------------------------------------------------------------
 # Registry of ML route modules to attempt loading.
@@ -79,7 +93,7 @@ def register_ml_routers(app: "FastAPI") -> list[str]:
             continue
 
         try:
-            app.include_router(router)
+            app.include_router(router, dependencies=[Depends(verify_api_key)])
         except Exception as exc:
             logger.warning(
                 "Skipping ML router '%s' (%s): failed to register routes — %s",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,9 @@ services:
       - no-new-privileges:true
 
   # ─── ML Engine ─────────────────────────────────────────────────────────────
+  # Security: NOT published on the host network — reachable only by the API
+  # service on the internal Docker network (`http://ml-engine:8000`). All routes
+  # require the shared X-API-Key, and interactive docs are disabled in production.
   ml-engine:
     build:
       context: ./backend/ml
@@ -80,8 +83,7 @@ services:
       - .env
     environment:
       ML_API_KEY: ${ML_API_KEY:?ML_API_KEY is required}
-    ports:
-      - "${ML_PORT:-8001}:8000"
+      ENVIRONMENT: production
     volumes:
       # Remove dev code mount — code is baked into the production image
       # Persist trained models across restarts


### PR DESCRIPTION
## Summary
All 17 ML route modules were registered without any authentication, and the ML engine's port was host-exposed, letting anyone on the network call price/ETA/safety/model endpoints directly.

## Changes
- **Mandatory auth on all ML routers** (`backend/ml/routes/__init__.py`, `backend/ml/main.py`): every route module now requires a valid `X-API-Key` before it can be invoked; missing/invalid keys are rejected with 401/503.
- **Host exposure removed** (`docker-compose.prod.yml`): the ML engine port is no longer published to the host network; it is reachable only from the internal Docker network where the API gateway can forward requests.

Closes #5776