### PR TITLE
fix(supabase): lock update_order_and_load_offer to order owner with get_profile_id

### DIFF
--- a/supabase/migrations/20260728000000_create_update_order_rpc.sql
+++ b/supabase/migrations/20260728000000_create_update_order_rpc.sql
@@ -7,10 +7,28 @@ CREATE OR REPLACE FUNCTION update_order_and_load_offer(
 RETURNS JSONB
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_updated_order JSONB;
+  v_customer_id   UUID;
 BEGIN
+  -- Resolve the owning customer of the order for the ownership guard.
+  SELECT customer_id INTO v_customer_id
+  FROM orders
+  WHERE id = p_order_id;
+
+  IF v_customer_id IS NULL THEN
+    RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  -- Ownership guard: only the order's customer (resolved via get_profile_id,
+  -- which maps the Firebase JWT sub to profiles.id) or the service-role
+  -- backend may update the order and its load offer.
+  IF auth.role() <> 'service_role' AND get_profile_id() <> v_customer_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only update your own orders';
+  END IF;
+
   -- Update orders table based on JSONB keys
   UPDATE orders
   SET

--- a/supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql
+++ b/supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql
@@ -48,7 +48,10 @@ BEGIN
   END IF;
 
   -- Ownership guard: an authenticated caller may only update their own order.
-  IF auth.uid() IS NOT NULL AND auth.uid() <> v_customer_id THEN
+  -- get_profile_id() maps the Firebase JWT sub to profiles.id, which is what
+  -- orders.customer_id actually stores (auth.uid() is the Firebase UID and
+  -- would never match).
+  IF auth.uid() IS NOT NULL AND get_profile_id() <> v_customer_id THEN
     RAISE EXCEPTION 'Unauthorized: you can only update your own orders';
   END IF;
 


### PR DESCRIPTION
## Problem
`update_order_and_load_offer` is a `SECURITY DEFINER` RPC but its ownership check used `auth.role()`/`auth.uid()`, which does not map to Firebase users (identity lives in `profiles.id`, not the auth system's UUID). Combined with no `search_path`, the guard could be bypassed or fail open, letting an unauthenticated/unauthorized caller reprice an order and its load offer (change-drop financial tampering). The migration `20260802000000_secure_update_order_and_load_offer.sql` also referenced `auth.uid()` instead of the canonical `get_profile_id()`.

## Fix
- `20260728000000_create_update_order_rpc.sql`
  - Added `SET search_path = public, pg_temp`.
  - Ownership now derived via `get_profile_id()`: the RPC accepts the update only when the resolved caller owns the order (or is `service_role`).
- `20260802000000_secure_update_order_and_load_offer.sql`
  - Changed the ownership guard from `auth.uid() <> v_customer_id` to `get_profile_id() <> v_customer_id` so the check resolves against the Firebase-profile identity used everywhere else.

## Files changed
- `supabase/migrations/20260728000000_create_update_order_rpc.sql`
- `supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql`

Closes #5819