### PR TITLE
fix: add break to every case in _onNavigate switch so customer app compiles

### DIFF
--- a/apps/customer/lib/screens/shell_screen.dart
+++ b/apps/customer/lib/screens/shell_screen.dart
@@ -224,6 +224,7 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
             ),
           );
         });
+        break;
 
       case NavigateToLiveTracking(:final orderId):
         _openInOrdersTab(() {
@@ -233,9 +234,11 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
             ),
           );
         });
+        break;
 
       case NavigateToWallet():
         _switchTab(3);
+        break;
 
       case NavigateToSupportTicket():
         // Navigate to notifications screen — support ticket detail is
@@ -245,6 +248,7 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
             AppPageRoute(builder: (_) => const NotificationsScreen()),
           );
         });
+        break;
 
       case NavigateToNotificationsList():
         _openInHomeTab(() {
@@ -252,6 +256,7 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
             AppPageRoute(builder: (_) => const NotificationsScreen()),
           );
         });
+        break;
 
       case NavigateToEarnings():
       case NavigateToLoadDetail():
@@ -262,6 +267,7 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
             AppPageRoute(builder: (_) => const NotificationsScreen()),
           );
         });
+        break;
     }
   }
 


### PR DESCRIPTION
Closes #5986

## What

Adds a terminating `break;` to every non-empty `case` in `_onNavigate` in `apps/customer/lib/screens/shell_screen.dart`.

## Why

The `switch` cases (lines 208-270) ended without `break`/`return`, which is a Dart compile error — "case clause must not complete normally". The customer app could not compile because `shell_screen.dart` is the main app scaffold.

## Changes

- `NavigateToOrderDetail`, `NavigateToLiveTracking`, `NavigateToWallet`, `NavigateToSupportTicket`, `NavigateToNotificationsList`, and the grouped `NavigateToEarnings`/`NavigateToLoadDetail` cases now end with `break;`.

GSSOC
