### PR TITLE
fix(rpc): restore caller verification + search_path on complete_trip_tx

### DIFF
--- a/supabase/migrations/20260803100000_update_complete_trip_tx.sql
+++ b/supabase/migrations/20260803100000_update_complete_trip_tx.sql
@@ -10,6 +10,7 @@ create or replace function complete_trip_tx(
 returns table(driver_id uuid)
 language plpgsql
 security definer
+set search_path = public, pg_temp
 as $$
 declare
   v_order record;
@@ -23,6 +24,13 @@ begin
 
   if not found then
     raise exception 'Order not found';
+  end if;
+
+  -- Verify the caller is the driver assigned to this order. get_profile_id()
+  -- maps the Firebase JWT sub to profiles.id, which is what orders.driver_id
+  -- stores (auth.uid() is the Firebase UID and would never match).
+  if auth.uid() is not null and get_profile_id() <> v_order.driver_id then
+    raise exception 'Unauthorized: you can only complete trips you are assigned to';
   end if;
 
   if v_order.driver_id is null then
@@ -150,3 +158,8 @@ begin
   return next;
 end;
 $$;
+
+-- Only the assigned driver (via the authenticated backend) or service_role may
+-- invoke this RPC. Block anonymous REST access as defense-in-depth; the
+-- authenticated caller is still bound to their own driver assignment above.
+REVOKE EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) FROM anon;


### PR DESCRIPTION
## Summary

Issue #5890 — grep all `SECURITY DEFINER` functions for missing `auth.uid()`/`auth.role()` checks and `search_path` as a release gate.

A full audit of every `SECURITY DEFINER` function in the migration chain found that the two RPCs named in the issue were **already hardened** by previously-merged migrations:

- `update_order_and_load_offer` → hardened by `20260802000000_secure_update_order_and_load_offer.sql` (#5722): ownership guard via `get_profile_id()`, `SET search_path = public, pg_temp`, `REVOKE EXECUTE FROM anon, authenticated`.
- `create_order_tx` → hardened (issue #5823): `service_role` may supply `p_customer_id`, all other callers bound to their own JWT-derived profile via `get_profile_id()`, `SET search_path = public, pg_temp`.

The audit did surface **one genuine regression**: the latest `complete_trip_tx` definition (`20260803100000_update_complete_trip_tx.sql`) dropped both the caller verification and the search path that prior versions (`20260704000001`, `20260706075009`) had established. It is `SECURITY DEFINER`, pays the driver wallet and flips escrow to `released`, and was callable by **any** anon/authenticated user directly via the PostgREST RPC endpoint with no ownership check.

## Changes

`supabase/migrations/20260803100000_update_complete_trip_tx.sql`

1. Added `SET search_path = public, pg_temp` to the function header (prevents search-path hijacking).
2. Restored the caller-verification guard, using the canonical comparison from #5722:
   ```sql
   if auth.uid() is not null and get_profile_id() <> v_order.driver_id then
     raise exception 'Unauthorized: you can only complete trips you are assigned to';
   end if;
   ```
   `auth.uid()` is the Firebase UID and never matches the `profiles.id` stored in `orders.driver_id`; `get_profile_id()` maps the JWT sub to `profiles.id`, so the assigned driver passes, `service_role` (backend) passes, and any other authenticated user is rejected.
3. Added `REVOKE EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) FROM anon;` as defense-in-depth. `authenticated` is intentionally left executable because the driver-facing backend invokes this RPC with the user's authenticated client (`orderMilestoneService.js`, `deliveryVerificationService.js`).

## Verification

- `npx vitest run test/unit/rlsSecurity.test.js test/unit/verifyDbSchema.test.js` → 140 tests passed (RLS guard assertions, search-path assertions, complete_trip_tx structure tests all green).
- No backend call sites changed; both callers pass the authenticated driver client, which the guard permits.

## Related

- Fixes the vulnerable function found during the issue #5890 release-gate audit.
- Follows the exact hardening pattern established in #5722.
