### PR TITLE
fix: add proof replay protection and zero-amount guard to withdrawFromL2 (#6007)

### DIFF
--- a/blockchain/contracts/zkEVMBridge.sol
+++ b/blockchain/contracts/zkEVMBridge.sol
@@ -36,19 +36,28 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
         emit BridgeDeposit(msg.sender, amount, bridgeFee);
     }
 
-    function withdrawFromL2(
-        uint256 amount,
-        bytes calldata proof
-    ) external nonReentrant {
-        require(proof.length > 0, "Empty proof");
-        require(depositedAmount[msg.sender] >= amount, "Exceeds deposited amount");
-        // Withdraw from L2
-        zkEVM.withdrawFromL2(amount, proof);
-        depositedAmount[msg.sender] -= amount;
-        pendingWithdrawals[msg.sender] += amount;
+    mapping(bytes32 => bool) public usedProofs;
 
-        emit BridgeWithdraw(msg.sender, amount);
-    }
+function withdrawFromL2(
+    uint256 amount,
+    bytes calldata proof
+) external nonReentrant {
+    require(proof.length > 0, "Empty proof");
+    require(amount > 0, "Amount must be > 0");
+    require(depositedAmount[msg.sender] >= amount, "Exceeds deposited amount");
+
+    bytes32 proofHash = keccak256(proof);
+    require(!usedProofs[proofHash], "Proof already used");
+    usedProofs[proofHash] = true;
+
+    // Withdraw from L2 — proof is verified inside zkEVM.withdrawFromL2
+    zkEVM.withdrawFromL2(amount, proof);
+
+    depositedAmount[msg.sender] -= amount;
+    pendingWithdrawals[msg.sender] += amount;
+
+    emit BridgeWithdraw(msg.sender, amount);
+}
 
     function claimWithdrawal() external nonReentrant {
         uint256 amount = pendingWithdrawals[msg.sender];


### PR DESCRIPTION

## Description
withdrawFromL2 had no proof replay protection, meaning the same proof could be submitted multiple times to repeatedly claim the same L2 withdrawal. Added a usedProofs mapping keyed by keccak256(proof) that marks each proof as consumed on first use and reverts on any subsequent attempt. Also added an amount > 0 guard to prevent zero-value drain calls. The existing depositedAmount accounting already prevents withdrawing more than deposited, so combined with these fixes the bridge can no longer be drained via proof replay or zero-amount abuse.

## Type of Change
<!-- Select all that apply: -->
- [x] Bug fix (non-breaking change fixing an issue)


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- **Test Commands:**
npx hardhat test
- **Test Steps / Prerequisites:**
1. Deposit ETH to the bridge
2. Call withdrawFromL2 with a valid proof — should succeed
3. Call withdrawFromL2 again with the same proof — should revert with Proof already used
4. Call withdrawFromL2 with amount = 0 — should revert with Amount must be > 0
5. Call withdrawFromL2 with amount > depositedAmount — should revert with Exceeds deposited amount
6. Call claimWithdrawal — should transfer correct amount to caller

- **Expected Result:**
Each proof can only be used once. Zero-amount calls are rejected. Withdrawal amount is always bounded by what the caller deposited. Bridge balance cannot be drained via replay or zero-value abuse.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
<!-- Link the issue(s) resolved or referenced by this PR. -->
<!-- Examples: Closes #1234, Related to #5678 -->
Closes 6007

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

