### PR TITLE
fix(wasm): isolate edge function execution in worker thread with timeout

### DIFF
--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { Worker } from 'worker_threads';
 import { WASI } from 'wasi';
 import { createRequire } from 'module';
 import logger from '../backend/api/src/middleware/logger.js';
@@ -24,6 +25,7 @@ class EdgeRuntime {
             if (fs.existsSync(wasmPath)) {
                 const wasmBytes = fs.readFileSync(wasmPath);
                 const wasi = new WASI({
+                    version: 'preview1',
                     args: [],
                     env: Object.fromEntries(
                         Object.entries(process.env).filter(([k]) =>
@@ -75,6 +77,15 @@ class EdgeRuntime {
                 throw new Error(`Function ${functionName} not found`);
             }
             
+            // A synchronous WASM export cannot be aborted from the main thread:
+            // JS is single-threaded, so a runaway export blocks the event loop
+            // forever. Run it in a worker thread so it can be hard-killed once
+            // it exceeds timeoutLimit instead of taking down the process.
+            if (wasm.module) {
+                return await this._runInWorker(functionName, params);
+            }
+
+            // Native JS fallback engine (in-repo code) runs on the main thread.
             const result = func(...params);
             
             return {
@@ -90,20 +101,42 @@ class EdgeRuntime {
         }
     }
 
-    async executeWithTimeout(fn, timeout) {
-        return new Promise((resolve, reject) => {
-            const timer = setTimeout(() => {
-                reject(new Error(`Execution timeout after ${timeout}ms`));
-            }, timeout);
-            
+    _runInWorker(functionName, params) {
+        return new Promise((resolve) => {
+            const wasmPath = process.env.WASM_MODULE_PATH || './wasm/truxify_wasm.wasm';
+            let worker;
             try {
-                const result = fn();
-                clearTimeout(timer);
-                resolve(result);
-            } catch (error) {
-                clearTimeout(timer);
-                reject(error);
+                worker = new Worker(new URL('./edge-runtime.worker.js', import.meta.url), {
+                    workerData: { wasmPath, functionName, params }
+                });
+            } catch (err) {
+                resolve({ success: false, error: `Failed to start edge function worker: ${err.message}` });
+                return;
             }
+
+            const timer = setTimeout(() => {
+                worker.terminate().catch(() => {});
+                resolve({ success: false, error: `Edge function execution timeout after ${this.timeoutLimit}ms` });
+            }, this.timeoutLimit);
+            const settled = () => clearTimeout(timer);
+
+            worker.once('message', (result) => {
+                settled();
+                worker.terminate().catch(() => {});
+                resolve(result && result.success
+                    ? { success: true, data: result.data }
+                    : { success: false, error: (result && result.error) || 'Unknown edge function error' });
+            });
+            worker.once('error', (err) => {
+                settled();
+                resolve({ success: false, error: err.message });
+            });
+            worker.once('exit', (code) => {
+                if (code !== 0) {
+                    settled();
+                    resolve({ success: false, error: `Edge function worker exited with code ${code}` });
+                }
+            });
         });
     }
 

--- a/wasm/edge-runtime.worker.js
+++ b/wasm/edge-runtime.worker.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import { parentPort, workerData } from 'worker_threads';
+import { WASI } from 'wasi';
+
+const { wasmPath, functionName, params } = workerData;
+
+async function main() {
+    const wasmBytes = fs.readFileSync(wasmPath);
+    const wasi = new WASI({
+        version: 'preview1',
+        args: [],
+        env: Object.fromEntries(
+            Object.entries(process.env).filter(([k]) =>
+                /^(PATH|HOME|TMP|USER|LANG|LC_|RUST_|WASM_)/.test(k)
+            )
+        ),
+        preopens: { '/': './' }
+    });
+    const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+    const module = await WebAssembly.instantiate(wasmBytes, importObject);
+    const func = module.instance.exports[functionName];
+    if (typeof func !== 'function') {
+        throw new Error(`Function ${functionName} not found`);
+    }
+    const result = func(...params);
+    parentPort.postMessage({ success: true, data: result });
+}
+
+main().catch((err) => {
+    parentPort.postMessage({ success: false, error: err.message });
+});


### PR DESCRIPTION
## Problem

`wasm/edge-runtime.js` `executeEdgeFunction` (line 62) calls a synchronous WASM export directly with `func(...params)` and no timeout. A runaway export (infinite loop / expensive computation) blocks the Node.js event loop forever — the process never responds again. The existing `executeWithTimeout` helper (line 93) is dead code and cannot help: since JS is single-threaded, the `setTimeout` rejection can never fire while a synchronous WASM call is still running.

## Fix

- **Worker-thread isolation with a hard timeout**: real WASM exports now execute inside a dedicated `worker_threads.Worker` (`wasm/edge-runtime.worker.js`). The worker loads the `.wasm` binary, calls the requested export, and posts the result back. In `edge-runtime.js`, `_runInWorker` resolves the result, rejects with `Edge function execution timeout after N ms` and `worker.terminate()`s the thread once `timeoutLimit` (5s) elapses — so a stuck export can no longer block the server.
- The trusted in-repo JS fallback engine (used when no `.wasm` binary exists) still runs on the main thread.
- Removed the dead, misleading `executeWithTimeout`.
- Fixed `new WASI(...)` to pass `version: 'preview1'` (required on current Node; without it the module failed to instantiate at all).

## Files changed

- `wasm/edge-runtime.js`
- `wasm/edge-runtime.worker.js` (new)

## Testing

Smoke-tested against hand-built WASM binaries:
- Infinite-loop export → `Edge function execution timeout after 1000ms` at ~1s, event loop stays responsive.
- `add(3, 4)` export → `{ success: true, data: 7 }` round-tripped through the worker.
- Missing export → `Function nope not found`.
- `node --check` on both files passes.

Closes #6006
