### PR TITLE
fix: correct logger import path in kafka config so Kafka service boots

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -1,6 +1,6 @@
 import { Kafka } from 'kafkajs';
 import { context, propagation } from '@opentelemetry/api';
-import logger from '../api/src/middleware/logger.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const kafka = new Kafka({
   clientId: 'truxify',


### PR DESCRIPTION
Closes #6105

## What

Fixes the logger import path in `backend/kafka/config/kafka.config.js`.

## Why

From `backend/kafka/config/`, `'../api/src/middleware/logger.js'` resolves to `backend/kafka/api/src/middleware/logger.js`, which does not exist. The correct target is `backend/api/src/middleware/logger.js`. The Kafka service (`cd backend/kafka && node index.js`, per README) crashed at boot with `ERR_MODULE_NOT_FOUND`.

## Changes

- `backend/kafka/config/kafka.config.js:3` — `'../api/src/middleware/logger.js'` → `'../../api/src/middleware/logger.js'`.

## Verification

- `node --check backend/kafka/config/kafka.config.js` passes.

GSSOC
