### PR TITLE
fix(api): gate test auth bypass behind ENABLE_TEST_AUTH opt-in

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -161,6 +161,12 @@ if (process.env.BYPASS_AUTH === 'true' && process.env.NODE_ENV !== 'development'
   logger.fatal('BYPASS_AUTH is enabled outside development. This is a severe security misconfiguration. Set BYPASS_AUTH=false (or unset it), and set NODE_ENV=development if you need local testing.')
   process.exit(1)
 }
+// ENABLE_TEST_AUTH allows plaintext x-user-id/x-user-role header impersonation
+// and must never be active outside a dedicated test harness (NODE_ENV=test).
+if (process.env.ENABLE_TEST_AUTH === 'true' && process.env.NODE_ENV !== 'test') {
+  logger.fatal('ENABLE_TEST_AUTH is enabled outside a test harness. This is a severe security misconfiguration — it trusts client-supplied identity headers. Only set it in NODE_ENV=test processes.')
+  process.exit(1)
+}
 if (process.env.NODE_ENV === 'production' && !process.env.ML_API_KEY) {
   logger.fatal('ML_API_KEY is not set. ML engine calls will fail with 401 errors. Set ML_API_KEY and restart.')
   process.exit(1)

--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -84,17 +84,26 @@ export async function verifyAuthToken(token) {
 }
 
 export async function authenticate(req, res, next) {
+  const bypassAuth = process.env.BYPASS_AUTH === 'true';
+  // Header-based test impersonation is an explicit opt-in (ENABLE_TEST_AUTH),
+  // independent of NODE_ENV, so a stray NODE_ENV=test deployment cannot
+  // silently turn plaintext x-user-id/x-user-role headers into a full
+  // impersonation primitive.
+  const testAuthEnabled = process.env.ENABLE_TEST_AUTH === 'true';
+
   // ── Production header sanitization (defense in depth) ──────────────
   // Strip dev-only authentication headers before any logic runs.
   // This ensures they cannot be used even if BYPASS_AUTH is accidentally
   // enabled or a proxy misconfiguration exposes them.
-  if (process.env.NODE_ENV === 'production' || !process.env.BYPASS_AUTH) {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    !bypassAuth ||
+    (process.env.NODE_ENV === 'test' && !testAuthEnabled)
+  ) {
     delete req.headers['x-user-id'];
     delete req.headers['x-user-role'];
     delete req.headers['x-user-name'];
   }
-
-  const bypassAuth = process.env.BYPASS_AUTH === 'true';
 
   // Support local development bypass mode using DEV_ACCESS_TOKEN
   if (bypassAuth) {
@@ -104,8 +113,9 @@ export async function authenticate(req, res, next) {
       });
     }
 
-    // In test mode, allow x-user-id header directly without DEV_ACCESS_TOKEN
-    if (process.env.NODE_ENV === 'test') {
+    // Header-based test bypass is only reachable with the explicit
+    // ENABLE_TEST_AUTH opt-in, which the dedicated test harness sets.
+    if (testAuthEnabled) {
       const testUserId = req.headers['x-user-id'];
       const testUserRole = req.headers['x-user-role'] || 'customer';
       const testFullName = req.headers['x-user-name'] || 'Test User';

--- a/backend/api/test/setup.js
+++ b/backend/api/test/setup.js
@@ -10,6 +10,10 @@
 // Required by auth.js middleware to read x-user-id/x-user-role headers
 // directly from the request instead of verifying a Firebase token.
 process.env.BYPASS_AUTH = 'true';
+// Explicit opt-in for the header-based test bypass. It is independent of
+// NODE_ENV and only ever set here (the dedicated test harness) so a stray
+// NODE_ENV=test deployment can never impersonate users.
+process.env.ENABLE_TEST_AUTH = 'true';
 process.env.DEV_ACCESS_TOKEN = 'test-dev-token-123';
 process.env.MONGODB_SHUTDOWN_WAIT_MS = '0';
 process.env.ESCROW_MATIC_PER_PAISA = '0.000004';

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -392,6 +392,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
   beforeEach(() => {
     process.env.BYPASS_AUTH = 'true';
     process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_AUTH = 'true';
     process.env.DEV_ACCESS_TOKEN = 'dev-token-123';
     vi.resetModules();
   });
@@ -399,6 +400,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
   afterEach(() => {
     delete process.env.BYPASS_AUTH;
     delete process.env.NODE_ENV;
+    delete process.env.ENABLE_TEST_AUTH;
     delete process.env.DEV_ACCESS_TOKEN;
   });
 
@@ -508,6 +510,39 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
       fullName: 'Test Driver',
       uid: 'test_firebase_uid_123',
     });
+  });
+
+  it('does not trust x-user-id/x-user-role headers when ENABLE_TEST_AUTH is unset', async () => {
+    delete process.env.ENABLE_TEST_AUTH;
+
+    vi.doMock('../../src/config/db.js', () => ({
+      firebaseAdmin: null,
+      supabase: null,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = {
+      headers: {
+        'x-user-id': 'victim-uuid',
+        'x-user-role': 'admin',
+        'authorization': 'Bearer token123',
+      },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    // Headers must be stripped (not trusted) and the request must fall
+    // through to real token verification rather than impersonating a user.
+    expect(req.headers['x-user-id']).toBeUndefined();
+    expect(req.headers['x-user-role']).toBeUndefined();
+    expect(req.user).toBeUndefined();
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('defaults role to customer and name to Test User when headers are absent', async () => {


### PR DESCRIPTION
fix(auth): gate test-auth header bypass behind an explicit flag

The test/development header auth bypass could be activated in any
environment. The bypass now requires `ENABLE_TEST_AUTH === 'true'`, and
the API refuses to start with that flag unless `NODE_ENV=test`.
`test/setup.js` updated accordingly. All 28 auth tests pass.

Closes #5847