### PR TITLE
fix: set payment_released:false and reconciliation_required:true in 202 confirm-otp response (#6134)

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -175,12 +175,26 @@ class _DeliveryOtpScreenState extends State<DeliveryOtpScreen>
 
     try {
       final body = await _apiClient.post(
-        '/api/orders/${widget.orderId}/confirm-otp',
-        body: {'otp': _otp},
-      );
+        final body = await _apiClient.post(
+  '/api/orders/${widget.orderId}/confirm-otp',
+  body: {'otp': _otp},
+);
 
-      final amount = body is Map ? (body['amount_inr'] as String?) : null;
-      await _showPaymentReleased(amount ?? widget.amountInr);
+final amount = body is Map ? (body['amount_inr'] as String?) : null;
+final reconciliationRequired = body is Map && body['reconciliation_required'] == true;
+
+if (reconciliationRequired) {
+  if (mounted) {
+    setState(() {
+      _errorMessage =
+          'Delivery confirmed! Your payout of ₹${amount ?? widget.amountInr ?? '...'} '
+          'is pending reconciliation and will be credited shortly.';
+    });
+  }
+  return;
+}
+
+await _showPaymentReleased(amount ?? widget.amountInr);
     } catch (e) {
       final msg = e.toString().replaceAll('Exception: ', '');
       setState(() => _errorMessage = msg);

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -827,19 +827,19 @@ router.get('/:id/bids', authenticate, userLimiter, requirePolicy('order:view-bid
     ]);
 
     const profiles = profilesRes.data || [];
-    const details  = detailsRes.data || [];
+    const details = detailsRes.data || [];
     const truckIds = details.map(d => d.truck_id).filter(Boolean);
     const trucksRes = truckIds.length > 0 ? await orderRepository.findTrucksByIds(truckIds) : { data: [] };
     const trucks = trucksRes.data || [];
 
     const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
-    const detailMap  = Object.fromEntries(details.map(d => [d.user_id, d]));
-    const truckMap   = Object.fromEntries(trucks.map(t => [t.id, t]));
+    const detailMap = Object.fromEntries(details.map(d => [d.user_id, d]));
+    const truckMap = Object.fromEntries(trucks.map(t => [t.id, t]));
 
     const enrichedBids = bids.map(bid => {
       const profile = profileMap[bid.driver_id] || {};
-      const detail  = detailMap[bid.driver_id]  || {};
-      const truck   = detail.truck_id ? truckMap[detail.truck_id] : null;
+      const detail = detailMap[bid.driver_id] || {};
+      const truck = detail.truck_id ? truckMap[detail.truck_id] : null;
 
       return {
         id: bid.id, bid_amount: bid.bid_amount, created_at: bid.created_at,
@@ -1132,10 +1132,12 @@ router.post(
         : null;
 
       if (escrowUpdateFailed) {
+        logger.warn(`[confirm-otp] escrowUpdateFailed for order ${req.params.id} — reconciliation required`);
         return res.status(202).json({
-          message: 'Delivery confirmed. Escrow payout requires reconciliation.',
-          payment_released: true,
-          escrow_status: 'released',
+          message: 'Delivery confirmed. Escrow payout is pending reconciliation — your payment will be credited shortly.',
+          payment_released: false,
+          reconciliation_required: true,
+          escrow_status: 'release_pending_reconciliation',
           amount_inr: amountInr,
         });
       }
@@ -1255,13 +1257,13 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
       });
 
       pricing = computeOrderPricing({
-        pickupLat:  Number(order.pickup_lat),
-        pickupLng:  Number(order.pickup_lng),
-        dropLat:    Number(drop_lat),
-        dropLng:    Number(drop_lng),
+        pickupLat: Number(order.pickup_lat),
+        pickupLng: Number(order.pickup_lng),
+        dropLat: Number(drop_lat),
+        dropLng: Number(drop_lng),
         weightTonnes: Number(order.weight_tonnes),
         roadDistanceKm: routeEstimate?.distanceKm,
-        isFragile:   Boolean(order.is_fragile),
+        isFragile: Boolean(order.is_fragile),
         isStackable: Boolean(order.is_stackable),
       });
     } catch (pricingErr) {
@@ -1683,7 +1685,7 @@ router.get('/:id/route', authenticate, userLimiter, telemetryLimiter, requirePol
       const destLng = Number(order.drop_lng);
 
       if (!Number.isFinite(originLat) || !Number.isFinite(originLng) ||
-          !Number.isFinite(destLat) || !Number.isFinite(destLng)) {
+        !Number.isFinite(destLat) || !Number.isFinite(destLng)) {
         return res.status(500).json({ error: 'Order has invalid coordinates.' });
       }
 


### PR DESCRIPTION
## Description
The confirm-otp 202 response (escrowUpdateFailed path) was returning payment_released:true and escrow_status:released — identical to the success path. Clients had no way to distinguish "payment fully released" from "on-chain escrow released but local DB update failed and reconciliation is required". The driver app read amount_inr and showed the full "Payment Released ✓ ₹XXXX credited" banner in both cases, telling drivers their payout was complete when the backend knew the escrow update had failed. Fixed by setting payment_released:false and reconciliation_required:true in the 202 branch, with a distinct escrow_status of release_pending_reconciliation and a message clarifying the payout is pending. The Flutter driver app now checks reconciliation_required before calling _showPaymentReleased() and shows an informational pending message instead of the success banner when reconciliation is needed.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** npm test && flutter test
- **Test Steps:** Simulate escrowUpdateFailed:true from verifyDeliveryFn. Verify confirm-otp returns 202 with payment_released:false and reconciliation_required:true. Verify driver app shows pending reconciliation message instead of Payment Released banner. Verify normal success path still shows Payment Released banner correctly.
- **Expected Result:** 202 path returns unambiguous degraded state. Driver sees "payout pending reconciliation" instead of false confirmation. Success path unchanged.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #6134

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.