### PR TITLE
fix(contracts): add buy-back payout mechanism to AssetToken.sellFraction

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -55,6 +55,9 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
     mapping(address => uint256[]) public userAssets;
     mapping(uint256 => TradeOrder[]) public tradeOrders;
     mapping(uint256 => bool) public assetExists;
+    // ETH accrued to each user from treasury buy-backs (sellFraction); the
+    // funds are held by the contract and released via claimPayout().
+    mapping(address => uint256) public claimableBalances;
 
     uint256 private _assetCounter;
     uint256 private _tradeOrderCounter;
@@ -72,6 +75,8 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
     event TradeOrderExecuted(uint256 indexed orderId, uint256 tokenId, address indexed buyer);
     event AssetTraded(uint256 indexed assetId, address indexed from, address indexed to, uint256 amount);
     event ComplianceCheck(address indexed user, bool verified);
+    event PayoutAccrued(uint256 indexed assetId, address indexed user, uint256 amount);
+    event PayoutClaimed(address indexed user, uint256 amount);
 
     // ============ Constructor ============
 
@@ -192,20 +197,48 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         FractionalOwnership storage ownership = fractionalOwnership[assetId][msg.sender];
         require(ownership.amount >= amount, "Insufficient balance");
 
+        Asset storage asset = assets[assetId];
+        uint256 payout = (amount * asset.tokenPrice) / 1e18;
+
         // Burn tokens
         _burn(msg.sender, amount);
 
         // Update ownership
         ownership.amount -= amount;
 
-        // Update asset
+        // Update asset — returned fractions re-enter the available pool
         assets[assetId].availableTokens += amount;
 
         if (ownership.amount == 0) {
             _removeUserAsset(msg.sender, assetId);
         }
 
+        // Accrue the buy-back payout; the seller claims it with claimPayout().
+        // The contract's ETH balance is backed by purchase proceeds, so a
+        // failing claim is guarded in claimPayout() with a fail-closed require.
+        claimableBalances[msg.sender] += payout;
+
+        emit PayoutAccrued(assetId, msg.sender, payout);
         emit FractionalSale(assetId, msg.sender, amount);
+    }
+
+    /// @notice Releases the caller's accrued buy-back payouts. The contract
+    ///         holds the ETH from fraction purchases until sellers claim it.
+    function claimPayout() external nonReentrant whenNotPaused {
+        uint256 amount = claimableBalances[msg.sender];
+        require(amount > 0, "No claimable balance");
+
+        claimableBalances[msg.sender] = 0;
+
+        (bool paid, ) = payable(msg.sender).call{value: amount}("");
+        require(paid, "Payout transfer failed");
+
+        emit PayoutClaimed(msg.sender, amount);
+    }
+
+    /// @notice View the accrued buy-back balance claimable by *user*.
+    function getClaimableBalance(address user) external view returns (uint256) {
+        return claimableBalances[user];
     }
 
     // ============ Trading ============

--- a/blockchain/test/AssetToken.test.js
+++ b/blockchain/test/AssetToken.test.js
@@ -142,4 +142,66 @@ describe("AssetToken", function () {
     assert.equal(buyer2Assets.length, 1);
     assert.equal(buyer2Assets[0], 1n);
   });
+
+  it("should accrue a claimable payout on sellFraction and pay it via claimPayout", async function () {
+    const { assetToken, owner, buyer1 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    // tokenPrice = 1 ETH/token
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("10"), {
+      value: ethers.parseEther("10")
+    });
+
+    // Sell 4 tokens back to the treasury -> 4 ETH claimable, tokens burned
+    await assetToken.connect(buyer1).sellFraction(1, ethers.parseEther("4"));
+    assert.equal(await assetToken.getClaimableBalance(buyer1.address), ethers.parseEther("4"));
+    assert.equal(await assetToken.balanceOf(buyer1.address), ethers.parseEther("6"));
+
+    const balanceBefore = await ethers.provider.getBalance(buyer1.address);
+    await assetToken.connect(buyer1).claimPayout();
+    assert.equal(await assetToken.getClaimableBalance(buyer1.address), 0n);
+    const balanceAfter = await ethers.provider.getBalance(buyer1.address);
+    assert.equal(balanceAfter - balanceBefore, ethers.parseEther("4"));
+  });
+
+  it("should return sold fractions to the available pool and not double count ownership", async function () {
+    const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("10"), {
+      value: ethers.parseEther("10")
+    });
+    await assetToken.connect(buyer1).sellFraction(1, ethers.parseEther("6"));
+
+    // 6 fractions are back in the pool and can be purchased again
+    const asset = await assetToken.getAsset(1);
+    assert.equal(asset.availableTokens, ethers.parseEther("96"));
+
+    await assetToken.connect(buyer2).purchaseFraction(1, ethers.parseEther("6"), {
+      value: ethers.parseEther("6")
+    });
+    assert.equal(await assetToken.balanceOf(buyer2.address), ethers.parseEther("6"));
+  });
+
+  it("should revert claimPayout when there is nothing to claim", async function () {
+    const { assetToken, buyer1 } = await deployAssetToken();
+    await assert.rejects(
+      assetToken.connect(buyer1).claimPayout(),
+      /No claimable balance/
+    );
+  });
 });


### PR DESCRIPTION
## Problem

Issue #6072: `AssetToken.sellFraction` burns the seller's tokens, returns them to the asset's `availableTokens` pool, and emits `FractionalSale` — but **never pays the seller anything**. There is no withdraw/payout path anywhere in the contract, so selling fractions back to the treasury destroys the seller's value. The only value-recovery path (`createTradeOrder` + `executeTradeOrder`) requires a third-party buyer.

## Fix

Implemented a treasury buy-back payout mechanism:

- **`sellFraction`** now prices the sold amount at the asset's `tokenPrice` (the same price `purchaseFraction` charges) and accrues the proceeds to a new `claimableBalances[user]` mapping, emitting `PayoutAccrued`. Fractions still burn and re-enter the available pool, so a buyer can repurchase them — funding the payout pool.
- **`claimPayout()`** (new, `nonReentrant`, `whenNotPaused`) releases the caller's accrued balance via a fail-closed `require(paid, ...)` transfer and zeroes it. The contract's ETH holdings are backed by `purchaseFraction`/`executeTradeOrder` proceeds, and ETH can be added via the existing `receive()`.
- **`getClaimableBalance(address)`** (new view) lets users/UI read the accrued amount.

## Files changed

- `blockchain/contracts/AssetToken.sol`
- `blockchain/test/AssetToken.test.js`

## Testing

- Compiled with solc 0.8.26 (standard-json) — COMPILE OK.
- Added hardhat tests (repo convention): sellFraction accrues the correct claimable balance and claimPayout transfers it; sold fractions return to the available pool and can be repurchased; claimPayout reverts when there is nothing to claim.
- Note: `npx hardhat test` could not be executed in this environment due to a **pre-existing** toolchain break (`hardhat@2.29.0` CJS vs `@nomicfoundation/hardhat-verify@3.0.22` ESM — `ERR_MODULE_NOT_FOUND` on `hardhat/plugins`), which also breaks `hardhat compile`. Contract was validated via direct solc compilation instead; the test file is syntactically valid ESM matching the existing suite.

Closes #6072
