### PR TITLE
fix(rls): profiles clients cannot self-assign or flip role

### DIFF
--- a/supabase/migrations/20240101000000_rls.sql
+++ b/supabase/migrations/20240101000000_rls.sql
@@ -30,16 +30,24 @@ CREATE POLICY "Users select own profile"
   ON profiles FOR SELECT TO authenticated
   USING (firebase_uid = (auth.jwt() ->> 'sub'));
 
+-- Users may only ever create their own profile AS a customer. Self-claiming
+-- the driver (or admin) role on signup is not permitted; role upgrades must be
+-- assigned server-side (service_role / SECURITY DEFINER RPCs) after verification.
 DROP POLICY IF EXISTS "Users insert own profile" ON profiles;
 CREATE POLICY "Users insert own profile"
   ON profiles FOR INSERT TO authenticated
-  WITH CHECK (firebase_uid = (auth.jwt() ->> 'sub'));
+  WITH CHECK (firebase_uid = (auth.jwt() ->> 'sub') AND role = 'customer');
 
 DROP POLICY IF EXISTS "Users update own profile" ON profiles;
 CREATE POLICY "Users update own profile"
   ON profiles FOR UPDATE TO authenticated
   USING (firebase_uid = (auth.jwt() ->> 'sub'))
   WITH CHECK (firebase_uid = (auth.jwt() ->> 'sub'));
+
+-- Clients may never rewrite the role column (blocks flipping customer -> driver
+-- at will, matching the #5726 column-privilege hardening for orders/driver_details).
+-- service_role and SECURITY DEFINER RPCs are unaffected by this REVOKE.
+REVOKE UPDATE (role) ON profiles FROM anon, authenticated;
 
 
 -- ─── DRIVER DETAILS ───


### PR DESCRIPTION
## Problem

The `profiles` INSERT and UPDATE RLS policies scope writes only by `firebase_uid` and do not restrict the `role` column (`supabase/migrations/20240101000000_rls.sql`), so any authenticated user can:

- self-insert a profile claiming `role = 'driver'` (or `'admin'`) without any verification, or
- flip their existing account's role between `customer` and `driver` at will.

Because downstream RLS policies, RPCs, and dashboards branch on `profiles.role`, an attacker can unlock driver-only surfaces and undermine driver verification.

## Fix

- **INSERT**: narrowed `"Users insert own profile"` to `WITH CHECK (firebase_uid = (auth.jwt() ->> 'sub') AND role = 'customer')` — a user can only create their own profile as a `customer`; `role` upgrades must be assigned server-side after verification.
- **UPDATE**: kept the ownership-scoped self-update policy (so drivers/customers can still edit non-role fields like `full_name`/`language`/`dark_mode`) and added `REVOKE UPDATE (role) ON profiles FROM anon, authenticated` so clients can never rewrite the `role` column. This mirrors the established #5726 column-privilege hardening for `orders`/`driver_details`; `service_role` and SECURITY DEFINER RPCs are unaffected by the revoke.

## Files changed

- `supabase/migrations/20240101000000_rls.sql`

## Testing

- Existing unit assertions in `backend/api/test/unit/rlsSecurity.test.js` for the `"Users insert own profile"` / `"Users update own profile"` / `"Users select own profile"` policies still match.
- Backend driver-verification and role reads (`VerificationService`, `auth` middleware) use `service_role` or read-only queries, so the narrowed INSERT policy and the column revoke do not change any current write path; the driver app never inserts `profiles` directly.

Closes #5888
