### PR TITLE
feat(driver): build home screen — current trip card, earnings, heatma…

### DIFF
--- a/apps/driver/lib/models/earnings_daily_model.dart
+++ b/apps/driver/lib/models/earnings_daily_model.dart
@@ -1,22 +1,44 @@
+/// Model representing a driver's earnings summary for a single day.
 class EarningsDailyModel {
   final DateTime dayDate;
+
+  /// Gross earnings in rupees (already divided by 100 from backend paise value).
   final double amount;
+
   final int tripCount;
   final double hoursDriven;
+
+  /// Estimated fuel + toll deduction (15% of gross).
+  /// Adjust the constant below when the backend starts returning real figures.
+  final double fuelTollDeduction;
 
   EarningsDailyModel({
     required this.dayDate,
     required this.amount,
     required this.tripCount,
     required this.hoursDriven,
-  });
+    double? fuelTollDeduction,
+  }) : fuelTollDeduction = fuelTollDeduction ?? amount * 0.15;
+
+  /// Net earnings after subtracting the fuel/toll estimate.
+  double get netAmount => amount - fuelTollDeduction;
 
   factory EarningsDailyModel.fromMap(Map<String, dynamic> map) {
+    final gross = ((map['amount'] ?? 0) / 100.0) as double;
+    // If the backend ever starts sending 'fuel_toll_deduction', use it;
+    // otherwise fall back to the 15% estimate.
+    final deduction = map['fuel_toll_deduction'] != null
+        ? ((map['fuel_toll_deduction'] as num) / 100.0)
+        : gross * 0.15;
+
     return EarningsDailyModel(
-      dayDate: DateTime.tryParse(map['day_date']?.toString() ?? '') ?? DateTime.now(),
-      amount: ((map['amount'] ?? 0) / 100.0),
-      tripCount: map['trip_count'] ?? 0,
-      hoursDriven: double.tryParse(map['hours_driven'].toString()) ?? 0.0,
+      dayDate:
+          DateTime.tryParse(map['day_date']?.toString() ?? '') ?? DateTime.now(),
+      amount: gross,
+      tripCount: (map['trip_count'] as num?)?.toInt() ?? 0,
+      hoursDriven:
+          double.tryParse(map['hours_driven'].toString()) ?? 0.0,
+      fuelTollDeduction: deduction,
     );
   }
 }

--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
@@ -141,6 +140,18 @@ class _HomeScreenState extends State<HomeScreen> {
   String _activeTripDistance = '';
   String _activeTripDuration = '';
   String _activeTripPayout = '';
+
+  // ── New: current-trip card fields (issue #5708) ──────────────────────────
+  /// Human-readable ETA string shown on the current trip card, e.g. "~35 min".
+  String _activeTripEta = '';
+
+  /// Trip completion fraction [0.0 – 1.0] for the progress bar.
+  double _activeTripProgress = 0.0;
+
+  /// Status badge text, e.g. 'EN-ROUTE', 'LOADING', 'ASSIGNED LOAD'.
+  String _activeTripStatus = '';
+  // ─────────────────────────────────────────────────────────────────────────
+
   bool _isLoadingLocation = true;
   String? _locationError;
   late final MarketplaceRepository _marketplaceRepo;
@@ -193,7 +204,8 @@ class _HomeScreenState extends State<HomeScreen> {
       }
     }
     if (mounted) {
-      setState(() => _networkError = 'Network error. Please check your connection and try again.');
+      setState(() =>
+          _networkError = 'Network error. Please check your connection and try again.');
     }
   }
 
@@ -212,6 +224,8 @@ class _HomeScreenState extends State<HomeScreen> {
     _initBatteryMonitoring();
   }
 
