### PR TITLE
fix: add trip_events database migration

### DIFF
--- a/docs/supabase/migrations/004_create_trip_events.sql
+++ b/docs/supabase/migrations/004_create_trip_events.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Migration: 004_create_trip_events.sql
+-- Creates the trip_events table backing offline trip-event sync
+-- (backend/api/src/routes/tripRoutes.js: POST /events/batch, GET /:id/events)
+-- ============================================================================
+--
+-- Column choices reflect exactly how tripRoutes.js reads/writes this table:
+--   - event_id:        client-generated id (Flutter offline SQLite pk), used
+--                       as the upsert conflict target -> TEXT PRIMARY KEY
+--   - user_id:          req.user.id, the uploading user (driver or customer)
+--   - trip_id:          nullable, references orders.id (trip/order identifier)
+--   - event_type:       event.type (e.g. 'gpsUpdate', 'otpDelivery')
+--   - event_timestamp:  event.occurred_at, ISO 8601 -> TIMESTAMPTZ
+--   - latitude/longitude: parsed from payload.lat/lng, nullable
+--   - metadata:          sanitized payload JSON (SENSITIVE_FIELDS stripped)
+--   - created_at:        server-side insert time
+--
+-- NOTE: 002_rls_policies.sql's "Users read own trip_events" policy filters
+-- on order_display_id, a column tripRoutes.js never populates. That policy
+-- will need to be fixed separately (filed as a follow-up) — this migration
+-- intentionally matches the application code, not the pre-existing policy.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS trip_events (
+  event_id        TEXT PRIMARY KEY,
+  user_id         UUID NOT NULL,
+  trip_id         UUID NULL,
+  event_type      TEXT NOT NULL,
+  event_timestamp TIMESTAMPTZ NOT NULL,
+  latitude        DOUBLE PRECISION NULL,
+  longitude       DOUBLE PRECISION NULL,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- GET /:id/events filters/sorts by trip_id + event_timestamp
+CREATE INDEX IF NOT EXISTS idx_trip_events_trip_id_timestamp
+  ON trip_events (trip_id, event_timestamp);
+
+-- Ownership checks in POST /events/batch look up by user_id
+CREATE INDEX IF NOT EXISTS idx_trip_events_user_id
+  ON trip_events (user_id);
+
+-- GET /:id/events supports ?type= filtering
+CREATE INDEX IF NOT EXISTS idx_trip_events_event_type
+  ON trip_events (event_type);
+
+COMMIT;


### PR DESCRIPTION
## Description

This PR adds a new Supabase migration to create the missing `trip_events` table required by the trip offline-sync and trip event APIs.

Previously, `tripRoutes.js` attempted to read from and upsert into the `trip_events` table, but no migration created the table. This caused offline trip-event synchronization and event retrieval requests to fail with database errors. The new migration creates the required table with the columns expected by the application and adds indexes to support common query patterns.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

**Test Commands:**
```bash
# Apply the migration
supabase db push
# or run the migration using your project's migration workflow
```

**Test Steps / Prerequisites:**
1. Apply the new database migration.
2. Verify that the `trip_events` table is created successfully.
3. Confirm the table includes the required columns (`event_id`, `user_id`, `trip_id`, `event_type`, `event_timestamp`, `latitude`, `longitude`, `metadata`, and `created_at`).
4. Verify that offline trip-event synchronization and trip event queries can access the table without schema-related errors.

**Expected Result:**
- The `trip_events` table is created successfully.
- Offline trip-event synchronization no longer fails because of a missing table.
- Trip event retrieval endpoints can query the table successfully.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues

Closes #<ISSUE_NUMBER>

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5686