### PR TITLE
fix: pass requestingUser to offline GPS signaling calls so sync works

### DIFF
--- a/backend/api/src/routes/webrtcRoutes.js
+++ b/backend/api/src/routes/webrtcRoutes.js
@@ -112,7 +112,7 @@ router.get('/webrtc/offline/:peerId', authenticate, userLimiter, requirePolicy('
       });
     }
 
-    const data = await signaling.getOfflineGPSData(peerId, since);
+    const data = await signaling.getOfflineGPSData(peerId, since, req.user);
     res.json({
       success: true,
       data
@@ -145,7 +145,7 @@ router.post('/webrtc/sync/:peerId', authenticate, userLimiter, requirePolicy('we
       });
     }
 
-    await signaling.syncOfflineData(peerId);
+    await signaling.syncOfflineData(peerId, req.user);
     res.json({
       success: true,
       message: 'Offline data synced'


### PR DESCRIPTION
Closes #6104

## What

Passes `req.user` as the `requestingUser` argument to `getOfflineGPSData` and `syncOfflineData` in `backend/api/src/routes/webrtcRoutes.js`.

## Why

`WebRTCSignalingServer.js` defines `getOfflineGPSData(peerId, since, requestingUser)` and `syncOfflineData(peerId, requestingUser)`, both early-returning (`[]` / no-op) when `requestingUser` is falsy. The routes called them without the argument, so `GET /api/webrtc/offline/:peerId` always returned `[]` and `POST /api/webrtc/sync/:peerId` never synced.

## Changes

- `webrtcRoutes.js:115` — `getOfflineGPSData(peerId, since, req.user)`
- `webrtcRoutes.js:148` — `syncOfflineData(peerId, req.user)`

## Verification

- `node --check backend/api/src/routes/webrtcRoutes.js` passes.

GSSOC
