### PR TITLE
fix: require both participants' signatures in StateChannel.resolveDis…

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -260,37 +260,55 @@ contract StateChannel is Ownable, ReentrancyGuard, Pausable {
     }
 
     function resolveDispute(uint256 channelId, bytes memory proof) external onlyOwner {
-        Dispute storage dispute = disputes[channelId];
-        require(dispute.challenger != address(0), "No dispute");
-        require(!dispute.resolved, "Already resolved");
-        require(block.timestamp >= dispute.startedAt + SETTLEMENT_PERIOD, "Settlement period not elapsed");
+    Dispute storage dispute = disputes[channelId];
+    require(dispute.challenger != address(0), "No dispute");
+    require(!dispute.resolved, "Already resolved");
+    require(block.timestamp >= dispute.startedAt + SETTLEMENT_PERIOD, "Settlement period not elapsed");
 
-        Channel storage channel = channels[channelId];
+    Channel storage channel = channels[channelId];
 
-        // Decode proof: (balanceA, balanceB, signatureA, signatureB)
-        (uint256 proofBalanceA, uint256 proofBalanceB, bytes memory sigA, bytes memory sigB) =
-            abi.decode(proof, (uint256, uint256, bytes, bytes));
+    // Decode proof: (balanceA, balanceB, nonce, signatureA, signatureB)
+    (uint256 proofBalanceA, uint256 proofBalanceB, uint256 proofNonce, bytes memory sigA, bytes memory sigB) =
+        abi.decode(proof, (uint256, uint256, uint256, bytes, bytes));
 
-        // Verify that balances sum to the channel's total
-        uint256 totalBalance = channel.balanceA + channel.balanceB;
-        require(proofBalanceA + proofBalanceB == totalBalance, "Invalid proof balances");
+    // Verify that balances sum to the channel's total
+    uint256 totalBalance = channel.balanceA + channel.balanceB;
+    require(proofBalanceA + proofBalanceB == totalBalance, "Invalid proof balances");
 
-        // Verify that the proof is signed by the challenger (the party who raised the dispute)
-        bytes32 stateHash = keccak256(abi.encodePacked(
-            channelId, proofBalanceA, proofBalanceB, dispute.challenger
-        ));
-        require(_verifySignature(stateHash, sigA, dispute.challenger), "Invalid challenger signature");
+    // The disputed state must be at least as recent as the last state the
+    // contract already knows about via updateState — this stops a stale,
+    // mutually-signed state from overriding a newer one.
+    require(proofNonce >= channel.nonce, "Stale disputed state");
 
-        dispute.resolved = true;
+    // Use the exact same state encoding as updateState so a dispute proof
+    // is nothing more than a (channelId, balanceA, balanceB, nonce) state
+    // that both channel participants actually signed off on.
+    bytes32 stateHash = keccak256(abi.encodePacked(
+        channelId, proofBalanceA, proofBalanceB, proofNonce
+    ));
 
-        // Update to disputed state and settle
+    // Require BOTH participants' signatures on the SAME state. A proof
+    // signed only by the challenger (the previous behaviour) let either
+    // party fabricate an arbitrary payout and win by default.
+    require(_verifySignature(stateHash, sigA, channel.participantA), "Invalid signature A");
+    require(_verifySignature(stateHash, sigB, channel.participantB), "Invalid signature B");
+
+    dispute.resolved = true;
+
+    // Only move the channel state forward — never backward — and only to
+    // a state number that is provably authoritative (signed by both
+    // participants above).
+    if (proofNonce > channel.nonce) {
         channel.balanceA = proofBalanceA;
         channel.balanceB = proofBalanceB;
-
-        _settleChannel(channelId);
-
-        emit DisputeResolved(channelId, true);
+        channel.nonce = proofNonce;
+        channel.latestStateHash = stateHash;
     }
+
+    _settleChannel(channelId);
+
+    emit DisputeResolved(channelId, true);
+}
 
     // ============ Batch Settlement ============
 

