### PR TITLE
fix(api): release payment lock with owner token in finally

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -312,9 +312,9 @@ router.post(
       return res.status(500).json({ error: 'Internal Server Error' });
 
     } finally {
-      if (lockAcquired) {
+      if (lockValue) {
         try {
-          await releaseLock(lockKey);
+          await releaseLock(lockKey, lockValue);
         } catch (releaseErr) {
           logger.error(
             { err: releaseErr, lockKey },


### PR DESCRIPTION
## Problem

Issue #6068: in `POST /api/payments/lock`, the `finally` block at paymentRoutes.js:314 references **`lockAcquired`**, a variable that is never declared anywhere in the file. Because `finally` runs on every request, every call to the route throws `ReferenceError: lockAcquired is not defined` and returns HTTP 500 — the payment lock API is completely broken, even on the happy path.

A second, masked defect: `releaseLock(lockKey)` was called with a single argument, but `releaseLock(resourceKey, lockValue)` (redisLock.js:109) only deletes the lock **when the caller's owner token matches** (`if (!redisClient || !lockValue) return false;`). Without the owner token the release is a no-op, so even after the ReferenceError was fixed the lock would never be released and would linger for its full TTL.

## Fix

Replaced the broken `finally` block with the intended owner-token flow (the `lockValue` variable was already declared at line 195 with this purpose):

```js
} finally {
  if (lockValue) {
    try {
      await releaseLock(lockKey, lockValue);
    } catch (releaseErr) {
      logger.error({ err: releaseErr, lockKey }, 'Failed to release payment lock');
    }
  }
}
```

- `lockValue` is `null` when the lock was never acquired (409 conflict or 503 `LockAcquisitionError`), so no release is attempted.
- `lockValue` is the UUID owner token after `acquireLock` succeeds, so `releaseLock` now deletes the lock atomically via the Lua owner check.

## Files changed

- `backend/api/src/routes/paymentRoutes.js`

## Testing

- `node --check backend/api/src/routes/paymentRoutes.js` — syntax OK.
- Confirmed via `git grep` that `lockAcquired` has no declaration anywhere; `releaseLock`'s two-arg signature matches the call sites in `orderRoutes.js:1518` and `escrowFundingReconciliation.js:131`.

Closes #6068
