### PR TITLE
fix(docker): require DB passwords, stop publishing DB ports, secure mongo/redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,12 +26,24 @@ DATABASE_URL=postgresql://postgres.your-project-id:your-db-password@aws-0-us-eas
 
 # Local PostgreSQL/PostGIS via docker-compose
 # Use this DATABASE_URL instead when running the backend inside Docker Compose:
-# DATABASE_URL=postgresql://postgres:postgrespassword@db:5432/truxify
+# DATABASE_URL=postgresql://postgres:${DB_PASSWORD}@db:5432/truxify
 # Use this host URL for local CLI tools running outside Docker:
-# LOCAL_DATABASE_URL=postgresql://postgres:postgrespassword@localhost:5432/truxify
+# LOCAL_DATABASE_URL=postgresql://postgres:${DB_PASSWORD}@localhost:5432/truxify
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgrespassword
 POSTGRES_DB=truxify
+
+# Required by docker-compose.yml — no defaults are baked into the file, so these
+# MUST be set in .env or `docker compose up` will fail closed.
+# Password for the main Postgres instance (`db` service).
+DB_PASSWORD=<generate-a-secure-random-password>
+# Shared password for the geographic shards (shard-north/south/east/west).
+SHARD_PASSWORD=<generate-a-secure-random-password>
+# Root credentials for the MongoDB container (used for auth + app connection).
+MONGO_ROOT_USER=root
+MONGO_ROOT_PASSWORD=<generate-a-secure-random-password>
+# Password for the Redis container (requirepass).
+REDIS_PASSWORD=<generate-a-secure-random-password>
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
     ports:
       - "5000:5000"
     environment:
-      MONGODB_URI: mongodb://mongo:27017
+      MONGODB_URI: mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@mongo:27017/truxify_telemetry?authSource=admin
       MONGODB_DB_NAME: truxify_telemetry
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       ML_API_KEY: ${ML_API_KEY:?ML_API_KEY is required}
       ML_ENGINE_URL: http://ml-engine:8000
       OSRM_BASE_URL: http://osrm:5000
@@ -20,22 +20,22 @@ services:
       SHARD_NORTH_PORT: 5432
       SHARD_NORTH_DB: truxify_north
       SHARD_NORTH_USER: postgres
-      SHARD_NORTH_PASSWORD: ${SHARD_PASSWORD:-password}
+      SHARD_NORTH_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       SHARD_SOUTH_HOST: shard-south
       SHARD_SOUTH_PORT: 5432
       SHARD_SOUTH_DB: truxify_south
       SHARD_SOUTH_USER: postgres
-      SHARD_SOUTH_PASSWORD: ${SHARD_PASSWORD:-password}
+      SHARD_SOUTH_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       SHARD_EAST_HOST: shard-east
       SHARD_EAST_PORT: 5432
       SHARD_EAST_DB: truxify_east
       SHARD_EAST_USER: postgres
-      SHARD_EAST_PASSWORD: ${SHARD_PASSWORD:-password}
+      SHARD_EAST_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       SHARD_WEST_HOST: shard-west
       SHARD_WEST_PORT: 5432
       SHARD_WEST_DB: truxify_west
       SHARD_WEST_USER: postgres
-      SHARD_WEST_PASSWORD: ${SHARD_PASSWORD:-password}
+      SHARD_WEST_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       # Malware scanning
       CLAMAV_HOST: clamav
       CLAMAV_PORT: "3310"
