### PR TITLE
fix(supabase): allow admin role on profiles so admin RLS policies can match

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -156,6 +156,35 @@ describe('Revoke anon privileges (revoke_anon_privileges.sql)', () => {
   });
 });
 
+describe('Admin role on profiles (issue #5848)', () => {
+  let migrationContent;
+  let setupContent;
+  let auditLogContent;
+
+  beforeAll(async () => {
+    const migrationPath = path.resolve(__dirname, '../../../../supabase/migrations/20260802160000_add_admin_role_to_profiles.sql');
+    migrationContent = await fs.readFile(migrationPath, 'utf8');
+    const setupPath = path.resolve(__dirname, '../../../../docs/supabase_setup.sql');
+    setupContent = await fs.readFile(setupPath, 'utf8');
+    const auditPath = path.resolve(__dirname, '../../../../supabase/migrations/20260723000010_create_application_audit_logs.sql');
+    auditLogContent = await fs.readFile(auditPath, 'utf8');
+  });
+
+  it('adds admin to the profiles.role CHECK constraint in a migration', () => {
+    expect(migrationContent).toMatch(/ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_role_check/i);
+    expect(migrationContent).toMatch(/CHECK \(role IN \('customer', 'driver', 'admin'\)\)/i);
+  });
+
+  it('updates the canonical profiles.role constraint in docs/supabase_setup.sql', () => {
+    expect(setupContent).toMatch(/role\s+text\s+not\s+null\s+check\s*\(\s*role\s+in\s*\(\s*'customer'\s*,\s*'driver'\s*,\s*'admin'\s*\)\s*\)/i);
+  });
+
+  it('keeps the audit-logs admin-read policy on role = \'admin\', which is now satisfiable', () => {
+    expect(auditLogContent).toMatch(/CREATE POLICY "Admins can read audit logs"/i);
+    expect(auditLogContent).toMatch(/profiles\.role = 'admin'/i);
+  });
+});
+
 describe('RPC Security Fix (20260708000000_fix_rpc_security.sql)', () => {
   let fixContent;
 

--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -64,7 +64,7 @@ $$;
 create table if not exists profiles (
   id            uuid primary key default gen_random_uuid(),
   firebase_uid  text unique not null,                         -- Firebase Auth UID
-  role          text not null check (role in ('customer', 'driver')),
+  role          text not null check (role in ('customer', 'driver', 'admin')),
   full_name     text not null,
   phone         text not null,
   email         text,

--- a/supabase/migrations/20260802160000_add_admin_role_to_profiles.sql
+++ b/supabase/migrations/20260802160000_add_admin_role_to_profiles.sql
@@ -1,0 +1,12 @@
+-- Allows the 'admin' role on profiles so admin-gated RLS policies can match.
+--
+-- The original profiles.role CHECK constraint only allowed ('customer', 'driver'),
+-- which made the "Admins can read audit logs" policy (and the older admin RLS
+-- policy docs) unsatisfiable — no row could ever carry role = 'admin', so the
+-- admin audit-read feature was dead on arrival.
+
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_role_check;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_role_check
+  CHECK (role IN ('customer', 'driver', 'admin'));


### PR DESCRIPTION
feat(supabase): allow 'admin' role on profiles

The `profiles_role_check` constraint rejected role 'admin', so audit-log
admin policies could never match. Added migration
`20260802160000_add_admin_role_to_profiles.sql` dropping and recreating
the CHECK to include 'admin'; `docs/supabase_setup.sql` updated and a
test block added in `rlsSecurity.test.js`. 123/123 tests pass.

Closes #5848