### PR TITLE
fix(supabase): scope webhook_failures policy to service_role

### DIFF
--- a/supabase/migrations/20260710000000_create_webhook_failures.sql
+++ b/supabase/migrations/20260710000000_create_webhook_failures.sql
@@ -20,6 +20,6 @@ ALTER TABLE webhook_failures ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Allow Service Role full access to webhook_failures" 
   ON webhook_failures 
-  FOR ALL 
+  FOR ALL TO service_role
   USING (true)
   WITH CHECK (true);


### PR DESCRIPTION
## Problem
`20260710000000_create_webhook_failures.sql` created the RLS policy without a `TO <role>` clause. When a policy omits `TO`, it defaults to `PUBLIC`, which means **any** role (including anonymous clients) can read/insert into the `webhook_failures` table — exposing internal webhook retry state and allowing unauthenticated writes.

## Fix
The policy is now scoped with `FOR ALL TO service_role`, so only the service-role client (backend workers writing webhook failure records) can access the table; the general and anon roles are denied.

## Files changed
- `supabase/migrations/20260710000000_create_webhook_failures.sql`

Closes #5822