### PR TITLE
fix(api): pass userClient to verifyDeliveryFn in confirm-otp alias route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1107,7 +1107,8 @@ router.post(
       const { escrowUpdateFailed } = await orderLifecycleService.verifyDeliveryFn(
         req.params.id,
         req.user.id,
-        req.body.otp
+        req.body.otp,
+        req.token ? createUserClient(req.token) : undefined
       );
 
       // Fetch the released amount to include in the response


### PR DESCRIPTION
## Problem

`orderLifecycleService.verifyDeliveryFn(orderId, driverId, otp, userClient)` needs a per-request Supabase client (`userClient`) so it can execute SECURITY DEFINER RPCs as the authenticated driver. The primary route `/orders/:id/verify-delivery` passes `req.token ? createUserClient(req.token) : undefined` (orderRoutes.js:982), but the driver-alias route `/orders/:id/confirm-otp` (mounted as `/api/deliveries/:id/confirm-otp`) called `verifyDeliveryFn` with only three arguments — dropping the client. On the alias path, delivery verification then falls back to a non-user scoped client (or fails) instead of acting as the driver.

## Fix

Pass the per-request `userClient` as the 4th argument in the `confirm-otp` alias route, matching the primary `verify-delivery` route: `req.token ? createUserClient(req.token) : undefined`.

## Files changed

- `backend/api/src/routes/orderRoutes.js`

## Testing

- `node --check backend/api/src/routes/orderRoutes.js` passes.
- `createUserClient` is already imported in the file and used identically by the primary route.

Closes #5997
