### PR TITLE
fix: add migration creating reputation_failures table for on-chain retry queue

### DIFF
--- a/supabase/migrations/20260804100000_create_reputation_failures.sql
+++ b/supabase/migrations/20260804100000_create_reputation_failures.sql
@@ -1,0 +1,16 @@
+-- Migration: Create reputation_failures table
+-- Backs the on-chain reputation retry queue. awardReputationPoints failures
+-- are persisted here and retried by reputationReconciliation.
+
+CREATE TABLE IF NOT EXISTS reputation_failures (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  driver_wallet   text NOT NULL,
+  stars           numeric NOT NULL DEFAULT 0,
+  failed_at       timestamptz NOT NULL DEFAULT now(),
+  retry_count     integer NOT NULL DEFAULT 0,
+  last_error      text,
+  last_attempt_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS reputation_failures_retry_idx
+  ON reputation_failures (retry_count);


### PR DESCRIPTION
Closes #6108

## What

Adds the missing `reputation_failures` table migration: `supabase/migrations/20260804100000_create_reputation_failures.sql`.

## Why

`reputation_failures` is used in four live code paths — `orderRoutes.js:756`, `reputationSubscriber.js:42`, `reputationReconciliation.js:54,80,89`, `orderRepository.js:554` — but no migration ever creates it. The reconciliation worker (started at index.js:645) and subscriber (index.js:138) therefore silently lose on-chain reputation retries against a fresh database.

## Changes

- `CREATE TABLE reputation_failures` with `driver_wallet`, `stars`, `failed_at`, `retry_count`, `last_error`, `last_attempt_at` (columns match all query sites) and a `retry_count` index used by `reputationReconciliation.js`.

GSSOC
