### PR TITLE
fix: auto-revoke public tracking tokens when a trip completes or is cancelled

### DIFF
--- a/backend/api/src/core/container.js
+++ b/backend/api/src/core/container.js
@@ -4,6 +4,7 @@ import logger from '../middleware/logger.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
 import OracleService from '../oracle/OracleService.js';
 import VerificationService from '../services/verification/VerificationService.js';
+import { TrackingTokenService } from '../services/trackingTokenService.js';
 
 import { OrderTimelineService } from '../services/order/orderTimelineService.js';
 import { OrderValidationService } from '../services/order/orderValidationService.js';
@@ -38,19 +39,25 @@ const bidAcceptanceService = new BidAcceptanceService({
   logger,
 });
 
-const deliveryVerificationService = new DeliveryVerificationService(orderRepository);
+const trackingTokenService = new TrackingTokenService({ supabase, logger });
+
+const deliveryVerificationService = new DeliveryVerificationService(orderRepository, {
+  trackingTokenService,
+});
 
 const orderMilestoneService = new OrderMilestoneService({
   orderRepository,
   orderValidationService,
   orderTimelineService,
   orderNotificationService,
+  trackingTokenService,
 });
 
 const orderLifecycleService = new OrderLifecycleService({
   orderRepository,
   orderTimelineService,
   bidAcceptanceService,
+  trackingTokenService,
 });
 
 export {
@@ -69,6 +76,7 @@ export {
   orderMilestoneService,
   orderNotificationService,
   bidAcceptanceService,
+  trackingTokenService,
   deliveryVerificationService,
   orderLifecycleService,
 

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -47,6 +47,7 @@ export class DeliveryVerificationService {
       verifyDeliveryOtp,
     };
     this.escrowReleaseFn = deps.escrowReleaseFn || defaultEscrowRelease;
+    this.trackingTokenService = deps.trackingTokenService || null;
   }
 
   async validateDeliveryOtp({ orderId, driverId, otp }) {
@@ -362,6 +363,11 @@ export class DeliveryVerificationService {
     } else {
       logger.info(`[verify-delivery] Retry for stuck escrow for order ${orderId} by driver ${driverId}`);
     }
+
+    // The trip is complete (payment_released) — kill any active public
+    // tracking tokens so a shared link can no longer broadcast the driver's
+    // live location. Best-effort: revokeAllForOrder never throws.
+    await this.trackingTokenService?.revokeAllForOrder(order.order_display_id);
 
     let escrowUpdateFailed = false;
     if (releaseTxHash || escrowAlreadyReleased) {

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -38,11 +38,21 @@ import { generateOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } from '../../lib/
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class OrderLifecycleService {
-  constructor({ orderRepository, orderTimelineService, bidAcceptanceService, deliveryVerificationService }) {
+  constructor({ orderRepository, orderTimelineService, bidAcceptanceService, deliveryVerificationService, trackingTokenService }) {
     this.orderRepository = orderRepository;
     this.orderTimelineService = orderTimelineService;
     this.bidAcceptanceService = bidAcceptanceService;
     this.deliveryVerification = deliveryVerificationService || new DeliveryVerificationService(orderRepository);
+    this.trackingTokenService = trackingTokenService || null;
+  }
+
+  async revokeTrackingTokensForOrder(orderDisplayId) {
+    if (!this.trackingTokenService || !orderDisplayId) return;
+    try {
+      await this.trackingTokenService.revokeAllForOrder(orderDisplayId);
+    } catch (error) {
+      logger.error(`[OrderLifecycleService] Failed to revoke tracking tokens for order ${orderDisplayId}:`, error);
+    }
   }
 
   async createOrder(customerId, customerName, body) {
@@ -660,6 +670,7 @@ export class OrderLifecycleService {
       const driverFeeWei = (escrowAmountWei * BigInt(penaltyBps)) / 10_000n;
 
       if (currentOrder.status === 'cancelled' && (!requiresRefund || currentOrder.escrow_status === 'refunded')) {
+        await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
         return {
           status: 200,
           body: {
@@ -760,6 +771,7 @@ export class OrderLifecycleService {
 
           await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
           await expireDeliveryOtps(currentOrder.id);
+          await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
 
           return {
             status: 200,
@@ -820,6 +832,7 @@ export class OrderLifecycleService {
 
       await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
       await expireDeliveryOtps(currentOrder.id);
+      await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
 
       return {
         status: 200,

--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -27,6 +27,7 @@ export class OrderMilestoneService {
     if (args.orderValidationService) this.validation = args.orderValidationService;
     if (args.orderTimelineService) this.orderTimelineService = args.orderTimelineService;
     if (args.orderNotificationService) this.orderNotificationService = args.orderNotificationService;
+    if (args.trackingTokenService) this.trackingTokenService = args.trackingTokenService;
   }
 
   async updateMilestone({ orderId, milestone, driverId }) {
@@ -211,6 +212,10 @@ export class OrderMilestoneService {
         error: 'Order status changed during processing. Payment was not released.',
       });
     }
+
+    // Trip complete — revoke any public tracking tokens so the shared link
+    // can no longer expose the driver's live location. Best-effort.
+    await this.trackingTokenService?.revokeAllForOrder(order.order_display_id);
 
     await verifyDeliveryOtp(otpRecord.id);
     await clearOtpState(orderId);


### PR DESCRIPTION
## Summary
Public tracking tokens were never revoked, so a completed or cancelled trip kept broadcasting live driver location for up to 7 days.

## Changes
- **Auto-revoke on completion/cancellation** (`backend/api/src/services/order/orderLifecycleService.js`, `orderMilestoneService.js`, `deliveryVerificationService.js`): tokens are revoked when a trip completes or is cancelled.
- **Wiring** (`backend/api/src/core/container.js`): the revocation dependency is injected into the order lifecycle/milestone/verification services so the behavior is applied consistently across all completion paths.

Closes #5781