### PR TITLE
fix(driver): add OTP resend cooldown and resend button (#762)

### DIFF
--- a/apps/driver/lib/app.dart
+++ b/apps/driver/lib/app.dart
@@ -85,11 +85,15 @@ class _TruxifyAppState extends State<TruxifyApp> {
 
             case AppRoutes.otp:
               final args = settings.arguments as Map<String, String>? ?? {};
+              // resendToken is stored as a string in the args map because
+              // Navigator arguments are typed as Map<String, String>.
+              final resendToken = int.tryParse(args['resendToken'] ?? '');
               return truxifyPageRoute(
                 (context) => OtpScreen(
                   phone: args['phone'] ?? '',
                   verificationId: args['verificationId'] ?? '',
                   countryCode: args['countryCode'] ?? '+91',
+                  resendToken: resendToken, // issue #762
                 ),
               );
 

--- a/apps/driver/lib/l10n/app_en.arb
+++ b/apps/driver/lib/l10n/app_en.arb
@@ -862,4 +862,25 @@
   "@dark": {
     "description": "Dark theme option label"
   }
+
+  "otpResent": "OTP resent successfully",
+  "@otpResent": {
+    "description": "Snackbar message shown when the OTP is resent to the driver's phone."
+  },
+
+  "resendOtpIn": "Resend in {seconds}s",
+  "@resendOtpIn": {
+    "description": "Countdown label shown while the resend cooldown timer is running.",
+    "placeholders": {
+      "seconds": {
+        "type": "int",
+        "description": "Number of seconds remaining before the resend button becomes active."
+      }
+    }
+  },
+
+  "resendOtp": "Resend OTP",
+  "@resendOtp": {
+    "description": "Label for the button that resends the OTP to the driver's phone."
+  }
 }

--- a/apps/driver/lib/screens/login_screen.dart
+++ b/apps/driver/lib/screens/login_screen.dart
@@ -88,6 +88,8 @@ class _LoginScreenState extends State<LoginScreen> {
               'phone': phone,
               'verificationId': verificationId,
               'countryCode': _selectedCode,
+              if (resendToken != null)
+            'resendToken': resendToken.toString(),
             },
           );
         },

--- a/apps/driver/lib/screens/otp_screen.dart
+++ b/apps/driver/lib/screens/otp_screen.dart
@@ -10,17 +10,25 @@ import '../theme/app_theme.dart';
 import '../widgets/app_logo.dart';
 import '../widgets/common_widgets.dart';
 
