### PR TITLE
feat: Automated Daily Backups for MongoDB and PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,6 +289,30 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  backup:
+    build:
+      context: ./infrastructure/backup
+    container_name: truxify-backup
+    env_file:
+      - .env
+    environment:
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      SHARD_PASSWORD: ${SHARD_PASSWORD:?SHARD_PASSWORD is required}
+      MONGO_ROOT_USER: ${MONGO_ROOT_USER:?MONGO_ROOT_USER is required}
+      MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?MONGO_ROOT_PASSWORD is required}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET:?AWS_S3_BUCKET is required}
+    depends_on:
+      - db
+      - shard-north
+      - shard-south
+      - shard-east
+      - shard-west
+      - mongo
+    restart: unless-stopped
+
 volumes:
   mongo_data:
   postgres_data:

--- a/infrastructure/backup/Dockerfile
+++ b/infrastructure/backup/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.19
+
+RUN apk add --no-cache bash postgresql-client mongodb-tools tar aws-cli
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh
+
+# Set up cron job to run daily at 3:00 AM UTC
+RUN echo "0 3 * * * /usr/local/bin/backup.sh >> /var/log/backup.log 2>&1" > /etc/crontabs/root
+
+CMD ["crond", "-f", "-d", "8"]

--- a/infrastructure/backup/backup.sh
+++ b/infrastructure/backup/backup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_DIR="/tmp/backup_${TIMESTAMP}"
+mkdir -p "$BACKUP_DIR"
+
+echo "Running pg_dump for main database..."
+PGPASSWORD="${DB_PASSWORD}" pg_dump -h "db" -U postgres -d "truxify" > "${BACKUP_DIR}/db_${TIMESTAMP}.sql"
+
+for SHARD in north south east west; do
+  echo "Running pg_dump for shard-${SHARD}..."
+  PGPASSWORD="${SHARD_PASSWORD}" pg_dump -h "shard-${SHARD}" -U postgres -d "truxify_${SHARD}" > "${BACKUP_DIR}/shard_${SHARD}_${TIMESTAMP}.sql"
+done
+
+echo "Running mongodump..."
+mongodump --uri="mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@mongo:27017/?authSource=admin" --archive="${BACKUP_DIR}/mongo_${TIMESTAMP}.archive"
+
+echo "Compressing backups..."
+tar -czvf "/tmp/backup_${TIMESTAMP}.tar.gz" -C /tmp "backup_${TIMESTAMP}"
+
+echo "Uploading to S3..."
+aws s3 cp "/tmp/backup_${TIMESTAMP}.tar.gz" "s3://${AWS_S3_BUCKET}/backups/"
+
+echo "Cleaning up..."
+rm -rf "$BACKUP_DIR"
+rm "/tmp/backup_${TIMESTAMP}.tar.gz"
+
+echo "Backup completed successfully."


### PR DESCRIPTION
Description: Resolves #5953

This PR introduces an automated infrastructure backup strategy for our database cluster to prevent data loss ahead of our production release.

Changes Included:

Backup Script: Added infrastructure/backup/backup.sh which executes pg_dump for the primary PostgreSQL database and all 4 geographic shards (North, South, East, West). It also runs mongodump for our MongoDB telemetry database.
Compression & S3 Upload: The script archives the dumps into .tar.gz format and automatically uses the AWS CLI to upload the backup archive to a designated S3 bucket.
Dockerized Cron Job: Created a lightweight Alpine-based Dockerfile with cron configured to run the backup script daily at 3:00 AM UTC.
Compose Integration: Added the backup service to docker-compose.yml, appropriately passing the required database credentials and AWS configuration via environment variables, and ensuring it starts after all databases.