### PR TITLE
fix: enforce per-credential-type issuer authorization in DIDRegistry …

### DIFF
--- a/blockchain/contracts/DIDRegistry.sol
+++ b/blockchain/contracts/DIDRegistry.sol
@@ -53,6 +53,9 @@ contract DIDRegistry is Ownable, Pausable {
     mapping(address => string[]) public addressToDIDs;
     mapping(bytes32 => bool) public credentialRevoked;
 
+    // issuer => keccak256(credentialType) => authorized
+    mapping(address => mapping(bytes32 => bool)) public issuerAuthorizedForType;
+
     uint256 public totalDIDs;
     uint256 public totalCredentials;
 
@@ -65,8 +68,31 @@ contract DIDRegistry is Ownable, Pausable {
     event CredentialIssued(bytes32 indexed credentialId, address issuer, address subject);
     event CredentialRevoked(bytes32 indexed credentialId);
     event CredentialVerified(bytes32 indexed credentialId, bool isValid);
+    event IssuerAuthorizationUpdated(address indexed issuer, string credentialType, bool authorized);
 
     constructor() Ownable(msg.sender) {}
+
+    // ============ Issuer Authorization ============
+
+    // Only the registry owner may grant or revoke an address's ability to
+    // issue a specific credentialType. Without this, any address could mint
+    // a "KYC"/"DriverLicense"/etc. credential for any subject.
+    function setIssuerAuthorization(
+        address issuer,
+        string memory credentialType,
+        bool authorized
+    ) external onlyOwner {
+        require(issuer != address(0), "Invalid issuer");
+        require(bytes(credentialType).length > 0, "Credential type cannot be empty");
+
+        issuerAuthorizedForType[issuer][keccak256(bytes(credentialType))] = authorized;
+
+        emit IssuerAuthorizationUpdated(issuer, credentialType, authorized);
+    }
+
+    function isIssuerAuthorizedForType(address issuer, string memory credentialType) public view returns (bool) {
+        return issuerAuthorizedForType[issuer][keccak256(bytes(credentialType))];
+    }
 
     // ============ DID Management ============
 
@@ -168,6 +194,11 @@ contract DIDRegistry is Ownable, Pausable {
         bytes32 proofHash
     ) external returns (bytes32) {
         require(subject != address(0), "Invalid subject");
+        require(bytes(credentialType).length > 0, "Credential type cannot be empty");
+        require(
+            isIssuerAuthorizedForType(msg.sender, credentialType),
+            "Issuer not authorized for credential type"
+        );
 
         bytes32 credentialId = keccak256(
             abi.encodePacked(
@@ -208,11 +239,12 @@ contract DIDRegistry is Ownable, Pausable {
 
     function verifyCredential(bytes32 credentialId) external view returns (bool) {
         Credential memory cred = credentials[credentialId];
-        
+
         bool isValid = (
             cred.issuer != address(0) &&
             !cred.revoked &&
-            cred.validUntil > block.timestamp
+            cred.validUntil > block.timestamp &&
+            isIssuerAuthorizedForType(cred.issuer, cred.credentialType)
         );
 
         return isValid;

--- a/blockchain/test/DIDRegistry.test.js
+++ b/blockchain/test/DIDRegistry.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, error => error.message.includes(message));
+}
+
+describe("DIDRegistry issuer authorization", function () {
+  async function deployRegistry() {
+    const [owner, issuer, attacker, subject] = await ethers.getSigners();
+    const DIDRegistry = await ethers.getContractFactory("DIDRegistry");
+    const registry = await DIDRegistry.deploy();
+    await registry.waitForDeployment();
+    return { registry, owner, issuer, attacker, subject };
+  }
+
+  it("rejects issueCredential from an address the owner never authorized", async function () {
+    const { registry, attacker, subject } = await deployRegistry();
+
+    await assertRejectsWith(
+      registry.connect(attacker).issueCredential(
+        subject.address,
+        "KYC",
+        ethers.ZeroHash,
+        (await ethers.provider.getBlock("latest")).timestamp + 3600,
+        ethers.ZeroHash
+      ),
+      "Issuer not authorized for credential type"
+    );
+  });
+
+  it("only the owner can grant issuer authorization", async function () {
+    const { registry, attacker, issuer } = await deployRegistry();
+
+    await assertRejectsWith(
+      registry.connect(attacker).setIssuerAuthorization(issuer.address, "KYC", true),
+      "OwnableUnauthorizedAccount"
+    );
+  });
+
+  it("lets an authorized issuer issue a credential of that type, and verifyCredential reports it valid", async function () {
+    const { registry, owner, issuer, subject } = await deployRegistry();
+
+    await registry.connect(owner).setIssuerAuthorization(issuer.address, "KYC", true);
+
+    const validUntil = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+    const tx = await registry.connect(issuer).issueCredential(
+      subject.address,
+      "KYC",
+      ethers.ZeroHash,
+      validUntil,
+      ethers.ZeroHash
+    );
+    const receipt = await tx.wait();
+    const event = receipt.logs
+      .map(log => { try { return registry.interface.parseLog(log); } catch { return null; } })
+      .find(parsed => parsed && parsed.name === "CredentialIssued");
+    const credentialId = event.args[0];
+
+    assert.equal(await registry.verifyCredential(credentialId), true);
+  });
+
+  it("authorization is scoped to the credential type — an issuer authorized for KYC cannot mint a DriverLicense credential", async function () {
+    const { registry, owner, issuer, subject } = await deployRegistry();
+
+    await registry.connect(owner).setIssuerAuthorization(issuer.address, "KYC", true);
+
+    await assertRejectsWith(
+      registry.connect(issuer).issueCredential(
+        subject.address,
+        "DriverLicense",
+        ethers.ZeroHash,
+        (await ethers.provider.getBlock("latest")).timestamp + 3600,
+        ethers.ZeroHash
+      ),
+      "Issuer not authorized for credential type"
+    );
+  });
+
+  it("verifyCredential turns false once the issuer's authorization is revoked, even if the credential itself was never revoked", async function () {
+    const { registry, owner, issuer, subject } = await deployRegistry();
+
+    await registry.connect(owner).setIssuerAuthorization(issuer.address, "KYC", true);
+    const validUntil = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+    const tx = await registry.connect(issuer).issueCredential(
+      subject.address, "KYC", ethers.ZeroHash, validUntil, ethers.ZeroHash
+    );
+    const receipt = await tx.wait();
+    const event = receipt.logs
+      .map(log => { try { return registry.interface.parseLog(log); } catch { return null; } })
+      .find(parsed => parsed && parsed.name === "CredentialIssued");
+    const credentialId = event.args[0];
+
+    assert.equal(await registry.verifyCredential(credentialId), true);
+
+    await registry.connect(owner).setIssuerAuthorization(issuer.address, "KYC", false);
+
+    assert.equal(await registry.verifyCredential(credentialId), false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a critical vulnerability in `DIDRegistry.issueCredential` where any address could mint a credential for any subject with any credential type, and `verifyCredential` would report it as valid.

Fixes #5939

## Root Cause

`issueCredential` only validated that `subject != address(0)` — there was no check on who `msg.sender` was, so anyone could issue a "KYC", "DriverLicense", "Insurance", etc. credential for any subject. `verifyCredential` compounded this: it only checked that the credential existed, wasn't revoked, and hadn't expired — it never checked whether the issuer was trusted or authorized for that credential type. Forged credentials were indistinguishable from legitimate ones to any downstream consumer of the registry.

## Fix

- Added an owner-managed, per-credential-type issuer whitelist: `mapping(address => mapping(bytes32 => bool)) issuerAuthorizedForType`.
- Added `setIssuerAuthorization(issuer, credentialType, authorized)` (`onlyOwner`) to grant/revoke an address's ability to issue a specific credential type, and a public `isIssuerAuthorizedForType(...)` view helper.
- `issueCredential` now reverts with `"Issuer not authorized for credential type"` unless `msg.sender` is authorized for the exact `credentialType` being issued.
- `verifyCredential` now also re-checks the issuer's *current* authorization for that credential type, so revoking a compromised or offboarded issuer immediately invalidates all credentials they previously issued — not just future ones.

## Backward Compatibility / Rollout

The backend (`backend/did/did.service.js`) issues all credentials from a single relayer wallet (`process.env.PRIVATE_KEY`). After this change is deployed, the registry owner needs to call `setIssuerAuthorization(<relayerWalletAddress>, "<credentialType>", true)` once for each credential type the backend issues (e.g. `"KYC"`, `"DriverLicense"`), or credential issuance will revert.

## Testing

Added `blockchain/test/DIDRegistry.test.js` covering:
- Unauthorized address cannot issue a credential.
- Only the contract owner can grant issuer authorization.
- An authorized issuer can issue a credential, and `verifyCredential` reports it valid.
- Authorization is scoped per credential type — an issuer authorized for `"KYC"` cannot mint a `"DriverLicense"` credential.
- Revoking an issuer's authorization flips `verifyCredential` to `false` for their previously issued credentials, even though the credential itself was never explicitly revoked.

Ran `npm test` in `blockchain/` — all cases pass.

## Impact

Confirmed via repo-wide search that only `backend/did/did.service.js` calls `issueCredential`/`verifyCredential`; no other contract or service depends on the old unrestricted behavior.