### PR TITLE
fix: add missing voiceRoutes import

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -54,6 +54,7 @@ import webhookRoutes from './routes/webhookRoutes.js'
 import auditRoutes from './routes/auditRoutes.js'
 import paymentRoutes from './routes/paymentRoutes.js'
 import userRoutes from './routes/userRoutes.js'
+import voiceRoutes from './routes/voiceRoutes.js'
 
 // ============================================================================
 // 🆕 MULTI-PROVIDER ORACLE & VERIFICATION ROUTES


### PR DESCRIPTION
## Description

This PR adds the missing `voiceRoutes` import in `backend/api/src/index.js`.

The file was registering the voice API router using `app.use('/api/voice', voiceRoutes)` without importing `voiceRoutes`, which could result in a `ReferenceError` and prevent the API from starting successfully. This change ensures the router is properly imported before being registered.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

**Test Commands:**
```bash
npm start
```

**Test Steps / Prerequisites:**
1. Start the backend server.
2. Verify that `backend/api/src/index.js` imports `voiceRoutes`.
3. Confirm the application starts without import-related errors.

**Expected Result:**
- The server starts successfully.
- `voiceRoutes` is available when `/api/voice` is registered.
- No `ReferenceError` related to `voiceRoutes` occurs.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5928