### PR TITLE
fix: restore balanced braces in order service tests

### DIFF
--- a/apps/customer/test/services/order_service_test.dart
+++ b/apps/customer/test/services/order_service_test.dart
@@ -342,6 +342,9 @@ void main() {
       expect(draft.minCapacity, isNull);
       expect(draft.maxCapacity, isNull);
       expect(draft.materialType, isNull);
+    });
+  });
+
   group('submitRating', () {
     test('sends correct payload to POST /api/orders/:id/ratings', () async {
       when(() => apiClient.post(


### PR DESCRIPTION
## Description

This PR fixes a syntax issue in `apps/customer/test/services/order_service_test.dart` by restoring the missing closing braces for the `defaults filter fields to null when omitted` test and its enclosing `RouteDraft filter fields` group.

Without these closing braces, the test file contains unbalanced braces, preventing it from compiling correctly. This change restores the proper test structure so the `submitRating` test group is declared outside the previous group as intended.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

**Test Commands:**
```bash
flutter test apps/customer/test/services/order_service_test.dart
```

**Test Steps / Prerequisites:**
1. Apply the missing closing braces.
2. Run the test file using the Flutter test command.
3. Verify that the file parses successfully.

**Expected Result:**
- The test file compiles successfully.
- All test groups are properly nested.
- No syntax errors are reported due to unbalanced braces.

### Test Environment

- [x] Local manual testing
- [x] Unit / Integration tests (`flutter test`)
- [ ] Tested via Docker Compose

## Related Issues

Closes #<ISSUE_NUMBER>

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5841