### PR TITLE
fix : added error logging to bare catch in CacheEvent.js deserializeCacheEvent

### DIFF
--- a/backend/api/src/cache/CacheEvent.js
+++ b/backend/api/src/cache/CacheEvent.js
@@ -14,6 +14,7 @@
  */
 
 import crypto from 'crypto';
+import logger from '../middleware/logger.js';
 
 export const CacheEventType = Object.freeze({
   INVALIDATE_KEY: 'INVALIDATE_KEY',
@@ -73,7 +74,8 @@ export function deserializeCacheEvent(json) {
     const event = JSON.parse(json);
     if (!event || !event.type || !event.namespace) return null;
     return event;
-  } catch {
+  } catch (err) {
+    logger.warn('[CacheEvent] Deserialization failed:', err?.message);
     return null;
   }
 }


### PR DESCRIPTION
Closes #5865.

Summary of What Has Been Done:
The deserializeCacheEvent function in backend/api/src/cache/CacheEvent.js had a bare catch {} block that silently swallowed JSON parse errors without any logging. This change adds a logger.warn call so that deserialization failures are observable in production logs.

Changes Made:
- backend/api/src/cache/CacheEvent.js: Added import for logger middleware
- backend/api/src/cache/CacheEvent.js: Changed bare catch {} to catch (err) with logger.warn('[CacheEvent] Deserialization failed:', err?.message) before returning null

Impact it Made:
- Makes Redis Pub/Sub deserialization failures observable in production logs
- Consistent error handling with other cache module functions
- Faster diagnosis of cache data corruption issues
- All existing cacheEvent tests (25 tests) pass

Note: This PR is submitted as part of GSSOC (Girl Script Summer of Code). Please assign this PR to the tmdeveloper007 account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when cache event data cannot be deserialized by recording a warning with available error details.
  * Preserved existing behavior by safely ignoring invalid cache event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->