### PR TITLE
feat: Create unified API Gateway (NGINX) and route traffic

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -18,10 +18,11 @@ class SyncEngine {
   static String get apiBaseUrl {
     const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
     if (envUrl.isNotEmpty) return envUrl;
-    if (kReleaseMode) {
-      throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');
-    }
-    return 'http://localhost:5000';
+    if (kReleaseMode) throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');
+
+    if (kIsWeb) return 'http://localhost:8080';
+    if (Platform.isAndroid) return 'http://10.0.2.2:8080';
+    return 'http://localhost:8080';
   }
 
   static Future<Database> get database async {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,16 @@
 services:
+  gateway:
+    image: nginx:alpine
+    container_name: truxify-gateway
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api
+      - ml-engine
+    restart: unless-stopped
+
   api:
     build:
       context: ./backend/api

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,39 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 8080;
+
+        # Node.js Auth Service
+        location /api/v1/auth {
+            proxy_pass http://api:5000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Node.js Trips Service
+        location /api/v1/trips {
+            proxy_pass http://api:5000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # FastAPI ML Service
+        location /api/v1/ml {
+            proxy_pass http://ml-engine:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # FastAPI Pricing Service
+        location /api/v1/pricing {
+            proxy_pass http://ml-engine:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/packages/truxify_shared/lib/src/config/env.dart
+++ b/packages/truxify_shared/lib/src/config/env.dart
@@ -45,7 +45,7 @@ class Env {
   // ── Backend API ────────────────────────────────────────────────────────────
   static const String apiBaseUrl = String.fromEnvironment(
     'API_BASE_URL',
-    defaultValue: 'http://localhost:3000',  // Local Node.js backend
+    defaultValue: 'http://localhost:8080',  // Local API Gateway
   );
 
   static const String mlEngineUrl = String.fromEnvironment(

--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -96,7 +96,10 @@ class ApiClient {
     const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
     if (envUrl.isNotEmpty) return envUrl;
     if (kReleaseMode) throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');
-    return 'http://localhost:5000';
+    
+    if (kIsWeb) return 'http://localhost:8080';
+    if (Platform.isAndroid) return 'http://10.0.2.2:8080';
+    return 'http://localhost:8080';
   }
 
   static String _normalise(String url) =>


### PR DESCRIPTION
Description: Resolves #5949

This PR introduces a unified API Gateway using NGINX to route all traffic cleanly to our microservices and streamline client-side API configuration.

Changes Included:

API Gateway Service: Added a new gateway service (port 8080) to docker-compose.yml using nginx:alpine.
NGINX Configuration: Created nginx.conf to dynamically reverse proxy requests based on endpoints:
/api/v1/auth & /api/v1/trips route to the Node.js API (api:5000).
/api/v1/ml & /api/v1/pricing route to the FastAPI ML Engine (ml-engine:8000).
Flutter App Integration: Refactored the API_BASE_URL in truxify_shared (env.dart and api_client.dart) and updated the sync_engine.dart in the driver app to strictly connect to the API Gateway on port 8080.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified local API gateway for authentication, trips, machine learning, and pricing services.
  * Standardized local development access through port 8080.
  * Improved connectivity across web, Android emulators, and other supported platforms with platform-specific local routing.

* **Bug Fixes**
  * Resolved inconsistent local API endpoint configuration that could prevent the app from connecting to backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->