### PR TITLE
fix: enforce Firebase token revocation checks and shorten cached profile TTL

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -20,7 +20,7 @@ async function _publishProfileInvalidation(eventOpts) {
   }
 }
 
-export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || '900', 10); // 15 minutes default
+export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || '120', 10); // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 
 let cacheHits = 0;

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -49,7 +49,7 @@ export async function verifyAuthToken(token) {
     if (!firebaseAdmin) {
       throw new Error('Firebase Auth verification is not configured on this server.');
     }
-    const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
+    const decodedToken = await firebaseAdmin.auth().verifyIdToken(token, true);
     firebaseUid = decodedToken.uid;
 
     if (!supabase) {
@@ -226,7 +226,7 @@ export async function authenticate(req, res, next) {
       if (!firebaseAdmin) {
         return res.status(500).json({ error: 'Firebase Auth verification is not configured on this server.' });
       }
-      const decodedToken = await firebaseAdmin.auth().verifyIdToken(token);
+      const decodedToken = await firebaseAdmin.auth().verifyIdToken(token, true);
       firebaseUid = decodedToken.uid;
 
       // Check Redis cache first.


### PR DESCRIPTION
## Summary
Firebase auth verified ID tokens without `checkRevoked`, so tokens for revoked sessions remained valid. The profile cache also held data for 15 minutes, serving stale user state (including revoked roles) for too long.

## Changes
- **Revocation enforced** (`backend/api/src/middleware/auth.js`): `verifyIdToken` now uses `checkRevoked: true`, rejecting revoked/disabled tokens.
- **Shortened cache TTL** (`backend/api/src/lib/profileCache.js`): cached profile TTL reduced to 120 seconds to bound staleness while keeping load off the DB.

Closes #5782