### PR TITLE
fix: add missing markEscrowBookingStarted export in escrow.js (Issue #6123)

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -348,6 +348,45 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
 }
 
 /**
+ * Mark a booking as started on-chain after the goods are loaded (picked_up).
+ * This is required so cancelBooking / cancelWithPenalty revert for a full
+ * refund once the trip has begun.
+ *
+ * @param {string} orderDisplayId
+ * @returns {Promise<{txHash: string|null, bookingId: string, waitForConfirmation?: Function, error?: string}>}
+ */
+export async function markEscrowBookingStarted (orderDisplayId) {
+  return measureExecution('EscrowService.markEscrowBookingStarted', async () => {
+  const bookingId = getEscrowBookingId(orderDisplayId)
+
+  if (!escrowContract) {
+    logger.warn('[escrow] Contract not initialised — skipping markBookingStarted.')
+    return { txHash: null, bookingId }
+  }
+
+  try {
+    const tx = await escrowContract.markBookingStarted(bookingId)
+    logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+    return {
+      txHash: tx.hash,
+      bookingId,
+      waitForConfirmation: async () => {
+        const receipt = await tx.wait(1)
+        if (!receipt || receipt.status === 0) {
+          throw new Error('Escrow markBookingStarted transaction reverted or was not found.')
+        }
+        logger.info(`[escrow] markBookingStarted confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
+        return receipt
+      },
+    }
+  } catch (err) {
+    logger.error(`[escrow] markBookingStarted failed for booking ${orderDisplayId}: ${err.message}`)
+    return { txHash: null, bookingId, error: err.message }
+  }
+  });
+}
+
+/**
  * Release escrowed funds to the driver after successful delivery verification.
  * Must be called by an authorised relayer.
  *


### PR DESCRIPTION
## Problem

`backend/api/src/services/order/orderMilestoneService.js` statically imports and calls `markEscrowBookingStarted` (line 20 / line 116), but `escrow.js` never exported or implemented it. The missing export is a hard ESM link-time error (`SyntaxError: The requested module '../escrow.js' does not provide an export named 'markEscrowBookingStarted'`) that crashes the API server on startup.

## Fix

Added and exported `markEscrowBookingStarted(orderDisplayId)` in `backend/api/src/services/escrow.js`. It derives the booking id with `getEscrowBookingId`, submits `escrowContract.markBookingStarted(bookingId)`, and returns `{ txHash, bookingId, waitForConfirmation }` (or `{ txHash: null, bookingId, error }` on failure / when the contract is not initialised). The return shape matches exactly what `orderMilestoneService.js` consumes (`started?.txHash`, `started.waitForConfirmation`, `started?.error`).

## Files changed

- `backend/api/src/services/escrow.js`

## Testing

- Confirmed the caller (`orderMilestoneService.js` on `main`) consumes `txHash` / `waitForConfirmation` / `error`, which the wrapper returns.
- `node --check` passes on the modified file.

Closes #6123
