### PR TITLE
fix: remove mock UPI double-payout channel in verifyDelivery (Issue #6130)

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -22,7 +22,6 @@ import {
 import { escrowRelease as defaultEscrowRelease } from "../escrow.js";
 import logger from "../../middleware/logger.js";
 import { OrderTimelineService } from "./orderTimelineService.js";
-import upiPaymentService from "../payment/UpiPaymentService.js";
 
 const orderTimelineService = new OrderTimelineService({ supabase, logger });
 
@@ -472,39 +471,6 @@ export class DeliveryVerificationService {
               escrowAlreadyReleased = true;
             } else {
               throw new Error("Escrow release returned no transaction hash");
-            }
-
-            // Trigger UPI Payout to the Driver
-            try {
-              const driverId = order.driver_id;
-              const { data: driverProfile } = await supabase
-                .from("profiles")
-                .select("full_name")
-                .eq("id", driverId)
-                .maybeSingle();
-
-              const { data: driverPaymentMethod } = await supabase
-                .from("payment_methods")
-                .select("display_label")
-                .eq("user_id", driverId)
-                .eq("method_type", "upi")
-                .maybeSingle();
-
-              const driverUpiId =
-                driverPaymentMethod?.display_label ||
-                `${(driverProfile?.full_name || "driver").toLowerCase().replace(/[^a-z0-9]/g, "")}@okaxis`;
-
-              const payoutResult = await upiPaymentService.processDriverPayout(
-                driverUpiId,
-                order.total_amount,
-              );
-              logger.info(
-                `[payments] UPI Payout processed successfully for driver: ${driverUpiId}, payoutId: ${payoutResult.payout_id}`,
-              );
-            } catch (payoutErr) {
-              logger.error(
-                `[payments] UPI payout to driver failed: ${payoutErr.message}`,
-              );
             }
           } catch (releaseErr) {
             logger.error(


### PR DESCRIPTION
## Problem

`verifyDelivery` ran the real on-chain escrow release AND a second mock UPI payout of the full `order.total_amount` back-to-back. `UpiPaymentService.processDriverPayout` is a mock that fabricates `payout_id`/`utr` and sleeps, and the driver UPI id fell back to an invented `@okaxis` address when none was configured. Today this logs phantom payouts; once a real gateway replaces the mock it becomes a real double-payout of the full order value.

## Fix

Removed the UPI payout call (and its fabricated `@okaxis` fallback) entirely from `deliveryVerificationService.js`. The on-chain escrow release is now the single payment rail for a delivery; the mock UPI code path is gone, so no phantom or double payout can occur. Also removed the now-unused `upiPaymentService` import.

## Files changed

- `backend/api/src/services/order/deliveryVerificationService.js`

## Testing

- `node --check` passes on the modified file.
- Delivery payment is now exactly one channel (escrow), already recorded via `release_tx_hash`.
- No code path invokes the mock UPI provider anymore.

Closes #6130
