### PR TITLE
fix(supabase): restrict temperature_telemetry insert to service_role and fix SELECT identity

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { paramIdSchema } from '../validation/requestSchemas.js';
 import { authenticate } from '../middleware/auth.js';
@@ -61,8 +61,9 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       return res.status(403).json({ error: 'Access denied for this load' });
     }
 
-    // Insert telemetry
-    const { error: insertErr } = await supabase
+    // Insert telemetry (service-role client: RLS only permits service_role to
+    // write temperature_telemetry, so the backend must use supabaseAdmin).
+    const { error: insertErr } = await (supabaseAdmin ?? supabase)
       .from('temperature_telemetry')
       .insert({
         load_id: loadId,
@@ -148,7 +149,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
       }
     }
 
-    const { data, error } = await supabase
+    const { data, error } = await (supabaseAdmin ?? supabase)
       .from('temperature_telemetry')
       .select('*')
       .eq('load_id', loadId)

--- a/supabase/migrations/20260721000000_add_cold_chain_telemetry.sql
+++ b/supabase/migrations/20260721000000_add_cold_chain_telemetry.sql
@@ -13,16 +13,22 @@ CREATE TABLE IF NOT EXISTS temperature_telemetry (
 -- Enable RLS for temperature_telemetry
 ALTER TABLE temperature_telemetry ENABLE ROW LEVEL SECURITY;
 
+-- Drivers and Customers can view telemetry for their loads. get_profile_id()
+-- maps the Firebase JWT sub to profiles.id, which is what load_offers
+-- customer_id/driver_id actually store (auth.uid() is the Firebase UID and
+-- would never match for Firebase-auth users).
 CREATE POLICY "Drivers and Customers can view telemetry for their loads" ON temperature_telemetry
-  FOR SELECT
+  FOR SELECT TO authenticated
   USING (
     EXISTS (
       SELECT 1 FROM load_offers
       WHERE load_offers.id = temperature_telemetry.load_id
-      AND (load_offers.customer_id = auth.uid() OR load_offers.driver_id = auth.uid())
+      AND (load_offers.customer_id = get_profile_id() OR load_offers.driver_id = get_profile_id())
     )
   );
 
+-- Only the service-role backend (which bypasses RLS) may insert telemetry.
+-- Direct anon/authenticated clients cannot forge readings for arbitrary loads.
 CREATE POLICY "API can insert telemetry" ON temperature_telemetry
-  FOR INSERT
-  WITH CHECK (true); -- Usually restricted to a service role or specific authenticated user in production
+  FOR INSERT TO service_role
+  WITH CHECK (true);

--- a/supabase/migrations/revoke_anon_privileges.sql
+++ b/supabase/migrations/revoke_anon_privileges.sql
@@ -35,6 +35,7 @@ REVOKE ALL ON TABLE public.vehicle_types FROM anon;
 REVOKE ALL ON TABLE public.regions FROM anon;
 REVOKE ALL ON TABLE public.webhook_failures FROM anon;
 REVOKE ALL ON TABLE public.tracking_tokens FROM anon;
+REVOKE ALL ON TABLE public.temperature_telemetry FROM anon;
 
 -- Note: RLS policies should still be enabled and strictly defined 
 -- for authenticated users, but revoking from anon adds an extra layer 


### PR DESCRIPTION
## Problem
`temperature_telemetry` RLS was effectively broken:
- The SELECT policy used `auth.uid()` (invalid for Firebase identities) so legitimate authenticated history reads failed or fell through.
- The INSERT policy had no `TO` clause (defaults to PUBLIC), so any unauthenticated caller could write arbitrary cold-chain telemetry — spoofing temperature records for insurance/compliance.
- `anon` was never explicitly revoked.

## Fix
- `supabase/migrations/20260721000000_add_cold_chain_telemetry.sql`
  - SELECT policy now resolves identity via `get_profile_id()` and is scoped `TO authenticated`.
  - INSERT policy scoped `TO service_role` only.
- `supabase/migrations/revoke_anon_privileges.sql`
  - Added `REVOKE ALL PRIVILEGES ... temperature_telemetry FROM anon`.
- `backend/api/src/routes/iotRoutes.js`
  - Insert and history reads now use `(supabaseAdmin ?? supabase)` so the service-role backend can still write telemetry, while authenticated users read their own records.

## Files changed
- `supabase/migrations/20260721000000_add_cold_chain_telemetry.sql`
- `supabase/migrations/revoke_anon_privileges.sql`
- `backend/api/src/routes/iotRoutes.js`

Closes #5824