### PR TITLE
fix: token-weighted DAO voting, execution timelock, and privileged up…

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 
 
@@ -20,6 +21,12 @@ contract TruxifyUpgradeable is
     /// @notice Minimum delay before an emergency upgrade can be executed (2 days).
     ///         Gives the DAO time to detect and potentially block malicious upgrades.
     uint256 public constant EMERGENCY_UPGRADE_TIMELOCK = 2 days;
+
+    /// @notice Mandatory delay between a DAO proposal passing its vote and the
+    ///         actual implementation swap being executed. Gives token holders
+    ///         and admins time to notice and pause/react to a malicious but
+    ///         technically-passed proposal before it takes effect.
+    uint256 public constant UPGRADE_EXECUTION_DELAY = 2 days;
 
     // Escrow struct
     struct Escrow {
@@ -83,18 +90,39 @@ contract TruxifyUpgradeable is
     ///         Zero means no pending request.
     mapping(address => uint256) public emergencyUpgradeRequests;
 
+    /// @notice Implementations pre-approved by DEFAULT_ADMIN_ROLE as safe to
+    ///         propose for an upgrade. createProposal reverts for any
+    ///         implementation not in this allowlist, so a compromised or
+    ///         Sybil-controlled DAO_ROLE account cannot even put an arbitrary
+    ///         attacker-chosen implementation up for a vote.
+    mapping(address => bool) public approvedImplementations;
+
     uint256 public daoVotingPeriod;
-    uint256 public daoQuorum;
+
+    /// @notice Quorum required to execute a proposal, expressed in basis
+    ///         points (1/100 of a percent) of governanceToken's totalSupply().
+    ///         E.g. 1000 = 10% of supply must have voted (for or against)
+    ///         before a proposal can be executed. Replaces the old
+    ///         one-address-one-vote raw vote count, which any Sybil attacker
+    ///         could reach by creating throwaway addresses.
+    uint256 public daoQuorumBps;
+
     uint256 public daoThreshold;
 
     address public daoMultiSig;
+
+    /// @notice ERC20 token used to weight DAO votes. Voting power for an
+    ///         address is its current token balance — an address holding no
+    ///         tokens has no voting power, regardless of how many addresses
+    ///         it controls.
+    IERC20 public governanceToken;
 
     // Events
     event EscrowCreated(uint256 indexed escrowId, address customer, address driver, uint256 amount);
     event EscrowReleased(uint256 indexed escrowId, address driver, uint256 amount);
     event EscrowDisputed(uint256 indexed escrowId, address customer);
     event ProposalCreated(uint256 indexed proposalId, address proposer, address implementation);
-    event VoteCast(uint256 indexed proposalId, address voter, bool support);
+    event VoteCast(uint256 indexed proposalId, address voter, bool support, uint256 weight);
     event ProposalExecuted(uint256 indexed proposalId, bool passed);
     event ContractUpgraded(address indexed implementation, uint256 timestamp);
     event ContractPaused(address indexed pauser);
@@ -110,6 +138,12 @@ contract TruxifyUpgradeable is
     /// @notice Emitted when a pending emergency upgrade request is cancelled.
     event EmergencyUpgradeCancelled(address indexed implementation);
 
+    /// @notice Emitted when the governance token used to weight votes is set/changed.
+    event GovernanceTokenUpdated(address indexed token);
+
+    /// @notice Emitted when an implementation's allowlist status changes.
+    event ImplementationApprovalUpdated(address indexed implementation, bool approved);
+
     // ============ Initializer ============
     function initialize() public initializer {
         __AccessControl_init();
@@ -120,10 +154,38 @@ contract TruxifyUpgradeable is
         _grantRole(PAUSER_ROLE, msg.sender);
 
         daoVotingPeriod = 3 days;
-        daoQuorum = 1000; // 1000 votes required
+        daoQuorumBps = 1000; // 10% of governance token supply required
         daoThreshold = 60; // 60% approval required
 
         daoMultiSig = msg.sender;
+    }
+
+    // ============ Governance Configuration ============
+
+    /// @notice Sets the ERC20 token whose balances weight DAO votes. Until
+    ///         this is set, vote() and executeProposal() cannot be used —
+    ///         there is deliberately no unweighted fallback.
+    function setGovernanceToken(address token) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(token != address(0), "Invalid token");
+        governanceToken = IERC20(token);
+        emit GovernanceTokenUpdated(token);
+    }
+
+    /// @notice Sets the DAO execution quorum as basis points of the
+    ///         governance token's totalSupply() (10000 = 100%).
+    function setDAOQuorumBps(uint256 newQuorumBps) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(newQuorumBps > 0 && newQuorumBps <= 10000, "Quorum bps must be 1-10000");
+        daoQuorumBps = newQuorumBps;
+    }
+
+    /// @notice Adds or removes an implementation from the trusted-implementation
+    ///         allowlist. createProposal() reverts for any implementation not
+    ///         on this list, so a passing vote can never install arbitrary,
+    ///         unvetted bytecode.
+    function setApprovedImplementation(address implementation, bool approved) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(implementation != address(0), "Invalid implementation");
+        approvedImplementations[implementation] = approved;
+        emit ImplementationApprovalUpdated(implementation, approved);
     }
 
     // ============ UUPS Upgrade ============
