### PR TITLE
fix: stop fabricating tx_hash in booking_confirmation lock flow (Issue #6133)

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -219,34 +219,25 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   }
 
   // ── Step 4: Lock payment after UPI success ────────────────────────────────
+  // POST /api/payments/lock requires the real on-chain tx_hash that the wallet
+  // SDK returns once `createBooking` is mined; recordDepositTx() verifies it
+  // against Polygon. No wallet SDK is integrated in this app, so there is no
+  // real hash to submit. Fabricating one would post a hash the backend can
+  // never verify — the escrow would never lock and the booking would stay
+  // stuck in `funding`. Fail closed instead: never send a fake hash and never
+  // report the payment as locked.
   Future<void> _confirmPaymentLocked() async {
     if (_createdOrderId == null) return;
-    setState(() => _isSubmitting = true);
 
-    try {
-      // In mock UPI mode, generate a placeholder tx_hash
-      // In production, the wallet SDK would provide the real on-chain hash
-      final mockTxHash =
-          '0x${_createdOrderId!.replaceAll('-', '').padRight(64, '0').substring(0, 64)}';
-
-      await _apiClient.post(
-        '/api/payments/lock',
-        body: {
-          'order_id': _createdOrderId,
-          'tx_hash': mockTxHash,
-        },
-      );
-
-      _showSuccessPanel();
-    } catch (e) {
-      debugPrint('Payment lock failed: $e');
-      // Even if lock fails, show booking success — reconciliation will handle it
-      _showSuccessPanel();
-    } finally {
-      if (mounted) {
-        setState(() => _isSubmitting = false);
-      }
-    }
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(
+            'On-chain escrow confirmation is unavailable on this device. '
+            'Your booking is created, but the escrow could not be locked. '
+            'Please contact support to complete the payment.'),
+      ),
+    );
   }
 
   void _showSuccessPanel() {


### PR DESCRIPTION
## Problem

When the customer tapped "I've Paid", `booking_confirmation_screen.dart` fabricated a 64-char `tx_hash` from the order id and posted it to `/api/payments/lock`. The backend (`recordDepositTx`) verifies the hash against the real Polygon chain, so the lock could never succeed — the escrow was never funded from the customer's side and the order stayed stuck in `funding`, while the app reported the payment as completed.

## Fix

Removed the fabricated hash entirely. Since no wallet SDK is integrated in this app to return a real on-chain `createBooking` hash, the "I've Paid" path now fails closed: it no longer sends a fake hash to the backend and instead tells the customer that on-chain escrow confirmation is unavailable and to contact support — it never reports the payment as locked.

## Files changed

- `apps/customer/lib/screens/booking_confirmation_screen.dart`

## Testing

- No code path posts a fabricated `tx_hash` anymore.
- The state stays honest: booking created, escrow not locked, customer informed of the unresolved payment.

Closes #6133