+/// How long the "Resend OTP" button stays disabled after sending a code (seconds).
+const int _kResendCooldownSeconds = 30;
+
 class OtpScreen extends StatefulWidget {
   const OtpScreen({
     super.key,
     required this.phone,
     required this.verificationId,
     this.countryCode = '+91',
+    this.resendToken,
   });
 
   final String phone;
   final String verificationId;
   final String countryCode;
+
+  /// Firebase resend token returned by the initial [verifyPhoneNumber] call.
+  /// Passing it back on resend avoids re-sending a fresh SMS unnecessarily.
+  final int? resendToken;
 
   @override
   State<OtpScreen> createState() => _OtpScreenState();
@@ -30,25 +38,120 @@ class _OtpScreenState extends State<OtpScreen> {
   late final List<TextEditingController> _controllers =
       List.generate(6, (_) => TextEditingController());
   late final List<FocusNode> _focusNodes = List.generate(6, (_) => FocusNode());
+
   final AuthService _authService = AuthService();
+
+  /// Mutable verification ID — updated when the user successfully resends.
+  late String _verificationId = widget.verificationId;
+
+  /// Mutable resend token — updated after each successful resend call.
+  int? _resendToken = widget.resendToken;
+
   bool _loading = false;
+  bool _resending = false;
+
+  // ── Cooldown timer ────────────────────────────────────────────────────────
+
+  /// Seconds remaining in the current cooldown window.
+  int _cooldownSeconds = _kResendCooldownSeconds;
+  Timer? _cooldownTimer;
+
+  bool get _canResend => _cooldownSeconds == 0 && !_resending;
+
+  @override
+  void initState() {
+    super.initState();
+    _startCooldown();
+  }
 
   @override
   void dispose() {
-    for (final controller in _controllers) {
-      controller.dispose();
-    }
-    for (final node in _focusNodes) {
-      node.dispose();
-    }
+    _cooldownTimer?.cancel();
+    for (final c in _controllers) c.dispose();
+    for (final n in _focusNodes) n.dispose();
     super.dispose();
   }
+
+  void _startCooldown() {
+    _cooldownTimer?.cancel();
+    setState(() => _cooldownSeconds = _kResendCooldownSeconds);
+
+    _cooldownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      setState(() {
+        if (_cooldownSeconds > 0) {
+          _cooldownSeconds--;
+        } else {
+          timer.cancel();
+        }
+      });
+    });
+  }
+
+  // ── Resend OTP ────────────────────────────────────────────────────────────
+
+  Future<void> _resendOtp() async {
+    if (!_canResend) return;
+
+    setState(() => _resending = true);
+
+    try {
+      await _authService.verifyPhoneNumber(
+        phoneNumber: '${widget.countryCode}${widget.phone}',
+        forceResendingToken: _resendToken,
+        onCodeSent: (String newVerificationId, int? newResendToken) {
+          if (!mounted) return;
+          setState(() {
+            _verificationId = newVerificationId;
+            _resendToken = newResendToken;
+          });
+          _startCooldown();
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(AppLocalizations.of(context)!.otpResent),
+              backgroundColor: TruxifyColors.success,
+            ),
+          );
+          // Clear existing OTP inputs so the user enters the new code.
+          for (final c in _controllers) c.clear();
+          if (_focusNodes.isNotEmpty) {
+            _focusNodes.first.requestFocus();
+          }
+        },
+        onVerificationFailed: (FirebaseAuthException e) {
+          if (!mounted) return;
+          final msg = e.message ?? AppLocalizations.of(context)!.verificationFailedMsg;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(msg)),
+          );
+        },
+        onAutoVerification: (PhoneAuthCredential credential) {
+          // Auto-verification is handled by Firebase; navigate on success.
+          if (!mounted) return;
+          Navigator.of(context).pushReplacementNamed(AppRoutes.shell);
+        },
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)!.verificationFailedMsg)),
+      );
+    } finally {
+      if (mounted) setState(() => _resending = false);
+    }
+  }
+
+  // ── Verify OTP ────────────────────────────────────────────────────────────
 
   Future<void> _verifyOtp() async {
     if (_loading) return;
 
     final code =
-        _controllers.map((c) => c.text.replaceAll('\u200B', '')).join();
+        _controllers.map((c) => c.text.replaceAll('​', '')).join();
+
     if (!RegExp(r'^\d{6}$').hasMatch(code)) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context)!.invalidOtp)),
@@ -58,15 +161,13 @@ class _OtpScreenState extends State<OtpScreen> {
 
     setState(() => _loading = true);
     try {
-      await _authService.verifyOtp(widget.verificationId, code);
-
+      await _authService.verifyOtp(_verificationId, code);
       if (!mounted) return;
-
       Navigator.of(context).pushReplacementNamed(AppRoutes.shell);
     } on FirebaseAuthException catch (e) {
       if (!mounted) return;
-      String message;
       final l10n = AppLocalizations.of(context)!;
+      final String message;
       switch (e.code) {
         case 'invalid-verification-code':
           message = l10n.invalidOtp;
@@ -85,23 +186,24 @@ class _OtpScreenState extends State<OtpScreen> {
       );
     } catch (e) {
       if (!mounted) return;
-      String errorMsg = AppLocalizations.of(context)!.couldNotVerifyOtp;
-      if (e.toString().contains('SocketException') || e.toString().contains('network-request-failed')) {
-        errorMsg = AppLocalizations.of(context)!.networkError;
-      }
+      final errorMsg = (e.toString().contains('SocketException') ||
+              e.toString().contains('network-request-failed'))
+          ? AppLocalizations.of(context)!.networkError
+          : AppLocalizations.of(context)!.couldNotVerifyOtp;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(errorMsg)),
       );
     } finally {
-      if (mounted) {
-        setState(() => _loading = false);
-      }
+      if (mounted) setState(() => _loading = false);
     }
   }
+
+  // ── Build ─────────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
@@ -111,10 +213,8 @@ class _OtpScreenState extends State<OtpScreen> {
         elevation: 0,
         foregroundColor: TruxifyColors.primaryText,
         title: Text(
-          AppLocalizations.of(context)!.verifyOtp,
-          style: TextStyle(
-            color: colorScheme.onSurface,
-          ),
+          l10n.verifyOtp,
+          style: TextStyle(color: colorScheme.onSurface),
         ),
       ),
       body: SafeArea(
@@ -126,24 +226,55 @@ class _OtpScreenState extends State<OtpScreen> {
               const TruxifyLogo(size: 28),
               const SizedBox(height: 30),
               Text(
-                AppLocalizations.of(context)!.enterOtp,
+                l10n.enterOtp,
                 style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                       color: colorScheme.onSurface,
                     ),
               ),
               const SizedBox(height: 8),
               Text(
-                AppLocalizations.of(context)!.sentTo('${widget.countryCode} ${widget.phone}'),
+                l10n.sentTo('${widget.countryCode} ${widget.phone}'),
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: TruxifyColors.adaptiveSecondaryText(context),
                     ),
               ),
               const SizedBox(height: 24),
