### PR TITLE
fix(rls): trips FOR ALL self-policy -> read-only + status transition trigger

### DIFF
--- a/supabase/migrations/20240101000000_rls.sql
+++ b/supabase/migrations/20240101000000_rls.sql
@@ -238,11 +238,47 @@ DROP POLICY IF EXISTS "Service role full access on trips" ON trips;
 CREATE POLICY "Service role full access on trips"
   ON trips FOR ALL TO service_role USING (true) WITH CHECK (true);
 
+-- Drivers may only READ their own trips. Writes (create/complete/cancel) are
+-- deliberately NOT exposed to authenticated users: they must go through
+-- server-side, SECURITY DEFINER RPCs (e.g. complete_trip_tx) or the backend
+-- service role, so trip history can never be fabricated or edited by a driver.
 DROP POLICY IF EXISTS "Drivers access own trips" ON trips;
-CREATE POLICY "Drivers access own trips"
-  ON trips FOR ALL TO authenticated
-  USING (driver_id = get_profile_id())
-  WITH CHECK (driver_id = get_profile_id());
+DROP POLICY IF EXISTS "Drivers insert own trips" ON trips;
+DROP POLICY IF EXISTS "Drivers update own trips" ON trips;
+DROP POLICY IF EXISTS "Drivers delete own trips" ON trips;
+CREATE POLICY "Drivers read own trips"
+  ON trips FOR SELECT TO authenticated
+  USING (driver_id = get_profile_id());
+
+-- Trip lifecycle enforcement: a trip must be created as 'active' and can only
+-- transition active -> completed / active -> cancelled. Reverting a finished
+-- trip (or completing/cancelling one created finished) is rejected, so trip
+-- statistics can't be inflated or rewritten by any role.
+CREATE OR REPLACE FUNCTION enforce_trip_status_transitions()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status <> 'active' THEN
+      RAISE EXCEPTION 'Trips must be created with status = active (got %)', NEW.status;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status IS DISTINCT FROM NEW.status THEN
+    IF NOT (OLD.status = 'active' AND NEW.status IN ('completed', 'cancelled')) THEN
+      RAISE EXCEPTION 'Invalid trip status transition: % -> %', OLD.status, NEW.status;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_trips_status_transitions ON trips;
+CREATE TRIGGER trg_trips_status_transitions
+  BEFORE INSERT OR UPDATE OF status ON trips
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_trip_status_transitions();
 
 
 -- ─── TRIP ITEMS ───


### PR DESCRIPTION
## Problem

The `trips` table is protected only by a permissive `FOR ALL` self-policy (`supabase/migrations/20240101000000_rls.sql:241-245`), so any authenticated user can INSERT, UPDATE, or DELETE arbitrary rows of their own trips:

- A driver can insert fabricated trip history (e.g. pre-completed trips), inflating `total_trips` / `earnings` reports and gamification data.
- Trip rows can be edited or deleted, corrupting trip statistics consumed by dashboards and the driver profile screen.

## Fix

- Replaced the `FOR ALL` self-policy with a strict `FOR SELECT` policy (`"Drivers read own trips"`) scoped to `driver_id = get_profile_id()`. Writes are no longer possible for authenticated users; trip creation/completion/cancellation must go through server-side, `SECURITY DEFINER` RPCs (e.g. `complete_trip_tx`) or the backend service role.
- Added an `enforce_trip_status_transitions()` trigger (`trg_trips_status_transitions`, `BEFORE INSERT OR UPDATE OF status`) that enforces the trip lifecycle:
  - trips must be created with `status = 'active'` (no fabricating completed/cancelled trips);
  - the only allowed transition is `active -> completed` or `active -> cancelled`;
  - reverting a finished trip is rejected.

## Files changed

- `supabase/migrations/20240101000000_rls.sql`

## Testing

- SQL is idempotent (guarded `DROP POLICY IF EXISTS` / `DROP TRIGGER IF EXISTS`); no Postgres toolchain available locally, so verified by review against the existing policy/trigger conventions in the repo (`EXECUTE FUNCTION` style used consistently).
- Current backend code paths only read `trips` as authenticated users (see `driverRoutes.js`); trip writes flow through SECURITY DEFINER transaction functions, so read-only RLS preserves all existing flows.

Closes #5887
