### PR TITLE
fix(telemetry): authenticate ping and bound the active-driver cache

### DIFF
--- a/services/telemetry-ingestion/README.md
+++ b/services/telemetry-ingestion/README.md
@@ -22,6 +22,24 @@ This directory contains the **High-Throughput GPS Telemetry Ingestion Engine** w
 
 ---
 
+## 🔐 Authentication
+
+Ping ingestion is authenticated with a driver JWT (HS256, signed with `JWT_SECRET`). The token must be sent as `Authorization: Bearer <jwt>`, must carry `role: "driver"`, and its `sub` (user id) must match the `driver_id` in the ping payload. Requests without a valid token are rejected with `401`, and a token whose `sub` does not match the claimed `driver_id` is rejected with `403`.
+
+For local development only, set `BYPASS_AUTH=true` (with `NODE_ENV != production`) and send the driver id via the `X-Driver-ID` header.
+
+## ⚙️ Configuration
+
+| Env var | Default | Description |
+| :--- | :--- | :--- |
+| `TELEMETRY_PORT` | `8085` | HTTP listen port. |
+| `JWT_SECRET` | — | HMAC secret used to verify driver tokens. When unset, authenticated requests are rejected (`503`). |
+| `TELEMETRY_DRIVER_TTL` | `5m` | How long a driver's cached position stays live without a new ping. |
+| `TELEMETRY_MAX_ACTIVE_DRIVERS` | `100000` | Max number of drivers held in the in-memory cache; new drivers are rejected once the cap is reached. |
+| `TELEMETRY_MAX_PINGS_PER_SEC` | `10` | Per-driver sliding-window rate limit for ping ingestion. |
+
+---
+
 ## 🐳 Docker Deployment
 
 Build and run using Docker:

--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"math"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -43,10 +48,34 @@ type IngestionStats struct {
 }
 
 var (
-	pingCounter     uint64
-	activeDrivers   sync.Map
-	serviceStartTime = time.Now()
+	pingCounter       uint64
+	activeDrivers     sync.Map
+	pingRateLimit     sync.Map
+	serviceStartTime  = time.Now()
+	jwtSecret         []byte
+	bypassAuth        bool
+	driverTTL         = 5 * time.Minute
+	maxActiveDrivers  = 100000
+	maxPingsPerSec    = 10
 )
+
+// driverEntry is a cached ping plus its last-seen time so stale drivers can be evicted.
+type driverEntry struct {
+	ping     TelemetryPing
+	lastSeen time.Time
+}
+
+// rateEntry holds a sliding window of ping timestamps for one driver.
+type rateEntry struct {
+	mu     sync.Mutex
+	stamps []time.Time
+}
+
+// jwtClaims holds the subset of JWT claims the telemetry service needs.
+type jwtClaims struct {
+	Sub  string `json:"sub"`
+	Role string `json:"role"`
+}
 
 // Calculate Haversine distance in meters between two lat/lng points
 func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
@@ -63,10 +92,205 @@ func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	return earthRadiusMeters * c
 }
 
