### PR TITLE
fix: require owner, recipient, or admin authorization in ZKIdentity.revokeSelectiveDisclosure (fixes #5941)

### DIFF
--- a/blockchain/contracts/ZKIdentity.sol
+++ b/blockchain/contracts/ZKIdentity.sol
@@ -257,10 +257,17 @@ contract ZKIdentity is Ownable, ReentrancyGuard, Pausable {
     }
 
     function revokeSelectiveDisclosure(bytes32 disclosureId) external {
-        require(selectiveDisclosures[disclosureId].identityHash != bytes32(0), "Disclosure not found");
-        require(selectiveDisclosures[disclosureId].active, "Already revoked");
+        SelectiveDisclosure storage disclosure = selectiveDisclosures[disclosureId];
+        require(disclosure.identityHash != bytes32(0), "Disclosure not found");
+        require(disclosure.active, "Already revoked");
+        require(
+            msg.sender == identities[disclosure.identityHash].owner ||
+                msg.sender == disclosure.recipient ||
+                msg.sender == owner(),
+            "Not authorized"
+        );
 
-        selectiveDisclosures[disclosureId].active = false;
+        disclosure.active = false;
 
         emit SelectiveDisclosureRevoked(disclosureId);
     }


### PR DESCRIPTION
## Problem

\evokeSelectiveDisclosure\ can be called by any address; it only checks that the disclosure exists and is active. An attacker can revoke any user's selective disclosure, breaking verification flows that depend on active disclosures.

## Fix

- Added an authorization check mirroring the ownership pattern used elsewhere in the contract: the caller must be the identity owner, the disclosure's \ecipient\, or the contract owner, otherwise the call reverts with \Not authorized\.

## Files changed

- \lockchain/contracts/ZKIdentity.sol\

## Testing

- Verified in an isolated Hardhat harness: the identity owner, the disclosure recipient, and the contract owner can revoke; a third-party address is rejected with \Not authorized\ and the disclosure stays active; nonexistent/already-revoked disclosures still revert.
- Confirmed the unmodified contract lets a third party revoke any disclosure (the third-party test fails).

Closes #5941