### PR TITLE
fix: add migration creating gps_offline_data table for offline GPS sync

### DIFF
--- a/supabase/migrations/20260804100500_create_gps_offline_data.sql
+++ b/supabase/migrations/20260804100500_create_gps_offline_data.sql
@@ -1,0 +1,23 @@
+-- Migration: Create gps_offline_data table
+-- Persists WebRTC offline GPS payloads for the offline-sync feature.
+
+CREATE TABLE IF NOT EXISTS gps_offline_data (
+  id        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "peerId"  text NOT NULL,
+  data      jsonb NOT NULL,
+  timestamp bigint NOT NULL,
+  synced    boolean NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS gps_offline_data_peer_idx
+  ON gps_offline_data ("peerId");
+
+-- Service uses the anon client on behalf of authenticated users.
+ALTER TABLE gps_offline_data ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY gps_offline_data_authenticated_all
+  ON gps_offline_data
+  FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
Closes #6109

## What

Adds the missing `gps_offline_data` table migration: `supabase/migrations/20260804100500_create_gps_offline_data.sql`.

## Why

`WebRTCSignalingServer.js:234,398,414` inserts, selects and updates `gps_offline_data`, but no migration ever creates it. This compounds the offline-GPS bug — even with `requestingUser` passed (#6104), the queries fail against a fresh database.

## Changes

- `CREATE TABLE gps_offline_data` with `peerId`, `data` (jsonb), `timestamp` (bigint), `synced` (boolean) — column names match the exact `.eq('peerId', ...)`, `.gt('timestamp', ...)`, `.update({ synced: true })` query sites.
- Index on `peerId`; RLS enabled with an `authenticated` policy since the server uses the anon client.

GSSOC