@@ -239,6 +301,7 @@ contract TruxifyUpgradeable is
     ) external onlyRole(DAO_ROLE) returns (uint256) {
         require(newImplementation != address(0), "Invalid implementation");
         require(bytes(reason).length > 0, "Reason required");
+        require(approvedImplementations[newImplementation], "Implementation not approved");
 
         _proposalIdCounter += 1;
         uint256 proposalId = _proposalIdCounter;
@@ -264,28 +327,50 @@ contract TruxifyUpgradeable is
         require(proposal.proposer != address(0), "Proposal not found");
         require(block.timestamp < proposal.votingEndsAt, "Voting ended");
         require(!hasVoted[proposalId][msg.sender], "Already voted");
+        require(address(governanceToken) != address(0), "Governance token not configured");
+
+        // Voting power comes from token balance, not address count. An
+        // attacker who spins up 1000 empty addresses gets zero extra votes —
+        // they'd need to actually acquire 1000 addresses' worth of tokens.
+        uint256 weight = governanceToken.balanceOf(msg.sender);
+        require(weight > 0, "No voting power");
 
         hasVoted[proposalId][msg.sender] = true;
 
         if (support) {
-            proposal.votesFor++;
+            proposal.votesFor += weight;
         } else {
-            proposal.votesAgainst++;
+            proposal.votesAgainst += weight;
         }
 
-        emit VoteCast(proposalId, msg.sender, support);
+        emit VoteCast(proposalId, msg.sender, support, weight);
     }
 
