### PR TITLE
fix(digilocker): gate mock mode behind DIGILOCKER_MOCK and fail closed

### DIFF
--- a/backend/api/src/services/digilockerService.js
+++ b/backend/api/src/services/digilockerService.js
@@ -36,11 +36,17 @@ class DigilockerService {
     let tokenData;
     let isMock = false;
 
+    // Mock mode must be explicitly opted into. Without DIGILOCKER_MOCK=true the
+    // service fails closed whenever credentials or the OAuth code are missing,
+    // so staging/demo deployments can never silently fabricate government-verified
+    // KYC documents.
+    const mockModeEnabled = process.env.DIGILOCKER_MOCK === 'true';
+
     if (!this.clientId || !this.clientSecret || !code) {
-      if (process.env.NODE_ENV === 'production') {
-        throw new Error('DigiLocker credentials or OAuth code are missing. This is a server misconfiguration in production.');
+      if (!mockModeEnabled) {
+        throw new Error('DigiLocker credentials or OAuth code are missing. This is a server misconfiguration. Set DIGILOCKER_MOCK=true only for local testing.');
       }
-      logger.warn('Digilocker credentials or code missing. Running in high-fidelity mock mode.');
+      logger.warn('Digilocker credentials or code missing. Running in high-fidelity mock mode (DIGILOCKER_MOCK=true).');
       isMock = true;
       tokenData = {
         access_token: 'mock_digilocker_access_token_12345',
@@ -135,7 +141,7 @@ class DigilockerService {
       const docHash = ethers.keccak256(docBytes);
       
       let txHash;
-      if (this.contract) {
+      if (this.contract && !isMock) {
         try {
           const tx = await this.contract.registerDocument(driverWallet, doc.type, docHash, true);
           const receipt = await tx.wait();
@@ -169,8 +175,8 @@ class DigilockerService {
             document_type: doc.type,
             storage_path: storagePath,
             mime_type: 'application/json',
-            status: 'approved',
-            is_govt_verified: true,
+            status: isMock ? 'pending' : 'approved',
+            is_govt_verified: !isMock,
             blockchain_tx_hash: txHash
           }, { onConflict: 'driver_id,document_type' })
           .select('id, document_type, status, is_govt_verified, blockchain_tx_hash')
@@ -193,8 +199,8 @@ class DigilockerService {
             user_id: driverId,
             doc_type: doc.type,
             storage_path: storagePath,
-            status: 'verified',
-            is_govt_verified: true,
+            status: isMock ? 'pending' : 'verified',
+            is_govt_verified: !isMock,
             blockchain_tx_hash: txHash,
             last_verified_at: new Date().toISOString()
           }, { onConflict: 'user_id,doc_type' });
@@ -211,8 +217,8 @@ class DigilockerService {
       } else {
         syncedResults.push({
           document_type: doc.type,
-          status: 'approved',
-          is_govt_verified: true,
+          status: isMock ? 'pending' : 'approved',
+          is_govt_verified: !isMock,
           blockchain_tx_hash: txHash
         });
       }


### PR DESCRIPTION
## Problem
`DigiLockerService` activates mock mode based only on a hardcoded `NODE_ENV`/config check, so mock can silently run in production. In mock mode the service (a) never registers the document on-chain and (b) fabricates `is_govt_verified: true` / `status: 'approved'` for documents that were never actually verified — a false "government verified" signal on real users' documents.

## Fix
`backend/api/src/services/digilockerService.js`:
- Mock mode now activates **only** when `DIGILOCKER_MOCK === 'true'` is explicitly set; otherwise it fails closed with a clear error instead of falling back to mock.
- When mock is active, on-chain registration is skipped, and documents are stored as `status: 'pending'` with `is_govt_verified: false` — mock data can no longer be presented as government-verified.

## Files changed
- `backend/api/src/services/digilockerService.js`

Closes #5821