### PR TITLE
fix: initialize connectivity subscription in trip_detail_screen (Issue #6129)

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -51,6 +51,11 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
     super.initState();
     _routeFuture = _loadRouteForTrip(widget.trip.route);
     _maybeStartGpsTracking();
+    _connectivitySubscription =
+        Connectivity().onConnectivityChanged.listen((List<ConnectivityResult> results) {
+      final offline = results.every((result) => result == ConnectivityResult.none);
+      if (mounted) setState(() => _isOffline = offline);
+    });
   }
 
   @override


### PR DESCRIPTION
## Problem

`trip_detail_screen.dart` declared `late StreamSubscription<List<ConnectivityResult>> _connectivitySubscription` and cancelled it in `dispose()`, but never assigned it anywhere in the file. Every time the driver leaves the trip detail screen, `dispose()` dereferences an uninitialised `late` field and throws `LateInitializationError`, crashing the app. The offline banner tied to `_isOffline` was also dead code.

## Fix

Assigned the subscription in `initState()` using `Connectivity().onConnectivityChanged.listen(...)`, updating `_isOffline` via `setState` when all connectivity results are `none` (guarded by `mounted`). `dispose()` now cancels an actually-initialised subscription and the offline banner becomes functional.

## Files changed

- `apps/driver/lib/screens/trip_detail_screen.dart`

## Testing

- `connectivity_plus` was already imported; `Connectivity()` / `onConnectivityChanged` used per the package API.
- `dispose()` no longer touches an unassigned `late` field, so no `LateInitializationError` on pop.

Closes #6129
