### PR TITLE
fix(escrow): add missing markEscrowBookingStarted and getEscrowBooking exports

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -206,6 +206,33 @@ export function getEscrowBookingId (orderDisplayId) {
 }
 
 /**
+ * Query the escrow contract's bookings mapping for a given booking ID.
+ * Used by escrowFundingReconciliation to check on-chain booking state.
+ *
+ * @param {string} escrowBookingId — bytes32 hash (result of getEscrowBookingId)
+ * @returns {Promise<{customer: string, driver: string, amount: bigint, status: number, paid: boolean, started: boolean, createdAt: bigint} | null>}
+ */
+export async function getEscrowBooking(escrowBookingId) {
+  if (!escrowContract) {
+    logger.warn('[escrow] Contract not initialised — cannot query bookings.');
+    return null;
+  }
+
+  if (!ethers.isHexString(escrowBookingId, 32)) {
+    logger.warn('[escrow] Invalid escrowBookingId format — cannot query bookings.');
+    return null;
+  }
+
+  try {
+    const booking = await escrowContract.bookings(escrowBookingId);
+    return booking;
+  } catch (err) {
+    logger.error(`[escrow] getEscrowBooking failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * Build an unsigned deposit transaction for the customer's wallet to sign.
  * Called when a bid is accepted and the order moves to in_progress.
  *
@@ -503,6 +530,45 @@ export async function submitEscrowCancelWithPenalty (orderDisplayId, driverFeeWe
       }
     } catch (err) {
       logger.error(`[escrow] cancelWithPenalty failed for booking ${orderDisplayId}: ${err.message}`)
+      return { txHash: null, bookingId, error: err.message }
+    }
+  })
+}
+
+/**
+ * Call the contract's markBookingStarted function when a driver begins a trip.
+ * Marks the on-chain booking as started, which is required for the escrow
+ * release/withdraw logic to proceed.
+ *
+ * @param {string} orderDisplayId — display ID of the order, e.g. "#FF20260521"
+ * @returns {Promise<{txHash: string | null, bookingId: string, error?: string}>}
+ */
+export async function markEscrowBookingStarted(orderDisplayId) {
+  return measureExecution('EscrowService.markEscrowBookingStarted', async () => {
+    const bookingId = getEscrowBookingId(orderDisplayId)
+
+    if (!escrowContract) {
+      logger.warn('[escrow] Contract not initialised — skipping markBookingStarted.')
+      return { txHash: null, bookingId }
+    }
+
+    try {
+      const tx = await escrowContract.markBookingStarted(bookingId)
+      logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
+      return {
+        txHash: tx.hash,
+        bookingId,
+        waitForConfirmation: async () => {
+          const receipt = await tx.wait(1)
+          if (!receipt || receipt.status === 0) {
+            throw new Error('Escrow markBookingStarted transaction reverted or was not found.')
+          }
+          logger.info(`[escrow] markBookingStarted confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
+          return receipt
+        },
+      }
+    } catch (err) {
+      logger.error(`[escrow] markBookingStarted failed for booking ${orderDisplayId}: ${err.message}`)
       return { txHash: null, bookingId, error: err.message }
     }
   })


### PR DESCRIPTION
## Description

Adds two missing exports to `backend/api/src/services/escrow.js` that are required by other services at startup:

- `markEscrowBookingStarted(orderDisplayId)`: calls the `markBookingStarted(uint256 bookingId)` contract ABI. Used by `orderMilestoneService` when a driver begins a trip to mark the on-chain booking as started.

- `getEscrowBooking(escrowBookingId)`: queries the `bookings(uint256 bookingId)` contract view for on-chain booking state. Used by `escrowFundingReconciliation` to check if a deposit has landed on-chain.

Without these exports the server fails to boot with ESM link-time errors:

```
SyntaxError: The requested module '../escrow.js' does not provide an export named 'markEscrowBookingStarted'
SyntaxError: The requested module './escrow.js' does not provide an export named 'getEscrowBooking'
```

## Related Issues

Fixes #6123
Fixes #6122

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Checklist

- ESLint passes on all modified files
- No new test failures introduced
- Changes are minimal and targeted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving escrow booking details using a valid booking ID.
  - Added the ability to mark an escrow booking as started and receive confirmation once the transaction is processed.

- **Bug Fixes**
  - Improved handling of unavailable escrow configuration, invalid booking IDs, failed submissions, and reverted transactions.
  - Escrow operation failures are now handled gracefully without disrupting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->