### PR TITLE
fix(orders): reject change-drop while escrow funding is in flight 

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -538,9 +538,10 @@ export class OrderLifecycleService {
       if (!order) throw new DomainError(404, { error: 'Order not found.' });
 
       if (order.customer_id !== customerId) throw new DomainError(403, { error: 'Access Denied: You do not own this order.' });
-      if (order.escrow_status === 'funded' || order.status !== 'pending') {
-        const reason = order.escrow_status === 'funded'
-          ? 'after escrow has been funded'
+      const escrowInFlight = order.escrow_status === 'funding' || order.escrow_status === 'funded';
+      if (escrowInFlight || order.status !== 'pending') {
+        const reason = escrowInFlight
+          ? `after escrow ${order.escrow_status === 'funding' ? 'funding has been initiated' : 'has been funded'}`
           : `after order status is '${order.status}'`;
         throw new DomainError(409, {
           error: `Drop location cannot be changed ${reason}.`,

--- a/backend/api/src/services/order/orderValidationService.js
+++ b/backend/api/src/services/order/orderValidationService.js
@@ -158,9 +158,10 @@ export class OrderValidationService {
   }
 
   assertChangeDropAllowed(order) {
-    if (order.escrow_status === 'funded' || order.status !== 'pending') {
-      const reason = order.escrow_status === 'funded'
-        ? 'after escrow has been funded'
+    const escrowInFlight = order.escrow_status === 'funding' || order.escrow_status === 'funded';
+    if (escrowInFlight || order.status !== 'pending') {
+      const reason = escrowInFlight
+        ? `after escrow ${order.escrow_status === 'funding' ? 'funding has been initiated' : 'has been funded'}`
         : `after order status is '${order.status}'`;
       throw new DomainError(409, {
         error: `Drop location cannot be changed ${reason}.`,


### PR DESCRIPTION
## Problem
A change-drop reprices an order (`total_amount`, `base_freight`, …) but never rebalances the escrow booking. The booking is locked at the **original** bid amount: `bidAcceptanceService` sets `escrow_amount_wei` when funding starts, and `confirmDeposit` funds the on-chain booking at that stale amount. Payouts and cancellation penalties read `escrow_amount_wei`, so after a change-drop the escrow is permanently desynced from the agreed price — either over- or under-protecting the order. The current guard only rejects change-drop after `escrow_status = 'funded'`, leaving the whole `funding` window open to the desync.

## Fix
Chosen approach from the issue: **reject the change-drop while an escrow booking is in flight** (`escrow_status` is `funding` or `funded`) and require a fresh booking. Rebalancing on-chain mid-deposit (option a) is unsafe — the deposit transaction is already in flight, and a failed delta refund/deposit would leave the amount desynced with no clean recovery.

Both change-drop paths now use the same guard:
- `orderValidationService.assertChangeDropAllowed()` (used by the REST route)
- `orderLifecycleService.changeDrop()` (internal path)

A change-drop is only permitted while the order is `pending` and no escrow has been initiated.

## Files changed
- `backend/api/src/services/order/orderValidationService.js`
- `backend/api/src/services/order/orderLifecycleService.js`

## Testing
- `node --check` passes on both files.

Closes #5827