### PR TITLE
fix: prevent OCR fallback from approving invalid KYC

### DIFF
--- a/backend/ml/app/models/ocr_verifier.py
+++ b/backend/ml/app/models/ocr_verifier.py
@@ -6,6 +6,7 @@ import re
 
 logger = logging.getLogger(__name__)
 
+
 class OCRVerifier:
     def __init__(self):
         # In a real environment, you might need to set the tesseract_cmd path if it's not in PATH
@@ -14,47 +15,44 @@ class OCRVerifier:
 
     def extract_text(self, image_bytes: bytes) -> str:
         """
-        Extracts text from an image using Tesseract OCR.
-        If Tesseract is not installed or fails, falls back to a simulated response.
+        Extract text from an image using Tesseract OCR.
+
+        Raises:
+            Exception: If OCR extraction fails.
         """
         try:
             image = Image.open(io.BytesIO(image_bytes))
             text = pytesseract.image_to_string(image)
             return text
         except Exception as e:
-            logger.warning(f"OCR Extraction failed (possibly Tesseract not installed): {e}")
-            logger.warning("Falling back to simulated OCR response for testing.")
-            return "SIMULATED_DL_NUMBER: DL-1234567890123"
+            logger.error("OCR extraction failed: %s", e)
+            raise
 
     def verify_license(self, text: str) -> dict:
         """
-        Searches for a typical Indian Driving License pattern or simulated pattern.
+        Searches for a typical Indian Driving License pattern.
         """
-        # Common pattern: two letters, two digits, year, followed by 7 digits
+        # Common pattern:
         # DL-1420110012345
         dl_pattern = r"([A-Z]{2}[-\s]?\d{2}[-\s]?\d{4}[-\s]?\d{7})"
-        simulated_pattern = r"(DL-\d{13})"
-        
-        dl_match = re.search(dl_pattern, text)
-        sim_match = re.search(simulated_pattern, text)
 
+        dl_match = re.search(dl_pattern, text)
         found_dl = dl_match.group(1) if dl_match else None
-        if not found_dl:
-            found_dl = sim_match.group(1) if sim_match else None
 
         if found_dl:
             return {
                 "verified": True,
                 "document_type": "Driving License",
                 "extracted_number": found_dl,
-                "raw_text": text.strip()[:200] # Return first 200 chars for logging
+                "raw_text": text.strip()[:200]
             }
-        
+
         return {
             "verified": False,
             "document_type": "Unknown",
             "extracted_number": None,
             "raw_text": text.strip()[:200]
         }
+
 
 ocr_verifier = OCRVerifier()

--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from app.models.eta_prediction import eta_predictor
+from fastapi import HTTPException
 
 from app.models.demand_forecast import (
     predict_demand,
@@ -700,20 +701,50 @@ async def predict_maintenance_endpoint(input: PredictiveMaintenanceInput, _auth=
 # ---------------------------------------------------------------------------
 # KYC Document OCR Verification
 # ---------------------------------------------------------------------------
-
-class KYCVerificationOutput(BaseModel):
-    verified: bool
-    document_type: str
-    extracted_number: Optional[str] = None
-    raw_text: str
-
 @app.post("/verify/kyc", response_model=KYCVerificationOutput)
-async def verify_kyc_endpoint(file: UploadFile = File(...), _auth=Depends(verify_api_key)):
+async def verify_kyc_endpoint(
+    file: UploadFile = File(...),
+    _auth=Depends(verify_api_key)
+):
     try:
+        allowed_types = {
+            "image/jpeg",
+            "image/png",
+            "image/jpg",
+            "image/webp",
+            "application/pdf",
+        }
+
+        if file.content_type not in allowed_types:
+            raise HTTPException(
+                status_code=400,
+                detail="Only image and PDF files are allowed."
+            )
+
         image_bytes = await file.read()
+
+        MAX_FILE_SIZE = 5 * 1024 * 1024  # 5 MB
+
+        if len(image_bytes) > MAX_FILE_SIZE:
+            raise HTTPException(
+                status_code=400,
+                detail="File size exceeds the 5 MB limit."
+            )
+
         text = ocr_verifier.extract_text(image_bytes)
         result = ocr_verifier.verify_license(text)
+
         return KYCVerificationOutput(**result)
+
+    except HTTPException:
+        raise
+
     except Exception as e:
         logger.error("KYC OCR verification failed: %s", e)
-        raise HTTPException(status_code=500, detail="KYC OCR verification failed")
+
+        return KYCVerificationOutput(
+            verified=False,
+            document_type="Unknown",
+            extracted_number=None,
+            raw_text=""
+        )


### PR DESCRIPTION
## Summary

This PR fixes a security issue where OCR failures could incorrectly approve KYC using a hardcoded simulated driving licence number.

### Changes Made

- Removed the simulated OCR fallback in `extract_text()`.
- OCR failures now return a failed verification instead of approving KYC.
- Removed simulated driving licence pattern matching.
- Added upload content-type validation.
- Added upload file-size validation before OCR processing.

### Why

Previously, OCR exceptions returned a hardcoded simulated licence number (`DL-1234567890123`), which could cause invalid documents to be marked as verified.

This change ensures OCR failures do not result in successful KYC verification.

Closes #6070


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for KYC document uploads, allowing only image and PDF files up to 5 MB.
- **Bug Fixes**
  - Improved handling of invalid uploads and validation errors.
  - Unexpected document-processing failures now return an unverified result instead of a server error.
  - OCR verification no longer accepts simulated license text, improving verification accuracy.
  - OCR failures are now reported and handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->