### PR TITLE
fix(ml): stop passing stale rated_drivers/rated_loads kwargs to recommender

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -516,7 +516,6 @@ async def recommend_loads_endpoint(input: RecommendLoadsInput, _auth=Depends(ver
         result = collaborative_filter.recommend_loads(
             user_id=input.user_id,
             booking_history=input.booking_history,
-            rated_drivers=input.rated_drivers,
             top_n=input.top_n,
         )
         return RecommendOutput(**result)
@@ -535,7 +534,6 @@ async def recommend_trucks_endpoint(input: RecommendTrucksInput, _auth=Depends(v
         result = collaborative_filter.recommend_trucks(
             user_id=input.user_id,
             booking_history=input.booking_history,
-            rated_loads=input.rated_loads,
             top_n=input.top_n,
         )
         return RecommendOutput(**result)


### PR DESCRIPTION
## Problem

Issue #6071: `POST /recommend/loads` and `POST /recommend/trucks` call `collaborative_filter.recommend_loads(...)` / `recommend_trucks(...)` with `rated_drivers=` / `rated_loads=` keyword arguments. Those parameters no longer exist on the functions (they accept only `user_id`, `booking_history`, `top_n`), so every request raises `TypeError: recommend_loads() got an unexpected keyword argument 'rated_drivers'` → caught → HTTP 500. The recommendation endpoints are effectively broken.

## Fix

- Removed the stale `rated_drivers=input.rated_drivers` and `rated_loads=input.rated_loads` keyword arguments from the two endpoint call sites in `main.py`.
- Kept the `rated_drivers` / `rated_loads` fields on `RecommendLoadsInput` / `RecommendTrucksInput` for backward compatibility — existing clients and tests still send them, and pydantic would otherwise reject the payloads with 422.

## Files changed

- `backend/ml/main.py`

## Testing

- `py -3 -m pytest tests/test_collaborative_filter.py` — **6/6 passed** (previously 4 failed on `main` with 500 errors): valid load/truck recommendations, unknown-user cold start, and auth scenarios all return 200.

Closes #6071
