### PR TITLE
fix(db): restore fail-closed escrow guard in complete_trip_tx

### DIFF
--- a/supabase/migrations/20260803100000_update_complete_trip_tx.sql
+++ b/supabase/migrations/20260803100000_update_complete_trip_tx.sql
@@ -67,6 +67,17 @@ begin
     raise exception 'Order has already been delivered';
   end if;
 
+  -- Fail closed (restored from 20260802130000_complete_trip_tx_require_funded_escrow.sql):
+  -- credit the driver wallet ONLY when the escrow was actually funded and released
+  -- on-chain (`escrow_status = 'released'` or a release tx hash is supplied), or
+  -- when the order is explicitly marked `escrow_disabled`. Any ambiguous/unfunded
+  -- state raises instead of crediting.
+  if not v_order.escrow_disabled
+     and coalesce(v_order.escrow_status, '') <> 'released'
+     and p_release_tx_hash is null then
+    raise exception 'Blockchain escrow release must complete before crediting driver wallet';
+  end if;
+
   -- Safe lookup for the driver's active trip
   select count(*) into v_active_trip_count
   from trips
@@ -102,16 +113,29 @@ begin
     where trip_display_id = v_trip_display_id;
   end if;
 
-  -- Update order status and escrow details
-  update orders
-  set status = 'payment_released',
-      escrow_status = 'released',
-      escrow_released_at = now(),
-      blockchain_tx_hash = coalesce(p_release_tx_hash, blockchain_tx_hash),
-      updated_at = now()
-  where id = p_order_id
-    and status != 'cancelled'
-    and status != 'payment_released';
+  -- Update order status and escrow details. Escrow fields are only synced for
+  -- escrow-backed orders (the fail-closed guard above guarantees the escrow was
+  -- released on-chain); escrow-disabled orders never enter the escrow lifecycle,
+  -- so their escrow_status must not be rewritten to 'released'.
+  if v_order.escrow_disabled then
+    update orders
+    set status = 'payment_released',
+        blockchain_tx_hash = coalesce(p_release_tx_hash, blockchain_tx_hash),
+        updated_at = now()
+    where id = p_order_id
+      and status != 'cancelled'
+      and status != 'payment_released';
+  else
+    update orders
+    set status = 'payment_released',
+        escrow_status = 'released',
+        escrow_released_at = now(),
+        blockchain_tx_hash = coalesce(p_release_tx_hash, blockchain_tx_hash),
+        updated_at = now()
+    where id = p_order_id
+      and status != 'cancelled'
+      and status != 'payment_released';
+  end if;
 
   -- Verify the update actually affected a row
   get diagnostics v_updated_count = row_count;


### PR DESCRIPTION
## Problem

Issue #6066: `20260803100000_update_complete_trip_tx.sql` recreated `complete_trip_tx` but silently **dropped the fail-closed funded-escrow guard** introduced by `20260802130000_complete_trip_tx_require_funded_escrow.sql` (itself a fix for #5778):

- The orders `UPDATE` at the old lines 105–114 unconditionally set `escrow_status = 'released'` and `escrow_released_at = now()` even when escrow was never funded.
- The wallet credit (old lines 128–135) ran unconditionally, so a driver could be credited `confirmed` wallet funds for an order whose escrow was never secured on-chain — exactly the regression #5778 closed.

## Fix

Restored the fail-closed semantics from the 20260802130000 migration:

- Added the guard before any mutation: unless the order is explicitly `escrow_disabled`, the wallet may only be credited when `escrow_status = 'released'` or a `p_release_tx_hash` was supplied; any other (unfunded/ambiguous) state raises `Blockchain escrow release must complete before crediting driver wallet`.
- Split the order `UPDATE` so escrow fields (`escrow_status`, `escrow_released_at`) are only synced to `released` for escrow-backed orders. Escrow-disabled orders now just mark `status = 'payment_released'` and keep their escrow fields untouched instead of being falsely rewritten to `released`.

## Files changed

- `supabase/migrations/20260803100000_update_complete_trip_tx.sql`

## Testing

- Verified against the canonical `complete_trip_tx` in `20260802130000_complete_trip_tx_require_funded_escrow.sql` — the guard expression matches exactly.
- SQL review: function remains `SECURITY DEFINER`, `search_path = public, pg_temp`, and the `REVOKE ... FROM anon` is preserved.

Closes #6066
