### PR TITLE
fix(contracts): disable initializer on TruxifyUpgradeable implementation

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -144,6 +144,16 @@ contract TruxifyUpgradeable is
     /// @notice Emitted when an implementation's allowlist status changes.
     event ImplementationApprovalUpdated(address indexed implementation, bool approved);
 
+    // ============ Constructor ============
+
+    /// @notice The implementation contract is never used directly, only behind a
+    ///         UUPS proxy. Locking initialization here prevents an attacker from
+    ///         calling initialize() on the implementation itself and seizing the
+    ///         DEFAULT_ADMIN_ROLE (and thereby upgrade rights).
+    constructor() {
+        _disableInitializers();
+    }
+
     // ============ Initializer ============
     function initialize() public initializer {
         __AccessControl_init();


### PR DESCRIPTION
## Problem

Issue #6065: `TruxifyUpgradeable.sol` has a public `initialize()` (with the `initializer` modifier) but **no constructor**, so the `initializer` guard is only armed once someone calls `initialize()` on the implementation address directly. An attacker can deploy/call the implementation, run `initialize()` as `msg.sender`, and seize `DEFAULT_ADMIN_ROLE` (plus `UPGRADER_ROLE`, `PAUSER_ROLE`) on the implementation contract. With a UUPS proxy, the upgrade path then trusts `_authorizeUpgrade`, so taking the admin role on the implementation is a classic unguarded-initializer vulnerability.

## Fix

- Added a `constructor()` that calls `_disableInitializers()`, permanently disabling the `initializer` modifier on the implementation contract itself. Proxies are unaffected — they never execute the constructor, so `initialize()` remains callable through the proxy exactly once.

## Files changed

- `blockchain/contracts/TruxifyUpgradeable.sol`

## Testing

- Compiled with solc 0.8.26 (standard-json) — COMPILE OK.

Closes #6065
