### PR TITLE
fix(escrow): make MEVProtectedEscrow commit-reveal-release flow reachable

### DIFF
--- a/blockchain/contracts/MEVProtectedEscrow.sol
+++ b/blockchain/contracts/MEVProtectedEscrow.sol
@@ -39,11 +39,12 @@ contract MEVProtectedEscrow is Ownable, ReentrancyGuard, Pausable {
     mapping(uint256 => Escrow) public escrows;
     mapping(address => bytes32) public userCommitments;
     mapping(bytes32 => bool) public usedCommits;
+    mapping(bytes32 => bool) public revealedCommits;
     mapping(address => uint256) public userNonces;
 
     uint256 public escrowCounter;
     uint256 public commitRevealPeriod = 10; // blocks
-    uint256 public flashbotsProtection = 1; // blocks
+    uint256 public flashbotsProtection = 1; // seconds (anti-back-running window)
 
     // MEV Protection Parameters
     uint256 public minPriorityFee = 1 gwei;
@@ -76,9 +77,9 @@ contract MEVProtectedEscrow is Ownable, ReentrancyGuard, Pausable {
     function revealCommitment(bytes32 secret) external whenNotPaused {
         bytes32 commitHash = keccak256(abi.encodePacked(secret, msg.sender));
         require(userCommitments[msg.sender] == commitHash, "Invalid commit");
-        require(!usedCommits[commitHash], "Already revealed");
+        require(!revealedCommits[commitHash], "Already revealed");
 
-        usedCommits[commitHash] = true;
+        revealedCommits[commitHash] = true;
         
         emit CommitmentRevealed(msg.sender, secret);
     }
@@ -167,8 +168,8 @@ contract MEVProtectedEscrow is Ownable, ReentrancyGuard, Pausable {
         // In production: verify Flashbots bundle signature
         // Check if transaction is front-run protected
         
-        // 1. Check block number (prevent back-running)
-        require(block.number > escrows[escrowId].createdAt + flashbotsProtection, "Too early");
+        // 1. Check block timestamp (prevent back-running)
+        require(block.timestamp > escrows[escrowId].createdAt + flashbotsProtection, "Too early");
         
         // 2. Check gas price (prevent front-running)
         require(tx.gasprice >= minPriorityFee, "Gas price too low");

--- a/blockchain/test/MEVProtectedEscrow.test.js
+++ b/blockchain/test/MEVProtectedEscrow.test.js
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, error => error.message.includes(message));
+}
+
+function commitHashFor(secret, address) {
+  return ethers.keccak256(ethers.solidityPacked(["bytes32", "address"], [secret, address]));
+}
+
+describe("MEVProtectedEscrow", function () {
+  async function deployEscrow() {
+    const [owner, customer, driver, outsider] = await ethers.getSigners();
+    const Escrow = await ethers.getContractFactory("MEVProtectedEscrow");
+    const escrow = await Escrow.deploy();
+    await escrow.waitForDeployment();
+    return { escrow, owner, customer, driver, outsider };
+  }
+
+  it("allows the full commit -> reveal -> release flow", async function () {
+    const { escrow, owner, customer, driver } = await deployEscrow();
+    const secret = ethers.id("mev-secret-1");
+    const secretHash = commitHashFor(secret, customer.address);
+    const amount = ethers.parseEther("1");
+
+    await escrow.connect(customer).createCommitment(secretHash);
+    await escrow.connect(customer).createEscrow(driver.address, secretHash, { value: amount });
+    await escrow.connect(customer).revealCommitment(secret);
+
+    assert.equal(await escrow.revealedCommits(secretHash), true);
+    assert.equal(await escrow.userCommitments(customer.address), secretHash);
+
+    // Advance past the anti-back-running window so release is permitted.
+    await time.increase(2);
+    const driverBefore = await ethers.provider.getBalance(driver.address);
+    const proof = ethers.randomBytes(65);
+    await escrow.connect(owner).releaseEscrowWithProof(1, secret, proof, { gasPrice: ethers.parseUnits("1", "gwei") });
+
+    const saved = await escrow.escrows(1);
+    assert.equal(saved.released, true);
+    assert.equal(saved.revealed, true);
+    assert.equal(saved.secret, secret);
+    assert.equal(await ethers.provider.getBalance(driver.address) - driverBefore, amount);
+  });
+
+  it("rejects a second reveal of the same commitment", async function () {
+    const { escrow, customer } = await deployEscrow();
+    const secret = ethers.id("mev-secret-2");
+    const secretHash = commitHashFor(secret, customer.address);
+
+    await escrow.connect(customer).createCommitment(secretHash);
+    await escrow.connect(customer).revealCommitment(secret);
+    await assertRejectsWith(escrow.connect(customer).revealCommitment(secret), "Already revealed");
+  });
+
+  it("rejects revealing a commitment with the wrong secret", async function () {
+    const { escrow, customer } = await deployEscrow();
+    const secret = ethers.id("mev-secret-3");
+    const wrongSecret = ethers.id("mev-secret-3-wrong");
+    const secretHash = commitHashFor(secret, customer.address);
+
+    await escrow.connect(customer).createCommitment(secretHash);
+    await assertRejectsWith(escrow.connect(customer).revealCommitment(wrongSecret), "Invalid commit");
+    assert.equal(await escrow.revealedCommits(secretHash), false);
+  });
+
+  it("rejects releasing an escrow whose commitment was never revealed", async function () {
+    const { escrow, owner, customer, driver } = await deployEscrow();
+    const secret = ethers.id("mev-secret-4");
+    const secretHash = commitHashFor(secret, customer.address);
+    const amount = ethers.parseEther("0.5");
+
+    await escrow.connect(customer).createCommitment(secretHash);
+    await escrow.connect(customer).createEscrow(driver.address, secretHash, { value: amount });
+
+    await time.increase(2);
+    const proof = ethers.randomBytes(65);
+    await assertRejectsWith(
+      escrow.connect(owner).releaseEscrowWithProof(1, ethers.id("wrong-secret"), proof, { gasPrice: ethers.parseUnits("1", "gwei") }),
+      "Invalid secret"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`MEVProtectedEscrow.revealCommitment` can never succeed. `createCommitment` stores the caller's `secretHash` in `userCommitments` and pre-marks `usedCommits[secretHash] = true`. The reveal step requires `userCommitments[msg.sender] == commitHash` **and** `!usedCommits[commitHash]`, but those two requirements are mutually exclusive: for the first to hold the caller must have committed `commitHash`, which already sets `usedCommits[commitHash] = true`, so the second always fails with `Already revealed`. Every MEV-protected escrow deposit therefore can never complete its commit-reveal and release path.

Additionally, `_verifyMEVProof` compared `block.number` against `createdAt` (a `block.timestamp` value), so `releaseEscrowWithProof` would always revert with `Too early` even after the reveal, leaving funds permanently stuck.

## Fix

- Add a dedicated `revealedCommits` mapping to track the reveal step separately from the create-time `usedCommits` marker.
- `revealCommitment` now guards against re-reveals with `!revealedCommits[commitHash]` instead of `!usedCommits[commitHash]`, so a committed escrow can actually be revealed.
- Fix the anti-back-running timing guard in `_verifyMEVProof` to compare timestamps (`block.timestamp > createdAt + flashbotsProtection`) instead of mixing block numbers with timestamps.
- Add unit tests covering commit -> reveal -> release, double-reveal rejection, wrong-secret rejection, and release-without-reveal rejection.

## Files changed

- `blockchain/contracts/MEVProtectedEscrow.sol`
- `blockchain/test/MEVProtectedEscrow.test.js`

## Testing

Added `blockchain/test/MEVProtectedEscrow.test.js` exercising:
- Full commit -> reveal -> release flow (asserts escrow `released`/`revealed` state and driver payout).
- Double reveal of the same commitment reverts with `Already revealed`.
- Revealing with the wrong secret reverts with `Invalid commit` and does not mark the commitment revealed.
- Releasing an escrow whose secret was never revealed reverts with `Invalid secret`.

Closes #5889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved commitment tracking to prevent duplicate revelations.
  - Updated MEV protection timing to use seconds and escrow creation timestamps, providing more accurate validation during the release window.
  - Strengthened handling of invalid secrets and unrevealed commitments.

- **Tests**
  - Added coverage for successful commit–reveal–release flows, duplicate reveals, invalid secrets, timing windows, balance updates, and expected transaction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->