### PR TITLE
fix: add qr_flutter dependency to driver app

### DIFF
--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   share_plus: ^10.1.4
   pdf: ^3.11.2
   printing: ^5.13.4
+  qr_flutter: ^4.1.0
   camera: ^0.11.0
   signature: ^6.3.0
   image_picker: ^1.1.2


### PR DESCRIPTION
Closes #5982

## What

Adds `qr_flutter` to the driver app's `pubspec.yaml` dependencies.

## Why

`apps/driver/lib/screens/home_screen.dart:24` imports `package:qr_flutter/qr_flutter.dart` and uses `QrImageView` at line 1113, but `qr_flutter` was not declared in `apps/driver/pubspec.yaml`. `flutter pub get` could not resolve the package, so the driver app could not build at all.

## Changes

- Added `qr_flutter: ^4.1.0` to `apps/driver/pubspec.yaml` dependencies.

GSSOC
