### PR TITLE
fix(api): bind profile and DLQ lookups to authenticated clients for RLS

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -1,4 +1,4 @@
-import { firebaseAdmin, supabase } from "../config/db.js";
+import { firebaseAdmin, supabase, createUserClient } from "../config/db.js";
 import jwt from "jsonwebtoken";
 import {
   getCachedProfile,
@@ -53,7 +53,11 @@ export async function verifyAuthToken(token) {
     }
     supabaseUserId = user.id;
 
-    const { data: profile, error } = await supabase
+    // Profile lookups must run as the authenticated user (RLS is enforced on
+    // profiles: anon has no read privileges). The user-bound client carries the
+    // caller's JWT so PostgREST resolves the authenticated role for this query.
+    const userClient = createUserClient?.(token) || supabase;
+    const { data: profile, error } = await userClient
       .from("profiles")
       .select("id, firebase_uid, role, full_name, phone")
       .eq("id", user.id)
@@ -77,7 +81,8 @@ export async function verifyAuthToken(token) {
       throw new Error("Supabase client is not configured on this server.");
     }
 
-    const { data: profile, error } = await supabase
+    const userClient = createUserClient?.(token) || supabase;
+    const { data: profile, error } = await userClient
       .from("profiles")
       .select("id, firebase_uid, role, full_name, phone")
       .eq("firebase_uid", firebaseUid)
@@ -218,6 +223,7 @@ export async function authenticate(req, res, next) {
     let userProfile = null;
     let firebaseUid = null;
     let supabaseUserId = null;
+    let userClient = null;
 
     let decoded;
     try {
@@ -250,6 +256,10 @@ export async function authenticate(req, res, next) {
           });
       }
       supabaseUserId = user.id;
+      // Bind the profile lookup to the caller's JWT: profiles RLS grants reads
+      // only to the authenticated owner, so a sessionless anon client cannot
+      // resolve the profile.
+      userClient = createUserClient?.(token) || supabase;
 
       // Token is verified above; the cache only skips the profile lookup, keyed
       // by the verified user id. Cache entries are bounded by the token's own
@@ -270,7 +280,7 @@ export async function authenticate(req, res, next) {
       }
 
       // Fetch corresponding profile from Supabase by user.id
-      const { data: profile, error } = await supabase
+      const { data: profile, error } = await userClient
         .from("profiles")
         .select("id, firebase_uid, role, full_name, phone")
         .eq("id", user.id)
@@ -334,7 +344,8 @@ export async function authenticate(req, res, next) {
       }
 
       // Fetch corresponding profile from Supabase by firebase_uid
-      const { data: profile, error } = await supabase
+      userClient = createUserClient?.(token) || supabase;
+      const { data: profile, error } = await userClient
         .from("profiles")
         .select("id, firebase_uid, role, full_name, phone")
         .eq("firebase_uid", firebaseUid)
@@ -357,16 +368,16 @@ export async function authenticate(req, res, next) {
       // The main queries above filter on is_active=true, so null could mean
       // missing OR deactivated. We distinguish here to give accurate errors.
       let profileIsDeactivated = false;
-      if (supabaseUserId) {
-        const { data: inactive } = await supabase
+      if (supabaseUserId && userClient) {
+        const { data: inactive } = await userClient
           .from("profiles")
           .select("id")
           .eq("id", supabaseUserId)
           .eq("is_active", false)
           .maybeSingle();
         profileIsDeactivated = !!inactive;
-      } else if (firebaseUid && supabase) {
-        const { data: inactive } = await supabase
+      } else if (firebaseUid && userClient) {
+        const { data: inactive } = await userClient
           .from("profiles")
           .select("id")
           .eq("firebase_uid", firebaseUid)

--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -1,8 +1,16 @@
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import logger from '../../middleware/logger.js';
 
 // Retries in minutes
-const RETRY_BACKOFF = [1, 5, 15, 60]; 
+const RETRY_BACKOFF = [1, 5, 15, 60];
+
+// webhook_failures RLS grants access only to service_role (internal DLQ table).
+// Use the service-role client so enqueue/claim/retry operations are not
+// silently denied for the sessionless anon role; fall back to the anon client
+// in environments where the service key is not configured (tests/dev).
+function dlqDb() {
+  return supabaseAdmin || supabase;
+}
 
 export const dlqService = {
   /**
@@ -10,7 +18,7 @@ export const dlqService = {
    */
   async enqueueFailure(provider, eventType, payload, error) {
     try {
-      const { error: insertErr } = await supabase
+      const { error: insertErr } = await dlqDb()
         .from('webhook_failures')
         .insert({
           provider,
@@ -40,7 +48,7 @@ export const dlqService = {
       const now = new Date().toISOString();
 
       // 1. Fetch up to 50 pending events safely without modifying them yet
-      const { data: pendingEvents, error: fetchErr } = await supabase
+      const { data: pendingEvents, error: fetchErr } = await dlqDb()
         .from('webhook_failures')
         .select('id')
         .eq('status', 'pending')
@@ -60,7 +68,7 @@ export const dlqService = {
       const eventIds = pendingEvents.map(e => e.id);
 
       // 2. Atomically claim only those specific events using CAS
-      const { data: claimedEvents, error: claimErr } = await supabase
+      const { data: claimedEvents, error: claimErr } = await dlqDb()
         .from('webhook_failures')
         .update({ status: 'processing', updated_at: now })
         .eq('status', 'pending')
@@ -87,7 +95,7 @@ export const dlqService = {
           await handler(event.event_type, event.payload);
 
           // Success, mark as resolved
-          await supabase
+          await dlqDb()
             .from('webhook_failures')
             .update({ status: 'resolved', updated_at: new Date().toISOString() })
             .eq('id', event.id);
@@ -102,7 +110,7 @@ export const dlqService = {
 
           if (nextBackoffMin === -1) {
             // Failed permanently
-            await supabase
+            await dlqDb()
               .from('webhook_failures')
               .update({ 
                 status: 'failed_permanently', 
@@ -114,7 +122,7 @@ export const dlqService = {
           } else {
             // Schedule next retry
             const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
-            await supabase
+            await dlqDb()
               .from('webhook_failures')
               .update({ 
                 retry_count: newRetryCount,

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -9,6 +9,7 @@ describe('authenticate middleware - non bypass flow', () => {
 
   it('returns 401 when authorization header missing', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -29,6 +30,7 @@ describe('authenticate middleware - non bypass flow', () => {
   it('returns 500 when supabase missing for supabase token', async () => {
     const token = jwt.sign({ iss: 'https://test.supabase.co/auth/v1' }, 'secret');
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: {},
       supabase: null,
     }));
@@ -63,6 +65,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: {},
       supabase,
     }));
@@ -118,6 +121,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: {},
       supabase,
     }));
@@ -146,6 +150,7 @@ describe('authenticate middleware - non bypass flow', () => {
 
   it('returns 500 when firebase admin missing', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -178,6 +183,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin,
       supabase: null,
     }));
@@ -226,6 +232,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin,
       supabase,
     }));
@@ -276,6 +283,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin,
       supabase,
     }));
@@ -330,6 +338,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin,
       supabase,
     }));
@@ -365,6 +374,7 @@ describe('authenticate middleware - non bypass flow', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin,
       supabase: {},
     }));
@@ -408,6 +418,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
     process.env.NODE_ENV = 'production';
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -430,6 +441,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
     process.env.NODE_ENV = 'production';
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -459,6 +471,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
 
   it('returns 401 when BYPASS_AUTH is enabled but x-user-id header is missing', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -481,6 +494,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
 
   it('sets req.user and calls next when x-user-id is provided', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -516,6 +530,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
     delete process.env.ENABLE_TEST_AUTH;
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -547,6 +562,7 @@ describe('authenticate middleware - BYPASS_AUTH flow', () => {
 
   it('defaults role to customer and name to Test User when headers are absent', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -580,6 +596,7 @@ describe('requireRole middleware', () => {
 
   it('returns 401 when req.user is not set', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -600,6 +617,7 @@ describe('requireRole middleware', () => {
 
   it('throws an error on initialization if allowedRoles is missing or empty', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -613,6 +631,7 @@ describe('requireRole middleware', () => {
 
   it('returns 403 when user role is not in allowedRoles', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -638,6 +657,7 @@ describe('requireRole middleware', () => {
 
   it('calls next when user role is in allowedRoles', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -659,6 +679,7 @@ describe('requireRole middleware', () => {
 
   it('allows access when multiple roles are allowed and user matches one', async () => {
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: null,
       supabase: null,
     }));
@@ -724,6 +745,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: firebaseAdminMock,
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -792,6 +814,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: firebaseAdminMock,
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -846,6 +869,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: firebaseAdminMock,
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -917,6 +941,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: firebaseAdminMock,
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -1004,6 +1029,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: firebaseAdminMock,
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -1073,6 +1099,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: {},
       supabase: supabaseMock,
       redisClient: redisClientMock,
@@ -1132,6 +1159,7 @@ describe('authenticate middleware - Redis caching', () => {
     };
 
     vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
       firebaseAdmin: {},
       supabase: supabaseMock,
       redisClient: redisClientMock,

--- a/backend/api/test/unit/dlqService.test.js
+++ b/backend/api/test/unit/dlqService.test.js
@@ -68,6 +68,7 @@ vi.mock('../../src/config/db.js', () => ({
   supabase: {
     from: vi.fn(makeBuilder),
   },
+  supabaseAdmin: null,
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
## Problem

Issue #6064: server-side code uses the shared, **sessionless anon-key** Supabase client (`backend/api/src/config/db.js`) for queries that Row Level Security gates behind the `authenticated` role. `revoke_anon_privileges.sql` revokes all privileges from `anon`, and the RLS policies scope reads to the authenticated owner (`firebase_uid = (auth.jwt() ->> 'sub')` / `get_profile_id()`). As a result:

- **Auth middleware profile lookup fails** — `middleware/auth.js` fetches the caller's `profiles` row with the anon client, so RLS denies it and every token-authenticated request fails with a database error.
- **The DLQ cannot persist failures** — `services/webhook/dlqService.js` writes to `webhook_failures`, whose RLS policy grants access **only** to `service_role`, so inserts are silently denied.

## Fix

- `middleware/auth.js`: profile lookups (and the deactivated-profile probe) now run through a per-request user-bound client via `createUserClient(token)` (already exported from `config/db.js`), so PostgREST authenticates the caller and the owner-scoped RLS policies apply. A defensive `|| supabase` fallback keeps behaviour identical when no token client is available.
- `services/webhook/dlqService.js`: all `webhook_failures` operations (enqueue, claim, resolve, retry, fail-permanent) now use the **service-role** client (`supabaseAdmin`), falling back to the anon client only when the service key is not configured (tests/dev).
- Test mocks updated: `test/unit/auth.test.js` and `test/unit/dlqService.test.js` now expose `createUserClient` / `supabaseAdmin` so the mocked `config/db.js` matches the new imports (vitest requires mocks to define every named export the module reads).

The per-request RPC path was already correct: routes pass `createUserClient(req.token)` into `executeRpc` (SECURITY DEFINER RPCs receive `auth.uid()`), and the shared client remains appropriate for unauthenticated/public reads.

## Files changed

- `backend/api/src/middleware/auth.js`
- `backend/api/src/services/webhook/dlqService.js`
- `backend/api/test/unit/auth.test.js`
- `backend/api/test/unit/dlqService.test.js`

## Testing

- `npx vitest run test/unit` — 1172 passed / 26 failed (identical failure count to the clean `main` baseline; all 26 are pre-existing full-suite test-pollution failures, none introduced here).
- `npx vitest run test/integration` — 293 passed / 31 failed (identical to the clean `main` baseline).
- `auth.test.js` (28/28) and `dlqService.test.js` (1/1) pass after the mock updates.

Closes #6064
