### PR TITLE
fix: validate submitted OTP in OracleService._verifyOTP (Issue #6124)

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -1,5 +1,6 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
+import { verifyDeliveryOtpHash } from '../services/notificationService.js';
 
 const DELIVERY_COMPLETED_STATUSES = new Set([
   'delivered',
@@ -42,30 +43,28 @@ class OracleService {
 
   async _verifyOTP(orderId, otp) {
     try {
-      const { data: order, error: orderErr } = await this.supabase
-        .from('orders')
-        .select('id, otp_verified')
-        .eq('id', orderId)
-        .maybeSingle();
-
-      if (orderErr) {
-        logger.warn('[OracleService] OTP verification DB error:', orderErr.message);
-        return { confirmed: false, provider: 'OTPVerifier', error: orderErr.message, timestamp: new Date().toISOString() };
-      }
-
-      if (!order) {
-        return { confirmed: false, provider: 'OTPVerifier', reason: 'Order not found', timestamp: new Date().toISOString() };
-      }
-
-      const { data: otpRecord } = await this.supabase
+      const { data: otpRecord, error: otpErr } = await this.supabase
         .from('delivery_otps')
-        .select('id, verified')
+        .select('id, otp_hash, otp_salt, expires_at')
         .eq('order_id', orderId)
-        .eq('verified', true)
+        .order('created_at', { ascending: false })
         .limit(1)
         .maybeSingle();
 
-      const isVerified = order.otp_verified === true || (otpRecord && otpRecord.verified === true);
+      if (otpErr) {
+        logger.warn('[OracleService] OTP verification DB error:', otpErr.message);
+        return { confirmed: false, provider: 'OTPVerifier', error: otpErr.message, timestamp: new Date().toISOString() };
+      }
+
+      if (!otpRecord) {
+        return { confirmed: false, provider: 'OTPVerifier', reason: 'No OTP record found for order', timestamp: new Date().toISOString() };
+      }
+
+      if (otpRecord.expires_at && new Date(otpRecord.expires_at) <= new Date()) {
+        return { confirmed: false, provider: 'OTPVerifier', reason: 'OTP expired', timestamp: new Date().toISOString() };
+      }
+
+      const isVerified = verifyDeliveryOtpHash(otp, otpRecord);
 
       return {
         confirmed: isVerified,


### PR DESCRIPTION
## Problem

`OracleService._verifyOTP` ignored the submitted `otp` argument entirely — it derived `confirmed` purely from persisted `verified` flags, so `confirmDelivery` could confirm delivery with a wrong or empty OTP as long as the order was already flagged verified.

## Fix

`_verifyOTP` now loads the latest `delivery_otps` row for the order, rejects expired records (`expires_at` in the past), and validates the submitted code against the stored hash using the existing timing-safe `verifyDeliveryOtpHash` utility (which supports both salted 128-hex and plain sha256 64-hex hashes). `confirmed: true` is only returned on an actual hash match.

## Files changed

- `backend/api/src/oracle/OracleService.js`

## Testing

- Verified `verifyDeliveryOtpHash` (exported from `notificationService.js`) handles both stored hash formats and returns `false` for mismatches.
- `node --check` passes on the modified file.

Closes #6124