--- a/blockchain/test/StateChannel.test.js
+++ b/blockchain/test/StateChannel.test.js
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, error => error.message.includes(message));
+}
+
+async function signState(signer, channelId, balanceA, balanceB, nonce) {
+  const stateHash = ethers.solidityPackedKeccak256(
+    ["uint256", "uint256", "uint256", "uint256"],
+    [channelId, balanceA, balanceB, nonce]
+  );
+  return signer.signMessage(ethers.getBytes(stateHash));
+}
+
+function encodeDisputeProof(balanceA, balanceB, nonce, sigA, sigB) {
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ["uint256", "uint256", "uint256", "bytes", "bytes"],
+    [balanceA, balanceB, nonce, sigA, sigB]
+  );
+}
+
+const CHALLENGE_PERIOD = 24 * 60 * 60;
+const SETTLEMENT_PERIOD = 7 * 24 * 60 * 60;
+
+describe("StateChannel.resolveDispute", function () {
+  async function deployFundedChannel() {
+    const [owner, partyA, partyB, outsider] = await ethers.getSigners();
+    const StateChannel = await ethers.getContractFactory("StateChannel");
+    const channel = await StateChannel.deploy();
+    await channel.waitForDeployment();
+
+    await channel.connect(partyA).openChannel(partyB.address);
+    const channelId = 1n;
+
+    await channel.connect(partyA).fundChannel(channelId, { value: ethers.parseEther("5") });
+    await channel.connect(partyB).fundChannel(channelId, { value: ethers.parseEther("5") });
+
+    return { channel, owner, partyA, partyB, outsider, channelId };
+  }
+
+  it("rejects a dispute resolved with only the challenger's self-signed proof", async function () {
+    const { channel, owner, partyA, partyB, channelId } = await deployFundedChannel();
+    const total = ethers.parseEther("10");
+
+    // partyA raises a dispute and tries to win the entire channel balance
+    // using a state that only they signed (old vulnerability).
+    await channel.connect(partyA).raiseDispute(channelId, ethers.ZeroHash);
+
+    const forgedSig = await signState(partyA, channelId, total, 0n, 1n);
+    const proof = encodeDisputeProof(total, 0n, 1n, forgedSig, forgedSig);
+
+    await time.increase(SETTLEMENT_PERIOD + 1);
+
+    await assertRejectsWith(
+      channel.connect(owner).resolveDispute(channelId, proof),
+      "Invalid signature"
+    );
+  });
+
+  it("resolves a dispute only when both participants signed the disputed state", async function () {
+    const { channel, owner, partyA, partyB, channelId } = await deployFundedChannel();
+    const newBalanceA = ethers.parseEther("8");
+    const newBalanceB = ethers.parseEther("2");
+
+    await channel.connect(partyB).raiseDispute(channelId, ethers.ZeroHash);
+
+    const sigA = await signState(partyA, channelId, newBalanceA, newBalanceB, 1n);
+    const sigB = await signState(partyB, channelId, newBalanceA, newBalanceB, 1n);
+    const proof = encodeDisputeProof(newBalanceA, newBalanceB, 1n, sigA, sigB);
+
+    await time.increase(SETTLEMENT_PERIOD + 1);
+
+    await channel.connect(owner).resolveDispute(channelId, proof);
+
+    await channel.connect(partyA).withdraw(channelId);
+    await channel.connect(partyB).withdraw(channelId);
+
+    const finalA = await ethers.provider.getBalance(await channel.getAddress());
+    assert.equal(finalA, 0n);
+  });
+
+  it("rejects a disputed state whose nonce is older than the channel's last mutually-signed state", async function () {
+    const { channel, owner, partyA, partyB, channelId } = await deployFundedChannel();
+    const total = ethers.parseEther("10");
+
+    // Both parties mutually agree on a later state (nonce 2) via updateState.
+    const sigA2 = await signState(partyA, channelId, ethers.parseEther("6"), ethers.parseEther("4"), 2n);
+    const sigB2 = await signState(partyB, channelId, ethers.parseEther("6"), ethers.parseEther("4"), 2n);
+    await channel.connect(partyA).updateState(channelId, ethers.parseEther("6"), ethers.parseEther("4"), 2n, sigA2, sigB2);
+
+    await channel.connect(partyA).raiseDispute(channelId, ethers.ZeroHash);
+
+    // partyB tries to settle using an older mutually-signed state (nonce 1) to
+    // claim more than they're currently entitled to.
+    const sigA1 = await signState(partyA, channelId, 0n, total, 1n);
+    const sigB1 = await signState(partyB, channelId, 0n, total, 1n);
+    const staleProof = encodeDisputeProof(0n, total, 1n, sigA1, sigB1);
+
+    await time.increase(SETTLEMENT_PERIOD + 1);
+
+    await assertRejectsWith(
+      channel.connect(owner).resolveDispute(channelId, staleProof),
+      "Stale disputed state"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a critical vulnerability in `StateChannel.resolveDispute` where a channel participant could steal the entire channel balance by submitting a self-signed, fabricated proof.

Fixes #5936

## Root Cause

`resolveDispute` decoded a proof and only verified that `signatureA` came from `dispute.challenger` — the party who raised the dispute. `signatureB` was decoded but never checked against anything, and the hashed message didn't match the state format used in `updateState` (it included `dispute.challenger` instead of the state `nonce`).

This meant the first party to call `raiseDispute` could submit any `(balanceA, balanceB)` split they liked, sign it themselves, wait out the `SETTLEMENT_PERIOD`, and drain the counterparty's funds — with no way for the counterparty to contest it on-chain.

## Fix

- `resolveDispute` now decodes a `nonce` alongside the balances in the proof.
- The state hash is built with the exact same encoding `updateState` uses (`channelId, balanceA, balanceB, nonce`), so a dispute proof is just a state both parties actually signed off on.
- Both `signatureA` and `signatureB` are now verified against `channel.participantA` and `channel.participantB` respectively. A proof missing either participant's signature reverts.
- Added `require(proofNonce >= channel.nonce, "Stale disputed state")` so a proof can't roll the channel back to an older, already-superseded state. Balances/nonce only advance if `proofNonce > channel.nonce`.

## Testing

Added `blockchain/test/StateChannel.test.js` covering:
- A challenger-only self-signed proof is rejected (`Invalid signature A`).
- A proof signed by both participants resolves the dispute and settles correctly.
- A stale proof (older nonce than the channel's current mutually-signed state) is rejected (`Stale disputed state`).

Ran `npm test` in `blockchain/` — all cases pass.

## Impact

No other contract or backend service calls `StateChannel.resolveDispute` (confirmed via repo-wide search), so this change is self-contained and doesn't require updates elsewhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispute resolution by requiring valid signatures from both channel participants.
  * Prevented stale or forged state proofs from replacing newer channel balances.
  * Ensured channel state updates only when a newer dispute nonce is provided.

* **Tests**
  * Added coverage for forged signatures, valid dispute resolution, and stale state rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->