### PR TITLE
fix: correct event version calculation

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -174,7 +174,7 @@ class EventStore {
                         cancelledAt: timestamp
                     },
                     timestamp,
-                    version: (await this.getAggregateState(command.aggregateId)?.version || 0) + 1
+                    version: ((await this.getAggregateState(command.aggregateId))?.version || 0) + 1
                 });
                 break;
 
@@ -189,7 +189,7 @@ class EventStore {
                         assignedAt: timestamp
                     },
                     timestamp,
-                    version: (await this.getAggregateState(command.aggregateId)?.version || 0) + 1
+                    version: ((await this.getAggregateState(command.aggregateId))?.version || 0) + 1
                 });
                 break;
 


### PR DESCRIPTION
## Description

This PR fixes the event version calculation for the `CANCEL_ORDER` and `ASSIGN_DRIVER` command handlers in the event store.

Previously, the version was calculated using:

```js
(await this.getAggregateState(command.aggregateId)?.version || 0) + 1
```

Because optional chaining was applied before `await` completed, the code accessed `.version` on the returned `Promise` instead of the resolved aggregate state. As a result, the version always evaluated to `1`.

This PR corrects the evaluation order by awaiting the aggregate state before accessing its `version`, allowing event versions to increment correctly for subsequent events.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

**Test Commands:**
```bash
npm test
```

**Test Steps / Prerequisites:**
1. Execute multiple `CANCEL_ORDER` or `ASSIGN_DRIVER` commands for the same aggregate.
2. Inspect the stored events in the event store.
3. Verify that each new event version increments from the previous one.

**Expected Result:**
- Event versions increase sequentially (1, 2, 3, ...).
- `ORDER_CANCELLED` and `DRIVER_ASSIGNED` events no longer always store `version: 1`.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5688