### PR TITLE
fix(payments): never fund escrow without a verified payment capture

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -30,7 +30,7 @@ import {
   getEscrowBookingId,
   paisaToMaticWei,
   isEscrowEnabled,
-  escrowLockPayment,
+  buildDepositTx,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
 import upiPaymentService from '../services/payment/UpiPaymentService.js';
@@ -334,18 +334,40 @@ const chargeAndLockSchema = z.object({
   customer_upi_id: z.string().min(1, 'customer_upi_id is required'),
 }).strict();
 
+/**
+ * Convert an ethers populated transaction into a JSON-serializable object
+ * (bigint fields such as `value` are emitted as decimal strings).
+ */
+function serializeDepositTx(txData) {
+  if (!txData) return null;
+  const out = {};
+  for (const [key, value] of Object.entries(txData)) {
+    out[key] = typeof value === 'bigint' ? value.toString() : value;
+  }
+  return out;
+}
+
 router.post(
   '/charge-and-lock',
   authenticate,
   lockLimiter,
+  requireIdempotency(3600),
   validateBody(chargeAndLockSchema),
+  auditLog({ action: 'payment:charge-and-lock', resourceType: 'escrow' }),
   async (req, res) => {
+    const { order_id, customer_upi_id } = req.body;
+    const lockKey = `payment_lock:${order_id}`;
+    let lockAcquired = false;
+
     try {
-      const { order_id, customer_upi_id } = req.body;
+      lockAcquired = await acquireLock(lockKey, 30);
+      if (!lockAcquired) {
+        return res.status(409).json({ error: 'Payment is already being processed for this order. Please wait.' });
+      }
 
       const { data: order, error: orderErr } = await orderRepository.findOrderByIdOrDisplayId(
         order_id,
-        'id, order_display_id, customer_id, driver_id, total_amount, escrow_status, wallet_address'
+        'id, order_display_id, customer_id, driver_id, total_amount, escrow_status, escrow_booking_id, wallet_address'
       );
 
       if (orderErr || !order) {
@@ -356,8 +378,14 @@ router.post(
         return res.status(403).json({ error: 'Access denied.' });
       }
 
-      if (order.escrow_status === 'funded') {
-        return res.status(409).json({ error: 'Escrow payment already locked.' });
+      // Status transition guard: only unfunded, unreleased, unrefunded
+      // orders may enter the funding flow.
+      const terminalStatuses = ['funded', 'released', 'refunded'];
+      if (terminalStatuses.includes(order.escrow_status)) {
+        return res.status(409).json({
+          error: `Cannot charge and lock — escrow is already in status: ${order.escrow_status}`,
+          escrow_status: order.escrow_status,
+        });
       }
 
       if (!order.driver_id) {
@@ -375,68 +403,95 @@ router.post(
         return res.status(400).json({ error: 'Assigned driver has no registered Polygon wallet on file.' });
       }
 
-      const upiOrder = await upiPaymentService.createPaymentOrder(order.id, order.total_amount);
-
-      let txHash = `mock_tx_${Math.random().toString(36).substring(2, 15)}`;
-      const bookingId = getEscrowBookingId(order.order_display_id);
-      
-      if (isEscrowEnabled()) {
-        try {
-          const amountWei = paisaToMaticWei(order.total_amount);
-          const lockResult = await escrowLockPayment(
-            order.order_display_id,
-            order.wallet_address || req.user.wallet_address || '0x0000000000000000000000000000000000000000',
-            driverWallet,
-            amountWei
-          );
-
-          if (lockResult.error) {
-            logger.error(`[payments] lockPayment failed: ${lockResult.error}`);
-            return res.status(500).json({ error: `On-chain lockPayment failed: ${lockResult.error}` });
-          }
-          txHash = lockResult.txHash;
-        } catch (chainErr) {
-          logger.error(`[payments] lockPayment chain error: ${chainErr.message}`);
-          return res.status(500).json({ error: `On-chain lockPayment call failed: ${chainErr.message}` });
-        }
-      } else {
-        logger.warn('[payments] Escrow disabled. Simulating lockPayment call.');
+      // ── Critical gate (issue #5998): the escrow may only be funded after a
+      //    real payment has been captured by a configured gateway. Without a
+      //    confirmed capture the order must never be marked 'funded'.
+      const capture = await upiPaymentService.verifyPaymentCaptured(order_id, customer_upi_id);
+      if (!capture || capture.captured !== true) {
+        const reason = capture?.reason || 'payment_capture_unverified';
+        logger.warn(`[payments] charge-and-lock refused for ${order.order_display_id}: ${reason}`);
+        return res.status(503).json({
+          error: 'Payment capture could not be verified. This order cannot be funded until a real payment is captured.',
+          reason,
+        });
       }
 
-      const { error: dbErr } = await orderRepository.updateOrder(order.id, {
-        escrow_status: 'funded',
-        escrow_booking_id: bookingId,
-        escrow_tx_hash: txHash,
-        escrow_deposited_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      });
+      if (!isEscrowEnabled()) {
+        logger.warn(`[payments] charge-and-lock refused for ${order.order_display_id}: escrow contract not configured`);
+        return res.status(503).json({
+          error: 'Escrow is not configured. Payment capture verified but escrow funding is unavailable.',
+        });
+      }
+
+      // ── No relayer-funded lockPayment. Build an unsigned createBooking()
+      //    deposit for the CUSTOMER's wallet; the customer signs and submits
+      //    it, then confirms via the existing deposit flow. The order is
+      //    moved to 'funding' — never directly to 'funded'.
+      let amountWei;
+      try {
+        amountWei = paisaToMaticWei(order.total_amount);
+      } catch (capErr) {
+        return res.status(422).json({
+          error: 'Deposit amount exceeds the escrow safety cap.',
+          details: capErr.message,
+        });
+      }
+
+      const bookingId = order.escrow_booking_id || getEscrowBookingId(order.order_display_id);
+      const { txData, error: depositErr } = await buildDepositTx(
+        order.order_display_id,
+        driverWallet,
+        amountWei
+      );
+
+      if (!txData) {
+        logger.error(`[payments] buildDepositTx failed for ${order.order_display_id}: ${depositErr || 'no tx data returned'}`);
+        return res.status(502).json({
+          error: 'Failed to build the on-chain deposit transaction.',
+          details: depositErr || 'escrow contract is unreachable or misconfigured',
+        });
+      }
+
+      const { error: dbErr } = await orderRepository.updateOrderWithFilter(
+        order.id,
+        {
+          escrow_status: 'funding',
+          escrow_booking_id: bookingId,
+          escrow_amount_wei: amountWei.toString(),
+          escrow_driver_wallet: driverWallet,
+          escrow_funding_started_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        [{ op: 'eq', column: 'escrow_status', value: order.escrow_status }],
+        'escrow_status'
+      );
 
       if (dbErr) {
-        logger.error('[payments] DB update failed:', dbErr.message);
-        return res.status(500).json({ error: 'Payment locked on-chain but database update failed.' });
+        logger.error('[payments] charge-and-lock DB update failed:', dbErr.message);
+        return res.status(409).json({
+          error: 'Order escrow state changed while processing. Please refresh and try again.',
+        });
       }
 
-      if (order.driver_id) {
-        sendPushNotification(
-          order.driver_id,
-          '💰 Payment Locked',
-          `Escrow payment for order ${order.order_display_id} is locked. Please deliver.`,
-          'payment_locked',
-          { order_display_id: order.order_display_id }
-        ).catch(err => logger.warn('[payments] Push failed:', err.message));
-      }
-
-      return res.status(201).json({
+      return res.status(200).json({
         success: true,
-        message: 'UPI payment received and locked in escrow.',
-        escrow_status: 'funded',
-        tx_hash: txHash,
-        gateway_order_id: upiOrder.gateway_order_id,
+        message: 'Payment verified. Sign and submit the deposit transaction from your wallet, then confirm it to fund the escrow.',
+        escrow_status: 'funding',
+        booking_id: bookingId,
+        deposit_tx: serializeDepositTx(txData),
       });
 
     } catch (err) {
       logger.error('[payments] charge-and-lock error:', err.message);
       return res.status(500).json({ error: 'Internal Server Error' });
+    } finally {
+      if (lockAcquired) {
+        try {
+          await releaseLock(lockKey);
+        } catch (releaseErr) {
+          logger.error({ err: releaseErr, lockKey }, 'Failed to release payment lock');
+        }
+      }
     }
   }
 );

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -445,35 +445,6 @@ export async function confirmEscrowRefund (txHash) {
   });
 }
 
-export async function escrowLockPayment(orderDisplayId, customerWalletAddress, driverWalletAddress, amountWei) {
-  return measureExecution('EscrowService.escrowLockPayment', async () => {
-    const bookingId = getEscrowBookingId(orderDisplayId);
-
-    if (!escrowContract) {
-      logger.warn('[escrow] Contract not initialised — skipping lockPayment.');
-      return { txHash: null, bookingId };
-    }
-
-    try {
-      const tx = await escrowContract.lockPayment(
-        bookingId,
-        customerWalletAddress,
-        driverWalletAddress,
-        {
-          value: amountWei
-        }
-      );
-      logger.info(`[escrow] lockPayment tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
-      const receipt = await tx.wait(1);
-      logger.info(`[escrow] lockPayment confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`);
-      return { txHash: receipt.hash, bookingId };
-    } catch (err) {
-      logger.error(`[escrow] lockPayment failed for booking ${orderDisplayId}: ${err.message}`);
-      return { txHash: null, bookingId, error: err.message };
-    }
-  });
-}
-
 export function bookingIdFromUuid (orderId) {
   return getEscrowBookingId(orderId)
 }

--- a/backend/api/src/services/payment/UpiPaymentService.js
+++ b/backend/api/src/services/payment/UpiPaymentService.js
@@ -2,22 +2,55 @@ import logger from '../../middleware/logger.js';
 
 class UpiPaymentService {
   constructor() {
-    this.gatewayName = process.env.UPI_GATEWAY || 'Razorpay (Mock)';
+    this.gateway = (process.env.UPI_GATEWAY || '').toLowerCase();
+    this.gatewayName = process.env.UPI_GATEWAY || 'none';
+    this.razorpayKeyId = process.env.RAZORPAY_KEY_ID || '';
+    this.razorpayKeySecret = process.env.RAZORPAY_KEY_SECRET || '';
   }
 
   /**
-   * Mock payment collection creation (e.g. Razorpay Order)
+   * Whether a real payment gateway is configured. A mock gateway must never
+   * be used to fund escrow, because that lets an order reach
+   * escrow_status = 'funded' without collecting any payment (issue #5998).
    */
-  async createPaymentOrder(orderId, amountPaisa) {
-    logger.info(`[UPI Payment] Creating order on ${this.gatewayName} for Truxify Order ${orderId}, amount: ${amountPaisa} paisa`);
-    // Mock successful order/intent creation
-    return {
-      gateway_order_id: `pay_${Math.random().toString(36).substring(2, 15)}`,
-      amount: amountPaisa,
-      currency: 'INR',
-      status: 'created',
-      upi_deep_link: `upi://pay?pa=truxify@merchant&pn=Truxify&am=${(amountPaisa / 100).toFixed(2)}&cu=INR`
-    };
+  isGatewayConfigured() {
+    return this.gateway === 'razorpay' &&
+      Boolean(this.razorpayKeyId) &&
+      Boolean(this.razorpayKeySecret);
+  }
+
+  /**
+   * Create a payment collection order on the configured gateway.
+   *
+   * Never fabricates an order: a placeholder gateway_order_id would let
+   * downstream flows treat an unpaid order as paid. Fails loudly instead.
+   */
+  async createPaymentOrder(orderId, amountPaisa, customerUpiId) {
+    if (!this.isGatewayConfigured()) {
+      throw new Error(
+        'UPI payment gateway is not configured. Set UPI_GATEWAY=razorpay with RAZORPAY_KEY_ID and RAZORPAY_KEY_SECRET.'
+      );
+    }
+    // Real integration would create an order via the gateway SDK here and
+    // return { gateway_order_id, amount, currency, status: 'created' }.
+    // Refuse to fabricate an order until that SDK is wired up.
+    throw new Error('Payment gateway SDK is not wired up; refusing to create a mock payment order.');
+  }
+
+  /**
+   * Verify that a payment for the given order was actually captured by the
+   * gateway. Returns { captured: true } ONLY for a confirmed capture.
+   *
+   * Fail closed: when no gateway is configured, or the capture cannot be
+   * confirmed, this returns { captured: false } so callers must not proceed.
+   */
+  async verifyPaymentCaptured(orderId, customerUpiId) {
+    if (!this.isGatewayConfigured()) {
+      return { captured: false, reason: 'payment_gateway_not_configured' };
+    }
+    // Real integration would query the gateway for the order status /
+    // payment capture confirmation. Never assume a payment was captured.
+    return { captured: false, reason: 'payment_capture_unverified' };
   }
 
   /**

--- a/backend/api/test/integration/chargeAndLock.test.js
+++ b/backend/api/test/integration/chargeAndLock.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const CUSTOMER_ID = 'cust-123';
+const DRIVER_ID = 'driver-456';
+const DRIVER_WALLET = '0xDriverWallet000000000000000000000000000000000';
+const BOOKING_ID = '0xbooking1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+function buildApp(router) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/payments', router);
+  return app;
+}
+
+describe('POST /api/payments/charge-and-lock', () => {
+  let mockFindOrder;
+  let mockUpdateOrderWithFilter;
+  let mockVerifyCapture;
+  let mockBuildDepositTx;
+  let mockIsEscrowEnabled;
+  let mockCreatePaymentOrder;
+  let mockPaisaToMaticWei;
+
+  const mockOrder = (overrides = {}) => ({
+    id: 'order-abc',
+    order_display_id: 'TX1001',
+    customer_id: CUSTOMER_ID,
+    driver_id: DRIVER_ID,
+    total_amount: 50000,
+    escrow_status: 'pending',
+    escrow_booking_id: null,
+    wallet_address: '0xCustomerWallet0000000000000000000000000000000',
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    process.env.NODE_ENV = 'test';
+    process.env.BYPASS_AUTH = 'true';
+    process.env.ENABLE_TEST_AUTH = 'true';
+
+    mockFindOrder = vi.fn();
+    mockUpdateOrderWithFilter = vi.fn();
+    mockVerifyCapture = vi.fn();
+    mockBuildDepositTx = vi.fn();
+    mockIsEscrowEnabled = vi.fn().mockReturnValue(true);
+    mockCreatePaymentOrder = vi.fn();
+    mockPaisaToMaticWei = vi.fn().mockReturnValue(100n);
+
+    vi.resetModules();
+    vi.doMock('../../src/core/container.js', () => ({
+      orderRepository: {
+        findOrderByIdOrDisplayId: mockFindOrder,
+        updateOrderWithFilter: mockUpdateOrderWithFilter,
+      },
+    }));
+    vi.doMock('../../src/config/db.js', () => ({
+      supabase: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { polygon_wallet_address: DRIVER_WALLET },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      },
+      supabaseAdmin: null,
+      redisClient: null,
+      firebaseAdmin: null,
+    }));
+    vi.doMock('../../src/lib/redisLock.js', () => ({
+      acquireLock: async () => 'lock-value',
+      releaseLock: async () => true,
+      renewLock: async () => true,
+    }));
+    vi.doMock('../../src/services/escrow.js', () => ({
+      recordDepositTx: vi.fn(),
+      getEscrowBookingId: vi.fn(() => BOOKING_ID),
+      paisaToMaticWei: mockPaisaToMaticWei,
+      isEscrowEnabled: mockIsEscrowEnabled,
+      buildDepositTx: mockBuildDepositTx,
+    }));
+    vi.doMock('../../src/services/payment/UpiPaymentService.js', () => ({
+      default: {
+        verifyPaymentCaptured: mockVerifyCapture,
+        createPaymentOrder: mockCreatePaymentOrder,
+        processDriverPayout: vi.fn(),
+      },
+    }));
+    vi.doMock('../../src/middleware/auditLog.js', () => ({
+      auditLog: () => (req, res, next) => next(),
+    }));
+    vi.doMock('../../src/services/notificationService.js', () => ({
+      sendPushNotification: vi.fn().mockResolvedValue(true),
+    }));
+  });
+
+  afterEach(() => {
+    delete process.env.BYPASS_AUTH;
+    delete process.env.ENABLE_TEST_AUTH;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function bootApp() {
+    const mod = await import('../../src/routes/paymentRoutes.js');
+    return buildApp(mod.default);
+  }
+
+  function authenticatedRequest(app) {
+    return request(app)
+      .post('/api/payments/charge-and-lock')
+      .set('x-user-id', CUSTOMER_ID);
+  }
+
+  it('refuses to fund an order when no real payment capture can be verified — an unpaid order never reaches funded', async () => {
+    mockFindOrder.mockResolvedValue({ data: mockOrder(), error: null });
+    mockVerifyCapture.mockResolvedValue({ captured: false, reason: 'payment_gateway_not_configured' });
+
+    const app = await bootApp();
+    const res = await authenticatedRequest(app).send({
+      order_id: 'order-abc',
+      customer_upi_id: 'customer@upi',
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain('Payment capture could not be verified');
+    expect(res.body.escrow_status).toBeUndefined();
+    // An unpaid order must never have any database write applied…
+    expect(mockUpdateOrderWithFilter).not.toHaveBeenCalled();
+    // …and no deposit transaction may be built for it.
+    expect(mockBuildDepositTx).not.toHaveBeenCalled();
+    // No mock/placeholder payment order may be fabricated either.
+    expect(mockCreatePaymentOrder).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the order is already funded', async () => {
+    mockFindOrder.mockResolvedValue({ data: mockOrder({ escrow_status: 'funded' }), error: null });
+
+    const app = await bootApp();
+    const res = await authenticatedRequest(app).send({
+      order_id: 'order-abc',
+      customer_upi_id: 'customer@upi',
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.escrow_status).toBe('funded');
+    expect(mockVerifyCapture).not.toHaveBeenCalled();
+    expect(mockUpdateOrderWithFilter).not.toHaveBeenCalled();
+  });
+
+  it('moves a captured order to funding (never funded) and returns an unsigned customer deposit tx', async () => {
+    mockFindOrder.mockResolvedValue({ data: mockOrder(), error: null });
+    mockVerifyCapture.mockResolvedValue({ captured: true });
+    mockBuildDepositTx.mockResolvedValue({
+      txData: { to: '0xEscrowContract', data: '0xdeadbeef', value: 100n },
+      bookingId: BOOKING_ID,
+    });
+    mockUpdateOrderWithFilter.mockResolvedValue({
+      data: { escrow_status: 'funding' },
+      error: null,
+    });
+
+    const app = await bootApp();
+    const res = await authenticatedRequest(app).send({
+      order_id: 'order-abc',
+      customer_upi_id: 'customer@upi',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.escrow_status).toBe('funding');
+    expect(res.body.booking_id).toBe(BOOKING_ID);
+    // bigint `value` must be serialized as a decimal string.
+    expect(res.body.deposit_tx.value).toBe('100');
+
+    // The escrow deposit is built for the CUSTOMER's wallet, not funded by the relayer.
+    expect(mockBuildDepositTx).toHaveBeenCalledWith('TX1001', DRIVER_WALLET, 100n);
+
+    expect(mockUpdateOrderWithFilter).toHaveBeenCalledTimes(1);
+    const [orderId, updates, filters] = mockUpdateOrderWithFilter.mock.calls[0];
+    expect(orderId).toBe('order-abc');
+    // Only the intermediate 'funding' state may be persisted.
+    expect(updates.escrow_status).toBe('funding');
+    expect(updates.escrow_amount_wei).toBe('100');
+    expect(updates.escrow_driver_wallet).toBe(DRIVER_WALLET);
+    expect(filters).toEqual([{ op: 'eq', column: 'escrow_status', value: 'pending' }]);
+  });
+
+  it('rejects unauthenticated requests before touching the order', async () => {
+    const app = await bootApp();
+    const res = await request(app)
+      .post('/api/payments/charge-and-lock')
+      .send({ order_id: 'order-abc', customer_upi_id: 'customer@upi' });
+
+    expect(res.status).toBe(401);
+    expect(mockFindOrder).not.toHaveBeenCalled();
+  });
+});

--- a/backend/api/test/unit/upiPaymentService.test.js
+++ b/backend/api/test/unit/upiPaymentService.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('UpiPaymentService (fail-closed)', () => {
+  afterEach(() => {
+    delete process.env.UPI_GATEWAY;
+    delete process.env.RAZORPAY_KEY_ID;
+    delete process.env.RAZORPAY_KEY_SECRET;
+    vi.resetModules();
+  });
+
+  it('reports gateway not configured when UPI_GATEWAY is unset', async () => {
+    delete process.env.UPI_GATEWAY;
+    delete process.env.RAZORPAY_KEY_ID;
+    delete process.env.RAZORPAY_KEY_SECRET;
+    vi.resetModules();
+
+    const { default: svc } = await import('../../src/services/payment/UpiPaymentService.js');
+
+    expect(svc.isGatewayConfigured()).toBe(false);
+
+    const verification = await svc.verifyPaymentCaptured('order-1', 'customer@upi');
+    expect(verification.captured).toBe(false);
+    expect(verification.reason).toBe('payment_gateway_not_configured');
+
+    await expect(svc.createPaymentOrder('order-1', 5000)).rejects.toThrow('not configured');
+  });
+
+  it('reports not configured for razorpay without credentials', async () => {
+    process.env.UPI_GATEWAY = 'razorpay';
+    delete process.env.RAZORPAY_KEY_ID;
+    delete process.env.RAZORPAY_KEY_SECRET;
+    vi.resetModules();
+
+    const { default: svc } = await import('../../src/services/payment/UpiPaymentService.js');
+
+    expect(svc.isGatewayConfigured()).toBe(false);
+  });
+
+  it('never fabricates an order or a capture even when a gateway is configured', async () => {
+    process.env.UPI_GATEWAY = 'razorpay';
+    process.env.RAZORPAY_KEY_ID = 'rzp_test_key_id';
+    process.env.RAZORPAY_KEY_SECRET = 'rzp_test_key_secret';
+    vi.resetModules();
+
+    const { default: svc } = await import('../../src/services/payment/UpiPaymentService.js');
+
+    expect(svc.isGatewayConfigured()).toBe(true);
+
+    const verification = await svc.verifyPaymentCaptured('order-1', 'customer@upi');
+    expect(verification.captured).toBe(false);
+    expect(verification.reason).toBe('payment_capture_unverified');
+
+    await expect(svc.createPaymentOrder('order-1', 5000)).rejects.toThrow(
+      'refusing to create a mock payment order'
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`POST /payments/charge-and-lock` marked orders `escrow_status = 'funded'` and spent **real relayer MATIC** while collecting no payment. Three defects stacked:

1. **The "payment" was entirely mock.** `UpiPaymentService.createPaymentOrder` performed no network call; it returned a random `gateway_order_id` and a hardcoded `upi://pay?pa=truxify@merchant...` deep link. Nothing was charged and no webhook/status check confirmed capture.
2. **The escrow was funded with the platform relayer's wallet.** `escrowLockPayment` signed and submitted `lockPayment(bookingId, customer, driver, { value: amountWei })` with the relayer signer — the money sent with `{ value }` came out of the relayer's balance, so the platform funded every "payment".
3. **The order was unconditionally flipped to `funded`** with a fabricated `mock_tx_${Math.random()...}` hash (or the relayer's real tx hash), with no idempotency lock and no verification that any payment was captured.

Any authenticated customer could call the endpoint once per order with an arbitrary `customer_upi_id` and each order became fully funded by the platform; a driver completing delivery later received the relayer's MATIC while the customer paid nothing.

## Fix

- **Verified-capture gate (fail closed).** The endpoint now calls `upiPaymentService.verifyPaymentCaptured(order_id, customer_upi_id)` and refuses with `503` unless a real gateway reports a confirmed capture. Since no real gateway is configured today, an unpaid order can never be marked `funded` via this endpoint.
- **Dropped the relayer-funded `lockPayment` path entirely** — removed `escrowLockPayment` from `services/escrow.js` (dead code) and its call site.
- **Customer-wallet deposit.** After a verified capture the handler builds an unsigned `createBooking()` deposit transaction for the **customer's** wallet via `buildDepositTx` and persists the order as `escrow_status = 'funding'` (never `funded`). The transition to `funded` happens only through the existing deposit flow (`recordDepositTx`), which verifies the on-chain sender is the customer's registered wallet, the booking ID, the assigned driver wallet and the escrow amount.
- **No fabrication.** Removed `mock_tx_${Math.random()}` and the unconditional `escrow_status: 'funded'` update; `UpiPaymentService.createPaymentOrder` now throws instead of returning a placeholder order.
- **Idempotency + transition guard.** Added `requireIdempotency`, a Redis `acquireLock` guard, and an atomic `updateOrderWithFilter` status transition (only non-terminal statuses may enter `funding`).
- **Serialization.** The unsigned deposit tx is returned with bigint fields (`value`) converted to decimal strings so the client can sign it.

## Files changed

- `backend/api/src/routes/paymentRoutes.js`
- `backend/api/src/services/payment/UpiPaymentService.js`
- `backend/api/src/services/escrow.js`
- `backend/api/test/integration/chargeAndLock.test.js` (new)
- `backend/api/test/unit/upiPaymentService.test.js` (new)

## Testing

- `test/integration/chargeAndLock.test.js`: unpaid order with gateway not configured → `503`, no DB write, no deposit built, no mock payment order created; already-`funded` order → `409`; captured order → `200` with `escrow_status: 'funding'` (never `funded`) and a serialized unsigned customer deposit tx; unauthenticated → `401`.
- `test/unit/upiPaymentService.test.js`: gateway-not-configured and razorpay-with-credentials both fail closed (`verifyPaymentCaptured` returns `captured: false`; `createPaymentOrder` throws).
- `npx vitest run` on the new suites: 7/7 pass. Escrow suites (unit + integration + sender verification) remain green after removing `escrowLockPayment` (64 tests pass). Pre-existing failures in `escrowReleaseReconciliation`, `escrowRefundReconciliation` and `idempotency` tests are unchanged on `origin/main`.

Closes #5998
