### PR TITLE
fix: implement OTP verification logic in POST /api/auth/verify-otp (#6136)

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -165,26 +165,96 @@ router.get("/session", authenticate, userLimiter, (req, res) => {
   });
 });
 
+import crypto from "crypto";
+import { supabase } from "../config/db.js";
+import { otpSendSchema } from "../validation/requestSchemas.js";
+import { z } from "zod";
+
+const verifyOtpSchema = z.object({
+  phone: z.string().min(10).max(20),
+  otp: z.string().regex(/^\d{6}$/, "OTP must be 6 digits"),
+}).strict();
+
 /**
  * @openapi
  * /api/auth/verify-otp:
  *   post:
  *     tags: [Authentication]
  *     summary: Verify OTP
- *     description: Endpoint for verifying OTPs. Protected by strict rate limiting to prevent brute-forcing.
+ *     description: Verifies a 6-digit OTP submitted for a given phone number. Timing-safe comparison. OTP is consumed on success.
  *     responses:
- *       501:
- *         description: Not Implemented
+ *       200:
+ *         description: OTP verified successfully
+ *       400:
+ *         description: Invalid or expired OTP
+ *       429:
+ *         description: Too many attempts
  */
 router.post("/verify-otp", otpVerificationLimiter, async (req, res) => {
-  // To be implemented: backend OTP verification logic.
-  // This endpoint serves as a rate-limited proxy/placeholder to satisfy
-  // security requirements preventing OTP brute forcing.
-  return res.status(501).json({
-    success: false,
-    error: "Not Implemented",
-    message: "OTP verification logic should be executed here.",
-  });
+  const parsed = verifyOtpSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      error: "Validation failed",
+      details: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const { phone, otp } = parsed.data;
+
+  try {
+    // Look up the latest unused, unexpired OTP for this phone number
+    const { data: otpRecord, error: fetchErr } = await supabase
+      .from("phone_otps")
+      .select("id, otp_hash, expires_at, verified")
+      .eq("phone", phone)
+      .eq("verified", false)
+      .gt("expires_at", new Date().toISOString())
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (fetchErr) {
+      logger.error("[auth/verify-otp] DB fetch error:", fetchErr.message);
+      return res.status(500).json({ success: false, error: "Internal server error." });
+    }
+
+    if (!otpRecord) {
+      return res.status(400).json({ success: false, error: "OTP not found or has expired." });
+    }
+
+    // Timing-safe comparison to prevent timing attacks
+    const submittedHash = crypto.createHash("sha256").update(String(otp)).digest("hex");
+    const storedHash = otpRecord.otp_hash;
+
+    const isMatch =
+      submittedHash.length === storedHash.length &&
+      crypto.timingSafeEqual(
+        Buffer.from(submittedHash, "hex"),
+        Buffer.from(storedHash, "hex"),
+      );
+
+    if (!isMatch) {
+      return res.status(400).json({ success: false, error: "Invalid OTP." });
+    }
+
+    // Consume the OTP so it cannot be reused
+    const { error: updateErr } = await supabase
+      .from("phone_otps")
+      .update({ verified: true, verified_at: new Date().toISOString() })
+      .eq("id", otpRecord.id);
+
+    if (updateErr) {
+      logger.error("[auth/verify-otp] Failed to mark OTP as verified:", updateErr.message);
+      return res.status(500).json({ success: false, error: "Internal server error." });
+    }
+
+    logger.info(`[auth/verify-otp] OTP verified for phone: ${phone}`);
+    return res.status(200).json({ success: true, message: "OTP verified successfully." });
+  } catch (err) {
+    logger.error("[auth/verify-otp] Unexpected error:", err.message);
+    return res.status(500).json({ success: false, error: "Internal server error." });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Description
POST /api/auth/verify-otp was a permanently-501 stub that never verified anything. It existed only as a rate-limit choke point with no actual OTP verification logic. Any client following the documented contract received a static 501 Not Implemented response. Implemented the full verification flow: validates request body (phone + 6-digit OTP) using Zod, looks up the latest unexpired and unconsumed OTP record for the phone number from the phone_otps table, performs a timing-safe SHA-256 hash comparison to prevent timing attacks, marks the OTP as consumed on success so it cannot be reused, and returns 200 on success or a 400 with the reason on failure. The existing otpVerificationLimiter is kept to prevent brute-forcing.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** npm test
- **Test Steps:** POST /api/auth/verify-otp with a valid phone + correct OTP — should return 200. POST with wrong OTP — should return 400 Invalid OTP. POST with expired OTP — should return 400 OTP not found or has expired. POST with already-verified OTP — should return 400. POST with missing fields — should return 400 validation error.
- **Expected Result:** Valid unexpired OTP returns 200 and is marked consumed. All invalid cases return 400 with a clear reason. Rate limiter still enforces brute-force protection.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #6136

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.