### PR TITLE
pr workflow 

### DIFF
--- a/.github/workflows/auto_pr_assign.yml
+++ b/.github/workflows/auto_pr_assign.yml
@@ -1,0 +1,26 @@
+name: Assign PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pull-requests: write
+      
+    steps:
+      - name: 'Auto-assign PR to creator'
+        uses: actions/github-script@v7
+        with:
+        
+          script: |
+            github.rest.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [context.payload.pull_request.user.login]
+            })
+            


### PR DESCRIPTION
## **Description**
Adds a GitHub Actions workflow to automatically assign incoming pull requests to their respective authors upon opening.

---

### **1. Type of Change**
- [x] **New Feature** (non-breaking change which adds functionality)
---

### **2. Related Issue**
- Fixes #5863 

---

### **3. How Has This Been Tested?**
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified workflow syntax using GitHub Actions standards.
  2. Tested triggering on `pull_request_target` with write access permissions for PR authors.

---

### **4. Visual Verification**

<img width="737" height="68" alt="image" src="https://github.com/user-attachments/assets/f2c59a68-5496-46fa-92eb-e4f05bf15c94" />
 
<img width="441" height="228" alt="image" src="https://github.com/user-attachments/assets/eb1be820-985b-467f-8630-f68c7f26eac5" />


---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.


review it under gssoc @KanishJebaMathewM 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to assign newly opened pull requests to their creators.
  * Configured the workflow to update pull request assignments automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->