### PR TITLE
fix: use real driver truck specs for deadhead recommendations (Issue #6131)

### DIFF
--- a/apps/driver/lib/models/truck_models.dart
+++ b/apps/driver/lib/models/truck_models.dart
@@ -9,6 +9,9 @@ class Truck {
     required this.insuranceExpiry,
     required this.pucExpiry,
     required this.permitExpiry,
+    this.cargoLengthFt = 0,
+    this.cargoWidthFt = 0,
+    this.cargoHeightFt = 0,
   });
 
   final String id;
@@ -20,6 +23,9 @@ class Truck {
   final DateTime? insuranceExpiry;
   final DateTime? pucExpiry;
   final DateTime? permitExpiry;
+  final double cargoLengthFt;
+  final double cargoWidthFt;
+  final double cargoHeightFt;
 
   factory Truck.fromJson(Map<String, dynamic> json) {
     return Truck(
@@ -38,6 +44,9 @@ class Truck {
       permitExpiry: json['permit_expiry'] != null
           ? DateTime.tryParse(json['permit_expiry'] as String)
           : null,
+      cargoLengthFt: (json['cargo_length_ft'] as num?)?.toDouble() ?? 0.0,
+      cargoWidthFt: (json['cargo_width_ft'] as num?)?.toDouble() ?? 0.0,
+      cargoHeightFt: (json['cargo_height_ft'] as num?)?.toDouble() ?? 0.0,
     );
   }
 
@@ -52,6 +61,9 @@ class Truck {
       'insurance_expiry': insuranceExpiry?.toIso8601String(),
       'puc_expiry': pucExpiry?.toIso8601String(),
       'permit_expiry': permitExpiry?.toIso8601String(),
+      'cargo_length_ft': cargoLengthFt,
+      'cargo_width_ft': cargoWidthFt,
+      'cargo_height_ft': cargoHeightFt,
     };
   }
 }

--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -21,6 +21,7 @@ import '../services/marketplace_repository.dart';
 import '../services/trip_cache.dart';
 import '../services/trip_service.dart';
 import '../services/sync_service.dart';
