### PR TITLE
fix: evaluate unusual-time window in UTC (Issue #6127)

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -130,7 +130,7 @@ class AnomalyDetectionService {
 
   detectUnusualTime(transaction) {
     const txTime = new Date(transaction.timestamp);
-    const hour = txTime.getHours();
+    const hour = txTime.getUTCHours();
 
     if (hour >= ANOMALY_THRESHOLDS.UNUSUAL_TIME.startHour &&
         hour < ANOMALY_THRESHOLDS.UNUSUAL_TIME.endHour) {

--- a/backend/api/test/unit/anomalyDetectionService.test.js
+++ b/backend/api/test/unit/anomalyDetectionService.test.js
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for backend/api/src/services/security/anomalyDetectionService.js
+ *
+ * Coverage:
+ *   - detectUnusualTime evaluates the UTC hour (not the server-local hour)
+ *   - A transaction inside the unusual window is flagged
+ *   - A transaction outside the unusual window is not flagged
+ *
+ * Run with:  npm run test:unit -- test/unit/anomalyDetectionService.test.js
+ */
+import { describe, it, expect } from 'vitest';
+import AnomalyDetectionService from '../../src/services/security/anomalyDetectionService.js';
+
+describe('AnomalyDetectionService.detectUnusualTime', () => {
+  const service = new AnomalyDetectionService();
+
+  it('flags a transaction whose UTC hour is inside the unusual window', () => {
+    // 2026-08-04T01:30:00Z -> UTC hour 1, inside [0, 6)
+    const result = service.detectUnusualTime({ timestamp: '2026-08-04T01:30:00.000Z' });
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('UNUSUAL_TIME');
+    expect(result.message).toContain('1:00 UTC');
+  });
+
+  it('does not flag a transaction whose UTC hour is outside the unusual window', () => {
+    // 2026-08-04T18:30:00Z -> UTC hour 18, outside [0, 6)
+    const result = service.detectUnusualTime({ timestamp: '2026-08-04T18:30:00.000Z' });
+    expect(result).toBeNull();
+  });
+
+  it('does not flag a late-evening UTC transaction even when it is a local morning hour', () => {
+    // 2026-08-04T23:30:00Z -> UTC hour 23. On a server at UTC+5:30 this is
+    // 05:00 local, which would previously be misclassified as inside the window.
+    const result = service.detectUnusualTime({ timestamp: '2026-08-04T23:30:00.000Z' });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`AnomalyDetectionService.detectUnusualTime` compared `Date.prototype.getHours()` (the server-local hour) against the `UNUSUAL_TIME` window while the message and `time` field both claim UTC. On a non-UTC server (e.g. IST, UTC+5:30), the wrong transactions are flagged and labelled — a false/missed flag in the security detector.

## Fix

Evaluate the hour with `getUTCHours()` so the window comparison, the `toISOString()` output and the `:00 UTC` label all refer to the same (UTC) timezone. Added a unit test that pins the expected behavior for known UTC instants, including the IST-misclassification case.

## Files changed

- `backend/api/src/services/security/anomalyDetectionService.js`
- `backend/api/test/unit/anomalyDetectionService.test.js`

## Testing

- New vitest unit tests cover: in-window (01:30Z flagged), out-of-window (18:30Z not flagged), and late-evening UTC (23:30Z not flagged even though it is 05:00 local on a UTC+5:30 server).
- `node --check` passes on the modified source file.

Closes #6127
