### PR TITLE
fix: persist driver Edit Profile changes via PUT /api/profile (Issue #6132)

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/common_widgets.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../services/fcm_service.dart';
 import '../services/secure_storage.dart';
+import '../services/truck_repository.dart';
 import '../core/supabase_config.dart';
 import 'package:truxify_shared/truxify_shared.dart' hide NotificationsScreen, FcmService;
 import 'notifications_screen.dart';
@@ -102,6 +103,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             .select('polygon_wallet_address, full_name, phone, email, is_digilocker_verified')
             .eq('id', userId)
             .maybeSingle();
+        final truck = await TruckRepository().fetchTruckForDriver(userId);
         if (data != null && mounted) {
           setState(() {
             _walletAddress = data['polygon_wallet_address']?.toString() ?? '';
@@ -109,6 +111,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             _driverPhone = data['phone']?.toString() ?? '';
             _driverEmail = data['email']?.toString() ?? '';
             _isDigilockerVerified = data['is_digilocker_verified'] as bool? ?? false;
+            _truckNumber = truck?.numberPlate ?? '';
           });
         }
       }
@@ -318,22 +321,58 @@ class _ProfileScreenState extends State<ProfileScreen> {
               const SizedBox(height: 20),
               PrimaryButton(
                 label: AppLocalizations.of(context)!.saveChanges,
-                onPressed: () {
+                onPressed: () async {
                   if (formKey.currentState?.validate() ?? false) {
+                    final messenger = ScaffoldMessenger.of(context);
+                    final navigator = Navigator.of(context);
+                    final successMessage =
+                        AppLocalizations.of(context)!.profileUpdatedSuccessfully;
+                    final apiClient =
+                        ApiClient(timeout: AppConfig.profileUpdateTimeout);
+                    try {
+                      await apiClient.put(
+                        '/api/profile',
+                        body: <String, String>{
+                          'full_name': nameController.text.trim(),
+                          'phone': phoneController.text.trim(),
+                          'email': emailController.text.trim(),
+                          'number_plate': truckNumberController.text.trim(),
+                        },
+                      );
+                    } on ApiException catch (e) {
+                      messenger.showSnackBar(
+                        SnackBar(
+                          content: Text(e.message),
+                          backgroundColor: TruxifyColors.errorRed,
+                        ),
+                      );
+                      return;
+                    } catch (e) {
+                      messenger.showSnackBar(
+                        SnackBar(
+                          content: Text('Failed to save profile: $e'),
+                          backgroundColor: TruxifyColors.errorRed,
+                        ),
+                      );
+                      return;
+                    } finally {
+                      apiClient.dispose();
+                    }
+                    if (!mounted) return;
                     setState(() {
                       _driverName = nameController.text.trim();
                       _driverPhone = phoneController.text.trim();
                       _driverEmail = emailController.text.trim();
                       _truckNumber = truckNumberController.text.trim();
                     });
-                    Navigator.of(context).pop();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(AppLocalizations.of(context)!.profileUpdatedSuccessfully),
-                      backgroundColor: TruxifyColors.success,
-                    ),
-                  );
-                }
+                    navigator.pop();
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(successMessage),
+                        backgroundColor: TruxifyColors.success,
+                      ),
+                    );
+                  }
                 },
               ),
             ],

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -35,6 +35,12 @@
  *       properties:
  *         full_name:
  *           type: string
+ *         phone:
+ *           type: string
+ *         email:
+ *           type: string
+ *         number_plate:
+ *           type: string
  *         language:
  *           type: string
  *         dark_mode:
