### PR TITLE
fix: add reputation_failures migration (Issue #6126)

### DIFF
--- a/supabase/migrations/20260804000000_create_reputation_failures.sql
+++ b/supabase/migrations/20260804000000_create_reputation_failures.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- Reputation failure tracking (Issue #6126)
+-- -----------------------------------------------------------------------------
+-- Problem:
+--   orderRepository.insertReputationFailure and reputationReconciliation.js
+--   read/write a `reputation_failures` table, but no migration ever created it.
+--   On any fresh environment the first insert throws
+--   'relation "reputation_failures" does not exist', so failed reputation
+--   awards are never persisted for the retry worker.
+--
+-- Fix:
+--   Create the table with the exact columns the repository and reconciliation
+--   code insert/filter on (driver_wallet, stars, retry_count, last_error,
+--   last_attempt_at, failed_at) and restrict it to the service role.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.reputation_failures (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  driver_wallet text NOT NULL,
+  stars integer,
+  failed_at timestamptz DEFAULT now(),
+  retry_count integer DEFAULT 0,
+  last_error text,
+  last_attempt_at timestamptz,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Index for efficient polling of retryable failures.
+CREATE INDEX IF NOT EXISTS idx_reputation_failures_retry_count
+  ON public.reputation_failures (retry_count);
+
+-- Internal table: only the backend (service_role) may access it.
+ALTER TABLE public.reputation_failures ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow Service Role full access to reputation_failures"
+  ON public.reputation_failures
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);

--- a/supabase/migrations/revoke_anon_privileges.sql
+++ b/supabase/migrations/revoke_anon_privileges.sql
@@ -34,6 +34,7 @@ REVOKE ALL ON TABLE public.driver_documents FROM anon;
 REVOKE ALL ON TABLE public.vehicle_types FROM anon;
 REVOKE ALL ON TABLE public.regions FROM anon;
 REVOKE ALL ON TABLE public.webhook_failures FROM anon;
+REVOKE ALL ON TABLE public.reputation_failures FROM anon;
 REVOKE ALL ON TABLE public.tracking_tokens FROM anon;
 REVOKE ALL ON TABLE public.temperature_telemetry FROM anon;
 


### PR DESCRIPTION
## Problem

`orderRepository.insertReputationFailure` and `reputationReconciliation.js` write to a `reputation_failures` table that no migration ever creates. On any fresh environment (CI, staging, new prod deployment) the first insert fails with `PostgrestError: relation "reputation_failures" does not exist`, so reputation failure tracking silently never works.

## Fix

Added migration `20260804000000_create_reputation_failures.sql` that creates the table with the exact columns the repository/reconciliation code inserts, upserts and filters on (`driver_wallet`, `stars`, `retry_count`, `last_error`, `last_attempt_at`, `failed_at`), plus an index on `retry_count` for the retry poll. RLS is enabled with a `service_role`-only policy, and `revoke_anon_privileges.sql` now also revokes all privileges on the table from `anon`.

## Files changed

- `supabase/migrations/20260804000000_create_reputation_failures.sql`
- `supabase/migrations/revoke_anon_privileges.sql`

## Testing

- Confirmed the columns match the `insert` / `upsert` / `select` / `delete` calls in `reputationReconciliation.js`.
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`).

Closes #6126
