### PR TITLE
fix(api): start escrow release/funding reconciliation workers

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -640,6 +640,8 @@ server.listen(PORT, () => {
 
 
   startEscrowRefundReconciliation(orderRepository)
+  startEscrowReleaseReconciliation()
+  startEscrowFundingReconciliation(orderRepository)
   startReputationReconciliation(orderRepository)
   startDlqWorker()
   startStaleOrderWorker()
@@ -648,6 +650,8 @@ server.listen(PORT, () => {
   // Register worker states for health aggregation
   globalThis.__truxify_workers = {
     escrowRefundReconciliation: true,
+    escrowReleaseReconciliation: true,
+    escrowFundingReconciliation: true,
     reputationReconciliation: true,
     dlqWorker: true,
     staleOrderWorker: true,
@@ -677,6 +681,7 @@ async function shutdown (signal) {
   // Stop background workers
   stopEscrowReleaseReconciliation()
   stopEscrowRefundReconciliation()
+  stopEscrowFundingReconciliation()
   stopReputationReconciliation()
   stopDlqWorker()
   stopDocumentExpiryWorker()


### PR DESCRIPTION
## Problem

`backend/api/src/index.js` imports `startEscrowReleaseReconciliation` / `stopEscrowReleaseReconciliation` (line 28) and `startEscrowFundingReconciliation` / `stopEscrowFundingReconciliation` (lines 121–124), and already calls `stopEscrowReleaseReconciliation()` during graceful shutdown (line 678), but **never starts** either worker. The funding/release reconciliation loops are dead code: stale funding and pending escrow releases are never reconciled, and the shutdown path is unbalanced (a stop without a matching start).

## Fix

- On startup (inside the `server.listen` callback), call `startEscrowReleaseReconciliation()` and `startEscrowFundingReconciliation(orderRepository)` alongside the existing `startEscrowRefundReconciliation(orderRepository)`.
- Register both workers in `globalThis.__truxify_workers` so the health aggregation reflects them.
- In `shutdown()`, add the missing `stopEscrowFundingReconciliation()` so both workers are torn down cleanly.

## Files changed

- `backend/api/src/index.js`

## Testing

- `node --check backend/api/src/index.js` passes.
- `npm test` (vitest) continues to pass.

Closes #6002
