### PR TITLE
fix: point ZKP service at profiles table and create missing zk_proofs/kyc_audit_logs

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+﻿import { ethers } from 'ethers';
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
 import { supabase } from '../../config/db.js';
@@ -106,7 +106,7 @@ class ZKPService {
 
   async getUserAddress(userId) {
     const { data, error } = await supabase
-      .from('users')
+      .from('profiles')
       .select('wallet_address')
       .eq('id', userId)
       .single();
@@ -128,7 +128,7 @@ class ZKPService {
 
   async updateVerificationStatus(userId, verified, txHash) {
     const { error } = await supabase
-      .from('users')
+      .from('profiles')
       .update({
         kyc_verified: verified,
         kyc_verified_at: new Date().toISOString(),
@@ -156,7 +156,7 @@ class ZKPService {
    */
   async isVerifiedInDb(userId) {
     const { data, error } = await supabase
-      .from('users')
+      .from('profiles')
       .select('kyc_verified')
       .eq('id', userId)
       .single();
@@ -185,21 +185,21 @@ class ZKPService {
    *   before any processing begins. This guarantees at-most-one execution
    *   even under concurrent duplicate requests:
    *
-   *   - LockAcquisitionError (Redis unavailable) → propagated to caller → 503
-   *   - lockValue === null (lock held by another request) → propagated → 409
+   *   - LockAcquisitionError (Redis unavailable) â†’ propagated to caller â†’ 503
+   *   - lockValue === null (lock held by another request) â†’ propagated â†’ 409
    *   - After acquiring the lock, re-check `kyc_verified` in the DB; if the
    *     first request already completed, return early without re-running the
    *     blockchain transaction or inserting duplicate audit rows.
    *
    * @param {object} driverData
-   * @throws {LockAcquisitionError} When Redis is unavailable — caller must return 503.
+   * @throws {LockAcquisitionError} When Redis is unavailable â€” caller must return 503.
    * @returns {{ success: boolean, alreadyVerified?: boolean, proof?, onChain?, verified? }}
    */
   async verifyDriver(driverData) {
     const lockKey = `zkp:verify:${driverData.userId}`;
     let lockValue = null;
 
-    // Throws LockAcquisitionError if Redis is down — propagate to route handler.
+    // Throws LockAcquisitionError if Redis is down â€” propagate to route handler.
     lockValue = await acquireLock(lockKey, ZKP_LOCK_TTL_MS);
 
     if (lockValue === null) {
@@ -218,7 +218,7 @@ class ZKPService {
       // exits without re-running the expensive blockchain transaction.
       const alreadyVerified = await this.isVerifiedInDb(driverData.userId);
       if (alreadyVerified) {
-        logger.info(`[ZKP] User ${driverData.userId} is already KYC-verified — skipping duplicate processing`);
+        logger.info(`[ZKP] User ${driverData.userId} is already KYC-verified â€” skipping duplicate processing`);
         return {
           success: true,
           alreadyVerified: true,
@@ -276,8 +276,8 @@ class ZKPService {
 
   async getVerificationStats() {
     const [verifiedResult, unverifiedResult] = await Promise.all([
-      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', true),
-      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', false),
+      supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('kyc_verified', true),
+      supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('kyc_verified', false),
     ]);
     if (verifiedResult.error) throw verifiedResult.error;
     if (unverifiedResult.error) throw unverifiedResult.error;

--- a/supabase/migrations/20260804102000_create_zkp_tables.sql
+++ b/supabase/migrations/20260804102000_create_zkp_tables.sql
@@ -1,0 +1,29 @@
+-- Migration: Add KYC columns to profiles + create zk_proofs and kyc_audit_logs
+-- The ZKP service queried a non-existent users table and two tables that were
+-- never created. This points auth at the real profiles table and creates the
+-- missing tables.
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS kyc_verified boolean NOT NULL DEFAULT false;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS kyc_verified_at timestamptz;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS kyc_tx_hash text;
+
+CREATE TABLE IF NOT EXISTS zk_proofs (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  proof          jsonb NOT NULL,
+  public_signals jsonb,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS zk_proofs_user_idx ON zk_proofs (user_id);
+
+CREATE TABLE IF NOT EXISTS kyc_audit_logs (
+  id        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id   uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  action    text NOT NULL,
+  status    text NOT NULL,
+  tx_hash   text,
+  timestamp timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS kyc_audit_logs_user_idx ON kyc_audit_logs (user_id);


### PR DESCRIPTION
Closes #6106

## What

Fixes the ZKP service's database layer:

1. Migration `supabase/migrations/20260804102000_create_zkp_tables.sql` adds `kyc_verified`/`kyc_verified_at`/`kyc_tx_hash` to `profiles` and creates the missing `zk_proofs` and `kyc_audit_logs` tables.
2. `zkp.service.js` now queries `profiles` instead of the non-existent `users` table (lines 109, 131, 159, 279-280).

## Why

`zkp.service.js` queried `users`, `zk_proofs` and `kyc_audit_logs` — none of which any migration creates (verified). The auth table is `profiles` (with `wallet_address`). `/api/zkp/stats` threw when `verifiedResult.error`, and `verifyDriver` failed in `storeProof`.

## Changes

- `ALTER TABLE profiles` add KYC columns (`IF NOT EXISTS`, safe to re-run).
- `CREATE TABLE zk_proofs (user_id, proof, public_signals, created_at)` matching `storeProof`.
- `CREATE TABLE kyc_audit_logs (user_id, action, status, tx_hash, timestamp)` matching `logVerification`.
- `from('users')` → `from('profiles')` (5 sites).

## Verification

- `node --check backend/api/src/services/zkp/zkp.service.js` passes.

GSSOC
