### PR TITLE
fix(raft): start as follower and run real elections before leading

### DIFF
--- a/services/consensus-raft-go/README.md
+++ b/services/consensus-raft-go/README.md
@@ -7,8 +7,34 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 ## 🌐 Raft Consensus Features
 
 - **Distributed State Machine**: Guarantees linearizable order state transitions (`CREATED` $\rightarrow$ `DISPATCHED` $\rightarrow$ `COMPLETED`) across multi-cloud regions.
-- **Leader Election & Heartbeats**: Built-in leader election timer and term bump logic to survive regional network partitions.
+- **Leader Election & Heartbeats**: Nodes start as `FOLLOWER`, campaign for leadership via `RequestVote` RPCs, and keep leadership with `AppendEntries` heartbeats and term bumps (Raft paper §5).
 - **Atomic Log Replication**: Appends transactional state transition entries into an append-only WAL log.
+- **Quorum-Aware Health**: `/api/v1/raft/status` reports `HEALTHY_CLUSTER` only when a leader has quorum; `NO_LEADER`, `ELECTION_IN_PROGRESS`, and `UNHEALTHY_CLUSTER` are reported otherwise.
+
+---
+
+## 🔌 REST Endpoints
+
+| Endpoint | Method | Description |
+| :--- | :--- | :--- |
+| `/api/v1/raft/status` | `GET` | Returns node role, current term, leader id, log length, quorum, and cluster health. |
+| `/api/v1/raft/commit` | `POST` | Commits an order entry. Only the leader may commit; without quorum it returns `503`, and non-leaders return `409` with the current `leader_id`. |
+| `/api/v1/raft/vote` | `POST` | Internal Raft `RequestVote` RPC used during elections. |
+| `/api/v1/raft/append` | `POST` | Internal Raft `AppendEntries` (heartbeat) RPC used by the leader. |
+
+---
+
+## ⚙️ Configuration
+
+| Env var | Default | Description |
+| :--- | :--- | :--- |
+| `RAFT_PORT` | `8089` | HTTP listen port. |
+| `NODE_ID` | `raft-node-north-1` | Unique id for this node. |
+| `RAFT_PEER_IDS` | `raft-node-south-1,...` | Comma-separated peer node ids reported in `/status`. |
+| `RAFT_PEER_URLS` | *(none)* | Comma-separated `scheme://host:port` base URLs of peers used for `vote`/`append` RPCs. When empty, the node cannot reach a quorum and stays in `NO_LEADER`/`UNHEALTHY_CLUSTER` until a leader is reachable. A single-node cluster with no peers elects itself. |
+| `RAFT_HEARTBEAT_MS` | `100` | Leader heartbeat interval. |
+| `RAFT_ELECTION_TIMEOUT_MIN_MS` | `500` | Lower bound of the randomized election timeout. |
+| `RAFT_ELECTION_TIMEOUT_MAX_MS` | `1200` | Upper bound of the randomized election timeout. |
 
 ---
 

