### PR TITLE
fix(logout): make Firebase and Supabase sign-out independent

### DIFF
--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -113,8 +113,25 @@ class ProfileService {
     }
 
     await Future.wait([
-      FirebaseAuth.instance.signOut(),
-      SupabaseService.client.auth.signOut(),
+      _safeSignOut(
+        () => FirebaseAuth.instance.signOut(),
+        'Firebase',
+      ),
+      _safeSignOut(
+        () => SupabaseService.client.auth.signOut(),
+        'Supabase',
+      ),
     ]);
+  }
+
+  Future<void> _safeSignOut(
+    Future<void> Function() signOut,
+    String provider,
+  ) async {
+    try {
+      await signOut();
+    } catch (e) {
+      developer.log('$provider sign-out failed during logout: $e');
+    }
   }
 }


### PR DESCRIPTION
## Description
Fixes a bug in `ProfileService.logout()` where `Future.wait([...])` was used to run the Firebase and Supabase sign-out calls concurrently without individual error handling. If one call threw (e.g. `FirebaseAuth.instance.signOut()` throwing when Firebase isn't initialized in a mock/local environment), `Future.wait` would reject immediately, and the other provider's sign-out was not guaranteed to complete safely — leaving the user still logged into that provider.

Each sign-out call is now wrapped in a new `_safeSignOut` helper with its own try/catch, so both Firebase and Supabase sign-out are always attempted independently and failures are logged rather than propagated, while still running concurrently (no serialization / performance regression).

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `flutter analyze`, manual run of the customer app
- **Test Steps / Prerequisites:**
  1. Run the app in a local/mock environment where Firebase is disabled or uninitialized.
  2. Log in, then trigger the logout action.
  3. Observe that logout completes and the user is signed out of Supabase even though Firebase sign-out throws.
- **Expected Result:** Both sign-out attempts run; a failure in one (e.g. Firebase) no longer blocks or skips the other (Supabase). Errors are logged via `developer.log` with the provider name.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #1630

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout reliability by signing out of Firebase and Supabase independently.
  * A failure with one sign-out provider no longer prevents the other sign-out operation from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->