### PR TITLE
fix: correct depth of root-subsystem router imports in index.js so API boots

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -80,11 +80,11 @@ import webrtcRoutes from './routes/webrtcRoutes.js'
 // ============================================================================
 // 🆕 ROOT SUBSYSTEM ROUTES (eBPF, WASI, WASM, Snyk, Liquibase)
 // ============================================================================
-import ebpfRoutes from '../../ebpf/routes.js'
-import wasiRoutes from '../../wasi/routes.js'
-import wasmRoutes from '../../wasm/routes.js'
-import snykRoutes from '../../snyk/routes.js'
-import liquibaseRoutes from '../../database/liquibase/routes.js'
+import ebpfRoutes from '../../../ebpf/routes.js'
+import wasiRoutes from '../../../wasi/routes.js'
+import wasmRoutes from '../../../wasm/routes.js'
+import snykRoutes from '../../../snyk/routes.js'
+import liquibaseRoutes from '../../../database/liquibase/routes.js'
 import earningsRouter from '../routes/earnings.js'
 import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 


### PR DESCRIPTION
Closes #6102

## What

Fixes the import depth of the five root-subsystem routers in `backend/api/src/index.js` (`ebpf`, `wasi`, `wasm`, `snyk`, `database/liquibase`).

## Why

From `backend/api/src/`, `'../../ebpf/routes.js'` resolves to `backend/ebpf/routes.js` which does not exist — the real modules live at the repo root (`ebpf/routes.js`, `wasi/routes.js`, `wasm/routes.js`, `snyk/routes.js`, `database/liquibase/routes.js`). The API server failed to boot with `ERR_MODULE_NOT_FOUND`.

## Changes

- `backend/api/src/index.js:83-87` — `../../` → `../../../` for all five imports.

## Verification

- `node --check backend/api/src/index.js` passes.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal route loading so root-level API endpoints are accessed reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->