### PR TITLE
fix: require manufacturer or owner authorization in SupplyChain.createShipment (fixes #5938)

### DIFF
--- a/blockchain/contracts/SupplyChain.sol
+++ b/blockchain/contracts/SupplyChain.sol
@@ -146,6 +146,7 @@ contract SupplyChain is Ownable, Pausable, ReentrancyGuard {
     ) external whenNotPaused returns (uint256) {
         require(products[productId].isActive, "Product not active");
         require(receiver != address(0), "Invalid receiver");
+        require(products[productId].manufacturer == msg.sender || msg.sender == owner(), "Not authorized");
 
         _shipmentCounter++;
         uint256 shipmentId = _shipmentCounter;


### PR DESCRIPTION
## Problem

\createShipment\ never checks that the caller is the product's manufacturer (or the owner), so any address can attach arbitrary shipment and trace records to any active product, corrupting the provenance history that downstream verifiers consume. The other product-mutating functions (\updateProduct\, \erifyProduct\, \ddCustomEvent\) already gate on \products[productId].manufacturer == msg.sender || msg.sender == owner()\; \createShipment\ missed it.

## Fix

- Added the same manufacturer-or-owner authorization check to \createShipment\, preventing unauthorized shipment creation and \TraceEvent\ pollution.

## Files changed

- \lockchain/contracts/SupplyChain.sol\

## Testing

- Verified in an isolated Hardhat harness: manufacturer and owner can create shipments; a third-party attacker is rejected with \Not authorized\ and cannot inject fake records into a product's history.
- Confirmed the unmodified contract allows the attacker (both authorization-revert tests fail).

Closes #5938