### PR TITLE
fix(api): resolve _haversineM ReferenceError in delivery geofence check

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -419,12 +419,9 @@ export class DeliveryVerificationService {
       });
     }
 
-    const distanceM = _haversineM(
-      lat,
-      lng,
-      Number(order.drop_lat),
-      Number(order.drop_lng),
-    );
+    const distanceM =
+      haversineKm(lat, lng, Number(order.drop_lat), Number(order.drop_lng)) *
+      1000;
     if (distanceM > DELIVERY_GEOFENCE_RADIUS_KM * 1000) {
       throw new DomainError(409, {
         error: `Driver is ${(distanceM / 1000).toFixed(2)}km from the drop-off location. Must be within ${DELIVERY_GEOFENCE_RADIUS_KM * 1000}m to confirm delivery.`,


### PR DESCRIPTION
## Problem

`assertDriverAtDropoff()` in `backend/api/src/services/order/deliveryVerificationService.js` calls `_haversineM(...)`, but that helper no longer exists anywhere in the module. `haversineKm` is imported from `../../lib/pricing.js` but never used. The delivery geofence check therefore throws a runtime `ReferenceError` instead of measuring the driver's distance from the drop-off point, so confirming delivery (and the subsequent escrow release) always fails.

## Fix

Use the already-imported `haversineKm(lat1, lon1, lat2, lon2)` from `backend/api/src/lib/pricing.js`, scaling from kilometres to metres so the `DELIVERY_GEOFENCE_RADIUS_KM * 1000` comparison keeps its existing semantics.

## Files changed

- `backend/api/src/services/order/deliveryVerificationService.js`

## Testing

- `npx vitest run test/unit/deliveryVerificationGeofence.test.js` — 11/11 pass (missing coordinates, unavailable location store, invalid coordinates, stale telemetry, outside/inside geofence radius, exact drop-off, verifyDelivery gating).

Closes #5996


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery location verification by accurately calculating the driver’s distance from the drop-off point in meters.
  * Ensured geofence radius checks continue to work consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->