+import '../services/truck_repository.dart';
 import 'pod_screen.dart';
 
 class TripsScreen extends StatefulWidget {
@@ -39,6 +40,7 @@ class _TripsScreenState extends State<TripsScreen> {
   RealtimeChannel? _bidChannel;
   final MarketplaceRepository _marketplaceRepository = MarketplaceRepository();
   final BidSubmissionGuard _bidSubmissionGuard = BidSubmissionGuard();
+  final TruckRepository _truckRepository = TruckRepository();
   late final TripService _tripService;
 
   List<Map<String, dynamic>> _trips = [];
@@ -68,6 +70,8 @@ class _TripsScreenState extends State<TripsScreen> {
   List<DeadheadRecommendation> _deadheadRecommendations = const [];
   Map<String, DriverBid> _deadheadBidsByLoadId = const {};
   Set<String> _submittingDeadheadLoadIds = const <String>{};
+
+  Truck? _truck;
 
   final List<String> _statusFilters = [
     'All',
@@ -487,6 +491,20 @@ class _TripsScreenState extends State<TripsScreen> {
         .subscribe();
   }
 
+  Future<Truck?> _loadDriverTruck() async {
+    if (_truck != null) return _truck;
+    try {
+      final truck =
+          await _truckRepository.fetchTruckForDriver(DriverSession.driverId);
+      if (!mounted) return null;
+      setState(() => _truck = truck);
+      return truck;
+    } catch (e) {
+      debugPrint('Failed to load truck specs: $e');
+      return null;
+    }
+  }
+
   Future<void> _fetchDeadheadRecommendations() async {
     final activeTrip = _trips.cast<Map<String, dynamic>?>().firstWhere(
       (t) => t?['status'] == 'active',
@@ -510,6 +528,27 @@ class _TripsScreenState extends State<TripsScreen> {
       _deadheadError = null;
     });
 
+    // The deadhead ML model is filtered by the driver's real truck capacity.
+    // Without a configured truck there are no real specs to use, so the
+    // feature is disabled instead of silently assuming a 25-ton box-truck.
+    final truck = await _loadDriverTruck();
+    if (truck == null ||
+        truck.maxCapacityTons <= 0 ||
+        truck.cargoLengthFt <= 0 ||
+        truck.cargoWidthFt <= 0 ||
+        truck.cargoHeightFt <= 0) {
+      if (!mounted) return;
+      setState(() {
+        _deadheadLoading = false;
+        _deadheadError = 'Add your truck details first';
+      });
+      return;
+    }
+    final truckMaxWeightKg = truck.maxCapacityTons * 1000;
+    final truckMaxLengthM = truck.cargoLengthFt * 0.3048;
+    final truckMaxWidthM = truck.cargoWidthFt * 0.3048;
+    final truckMaxHeightM = truck.cargoHeightFt * 0.3048;
+
     try {
       final loads = await _marketplaceRepository.fetchLoadOffers();
       if (!mounted) return;
@@ -526,10 +565,10 @@ class _TripsScreenState extends State<TripsScreen> {
         loads: loads,
         driverLat: destLat,
         driverLng: destLng,
-        truckMaxWeightKg: 25000,
-        truckMaxLengthM: 12,
-        truckMaxWidthM: 2.5,
-        truckMaxHeightM: 4,
+        truckMaxWeightKg: truckMaxWeightKg,
+        truckMaxLengthM: truckMaxLengthM,
+        truckMaxWidthM: truckMaxWidthM,
+        truckMaxHeightM: truckMaxHeightM,
         arrivalTime: now.add(const Duration(hours: 6)).toIso8601String(),
       );
       final availableLoadMaps = payload['available_loads'] as List<Map<String, dynamic>>;
@@ -538,10 +577,10 @@ class _TripsScreenState extends State<TripsScreen> {
           .fetchDeadheadRecommendations(
         destLat: destLat,
         destLng: destLng,
-        maxWeightKg: 25000,
-        maxLengthM: 12,
-        maxWidthM: 2.5,
-        maxHeightM: 4,
+        maxWeightKg: truckMaxWeightKg,
+        maxLengthM: truckMaxLengthM,
+        maxWidthM: truckMaxWidthM,
+        maxHeightM: truckMaxHeightM,
         arrivalTime: now.add(const Duration(hours: 6)).toIso8601String(),
         availableLoads: availableLoadMaps,
       );
@@ -1157,18 +1196,43 @@ class _TripsScreenState extends State<TripsScreen> {
                                                         strokeWidth: 2),
                                               )
                                             else if (_deadheadError != null)
-                                              GestureDetector(
-                                                onTap:
-                                                    _fetchDeadheadRecommendations,
-                                                child: Text(
-                                                  AppLocalizations.of(context)!
-                                                      .retry,
-                                                  style: GoogleFonts.dmSans(
-                                                    fontSize: 12,
-                                                    color:
-                                                        TruxifyColors.accent,
+                                              Row(
+                                                mainAxisSize:
+                                                    MainAxisSize.min,
+                                                children: [
+                                                  Flexible(
+                                                    child: Text(
+                                                      _deadheadError!,
+                                                      maxLines: 1,
+                                                      overflow:
+                                                          TextOverflow.ellipsis,
+                                                      style:
+                                                          GoogleFonts.dmSans(
+                                                        fontSize: 11,
+                                                        color: TruxifyColors
+                                                            .hintText,
+                                                      ),
+                                                    ),
                                                   ),
-                                                ),
+                                                  const SizedBox(width: 8),
+                                                  GestureDetector(
+                                                    onTap:
+                                                        _fetchDeadheadRecommendations,
+                                                    child: Text(
+                                                      AppLocalizations.of(
+                                                              context)!
+                                                          .retry,
+                                                      style:
+                                                          GoogleFonts.dmSans(
+                                                        fontSize: 12,
+                                                        color: TruxifyColors
+                                                            .accent,
+                                                        fontWeight:
+                                                            FontWeight.w600,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ],
                                               ),
                                           ],
                                         ),


### PR DESCRIPTION
## Problem

`trips_screen.dart` hardcoded 25-ton / 12m / 2.5m / 4m truck specs for the deadhead ("En-Route Loads") recommendation payload and fetch call, ignoring the driver's actual truck. Every recommendation was computed against a fixed 25-ton box-truck profile regardless of the logged-in driver's real vehicle.

## Fix

- Added `cargoLengthFt`, `cargoWidthFt`, `cargoHeightFt` to the `Truck` model with JSON serialization support.
- The deadhead flow now loads the driver's real truck via `TruckRepository.fetchTruckForDriver(DriverSession.driverId)` and passes its specs into both `buildDeadheadPayload` and `fetchDeadheadRecommendations` (tons→kg, ft→m conversions).
- If no truck is configured (or its specs are missing/zero), the feature is disabled with a clear "Add your truck details first" prompt instead of silently using the 25-ton defaults.

## Files changed

- `apps/driver/lib/models/truck_models.dart`
- `apps/driver/lib/screens/trips_screen.dart`

## Testing

- Verified `TruckRepository.fetchTruckForDriver`, `Truck.maxCapacityTons`, and `DriverSession.driverId` exist and are used correctly.
- Deadhead is disabled with the prompt when the truck is missing; real truck specs are used when present.

Closes #6131