+// envInt reads an integer from the environment with a default fallback.
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// envDuration reads a duration from the environment with a default fallback.
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+// parseDriverToken verifies an HS256 JWT with JWT_SECRET and returns its claims.
+func parseDriverToken(token string) (jwtClaims, error) {
+	var claims jwtClaims
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return claims, fmt.Errorf("malformed token")
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return claims, fmt.Errorf("malformed token")
+	}
+
+	mac := hmac.New(sha256.New, jwtSecret)
+	mac.Write([]byte(parts[0] + "." + parts[1]))
+	if !hmac.Equal(sig, mac.Sum(nil)) {
+		return claims, fmt.Errorf("invalid token signature")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return claims, fmt.Errorf("malformed token")
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return claims, fmt.Errorf("malformed token")
+	}
+
+	return claims, nil
+}
+
+// authenticateDriver extracts and verifies the caller's bearer JWT, requiring
+// the driver role. On success it returns the authenticated subject (driver id).
+func authenticateDriver(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if bypassAuth {
+		return r.Header.Get("X-Driver-ID"), true
+	}
+
+	if len(jwtSecret) == 0 {
+		http.Error(w, "authentication is not configured", http.StatusServiceUnavailable)
+		return "", false
+	}
+
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return "", false
+	}
+
+	claims, err := parseDriverToken(strings.TrimPrefix(auth, "Bearer "))
+	if err != nil {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return "", false
+	}
+
+	if claims.Role != "driver" {
+		http.Error(w, "forbidden: driver role required", http.StatusForbidden)
+		return "", false
+	}
+
+	return claims.Sub, true
+}
+
+// validatePing checks that a ping payload is plausible before it is accepted.
+func validatePing(ping *TelemetryPing) error {
+	if ping.DriverID == "" {
+		return fmt.Errorf("driver_id is required")
+	}
+	if math.IsNaN(ping.Latitude) || math.IsNaN(ping.Longitude) ||
+		ping.Latitude < -90 || ping.Latitude > 90 ||
+		ping.Longitude < -180 || ping.Longitude > 180 {
+		return fmt.Errorf("latitude or longitude out of plausible bounds")
+	}
+	if ping.SpeedKMH < 0 {
+		return fmt.Errorf("speed_kmh cannot be negative")
+	}
+	if ping.Heading < 0 || ping.Heading > 360 {
+		return fmt.Errorf("heading_deg must be between 0 and 360")
+	}
+	if ping.FuelLevel < 0 || ping.FuelLevel > 100 {
+		return fmt.Errorf("fuel_level_pct must be between 0 and 100")
+	}
+	if ping.Timestamp.IsZero() {
+		ping.Timestamp = time.Now()
+	}
+	if ping.Timestamp.After(time.Now().Add(time.Minute)) {
+		return fmt.Errorf("timestamp too far in the future")
+	}
+	return nil
+}
+
+// allowPing enforces a per-driver sliding-window rate limit.
+func allowPing(driverID string) bool {
+	v, _ := pingRateLimit.LoadOrStore(driverID, &rateEntry{})
+	e := v.(*rateEntry)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cutoff := time.Now().Add(-time.Second)
+	kept := e.stamps[:0]
+	for _, t := range e.stamps {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	e.stamps = kept
+
+	if len(e.stamps) >= maxPingsPerSec {
+		return false
+	}
+
+	e.stamps = append(e.stamps, time.Now())
+	return true
+}
+
+// countActiveDrivers returns the current number of cached drivers.
+func countActiveDrivers() int {
+	count := 0
+	activeDrivers.Range(func(key, value interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}
+
+// storePing caches a ping for a driver, enforcing the max-map-size cap.
+func storePing(driverID string, ping TelemetryPing) bool {
+	now := time.Now()
+
+	if _, ok := activeDrivers.Load(driverID); ok {
+		activeDrivers.Store(driverID, driverEntry{ping: ping, lastSeen: now})
+		return true
+	}
+
+	if countActiveDrivers() >= maxActiveDrivers {
+		sweepDrivers()
+		if countActiveDrivers() >= maxActiveDrivers {
+			return false
+		}
+	}
+
+	activeDrivers.Store(driverID, driverEntry{ping: ping, lastSeen: now})
+	return true
+}
+
+// sweepDrivers removes drivers whose last ping is older than the TTL and drops
+// empty rate-limit entries.
+func sweepDrivers() {
+	now := time.Now()
+
+	activeDrivers.Range(func(key, value interface{}) bool {
+		if now.Sub(value.(driverEntry).lastSeen) > driverTTL {
+			activeDrivers.Delete(key)
+		}
+		return true
+	})
+
+	pingRateLimit.Range(func(key, value interface{}) bool {
+		e := value.(*rateEntry)
+		e.mu.Lock()
+		empty := len(e.stamps) == 0
+		e.mu.Unlock()
+		if empty {
+			pingRateLimit.Delete(key)
+		}
+		return true
+	})
+}
+
 // Handle Single Telemetry Ping
 func handlePing(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	callerID, ok := authenticateDriver(w, r)
+	if !ok {
 		return
 	}
 
@@ -76,18 +300,27 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ping.DriverID == "" || ping.Latitude == 0 || ping.Longitude == 0 {
-		http.Error(w, "driver_id, latitude, and longitude are required", http.StatusBadRequest)
+	if err := validatePing(&ping); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid telemetry payload: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	if ping.Timestamp.IsZero() {
-		ping.Timestamp = time.Now()
+	if callerID != "" && callerID != ping.DriverID {
+		http.Error(w, "driver_id does not match authenticated caller", http.StatusForbidden)
+		return
+	}
+
+	if !allowPing(ping.DriverID) {
+		http.Error(w, "Too many telemetry requests", http.StatusTooManyRequests)
+		return
 	}
 
 	// Update atomic stats & active driver cache
 	atomic.AddUint64(&pingCounter, 1)
-	activeDrivers.Store(ping.DriverID, ping)
+	if !storePing(ping.DriverID, ping) {
+		http.Error(w, "Active driver capacity reached", http.StatusServiceUnavailable)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -124,7 +357,14 @@ func handleGeofence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ping := val.(TelemetryPing)
+	entry := val.(driverEntry)
+	if time.Since(entry.lastSeen) > driverTTL {
+		activeDrivers.Delete(req.DriverID)
+		http.Error(w, "Driver telemetry not found", http.StatusNotFound)
+		return
+	}
+
+	ping := entry.ping
 	radius := req.RadiusM
 	if radius == 0 {
 		radius = 500.0 // Default 500 meters geofence
@@ -172,6 +412,24 @@ func main() {
 	if port == "" {
 		port = "8085"
 	}
+
+	jwtSecret = []byte(os.Getenv("JWT_SECRET"))
+	bypassAuth = os.Getenv("BYPASS_AUTH") == "true" && os.Getenv("NODE_ENV") != "production"
+	driverTTL = envDuration("TELEMETRY_DRIVER_TTL", 5*time.Minute)
+	maxActiveDrivers = envInt("TELEMETRY_MAX_ACTIVE_DRIVERS", 100000)
+	maxPingsPerSec = envInt("TELEMETRY_MAX_PINGS_PER_SEC", 10)
+	if driverTTL <= 0 {
+		driverTTL = time.Second
+	}
+
+	// Periodically evict stale drivers so the in-memory map stays bounded.
+	go func() {
+		ticker := time.NewTicker(driverTTL / 2)
+		defer ticker.Stop()
+		for range ticker.C {
+			sweepDrivers()
+		}
+	}()
 
 	http.HandleFunc("/api/v1/telemetry/ping", handlePing)
 	http.HandleFunc("/api/v1/telemetry/geofence", handleGeofence)


### PR DESCRIPTION
## Problem

`services/telemetry-ingestion/main.go` exposes an unauthenticated ping endpoint. Any client could submit a GPS ping for ANY `driver_id`, and every accepted ping was stored forever in an in-memory `sync.Map` that was never pruned. This allowed GPS spoofing of any driver and unbounded memory growth from pings with unique `driver_id` values.

## Fix

- Authenticated the `/api/v1/telemetry/ping` endpoint: the caller must present a driver JWT (`Authorization: Bearer <jwt>`) signed with `JWT_SECRET`. The token must carry `role: "driver"`, and its `sub` must match the `driver_id` in the ping body (mismatch returns `403`). Requests without a valid token return `401`; if `JWT_SECRET` is unset the endpoint fails closed (`503`). `BYPASS_AUTH=true` (non-production only) preserves local-dev workflows via an `X-Driver-ID` header.
- Bounded the active-driver map:
  - Each cached ping now carries a `lastSeen` time (`driverEntry`).
  - A background sweeper evicts drivers whose last ping is older than `TELEMETRY_DRIVER_TTL` (default `5m`).
  - A max-map-size cap (`TELEMETRY_MAX_ACTIVE_DRIVERS`, default `100000`) rejects new drivers once the cap is reached (after a stale sweep).
- Rate-limited ping ingestion with a per-driver sliding window (`TELEMETRY_MAX_PINGS_PER_SEC`, default `10`) returning `429`.
- Validated ping payloads: lat/lon ranges and NaN rejection, non-negative speed, heading `0-360`, fuel `0-100`, and a timestamp-not-too-far-in-the-future check (also prevents TTL bypass via forged timestamps).
- The geofence handler now works with the cached `driverEntry` and treats stale entries as not-found.
- Documented the auth flow and all new env vars in `services/telemetry-ingestion/README.md`.

## Files changed

- `services/telemetry-ingestion/main.go`
- `services/telemetry-ingestion/README.md`

## Testing

- Go code reviewed against the stdlib-only `go 1.21` module (no toolchain or Docker daemon available on this machine to run `go build`).
- No existing unit tests exist for this service.

Closes #5882
