### PR TITLE
fix(escrow): complete Booking literal in lockPayment with started/disputedAt

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -190,7 +190,9 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             amount:    msg.value,
             status:    BookingStatus.Active,
             paid:      false,
-            createdAt: block.timestamp
+            started:   false,
+            createdAt: block.timestamp,
+            disputedAt: 0
         });
 
         bookingCount++;


### PR DESCRIPTION
## Problem

`lockPayment()` in `blockchain/contracts/TruxifyEscrow.sol` constructs the `Booking` struct with only 6 of its 8 members — the `started` and `disputedAt` fields are omitted. Because `Booking` is a named struct, the compiler rejects the literal with `TypeError: Wrong argument count for struct constructor: 6 arguments given but expected 8`, so the owner-relayer escrow path cannot compile at all.

## Fix

Supply the two missing fields in the `Booking({ ... })` literal inside `lockPayment()`: `started: false` and `disputedAt: 0`, mirroring the complete literal already used in `createBooking()`.

## Files changed

- `blockchain/contracts/TruxifyEscrow.sol`

## Testing

- Compiled with `solc 0.8.24` (same version as `hardhat.config.cjs`):
  - Pre-fix: `TypeError: Wrong argument count for struct constructor: 6 arguments given but expected 8` (at `lockPayment`, line 187).
  - Post-fix: compiles successfully with no errors.

Closes #6063
