### PR TITLE
fix(api): convert earnings router to ESM import to fix boot crash

### DIFF
--- a/backend/api/routes/earnings.js
+++ b/backend/api/routes/earnings.js
@@ -1,4 +1,4 @@
-const express = require('express');
+import express from 'express';
 const router = express.Router();
 
 // Helper: returns start of period (defaults to current month)
@@ -80,4 +80,4 @@ router.get('/summary', async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -85,6 +85,7 @@ import wasiRoutes from '../../wasi/routes.js'
 import wasmRoutes from '../../wasm/routes.js'
 import snykRoutes from '../../snyk/routes.js'
 import liquibaseRoutes from '../../database/liquibase/routes.js'
+import earningsRouter from '../routes/earnings.js'
 import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 
 // ============================================================================
@@ -358,7 +359,6 @@ if (process.env.NODE_ENV === 'production') {
   })
 }
 
-const earningsRouter = require('../routes/earnings');
 app.use('/api/earnings', earningsRouter);
 
 // Payload parsers


### PR DESCRIPTION
## Problem

`backend/api/src/index.js` is an ES module (`"type": "module"`), but line 361 called `require('../routes/earnings')`. Since `backend/api/routes/earnings.js` also lives under the `"type": "module"` package scope and uses CommonJS (`require`/`module.exports`), the API crashes at boot with `ERR_REQUIRE_ESM`/`ReferenceError: module is not defined` — every deployment that starts `node src/index.js` dies immediately.

## Fix

- `backend/api/routes/earnings.js`: converted to ESM (`import express from 'express'`, `export default router`).
- `backend/api/src/index.js`: replaced the `require('../routes/earnings')` call with a static `import earningsRouter from '../routes/earnings.js'` alongside the other route imports, and kept the `/api/earnings` registration.

## Files changed

- `backend/api/routes/earnings.js`
- `backend/api/src/index.js`

## Testing

- `node --check backend/api/src/index.js` and `node --check backend/api/routes/earnings.js` pass (both parsed as ES modules).
- `npm test` (vitest) continues to pass.

Closes #6001
