### PR TITLE
fix(consensus): resolve http rpc deadlock during concurrent raft elections

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -197,11 +197,13 @@ func (rn *RaftNode) stepDownLocked(term uint64) {
 	rn.lastLeaderSeen = time.Now()
 }
 
-// startElectionLocked campaigns for leadership: bump term, vote for self, and
-// request votes from peers. A candidate with a majority becomes leader.
-func (rn *RaftNode) startElectionLocked() {
+// startElection campaigns for leadership: bump term, vote for self, and
+// request votes from peers outside the mutex lock to prevent deadlock.
+func (rn *RaftNode) startElection() {
+	rn.mu.Lock()
 	rn.Role = Candidate
 	rn.CurrentTerm++
+	term := rn.CurrentTerm
 	rn.VotedFor = rn.NodeID
 	rn.LeaderID = ""
 	rn.electionStarted = time.Now()
@@ -213,8 +215,18 @@ func (rn *RaftNode) startElectionLocked() {
 		LastLogIndex: rn.lastLogIndex(),
 		LastLogTerm:  rn.lastLogTerm(),
 	}
+	rn.mu.Unlock()
 
+	// Perform outbound HTTP RPC requests without holding rn.mu to avoid deadlocks
 	responses := rn.requestVotes(req)
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	// Verify the node is still a candidate in the same term
+	if rn.Role != Candidate || rn.CurrentTerm != term {
+		return
+	}
 
 	votes := 1 // self vote
 	for _, resp := range responses {
@@ -303,9 +315,15 @@ func (rn *RaftNode) callAppend(peerURL string, req AppendEntriesRequest) (Append
 	return resp, err
 }
 
-// sendHeartbeatsLocked replicates AppendEntries RPCs to peers and records which
-// peers acknowledge the current leadership.
-func (rn *RaftNode) sendHeartbeatsLocked() {
+// sendHeartbeats replicates AppendEntries RPCs to peers and records which
+// peers acknowledge the current leadership, performing HTTP calls outside rn.mu.
+func (rn *RaftNode) sendHeartbeats() {
+	rn.mu.Lock()
+	if rn.Role != Leader {
+		rn.mu.Unlock()
+		return
+	}
+	term := rn.CurrentTerm
 	req := AppendEntriesRequest{
 		Term:         rn.CurrentTerm,
 		LeaderID:     rn.NodeID,
@@ -313,16 +331,16 @@ func (rn *RaftNode) sendHeartbeatsLocked() {
 		PrevLogTerm:  rn.lastLogTerm(),
 		LeaderCommit: rn.CommitIndex,
 	}
-
 	rn.peerHeartbeats = make(map[string]bool, len(rn.PeerURLs))
+	rn.mu.Unlock()
 
-	var wg sync.WaitGroup
-	var mu sync.Mutex
 	type result struct {
 		url  string
 		resp AppendEntriesResponse
 		err  error
 	}
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	results := make([]result, 0, len(rn.PeerURLs))
 
 	for _, url := range rn.PeerURLs {
@@ -336,6 +354,13 @@ func (rn *RaftNode) sendHeartbeatsLocked() {
 		}(url)
 	}
 	wg.Wait()
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	if rn.Role != Leader || rn.CurrentTerm != term {
+		return
+	}
 
 	for _, res := range results {
 		if res.err != nil {
@@ -385,24 +410,31 @@ func (rn *RaftNode) clusterStatusLocked() string {
 func (rn *RaftNode) run() {
 	for {
 		var delay time.Duration
+		var action string
 
 		rn.mu.Lock()
 		switch rn.Role {
 		case Leader:
-			rn.sendHeartbeatsLocked()
+			action = "heartbeat"
 			delay = rn.heartbeatInterval
 		case Candidate:
 			if time.Since(rn.electionStarted) > rn.electionTimeout {
-				rn.startElectionLocked()
+				action = "election"
 			}
 			delay = 50 * time.Millisecond
 		default:
 			if time.Since(rn.lastLeaderSeen) > rn.electionTimeout {
-				rn.startElectionLocked()
+				action = "election"
 			}
 			delay = 50 * time.Millisecond
 		}
 		rn.mu.Unlock()
+
+		if action == "heartbeat" {
+			rn.sendHeartbeats()
+		} else if action == "election" {
+			rn.startElection()
+		}
 
 		time.Sleep(delay)
 	}

--- a/services/consensus-raft-go/main_test.go
+++ b/services/consensus-raft-go/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewRaftNodeInit(t *testing.T) {
+	node := NewRaftNode("node1", []string{"node2", "node3"}, []string{"http://localhost:8081", "http://localhost:8082"})
+	if node.NodeID != "node1" {
+		t.Errorf("expected node ID node1, got %s", node.NodeID)
+	}
+	if node.Role != Follower {
+		t.Errorf("expected initial role Follower, got %s", node.Role)
+	}
+	if q := node.quorum(); q != 2 {
+		t.Errorf("expected quorum 2 for 3-node cluster, got %d", q)
+	}
+}
+
+func TestRaftLogUpToDate(t *testing.T) {
+	node := NewRaftNode("node1", nil, nil)
+	node.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: time.Now()},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: time.Now()},
+	}
+
+	if !node.isLogUpToDate(2, 1) {
+		t.Errorf("expected (2, 1) to be up to date")
+	}
+	if node.isLogUpToDate(1, 1) {
+		t.Errorf("expected (1, 1) to be rejected as obsolete")
+	}
+	if !node.isLogUpToDate(1, 2) {
+		t.Errorf("expected higher term (1, 2) to be accepted")
+	}
+}
+
+func TestConcurrentVoteRPCNoDeadlock(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	// Create test server for Node 2
+	var node2 *RaftNode
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/raft/vote" {
+			node2.HandleVote(w, r)
+		}
+	}))
+	defer server2.Close()
+
+	node2 = NewRaftNode("node2", []string{"node1"}, []string{"http://localhost:1111"})
+
+	// Node 1 configured to talk to server2
+	node1 := NewRaftNode("node1", []string{"node2"}, []string{server2.URL})
+
+	// Perform election on node1 asynchronously
+	done := make(chan bool)
+	go func() {
+		node1.startElection()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Completed cleanly without deadlock
+	case <-time.After(2 * time.Second):
+		t.Fatal("startElection deadlocked during concurrent HTTP vote RPC")
+	}
+
+	if node1.Role != Leader {
+		t.Errorf("expected node1 to become leader, got %s", node1.Role)
+	}
+}


### PR DESCRIPTION
## Description
Refactored mutex lock scoping in `services/consensus-raft-go/main.go` so that outbound HTTP RPC calls during elections (`startElection`) and heartbeats (`sendHeartbeats`) are executed outside the node state mutex lock (`rn.mu`). This resolves circular wait lock contention deadlocks during concurrent node elections and incoming HTTP RPC processing.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `go test -v ./...` in `services/consensus-raft-go/`
- **Test Steps / Prerequisites:**
  1. Added and ran `main_test.go` unit tests covering node initialization, Raft log freshness validation (`isLogUpToDate`), and concurrent vote RPC processing between simulated HTTP nodes.
  2. Verified `startElection` completes asynchronously without timing out or deadlocking.
- **Expected Result:** Raft nodes transition roles cleanly and respond to incoming `/api/v1/raft/vote` and `/api/v1/raft/append` requests without lock contention.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #5991 

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raft election and heartbeat handling to prevent deadlocks during network communication.
  * Ensured outdated election and heartbeat responses are safely ignored when node state changes.

* **Tests**
  * Added coverage for node initialization, log recency checks, and concurrent vote requests.
  * Added safeguards to verify elections complete without deadlocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->