### PR TITLE
fix(sockets): stop accepting WS tokens in query string and harden upgrade rate limit

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -283,22 +283,40 @@ async function invalidateDriverOrderCache(driverId) {
 }
 
 function getClientIp(request) {
-  const forwardedFor = request.headers?.['x-forwarded-for'];
-
-  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
-    return forwardedFor.split(',')[0].trim();
-  }
-
+  // Trust only the TCP peer address. The X-Forwarded-For header is
+  // client-controlled and can be spoofed to rotate the per-IP rate-limit
+  // key and bypass the limit entirely (issue #5828).
   return request.socket?.remoteAddress || request.connection?.remoteAddress || 'unknown';
 }
 
-export async function isWebSocketUpgradeAllowed(request) {
-  if (!redisClient) {
-    return true;
-  }
+// Process-local fallback counter for the per-IP upgrade limit, used when Redis
+// is unavailable so the limit is still enforced instead of failing open.
+const wsUpgradeMemoryLimits = new Map();
 
+function enforceWsUpgradeMemoryLimit(ipAddress) {
+  const now = Date.now();
+  const windowMs = WS_UPGRADE_RATE_WINDOW_SECONDS * 1000;
+  let entry = wsUpgradeMemoryLimits.get(ipAddress);
+  if (!entry || now >= entry.resetAt) {
+    entry = { count: 0, resetAt: now + windowMs };
+    wsUpgradeMemoryLimits.set(ipAddress, entry);
+  }
+  entry.count++;
+  if (wsUpgradeMemoryLimits.size > 10000) {
+    for (const [key, e] of wsUpgradeMemoryLimits) {
+      if (now >= e.resetAt) wsUpgradeMemoryLimits.delete(key);
+    }
+  }
+  return entry.count <= WS_UPGRADE_RATE_LIMIT;
+}
+
+export async function isWebSocketUpgradeAllowed(request) {
   const ipAddress = getClientIp(request);
   const key = `ws:upgrade:${ipAddress}`;
+
+  if (!redisClient) {
+    return enforceWsUpgradeMemoryLimit(ipAddress);
+  }
 
   try {
     const attempts = await redisClient.incr(key);
@@ -315,7 +333,7 @@ export async function isWebSocketUpgradeAllowed(request) {
     return attempts <= WS_UPGRADE_RATE_LIMIT;
   } catch (err) {
     logger.error('Redis WebSocket upgrade rate limit error:', err.message);
-    return true;
+    return enforceWsUpgradeMemoryLimit(ipAddress);
   }
 }
 
@@ -331,10 +349,12 @@ export function rejectWebSocketUpgrade(socket) {
 /**
  * Authenticate a WebSocket connection with a bearer token.
  *
- * The token may arrive via the `token` query parameter or via a first-frame
- * `auth` event (issue #5739). On success sets `ws.user`, `ws.driverId` and
- * `ws.authenticated = true`, then restores persisted tracking subscriptions.
- * On failure sends an error with code 4001 and closes the socket.
+ * The token is accepted only via a first-frame `auth` event (issues #5739,
+ * #5828); it is never accepted from the connection URL because query-string
+ * credentials leak into proxy logs, web analytics and browser history. On
+ * success sets `ws.user`, `ws.driverId` and `ws.authenticated = true`, then
+ * restores persisted tracking subscriptions. On failure sends an error with
+ * code 4001 and closes the socket.
  */
 async function authenticateWs(ws, token) {
   if (!token) {
@@ -440,7 +460,6 @@ export function initWebSocketServer(server, orderRepository) {
   }
 
   _orderRepository = orderRepository;
-  const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD_BYTES });
   const MAX_WS_PAYLOAD_BYTES = parseInt(process.env.WS_MAX_PAYLOAD_BYTES, 10) || 4096;
   const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_WS_PAYLOAD_BYTES });
   wsServer = wss;
@@ -467,7 +486,6 @@ export function initWebSocketServer(server, orderRepository) {
   wss.on('connection', async (ws, req) => {
     ws._request = req;
     const reqUrl = new URL(req.url, 'http://localhost');
-    const token    = reqUrl.searchParams.get('token');
     const bypassAuth = process.env.BYPASS_AUTH === 'true';
 
     // Register event handlers up front so a first-frame `auth` message can be
@@ -519,17 +537,10 @@ export function initWebSocketServer(server, orderRepository) {
       return;
     }
 
-    if (token) {
-      await authenticateWs(ws, token);
-      if (ws.authenticated) {
-        logger.info('🔌 New WebSocket connection established on /ws/tracking');
-      }
-      return;
-    }
-
-    // No token in the URL: defer authentication until the client sends a
-    // first-frame `auth` event so credentials never leak via query strings
-    // into proxies, logs or web analytics (issue #5739).
+    // Tokens are never accepted from the URL query string (issue #5828).
+    // Authentication is deferred until the client sends a first-frame `auth`
+    // event so credentials never leak via query strings into proxies, logs or
+    // web analytics (issue #5739).
     ws.authenticated = false;
     const authTimeout = setTimeout(() => {
       if (ws.authenticated === false) {
@@ -684,9 +695,9 @@ export async function handleLocationPing(ws, data, req) {
     heading: typeof bearing === 'number' ? bearing : undefined,
   };
 
-  const validationErrors = validateTelemetryPayload(normalizedForValidation);
-  if (validationErrors) {
-    return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: validationErrors }));
+  const normalizedValidationErrors = validateTelemetryPayload(normalizedForValidation);
+  if (normalizedValidationErrors) {
+    return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: normalizedValidationErrors }));
   }
 
   // Schema-validate and sanitize the telemetry payload before further

--- a/backend/api/test/tracker.test.js
+++ b/backend/api/test/tracker.test.js
@@ -57,10 +57,12 @@ describe('tracker', () => {
   });
 
   describe('isWebSocketUpgradeAllowed', () => {
-    it('allows upgrade when no Redis client', async () => {
+    it('enforces the per-IP limit in memory when no Redis client is configured (no fail-open)', async () => {
       const req = makeRequest();
-      const result = await isWebSocketUpgradeAllowed(req);
-      expect(result).toBe(true);
+      for (let i = 0; i < 5; i++) {
+        await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(true);
+      }
+      await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(false);
     });
   });
 

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -438,8 +438,33 @@ describe('tracker WebSocket upgrade rate limiting', () => {
     });
 
     expect(allowed).toBe(true);
-    expect(incr).toHaveBeenCalledWith('ws:upgrade:203.0.113.10');
-    expect(expire).toHaveBeenCalledWith('ws:upgrade:203.0.113.10', 60);
+    // The spoofable X-Forwarded-For header must NOT be trusted for rate
+    // limiting — the TCP peer address is the key (issue #5828).
+    expect(incr).toHaveBeenCalledWith('ws:upgrade:10.0.0.2');
+    expect(expire).toHaveBeenCalledWith('ws:upgrade:10.0.0.2', 60);
+  });
+
+  it('ignores a spoofed X-Forwarded-For header when selecting the rate-limit key', async () => {
+    const incr = vi.fn().mockResolvedValue(1);
+    const expire = vi.fn().mockResolvedValue(1);
+    const ttl = vi.fn().mockResolvedValue(60);
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: { incr, expire, ttl },
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    await isWebSocketUpgradeAllowed({
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+      socket: { remoteAddress: '198.51.100.9' },
+    });
+
+    expect(incr).toHaveBeenCalledWith('ws:upgrade:198.51.100.9');
+    expect(incr).not.toHaveBeenCalledWith('ws:upgrade:1.2.3.4');
   });
 
   it('blocks the sixth upgrade attempt for the same IP', async () => {
@@ -522,7 +547,7 @@ describe('tracker WebSocket upgrade rate limiting', () => {
     expect(expire).toHaveBeenCalledWith('ws:upgrade:198.51.100.12', 60);
   });
 
-  it('allows upgrades and logs when Redis rate limiting fails', async () => {
+  it('enforces the per-IP limit via the in-memory fallback when Redis rate limiting fails (no fail-open)', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
     vi.resetModules();
@@ -538,15 +563,40 @@ describe('tracker WebSocket upgrade rate limiting', () => {
     }));
 
     const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
-    const allowed = await isWebSocketUpgradeAllowed({
+    const request = {
       headers: {},
       socket: { remoteAddress: '203.0.113.30' },
-    });
+    };
 
-    expect(allowed).toBe(true);
+    for (let i = 0; i < 5; i++) {
+      await expect(isWebSocketUpgradeAllowed(request)).resolves.toBe(true);
+    }
+    await expect(isWebSocketUpgradeAllowed(request)).resolves.toBe(false);
+
     expect(errorSpy).toHaveBeenCalledWith('Redis WebSocket upgrade rate limit error:', 'redis down');
 
     errorSpy.mockRestore();
+  });
+
+  it('enforces the per-IP limit in memory when no Redis client is configured (no fail-open)', async () => {
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      mongoDb: null,
+      redisClient: null,
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { isWebSocketUpgradeAllowed } = await import('../../src/sockets/tracker.js');
+    const request = {
+      headers: {},
+      socket: { remoteAddress: '198.51.100.40' },
+    };
+
+    for (let i = 0; i < 5; i++) {
+      await expect(isWebSocketUpgradeAllowed(request)).resolves.toBe(true);
+    }
+    await expect(isWebSocketUpgradeAllowed(request)).resolves.toBe(false);
   });
 
   it('rejects excessive upgrades with an HTTP 429 response', () => {


### PR DESCRIPTION
## Problem
Two WebSocket security issues on `/ws/tracking`:

1. **Credentials in the URL query string.** `initWebSocketServer` accepted `?token=<jwt>` and authenticated from it. Tokens in query strings leak into proxy/access logs, web analytics, and browser history. A first-frame `auth` handshake already existed (#5739) but the query-string path was still active.
2. **Spoofable, fail-open upgrade rate limit.** `isWebSocketUpgradeAllowed` derived the per-IP key from the client-supplied `X-Forwarded-For` header, so an attacker could rotate the header to bypass the 5-per-60s limit. It also returned `true` (unlimited) whenever Redis was missing or errored — fully failing open.

## Fix
`backend/api/src/sockets/tracker.js`:
- Removed the query-string `token` auth path entirely. Authentication now happens only via the first-frame `auth` event (the `dev_access_token` bypass remains, gated behind `BYPASS_AUTH` and production-disabled).
- `getClientIp` now keys on the TCP peer address (`socket.remoteAddress`) only — the spoofable `X-Forwarded-For` header is never trusted for rate limiting.
- `isWebSocketUpgradeAllowed` now enforces the limit with a process-local fixed-window counter when Redis is absent or errors, so the limit never fails open.
- Removed two pre-existing duplicate declarations that caused `SyntaxError`s and prevented the tracker module from loading at all: a duplicated `WebSocketServer` (`wss`) instance and a shadowed `validationErrors` const.

## Files changed
- `backend/api/src/sockets/tracker.js`
- `backend/api/test/unit/tracker.test.js` — updated XFF key expectation; added tests for header-spoofing resistance and in-memory no-fail-open enforcement.
- `backend/api/test/tracker.test.js` — updated no-Redis test to assert the limit is still enforced.

## Testing
`vitest run test/unit/tracker.test.js test/tracker.test.js` — 93 passed; the 22 remaining failures are pre-existing test drift (coordinate-validation messages, async buffer `.toArray()`) that also fail on a baseline build of `main` with only the SyntaxError fixes.

Closes #5828