### PR TITLE
fix(docker): require auth for prod redis and mongo

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -154,6 +154,8 @@ services:
       - .env
     environment:
       MONGO_INITDB_DATABASE: truxify_telemetry
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:?MONGO_ROOT_USER is required}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?MONGO_ROOT_PASSWORD is required}
     ports:
       - "${MONGO_PORT:-127.0.0.1:27017}:27017"
     volumes:
@@ -175,7 +177,7 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongosh", "--quiet", "--username", "${MONGO_ROOT_USER}", "--password", "${MONGO_ROOT_PASSWORD}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -206,7 +208,7 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -214,6 +216,7 @@ services:
     # Production Redis config
     command: >
       redis-server
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
       --appendonly yes
       --appendfsync everysec
       --auto-aof-rewrite-percentage 100


### PR DESCRIPTION
## Problem

`docker-compose.prod.yml` runs the production Redis and MongoDB services with no credentials required:

- Redis (`command: redis-server ...`) has no `--requirepass`, so the prod cache/session store is open.
- MongoDB sets only `MONGO_INITDB_DATABASE` — no root user/password, so the telemetry DB is open.

This contradicts the dev `docker-compose.yml`, which already requires `REDIS_PASSWORD`, `MONGO_ROOT_USER`, and `MONGO_ROOT_PASSWORD` (all present in `.env.example`).

## Fix

- **Redis**: added `--requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}` to the server command, and updated the healthcheck to authenticate (`redis-cli -a ${REDIS_PASSWORD} ping`).
- **MongoDB**: added `MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:?...}` and `MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?...}`, and updated the healthcheck to authenticate via the `admin` auth source.
- The `api` service already requires `MONGODB_URI` / `REDIS_URL` (credentialized URLs) from `.env`, so the app connects with credentials once the stores demand them.

## Files changed

- `docker-compose.prod.yml`

## Testing

- `docker compose -f docker-compose.prod.yml config --quiet` passes (with the required env vars set; the compose interpolation now enforces that `REDIS_PASSWORD`/`MONGO_ROOT_*` are supplied).

Closes #6005
