### PR TITLE
fix(api): rate-limit PoD uploads per driver and order 

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -277,6 +277,39 @@ export const deviceLimiter = rateLimit({
   message: { error: 'Rate limit exceeded', retryAfter: 600 },
 });
 
+const POD_WINDOW_MS = Number(process.env.POD_RATE_LIMIT_WINDOW_MS) || 60 * 60 * 1000;
+const POD_MAX_REQUESTS = Number(process.env.POD_RATE_LIMIT_MAX_REQUESTS) || 10;
+
+// PoD uploads carry up to 20MB each (signature + photo) and run a malware scan
+// per file, so they are throttled per driver *and* per order: a single assigned
+// driver can no longer fire an unbounded stream of uploads for one order.
+export const podUploadLimiter = rateLimit({
+  windowMs: POD_WINDOW_MS,
+  max: POD_MAX_REQUESTS,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const userKey = userKeyGenerator(req);
+    const orderId = req.params?.id || 'unknown';
+    return `${userKey}:order:${orderId}`;
+  },
+  validate: { keyGeneratorIpFallback: false },
+  store: createStore('rl:pod:'),
+  handler: (req, res) => {
+    logger.warn(
+      {
+        requestId: req.requestId,
+        path: req.originalUrl,
+        method: req.method,
+        userAgent: req.get('user-agent'),
+      },
+      'PoD upload rate limit exceeded'
+    );
+    Sentry.captureMessage('Rate limit exceeded: podUploadLimiter', 'warning');
+    res.status(429).json({ error: 'Rate limit exceeded', retryAfter: Math.ceil(POD_WINDOW_MS / 1000) });
+  },
+});
+
 const adminWindowMs = Number(process.env.ADMIN_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 const adminMaxRequests = Number(process.env.ADMIN_RATE_LIMIT_MAX_REQUESTS) || 50;
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -144,7 +144,7 @@ import multer from 'multer';
 import crypto from 'crypto';
 import rateLimit from 'express-rate-limit';
 
-import { bidLimiter, userLimiter, userKeyGenerator, createStore } from '../middleware/rateLimiter.js';
+import { bidLimiter, userLimiter, userKeyGenerator, podUploadLimiter, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
@@ -1595,7 +1595,10 @@ async function validateAndScanPodFile(file, label) {
 }
 
 // POST /api/orders/:id/pod
-router.post('/:id/pod', authenticate, requireRole(['driver']), podUpload.fields([{ name: 'signature', maxCount: 1 }, { name: 'photo', maxCount: 1 }]), async (req, res) => {
+// PoD uploads are rate-limited per driver + order: each request may carry up to
+// 20MB and triggers a malware scan, so without a limiter a driver could exhaust
+// storage, RAM (multer memoryStorage), and scan CPU with an unbounded stream.
+router.post('/:id/pod', authenticate, requireRole(['driver']), podUploadLimiter, podUpload.fields([{ name: 'signature', maxCount: 1 }, { name: 'photo', maxCount: 1 }]), async (req, res) => {
   try {
     const orderId = req.params.id;
     const { data: order, error: orderErr } = await orderRepository.findOrderById(orderId);


### PR DESCRIPTION
feat(routes): rate-limit POD upload endpoint

`POST /:id/pod` had no rate limit, allowing abuse. Added a
`podUploadLimiter` (default 10 requests/hour, configurable via
`POD_RATE_LIMIT_WINDOW_MS` / `POD_RATE_LIMIT_MAX_REQUESTS`) and wired it
into the route.

Closes #5845