### PR TITLE
fix(ws): authenticate via first-frame auth before subscribing to tracking

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -130,32 +130,30 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     wsPath = '$wsPath/ws/tracking';
 
     String buildUrl() {
-      final session = SupabaseService.client.auth.currentSession;
-      final token = session?.accessToken ?? '';
       final wsUri = Uri(
         scheme: wsScheme,
         host: baseUri.host,
         port: baseUri.hasPort ? baseUri.port : null,
         path: wsPath,
-        queryParameters: token.isNotEmpty ? {'token': token} : null,
       );
       return wsUri.toString();
     }
 
     final initialWsUrl = buildUrl();
-    final redactedUrl = initialWsUrl.replaceAll(RegExp(r'token=[^&]+'), 'token=[REDACTED]');
-    debugPrint('Connecting to tracking WebSocket at: $redactedUrl');
+    debugPrint('Connecting to tracking WebSocket at: $initialWsUrl');
 
     _trackingWebSocket = ResilientWebSocket(
       initialWsUrl,
       urlFactory: buildUrl,
       onConnect: () {
-        debugPrint('WebSocket connected, subscribing to order updates...');
+        debugPrint('WebSocket connected, authenticating...');
         if (mounted) setState(() => _wsConnected = true);
+        final session = SupabaseService.client.auth.currentSession;
+        final token = session?.accessToken ?? '';
         _trackingWebSocket?.send({
-          'event': 'subscribe_tracking',
+          'event': 'auth',
           'data': {
-            'order_display_id': widget.orderId,
+            'token': token,
           },
         });
       },
@@ -168,7 +166,15 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
         if (message == 'pong') return;
         final payload = jsonDecode(message) as Map<String, dynamic>;
 
-        if (payload['event'] == 'location_update') {
+        if (payload['status'] == 'authenticated') {
+          // First-frame auth succeeded; now register for order updates.
+          _trackingWebSocket?.send({
+            'event': 'subscribe_tracking',
+            'data': {
+              'order_display_id': widget.orderId,
+            },
+          });
+        } else if (payload['event'] == 'location_update') {
           final data = payload['data'] as Map<String, dynamic>?;
           if (data != null) {
             final lat = (data['latitude'] as num?)?.toDouble();


### PR DESCRIPTION
## Problem

The live-tracking WebSocket client leaked the Supabase access token by embedding it in the connection URL query string (`?token=...`). Query strings are persisted in proxy logs, web analytics and browser history, which is exactly what the server-side hardening in #5828 and #5739 was meant to prevent.

It also raced the server auth handshake: `onConnect` sent the `subscribe_tracking` event immediately after the `auth` event, but the server processes frames as they arrive without a queue. Since `ws.authenticated` is only set asynchronously by `authenticateWs`, the subscribe could arrive first and be rejected with `Unauthorized: Authenticate first` (tracker.js line 627-628), breaking live tracking.

## Fix

- Removed the `token` query parameter from the WebSocket URL entirely (`buildUrl()` now builds a plain `ws(s)://host/ws/tracking` URL) and dropped the now-unneeded `token=[REDACTED]` redaction.
- First-frame auth: `onConnect` now sends a single `auth` event with the token in the message body (the protocol required by the server since #5739).
- Deferred registration: `subscribe_tracking` is now sent from the stream listener only after the server's `{ "status": "authenticated", ... }` frame is received (tracker.js line 619-622), eliminating the auth/subscribe race.
- The existing server `error` frame handling already covers the auth-failure/timeout path (code 4001), which sets `_wsConnected = false`; `ResilientWebSocket` then reconnects and `onConnect` re-runs the auth handshake.

## Files changed

- `apps/customer/lib/screens/live_tracking_screen.dart`

## Testing

- Manually reviewed the change against the server protocol in `backend/api/src/sockets/tracker.js` (first-frame `auth`, `authenticated` status frame at line 619, `Unauthorized: Authenticate first` rejection at line 627, `WS_AUTH_TIMEOUT_MS` timeout close at line 546-551).
- Flutter is not installed in this environment, so `dart analyze`/widget tests could not be run here. The existing widget test (`apps/customer/test/screen/live_tracking_screen_test.dart`) uses an empty mock stream and only asserts `connect()` is called, so it is unaffected.

Closes #6000
