### PR TITLE
fix(api): make acquireLock fail closed when Redis is unavailable

### DIFF
--- a/backend/api/src/lib/redisLock.js
+++ b/backend/api/src/lib/redisLock.js
@@ -19,12 +19,13 @@ export class LockAcquisitionError extends Error {
  * Acquires a distributed lock using Redis.
  * @param {string} resourceKey - The unique key identifying the resource to lock (e.g. `escrow_lock:123`)
  * @param {number} ttlMs - Time to live in milliseconds
- * @returns {Promise<string|null>} lockValue if acquired, null if not acquired or Redis unavailable
+ * @returns {Promise<string|null>} lockValue if acquired, null if the lock is held by another process
+ * @throws {LockAcquisitionError} when the lock cannot be acquired due to Redis being unavailable,
+ *  so callers fail closed instead of proceeding without mutual exclusion
  */
 export async function acquireLock(resourceKey, ttlMs = 10000) {
   if (!redisClient) {
-    logger.warn('[RedisLock] redisClient not available, cannot acquire lock for', resourceKey);
-    return null;
+    throw new LockAcquisitionError(resourceKey, 'redisClient is not available');
   }
 
   const lockValue = crypto.randomUUID();
@@ -36,7 +37,7 @@ export async function acquireLock(resourceKey, ttlMs = 10000) {
     return null;
   } catch (err) {
     logger.error({ err }, '[RedisLock] Error acquiring lock for key', resourceKey);
-    return null;
+    throw new LockAcquisitionError(resourceKey, err.message);
   }
 }
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1392,7 +1392,15 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
   const { txHash } = req.body;
 
   const lockKey = `escrow_lock:${orderId}`;
-  const lockValue = await acquireLock(lockKey, 120000);
+  let lockValue;
+  try {
+    lockValue = await acquireLock(lockKey, 120000);
+  } catch (err) {
+    if (err?.name === 'LockAcquisitionError') {
+      return res.status(503).json({ error: 'Lock service is unavailable. Please retry.' });
+    }
+    throw err;
+  }
   if (!lockValue) {
     return res.status(409).json({ error: 'Another deposit confirmation is in progress for this order. Please try again.' });
   }

--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -2,10 +2,10 @@
  * Unit tests for backend/api/src/lib/redisLock.js
  *
  * Coverage:
- *   - acquireLock: returns null when redisClient is unavailable (no fake locks)
+ *   - acquireLock: throws LockAcquisitionError when redisClient is unavailable (fail closed)
  *   - acquireLock: returns a lock value when lock is successfully acquired
  *   - acquireLock: returns null when lock is already held by another process
- *   - acquireLock: returns null and logs error when redisClient.set throws
+ *   - acquireLock: throws LockAcquisitionError when redisClient.set throws (fail closed)
  *   - acquireLock: uses default TTL of 10000ms when ttlMs is not provided
  *   - renewLock: returns false when redisClient is unavailable
  *   - renewLock: returns false when lockValue is null or undefined
@@ -67,13 +67,8 @@ describe('redisLock — acquireLock', () => {
     vi.clearAllMocks();
   });
 
-  it('returns null when redisClient is unavailable (no fake lock)', async () => {
-    const result = await acquireLock('resource-1', 5000);
-    expect(result).toBeNull();
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      '[RedisLock] redisClient not available, cannot acquire lock for',
-      'resource-1'
-    );
+  it('throws LockAcquisitionError when redisClient is unavailable (fail closed)', async () => {
+    await expect(acquireLock('resource-1', 5000)).rejects.toThrow(LockAcquisitionError);
   });
 
   it('returns a lock value when lock is successfully acquired', async () => {
@@ -95,10 +90,9 @@ describe('redisLock — acquireLock', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null and logs error when redisClient.set throws', async () => {
+  it('throws LockAcquisitionError when redisClient.set throws (fail closed)', async () => {
     mockRedisClient.set.mockRejectedValueOnce(new Error('Redis connection lost'));
-    const result = await acquireLock('resource-error', 10000);
-    expect(result).toBeNull();
+    await expect(acquireLock('resource-error', 10000)).rejects.toThrow(LockAcquisitionError);
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       '[RedisLock] Error acquiring lock for key',


### PR DESCRIPTION
## Problem

`acquireLock` in `backend/api/src/lib/redisLock.js` returned `null` when Redis was unavailable or when the `SET NX` call threw. Callers interpret `null` as "the lock is held by another process" and skip the protected operation or return `409` — so when Redis goes down the system **fails open**: reconciliation workers skip healing work and lock-protected operations proceed without mutual exclusion. The `LockAcquisitionError` class already existed but was never thrown.

## Fix

- `acquireLock` now throws `LockAcquisitionError` when `redisClient` is unavailable or the Redis call errors (fail closed). It still returns `null` only for genuine contention (`SET NX` returns nothing when another process holds the lock), preserving the existing `409`/"already being processed" semantics.
- Guarded the one call site that invoked `acquireLock` outside a `try` block (`orderRoutes.js` `/confirm-deposit`), returning `503` when the lock service is unavailable. All other callers already propagate the error through their existing `try/catch` to the error handler (fail-closed `500`) or log-and-skip inside their reconciliation loop guards.
- Updated `test/unit/redisLock.test.js` to assert the new fail-closed behavior (throws `LockAcquisitionError` when Redis is unavailable or `set` throws).

## Files changed

- `backend/api/src/lib/redisLock.js`
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/unit/redisLock.test.js`

## Testing

- `npx vitest run test/unit/redisLock.test.js` — 18/18 pass.
- `node --check` on both modified source files passes.

Closes #6003