-              OtpInputRow(controllers: _controllers, focusNodes: _focusNodes),
+              OtpInputRow(
+                  controllers: _controllers, focusNodes: _focusNodes),
               const SizedBox(height: 24),
               PrimaryButton(
-                label: _loading ? AppLocalizations.of(context)!.verifying : AppLocalizations.of(context)!.verifyOtp,
+                label: _loading ? l10n.verifying : l10n.verifyOtp,
                 onPressed: _loading ? null : _verifyOtp,
+              ),
+              const SizedBox(height: 20),
+
+              // ── Resend row ──────────────────────────────────────────────
+              Center(
+                child: _resending
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : _cooldownSeconds > 0
+                        ? Text(
+                            l10n.resendOtpIn(_cooldownSeconds),
+                            style:
+                                Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                      color: TruxifyColors.adaptiveSecondaryText(
+                                          context),
+                                    ),
+                          )
+                        : TextButton(
+                            onPressed: _resendOtp,
+                            child: Text(
+                              l10n.resendOtp,
+                              style: TextStyle(
+                                color: TruxifyColors.accent,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
               ),
             ],
           ),


### PR DESCRIPTION
## fix(driver): add OTP resend cooldown and resend button — closes #762

### Problem

The driver OTP screen had no resend button at all. A driver who didn't receive their SMS had no in-app way to request a new code. Even if one were added naïvely, nothing prevented rapid-fire resend taps, which wastes Firebase Phone Auth quota and can trigger rate-limiting.

### Solution

**`apps/driver/lib/screens/otp_screen.dart`**
- Added optional `resendToken` constructor parameter (`int?`). Firebase returns this token alongside `verificationId` on the initial `verifyPhoneNumber` call; passing it back on resend lets Firebase skip re-sending where possible.
- Added a 30-second countdown timer (`Timer.periodic`) that starts in `initState` so the cooldown begins the moment the screen opens.
- Added `_resendOtp()` which calls `AuthService.verifyPhoneNumber` with `forceResendingToken: _resendToken`. On success it refreshes `_verificationId` + `_resendToken`, restarts the cooldown, clears the 6-box OTP input, and shows a success snackbar.
- Added a resend row below the "Verify" button:
  - `CircularProgressIndicator` while resending
  - `"Resend in Xs"` text during the cooldown window
  - `TextButton("Resend OTP")` once the cooldown expires

**`apps/driver/lib/app.dart`**
- The `AppRoutes.otp` route handler now reads `args['resendToken']`, parses it to `int?` with `int.tryParse`, and passes it to `OtpScreen`.

**`apps/driver/lib/screens/login_screen.dart`**
- The `onCodeSent` callback now includes `'resendToken': resendToken.toString()` in the named-route arguments so the token is available to `OtpScreen` on first navigation.

**`apps/driver/lib/l10n/app_en.arb`**
- Added three new localisation keys: `otpResent`, `resendOtpIn` (with `{seconds}` int placeholder), `resendOtp`.

### Testing

1. Run the driver app and log in with a valid phone number.
2. On the OTP screen, verify the resend button shows "Resend in 30s" and counts down.
3. Once the timer reaches 0, tap **Resend OTP** — a new SMS should arrive and the button should disable again for 30s.
4. Tapping the button while the timer is active should do nothing (guarded by `_canResend`).
5. Verify that the new OTP works for sign-in.

### Checklist

- [x] No breaking changes to existing routes or constructors
- [x] `forceResendingToken` used correctly per Firebase docs
- [x] Timer cancelled in `dispose()` to prevent memory leaks
- [x] All new strings added to `app_en.arb`
- [x] `mounted` guard on every async `setState` call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to resend verification codes from the OTP screen.
  - Added a 30-second cooldown timer and loading state while requesting a new code.
  - Automatically updates verification details and clears the previous OTP after a successful resend.
  - Added localized labels, countdown text, success feedback, and error messages.
  - Improved OTP verification flow after requesting a new code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->