--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -26,30 +29,323 @@ type LogEntry struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-type RaftNode struct {
-	mu          sync.Mutex
-	NodeID      string     `json:"node_id"`
-	CurrentTerm uint64     `json:"current_term"`
-	VotedFor    string     `json:"voted_for"`
-	Role        NodeRole   `json:"role"`
-	Log         []LogEntry `json:"log"`
-	CommitIndex uint64     `json:"commit_index"`
-	LastApplied uint64     `json:"last_applied"`
-	Peers       []string   `json:"peers"`
-	LeaderID    string     `json:"leader_id"`
+// RequestVoteRequest is the Raft RequestVote RPC payload.
+type RequestVoteRequest struct {
+	Term         uint64 `json:"term"`
+	CandidateID  string `json:"candidate_id"`
+	LastLogIndex uint64 `json:"last_log_index"`
+	LastLogTerm  uint64 `json:"last_log_term"`
 }
 
-func NewRaftNode(id string, peers []string) *RaftNode {
+// RequestVoteResponse is the Raft RequestVote RPC result.
+type RequestVoteResponse struct {
+	Term        uint64 `json:"term"`
+	VoteGranted bool   `json:"vote_granted"`
+}
+
+// AppendEntriesRequest is the Raft AppendEntries (heartbeat) RPC payload.
+type AppendEntriesRequest struct {
+	Term         uint64     `json:"term"`
+	LeaderID     string     `json:"leader_id"`
+	PrevLogIndex uint64     `json:"prev_log_index"`
+	PrevLogTerm  uint64     `json:"prev_log_term"`
+	Entries      []LogEntry `json:"entries"`
+	LeaderCommit uint64     `json:"leader_commit"`
+}
+
+// AppendEntriesResponse is the Raft AppendEntries RPC result.
+type AppendEntriesResponse struct {
+	Term    uint64 `json:"term"`
+	Success bool   `json:"success"`
+}
+
+type RaftNode struct {
+	mu                sync.Mutex
+	NodeID            string     `json:"node_id"`
+	CurrentTerm       uint64     `json:"current_term"`
+	VotedFor          string     `json:"voted_for"`
+	Role              NodeRole   `json:"role"`
+	Log               []LogEntry `json:"log"`
+	CommitIndex       uint64     `json:"commit_index"`
+	LastApplied       uint64     `json:"last_applied"`
+	Peers             []string   `json:"peers"`
+	PeerURLs          []string   `json:"peer_urls"`
+	LeaderID          string     `json:"leader_id"`
+
+	lastLeaderSeen    time.Time
+	electionStarted   time.Time
+	electionTimeout   time.Duration
+	electionTimeoutMin time.Duration
+	electionTimeoutMax time.Duration
+	heartbeatInterval time.Duration
+	peerHeartbeats    map[string]bool
+	httpClient        *http.Client
+}
+
+// rng is a source of randomness for election timeouts.
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func NewRaftNode(id string, peers []string, peerURLs []string) *RaftNode {
+	heartbeatMs := envInt("RAFT_HEARTBEAT_MS", 100)
+	electionMinMs := envInt("RAFT_ELECTION_TIMEOUT_MIN_MS", 500)
+	electionMaxMs := envInt("RAFT_ELECTION_TIMEOUT_MAX_MS", 1200)
+	if electionMaxMs < electionMinMs {
+		electionMaxMs = electionMinMs
+	}
+
 	return &RaftNode{
-		NodeID:      id,
-		CurrentTerm: 1,
-		Role:        Leader,
-		Log:         make([]LogEntry, 0),
-		Peers:       peers,
-		LeaderID:    id,
+		NodeID:             id,
+		CurrentTerm:        0,
+		Role:               Follower,
+		Log:                make([]LogEntry, 0),
+		Peers:              peers,
+		PeerURLs:           peerURLs,
+		LeaderID:           "",
+		lastLeaderSeen:     time.Now(),
+		heartbeatInterval:  time.Duration(heartbeatMs) * time.Millisecond,
+		electionTimeoutMin: time.Duration(electionMinMs) * time.Millisecond,
+		electionTimeoutMax: time.Duration(electionMaxMs) * time.Millisecond,
+		electionTimeout:    time.Duration(electionMinMs) * time.Millisecond,
+		peerHeartbeats:     make(map[string]bool),
+		httpClient:         &http.Client{Timeout: 500 * time.Millisecond},
 	}
 }
 
+func (rn *RaftNode) lastLogIndex() uint64 {
+	return uint64(len(rn.Log))
+}
+
+func (rn *RaftNode) lastLogTerm() uint64 {
+	if len(rn.Log) == 0 {
+		return 0
+	}
+	return rn.Log[len(rn.Log)-1].Term
+}
+
+func (rn *RaftNode) quorum() int {
+	return (len(rn.PeerURLs)+1)/2 + 1
+}
+
+func (rn *RaftNode) randomElectionTimeout() time.Duration {
+	minMs := int(rn.electionTimeoutMin / time.Millisecond)
+	maxMs := int(rn.electionTimeoutMax / time.Millisecond)
+	return time.Duration(minMs+rng.Intn(maxMs-minMs+1)) * time.Millisecond
+}
+
+// stepDownLocked resets the node to follower when a higher term is observed.
+func (rn *RaftNode) stepDownLocked(term uint64) {
+	if term <= rn.CurrentTerm {
+		return
+	}
+	rn.CurrentTerm = term
+	rn.VotedFor = ""
+	rn.LeaderID = ""
+	if rn.Role != Follower {
+		rn.Role = Follower
+	}
+	rn.lastLeaderSeen = time.Now()
+}
+
+// startElectionLocked campaigns for leadership: bump term, vote for self, and
+// request votes from peers. A candidate with a majority becomes leader.
+func (rn *RaftNode) startElectionLocked() {
+	rn.Role = Candidate
+	rn.CurrentTerm++
+	rn.VotedFor = rn.NodeID
+	rn.LeaderID = ""
+	rn.electionStarted = time.Now()
+	rn.electionTimeout = rn.randomElectionTimeout()
+
+	req := RequestVoteRequest{
+		Term:         rn.CurrentTerm,
+		CandidateID:  rn.NodeID,
+		LastLogIndex: rn.lastLogIndex(),
+		LastLogTerm:  rn.lastLogTerm(),
+	}
+
+	responses := rn.requestVotes(req)
+
+	votes := 1 // self vote
+	for _, resp := range responses {
+		if resp.Term > rn.CurrentTerm {
+			rn.stepDownLocked(resp.Term)
+			return
+		}
+		if resp.VoteGranted {
+			votes++
+		}
+	}
+
+	if votes >= rn.quorum() {
+		rn.Role = Leader
+		rn.LeaderID = rn.NodeID
+		rn.peerHeartbeats = make(map[string]bool, len(rn.PeerURLs))
+		log.Printf("🌐 node [%s] elected leader for term %d", rn.NodeID, rn.CurrentTerm)
+	}
+}
+
+// requestVotes sends RequestVote RPCs to all peers concurrently.
+func (rn *RaftNode) requestVotes(req RequestVoteRequest) []RequestVoteResponse {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	responses := make([]RequestVoteResponse, 0, len(rn.PeerURLs))
+
+	for _, url := range rn.PeerURLs {
+		wg.Add(1)
+		go func(peerURL string) {
+			defer wg.Done()
+			resp, err := rn.callVote(peerURL, req)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			responses = append(responses, resp)
+			mu.Unlock()
+		}(url)
+	}
+	wg.Wait()
+
+	return responses
+}
+
+// callVote sends a RequestVote RPC to a peer.
+func (rn *RaftNode) callVote(peerURL string, req RequestVoteRequest) (RequestVoteResponse, error) {
+	var resp RequestVoteResponse
+	body, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+	res, err := rn.httpClient.Post(peerURL+"/api/v1/raft/vote", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	return resp, err
+}
+
+// callAppend sends an AppendEntries RPC to a peer.
+func (rn *RaftNode) callAppend(peerURL string, req AppendEntriesRequest) (AppendEntriesResponse, error) {
+	var resp AppendEntriesResponse
+	body, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+	res, err := rn.httpClient.Post(peerURL+"/api/v1/raft/append", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	return resp, err
+}
+
+// sendHeartbeatsLocked replicates AppendEntries RPCs to peers and records which
+// peers acknowledge the current leadership.
+func (rn *RaftNode) sendHeartbeatsLocked() {
+	req := AppendEntriesRequest{
+		Term:         rn.CurrentTerm,
+		LeaderID:     rn.NodeID,
+		PrevLogIndex: rn.lastLogIndex(),
+		PrevLogTerm:  rn.lastLogTerm(),
+		LeaderCommit: rn.CommitIndex,
+	}
+
+	rn.peerHeartbeats = make(map[string]bool, len(rn.PeerURLs))
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	type result struct {
+		url  string
+		resp AppendEntriesResponse
+		err  error
+	}
+	results := make([]result, 0, len(rn.PeerURLs))
+
+	for _, url := range rn.PeerURLs {
+		wg.Add(1)
+		go func(peerURL string) {
+			defer wg.Done()
+			resp, err := rn.callAppend(peerURL, req)
+			mu.Lock()
+			results = append(results, result{url: peerURL, resp: resp, err: err})
+			mu.Unlock()
+		}(url)
+	}
+	wg.Wait()
+
+	for _, res := range results {
+		if res.err != nil {
+			continue
+		}
+		if res.resp.Term > rn.CurrentTerm {
+			rn.stepDownLocked(res.resp.Term)
+			return
+		}
+		if res.resp.Success {
+			rn.peerHeartbeats[res.url] = true
+		}
+	}
+}
+
+// leaderHasQuorumLocked reports whether a majority of the cluster acknowledges
+// the current leadership.
+func (rn *RaftNode) leaderHasQuorumLocked() bool {
+	acked := 1 // self
+	for _, ok := range rn.peerHeartbeats {
+		if ok {
+			acked++
+		}
+	}
+	return acked >= rn.quorum()
+}
+
+func (rn *RaftNode) clusterStatusLocked() string {
+	switch rn.Role {
+	case Leader:
+		if rn.leaderHasQuorumLocked() {
+			return "HEALTHY_CLUSTER"
+		}
+		return "UNHEALTHY_CLUSTER"
+	case Candidate:
+		return "ELECTION_IN_PROGRESS"
+	default:
+		if time.Since(rn.lastLeaderSeen) <= rn.electionTimeout {
+			return "HEALTHY_CLUSTER"
+		}
+		return "NO_LEADER"
+	}
+}
+
+// run drives the Raft state machine: heartbeats while leader, elections when
+// a leader has not been heard from.
+func (rn *RaftNode) run() {
+	for {
+		var delay time.Duration
+
+		rn.mu.Lock()
+		switch rn.Role {
+		case Leader:
+			rn.sendHeartbeatsLocked()
+			delay = rn.heartbeatInterval
+		case Candidate:
+			if time.Since(rn.electionStarted) > rn.electionTimeout {
+				rn.startElectionLocked()
+			}
+			delay = 50 * time.Millisecond
+		default:
+			if time.Since(rn.lastLeaderSeen) > rn.electionTimeout {
+				rn.startElectionLocked()
+			}
+			delay = 50 * time.Millisecond
+		}
+		rn.mu.Unlock()
+
+		time.Sleep(delay)
+	}
+}
+
+// HandleStatus reports node state and cluster health.
 func (rn *RaftNode) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	rn.mu.Lock()
 	defer rn.mu.Unlock()
@@ -59,14 +355,127 @@ func (rn *RaftNode) HandleStatus(w http.ResponseWriter, r *http.Request) {
 		"node_id":      rn.NodeID,
 		"role":         rn.Role,
 		"term":         rn.CurrentTerm,
+		"voted_for":    rn.VotedFor,
 		"leader_id":    rn.LeaderID,
 		"commit_index": rn.CommitIndex,
 		"log_length":   len(rn.Log),
-		"status":       "HEALTHY_CLUSTER",
+		"peers":        rn.Peers,
+		"quorum":       rn.quorum(),
+		"status":       rn.clusterStatusLocked(),
 		"timestamp":    time.Now().Format(time.RFC3339),
 	})
 }
 
+// HandleVote implements the Raft RequestVote RPC.
+func (rn *RaftNode) HandleVote(w http.ResponseWriter, r *http.Request) {
+	var req RequestVoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	resp := RequestVoteResponse{Term: rn.CurrentTerm, VoteGranted: false}
+
+	if req.Term > rn.CurrentTerm {
+		rn.stepDownLocked(req.Term)
+	}
+
+	if req.Term == rn.CurrentTerm &&
+		(rn.VotedFor == "" || rn.VotedFor == req.CandidateID) &&
+		rn.isLogUpToDate(req.LastLogIndex, req.LastLogTerm) {
+		rn.VotedFor = req.CandidateID
+		resp.VoteGranted = true
+	}
+
+	resp.Term = rn.CurrentTerm
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// isLogUpToDate reports whether the candidate's log is at least as up to date
+// as this node's log (Raft vote restriction).
+func (rn *RaftNode) isLogUpToDate(lastLogIndex, lastLogTerm uint64) bool {
+	myLastIdx, myLastTerm := rn.lastLogIndex(), rn.lastLogTerm()
+	if lastLogTerm != myLastTerm {
+		return lastLogTerm > myLastTerm
+	}
+	return lastLogIndex >= myLastIdx
+}
+
+// HandleAppend implements the Raft AppendEntries RPC.
+func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
+	var req AppendEntriesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	resp := AppendEntriesResponse{Term: rn.CurrentTerm, Success: false}
+
+	if req.Term > rn.CurrentTerm {
+		rn.stepDownLocked(req.Term)
+	}
+
+	if req.Term == rn.CurrentTerm {
+		rn.Role = Follower
+		rn.LeaderID = req.LeaderID
+		rn.VotedFor = ""
+		rn.lastLeaderSeen = time.Now()
+
+		if rn.appendLogFromLeaderLocked(req) {
+			if req.LeaderCommit > rn.CommitIndex {
+				last := uint64(len(rn.Log))
+				if req.LeaderCommit < last {
+					last = req.LeaderCommit
+				}
+				rn.CommitIndex = last
+			}
+			resp.Success = true
+		}
+	}
+
+	resp.Term = rn.CurrentTerm
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// appendLogFromLeaderLocked appends replicated entries after checking log
+// consistency with the previous entry.
+func (rn *RaftNode) appendLogFromLeaderLocked(req AppendEntriesRequest) bool {
+	if req.PrevLogIndex > uint64(len(rn.Log)) {
+		return false
+	}
+	if req.PrevLogIndex > 0 {
+		prev := rn.Log[req.PrevLogIndex-1]
+		if prev.Term != req.PrevLogTerm {
+			return false
+		}
+	}
+	for i, e := range req.Entries {
+		idx := int(req.PrevLogIndex) + 1 + i
+		if idx <= len(rn.Log) {
+			if rn.Log[idx-1].Term != e.Term {
+				rn.Log = rn.Log[:idx-1]
+				rn.Log = append(rn.Log, req.Entries[i:]...)
+				return true
+			}
+		} else {
+			rn.Log = append(rn.Log, req.Entries[i:]...)
+			return true
+		}
+	}
+	return true
+}
+
+// HandleCommitOrder accepts a committed order entry on the leader.
 func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -85,6 +494,27 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 
 	rn.mu.Lock()
 	defer rn.mu.Unlock()
+
+	if rn.Role != Leader {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success":   false,
+			"error":     "not the cluster leader",
+			"leader_id": rn.LeaderID,
+		})
+		return
+	}
+
+	if !rn.leaderHasQuorumLocked() {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "no cluster quorum",
+		})
+		return
+	}
 
 	entry := LogEntry{
 		Index:     uint64(len(rn.Log) + 1),
@@ -108,9 +538,27 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func main() {
-	rand.Seed(time.Now().UnixNano())
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
 
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func main() {
 	port := os.Getenv("RAFT_PORT")
 	if port == "" {
 		port = "8089"
@@ -122,12 +570,24 @@ func main() {
 	}
 
 	peers := []string{"raft-node-south-1", "raft-node-east-1", "raft-node-west-1"}
-	node := NewRaftNode(nodeID, peers)
+	if v := os.Getenv("RAFT_PEER_IDS"); v != "" {
+		peers = splitCSV(v)
+	}
+
+	var peerURLs []string
+	if v := os.Getenv("RAFT_PEER_URLS"); v != "" {
+		peerURLs = splitCSV(v)
+	}
+
+	node := NewRaftNode(nodeID, peers, peerURLs)
 
 	http.HandleFunc("/api/v1/raft/status", node.HandleStatus)
 	http.HandleFunc("/api/v1/raft/commit", node.HandleCommitOrder)
+	http.HandleFunc("/api/v1/raft/vote", node.HandleVote)
+	http.HandleFunc("/api/v1/raft/append", node.HandleAppend)
 
 	log.Printf("🌐 Go Raft Distributed Consensus Node [%s] starting on port %s...", nodeID, port)
+	go node.run()
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatalf("Fatal consensus server error: %v", err)
 	}


### PR DESCRIPTION
## Problem

`services/consensus-raft-go/main.go` hardcoded every node to start as `Leader` (`NewRaftNode` set `Role: Leader` and `LeaderID: id` for every node). A cluster in which every node believes it is the leader cannot form safe consensus: entries are committed without a real election, quorum, or term discipline, and `HandleStatus` reported `HEALTHY_CLUSTER` unconditionally, masking the problem.

## Fix

- Nodes now start as `Follower` with an empty `LeaderID`, and only act as leader after winning a real election.
- Implemented the Raft election protocol (paper §5) with stdlib only:
  - **RequestVote RPC** (`POST /api/v1/raft/vote`): term bumps, grant-once-per-term voting, and the log-up-to-date vote restriction.
  - **AppendEntries RPC** (`POST /api/v1/raft/append`): heartbeats with prev-log consistency checks, log appending/truncation, and leader-commit propagation.
  - **Election loop**: followers with no fresh leader heartbeat time out (randomized `RAFT_ELECTION_TIMEOUT_MIN_MS`..`MAX_MS`), become candidates, bump the term, vote for themselves, and request peer votes. A majority win makes them leader; seeing a higher term steps them down.
  - **Heartbeats**: the leader sends `AppendEntries` every `RAFT_HEARTBEAT_MS` (default `100ms`) and tracks per-peer acknowledgements to compute quorum.
- Only the leader may commit (`HandleCommitOrder` returns `409` with the current `leader_id` for non-leaders).
- A leader refuses to commit without quorum (`503`), so a partitioned leader cannot advance the log.
- `HandleStatus` now reports honest cluster health: `HEALTHY_CLUSTER` only with quorum/leader, plus `NO_LEADER`, `ELECTION_IN_PROGRESS`, and `UNHEALTHY_CLUSTER` states, and exposes `term`, `voted_for`, `leader_id`, and `quorum`.
- Single-node bootstrap: with no peers, a node elects itself (majority of 1) after its election timeout.
- Peer RPC endpoints are configured via `RAFT_PEER_URLS` (comma-separated `scheme://host:port`); all timings are env-configurable. Documented in the service README.

## Files changed

- `services/consensus-raft-go/main.go`
- `services/consensus-raft-go/README.md`

## Testing

- Go code reviewed against the stdlib-only `go 1.21` module (no Go toolchain or Docker daemon available on this machine to run `go build` / `go vet`).
- No existing unit tests exist for this service.

Closes #5884