@@ -104,6 +110,11 @@ import { invalidateCachedProfile, invalidateCachedSupabaseProfile, invalidateCac
 import { auditLog } from '../middleware/auditLog.js';
 
 const router = express.Router();
+
+function sanitizeNumberPlate(plate) {
+  if (!plate || typeof plate !== 'string') return '';
+  return plate.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
 
 
 // Cache control middleware for profile endpoints
@@ -332,7 +343,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
  *   put:
  *     tags: [Profile]
  *     summary: Update profile
- *     description: Updates basic profile fields (full_name, language, dark_mode) and optionally driver online status. Invalidates Redis cache.
+ *     description: Updates basic profile fields (full_name, phone, email, language, dark_mode) and, for drivers, the online status and the truck number plate. Invalidates Redis cache.
  *     security:
  *       - BearerAuth: []
  *     requestBody:
@@ -354,30 +365,52 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
 router.put('/', authenticate, userLimiter, validateBody(updateProfileSchema), async (req, res) => {
   try {
     const userId = req.user.id;
-    const { full_name, language, dark_mode, is_online } = req.body;
+    const { full_name, language, dark_mode, is_online, phone, email, number_plate } = req.body;
     const role = req.user.role;
+
+    const profileUpdate = {};
+    if (full_name !== undefined) profileUpdate.full_name = full_name;
+    if (language !== undefined) profileUpdate.language = language;
+    if (dark_mode !== undefined) profileUpdate.dark_mode = dark_mode;
+    if (phone !== undefined) profileUpdate.phone = phone;
+    if (email !== undefined) profileUpdate.email = email;
 
     const { data, error } = await supabase
       .from('profiles')
-      .update({
-        full_name,
-        language,
-        dark_mode
-      })
+      .update(profileUpdate)
       .eq('id', userId)
       .select()
       .single();
 
     if (error) throw error;
-    if (role === 'driver' && typeof is_online === 'boolean') {
-      const { error: driverError } = await supabase
-      .from('driver_details')
-      .update({
-        is_online
-      })
-      .eq('user_id', userId);
+    if (role === 'driver') {
+      if (typeof is_online === 'boolean') {
+        const { error: driverError } = await supabase
+        .from('driver_details')
+        .update({
+          is_online
+        })
+        .eq('user_id', userId);
 
-      if (driverError) throw driverError;
+        if (driverError) throw driverError;
+      }
+
+      if (number_plate !== undefined) {
+        const normalizedPlate = sanitizeNumberPlate(number_plate);
+        const { error: truckError } = await supabase
+          .from('trucks')
+          .update({
+            number_plate: normalizedPlate
+          })
+          .eq('driver_id', userId);
+
+        if (truckError) {
+          if (truckError.code === '23505') {
+            return res.status(409).json({ error: 'A truck with this number plate is already registered.' });
+          }
+          throw truckError;
+        }
+      }
     }
 
     // Invalidate the profile cache so that the next request retrieves fresh profile data.

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -272,6 +272,8 @@ export const updateProfileSchema = z.object({
   full_name: z.string().trim().min(1, 'Name cannot be empty').max(100, 'Name must be 100 characters or fewer').optional(),
   company_name: z.string().trim().min(1, 'Company name cannot be empty').max(200, 'Company name must be 200 characters or fewer').optional(),
   phone: z.string().trim().refine(isValidPhone, { message: 'Phone must be a valid number (digits, optional +, spaces/dashes/parens)' }).optional(),
+  email: z.string().trim().email('Invalid email address').optional(),
+  number_plate: z.string().trim().optional(),
   language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').refine((v) => VALID_LANGUAGES.includes(v), { message: 'Unsupported language code' }).optional(),
   dark_mode: z.boolean().optional(),
   is_online: z.boolean().optional(),


### PR DESCRIPTION
## Problem

The driver Edit Profile "Save Changes" handler ran the validator and then only mutated local widget state before showing a success SnackBar. There was no API call, no Supabase write and no persistence — the updated values were lost as soon as the profile was reloaded or the session restarted, while the app claimed "Profile updated successfully!".

## Fix

- Backend: `PUT /api/profile` now also persists `phone` and `email` on `profiles`, and for drivers persists `number_plate` by updating the matching `trucks` row (sanitised/alphabetised; a duplicate plate returns 409). `updateProfileSchema` was extended with `email` and `number_plate`.
- App: the save handler now awaits `PUT /api/profile`, and only then updates local state and shows success. Failures show an error SnackBar and keep the previous values. The truck number plate is also loaded from the driver's truck record when the screen loads.

## Files changed

- `apps/driver/lib/screens/profile_screen.dart`
- `backend/api/src/routes/profileRoutes.js`
- `backend/api/src/validation/requestSchemas.js`

## Testing

- Verified `ApiClient.put`, `ApiException`, `AppConfig.profileUpdateTimeout`, and `TruxifyColors.errorRed`/`success` exist and are used consistently with the rest of the app.
- `node --check` passes on the modified backend files.
- Success SnackBar is shown only after the write succeeds.

Closes #6132
