### PR TITLE
test : added unit tests for voiceService.js

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -167,3 +167,5 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     audio_url: audioUrl
   };
 }
+
+export const __testing = { getBookingContext };

--- a/backend/api/test/unit/services/voiceService.test.js
+++ b/backend/api/test/unit/services/voiceService.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for backend/api/src/services/voiceService.js
+ *
+ * Coverage:
+ *   - getBookingContext with valid UUID bookingId returns order
+ *   - getBookingContext with non-UUID bookingId uses order_display_id
+ *   - getBookingContext returns null when supabase query returns null
+ *   - getBookingContext returns null and logs warning on supabase error
+ *
+ * Run with: npx vitest run test/unit/services/voiceService.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSupabaseFrom = vi.fn();
+const mockEq = vi.fn();
+const mockMaybeSingle = vi.fn();
+
+const mockSupabase = {
+  from: mockSupabaseFrom,
+};
+
+vi.mock('../../../src/config/db.js', () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock('../../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const { __testing } = await import('../../../src/services/voiceService.js');
+const { getBookingContext } = __testing;
+
+describe('getBookingContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: mockEq.mockReturnValue({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+    });
+  });
+
+  it('returns order when bookingId is a valid UUID and query succeeds', async () => {
+    const mockOrder = { id: '550e8400-e29b-41d4-a716-446655440000', status: 'in_transit', eta: '2 hours' };
+    mockMaybeSingle.mockResolvedValue({ data: mockOrder, error: null });
+
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000');
+
+    expect(result).toEqual(mockOrder);
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('orders');
+    expect(mockEq).toHaveBeenCalledWith('id', '550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('uses order_display_id when bookingId is not a valid UUID', async () => {
+    const mockOrder = { id: '123e4567-e89b-12d3-a456-426614174000', order_display_id: '#FF20260101ABC123DEF456', status: 'delivered' };
+    mockMaybeSingle.mockResolvedValue({ data: mockOrder, error: null });
+
+    const result = await getBookingContext('#FF20260101ABC123DEF456');
+
+    expect(result).toEqual(mockOrder);
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('orders');
+    expect(mockEq).toHaveBeenCalledWith('order_display_id', '#FF20260101ABC123DEF456');
+  });
+
+  it('returns null when supabase query returns null data', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null and logs warning when supabase query throws an error', async () => {
+    mockMaybeSingle.mockRejectedValue(new Error('Connection refused'));
+
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000');
+
+    expect(result).toBeNull();
+  });
+
+  it('correctly identifies valid UUIDs vs non-UUIDs', async () => {
+    const validUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    mockMaybeSingle.mockResolvedValue({ data: { id: validUuid }, error: null });
+
+    await getBookingContext(validUuid);
+    expect(mockEq).toHaveBeenCalledWith('id', validUuid);
+
+    mockMaybeSingle.mockClear();
+
+    const invalidUuid = 'not-a-uuid';
+    await getBookingContext(invalidUuid);
+    expect(mockEq).toHaveBeenCalledWith('order_display_id', invalidUuid);
+  });
+});


### PR DESCRIPTION
Closes #5868.

Summary of What Has Been Done:
Added unit tests for the getBookingContext function in voiceService.js and exported it via __testing for testability. The tests cover UUID vs non-UUID booking ID routing, null data handling, and error handling.

Changes Made:
- backend/api/src/services/voiceService.js: Added __testing export for getBookingContext to enable unit testing
- backend/api/test/unit/services/voiceService.test.js: New test file with 5 tests covering getBookingContext behavior

Impact it Made:
- All 5 new tests pass
- Increases unit test coverage for backend/services/

Note: This PR is submitted as part of GSSOC (Girl Script Summer of Code). Please assign this PR to the tmdeveloper007 account.