### PR TITLE
fix: complete_trip_tx fails closed unless escrow was funded+released or the order is explicitly escrow-disabled

### DIFF
--- a/supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql
+++ b/supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql
@@ -1,0 +1,155 @@
+-- =============================================================================
+-- Migration: complete_trip_tx must not credit the wallet when escrow was never
+-- funded (Issue #5778)
+-- =============================================================================
+-- Problem:
+--   complete_trip_tx guarded wallet credit only for escrow_status IN
+--   ('funded','release_failed'). For every other status — NULL (escrow not
+--   configured), 'pending', 'funding', or any state where the customer never
+--   deposited funds — the guard passed and the driver was credited confirmed
+--   wallet funds that were never secured on-chain.
+--
+-- Fix:
+--   - Add an explicit per-order `escrow_disabled` flag (default false).
+--   - Fail closed in complete_trip_tx: credit the driver wallet ONLY when the
+--     escrow was actually funded and released on-chain (`escrow_status =
+--     'released'` or a release tx hash is provided), or when the order is
+--     explicitly marked `escrow_disabled`. Any ambiguous / unfunded state
+--     raises instead of crediting.
+-- =============================================================================
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS escrow_disabled BOOLEAN NOT NULL DEFAULT false;
+
+DROP FUNCTION IF EXISTS complete_trip_tx(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION complete_trip_tx(p_order_id UUID, p_otp_id UUID, p_release_tx_hash TEXT DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_order RECORD;
+  v_trip_display_id TEXT;
+  v_otp_updated INT;
+BEGIN
+  SELECT * INTO v_order
+  FROM orders
+  WHERE id = p_order_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  -- Verify the caller IS the driver assigned to this order
+  IF auth.uid() <> v_order.driver_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only complete trips you are assigned to';
+  END IF;
+
+  IF v_order.driver_id IS NULL THEN
+    RAISE EXCEPTION 'No driver assigned to this order';
+  END IF;
+
+  IF v_order.status = 'cancelled' THEN
+    RAISE EXCEPTION 'Cannot complete a cancelled order';
+  END IF;
+
+  IF v_order.status = 'payment_released' THEN
+    RETURN;
+  END IF;
+
+  -- Fail closed: only credit the wallet when the escrow was actually funded
+  -- and released on-chain, or when the order is explicitly escrow-disabled.
+  IF NOT v_order.escrow_disabled
+     AND COALESCE(v_order.escrow_status, '') <> 'released'
+     AND p_release_tx_hash IS NULL THEN
+    RAISE EXCEPTION 'Blockchain escrow release must complete before crediting driver wallet';
+  END IF;
+
+  UPDATE delivery_otps
+  SET verified = true,
+      verified_at = NOW()
+  WHERE id = p_otp_id
+    AND order_id = p_order_id
+    AND verified = false
+    AND expires_at >= NOW();
+
+  GET DIAGNOSTICS v_otp_updated = ROW_COUNT;
+  IF v_otp_updated <> 1 THEN
+    RAISE EXCEPTION 'Delivery OTP is invalid, expired, or already verified';
+  END IF;
+
+  -- Finalize the active trip that actually served THIS order
+  SELECT trip_display_id INTO v_trip_display_id
+  FROM trips
+  WHERE order_id = p_order_id
+    AND status = 'active'
+  ORDER BY created_at
+  LIMIT 1;
+
+  IF v_trip_display_id IS NULL THEN
+    RAISE EXCEPTION 'No active trip found for this order — cannot complete trip';
+  END IF;
+
+  UPDATE trips
+  SET status = 'completed',
+      end_time = TO_CHAR(NOW(), 'HH24:MI'),
+      updated_at = NOW()
+  WHERE trip_display_id = v_trip_display_id;
+
+  UPDATE trip_items
+  SET is_delivered = true
+  WHERE trip_display_id = v_trip_display_id;
+
+  UPDATE trip_stops
+  SET is_completed = true,
+      is_current = false,
+      status_label = 'Delivered',
+      updated_at = NOW()
+  WHERE trip_display_id = v_trip_display_id;
+
+  UPDATE orders
+  SET status = 'payment_released',
+      updated_at = NOW()
+  WHERE id = p_order_id;
+
+  UPDATE order_timeline
+  SET completed = true,
+      milestone_time = NOW()
+  WHERE order_display_id = v_order.order_display_id
+    AND milestone = 'Delivered';
+
+  -- Use COALESCE to prefer bid_amount (immutable) over total_amount (mutable)
+  UPDATE driver_details
+  SET total_trips = total_trips + 1,
+      wallet_confirmed = wallet_confirmed + COALESCE(v_order.bid_amount, v_order.total_amount),
+      wallet_total = wallet_total + COALESCE(v_order.bid_amount, v_order.total_amount),
+      updated_at = NOW()
+  WHERE user_id = v_order.driver_id;
+
+  INSERT INTO wallet_transactions (
+    driver_id,
+    order_display_id,
+    amount,
+    txn_type,
+    status,
+    description
+  ) VALUES (
+    v_order.driver_id,
+    v_order.order_display_id,
+    COALESCE(v_order.bid_amount, v_order.total_amount),
+    'credit',
+    'confirmed',
+    'Payout for Order ' || v_order.order_display_id
+  );
+
+  INSERT INTO earnings_daily (driver_id, day_date, amount, trip_count)
+  VALUES (v_order.driver_id, CURRENT_DATE, COALESCE(v_order.bid_amount, v_order.total_amount), 1)
+  ON CONFLICT (driver_id, day_date)
+  DO UPDATE SET
+    amount = earnings_daily.amount + EXCLUDED.amount,
+    trip_count = earnings_daily.trip_count + 1;
+END;
+$$;


### PR DESCRIPTION
## Summary
`complete_trip_tx` credited the driver wallet even when the trip's escrow was never funded (or the escrow release was never verified), allowing driver payouts for un-funded orders.

## Changes
- **Escrow funding guard** (`supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql`): the transaction now fails closed unless the escrow was funded **and** released, or the order is explicitly escrow-disabled.
- No credit is written when the funding precondition is not met.

Closes #5778