### PR TITLE
fix(supabase): derive create_order_tx customer identity from JWT or service_role

### DIFF
--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { getRouteEstimate } from '../osrm.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
 import { predictPrice } from '../ml.js';
@@ -72,7 +72,7 @@ export async function createOrder({ orderData, userId, user }) {
 
   for (let attempt = 0; attempt < MAX_ID_RETRIES; attempt++) {
     orderDisplayId = generateOrderDisplayId();
-    const { data: rpcData, error: rpcErr } = await supabase.rpc('create_order_tx', {
+    const { data: rpcData, error: rpcErr } = await (supabaseAdmin ?? supabase).rpc('create_order_tx', {
       p_order_display_id: orderDisplayId,
       p_customer_id: userId,
       p_customer_name: user?.fullName || 'Customer',

--- a/supabase/migrations/20260723000003_create_order_tx.sql
+++ b/supabase/migrations/20260723000003_create_order_tx.sql
@@ -35,12 +35,30 @@ CREATE OR REPLACE FUNCTION create_order_tx(
 RETURNS json
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_order_id UUID;
   v_status TEXT;
   v_created_at TIMESTAMPTZ;
+  v_customer_id UUID;
 BEGIN
+  -- Resolve the customer identity: only the service-role backend may supply a
+  -- p_customer_id. Any other caller is bound to their own JWT-derived profile
+  -- id (get_profile_id maps the Firebase JWT sub to profiles.id), so clients
+  -- can never create orders or load offers as another customer.
+  IF auth.role() = 'service_role' THEN
+    v_customer_id := p_customer_id;
+  ELSE
+    v_customer_id := get_profile_id();
+    IF v_customer_id IS NULL THEN
+      RAISE EXCEPTION 'Unauthorized: could not resolve caller profile';
+    END IF;
+    IF p_customer_id IS NOT NULL AND p_customer_id <> v_customer_id THEN
+      RAISE EXCEPTION 'Unauthorized: cannot create orders as another customer';
+    END IF;
+  END IF;
+
   -- 1. Insert into orders
   INSERT INTO orders (
     order_display_id, customer_id, status,
@@ -52,7 +70,7 @@ BEGIN
     base_freight, toll_estimate, platform_fee, total_amount, estimated_price,
     payment_method_id, upi_id
   ) VALUES (
-    p_order_display_id, p_customer_id, 'pending',
+    p_order_display_id, v_customer_id, 'pending',
     p_pickup_address, p_pickup_lat, p_pickup_lng,
     p_drop_address, p_drop_lat, p_drop_lng,
     p_pickup_date, p_pickup_time,
@@ -84,7 +102,7 @@ BEGIN
     freight_value, fuel_cost, toll_cost, net_profit, extra_distance_km,
     status
   ) VALUES (
-    p_order_display_id, p_customer_id, p_customer_name,
+    p_order_display_id, v_customer_id, p_customer_name,
     p_route_label, p_route_subtitle,
     p_pickup_address, p_pickup_lat, p_pickup_lng,
     p_drop_address, p_drop_lat, p_drop_lng,


### PR DESCRIPTION
## Problem
`create_order_tx` accepted a client-supplied `p_customer_id` and wrote the order's `customer_id` from it without verifying it against the caller. With `SECURITY DEFINER` and no `search_path`, any caller could create (or, after the new ordering logic, update) orders as another customer. Backend calls that use the service-role client also had no clean way to pass the intended customer.

## Fix
- `supabase/migrations/20260723000003_create_order_tx.sql`
  - Added `SET search_path = public, pg_temp`.
  - Resolved `v_customer_id` safely: if `auth.role() = 'service_role'`, it uses the provided `p_customer_id`; otherwise it binds to `get_profile_id()` (the JWT identity) and **rejects** the call when `p_customer_id` doesn't match the caller. No external caller can impersonate another customer.
- `backend/api/src/services/order/orderCreationService.js`
  - The RPC is now invoked through `supabaseAdmin ?? supabase` so service-role callers (e.g. admin/seed flows) send the intended customer id, while authenticated REST callers still go through the normal user client.

## Files changed
- `supabase/migrations/20260723000003_create_order_tx.sql`
- `backend/api/src/services/order/orderCreationService.js`

Closes #5823