### PR TITLE
fix(api): fail closed when webhook event cannot be enqueued to DLQ

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -66,14 +66,22 @@ router.post('/escrow', verifyWebhookSignature, async (req, res) => {
     return res.status(200).json({ received: true });
   } catch (error) {
     logger.error(`[Webhook] Failed to process escrow webhook for order ${orderId}: ${error.message}`);
-    
+
     // Enqueue to Dead Letter Queue for background retries
-    await dlqService.enqueueFailure('escrow', eventType, req.body, error);
+    const enqueued = await dlqService.enqueueFailure('escrow', eventType, req.body, error);
+
+    // Fail closed: if the event cannot be persisted to the DLQ, return 500 so
+    // the provider retries. Returning 202 would silently drop the event forever.
+    if (!enqueued) {
+      return res.status(500).json({
+        error: 'Webhook processing failed and the event could not be queued for retry',
+      });
+    }
 
     // Return 202 Accepted so the provider stops retrying - we now own the retry logic via our DLQ
-    return res.status(202).json({ 
-      received: true, 
-      status: 'queued_for_retry'
+    return res.status(202).json({
+      received: true,
+      status: 'queued_for_retry',
     });
   }
 });

--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -23,11 +23,14 @@ export const dlqService = {
 
       if (insertErr) {
         logger.error(`[DLQ] Failed to enqueue webhook failure: ${insertErr.message}`);
-      } else {
-        logger.info(`[DLQ] Webhook failure enqueued successfully for ${provider} - ${eventType}`);
+        return false;
       }
+
+      logger.info(`[DLQ] Webhook failure enqueued successfully for ${provider} - ${eventType}`);
+      return true;
     } catch (err) {
       logger.error(`[DLQ] Critical error enqueueing webhook failure: ${err.message}`);
+      return false;
     }
   },
 

--- a/backend/api/test/integration/webhookRoutes.test.js
+++ b/backend/api/test/integration/webhookRoutes.test.js
@@ -213,6 +213,29 @@ describe('Webhook Routes — HMAC Signature Verification', () => {
         expect.any(Error)
       );
     });
+
+    it('returns 500 instead of 202 when the DLQ enqueue fails', async () => {
+      mockEnqueueFailure.mockResolvedValueOnce(false);
+
+      const payload = {
+        eventType: 'EscrowReleased',
+        orderId: 'order-999',
+        txHash: '0xdef',
+        simulateFailure: true
+      };
+      const signature = signPayload(payload);
+
+      const res = await request(app)
+        .post('/api/webhooks/escrow')
+        .set('X-Webhook-Signature', signature)
+        .send(payload);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe(
+        'Webhook processing failed and the event could not be queued for retry'
+      );
+      expect(mockEnqueueFailure).toHaveBeenCalledTimes(1);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

Issue #6069: when `processEscrowWebhookEvent` throws, `POST /api/webhooks/escrow` calls `dlqService.enqueueFailure(...)` and then **unconditionally returns 202 Accepted** — telling the provider to stop retrying. But `enqueueFailure` swallows every failure:

- It catches all errors internally and only logs (`[DLQ] Failed to enqueue webhook failure: ...`).
- It never signals whether the insert actually succeeded.

So if the DLQ insert fails (DB down, RLS/permission denied, etc.), the event is dropped **forever** with no retry — the webhook payload is lost while the provider believes we now own retry logic.

## Fix

- `dlqService.enqueueFailure` now returns a **boolean**: `true` only when the row was inserted successfully, `false` on any insert error or thrown exception (backwards-compatible — no callers relied on the previous `undefined`).
- `webhookRoutes.js` checks the result. On failure it returns **HTTP 500** instead of 202, so the provider keeps retrying and the event is never silently lost. On success it still returns 202 `{ received: true, status: 'queued_for_retry' }`.

## Files changed

- `backend/api/src/services/webhook/dlqService.js`
- `backend/api/src/routes/webhookRoutes.js`
- `backend/api/test/integration/webhookRoutes.test.js`

## Testing

- `npx vitest run test/integration/webhookRoutes.test.js` — **11/11 passed**, including a new test: when `enqueueFailure` resolves `false`, the route returns 500 with `Webhook processing failed and the event could not be queued for retry` and the enqueue is attempted exactly once.

Closes #6069
