### PR TITLE
fix: make Kafka consumers idempotent via processed-event registry, producer idempotence, and deduplicated event-bus publishes

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -61,6 +61,8 @@ class KafkaConfig {
       this.producer = kafka.producer({
         allowAutoTopicCreation: true,
         transactionTimeout: 30000,
+        enableIdempotence: true,
+        maxInFlightRequests: 5,
       });
       await this.producer.connect();
       this.isConnected = true;

--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -1,4 +1,5 @@
 import kafka, { TOPICS, CONSUMER_GROUPS } from '../config/kafka.config.js';
+import processedEventRepository from '../repositories/processedEvent.repository.js';
 import logger from '../api/src/middleware/logger.js';
 
 class OrderConsumer {
@@ -79,6 +80,23 @@ class OrderConsumer {
     const handlers = this.handlers;
 
     const messageHandler = async (topic, message, rawMessage) => {
+      // Idempotency claim: only the first delivery of an event may apply side
+      // effects. Kafka redelivers messages on restarts/rebalances, so without
+      // this guard PAYMENT_CONFIRMED / TRIP_COMPLETED / ESCROW_RELEASED would
+      // be processed (and credit wallets) more than once.
+      const eventId = message?.metadata?.eventId || rawMessage?.key?.toString() || null;
+      if (eventId) {
+        const isNew = await processedEventRepository.claimProcessed(
+          topic,
+          eventId,
+          message?.orderId || message?.payload?.orderId || null
+        );
+        if (!isNew) {
+          logger.info(`[OrderConsumer] Skipping duplicate event ${eventId} on ${topic}`);
+          return;
+        }
+      }
+
       if (handlers.has(topic)) {
         const topicHandlers = handlers.get(topic);
         for (const handler of topicHandlers) {
@@ -92,11 +110,19 @@ class OrderConsumer {
 
       if (this._eventBus) {
         const eventType = topic.replace(/\./g, '_').toUpperCase();
-        this._eventBus.publish(eventType, message, {
-          adapters: [],
-          deduplicate: false,
-          source: `kafka:${groupId}`,
-        });
+        if (message && typeof message === 'object' && message.metadata) {
+          // Object form reuses the original event id so the in-process
+          // EventBus deduplication window applies to redelivered messages.
+          this._eventBus.publish(message, {
+            adapters: [],
+            source: `kafka:${groupId}`,
+          });
+        } else {
+          this._eventBus.publish(eventType, message, {
+            adapters: [],
+            source: `kafka:${groupId}`,
+          });
+        }
       }
     };
 

--- a/backend/kafka/events/order.events.js
+++ b/backend/kafka/events/order.events.js
@@ -28,7 +28,7 @@ class OrderEventService {
 
   _publish(event) {
     if (this._eventBus) {
-      this._eventBus.publish(event, { adapters: ['kafka'], deduplicate: false });
+      this._eventBus.publish(event, { adapters: ['kafka'] });
     }
     this.events.push(event.toJSON());
     return event;

--- a/backend/kafka/repositories/processedEvent.repository.js
+++ b/backend/kafka/repositories/processedEvent.repository.js
@@ -1,0 +1,37 @@
+import { supabase } from '../api/src/config/db.js';
+import logger from '../api/src/middleware/logger.js';
+
+class ProcessedEventRepository {
+  /**
+   * Atomically claim a Kafka message as processed.
+   *
+   * Uses an upsert on the (topic, event_id) primary key so concurrent or
+   * redelivered messages race safely: only the first insert wins.
+   *
+   * @returns {Promise<boolean>} true when the message was newly claimed,
+   *          false when it had already been processed.
+   */
+  async claimProcessed(topic, eventId, orderId = null) {
+    try {
+      const { data, error } = await supabase
+        .from('kafka_processed_events')
+        .upsert({
+          topic,
+          event_id: eventId,
+          order_id: orderId || null,
+        }, {
+          onConflict: 'topic,event_id',
+          ignoreDuplicates: true,
+        })
+        .select('event_id');
+
+      if (error) throw error;
+      return Array.isArray(data) ? data.length > 0 : data !== null;
+    } catch (error) {
+      logger.error(`Failed to claim processed event ${eventId} on ${topic}:`, error);
+      throw error;
+    }
+  }
+}
+
+export default new ProcessedEventRepository();

--- a/supabase/migrations/20260802140000_kafka_processed_events_idempotency.sql
+++ b/supabase/migrations/20260802140000_kafka_processed_events_idempotency.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- KAFKA CONSUMER IDEMPOTENCY — Processed-Event Registry
+-- ============================================================================
+-- Kafka consumers run with at-least-once delivery semantics, so the same
+-- message can be redelivered after a consumer restart, rebalance, or handler
+-- error.  This registry records every message that has already been applied so
+-- consumers can skip duplicates before applying side effects (read-model
+-- updates, wallet/earnings credits, notifications, etc.).
+--
+-- SECURITY MODEL:
+--   - Keyed on (topic, event_id), the event's natural idempotency key.
+--   - The registry is written by backend services using the service_role key
+--     and is never exposed to clients, so RLS allows service_role only.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. PROCESSED-EVENT REGISTRY TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists kafka_processed_events (
+  topic        text not null,       -- kafka topic (e.g. 'payment.confirmed')
+  event_id     text not null,       -- original event id / message key
+  order_id     uuid,                -- orders.id, when derivable from the event
+  processed_at timestamptz not null default now(),
+  primary key (topic, event_id)
+);
+
+create index if not exists idx_kafka_processed_events_order
+  on kafka_processed_events (order_id);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table kafka_processed_events enable row level security;
+
+drop policy if exists "Service role full access on kafka_processed_events"
+  on kafka_processed_events;
+create policy "Service role full access on kafka_processed_events"
+  on kafka_processed_events
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table kafka_processed_events from anon, authenticated;


### PR DESCRIPTION
## Summary
Kafka consumers were not idempotent: duplicate event delivery (consumer restart, reprocessing, exactly-once gaps in at-least-once delivery) caused double writes and double wallet credits.

## Changes
- **Processed-event registry** (`supabase/migrations/20260802140000_kafka_processed_events_idempotency.sql`, `backend/kafka/repositories/processedEvent.repository.js`): consumed events are recorded; reprocessed events are skipped.
- **Producer idempotence** (`backend/kafka/config/kafka.config.js`): producer configured for idempotent delivery to prevent duplicate broker writes.
- **Deduplicated publishes** (`backend/kafka/events/order.events.js`): event-bus publishes are de-duplicated by event id.
- **Consumer integration** (`backend/kafka/consumers/order.consumer.js`): handlers check/skip via the registry before applying side effects.

Closes #5780