### PR TITLE
fix: back bridge withdrawals with caller's own deposits (fixes #5940)

### DIFF
--- a/blockchain/contracts/zkEVMBridge.sol
+++ b/blockchain/contracts/zkEVMBridge.sol
@@ -13,6 +13,7 @@ interface IzkEVM {
 contract zkEVMBridge is Ownable, ReentrancyGuard {
     IzkEVM public zkEVM;
     mapping(address => uint256) public pendingWithdrawals;
+    mapping(address => uint256) public depositedAmount;
     uint256 public bridgeFee = 0.001 ether;
 
     event BridgeDeposit(address indexed user, uint256 amount, uint256 fee);
@@ -27,6 +28,8 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
         require(msg.value > bridgeFee, "Amount must be > fee");
         uint256 amount = msg.value - bridgeFee;
 
+        depositedAmount[msg.sender] += amount;
+
         // Deposit to L2
         zkEVM.depositToL2{value: amount}();
 
@@ -38,8 +41,10 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
         bytes calldata proof
     ) external nonReentrant {
         require(proof.length > 0, "Empty proof");
+        require(depositedAmount[msg.sender] >= amount, "Exceeds deposited amount");
         // Withdraw from L2
         zkEVM.withdrawFromL2(amount, proof);
+        depositedAmount[msg.sender] -= amount;
         pendingWithdrawals[msg.sender] += amount;
 
         emit BridgeWithdraw(msg.sender, amount);
@@ -61,4 +66,6 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
     function withdrawFees() external onlyOwner {
         payable(owner()).transfer(address(this).balance);
     }
+
+    receive() external payable {}
 }


### PR DESCRIPTION
## Problem

\withdrawFromL2\ unconditionally credits \pendingWithdrawals[msg.sender] += amount\ with no bridge-side backing check. Because every deposit forwards principal to the zkEVM contract and credits the bridge's L2 balance (not a per-user balance), any caller can request the whole pooled L2 balance in one withdrawal and \claimWithdrawal\ pays it out of the bridge — the first withdrawer drains the pool and later withdrawals are stranded. The bridge holds only fees, so credits are structurally unbacked.

## Fix

- Added a \depositedAmount\ ledger: \depositToL2\ records each user's principal, and \withdrawFromL2\ requires the requested amount to be covered by the caller's own deposits (\Exceeds deposited amount\) and decrements the ledger as withdrawals are credited. A user can never claim more than they deposited, so the bridge stays solvent per-user and the pooled drain is blocked before it reaches the zkEVM.
- Added a \eceive()\ so the bridge can actually accept the funds the zkEVM transfers back on withdrawal (previously the withdrawal path would revert since the contract could not receive ETH).

## Files changed

- \lockchain/contracts/zkEVMBridge.sol\

## Testing

- Verified in an isolated Hardhat harness (mock zkEVM honoring any non-empty proof, mirroring the placeholder verifier): deposit-backed withdrawals and claims work; withdrawals above the caller's deposit revert; an attacker with a 1 ETH deposit cannot pull the 2 ETH pooled L2 balance through the bridge; multi-withdrawal total is bounded by the deposit.
- Confirmed the unmodified contract lets the attacker drain the entire pooled L2 balance (all 5 tests fail).

Closes #5940