### PR TITLE
fix(db): finalize the order-linked trip in complete_trip_tx

### DIFF
--- a/supabase/migrations/20260803100000_update_complete_trip_tx.sql
+++ b/supabase/migrations/20260803100000_update_complete_trip_tx.sql
@@ -15,7 +15,6 @@ as $$
 declare
   v_order record;
   v_trip_display_id text;
-  v_active_trip_count int;
   v_updated_count int;
   v_otp_updated int;
 begin
@@ -67,40 +66,40 @@ begin
     raise exception 'Order has already been delivered';
   end if;
 
-  -- Safe lookup for the driver's active trip
-  select count(*) into v_active_trip_count
+  -- Finalize the active trip that actually served THIS order (restored from
+  -- 20260802060000_link_trips_to_orders.sql: selecting by driver_id could
+  -- complete the wrong trip when a driver has several active trips, and it
+  -- silently skipped trip finalization when the driver had no active trip).
+  select trip_display_id into v_trip_display_id
   from trips
-  where driver_id = v_order.driver_id and status = 'active';
+  where order_id = p_order_id
+    and status = 'active'
+  order by created_at
+  limit 1;
 
-  if v_active_trip_count > 1 then
-    raise exception 'Multiple active trips found for driver %', v_order.driver_id;
+  if v_trip_display_id is null then
+    raise exception 'No active trip found for this order — cannot complete trip';
   end if;
 
-  if v_active_trip_count = 1 then
-    select trip_display_id into v_trip_display_id
-    from trips
-    where driver_id = v_order.driver_id and status = 'active';
+  -- Update trip record
+  update trips
+  set status = 'completed',
+      end_time = to_char(now(), 'HH24:MI'),
+      updated_at = now()
+  where trip_display_id = v_trip_display_id;
 
-    -- Update trip record
-    update trips
-    set status = 'completed',
-        end_time = to_char(now(), 'HH24:MI'),
-        updated_at = now()
-    where trip_display_id = v_trip_display_id;
+  -- Update trip items to delivered
+  update trip_items
+  set is_delivered = true
+  where trip_display_id = v_trip_display_id;
 
-    -- Update trip items to delivered
-    update trip_items
-    set is_delivered = true
-    where trip_display_id = v_trip_display_id;
-
-    -- Update trip stops to completed/delivered
-    update trip_stops
-    set is_completed = true,
-        is_current = false,
-        status_label = 'Delivered',
-        updated_at = now()
-    where trip_display_id = v_trip_display_id;
-  end if;
+  -- Update trip stops to completed/delivered
+  update trip_stops
+  set is_completed = true,
+      is_current = false,
+      status_label = 'Delivered',
+      updated_at = now()
+  where trip_display_id = v_trip_display_id;
 
   -- Update order status and escrow details
   update orders


### PR DESCRIPTION
## Problem

Issue #6067: `20260803100000_update_complete_trip_tx.sql` reverted the trip finalization logic to selecting the driver's active trip by **`driver_id + status = 'active'`** instead of the canonical `order_id = p_order_id` lookup established by `20260802060000_link_trips_to_orders.sql` (#5756). Consequences:

- If a driver has multiple active trips, the function raises `Multiple active trips found` (or worse, without the count guard, completes an arbitrary trip).
- If the driver has no active trip at all, trip finalization is silently skipped while the wallet is still credited — reintroducing the "credit without trip" bug #5756 closed.

## Fix

Restored the canonical order-linked lookup:

```sql
select trip_display_id into v_trip_display_id
from trips
where order_id = p_order_id
  and status = 'active'
order by created_at
limit 1;

if v_trip_display_id is null then
  raise exception 'No active trip found for this order — cannot complete trip';
end if;
```

- The trip is always attributed to the order it served (`trips.order_id` is populated by the link migration; `idx_trips_order_id` indexes it).
- `ORDER BY created_at LIMIT 1` deterministically resolves multiple active trips instead of erroring on a legitimate driver state.
- Missing trip now fails closed (`RAISE`) instead of silently crediting the wallet.
- Removed the now-unused `v_active_trip_count` declaration.

## Files changed

- `supabase/migrations/20260803100000_update_complete_trip_tx.sql`

## Testing

- Verified the lookup matches the canonical implementation in `20260802060000_link_trips_to_orders.sql` (lines 71–81) and `20260802130000_complete_trip_tx_require_funded_escrow.sql` (lines 84–94).
- `git grep` confirms no remaining references to `v_active_trip_count`.

Closes #6067