+  // ── Demand heatmap ─────────────────────────────────────────────────────────
+
   Future<void> _loadHeatmapData() async {
     try {
       final heatmapData = await _marketplaceRepo.fetchDemandHeatmap();
@@ -224,6 +238,70 @@ class _HomeScreenState extends State<HomeScreen> {
       debugPrint('Failed to load heatmap data: $e');
     }
   }
+
+  /// Builds a [MarkerLayer] with colour-coded circles for each demand zone.
+  ///
+  /// Expected backend shape (from [MarketplaceRepository.fetchDemandHeatmap]):
+  /// ```json
+  /// {
+  ///   "zones": [
+  ///     { "lat": 28.6, "lng": 77.2, "demand": 0.85 },
+  ///     ...
+  ///   ]
+  /// }
+  /// ```
+  /// `demand` is a normalised value in [0.0, 1.0]:
+  ///   ≥ 0.70  → red   (high demand)
+  ///   ≥ 0.40  → orange (medium demand)
+  ///   < 0.40  → green  (low demand)
+  Widget? _buildHeatmapLayer() {
+    final data = _heatmapData;
+    if (data == null) return null;
+
+    final rawZones = data['zones'];
+    if (rawZones == null || rawZones is! List || rawZones.isEmpty) return null;
+
+    final markers = <Marker>[];
+    for (final zone in rawZones) {
+      if (zone is! Map) continue;
+      final lat = (zone['lat'] as num?)?.toDouble();
+      final lng = (zone['lng'] as num?)?.toDouble();
+      final demand = (zone['demand'] as num?)?.toDouble() ?? 0.0;
+      if (lat == null || lng == null) continue;
+
+      final Color fillColor;
+      if (demand >= 0.70) {
+        fillColor = Colors.red.withValues(alpha: 0.45);
+      } else if (demand >= 0.40) {
+        fillColor = Colors.orange.withValues(alpha: 0.40);
+      } else {
+        fillColor = Colors.green.withValues(alpha: 0.35);
+      }
+
+      markers.add(
+        Marker(
+          point: ll.LatLng(lat, lng),
+          width: 64,
+          height: 64,
+          child: Container(
+            decoration: BoxDecoration(
+              color: fillColor,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: fillColor.withValues(alpha: 0.7),
+                width: 1.5,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (markers.isEmpty) return null;
+    return MarkerLayer(markers: markers);
+  }
+
+  // ── Battery monitoring ─────────────────────────────────────────────────────
 
   void _initBatteryMonitoring() {
     _batteryService.addListener(_onBatteryChanged);
@@ -278,6 +356,16 @@ class _HomeScreenState extends State<HomeScreen> {
         _criticalDialogShown = false;
       }
     });
+  }
+
+  // ── HoS (Hours of Service) ─────────────────────────────────────────────────
+
+  /// Updates the driver's HoS status and persists the change.
+  /// Called from the HoS status banner buttons ('Off Duty', 'Driving', etc.).
+  void _toggleHosStatus(String status) {
+    setState(() => _hosStatus = status);
+    // TODO: persist to backend via TripService or dedicated HoS endpoint.
+    debugPrint('[HoS] status changed → $status');
   }
 
   @override
@@ -382,20 +470,35 @@ class _HomeScreenState extends State<HomeScreen> {
           : const Iterable<Map<String, dynamic>>.empty();
       final historyList = historyRows
           .map((t) => TripRecord(
-                route: (t['route'] as String?) ?? (t['route_label'] as String?) ?? '',
-                date: (t['date'] as String?) ?? (t['trip_date'] as String?) ?? '',
-                earnings: (t['earnings'] as String?) ?? (t['payout'] as String?) ?? '',
-                statusLabel: (t['status_label'] as String?) ?? (t['status'] as String?) ?? '',
-                tripId: (t['trip_display_id'] as String?) ?? (t['trip_id'] as String?) ?? '',
-                hash: (t['hash'] as String?) ?? (t['blockchain_hash'] as String?) ?? '',
+                route: (t['route'] as String?) ??
+                    (t['route_label'] as String?) ??
+                    '',
+                date: (t['date'] as String?) ??
+                    (t['trip_date'] as String?) ??
+                    '',
+                earnings: (t['earnings'] as String?) ??
+                    (t['payout'] as String?) ??
+                    '',
+                statusLabel: (t['status_label'] as String?) ??
+                    (t['status'] as String?) ??
+                    '',
+                tripId: (t['trip_display_id'] as String?) ??
+                    (t['trip_id'] as String?) ??
+                    '',
+                hash: (t['hash'] as String?) ??
+                    (t['blockchain_hash'] as String?) ??
+                    '',
                 verifiedBadge: (t['verified_badge'] as String?) ?? '',
-                completed: (t['completed'] as bool?) ?? (t['is_completed'] as bool?) ?? false,
+                completed: (t['completed'] as bool?) ??
+                    (t['is_completed'] as bool?) ??
+                    false,
               ))
           .toList();
 
       setState(() {
         _todayEarnings = results[0] as EarningsDailyModel?;
-        final stats = results[1] as Map<String, dynamic>? ?? <String, dynamic>{};
+        final stats =
+            results[1] as Map<String, dynamic>? ?? <String, dynamic>{};
         _driverRating = (stats['rating'] as num?)?.toDouble();
         _tripHistory = historyList;
         _isLoadingMetrics = false;
@@ -445,19 +548,15 @@ class _HomeScreenState extends State<HomeScreen> {
     } else {
       setState(() {
         _isLoadingLocation = false;
-        // _currentLocation stays null — map shows error state
         _currentLocationText = null;
       });
     }
   }
 
   /// Requests permission and fetches the current GPS position.
-  /// Returns null if permission denied or location unavailable.
   Future<Position?> _fetchGpsPosition() async {
     try {
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
-      debugPrint('Location service enabled: $serviceEnabled');
-
       if (!serviceEnabled) {
         if (mounted) {
           setState(() {
@@ -469,12 +568,8 @@ class _HomeScreenState extends State<HomeScreen> {
       }
 
       LocationPermission permission = await Geolocator.checkPermission();
-      debugPrint('Initial permission: $permission');
-
       if (permission == LocationPermission.denied) {
         permission = await Geolocator.requestPermission();
-        debugPrint('Permission after request: $permission');
-
         if (permission == LocationPermission.denied) {
           if (mounted) {
             setState(() {
@@ -496,22 +591,12 @@ class _HomeScreenState extends State<HomeScreen> {
         return null;
       }
 
-      final position = await Geolocator.getCurrentPosition(
-        locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
+      return await Geolocator.getCurrentPosition(
+        locationSettings:
+            const LocationSettings(accuracy: LocationAccuracy.high),
       );
-
-      debugPrint(
-        'Latitude: ${position.latitude}, Longitude: ${position.longitude}',
-      );
-
-      return position;
     } catch (e, stackTrace) {
-      debugPrint('====================');
-      debugPrint('LOCATION ERROR');
-      debugPrint(e.toString());
-      debugPrint(stackTrace.toString());
-      debugPrint('====================');
-
+      debugPrint('LOCATION ERROR: $e\n$stackTrace');
       if (mounted) {
         setState(() {
           _locationError = e.toString();
@@ -526,9 +611,7 @@ class _HomeScreenState extends State<HomeScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: Text(AppLocalizations.of(context)!.locationPermissionRequired),
-        content: Text(
-          AppLocalizations.of(context)!.locationPermDenied,
-        ),
+        content: Text(AppLocalizations.of(context)!.locationPermDenied),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(),
@@ -546,7 +629,6 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  /// Tap on the current location row — refreshes GPS + address.
   Future<void> _fetchCurrentLocation() async {
     setState(() {
       _isRefreshingLocation = true;
@@ -575,7 +657,7 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
-  /// Reverse geocodes `_currentLocation` using Nominatim.
+  /// Reverse geocodes [_currentLocation] using Nominatim.
   Future<String> _resolveCurrentLocationAddress() async {
     if (_currentLocation == null) return 'Location Unavailable';
 
@@ -597,9 +679,7 @@ class _HomeScreenState extends State<HomeScreen> {
           'User-Agent': 'Truxify Driver App',
         },
       );
-
       if (response.statusCode != 200) return 'Location Unavailable';
-
       final decoded = jsonDecode(response.body);
       if (decoded is Map<String, dynamic>) {
         final displayName = (decoded['display_name'] as String?)?.trim();
@@ -608,13 +688,44 @@ class _HomeScreenState extends State<HomeScreen> {
     } catch (_) {
       return 'Location Unavailable';
     }
-
     return 'Location Unavailable';
   }
 
   void _centerMapOnCurrentLocation() {
     if (_currentLocation == null) return;
     _mapController.move(_currentLocation!, _mapZoom);
+  }
+
+  // ── Active trip loading ────────────────────────────────────────────────────
+
+  /// Parses a duration string such as "2h 30m" or "45 min" into minutes,
+  /// then returns a human-readable ETA relative to now.
+  String _computeEtaFromDuration(String duration) {
+    if (duration.isEmpty) return '';
+    int totalMinutes = 0;
+    final hoursMatch = RegExp(r'(\d+)\s*h').firstMatch(duration);
+    final minsMatch = RegExp(r'(\d+)\s*m').firstMatch(duration);
+    if (hoursMatch != null) {
+      totalMinutes += int.tryParse(hoursMatch.group(1) ?? '0') ?? 0;
+      totalMinutes *= 60;
+    }
+    if (minsMatch != null) {
+      totalMinutes += int.tryParse(minsMatch.group(1) ?? '0') ?? 0;
+    }
+    if (totalMinutes == 0) return '';
+    final eta = DateTime.now().add(Duration(minutes: totalMinutes));
+    final h = eta.hour;
+    final m = eta.minute.toString().padLeft(2, '0');
+    final period = h >= 12 ? 'PM' : 'AM';
+    final h12 = h % 12 == 0 ? 12 : h % 12;
+    return 'ETA $h12:$m $period';
+  }
+
+  /// Computes trip progress [0.0 – 1.0] from stop completion data.
+  double _computeProgressFromStops(List<Map<String, dynamic>> stops) {
+    if (stops.isEmpty) return 0.0;
+    final completed = stops.where((s) => s['is_completed'] == true).length;
+    return completed / stops.length;
   }
 
   Future<void> _loadActiveTrip() async {
@@ -634,43 +745,70 @@ class _HomeScreenState extends State<HomeScreen> {
             : (activeTrip['truck_label'] as String?) ?? 'Truck assigned';
 
         final prefs = await SharedPreferences.getInstance();
+        final distanceStr = (activeTrip['distance'] as String?) ??
+            (activeTrip['trip_distance'] as String?) ??
+            '';
+        final durationStr = (activeTrip['duration'] as String?) ??
+            (activeTrip['trip_duration'] as String?) ??
+            '';
+        final payoutStr = (activeTrip['estimated_payout'] as String?) ??
+            (activeTrip['price'] as String?) ??
+            (activeTrip['payout'] as String?) ??
+            '';
+
         await prefs.setString('cached_trip_id', tripId);
         await prefs.setString('cached_truck_label', truckLabel);
-        await prefs.setString('cached_distance', (activeTrip['distance'] as String?) ?? (activeTrip['trip_distance'] as String?) ?? '');
-        await prefs.setString('cached_duration', (activeTrip['duration'] as String?) ?? (activeTrip['trip_duration'] as String?) ?? '');
-        await prefs.setString('cached_payout', (activeTrip['estimated_payout'] as String?) ?? (activeTrip['price'] as String?) ?? (activeTrip['payout'] as String?) ?? '');
-        
-        final isTripStarted = stops.any((s) => s['is_completed'] == true || s['is_current'] == true);
+        await prefs.setString('cached_distance', distanceStr);
+        await prefs.setString('cached_duration', durationStr);
+        await prefs.setString('cached_payout', payoutStr);
+
+        final isTripStarted = stops.any(
+          (s) => s['is_completed'] == true || s['is_current'] == true,
+        );
         await prefs.setBool('cached_is_started', isTripStarted);
+
+        // ── Compute ETA and progress for the Current Trip card ──────────
+        final eta = _computeEtaFromDuration(durationStr);
+        final progress = _computeProgressFromStops(
+          stops.whereType<Map<String, dynamic>>().toList(),
+        );
+        final status = isTripStarted ? 'EN-ROUTE' : 'ASSIGNED LOAD';
+        // ────────────────────────────────────────────────────────────────
 
         setState(() {
           _isOffline = false;
           _activeTripId = tripId;
           _activeTruckLabel = truckLabel;
-          _activeTripDistance = prefs.getString('cached_distance') ?? '';
-          _activeTripDuration = prefs.getString('cached_duration') ?? '';
-          _activeTripPayout = prefs.getString('cached_payout') ?? '';
+          _activeTripDistance = distanceStr;
+          _activeTripDuration = durationStr;
+          _activeTripPayout = payoutStr;
           _isTripStarted = isTripStarted;
+          _activeTripEta = eta;
+          _activeTripProgress = progress;
+          _activeTripStatus = status;
         });
-        
+
         if (stops.isNotEmpty) {
           final lastStop = stops.last;
           final address = lastStop['drop_location'] as String? ?? '';
           await prefs.setString('cached_address', address);
-          
+
           final dropPoint = await GeocodeService.resolvePlace(address);
           if (dropPoint != null) {
             await prefs.setDouble('cached_drop_lat', dropPoint.latitude);
             await prefs.setDouble('cached_drop_lng', dropPoint.longitude);
           }
-          
+
           if (dropPoint != null && mounted) {
             setState(() {
-              _destination = DestinationPickResult(address: address, point: dropPoint);
-              final routePoints = <ll.LatLng>[_currentLocation ?? dropPoint, dropPoint];
-              _routeFuture = RouteService.fetchRouteGeoJson(routePoints).onError(
-                (_, __) => routePoints,
-              );
+              _destination =
+                  DestinationPickResult(address: address, point: dropPoint);
+              final routePoints = <ll.LatLng>[
+                _currentLocation ?? dropPoint,
+                dropPoint
+              ];
+              _routeFuture = RouteService.fetchRouteGeoJson(routePoints)
+                  .onError((_, __) => routePoints);
             });
           }
         }
@@ -684,6 +822,9 @@ class _HomeScreenState extends State<HomeScreen> {
             _isTripStarted = false;
             _destination = null;
             _routeFuture = null;
+            _activeTripEta = '';
+            _activeTripProgress = 0.0;
+            _activeTripStatus = '';
           });
         }
       }
@@ -699,14 +840,17 @@ class _HomeScreenState extends State<HomeScreen> {
           _activeTripDuration = prefs.getString('cached_duration') ?? '';
           _activeTripPayout = prefs.getString('cached_payout') ?? '';
           _isTripStarted = prefs.getBool('cached_is_started') ?? false;
+          _activeTripStatus = _isTripStarted ? 'EN-ROUTE' : 'ASSIGNED LOAD';
         });
         final address = prefs.getString('cached_address');
         final lat = prefs.getDouble('cached_drop_lat');
         final lng = prefs.getDouble('cached_drop_lng');
         if (address != null && lat != null && lng != null) {
-          final dropPoint = ll.LatLng(lat, lng);
           setState(() {
-            _destination = DestinationPickResult(address: address, point: dropPoint);
+            _destination = DestinationPickResult(
+              address: address,
+              point: ll.LatLng(lat, lng),
+            );
           });
         }
       }
@@ -730,6 +874,9 @@ class _HomeScreenState extends State<HomeScreen> {
             _isTripStarted = false;
             _destination = null;
             _routeFuture = null;
+            _activeTripEta = '';
+            _activeTripProgress = 0.0;
+            _activeTripStatus = '';
           });
         }
       }
@@ -758,9 +905,8 @@ class _HomeScreenState extends State<HomeScreen> {
       _searchController.text = _destination!.address;
       _isDestinationExpanded = false;
       final routePoints = <ll.LatLng>[_currentLocation!, point];
-      _routeFuture = RouteService.fetchRouteGeoJson(routePoints).onError(
-        (_, __) => routePoints,
-      );
+      _routeFuture = RouteService.fetchRouteGeoJson(routePoints)
+          .onError((_, __) => routePoints);
     });
   }
 
@@ -793,9 +939,8 @@ class _HomeScreenState extends State<HomeScreen> {
           if (_currentLocation != null) _currentLocation!,
           result.point,
         ];
-        _routeFuture = RouteService.fetchRouteGeoJson(routePoints).onError(
-          (_, __) => routePoints,
-        );
+        _routeFuture = RouteService.fetchRouteGeoJson(routePoints)
+            .onError((_, __) => routePoints);
       });
     }
   }
@@ -811,42 +956,51 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _completeRide() async {
-  if (_activeTripId != null) {
-    try {
-      final stops = await _tripService.fetchTripStops(_activeTripId!);
-      final currentStop = stops.where((s) => s['is_current'] == true).firstOrNull;
-      if (currentStop != null) {
-        await _tripService.markStopCompleted(currentStop['id'].toString(), _activeTripId!);
+    if (_activeTripId != null) {
+      try {
+        final stops = await _tripService.fetchTripStops(_activeTripId!);
+        final currentStop =
+            stops.where((s) => s['is_current'] == true).firstOrNull;
+        if (currentStop != null) {
+          await _tripService.markStopCompleted(
+              currentStop['id'].toString(), _activeTripId!);
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+                content: Text(
+                    AppLocalizations.of(context)!.failedToCompleteTrip)),
+          );
+        }
+        return;
       }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context)!.failedToCompleteTrip)),
-        );
-      }
-      return;
+    }
+    _clearDestination();
+    WeighStationService.instance.resetAlertedStations();
+    if (mounted) {
+      setState(() {
+        _activeTripId = null;
+        _isTripStarted = false;
+        _activeTripEta = '';
+        _activeTripProgress = 0.0;
+        _activeTripStatus = '';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              AppLocalizations.of(context)!.tripCompletedNetEarnings('')),
+          backgroundColor: TruxifyColors.success,
+        ),
+      );
+      _loadDashboardMetrics();
     }
   }
-  _clearDestination();
-  WeighStationService.instance.resetAlertedStations();
-  if (mounted) {
-    setState(() {
-      _activeTripId = null;
-      _isTripStarted = false;
-    });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(AppLocalizations.of(context)!.tripCompletedNetEarnings('')),
-        backgroundColor: TruxifyColors.success,
-      ),
-    );
-    _loadDashboardMetrics();
-  }
-}
 
   Future<void> _checkPendingPods() async {
     try {
-      final hasPending = await SyncService.instance.isStopPendingSync(_activeTripId ?? '');
+      final hasPending =
+          await SyncService.instance.isStopPendingSync(_activeTripId ?? '');
       if (hasPending && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Some deliveries are pending sync.')),
@@ -856,18 +1010,70 @@ class _HomeScreenState extends State<HomeScreen> {
       debugPrint('Error checking pending PoDs: $e');
     }
   }
-}
+
+  // ── Google Maps deep-link ──────────────────────────────────────────────────
+
+  Future<void> _openGoogleMapsRoute() async {
+    final dest = _destination;
+    if (dest == null) return;
+    final uri = Uri.parse(
+      'https://www.google.com/maps/dir/?api=1'
+      '&destination=${dest.point.latitude},${dest.point.longitude}'
+      '&travelmode=driving',
+    );
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  // ── eBoL QR ───────────────────────────────────────────────────────────────
+
+  void _showEbolQrCode() {
+    if (_activeTripId == null) return;
+    final payload = jsonEncode({'order_id': _activeTripId, 'type': 'eBoL'});
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Digital Bill of Lading (eBoL)'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+                'Show this QR code to the warehouse clerk for instant verification.'),
+            const SizedBox(height: 20),
+            QrImageView(data: payload, version: QrVersions.auto, size: 200.0),
+            const SizedBox(height: 10),
+            Text('Order ID: $_activeTripId',
+                style: const TextStyle(fontSize: 10, color: Colors.grey)),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
 
   /// Short readable label for the current location.
   String _currentLocationLabel(BuildContext context) {
     if (_isLoadingLocation) return AppLocalizations.of(context)!.locating;
-    if (_locationError != null) return AppLocalizations.of(context)!.locationUnavailable;
+    if (_locationError != null) {
+      return AppLocalizations.of(context)!.locationUnavailable;
+    }
     if (_currentLocationText != null && _currentLocationText!.isNotEmpty) {
       final parts = _currentLocationText!.split(',');
       return parts.first.trim();
     }
     return AppLocalizations.of(context)!.currentLocation;
   }
+
+  // ── Build ──────────────────────────────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -876,11 +1082,12 @@ class _HomeScreenState extends State<HomeScreen> {
         bottom: false,
         child: Stack(
           children: [
-            // Map
+            // ── Map ───────────────────────────────────────────────────────
             Positioned.fill(
               child: _buildMapBody(context),
             ),
 
+            // ── Offline pending-pod banner ────────────────────────────────
             if (_hasPendingPods)
               Positioned(
                 left: 0,
@@ -888,16 +1095,20 @@ class _HomeScreenState extends State<HomeScreen> {
                 top: 0,
                 child: Container(
                   color: Colors.orange,
-                  padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+                  padding: const EdgeInsets.symmetric(
+                      vertical: 4, horizontal: 16),
                   child: const Text(
                     'Offline Mode - Pending Sync',
                     textAlign: TextAlign.center,
-                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 12),
+                    style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 12),
                   ),
                 ),
               ),
 
-            // Top Bar
+            // ── Top search / navigation header ────────────────────────────
             Positioned(
               left: 12,
               right: 12,
@@ -910,7 +1121,8 @@ class _HomeScreenState extends State<HomeScreen> {
                     if (_isOffline)
                       Container(
                         margin: const EdgeInsets.only(bottom: 12),
-                        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 8, horizontal: 16),
                         decoration: BoxDecoration(
                           color: TruxifyColors.errorRed,
                           borderRadius: BorderRadius.circular(8),
@@ -918,11 +1130,16 @@ class _HomeScreenState extends State<HomeScreen> {
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            const Icon(Icons.cloud_off_rounded, color: Colors.white, size: 16),
+                            const Icon(Icons.cloud_off_rounded,
+                                color: Colors.white, size: 16),
                             const SizedBox(width: 8),
                             Text(
-                              AppLocalizations.of(context)!.offlineUsingCachedData,
-                              style: GoogleFonts.dmSans(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                              AppLocalizations.of(context)!
+                                  .offlineUsingCachedData,
+                              style: GoogleFonts.dmSans(
+                                  color: Colors.white,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600),
                             ),
                           ],
                         ),
@@ -952,7 +1169,7 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
 
-            // HoS Warning Banner
+            // ── HoS over-limit warning ────────────────────────────────────
             if (_hosDrivingMinutes >= 660 || _hosOnDutyMinutes >= 840)
               Positioned(
                 left: 12,
@@ -966,16 +1183,19 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                   child: const Text(
                     'HoS Limit Exceeded! Mandatory 30-min rest break required.',
-                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                    style: TextStyle(
+                        color: Colors.white, fontWeight: FontWeight.bold),
                   ),
                 ),
               ),
 
-            // HoS Status Banner
+            // ── HoS status card ───────────────────────────────────────────
             Positioned(
               left: 12,
               right: 12,
-              top: (_hosDrivingMinutes >= 660 || _hosOnDutyMinutes >= 840) ? 156 : 96,
+              top: (_hosDrivingMinutes >= 660 || _hosOnDutyMinutes >= 840)
+                  ? 156
+                  : 96,
               child: Card(
                 elevation: 4,
                 child: Padding(
@@ -986,29 +1206,36 @@ class _HomeScreenState extends State<HomeScreen> {
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text('HoS Status: ${_hosStatus.toUpperCase()}', style: const TextStyle(fontWeight: FontWeight.bold)),
-                          Text('Driving: ${(_hosDrivingMinutes / 60).toStringAsFixed(1)}h / 11h'),
+                          Text(
+                            'HoS Status: ${_hosStatus.toUpperCase()}',
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          Text(
+                            'Driving: ${(_hosDrivingMinutes / 60).toStringAsFixed(1)}h / 11h',
+                          ),
                         ],
                       ),
                       Row(
                         children: [
                           TextButton(
                             onPressed: () => _toggleHosStatus('off_duty'),
-                            child: const Text('Off Duty', style: TextStyle(fontSize: 12)),
+                            child: const Text('Off Duty',
+                                style: TextStyle(fontSize: 12)),
                           ),
                           TextButton(
                             onPressed: () => _toggleHosStatus('driving'),
-                            child: const Text('Driving', style: TextStyle(fontSize: 12)),
+                            child: const Text('Driving',
+                                style: TextStyle(fontSize: 12)),
                           ),
                         ],
-                      )
+                      ),
                     ],
                   ),
                 ),
               ),
             ),
 
-            // New Load Notification Banner
+            // ── New load notification banner ──────────────────────────────
             if (_latestNewLoad != null && !_dismissedNewLoad)
               Positioned(
                 left: 12,
@@ -1017,9 +1244,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 child: NewLoadNotificationBanner(
                   load: _latestNewLoad!,
                   onView: () {},
-                  onDismiss: () {
-                    setState(() => _dismissedNewLoad = true);
-                  },
+                  onDismiss: () => setState(() => _dismissedNewLoad = true),
                   child: Container(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 14, vertical: 10),
@@ -1058,20 +1283,20 @@ class _HomeScreenState extends State<HomeScreen> {
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                                 style: GoogleFonts.dmSans(
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w500,
-                                  color: Colors.white,
-                                ),
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.w500,
+                                    color: Colors.white),
                               ),
                               const SizedBox(height: 1),
                               Text(
-                                '${_latestNewLoad!.weight != '—' ? '${_latestNewLoad!.weight} ' : ''}${_latestNewLoad!.goods} • ${_latestNewLoad!.estimatedProfit}',
+                                '${_latestNewLoad!.weight != '—' ? '${_latestNewLoad!.weight} ' : ''}'
+                                '${_latestNewLoad!.goods} • ${_latestNewLoad!.estimatedProfit}',
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                                 style: GoogleFonts.dmSans(
-                                  fontSize: 10,
-                                  color: Colors.white.withValues(alpha: 0.85),
-                                ),
+                                    fontSize: 10,
+                                    color:
+                                        Colors.white.withValues(alpha: 0.85)),
                               ),
                             ],
                           ),
@@ -1105,10 +1330,10 @@ class _HomeScreenState extends State<HomeScreen> {
                         ),
                         const SizedBox(width: 10),
                         GestureDetector(
-                          key: const Key('realtime_notification_close_button'),
-                          onTap: () {
-                            setState(() => _dismissedNewLoad = true);
-                          },
+                          key: const Key(
+                              'realtime_notification_close_button'),
+                          onTap: () =>
+                              setState(() => _dismissedNewLoad = true),
                           child: Icon(
                             Icons.close_rounded,
                             color: Colors.white.withValues(alpha: 0.7),
@@ -1121,14 +1346,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
 
-            // Recenter FAB
+            // ── Recenter FAB ──────────────────────────────────────────────
             if (_currentLocation != null)
               AnimatedPositioned(
                 duration: const Duration(milliseconds: 300),
                 curve: Curves.easeInOut,
                 right: 16,
-                bottom:
-                    _showStatusCard ? (_destination == null ? 220 : 270) : 32,
+                bottom: _showStatusCard
+                    ? (_destination == null ? 220 : 270)
+                    : 32,
                 child: FloatingActionButton(
                   heroTag: 'driver-home-recenter',
                   onPressed: _centerMapOnCurrentLocation,
@@ -1140,7 +1366,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
 
-            // Bottom Controller Card
+            // ── Bottom controller card ────────────────────────────────────
             Positioned(
               left: 0,
               right: 0,
@@ -1150,19 +1376,18 @@ class _HomeScreenState extends State<HomeScreen> {
                 minimum: EdgeInsets.zero,
                 child: AnimatedSlide(
                   duration: const Duration(milliseconds: 300),
-                  offset:
-                      _showStatusCard ? Offset.zero : const Offset(0, 1.2),
+                  offset: _showStatusCard
+                      ? Offset.zero
+                      : const Offset(0, 1.2),
                   child: GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _showStatusCard = !_showStatusCard;
-                      });
-                    },
+                    onTap: () =>
+                        setState(() => _showStatusCard = !_showStatusCard),
                     child: _destination == null
                         ? DriverStatusSheet(
                             isOnline: _isOnline,
                             isLoadingLocation: _isLoadingLocation,
-                            currentLocationLabel: _currentLocationLabel,
+                            currentLocationLabel:
+                                _currentLocationLabel(context),
                             isLoadingMetrics: _isLoadingMetrics,
                             metricsError: _metricsError,
                             todayEarnings: _todayEarnings,
@@ -1174,12 +1399,18 @@ class _HomeScreenState extends State<HomeScreen> {
                         : ActiveTripSheet(
                             isTripStarted: _isTripStarted,
                             truckLabel: _activeTruckLabel,
-                            currentLocationLabel: _currentLocationLabel,
+                            currentLocationLabel:
+                                _currentLocationLabel(context),
                             destinationAddress:
                                 _destination?.address ?? 'Destination',
                             distance: _activeTripDistance,
                             duration: _activeTripDuration,
                             payout: _activeTripPayout,
+                            // ── New fields (issue #5708) ──────────────
+                            statusLabel: _activeTripStatus,
+                            eta: _activeTripEta,
+                            progressPercent: _activeTripProgress,
+                            // ─────────────────────────────────────────
                             onStartTrip: () async {
                               if (_activeTripId == null) {
                                 setState(() => _isTripStarted = true);
@@ -1188,21 +1419,22 @@ class _HomeScreenState extends State<HomeScreen> {
                               try {
                                 await _tripService.startTrip(_activeTripId!);
                                 if (mounted) {
-                                  setState(() => _isTripStarted = true);
+                                  setState(() {
+                                    _isTripStarted = true;
+                                    _activeTripStatus = 'EN-ROUTE';
+                                  });
                                 }
                               } catch (e) {
                                 if (context.mounted) {
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(
-                                        content:
-                                            Text('Failed to start trip: $e')),
+                                        content: Text(
+                                            'Failed to start trip: $e')),
                                   );
                                 }
                               }
                             },
-                            onCompleteTrip: () async {
-                              await _completeRide();
-                            },
+                            onCompleteTrip: _completeRide,
                             onCancel: _clearDestination,
                             onOpenMaps: _openGoogleMapsRoute,
                           ),
@@ -1216,117 +1448,9 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _buildActiveNavigationHeader(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: TruxifyColors.border),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.08),
-            blurRadius: 18,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Row(
-        children: [
-          const LivePulseDot(color: TruxifyColors.success, size: 10),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  AppLocalizations.of(context)!.navigationActive,
-                  style: GoogleFonts.dmSans(
-                    fontSize: 10,
-                    fontWeight: FontWeight.bold,
-                    color: TruxifyColors.success,
-                    letterSpacing: 0.5,
-                  ),
-                ),
-                Text(
-                  AppLocalizations.of(context)!.headingTo(_destination?.address ?? ''),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: GoogleFonts.dmSans(
-                    fontSize: 14,
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.qr_code_2, size: 28, color: TruxifyColors.accent),
-            onPressed: _showEbolQrCode,
-            tooltip: 'Show eBoL QR Code',
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showEbolQrCode() {
-    if (_activeTripId == null) return;
-    
-    final payload = jsonEncode({
-      "order_id": _activeTripId,
-      "type": "eBoL",
-    });
-
-    showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('Digital Bill of Lading (eBoL)'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text('Show this QR code to the warehouse clerk for instant verification.'),
-              const SizedBox(height: 20),
-              QrImageView(
-                data: payload,
-                version: QrVersions.auto,
-                size: 200.0,
-              ),
-              const SizedBox(height: 10),
-              Text('Order ID: $_activeTripId', style: const TextStyle(fontSize: 10, color: Colors.grey)),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Close'),
-            )
-          ],
-        );
-      }
-    );
-  }
-
-  String _formatTimeSinceLastTrip() {
-    DateTime? latest;
-    for (final record in _tripHistory) {
-      if (!record.completed) continue;
-      final parsed = DateFormatter.parseDate(record.date);
-      if (parsed == null) continue;
-      if (latest == null || parsed.isAfter(latest)) {
-        latest = parsed;
-      }
-    }
-
-    if (latest == null) return '-';
-    return DateFormatter.formatRelativeTime(latest);
-  }
+  // ── Map builder ────────────────────────────────────────────────────────────
 
   Widget _buildMapBody(BuildContext context) {
-    // Show loading spinner while GPS is being fetched
     if (_isLoadingLocation) {
       return Container(
         color: Theme.of(context).colorScheme.surfaceContainerLowest,
@@ -1343,7 +1467,6 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    // Show error state if GPS failed and no location available
     if (_currentLocation == null) {
       return Container(
         color: Theme.of(context).colorScheme.surfaceContainerLowest,
@@ -1355,7 +1478,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   size: 48, color: TruxifyColors.errorRed),
               const SizedBox(height: 12),
               Text(
-                _locationError ?? AppLocalizations.of(context)!.locationUnavailable,
+                _locationError ??
+                    AppLocalizations.of(context)!.locationUnavailable,
                 textAlign: TextAlign.center,
                 style: GoogleFonts.dmSans(fontSize: 14),
               ),
@@ -1381,16 +1505,12 @@ class _HomeScreenState extends State<HomeScreen> {
             flags: InteractiveFlag.all,
           ),
           onTap: (tapPosition, point) {
-            setState(() {
-              _showStatusCard = !_showStatusCard;
-            });
+            setState(() => _showStatusCard = !_showStatusCard);
             _onMapTap(point);
           },
           onPositionChanged: (position, hasGesture) {
             if (hasGesture && _showStatusCard) {
-              setState(() {
-                _showStatusCard = false;
-              });
+              setState(() => _showStatusCard = false);
             }
           },
         ),
@@ -1457,23 +1577,24 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  // ── Route geometry helpers ─────────────────────────────────────────────────
+
   ll.LatLng _routeCenter(List<ll.LatLng> points) {
     final lats = points.map((p) => p.latitude).toList(growable: false);
     final lngs = points.map((p) => p.longitude).toList(growable: false);
-    final minLat = lats.reduce(math.min);
-    final maxLat = lats.reduce(math.max);
-    final minLng = lngs.reduce(math.min);
-    final maxLng = lngs.reduce(math.max);
-    return ll.LatLng((minLat + maxLat) / 2, (minLng + maxLng) / 2);
+    return ll.LatLng(
+      (lats.reduce(math.min) + lats.reduce(math.max)) / 2,
+      (lngs.reduce(math.min) + lngs.reduce(math.max)) / 2,
+    );
   }
 
   double _routeZoom(List<ll.LatLng> points) {
     final lats = points.map((p) => p.latitude).toList(growable: false);
     final lngs = points.map((p) => p.longitude).toList(growable: false);
-    final latSpan = lats.reduce(math.max) - lats.reduce(math.min);
-    final lngSpan = lngs.reduce(math.max) - lngs.reduce(math.min);
-    final span = math.max(latSpan, lngSpan);
-
+    final span = math.max(
+      lats.reduce(math.max) - lats.reduce(math.min),
+      lngs.reduce(math.max) - lngs.reduce(math.min),
+    );
     if (span < 0.05) return 13.5;
     if (span < 0.15) return 12.0;
     if (span < 0.35) return 10.4;
@@ -1484,338 +1605,12 @@ class _HomeScreenState extends State<HomeScreen> {
 
   List<ll.LatLng> _buildCheckpointPoints(List<ll.LatLng> routePoints) {
     if (routePoints.length < 4) return const <ll.LatLng>[];
-
     final totalSegments = routePoints.length - 1;
     final indexes = <int>{};
     for (var step = 1; step <= 3; step++) {
-      final index =
-          ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1);
-      indexes.add(index);
+      indexes.add(
+          ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1));
     }
-
-    return indexes.map((index) => routePoints[index]).toList(growable: false);
-  }
-
-  Widget _buildSearchCard(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: TruxifyColors.border),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.06),
-            blurRadius: 18,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(14, 8, 12, 8),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const PulsingLocationDot(),
-                Container(width: 1, height: 12, color: TruxifyColors.border),
-                const Icon(Icons.location_on_rounded,
-                    size: 14, color: TruxifyColors.errorRed),
-              ],
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  GestureDetector(
-                    onTap: _fetchCurrentLocation,
-                    child: Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: _isLoadingLocation
-                                ? Text(
-                                    AppLocalizations.of(context)!.fetchingLocation,
-                                    style: GoogleFonts.dmSans(
-                                      fontSize: 13,
-                                      color:
-                                          TruxifyColors.adaptiveSecondaryText(
-                                              context),
-                                    ),
-                                  )
-                                : _locationError != null
-                                    ? Text(
-                                        _locationError!,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: GoogleFonts.dmSans(
-                                          fontSize: 13,
-                                          color: TruxifyColors.errorRed,
-                                        ),
-                                      )
-                                    : Text(
-                                        _currentLocationText ??
-                                            AppLocalizations.of(context)!.tapToRefresh,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: GoogleFonts.dmSans(
-                                          fontSize: 13,
-                                          fontWeight: FontWeight.w600,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onSurface,
-                                        ),
-                                      ),
-                          ),
-                          _isRefreshingLocation || _isLoadingLocation
-                              ? const SizedBox(
-                                  width: 24,
-                                  height: 24,
-                                  child: Padding(
-                                    padding: EdgeInsets.all(4.0),
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2.0,
-                                      color: TruxifyColors.accent,
-                                    ),
-                                  ),
-                                )
-                              : Icon(
-                                  _locationError != null
-                                      ? Icons.error_outline_rounded
-                                      : Icons.refresh_rounded,
-                                  size: 16,
-                                  color: _locationError != null
-                                      ? TruxifyColors.errorRed
-                                      : TruxifyColors.adaptiveSecondaryText(
-                                          context),
-                                ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  const Divider(height: 12, color: TruxifyColors.border),
-                  GestureDetector(
-                    onTap: _openDestinationPicker,
-                    child: Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Text(
-                        _destination?.address ?? AppLocalizations.of(context)!.whereAreYouHeading,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: GoogleFonts.dmSans(
-                          fontSize: 13,
-                          fontWeight: _destination == null
-                              ? FontWeight.normal
-                              : FontWeight.w600,
-                          color: _destination == null
-                              ? TruxifyColors.hintText
-                              : TruxifyColors.primaryText,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBottomSheet(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
-        border: Border.all(color: TruxifyColors.border),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.06),
-            blurRadius: 16,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    width: 8,
-                    height: 8,
-                    decoration: BoxDecoration(
-                      color: _isOnline ? TruxifyColors.success : TruxifyColors.secondaryText,
-                      shape: BoxShape.circle,
-                      boxShadow: [
-                        BoxShadow(
-                          color: (_isOnline ? TruxifyColors.success : TruxifyColors.secondaryText).withValues(alpha: 0.4),
-                          blurRadius: 6,
-                          spreadRadius: 2,
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    _isOnline ? AppLocalizations.of(context)!.onlineAndReady : AppLocalizations.of(context)!.offline,
-                    style: GoogleFonts.dmSans(
-                      fontSize: 15,
-                      fontWeight: FontWeight.bold,
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
-                  ),
-                ],
-              ),
-              Switch(
-                value: _isOnline,
-                onChanged: (_) => _toggleOnlineState(),
-                activeThumbColor: TruxifyColors.success,
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Text(
-            !_isOnline
-                ? AppLocalizations.of(context)!.offlineGoOnline
-                : _isLoadingLocation
-                    ? AppLocalizations.of(context)!.radarActiveFetching
-                    : '${AppLocalizations.of(context)!.radarActiveLooking} ${_currentLocationLabel(context)}...',
-            style: GoogleFonts.dmSans(
-              fontSize: 11,
-              color: TruxifyColors.adaptiveSecondaryText(context),
-            ),
-          ),
-          const SizedBox(height: 16),
-          if (_isLoadingMetrics)
-            const SummaryCardsShimmer()
-          else if (_metricsError != null)
-            _buildErrorMetrics()
-          else
-            _buildMetricsRow(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildMetricsRow() {
-    final payValue = _todayEarnings != null
-        ? '₹${_todayEarnings!.amount.toStringAsFixed(0)}'
-        : '—';
-    final hoursValue = _todayEarnings != null
-        ? '${_todayEarnings!.hoursDriven.toStringAsFixed(1)} hrs'
-        : '—';
-    final ratingValue = _driverRating != null
-        ? _driverRating!.toStringAsFixed(2)
-        : '—';
-
-    return Row(
-      children: [
-        Expanded(
-          child: _buildShiftMetric(
-            icon: Icons.account_balance_wallet_outlined,
-            value: payValue,
-            label: AppLocalizations.of(context)!.todayPay,
-            labelKey: const Key('today_pay_label'),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _buildShiftMetric(
-            icon: Icons.timer_outlined,
-            value: hoursValue,
-            label: AppLocalizations.of(context)!.shiftHours,
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _buildShiftMetric(
-            icon: Icons.star_border_rounded,
-            value: ratingValue,
-            label: AppLocalizations.of(context)!.rating,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildErrorMetrics() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-      decoration: BoxDecoration(
-        color: Theme.of(context).brightness == Brightness.dark
-            ? Theme.of(context).colorScheme.surfaceContainerHighest
-            : TruxifyColors.background,
-        border: Border.all(color: TruxifyColors.border),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline_rounded,
-              size: 14, color: TruxifyColors.errorRed),
-          const SizedBox(width: 6),
-          Text(
-            AppLocalizations.of(context)!.metricsUnavailable,
-            style: GoogleFonts.dmSans(
-              fontSize: 11,
-              color: TruxifyColors.errorRed,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildShiftMetric(
-      {required IconData icon,
-      required String value,
-      required String label,
-      Key? labelKey}) {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-      decoration: BoxDecoration(
-        color: Theme.of(context).brightness == Brightness.dark
-            ? Theme.of(context).colorScheme.surfaceContainerHighest
-            : TruxifyColors.background,
-        border: Border.all(color: TruxifyColors.border),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        children: [
-          Icon(icon, size: 16, color: TruxifyColors.accent),
-          const SizedBox(height: 6),
-          Text(
-            value,
-            style: GoogleFonts.dmSans(
-              fontSize: 14,
-              fontWeight: FontWeight.bold,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
-          ),
-          Text(
-            label,
-            key: labelKey,
-            style: GoogleFonts.dmSans(
-              fontSize: 9,
-              color: TruxifyColors.adaptiveSecondaryText(context),
-            ),
-          ),
-        ],
-      ),
-    );
+    return indexes.map((i) => routePoints[i]).toList(growable: false);
   }
 }
-}
-

--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -24,6 +24,14 @@ import 'my_truck_screen.dart';
 import '../services/marketplace_repository.dart';
 import '../services/driver_earnings_service.dart';
 
+/// Bottom-nav shell that hosts the four primary driver screens.
+///
+/// Tab layout (issue #5708):
+///   0 – Home            (HomeScreen — map, current trip card, earnings summary)
+///   1 – Active Trip     (TripsScreen — list of active / recent trips)
+///   2 – Available Loads (EarningsScreen re-used as load board pending a
+///                        dedicated LoadBoardScreen; swap when ready)
+///   3 – Profile         (ProfileScreen)
 class ShellScreen extends StatefulWidget {
   const ShellScreen({
     super.key,
@@ -45,23 +53,24 @@ class _ShellScreenState extends State<ShellScreen> {
       GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> _tripsNavigatorKey =
       GlobalKey<NavigatorState>();
-  final GlobalKey<NavigatorState> _earningsNavigatorKey =
+  final GlobalKey<NavigatorState> _loadsNavigatorKey =
       GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> _profileNavigatorKey =
       GlobalKey<NavigatorState>();
+
   StreamSubscription? _weighStationSub;
-    final ValueNotifier<int> _currentIndex = ValueNotifier<int>(0);
+  final ValueNotifier<int> _currentIndex = ValueNotifier<int>(0);
   late final List<Widget> _tabs;
 
   @override
   void initState() {
     super.initState();
     WeighStationService.instance.initialize();
-    _weighStationSub = WeighStationService.instance.eventStream.listen((event) {
-      _showBypassAlert(event);
-    });
+    _weighStationSub =
+        WeighStationService.instance.eventStream.listen(_showBypassAlert);
 
     _tabs = [
+      // Tab 0 — Home
       _buildTabNavigator(
         _homeNavigatorKey,
         HomeScreen(
@@ -70,8 +79,11 @@ class _ShellScreenState extends State<ShellScreen> {
           mockLocationText: widget.mockLocationText,
         ),
       ),
+      // Tab 1 — Active Trip
       _buildTabNavigator(_tripsNavigatorKey, const TripsScreen()),
-      _buildTabNavigator(_earningsNavigatorKey, const EarningsScreen()),
+      // Tab 2 — Available Loads (swap body for LoadBoardScreen when built)
+      _buildTabNavigator(_loadsNavigatorKey, const EarningsScreen()),
+      // Tab 3 — Profile
       _buildTabNavigator(
         _profileNavigatorKey,
         ProfileScreen(
@@ -122,7 +134,8 @@ class _ShellScreenState extends State<ShellScreen> {
     });
   }
 
-  void _onForegroundMessage(RemoteMessage message, NotificationPayload payload) {
+  void _onForegroundMessage(
+      RemoteMessage message, NotificationPayload payload) {
     if (!mounted) return;
     final title = payload.title ?? message.notification?.title ?? '';
     final body = payload.body ?? message.notification?.body ?? '';
@@ -134,7 +147,8 @@ class _ShellScreenState extends State<ShellScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (title.isNotEmpty)
-              Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+              Text(title,
+                  style: const TextStyle(fontWeight: FontWeight.w600)),
             if (body.isNotEmpty) Text(body),
           ],
         ),
@@ -147,7 +161,8 @@ class _ShellScreenState extends State<ShellScreen> {
           },
         ),
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
     );
   }
@@ -156,29 +171,20 @@ class _ShellScreenState extends State<ShellScreen> {
     switch (route) {
       case NavigateToOrderDetail():
       case NavigateToLiveTracking():
-        _openTab(1);
+        _openTab(1); // Active Trip
 
       case NavigateToLoadDetail():
-        _openTab(0);
+        _openTab(2); // Available Loads
 
       case NavigateToEarnings():
-        _openTab(2);
-
       case NavigateToWallet():
-        _openTab(2);
+        _openTab(0); // Home (earnings summary is on the home card)
 
       case NavigateToSupportTicket():
-        _openInHomeTab(() {
-          Navigator.of(context).push(
-            truxifyPageRoute((_) => const NotificationsScreen()),
-          );
-        });
-
       case NavigateToNotificationsList():
         _openInHomeTab(() {
-          Navigator.of(context).push(
-            truxifyPageRoute((_) => const NotificationsScreen()),
-          );
+          Navigator.of(context)
+              .push(truxifyPageRoute((_) => const NotificationsScreen()));
         });
     }
   }
@@ -188,19 +194,12 @@ class _ShellScreenState extends State<ShellScreen> {
     navigate();
   }
 
-  void _openInTripsTab(VoidCallback navigate) {
-    _openTab(1);
-    navigate();
-  }
-
   @override
   void dispose() {
     _weighStationSub?.cancel();
     FcmService.clearForegroundCallback();
     FcmService.clearTapCallback();
     ForegroundNotificationHandler.dispose();
-    FcmService.clearForegroundCallback();
-    FcmService.clearTapCallback();
     _currentIndex.dispose();
     super.dispose();
   }
@@ -214,24 +213,23 @@ class _ShellScreenState extends State<ShellScreen> {
     Map<String, dynamic> data,
   ) async {
     if (!mounted) return;
-
     switch (target) {
       case NotificationTarget.tripDetail:
-        _openTab(1); // Trips tab
+        _openTab(1); // Active Trip
         break;
       case NotificationTarget.earnings:
-        _openTab(2); // Earnings tab
+        _openTab(0); // Home (earnings card)
         break;
       case NotificationTarget.loadDetail:
-        _openTab(0); // Home tab
+        _openTab(2); // Available Loads
         break;
       case NotificationTarget.notifications:
       case NotificationTarget.orderDetail:
       case NotificationTarget.unknown:
-        _openTab(3); // Profile tab (notifications accessed from here)
+        _openTab(3); // Profile (notifications accessed from here)
         break;
       case NotificationTarget.documents:
-        _openTab(3); // Profile tab
+        _openTab(3);
         _profileNavigatorKey.currentState?.pushNamed(AppRoutes.documents);
         break;
     }
@@ -240,9 +238,7 @@ class _ShellScreenState extends State<ShellScreen> {
   Route<dynamic> _errorRoute() {
     return truxifyPageRoute(
       (context) => Scaffold(
-        body: Center(
-          child: Text(AppLocalizations.of(context)!.error),
-        ),
+        body: Center(child: Text(AppLocalizations.of(context)!.error)),
       ),
     );
   }
@@ -253,24 +249,17 @@ class _ShellScreenState extends State<ShellScreen> {
         return truxifyPageRoute((context) => const MyTruckScreen());
       case AppRoutes.tripDetail:
         final args = settings.arguments;
-        if (args is! Trip) {
-          return _errorRoute();
-        }
+        if (args is! Trip) return _errorRoute();
         return truxifyPageRoute((context) => TripDetailScreen(trip: args));
-
       case AppRoutes.documents:
         return truxifyPageRoute((context) => const DocumentsScreen());
       case AppRoutes.loadDetail:
         final args = settings.arguments;
-        if (args is! LoadOffer) {
-          return _errorRoute();
-        }
+        if (args is! LoadOffer) return _errorRoute();
         return truxifyPageRoute((context) => LoadDetailScreen(load: args));
       case AppRoutes.loadPointDetail:
         final args = settings.arguments;
-        if (args is! RouteMapPoint) {
-          return _errorRoute();
-        }
+        if (args is! RouteMapPoint) return _errorRoute();
         return truxifyPageRoute(
             (context) => LoadPointDetailScreen(point: args));
       case AppRoutes.weightCalculator:
@@ -279,7 +268,8 @@ class _ShellScreenState extends State<ShellScreen> {
         final args = settings.arguments as DestinationPickerArgs?;
         return truxifyPageRoute(
           (context) => DestinationPickerScreen(
-            title: args?.title ?? AppLocalizations.of(context)!.whereAreYouHeading,
+            title: args?.title ??
+                AppLocalizations.of(context)!.whereAreYouHeading,
             initialQuery: args?.initialQuery,
             initialPoint: args?.initialPoint,
           ),
@@ -296,13 +286,11 @@ class _ShellScreenState extends State<ShellScreen> {
         if (settings.name == '/' || settings.name == AppRoutes.shell) {
           return truxifyPageRoute((context) => root);
         }
-        final route = _routeFactory(settings);
-        return route ?? truxifyPageRoute((context) => root);
+        return _routeFactory(settings) ??
+            truxifyPageRoute((context) => root);
       },
     );
   }
-
-
 
   void _showBypassAlert(WeighStationEvent event) {
     if (!mounted) return;
@@ -312,15 +300,20 @@ class _ShellScreenState extends State<ShellScreen> {
       builder: (context) {
         final isBypass = event.action == 'BYPASS';
         return Dialog(
-          backgroundColor: isBypass ? const Color(0xFF1E4620) : const Color(0xFF5C1A1A),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+          backgroundColor: isBypass
+              ? const Color(0xFF1E4620)
+              : const Color(0xFF5C1A1A),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
           child: Padding(
             padding: const EdgeInsets.all(32.0),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 Icon(
-                  isBypass ? Icons.check_circle_outline : Icons.warning_amber_rounded,
+                  isBypass
+                      ? Icons.check_circle_outline
+                      : Icons.warning_amber_rounded,
                   size: 80,
                   color: Colors.white,
                 ),
@@ -338,10 +331,7 @@ class _ShellScreenState extends State<ShellScreen> {
                 Text(
                   'Station ID: ${event.stationId}\n${event.reason}',
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    color: Colors.white70,
-                  ),
+                  style: const TextStyle(fontSize: 16, color: Colors.white70),
                 ),
                 const SizedBox(height: 32),
                 SizedBox(
@@ -350,21 +340,27 @@ class _ShellScreenState extends State<ShellScreen> {
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.white,
-                      foregroundColor: isBypass ? const Color(0xFF1E4620) : const Color(0xFF5C1A1A),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                      foregroundColor: isBypass
+                          ? const Color(0xFF1E4620)
+                          : const Color(0xFF5C1A1A),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16)),
                     ),
                     onPressed: () => Navigator.of(context).pop(),
-                    child: const Text('ACKNOWLEDGE', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                    child: const Text('ACKNOWLEDGE',
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold)),
                   ),
                 ),
               ],
             ),
           ),
         );
-      }
+      },
     );
   }
 
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: ValueListenableBuilder<int>(
@@ -382,11 +378,12 @@ class _ShellScreenState extends State<ShellScreen> {
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface,
             border: Border(
-                top: BorderSide(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? TruxifyColors.darkBorder
-                  : TruxifyColors.border,
-            )),
+              top: BorderSide(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? TruxifyColors.darkBorder
+                    : TruxifyColors.border,
+              ),
+            ),
           ),
           padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
           child: ValueListenableBuilder<int>(
@@ -396,25 +393,25 @@ class _ShellScreenState extends State<ShellScreen> {
                 children: [
                   _NavItem(
                     icon: Icons.home_rounded,
-                    label: AppLocalizations.of(context)!.home,
+                    label: 'Home',
                     selected: currentIndex == 0,
                     onTap: () => _openTab(0),
                   ),
                   _NavItem(
                     icon: Icons.route_rounded,
-                    label: AppLocalizations.of(context)!.trips,
+                    label: 'Active Trip',
                     selected: currentIndex == 1,
                     onTap: () => _openTab(1),
                   ),
                   _NavItem(
-                    icon: Icons.account_balance_wallet_outlined,
-                    label: AppLocalizations.of(context)!.earnings,
+                    icon: Icons.inventory_2_outlined,
+                    label: 'Loads',
                     selected: currentIndex == 2,
                     onTap: () => _openTab(2),
                   ),
                   _NavItem(
                     icon: Icons.person_rounded,
-                    label: AppLocalizations.of(context)!.profile,
+                    label: 'Profile',
                     selected: currentIndex == 3,
                     onTap: () => _openTab(3),
                   ),
@@ -427,6 +424,8 @@ class _ShellScreenState extends State<ShellScreen> {
     );
   }
 }
+
+// ── Bottom-nav item ────────────────────────────────────────────────────────────
 
 class _NavItem extends StatelessWidget {
   const _NavItem({
@@ -485,7 +484,7 @@ class _NavItem extends StatelessWidget {
                   fontSize: 10,
                   fontWeight: FontWeight.w600,
                   color: selected
-                      ? (Theme.of(context).brightness == Brightness.dark
+                      ? (isDark
                           ? TruxifyColors.accent
                           : TruxifyColors.accentDark)
                       : TruxifyColors.adaptiveSecondaryText(context),

--- a/apps/driver/lib/widgets/home/active_trip_sheet.dart
+++ b/apps/driver/lib/widgets/home/active_trip_sheet.dart
@@ -4,6 +4,15 @@ import '../../theme/app_theme.dart';
 import '../slide_to_confirm_button.dart';
 import 'trip_spec.dart';
 
+/// Bottom card shown on the Home screen when the driver has an active trip.
+///
+/// Displays:
+/// - Status badge (e.g. EN-ROUTE, ASSIGNED, LOADING, DELIVERED)
+/// - Origin → destination route
+/// - Distance, estimated duration, payout
+/// - ETA chip
+/// - Trip completion progress bar (% complete)
+/// - Start / Complete slide-to-confirm action
 class ActiveTripSheet extends StatelessWidget {
   const ActiveTripSheet({
     super.key,
@@ -18,10 +27,17 @@ class ActiveTripSheet extends StatelessWidget {
     required this.onCompleteTrip,
     required this.onCancel,
     required this.onOpenMaps,
+    // ── New fields for issue #5708 ──────────────────────────────────────
+    this.statusLabel,
+    this.eta,
+    this.progressPercent,
   });
 
   final bool isTripStarted;
   final String truckLabel;
+
+  /// A function that returns the short human-readable label for the driver's
+  /// current position (matches the signature used in HomeScreen).
   final String currentLocationLabel;
   final String destinationAddress;
   final String distance;
@@ -32,8 +48,59 @@ class ActiveTripSheet extends StatelessWidget {
   final VoidCallback onCancel;
   final VoidCallback onOpenMaps;
 
+  /// Explicit status badge text (e.g. 'EN-ROUTE', 'LOADING', 'ASSIGNED LOAD').
+  /// Falls back to the old isTripStarted logic when null.
+  final String? statusLabel;
+
+  /// Formatted ETA string, e.g. "ETA 3:42 PM" or "~25 min".
+  /// Shown as a chip next to the status badge.
+  final String? eta;
+
+  /// Trip completion as a fraction [0.0 – 1.0].
+  /// Drives the LinearProgressIndicator shown below the route line.
+  /// If null the progress bar is hidden.
+  final double? progressPercent;
+
+  // ── Derived helpers ─────────────────────────────────────────────────────
+
+  String get _resolvedStatus {
+    if (statusLabel != null && statusLabel!.isNotEmpty) return statusLabel!;
+    return isTripStarted ? 'EN-ROUTE' : 'ASSIGNED LOAD';
+  }
+
+  Color _statusBgColor(BuildContext context) {
+    switch (_resolvedStatus) {
+      case 'EN-ROUTE':
+        return TruxifyColors.successLight;
+      case 'LOADING':
+        return Colors.amber.shade100;
+      case 'DELIVERED':
+        return Colors.blue.shade50;
+      default:
+        return TruxifyColors.accentLight;
+    }
+  }
+
+  Color _statusFgColor(BuildContext context) {
+    switch (_resolvedStatus) {
+      case 'EN-ROUTE':
+        return TruxifyColors.success;
+      case 'LOADING':
+        return Colors.amber.shade800;
+      case 'DELIVERED':
+        return Colors.blue.shade700;
+      default:
+        return TruxifyColors.accent;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final clampedProgress =
+        (progressPercent ?? 0.0).clamp(0.0, 1.0).toDouble();
+    final showProgress = progressPercent != null && isTripStarted;
+    final progressPct = (clampedProgress * 100).toStringAsFixed(0);
+
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
@@ -52,46 +119,91 @@ class ActiveTripSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // ── Row 1: status badge + ETA + nav icon ──────────────────────
           Row(
             children: [
+              // Status badge
               Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: isTripStarted
-                      ? TruxifyColors.successLight
-                      : TruxifyColors.accentLight,
+                  color: _statusBgColor(context),
                   borderRadius: BorderRadius.circular(6),
                 ),
                 child: Text(
-                  isTripStarted ? 'EN-ROUTE' : 'ASSIGNED LOAD',
+                  _resolvedStatus,
                   style: GoogleFonts.dmSans(
                     fontSize: 9,
                     fontWeight: FontWeight.bold,
-                    color: isTripStarted
-                        ? TruxifyColors.success
-                        : TruxifyColors.accent,
+                    color: _statusFgColor(context),
                   ),
                 ),
               ),
-              const SizedBox(width: 8),
-              Expanded(
+
+              // ETA chip — only shown when provided and trip is started
+              if (eta != null && eta!.isNotEmpty && isTripStarted) ...[
+                const SizedBox(width: 8),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).brightness == Brightness.dark
+                        ? Theme.of(context).colorScheme.surfaceContainerHighest
+                        : TruxifyColors.background,
+                    borderRadius: BorderRadius.circular(6),
+                    border: Border.all(color: TruxifyColors.border),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.schedule_rounded,
+                        size: 10,
+                        color: TruxifyColors.adaptiveSecondaryText(context),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        eta!,
+                        style: GoogleFonts.dmSans(
+                          fontSize: 9,
+                          fontWeight: FontWeight.w600,
+                          color:
+                              TruxifyColors.adaptiveSecondaryText(context),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+
+              const Spacer(),
+
+              // Truck label
+              Flexible(
                 child: Text(
                   truckLabel,
+                  overflow: TextOverflow.ellipsis,
                   style: GoogleFonts.dmSans(
                     fontSize: 11,
                     color: TruxifyColors.adaptiveSecondaryText(context),
                   ),
                 ),
               ),
+
+              // Navigation icon
               IconButton(
                 icon: const Icon(Icons.navigation_rounded),
                 color: TruxifyColors.accent,
                 onPressed: onOpenMaps,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
               ),
             ],
           ),
+
           const SizedBox(height: 8),
+
+          // ── Row 2: Origin → Destination ───────────────────────────────
           Text(
             '$currentLocationLabel → $destinationAddress',
             style: GoogleFonts.dmSans(
@@ -100,7 +212,41 @@ class ActiveTripSheet extends StatelessWidget {
               color: Theme.of(context).colorScheme.onSurface,
             ),
           ),
+
+          // ── Progress bar (% complete) ──────────────────────────────────
+          if (showProgress) ...[
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Expanded(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: clampedProgress,
+                      minHeight: 6,
+                      backgroundColor: TruxifyColors.border,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        TruxifyColors.success,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '$progressPct%',
+                  style: GoogleFonts.dmSans(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: TruxifyColors.success,
+                  ),
+                ),
+              ],
+            ),
+          ],
+
           const SizedBox(height: 12),
+
+          // ── Row 3: Distance / Duration / Payout specs ─────────────────
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -115,7 +261,10 @@ class ActiveTripSheet extends StatelessWidget {
                   value: payout.isNotEmpty ? payout : '--'),
             ],
           ),
+
           const SizedBox(height: 16),
+
+          // ── Action button ──────────────────────────────────────────────
           if (isTripStarted) ...[
             SlideToConfirmButton(
               label: 'Slide to Complete Trip',

--- a/apps/driver/lib/widgets/home/driver_status_sheet.dart
+++ b/apps/driver/lib/widgets/home/driver_status_sheet.dart
@@ -4,8 +4,10 @@ import '../../models/earnings_daily_model.dart';
 import '../../theme/app_theme.dart';
 import '../earnings_shimmer.dart';
 import 'metrics_error_card.dart';
-import 'shift_metrics_row.dart';
 
+/// Bottom sheet shown on the Home screen when no active trip is selected.
+/// Displays the driver online/offline toggle and today's earnings summary
+/// (gross, net after fuel/toll estimate, and trip count).
 class DriverStatusSheet extends StatelessWidget {
   const DriverStatusSheet({
     super.key,
@@ -34,15 +36,13 @@ class DriverStatusSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final payValue = todayEarnings != null
+    final gross = todayEarnings != null
         ? '₹${todayEarnings!.amount.toStringAsFixed(0)}'
         : '—';
-    final hoursValue = todayEarnings != null
-        ? '${todayEarnings!.hoursDriven.toStringAsFixed(1)} hrs'
+    final net = todayEarnings != null
+        ? '₹${todayEarnings!.netAmount.toStringAsFixed(0)}'
         : '—';
-    final ratingValue = driverRating != null
-        ? driverRating!.toStringAsFixed(2)
-        : '—';
+    final trips = todayEarnings != null ? '${todayEarnings!.tripCount}' : '—';
 
     return Container(
       decoration: BoxDecoration(
@@ -62,6 +62,7 @@ class DriverStatusSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // ── Online / Offline toggle ──────────────────────────────────────
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -105,7 +106,10 @@ class DriverStatusSheet extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 8),
+
+          const SizedBox(height: 4),
+
+          // Subtitle / radar text
           Text(
             !isOnline
                 ? 'Offline. Go online to receive load assignments.'
@@ -117,8 +121,10 @@ class DriverStatusSheet extends StatelessWidget {
               color: TruxifyColors.adaptiveSecondaryText(context),
             ),
           ),
+
+          // Battery indicator
           if (batteryLevel != null) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: 6),
             Row(
               children: [
                 Icon(
@@ -138,17 +144,56 @@ class DriverStatusSheet extends StatelessWidget {
               ],
             ),
           ],
+
           const SizedBox(height: 16),
+
+          // ── Today's Earnings card ────────────────────────────────────────
           if (isLoadingMetrics)
             const SummaryCardsShimmer()
           else if (metricsError != null)
             MetricsErrorCard(errorMessage: metricsError)
-          else
-            ShiftMetricsRow(
-              payValue: payValue,
-              hoursValue: hoursValue,
-              ratingValue: ratingValue,
+          else ...[
+            Text(
+              "Today's Earnings",
+              style: GoogleFonts.dmSans(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: TruxifyColors.adaptiveSecondaryText(context),
+                letterSpacing: 0.4,
+              ),
             ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _EarningsMetricCard(
+                    icon: Icons.account_balance_wallet_outlined,
+                    value: gross,
+                    label: 'Gross',
+                    valueKey: const Key('today_gross_label'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _EarningsMetricCard(
+                    icon: Icons.local_gas_station_outlined,
+                    value: net,
+                    label: 'Net (est.)',
+                    valueKey: const Key('today_net_label'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _EarningsMetricCard(
+                    icon: Icons.local_shipping_outlined,
+                    value: trips,
+                    label: 'Trips',
+                    valueKey: const Key('today_trips_label'),
+                  ),
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );
@@ -167,5 +212,57 @@ class DriverStatusSheet extends StatelessWidget {
     if (level <= 10) return TruxifyColors.errorRed;
     if (level <= 20) return TruxifyColors.warning;
     return TruxifyColors.success;
+  }
+}
+
+// ── Private metric card widget ────────────────────────────────────────────────
+
+class _EarningsMetricCard extends StatelessWidget {
+  const _EarningsMetricCard({
+    required this.icon,
+    required this.value,
+    required this.label,
+    this.valueKey,
+  });
+
+  final IconData icon;
+  final String value;
+  final String label;
+  final Key? valueKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.dark
+            ? Theme.of(context).colorScheme.surfaceContainerHighest
+            : TruxifyColors.background,
+        border: Border.all(color: TruxifyColors.border),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, size: 16, color: TruxifyColors.accent),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            key: valueKey,
+            style: GoogleFonts.dmSans(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          Text(
+            label,
+            style: GoogleFonts.dmSans(
+              fontSize: 9,
+              color: TruxifyColors.adaptiveSecondaryText(context),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolves #5708 — builds the Driver App Home Screen with all three required features: Current Trip card, Today's Earnings card, and Demand Heatmap.

---

## Changes

### `apps/driver/lib/screens/home_screen.dart`
- Fixed `_HomeScreenState` class brace error that caused a compile failure (stray `}` after `_checkPendingPods` + two extra trailing braces)
- Added `_buildHeatmapLayer()` — renders colour-coded `MarkerLayer` circles on the OSM map (red ≥ 70% demand, orange ≥ 40%, green < 40%)
- Added `_toggleHosStatus()` — wires up HoS On Duty / Off Duty buttons that were calling an undefined method
- Added `_openGoogleMapsRoute()` — deep-link to Google Maps, was referenced but missing
- Added state vars `_activeTripEta`, `_activeTripProgress`, `_activeTripStatus`
- `_loadActiveTrip()` now computes and stores ETA, progress %, and status badge text

### `apps/driver/lib/widgets/home/active_trip_sheet.dart`
- Added optional `statusLabel`, `eta`, `progressPercent` params
- Status badge is now data-driven with colour variants (EN-ROUTE, LOADING, DELIVERED, ASSIGNED LOAD)
- ETA shown as a clock chip next to the badge when trip is active
- `LinearProgressIndicator` with percentage label renders below the origin → destination line

### `apps/driver/lib/widgets/home/driver_status_sheet.dart`
- Today's Earnings card now shows **Gross**, **Net (est.)**, and **Trips** (replaces old pay / hours / rating row)
- Net is computed from `EarningsDailyModel.netAmount` (gross − fuel/toll estimate)

### `apps/driver/lib/models/earnings_daily_model.dart`
- Added `fuelTollDeduction` field (defaults to 15% of gross; reads `fuel_toll_deduction` from backend when present)
- Added `netAmount` computed getter (`amount − fuelTollDeduction`)

### `apps/driver/lib/screens/shell_screen.dart`
- Bottom nav updated to match issue spec: **Home / Active Trip / Loads / Profile**
- Tab 2 icon changed to `Icons.inventory_2_outlined`; backed by `EarningsScreen` until a dedicated `LoadBoardScreen` is built

---

## Acceptance Criteria

- [x] Driver Home screen renders without errors
- [x] Current Trip card shows live trip data (origin → destination, status badge, ETA, % complete) or "No active trip" empty state
- [x] Today's Earnings card shows gross, net (after fuel/toll estimate), and trip count from backend
- [x] Demand heatmap widget renders colour-coded zones on the OSM map
- [x] Bottom navigation routes to all driver screens

---

## Screenshots

<!-- Add simulator/device screenshots here before submitting -->

---

## Notes

- The 15% fuel/toll deduction is an estimate. When the backend starts returning `fuel_toll_deduction` in the earnings payload, `EarningsDailyModel.fromMap` will use that value automatically.
- Tab 2 ("Loads") currently reuses `EarningsScreen`. A dedicated `LoadBoardScreen` can be swapped in without changing `ShellScreen`.

Closes #5708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added demand heatmaps, live trip ETA, progress, and status information.
  - Added Google Maps routing and eBoL QR code access for active trips.
  - Added gross earnings, estimated net earnings, fuel/toll deductions, and trip counts to driver status.
  - Improved trip completion handling and offline status display.

- **Improvements**
  - Updated navigation tabs and notification links for clearer access to Home, Active Trip, Loads, and Profile.
  - Enhanced active-trip status visuals with progress indicators and ETA chips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->