### PR TITLE
fix : added error logging to bare catch in CacheManager.js getVersion

### DIFF
--- a/backend/api/src/cache/CacheManager.js
+++ b/backend/api/src/cache/CacheManager.js
@@ -123,7 +123,8 @@ export async function getVersion(namespace, entityId, subKey) {
   try {
     const raw = await redisClient.get(key);
     return raw ? parseInt(raw, 10) : 1;
-  } catch {
+  } catch (err) {
+    logger.error({ err, key }, '[CacheManager] GET version error');
     return 1;
   }
 }


### PR DESCRIPTION
Closes #5866.

Summary of What Has Been Done:
The getVersion function in backend/api/src/cache/CacheManager.js had a bare catch {} block that silently swallowed Redis errors when reading a version key, always returning 1 regardless of the error. This change adds a logger.error call so that version key GET failures are observable in production logs.

Changes Made:
- backend/api/src/cache/CacheManager.js: Changed bare catch {} in getVersion to catch (err) with logger.error({ err, key }, '[CacheManager] GET version error') before returning 1. The return value of 1 is preserved (optimistic default), but the error is now logged.

Impact it Made:
- Makes Redis GET version failures observable in production logs
- Allows operators to detect cache backend degradation before it causes stale data issues
- Consistent error logging pattern with other CacheManager functions (get, set, invalidateBatch)
- All existing cacheManager tests (25 tests) pass

Note: This PR is submitted as part of GSSOC (Girl Script Summer of Code). Please assign this PR to the tmdeveloper007 account.