### PR TITLE
fix: correct ../api import depth in graphql gateway and services so it boots

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -1,10 +1,10 @@
-import { ApolloGateway, IntrospectAndCompose } from '@apollo/gateway';
+﻿import { ApolloGateway, IntrospectAndCompose } from '@apollo/gateway';
 import { RemoteGraphQLDataSource } from '@apollo/gateway';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
-import logger from '../api/src/middleware/logger.js';
-import { supabase } from '../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
 
 class GraphQLGateway {
     constructor() {
@@ -324,10 +324,10 @@ class GraphQLGateway {
                 }
             });
 
-            logger.info(`✅ GraphQL Gateway running at ${url}`);
+            logger.info(`âœ… GraphQL Gateway running at ${url}`);
             return { url };
         } catch (error) {
-            logger.error('❌ GraphQL Gateway startup failed:', error);
+            logger.error('âŒ GraphQL Gateway startup failed:', error);
             throw error;
         }
     }
@@ -352,7 +352,7 @@ class GraphQLGateway {
     async stop() {
         if (this.server) {
             await this.server.stop();
-            logger.info('✅ GraphQL Gateway stopped');
+            logger.info('âœ… GraphQL Gateway stopped');
         }
     }
 }

--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -1,9 +1,9 @@
-import { ApolloServer } from '@apollo/server';
+﻿import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const DISPATCH_ROLES = new Set(['ADMIN', 'admin', 'DISPATCHER', 'dispatcher']);
 
@@ -212,7 +212,7 @@ async function startDriverService() {
         listen: { port: 4002 }
     });
 
-    logger.info(`✅ Driver GraphQL service running at ${url}`);
+    logger.info(`âœ… Driver GraphQL service running at ${url}`);
     return { url };
 }
 

--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -1,9 +1,9 @@
-import { ApolloServer } from '@apollo/server';
+﻿import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const ADMIN_ROLES = new Set(['ADMIN', 'admin']);
 
@@ -285,7 +285,7 @@ async function startOrderService() {
         listen: { port: 4001 }
     });
 
-    logger.info(`✅ Order GraphQL service running at ${url}`);
+    logger.info(`âœ… Order GraphQL service running at ${url}`);
     return { url };
 }
 


### PR DESCRIPTION
Closes #6107

## What

Fixes the import depth in three GraphQL files that imported API modules from `../api/src/...` when they need `../../api/src/...`:

- `backend/graphql/gateway/index.js:6-7`
- `backend/graphql/services/driver.service.js:5-6`
- `backend/graphql/services/order.service.js:5-6`

## Why

From `backend/graphql/gateway/` and `backend/graphql/services/`, `'../api/src/middleware/logger.js'` resolves to `backend/graphql/api/src/...` which does not exist. The correct targets are `backend/api/src/middleware/logger.js` and `backend/api/src/config/db.js`. The GraphQL gateway (`backend/graphql/package.json` `start: node index.js`) crashed at boot.

## Changes

- `'../api/src/...'` → `'../../api/src/...'` in the 3 files (6 imports).

## Verification

- All 6 imports now resolve to existing files (`backend/api/src/middleware/logger.js`, `backend/api/src/config/db.js`).

GSSOC
