### PR TITLE
fix(supabase): pin search_path on get_profile_id SECURITY DEFINER

### DIFF
--- a/supabase/migrations/20240101000000_rls.sql
+++ b/supabase/migrations/20240101000000_rls.sql
@@ -12,7 +12,7 @@
 -- ─── Helper: map Firebase JWT sub → profiles.id ───
 CREATE OR REPLACE FUNCTION get_profile_id()
 RETURNS UUID
-LANGUAGE SQL STABLE SECURITY DEFINER
+LANGUAGE SQL STABLE SECURITY DEFINER SET search_path = public, pg_temp
 AS $$
   SELECT id FROM profiles WHERE firebase_uid = (auth.jwt() ->> 'sub') LIMIT 1;
 $$;


### PR DESCRIPTION
## Problem
`get_profile_id()` is a `SECURITY DEFINER` function that does not set `search_path`. A caller can therefore poison the resolution of `profiles` (or of the extension/operator used to look up the JWT sub claim) by manipulating `search_path`, which can break the function or escalate privileges. This affects every ownership guard that depends on `get_profile_id()`.

## Fix
Added `SET search_path = public, pg_temp` to `get_profile_id()` in `supabase/migrations/20240101000000_rls.sql`, matching the hardening applied to other SECURITY DEFINER functions in the codebase. `pg_temp` is kept last so attacker-controlled schemas can never shadow `public`.

## Files changed
- `supabase/migrations/20240101000000_rls.sql`

Closes #5818