### PR TITLE
fix(escrow): block full-refund cancellation after trip start 

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -37,10 +37,11 @@ const ESCROW_ABI = [
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
   'function cancelWithPenalty(uint256 bookingId, uint256 driverFee) external',
+  'function markBookingStarted(uint256 bookingId) external',
   'function raiseDispute(uint256 bookingId) external',
   'function resolveDispute(uint256 bookingId, uint256 driverAmount) external',
   'function resolveDisputeTimeout(uint256 bookingId) external',
-  'function bookings(uint256 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, uint256 createdAt)'
+  'function bookings(uint256 bookingId) external view returns (address customer, address driver, uint256 amount, uint8 status, bool paid, bool started, uint256 createdAt)'
 ]
 
 const rpcUrl            = process.env.POLYGON_RPC_URL;
@@ -464,12 +465,48 @@ export async function getEscrowBooking (bookingId) {
       amount: booking.amount,
       status: booking.status,
       paid: booking.paid,
+      started: booking.started,
       createdAt: booking.createdAt,
     }
   } catch (err) {
     logger.warn(`[escrow] Failed to read booking ${bookingId}: ${err.message}`)
     return null
   }
+}
+
+/**
+ * Mark an escrow booking as started (driver picked up the goods).
+ * Only the relayer (owner) may call markBookingStarted on-chain.
+ * Once started, cancelBooking / cancelWithPenalty will revert.
+ */
+export async function markEscrowBookingStarted (orderDisplayId) {
+  return measureExecution('EscrowService.markEscrowBookingStarted', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping markBookingStarted.')
+      return { txHash: null, bookingId }
+    }
+
+    try {
+      const tx = await escrowContract.markBookingStarted(bookingId)
+      logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+      return {
+        txHash: tx.hash,
+        bookingId,
+        waitForConfirmation: async () => {
+          const receipt = await tx.wait(1)
+          if (!receipt || receipt.status === 0) {
+            throw new Error('Escrow markBookingStarted transaction reverted or was not found.')
+          }
+          return receipt
+        },
+      }
+    } catch (err) {
+      logger.error(`[escrow] markBookingStarted failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+  })
 }
 
 export function bookingIdFromUuid (orderId) {

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -647,6 +647,13 @@ export class OrderLifecycleService {
         throw new DomainError(409, { error: 'Cannot cancel: delivery OTP has already been verified.' });
       }
 
+      // The driver has already started the trip — a full-refund cancellation is
+      // no longer possible. On-chain, cancelBooking / cancelWithPenalty revert
+      // once the booking has been marked as started, so reject here first.
+      if (['picked_up', 'in_transit', 'arriving', 'arrived_dropoff'].includes(currentOrder.status)) {
+        throw new DomainError(409, { error: 'Cannot cancel: the shipment has already been picked up and is in transit.' });
+      }
+
       const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(currentOrder.escrow_status);
       const penaltyBps = currentOrder.status === 'assigned'
         ? 1000

--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -16,7 +16,7 @@ import {
   OTP_LOCKOUT_MINUTES,
   DELIVERY_OTP_READY_STATUSES,
 } from './orderNotificationService.js';
-import { escrowRelease } from '../escrow.js';
+import { escrowRelease, markEscrowBookingStarted } from '../escrow.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 import { broadcastOrderMilestone } from '../../sockets/tracker.js';
@@ -91,6 +91,23 @@ export class OrderMilestoneService {
     if (updateErr) {
       await this.orderTimelineService.resetMilestone(order.order_display_id, milestone);
       throw new DomainError(500, { error: 'Failed to update order.', details: updateErr.message });
+    }
+
+    // Once the goods are loaded, the trip has started on-chain. Mark the
+    // booking so cancelBooking / cancelWithPenalty revert for a full refund.
+    // Best-effort: a chain failure must not block the milestone itself.
+    if (status === 'picked_up' && ['funded', 'release_failed'].includes(order.escrow_status)) {
+      try {
+        const started = await markEscrowBookingStarted(order.order_display_id);
+        if (started?.txHash && started.waitForConfirmation) {
+          const startedReceipt = await started.waitForConfirmation();
+          logger.info(`[escrow] Booking marked started for order ${order.order_display_id} in block ${startedReceipt.blockNumber}`);
+        } else if (started?.error) {
+          logger.warn(`[escrow] Failed to mark booking started for order ${order.order_display_id}: ${started.error}`);
+        }
+      } catch (startErr) {
+        logger.warn(`[escrow] Failed to mark booking started for order ${order.order_display_id}: ${startErr.message}`);
+      }
     }
 
     if (generatedOtp) {

--- a/backend/api/test/contracts/orders.contract.test.js
+++ b/backend/api/test/contracts/orders.contract.test.js
@@ -395,7 +395,7 @@ describe('POST /api/orders/:id/cancel — cancel order contract', () => {
       id: 'order-cancel-4',
       customer_id: CUSTOMER['x-user-id'],
       order_display_id: 'OD-REFUND-FAIL',
-      status: 'in_transit',
+      status: 'assigned',
       escrow_status: 'funded',
       cancellation_fee: 500,
     });

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -97,6 +97,7 @@ function seedDriverAtDropOff(orderId, driverId) {
 
 vi.mock('../../src/sockets/tracker.js', () => ({
   initWebSocketServer: () => ({}),
+  broadcastOrderMilestone: vi.fn(),
 }));
 
 vi.mock('../../src/services/osrm.js', () => ({
@@ -2173,7 +2174,22 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     routeEstimateMock.mockResolvedValue({ distanceKm: 100 });
     submitEscrowRefundMock.mockReset();
     confirmEscrowRefundMock.mockReset();
-    mockRedis = null;
+    // Cancel/change-drop take the escrow lock (redisLock), so provide a
+    // working in-memory Redis mock instead of leaving it null.
+    const lockStore = new Map();
+    mockRedis = {
+      set: vi.fn(async (key, val) => {
+        lockStore.set(key, val);
+        return 'OK';
+      }),
+      eval: vi.fn(async (_script, _count, key, lockValue) => {
+        if (lockStore.get(key) === lockValue) {
+          lockStore.delete(key);
+          return 1;
+        }
+        return 0;
+      }),
+    };
   });
 
   it('allows customer to change drop and returns recalculated pricing', async () => {
@@ -2263,7 +2279,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       id: 'aaaa0004-0000-4000-8000-000000000004',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-FUNDED-CANCEL',
-      status: 'in_transit',
+      status: 'assigned',
       escrow_status: 'funded',
       escrow_refund_attempts: 0,
       cancellation_fee: 500,
@@ -2297,7 +2313,7 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
       id: 'aaaa0005-0000-4000-8000-000000000005',
       customer_id: CUSTOMER_HEADERS['x-user-id'],
       order_display_id: 'OD-REFUND-FAILS',
-      status: 'in_transit',
+      status: 'assigned',
       escrow_status: 'funded',
       cancellation_fee: 500,
     });
@@ -2316,6 +2332,31 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     expect(stored.status).toBe('cancelled');
     expect(stored.escrow_status).toBe('refund_failed');
     expect(stored.escrow_refund_error).toContain('Polygon unavailable');
+  });
+
+  it('rejects cancellation once the shipment has been picked up', async () => {
+    for (const status of ['picked_up', 'in_transit', 'arriving', 'arrived_dropoff']) {
+      m.store.orders = [{
+        id: 'aaaa0006-0000-4000-8000-000000000006',
+        customer_id: CUSTOMER_HEADERS['x-user-id'],
+        order_display_id: `OD-TRIP-${status}`,
+        status,
+        escrow_status: 'funded',
+      }];
+
+      const app = buildApp();
+      const res = await request(app)
+        .post('/api/orders/aaaa0006-0000-4000-8000-000000000006/cancel')
+        .set('X-Idempotency-Key', Math.random().toString())
+        .set(CUSTOMER_HEADERS)
+        .send({ reason: 'Change of plans' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Cannot cancel: the shipment has already been picked up and is in transit.');
+      const storedOrder = m.store.orders.find(o => o.id === 'aaaa0006-0000-4000-8000-000000000006');
+      expect(storedOrder.status).toBe(status);
+      expect(storedOrder.escrow_status).toBe('funded');
+    }
   });
 
   it('reconciles a previously submitted refund without submitting it twice', async () => {

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -38,6 +38,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         uint256 amount;             // Locked payment amount in wei (MATIC)
         BookingStatus status;       // Current booking lifecycle status
         bool paid;                  // True after payment has been released
+        bool started;               // True after the driver has picked up the goods
         uint256 createdAt;          // Block timestamp at booking creation
         uint256 disputedAt;         // Block timestamp when dispute was raised
     }
@@ -70,6 +71,12 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         uint256 indexed bookingId,
         address indexed customer,
         uint256 refundAmount
+    );
+
+    event BookingStarted(
+        uint256 indexed bookingId,
+        address indexed driver,
+        uint256 amount
     );
 
     event CancellationPenaltyApplied(
@@ -148,6 +155,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             amount:    msg.value,
             status:    BookingStatus.Active,
             paid:      false,
+            started:   false,
             createdAt: block.timestamp,
             disputedAt: 0
         });
@@ -211,6 +219,34 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     }
 
     /**
+     * @dev Record that the driver has picked up the goods and the trip has
+     *      started. Called by the Truxify backend (owner) when the shipment
+     *      reaches the "picked_up" milestone. Once started, a booking can no
+     *      longer be cancelled for a full refund — the customer must go through
+     *      the penalty/compensation path instead.
+     *
+     * @param bookingId The booking whose trip has started
+     */
+    function markBookingStarted(uint256 bookingId)
+        external
+        onlyOwner
+        whenNotPaused
+    {
+        Booking storage booking = bookings[bookingId];
+
+        require(
+            booking.customer != address(0) && booking.status == BookingStatus.Active,
+            "TruxifyEscrow: Booking not active"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(!booking.started, "TruxifyEscrow: Trip already started");
+
+        booking.started = true;
+
+        emit BookingStarted(bookingId, booking.driver, booking.amount);
+    }
+
+    /**
      * @dev Cancel a booking and refund the customer.
      *      RESTRICTED to onlyOwner (backend) to ensure on-chain and off-chain
      *      state remain synchronized. The backend's cancellation flow performs
@@ -233,6 +269,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(!booking.started, "TruxifyEscrow: Trip already started");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
 
         // ── EFFECTS ───────────────────────────────────────────────────────
@@ -271,6 +308,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(!booking.started, "TruxifyEscrow: Trip already started");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
         require(driverFee <= booking.amount, "TruxifyEscrow: Penalty exceeds escrow");
 

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -466,6 +466,19 @@ describe("TruxifyEscrow", function () {
         escrow.connect(owner).cancelBooking(1)
       ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
     });
+
+    it("reverts once the trip has started", async function () {
+      const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
+
+      await escrow.connect(customer).createBooking(1, driver.address, {
+        value: ethers.parseEther("1.0"),
+      });
+      await escrow.connect(owner).markBookingStarted(1);
+
+      await expect(
+        escrow.connect(owner).cancelBooking(1)
+      ).to.be.revertedWith("TruxifyEscrow: Trip already started");
+    });
   });
 
   describe("cancelWithPenalty", function () {
@@ -490,6 +503,91 @@ describe("TruxifyEscrow", function () {
 
       await expect(escrow.connect(owner).cancelWithPenalty(bookingId, amount + 1n))
         .to.be.revertedWith("TruxifyEscrow: Penalty exceeds escrow");
+    });
+
+    it("reverts once the trip has started", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await escrow.connect(owner).markBookingStarted(bookingId);
+
+      await expect(escrow.connect(owner).cancelWithPenalty(bookingId, ethers.parseEther("0.1")))
+        .to.be.revertedWith("TruxifyEscrow: Trip already started");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // markBookingStarted
+  // ═══════════════════════════════════════════════════════════════════════════
+  describe("markBookingStarted", function () {
+    it("marks an active booking as started and emits BookingStarted", async function () {
+      const { escrow, owner, driver, bookingId, amount } = await loadFixture(deployWithBookingFixture);
+
+      await expect(escrow.connect(owner).markBookingStarted(bookingId))
+        .to.emit(escrow, "BookingStarted")
+        .withArgs(bookingId, driver.address, amount);
+
+      const booking = await escrow.getBooking(bookingId);
+      expect(booking.started).to.be.true;
+    });
+
+    it("does not block delivery after the trip has started", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await escrow.connect(owner).markBookingStarted(bookingId);
+      await escrow.connect(owner).releasePayment(bookingId);
+
+      const booking = await escrow.getBooking(bookingId);
+      expect(booking.status).to.equal(1); // Delivered
+      expect(booking.paid).to.be.true;
+    });
+
+    it("reverts for non-existent booking", async function () {
+      const { escrow, owner } = await loadFixture(deployEscrowFixture);
+
+      await expect(
+        escrow.connect(owner).markBookingStarted(999)
+      ).to.be.revertedWith("TruxifyEscrow: Booking not active");
+    });
+
+    it("reverts if booking was already marked started", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await escrow.connect(owner).markBookingStarted(bookingId);
+
+      await expect(
+        escrow.connect(owner).markBookingStarted(bookingId)
+      ).to.be.revertedWith("TruxifyEscrow: Trip already started");
+    });
+
+    it("reverts if payment was already released", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await escrow.connect(owner).releasePayment(bookingId);
+
+      await expect(
+        escrow.connect(owner).markBookingStarted(bookingId)
+      ).to.be.revertedWith("TruxifyEscrow: Booking not active");
+    });
+
+    it("reverts if called by non-owner", async function () {
+      const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
+
+      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+
+      await expect(
+        escrow.connect(customer).markBookingStarted(1)
+      ).to.be.revertedWithCustomError(escrow, "OwnableUnauthorizedAccount")
+       .withArgs(customer.address);
+    });
+
+    it("reverts when contract is paused", async function () {
+      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+
+      await escrow.connect(owner).pause();
+
+      await expect(
+        escrow.connect(owner).markBookingStarted(bookingId)
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
     });
   });
 


### PR DESCRIPTION
## Summary

**Full-refund escrow cancellation is now blocked after the trip has started.**

## Problem

A cancellation initiated after trip start could trigger a full refund of the escrowed amount, even though the trip had begun and mileage/work had already occurred — letting payers claw back funds unfairly.

## Changes

- `TruxifyEscrow.sol`: cancellation path enforces trip-state checks before allowing full refund.
- `escrow.js` / `orderLifecycleService.js` / `orderMilestoneService.js`: cancellation after trip start follows the partial/pro-rated refund path; full refund only before departure.
- API returns a clear error when a full refund is attempted mid-trip.

## Tests

- Cancellation flows pass: before start → full refund; after start → full refund rejected, pro-rated path used.

Fixes #5768