-    function executeProposal(uint256 proposalId) external returns (bool) {
+    function executeProposal(uint256 proposalId) external onlyRole(UPGRADER_ROLE) returns (bool) {
         Proposal storage proposal = proposals[proposalId];
         require(proposal.proposer != address(0), "Proposal not found");
         require(block.timestamp >= proposal.votingEndsAt, "Voting not ended");
         require(!proposal.executed, "Already executed");
+        require(address(governanceToken) != address(0), "Governance token not configured");
 
         uint256 totalVotes = proposal.votesFor + proposal.votesAgainst;
-        require(totalVotes >= daoQuorum, "Quorum not reached");
+        uint256 requiredQuorum = (governanceToken.totalSupply() * daoQuorumBps) / 10000;
+        require(totalVotes >= requiredQuorum, "Quorum not reached");
 
         bool passed = (proposal.votesFor * 100) / totalVotes >= daoThreshold;
+
+        if (passed) {
+            // The mandatory delay only applies to proposals that actually
+            // passed and are about to install new bytecode — this gives
+            // token holders/admins a final window to notice and react
+            // (e.g. pause, or revoke the implementation's allowlist entry)
+            // before the upgrade takes effect.
+            require(
+                block.timestamp >= proposal.votingEndsAt + UPGRADE_EXECUTION_DELAY,
+                "Execution timelock not elapsed"
+            );
+        }
+
         proposal.passed = passed;
         proposal.executed = true;
 
@@ -303,7 +388,7 @@ contract TruxifyUpgradeable is
 
             _upgradeHistoryCounter += 1;
             uint256 historyId = _upgradeHistoryCounter;
-            
+
             upgradeHistory[historyId] = UpgradeRecord({
                 implementation: proposal.newImplementation,
                 timestamp: block.timestamp,
@@ -419,11 +504,6 @@ contract TruxifyUpgradeable is
     function setDAOVotingPeriod(uint256 newPeriod) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(newPeriod >= 1 days, "Period too short");
         daoVotingPeriod = newPeriod;
-    }
-
-    function setDAOQuorum(uint256 newQuorum) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(newQuorum > 0, "Quorum must be > 0");
-        daoQuorum = newQuorum;
     }
 
     function setDAOThreshold(uint256 newThreshold) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/blockchain/contracts/interfaces/ITruxifyUpgradeable.sol
+++ b/blockchain/contracts/interfaces/ITruxifyUpgradeable.sol
@@ -16,4 +16,11 @@ interface ITruxifyUpgradeable {
     function daoApprovedUpgrades(address implementation) external view returns (bool);
     function emergencyUpgradeRequests(address implementation) external view returns (uint256);
     function EMERGENCY_UPGRADE_TIMELOCK() external view returns (uint256);
+    function UPGRADE_EXECUTION_DELAY() external view returns (uint256);
+    function setGovernanceToken(address token) external;
+    function setDAOQuorumBps(uint256 newQuorumBps) external;
+    function setApprovedImplementation(address implementation, bool approved) external;
+    function governanceToken() external view returns (address);
+    function daoQuorumBps() external view returns (uint256);
+    function approvedImplementations(address implementation) external view returns (bool);
 }

--- a/blockchain/scripts/deploy-upgradeable.js
+++ b/blockchain/scripts/deploy-upgradeable.js
@@ -44,6 +44,30 @@ async function main() {
   await truxify.grantPauserRole(pauserAddress);
   console.log(`⏸️ Pauser role granted to: ${pauserAddress}`);
 
+  // Wire up the governance token used to weight DAO votes. vote() and
+  // executeProposal() both revert until this is set — there is deliberately
+  // no unweighted (one-address-one-vote) fallback.
+  const governanceTokenAddress = process.env.GOVERNANCE_TOKEN_ADDRESS;
+  if (governanceTokenAddress) {
+    await truxify.setGovernanceToken(governanceTokenAddress);
+    console.log(`🗳️  Governance token set to: ${governanceTokenAddress}`);
+  } else {
+    console.warn(
+      "⚠️  GOVERNANCE_TOKEN_ADDRESS not set — DAO voting/execution will revert until setGovernanceToken() is called."
+    );
+  }
+
+  // Pre-approve any known-good implementations for the upgrade allowlist.
+  // Accepts a comma-separated list of addresses.
+  const approvedImplementations = (process.env.APPROVED_IMPLEMENTATIONS || "")
+    .split(",")
+    .map((addr) => addr.trim())
+    .filter(Boolean);
+  for (const addr of approvedImplementations) {
+    await truxify.setApprovedImplementation(addr, true);
+    console.log(`✅ Implementation approved for DAO proposals: ${addr}`);
+  }
+
   // Verify setup
   console.log("\n📊 Deployment Summary:");
   console.log(`Implementation: ${implementationAddress}`);
@@ -51,6 +75,7 @@ async function main() {
   console.log(`DAO Address: ${daoAddress}`);
   console.log(`Upgrader: ${upgraderAddress}`);
   console.log(`Pauser: ${pauserAddress}`);
+  console.log(`Governance Token: ${governanceTokenAddress || "(not set)"}`);
 
   // Save deployment info
   const deploymentInfo = {
@@ -59,6 +84,8 @@ async function main() {
     daoAddress: daoAddress,
     upgraderAddress: upgraderAddress,
     pauserAddress: pauserAddress,
+    governanceTokenAddress: governanceTokenAddress || null,
+    approvedImplementations: approvedImplementations,
     timestamp: new Date().toISOString(),
     network: hre.network.name
   };

--- a/blockchain/test/UUPSProxy.test.cjs
+++ b/blockchain/test/UUPSProxy.test.cjs
@@ -35,7 +35,7 @@ async function expectRevert(promise, expectedMessage) {
 }
 
 describe("TruxifyUpgradeable", function () {
-  let truxify, implementation, v2Implementation;
+  let truxify, implementation, v2Implementation, daoToken;
   let owner, upgrader, daoMember, voter1, voter2, other;
 
   const ONE_DAY = 86_400;
@@ -70,18 +70,44 @@ describe("TruxifyUpgradeable", function () {
       await proxyContract.getAddress()
     );
 
+    // ── Governance token: voting power comes from token balance, not raw
+    //    address count (this is the Sybil-resistance fix). Mint the entire
+    //    supply (400) split evenly across the four voting participants used
+    //    below, so each has equal weight — mirroring the old "1 address = 1
+    //    vote" test ratios but now backed by real, non-free-to-mint weight.
+    const DAOToken = await ethers.getContractFactory("DAOToken");
+    daoToken = await DAOToken.deploy(
+      "Truxify DAO",
+      "TDAO",
+      ethers.parseEther("400")
+    );
+    await daoToken.waitForDeployment();
+    for (const voter of [daoMember, voter1, voter2, other]) {
+      await daoToken.transfer(voter.address, ethers.parseEther("100"));
+    }
+    await truxify.setGovernanceToken(await daoToken.getAddress());
+
     // ── Test-friendly DAO config ─────────────────────────────────────────
-    // Set quorum to 3 (voter1 + voter2 + daoMember) so we can reach it.
-    // Set threshold to 51% so majority is clear.
-    // Set voting period to minimum (1 day = 86400s). Use time.increase()
-    // in tests to fast-forward past it.
-    await truxify.setDAOQuorum(3);
+    // Quorum: 75% of the 400-token supply (300 tokens) must have voted —
+    // equivalent to "3 out of 4" of the old address-count quorum.
+    // Threshold: 51% so majority is clear.
+    // Voting period: minimum (1 day = 86400s). Use time.increase() in tests
+    // to fast-forward past it, plus UPGRADE_EXECUTION_DELAY (2 days) before
+    // an already-passed proposal can actually be executed.
+    await truxify.setDAOQuorumBps(7500);
     await truxify.setDAOThreshold(51);
     await truxify.setDAOVotingPeriod(86400);
 
     // Grant roles
     await truxify.grantUpgraderRole(upgrader.address);
     await truxify.grantDAORole(daoMember.address);
+
+    // Pre-approve the implementations used as upgrade targets in these tests.
+    await truxify.setApprovedImplementation(other.address, true);
+    await truxify.setApprovedImplementation(
+      await v2Implementation.getAddress(),
+      true
+    );
   });
 
   // ══════════════════════════════════════════════════════════════════
@@ -144,7 +170,7 @@ describe("TruxifyUpgradeable", function () {
       await truxify.connect(daoMember).vote(1, true);
 
       const proposal = await truxify.proposals(1);
-      expect(proposal.votesFor).to.equal(1n);
+      expect(proposal.votesFor).to.equal(ethers.parseEther("100"));
     });
 
     it("Should not allow double voting", async function () {
@@ -192,7 +218,7 @@ describe("TruxifyUpgradeable", function () {
         "Upgrade to new version"
       );
 
-      // Only 1 vote, quorum is 3
+      // Only 1 voter's weight (100/400 = 25%), quorum requires 75%
       await truxify.connect(daoMember).vote(1, true);
       await time.increase(86401);
 
@@ -224,8 +250,8 @@ describe("TruxifyUpgradeable", function () {
       const proposal = await truxify.proposals(1);
       expect(proposal.executed).to.be.true;
       expect(proposal.passed).to.be.false;
-      expect(proposal.votesFor).to.equal(2n);
-      expect(proposal.votesAgainst).to.equal(2n);
+      expect(proposal.votesFor).to.equal(ethers.parseEther("200"));
+      expect(proposal.votesAgainst).to.equal(ethers.parseEther("200"));
     });
   });
 
@@ -248,8 +274,10 @@ describe("TruxifyUpgradeable", function () {
       await truxify.connect(voter1).vote(1, true);
       await truxify.connect(voter2).vote(1, true);
 
-      // Fast-forward past voting period
+      // Fast-forward past voting period, then past the mandatory
+      // UPGRADE_EXECUTION_DELAY (2 days) that applies once a proposal passes.
       await time.increase(86401);
+      await time.increase(2 * ONE_DAY);
 
       // Execute proposal — this should perform the upgrade via upgradeToAndCall
       const result = await truxify.executeProposal(1);
@@ -266,6 +294,71 @@ describe("TruxifyUpgradeable", function () {
       const proposal = await truxify.proposals(1);
       expect(proposal.executed).to.be.true;
       expect(proposal.passed).to.be.true;
+    });
+
+    it("Should reject execution of a passed proposal before the mandatory execution timelock elapses", async function () {
+      const v2Address = await v2Implementation.getAddress();
+
+      await truxify.connect(daoMember).createProposal(v2Address, "Upgrade to V2");
+
+      // Unanimous approval — quorum and threshold are both satisfied.
+      await truxify.connect(daoMember).vote(1, true);
+      await truxify.connect(voter1).vote(1, true);
+      await truxify.connect(voter2).vote(1, true);
+
+      // Only fast-forward past the voting period — NOT the additional
+      // UPGRADE_EXECUTION_DELAY. Even though the proposal has technically
+      // passed, execution must still wait out the timelock.
+      await time.increase(86401);
+
+      await expectRevert(
+        truxify.executeProposal(1),
+        "Execution timelock not elapsed"
+      );
+    });
+
+    it("Should reject executeProposal from an account without UPGRADER_ROLE", async function () {
+      const v2Address = await v2Implementation.getAddress();
+
+      await truxify.connect(daoMember).createProposal(v2Address, "Upgrade to V2");
+      await truxify.connect(daoMember).vote(1, true);
+      await truxify.connect(voter1).vote(1, true);
+      await truxify.connect(voter2).vote(1, true);
+
+      await time.increase(86401);
+      await time.increase(2 * ONE_DAY);
+
+      // `other` has DAO_ROLE (can propose/vote) but not UPGRADER_ROLE —
+      // passing a vote should never be enough to execute the upgrade
+      // yourself; a privileged account must do it.
+      await expectRevert(
+        truxify.connect(other).executeProposal(1),
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+
+    it("Should reject createProposal for an implementation that hasn't been approved by the admin", async function () {
+      const [, , , , , , unapproved] = await ethers.getSigners();
+
+      await expectRevert(
+        truxify.connect(daoMember).createProposal(unapproved.address, "Sneaky upgrade"),
+        "Implementation not approved"
+      );
+    });
+
+    it("Should reject voting from an address holding no governance tokens", async function () {
+      const v2Address = await v2Implementation.getAddress();
+      const [, , , , , , noTokens] = await ethers.getSigners();
+
+      await truxify.connect(daoMember).createProposal(v2Address, "Upgrade to V2");
+      await truxify.grantDAORole(noTokens.address);
+
+      // noTokens never received any DAOToken in beforeEach, so despite being
+      // a valid DAO_ROLE-holding address, it carries zero voting weight.
+      await expectRevert(
+        truxify.connect(noTokens).vote(1, true),
+        "No voting power"
+      );
     });
 
     it("Should reject upgrade via upgradeToAndCall() without DAO approval", async function () {
@@ -298,6 +391,7 @@ describe("TruxifyUpgradeable", function () {
       await truxify.connect(voter1).vote(1, true);
       await truxify.connect(voter2).vote(1, true);
       await time.increase(86401);
+      await time.increase(2 * ONE_DAY);
       await truxify.executeProposal(1);
 
       // Flag was cleared by executeProposal — trying upgradeToAndCall again should fail
@@ -504,15 +598,68 @@ describe("TruxifyUpgradeable", function () {
       );
     });
 
-    it("Should update quorum", async function () {
-      await truxify.setDAOQuorum(10);
-      expect(await truxify.daoQuorum()).to.equal(10n);
+    it("Should update quorum bps", async function () {
+      await truxify.setDAOQuorumBps(2000);
+      expect(await truxify.daoQuorumBps()).to.equal(2000n);
     });
 
-    it("Should reject zero quorum", async function () {
+    it("Should reject zero quorum bps", async function () {
       await expectRevert(
-        truxify.setDAOQuorum(0),
-        "Quorum must be > 0"
+        truxify.setDAOQuorumBps(0),
+        "Quorum bps must be 1-10000"
+      );
+    });
+
+    it("Should reject quorum bps above 10000 (100%)", async function () {
+      await expectRevert(
+        truxify.setDAOQuorumBps(10001),
+        "Quorum bps must be 1-10000"
+      );
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Governance Token & Implementation Allowlist
+  // ══════════════════════════════════════════════════════════════════
+
+  describe("Governance Token & Implementation Allowlist", function () {
+    it("Should reject voting when no governance token has been configured", async function () {
+      // Deploy a fresh proxy that never had setGovernanceToken() called.
+      const TruxifyUpgradeable = await ethers.getContractFactory("TruxifyUpgradeable");
+      const freshImpl = await TruxifyUpgradeable.deploy();
+      await freshImpl.waitForDeployment();
+
+      const UUPSProxy = await ethers.getContractFactory("UUPSProxy");
+      const initData = freshImpl.interface.encodeFunctionData("initialize");
+      const freshProxy = await UUPSProxy.deploy(await freshImpl.getAddress(), initData);
+      await freshProxy.waitForDeployment();
+
+      const freshTruxify = await ethers.getContractAt(
+        "TruxifyUpgradeable",
+        await freshProxy.getAddress()
+      );
+
+      await freshTruxify.grantDAORole(daoMember.address);
+      await freshTruxify.setApprovedImplementation(other.address, true);
+      await freshTruxify.connect(daoMember).createProposal(other.address, "Upgrade");
+
+      await expectRevert(
+        freshTruxify.connect(daoMember).vote(1, true),
+        "Governance token not configured"
+      );
+    });
+
+    it("Should only allow DEFAULT_ADMIN_ROLE to set the governance token", async function () {
+      await expectRevert(
+        truxify.connect(other).setGovernanceToken(await daoToken.getAddress()),
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+
+    it("Should only allow DEFAULT_ADMIN_ROLE to approve implementations", async function () {
+      await expectRevert(
+        truxify.connect(other).setApprovedImplementation(other.address, true),
+        "AccessControlUnauthorizedAccount"
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes a critical governance vulnerability in `TruxifyUpgradeable.sol` where DAO upgrade voting was one-address-one-vote with no timelock and no execution privilege check, making a Sybil takeover of the upgrade mechanism possible.

Fixes #5935

## Root Cause

- `vote()` gave every address exactly one unweighted vote — no check on token holdings or any other form of stake, so an attacker could create arbitrary numbers of addresses to reach quorum/threshold.
- `executeProposal()` was callable by any address, with no role or privilege check.
- A passing proposal was executed immediately inside `executeProposal()` — the existing `EMERGENCY_UPGRADE_TIMELOCK` (2 days) only applied to the separate emergency-upgrade path, not to the standard DAO path.
- There was no validation of the proposed implementation address against any trusted registry — a passing vote could install literally any bytecode.

Combined, this meant a Sybil attacker (or a bare majority in a low-turnout vote) could pass a proposal pointing at attacker-controlled bytecode and have it take effect instantly, taking over the escrow logic entirely.

## Fix

- **Token-weighted voting**: added `governanceToken` (`IERC20`). `vote()` now weighs each vote by `governanceToken.balanceOf(msg.sender)` instead of counting the address once. An address with no tokens has zero voting power regardless of how many addresses it controls.
- **Proportional quorum**: replaced the raw-count `daoQuorum` with `daoQuorumBps` — quorum is now a percentage (basis points) of the governance token's `totalSupply()`, defaulting to 10%. Configurable via `setDAOQuorumBps` (`DEFAULT_ADMIN_ROLE`).