@@ -107,10 +107,10 @@ services:
     container_name: truxify-postgres
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       POSTGRES_DB: truxify
-    ports:
-      - "5432:5432"
+    # Database ports are NOT published to the host. Bind 127.0.0.1:5432:5432
+    # for local CLI tools instead of exposing the DB on the LAN.
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -127,10 +127,8 @@ services:
     image: postgis/postgis:15-3.3-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${SHARD_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       POSTGRES_DB: truxify_north
-    ports:
-      - "5433:5432"
     volumes:
       - shard_north_data:/var/lib/postgresql/data
     healthcheck:
@@ -144,10 +142,8 @@ services:
     image: postgis/postgis:15-3.3-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${SHARD_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       POSTGRES_DB: truxify_south
-    ports:
-      - "5434:5432"
     volumes:
       - shard_south_data:/var/lib/postgresql/data
     healthcheck:
@@ -161,10 +157,8 @@ services:
     image: postgis/postgis:15-3.3-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${SHARD_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       POSTGRES_DB: truxify_east
-    ports:
-      - "5435:5432"
     volumes:
       - shard_east_data:/var/lib/postgresql/data
     healthcheck:
@@ -178,10 +172,8 @@ services:
     image: postgis/postgis:15-3.3-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${SHARD_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
       POSTGRES_DB: truxify_west
-    ports:
-      - "5436:5432"
     volumes:
       - shard_west_data:/var/lib/postgresql/data
     healthcheck:
@@ -198,34 +190,32 @@ services:
   mongo:
     image: mongo:6-jammy
     container_name: truxify-mongo
-    ports:
-      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:?MONGO_ROOT_USER is required}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?MONGO_ROOT_PASSWORD is required}
     volumes:
       - mongo_data:/data/db
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongosh", "--quiet", "--username", "${MONGO_ROOT_USER}", "--password", "${MONGO_ROOT_PASSWORD}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
-    restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     container_name: truxify-redis
-    ports:
-      - "6379:6379"
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?REDIS_PASSWORD is required}"]
     volumes:
       - redis_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
-    restart: unless-stopped
 
   # ── Optional: ClamAV malware scanner ──────────────────
   # Uncomment to enable on-demand malware scanning for uploads.

--- a/k8s/keda/scaledobject-redis.yaml
+++ b/k8s/keda/scaledobject-redis.yaml
@@ -15,10 +15,12 @@ spec:
   cooldownPeriod: 300
   pollingInterval: 30
   triggers:
+  # REDIS_PASSWORD must be injected into the redis-deployment pod via a Secret
+  # (e.g. env: - name: REDIS_PASSWORD, valueFrom: { secretKeyRef: ... }).
   - type: redis
     metadata:
       address: redis-service:6379
-      password: ""
+      passwordFromEnv: REDIS_PASSWORD
       database: "0"
       listName: orders
       listLength: "100"
@@ -40,8 +42,10 @@ spec:
   cooldownPeriod: 300
   pollingInterval: 30
   triggers:
+  # POSTGRES_CONNECTION_STRING must be injected into the postgres-deployment pod
+  # via a Secret (envFrom: - secretRef) — no credentials in the manifest.
   - type: postgresql
     metadata:
-      connection: postgresql://postgres:password@postgres-service:5432/truxify
+      connectionFromEnv: POSTGRES_CONNECTION_STRING
       query: "SELECT COUNT(*) FROM orders WHERE status = 'PENDING';"
       targetQueryValue: "50"

--- a/k8s/vitess/vitess.service.js
+++ b/k8s/vitess/vitess.service.js
@@ -20,11 +20,14 @@ class VitessService {
     }
 
     async initializePools() {
+        if (!process.env.VITESS_PASSWORD) {
+            throw new Error('VITESS_PASSWORD must be set — no default fallback is permitted');
+        }
         const config = {
             host: this.vtgateHost,
             port: this.vtgatePort,
             user: process.env.VITESS_USER || 'vitess',
-            password: process.env.VITESS_PASSWORD || 'vitess',
+            password: process.env.VITESS_PASSWORD,
             database: this.keyspace,
             connectionLimit: 20,
             queueLimit: 0


### PR DESCRIPTION
## Problem

`docker-compose.yml` bakes in insecure defaults and exposes every datastore on the host LAN:

- `POSTGRES_PASSWORD` and every `SHARD_*_PASSWORD` fall back to the literal password `password` via `${VAR:-password}`, so `docker compose up` runs with known credentials.
- Host ports are published for all databases: `5432` (db), `5433`–`5436` (shards), `27017` (mongo), `6379` (redis), exposing them beyond the compose network.
- MongoDB and Redis run **without authentication**, and the API connects with credential-less `MONGODB_URI` / `REDIS_URL`.
- `k8s/keda/scaledobject-redis.yaml` hardcodes `postgresql://postgres:password@postgres-service:5432/truxify` in the manifest.
- `k8s/vitess/vitess.service.js` falls back to `VITESS_PASSWORD || 'vitess'`, connecting with a known default.

## Fix

Fail closed instead of defaulting to known secrets:

- All DB passwords now use `${VAR:?message}` interpolation — `docker compose up` aborts unless `DB_PASSWORD` / `SHARD_PASSWORD` / `MONGO_ROOT_USER` / `MONGO_ROOT_PASSWORD` / `REDIS_PASSWORD` are provided in `.env`.
- Removed host-published ports for `db`, `shard-north/south/east/west`, `mongo`, and `redis`; datastores are now reachable only inside the compose network.
- MongoDB starts with a root user via `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`, and the API connects using authenticated `MONGODB_URI` (with `authSource=admin`).
- Redis starts with `--requirepass ${REDIS_PASSWORD}`, the API connects via `redis://:<password>@redis:6379`, and both datastore healthchecks authenticate.
- `k8s/keda/scaledobject-redis.yaml` replaces the hardcoded Postgres connection string with `connectionFromEnv: POSTGRES_CONNECTION_STRING` and uses `passwordFromEnv: REDIS_PASSWORD` for the Redis trigger, so credentials come from Secrets referenced in the deployment.
- `k8s/vitess/vitess.service.js` throws at startup if `VITESS_PASSWORD` is unset instead of silently falling back to `vitess`.
- `.env.example` documents the new required variables (no defaults baked into compose).

Also removed duplicated `restart` keys on the `mongo` and `redis` services that made `docker compose config` fail.

## Files changed

- `docker-compose.yml`
- `.env.example`
- `k8s/keda/scaledobject-redis.yaml`
- `k8s/vitess/vitess.service.js`

## Testing

- `docker compose config` passes with the required variables set (previously errored on the duplicate `restart` keys).
- `node --check k8s/vitess/vitess.service.js` passes.
- KEDA manifest validated as well-formed YAML (2 documents).
- Without the env vars set, compose correctly fails closed with `required variable X is missing`.

Closes #5886
