### PR TITLE
fix: add missing getEscrowBooking export in escrow.js (Issue #6122)

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -206,6 +206,34 @@ export function getEscrowBookingId (orderDisplayId) {
 }
 
 /**
+ * Read the on-chain booking struct for a booking id.
+ *
+ * @param {string} escrowBookingId — bytes32 booking id (e.g. from order.escrow_booking_id)
+ * @returns {Promise<{customer: string, driver: string, amount: bigint, status: number, paid: boolean, started: boolean, createdAt: bigint}|null>}
+ */
+export async function getEscrowBooking (escrowBookingId) {
+  if (!escrowContract) {
+    logger.warn('[escrow] Contract not initialised — cannot read booking.')
+    return null
+  }
+  if (!escrowBookingId) {
+    logger.warn('[escrow] Cannot read booking without a booking id.')
+    return null
+  }
+
+  const booking = await escrowContract.bookings(escrowBookingId)
+  return {
+    customer: booking.customer,
+    driver: booking.driver,
+    amount: booking.amount,
+    status: Number(booking.status),
+    paid: booking.paid,
+    started: booking.started,
+    createdAt: booking.createdAt,
+  }
+}
+
+/**
  * Build an unsigned deposit transaction for the customer's wallet to sign.
  * Called when a bid is accepted and the order moves to in_progress.
  *


### PR DESCRIPTION
## Problem

`backend/api/src/services/escrowFundingReconciliation.js` statically imports `getEscrowBooking` from `./escrow.js`, but that name is never exported or implemented in `escrow.js`. Because `index.js` boots the reconciliation worker through static imports, Node ESM link-time resolution fails with `SyntaxError: The requested module './escrow.js' does not provide an export named 'getEscrowBooking'`, preventing the API server from starting.

## Fix

Added and exported `getEscrowBooking(escrowBookingId)` in `backend/api/src/services/escrow.js`. It reads the on-chain booking struct via `escrowContract.bookings(escrowBookingId)` and returns a normalized JSON object (customer, driver, amount, status, paid, started, createdAt). It guards against an uninitialised contract and missing booking ids, so the funding reconciliation sweep degrades gracefully instead of crashing.

## Files changed

- `backend/api/src/services/escrow.js`

## Testing

- Confirmed the imported name now resolves for the static import in `escrowFundingReconciliation.js`.
- `node --check` passes on the modified file.
- With escrow env vars unset, the server boots without the ESM link-time error.

Closes #6122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving escrow booking details using an escrow booking ID.
  * Booking information now includes address, amount, status, payment, start date, and creation date.
  * Returns a clear empty result when the booking ID or escrow service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->