### PR TITLE
fix: add migration creating vehicle_types and regions lookup tables

### DIFF
--- a/supabase/migrations/20260804101000_create_lookup_tables.sql
+++ b/supabase/migrations/20260804101000_create_lookup_tables.sql
@@ -1,0 +1,16 @@
+-- Migration: Create vehicle_types and regions lookup tables
+-- Back GET /api/v1/vehicle-types and GET /api/v1/regions.
+
+CREATE TABLE IF NOT EXISTS vehicle_types (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name             text NOT NULL UNIQUE,
+  capacity_tonnes  numeric,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS regions (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       text NOT NULL UNIQUE,
+  code       text UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
Closes #6103

## What

Adds migrations creating the `vehicle_types` and `regions` lookup tables: `supabase/migrations/20260804101000_create_lookup_tables.sql`.

## Why

`lookupRoutes.js:92,106` queries `vehicle_types` and `regions` for `GET /api/v1/vehicle-types` and `GET /api/v1/regions`, but no migration ever creates them — the endpoints 500 with `relation "vehicle_types" does not exist` (verified: zero `CREATE TABLE` for either across all SQL/liquibase files; only defensive `ALTER TABLE IF EXISTS` RLS policies reference them).

## Changes

- `CREATE TABLE vehicle_types (id, name, capacity_tonnes, created_at)`
- `CREATE TABLE regions (id, name, code, created_at)`

GSSOC
