### PR TITLE
fix: remove imports and routes for non-existent dr/ module that broke server boot

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -102,12 +102,6 @@ import zkpRoutes from './routes/zkp.routes.js'
 
 
 // ============================================================================
-// 🆕 MULTI-CLOUD DISASTER RECOVERY
-// ============================================================================
-import drRoutes from '../../dr/routes.js'
-import multiCloudService from '../../dr/multi-cloud.service.js'
-
-// ============================================================================
 // 🆕 OPENTELEMETRY DISTRIBUTED TRACING
 // ============================================================================
 import tracing from './tracing/tracing.js'
@@ -578,29 +572,6 @@ app.get('/api/zkp/health', (req, res) => {
 })
 
 
-
-// ============================================================================
-// 🆕 MULTI-CLOUD DISASTER RECOVERY ROUTES
-// ============================================================================
-app.use('/api', drRoutes)
-
-// 🆕 DR Health Check Endpoint
-app.get('/api/dr/health', async (req, res) => {
-  try {
-    const health = await multiCloudService.checkHealth();
-    res.json({
-      status: 'healthy',
-      data: health,
-      activeCloud: multiCloudService.activeCloud,
-      timestamp: new Date().toISOString()
-    });
-  } catch (error) {
-    res.status(500).json({
-      status: 'unhealthy',
-      error: error.message
-    });
-  }
-})
 
 // ============================================================================
 // 🆕 OPENTELEMETRY HEALTH CHECK


### PR DESCRIPTION
Closes #5981

## What

Removes the `import drRoutes from '../../dr/routes.js'` and `import multiCloudService from '../../dr/multi-cloud.service.js'` statements from `backend/api/src/index.js`, plus the DR routes and `/api/dr/health` endpoint that depend on them.

## Why

The `backend/dr/` directory does not exist anywhere in the repository. Node ESM resolves imports at module evaluation, so `npm start` / `npm run dev` crashed immediately with `ERR_MODULE_NOT_FOUND` — the API server could never boot.

## Changes

- Removed the `../../dr/*` imports (`index.js`).
- Removed `app.use('/api', drRoutes)` and the `/api/dr/health` endpoint that called `multiCloudService.checkHealth()`.

## Verification

- `node --check backend/api/src/index.js` passes.
- No remaining references to `drRoutes` / `multiCloudService` in `index.js`.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the multi-cloud disaster recovery API and related health check.
  * Existing startup, routing, and standard health-check behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->