### PR TITLE
fix(database): require admin auth for liquibase migrate/rollback

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -101,6 +101,9 @@ const POLICIES = {
   'webrtc:view-nearby':        { roles: [ROLES.DRIVER, ROLES.ADMIN] },
   'webrtc:view-offline':       { roles: [ROLES.DRIVER, ROLES.ADMIN] },
   'webrtc:sync-offline':       { roles: [ROLES.DRIVER, ROLES.ADMIN] },
+
+  'liquibase:migrate':         { roles: [ROLES.ADMIN] },
+  'liquibase:rollback':        { roles: [ROLES.ADMIN] },
 };
 
 export class PolicyEngine {

--- a/backend/api/test/unit/policyEngine.test.js
+++ b/backend/api/test/unit/policyEngine.test.js
@@ -137,6 +137,14 @@ describe('PolicyEngine', () => {
         expect(() => policy.authorize(user('admin'), 'admin:invalidate-cache')).not.toThrow();
       });
 
+      it('allows admin to run liquibase migrations', () => {
+        expect(() => policy.authorize(user('admin'), 'liquibase:migrate')).not.toThrow();
+      });
+
+      it('allows admin to roll back liquibase migrations', () => {
+        expect(() => policy.authorize(user('admin'), 'liquibase:rollback')).not.toThrow();
+      });
+
       it('allows admin to view any order', () => {
         const order = { customer_id: 'other-user', driver_id: null };
         expect(() => policy.authorize(user('admin'), 'order:view', { order })).not.toThrow();
@@ -166,6 +174,14 @@ describe('PolicyEngine', () => {
 
       it('denies customer viewing admin dashboard', () => {
         expect(() => policy.authorize(user('customer'), 'admin:view-dashboard')).toThrow(PolicyError);
+      });
+
+      it('denies customer running liquibase migrations', () => {
+        expect(() => policy.authorize(user('customer'), 'liquibase:migrate')).toThrow(PolicyError);
+      });
+
+      it('denies driver rolling back liquibase migrations', () => {
+        expect(() => policy.authorize(user('driver'), 'liquibase:rollback')).toThrow(PolicyError);
       });
 
       it('denies driver viewing admin dashboard', () => {

--- a/database/liquibase/routes.js
+++ b/database/liquibase/routes.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import liquibaseService from './liquibase.service.js';
 import logger from '../../backend/api/src/middleware/logger.js';
+import { authenticate } from '../../backend/api/src/middleware/auth.js';
+import { requirePolicy } from '../../backend/api/src/middleware/requirePolicy.js';
 
 const router = express.Router();
 
-// Run migrations
-router.post('/liquibase/migrate', async (req, res) => {
+// Run migrations (admin only)
+router.post('/liquibase/migrate', authenticate, requirePolicy('liquibase:migrate'), async (req, res) => {
     try {
         const result = await liquibaseService.runMigrations();
         res.json({
@@ -19,8 +21,8 @@ router.post('/liquibase/migrate', async (req, res) => {
     }
 });
 
-// Rollback migrations
-router.post('/liquibase/rollback', async (req, res) => {
+// Rollback migrations (admin only)
+router.post('/liquibase/rollback', authenticate, requirePolicy('liquibase:rollback'), async (req, res) => {
     try {
         const { count } = req.body;
         const result = await liquibaseService.rollback(count || 1);


### PR DESCRIPTION
## Problem

`database/liquibase/routes.js` exposes `POST /api/liquibase/migrate` and `POST /api/liquibase/rollback` without any authentication. Anyone who can reach the API can run or roll back database migrations — a schema-destroying privilege escalation.

## Fix

- Added `liquibase:migrate` and `liquibase:rollback` policy actions restricted to the `admin` role in `backend/api/src/security/policyEngine.js`.
- Protected the `/liquibase/migrate` and `/liquibase/rollback` routes with `authenticate` + `requirePolicy('liquibase:migrate')` / `requirePolicy('liquibase:rollback')`, matching the policy-based authorization used across the rest of the API.
- Added unit tests for the new admin-only actions (allow admin / deny customer / deny driver).

## Files changed

- `backend/api/src/security/policyEngine.js`
- `backend/api/test/unit/policyEngine.test.js`
- `database/liquibase/routes.js`

## Testing

- `npx vitest run test/unit/policyEngine.test.js` — 55/55 pass.
- `node --check` on `database/liquibase/routes.js` passes.

Closes #6004
