### PR TITLE
fix: add company_name and phone to updateProfileSchema to stop 400 on customer profile save (#5793)

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -270,6 +270,8 @@ export const registerTruckSchema = z.object({
 
 export const updateProfileSchema = z.object({
   full_name: z.string().trim().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
+  company_name: z.string().trim().min(1, 'Company name cannot be empty').max(200, 'Company name must be 200 characters or fewer').optional(),
+  phone: z.string().trim().refine(isValidPhone, { message: 'Phone must be a valid number (digits, optional +, spaces/dashes/parens)' }).optional(),
   language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').refine((v) => VALID_LANGUAGES.includes(v), { message: 'Unsupported language code' }).optional(),
   dark_mode: z.boolean().optional(),
   is_online: z.boolean().optional(),


### PR DESCRIPTION

## Description
updateProfileSchema used .strict() and only allowed full_name, language, dark_mode, is_online, and verification_status. The customer app sends company_name and phone on every profile save, so every PUT /api/profile returned 400 and users could never update their profile. Fixed by adding company_name (string, max 200 chars) and phone (validated via the existing isValidPhone helper) as optional fields in the schema so the client payload is accepted and persisted correctly.

## Type of Change
<!-- Select all that apply: -->
- [x] Bug fix (non-breaking change fixing an issue)


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- **Test Commands:**
npm test
- **Test Steps / Prerequisites:**
1. Open the customer app and navigate to profile
2. Update company name and phone number
3. Tap save
4. Verify PUT /api/profile returns 200 instead of 400
5. Verify the updated values are persisted and visible on next profile load

- **Expected Result:**
PUT /api/profile with company_name and phone succeeds with 200. Profile fields are saved and returned correctly on subsequent GET.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues

Closes #5793

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

