### PR TITLE
fix(rls): use get_profile_id() in bids and audit log policies 

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -143,6 +143,32 @@ describe('Individual migration files with RLS policies', () => {
   });
 });
 
+describe('RLS ownership policies compare profile ids, not auth.uid() (issue #5852)', () => {
+  const readMigration = (name) =>
+    readFileSync(path.resolve(__dirname, `../../../../supabase/migrations/${name}`), 'utf8');
+
+  it('bids migration uses get_profile_id() for driver and customer ownership policies', () => {
+    const content = readMigration('20260730120000_create_bids_table.sql');
+    expect(content).toMatch(/USING \(get_profile_id\(\) = driver_id\)/);
+    expect(content).toMatch(/WITH CHECK \(get_profile_id\(\) = driver_id\)/);
+    expect(content).toMatch(/USING \(get_profile_id\(\) = driver_id AND status = 'pending'\)/);
+    expect(content).toMatch(/lo\.customer_id = get_profile_id\(\)/);
+    expect(content).not.toMatch(/auth\.uid\(\)/);
+  });
+
+  it('application_audit_logs admin-read policy resolves the profile via get_profile_id()', () => {
+    const content = readMigration('20260723000010_create_application_audit_logs.sql');
+    expect(content).toMatch(/profiles\.id = get_profile_id\(\)/);
+    expect(content).not.toMatch(/auth\.uid\(\)/);
+  });
+
+  it('cold chain telemetry policy uses get_profile_id() for load ownership checks', () => {
+    const content = readMigration('20260721000000_add_cold_chain_telemetry.sql');
+    expect(content).toMatch(/load_offers\.customer_id = get_profile_id\(\) OR load_offers\.driver_id = get_profile_id\(\)/);
+    expect(content).not.toMatch(/auth\.uid\(\) = [a-z_]+_id/);
+  });
+});
+
 describe('Revoke anon privileges (revoke_anon_privileges.sql)', () => {
   let revokeContent;
 

--- a/supabase/migrations/20260723000010_create_application_audit_logs.sql
+++ b/supabase/migrations/20260723000010_create_application_audit_logs.sql
@@ -46,7 +46,7 @@ CREATE POLICY "Admins can read audit logs"
   USING (
     EXISTS (
       SELECT 1 FROM profiles
-      WHERE profiles.id = auth.uid()
+      WHERE profiles.id = get_profile_id()
       AND profiles.role = 'admin'
     )
   );

--- a/supabase/migrations/20260730120000_create_bids_table.sql
+++ b/supabase/migrations/20260730120000_create_bids_table.sql
@@ -23,18 +23,18 @@ ALTER TABLE public.bids ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Drivers can view their own bids"
     ON public.bids
     FOR SELECT
-    USING (auth.uid() = driver_id);
+    USING (get_profile_id() = driver_id);
 
 CREATE POLICY "Drivers can insert their own bids"
     ON public.bids
     FOR INSERT
-    WITH CHECK (auth.uid() = driver_id);
+    WITH CHECK (get_profile_id() = driver_id);
 
 CREATE POLICY "Drivers can update their own pending bids"
     ON public.bids
     FOR UPDATE
-    USING (auth.uid() = driver_id AND status = 'pending')
-    WITH CHECK (auth.uid() = driver_id);
+    USING (get_profile_id() = driver_id AND status = 'pending')
+    WITH CHECK (get_profile_id() = driver_id);
 
 -- RLS Policy: Customers can view bids placed on their loads
 -- (Assumes load_offers table has a customer_id column linking to the creator)
@@ -45,7 +45,7 @@ CREATE POLICY "Customers can view bids on their loads"
         EXISTS (
             SELECT 1 FROM public.load_offers lo 
             WHERE lo.id = bids.load_id 
-            AND lo.customer_id = auth.uid()
+            AND lo.customer_id = get_profile_id()
         )
     );
 
@@ -57,13 +57,13 @@ CREATE POLICY "Customers can update bids on their loads"
         EXISTS (
             SELECT 1 FROM public.load_offers lo 
             WHERE lo.id = bids.load_id 
-            AND lo.customer_id = auth.uid()
+            AND lo.customer_id = get_profile_id()
         )
     )
     WITH CHECK (
         EXISTS (
             SELECT 1 FROM public.load_offers lo 
             WHERE lo.id = bids.load_id 
-            AND lo.customer_id = auth.uid()
+            AND lo.customer_id = get_profile_id()
         )
     );


### PR DESCRIPTION
fix(rls): compare profile ids, not auth.uid(), in bids and audit policies

`auth.uid()` returns the Firebase UID, while `bids.driver_id`,
`load_offers.customer_id`, and `profiles.id` store profile UUIDs, so the
policies could never match for Firebase-auth users. Replaced every
`auth.uid()` comparison in the bids policies
(20260730120000_create_bids_table.sql) and the audit-log admin-read
policy (20260723000010_create_application_audit_logs.sql) with the
canonical `get_profile_id()` helper. Added static tests asserting these
migrations (and the cold-chain telemetry migration) never compare
`auth.uid()` to profile-id columns. 123/123 tests pass.

Closes #5852