### PR TITLE
fix: register demand heatmap routes

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -54,6 +54,7 @@ import webhookRoutes from './routes/webhookRoutes.js'
 import auditRoutes from './routes/auditRoutes.js'
 import paymentRoutes from './routes/paymentRoutes.js'
 import userRoutes from './routes/userRoutes.js'
+import demandRoutes from './routes/demandRoutes.js'
 
 // ============================================================================
 // 🆕 MULTI-PROVIDER ORACLE & VERIFICATION ROUTES


### PR DESCRIPTION
## Description

This PR imports the `demandRoutes` router into `backend/api/src/index.js`.

Without importing the router, the demand heatmap route cannot be registered, causing the driver app's demand heatmap endpoint to remain unavailable. This change ensures the route definition is available for registration in the API.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

**Test Commands:**
```bash
npm start
```

**Test Steps / Prerequisites:**
1. Start the API server.
2. Verify that `demandRoutes` is successfully imported.
3. Ensure the application starts without import errors.

**Expected Result:**
- The API starts successfully.
- The demand heatmap route is available for registration.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled demand-related API routes in the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->