### PR TITLE
fix: show error with retry instead of false success panel when UPI intent or payment lock fails (#6135)

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -191,10 +191,22 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
         });
       }
     } catch (e) {
-      debugPrint('UPI intent failed: $e');
-      // Fallback: show success even without escrow
-      _showSuccessPanel();
-    }
+  debugPrint('UPI intent failed: $e');
+  if (!mounted) return;
+  setState(() {
+    _isAwaitingUpi = false;
+  });
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text('Payment setup failed: $e'),
+      action: SnackBarAction(
+        label: 'Retry',
+        onPressed: () => _fetchUpiIntent(_createdOrderId!),
+      ),
+      duration: const Duration(seconds: 8),
+    ),
+  );
+}
   }
 
   // ── Step 3: Open UPI deep-link ────────────────────────────────────────────
@@ -239,10 +251,19 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
 
       _showSuccessPanel();
     } catch (e) {
-      debugPrint('Payment lock failed: $e');
-      // Even if lock fails, show booking success — reconciliation will handle it
-      _showSuccessPanel();
-    } finally {
+  debugPrint('Payment lock failed: $e');
+  if (!mounted) return;
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text('Payment lock failed: $e'),
+      action: SnackBarAction(
+        label: 'Retry',
+        onPressed: _confirmPaymentLocked,
+      ),
+      duration: const Duration(seconds: 8),
+    ),
+  );
+}finally {
       if (mounted) {
         setState(() => _isSubmitting = false);
       }


### PR DESCRIPTION
## Description
Both _fetchUpiIntent and _confirmPaymentLocked were silently swallowing exceptions and calling _showSuccessPanel(), telling the customer their payment was secured when nothing was. On a UPI intent failure (network error, 5xx, validation), the customer saw a full "Booking Confirmed" panel with the amount shown as locked in escrow — even though no escrow was created and no payment was captured. Same issue in the payment lock catch block. Fixed by removing the false success fallback from both catch blocks and replacing it with a SnackBar that shows the real error and a Retry button so the customer can retry the failed step instead of being misled into thinking payment is complete.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** flutter test
- **Test Steps:** Simulate a network failure during _fetchUpiIntent and _confirmPaymentLocked. Verify error SnackBar appears with Retry button. Verify success panel is NOT shown on failure. Tap Retry and verify the flow re-attempts correctly.
- **Expected Result:** On failure, customer sees an error with a retry option. Success panel only appears after a confirmed payment lock.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #6135

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Booking confirmation is no longer shown when UPI intent or payment-lock failures occur.
  - Failed payments now clear the pending-payment state and display a retryable error message.
  - Error notifications remain visible for 8 seconds to give users time to retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->