### PR TITLE
fix: start withdrawalSettlementWorker in index.js (Issue #6125)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -135,6 +135,10 @@ import {
   stopDlqWorker,
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
+import {
+  startWithdrawalSettlementWorker,
+  stopWithdrawalSettlementWorker
+} from './workers/withdrawalSettlementWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -646,6 +650,7 @@ server.listen(PORT, () => {
   startDlqWorker()
   startStaleOrderWorker()
   startDocumentExpiryWorker()
+  startWithdrawalSettlementWorker()
 
   // Register worker states for health aggregation
   globalThis.__truxify_workers = {
@@ -656,6 +661,7 @@ server.listen(PORT, () => {
     dlqWorker: true,
     staleOrderWorker: true,
     documentExpiryWorker: true,
+    withdrawalSettlementWorker: true,
   }
 })
 
@@ -685,6 +691,7 @@ async function shutdown (signal) {
   stopReputationReconciliation()
   stopDlqWorker()
   stopDocumentExpiryWorker()
+  stopWithdrawalSettlementWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()
 


### PR DESCRIPTION
## Problem

`withdrawalSettlementWorker.js` is a fully implemented, provider-guarded worker but is never imported or started in `backend/api/src/index.js`. Pending driver withdrawals therefore never get dispatched or settled — funds stay reserved in `wallet_confirmed` forever.

## Fix

Wired the worker into `index.js`:

- Imports added alongside the other workers.
- `startWithdrawalSettlementWorker()` added to the startup block.
- `stopWithdrawalSettlementWorker()` added to the shutdown handler.
- Worker registered in `globalThis.__truxify_workers` so it is observable in health aggregation.

The worker retains its guard: it skips settlement when no payout provider is configured, so withdrawals are never falsely completed.

## Files changed

- `backend/api/src/index.js`

## Testing

- Verified `startWithdrawalSettlementWorker` / `stopWithdrawalSettlementWorker` exist as exports of the worker module.
- `node --check` passes on the modified file.

Closes #6125
