### PR TITLE
fix: remove driver_id from WebSocket URL query params (#5826)

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -352,9 +352,6 @@ class LocationService {
       host: baseUri.host,
       port: baseUri.hasPort ? baseUri.port : null,
       path: wsPath,
-      queryParameters: {
-        'driver_id': driverId,
-      },
     );
 
     try {


### PR DESCRIPTION
## Description
Removes `driver_id` from the WebSocket URL query parameters in `_buildWsUri()`. 
The driver ID is already sent securely via the `location_ping` payload and available 
on the server through `ws.driverId` after first-frame auth. Exposing it in the URL 
leaks it into proxy logs and browser history.

## Type of Change
<!-- Select all that apply: -->
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
Test Commands: flutter analyze
Test Steps: Verified WebSocket connects successfully without driver_id in URL.
Expected Result: No driver_id visible in WebSocket upgrade URL.

### Test Environment
- [x] Local manual testing

Closes 5826 

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated real-time location connections to omit driver identifiers from the connection URL, improving connection privacy and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->