### PR TITLE
fix(ml): remove trailing-colon SyntaxError in nine route modules 

### DIFF
--- a/backend/ml/routes/diffusion_routes.py
+++ b/backend/ml/routes/diffusion_routes.py
@@ -148,7 +148,7 @@ async def train_model(request: TrainRequest):
 
 @router.post("/save")
 async def save_model(path: str = "models/diffusion_route.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save diffusion model"""
     try:
         generator.save(path)
@@ -165,7 +165,7 @@ async def save_model(path: str = "models/diffusion_route.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/diffusion_route.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load diffusion model"""
     try:
         generator.load(path)

--- a/backend/ml/routes/foundation_routes.py
+++ b/backend/ml/routes/foundation_routes.py
@@ -235,7 +235,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/foundation_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save foundation model"""
     try:
         trainer.save(path)
@@ -253,7 +253,7 @@ async def save_model(path: str = "models/foundation_model.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/foundation_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load foundation model"""
     try:
         trainer.load(path)

--- a/backend/ml/routes/gat_routes.py
+++ b/backend/ml/routes/gat_routes.py
@@ -164,7 +164,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/gat_traffic.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save GAT model"""
     try:
         trainer.save(path)
@@ -181,7 +181,7 @@ async def save_model(path: str = "models/gat_traffic.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/gat_traffic.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load GAT model"""
     try:
         trainer.load(path)

--- a/backend/ml/routes/gnn_routes.py
+++ b/backend/ml/routes/gnn_routes.py
@@ -198,7 +198,7 @@ async def get_model_status():
 
 @router.post("/model/save")
 async def save_model(path: str = "models/gnn_route.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save GNN model"""
     try:
         optimizer.save_model(path)
@@ -215,7 +215,7 @@ async def save_model(path: str = "models/gnn_route.pth"):
 
 @router.post("/model/load")
 async def load_model(path: str = "models/gnn_route.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load GNN model"""
     try:
         optimizer.load_model(path)

--- a/backend/ml/routes/imitation_routes.py
+++ b/backend/ml/routes/imitation_routes.py
@@ -178,7 +178,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/imitation_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save imitation learning model"""
     try:
         model.save(path)
@@ -195,7 +195,7 @@ async def save_model(path: str = "models/imitation_model.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/imitation_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load imitation learning model"""
     try:
         model.load(path)

--- a/backend/ml/routes/meta_routes.py
+++ b/backend/ml/routes/meta_routes.py
@@ -185,7 +185,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/maml_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save MAML model"""
     try:
         maml.save(path)
@@ -202,7 +202,7 @@ async def save_model(path: str = "models/maml_model.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/maml_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load MAML model"""
     try:
         maml.load(path)

--- a/backend/ml/routes/mtl_routes.py
+++ b/backend/ml/routes/mtl_routes.py
@@ -149,7 +149,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/mtl_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save multi-task model"""
     try:
         trainer.save(path)
@@ -166,7 +166,7 @@ async def save_model(path: str = "models/mtl_model.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/mtl_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load multi-task model"""
     try:
         trainer.load(path)

--- a/backend/ml/routes/nerf_routes.py
+++ b/backend/ml/routes/nerf_routes.py
@@ -168,7 +168,7 @@ async def train_nerf(
 
 @router.post("/save")
 async def save_model(path: str = "models/nerf.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save NeRF model"""
     try:
         trainer.save(path)
@@ -185,7 +185,7 @@ async def save_model(path: str = "models/nerf.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/nerf.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load NeRF model"""
     try:
         trainer.load(path)

--- a/backend/ml/routes/pinns_routes.py
+++ b/backend/ml/routes/pinns_routes.py
@@ -114,7 +114,7 @@ async def get_model_info():
 
 @router.post("/save")
 async def save_model(path: str = "models/pinns_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Save PINN model"""
     try:
         trainer.save(path)
@@ -131,7 +131,7 @@ async def save_model(path: str = "models/pinns_model.pth"):
 
 @router.post("/load")
 async def load_model(path: str = "models/pinns_model.pth"):
-    path = os.path.join("models", os.path.basename(path)):
+    path = os.path.join("models", os.path.basename(path))
     """Load PINN model"""
     try:
         trainer.load(path)


### PR DESCRIPTION
## Problem
Nine ML router modules in `backend/ml/routes/` end an assignment with a trailing colon:

```python
path = os.path.join("models", os.path.basename(path)):
```
A colon there is a Python SyntaxError (invalid syntax), so every one of these routers fails to import and the entire ML engine fails to start.

## Fix
Removed the stray trailing colon in all nine modules. The surrounding logic is unchanged.

## Files changed

- backend/ml/routes/diffusion_routes.py
- backend/ml/routes/foundation_routes.py
- backend/ml/routes/gat_routes.py
- backend/ml/routes/gnn_routes.py
- backend/ml/routes/imitation_routes.py
- backend/ml/routes/meta_routes.py
- backend/ml/routes/mtl_routes.py
- backend/ml/routes/nerf_routes.py
- backend/ml/routes/pinns_routes.py

## Testing
python -m py_compile passes on all nine files (Python 3.13).

Closes #5820

