### PR TITLE
fix(client): handle Retry-After on rate limited requests

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -29,6 +29,20 @@ class ApiException implements Exception {
   String toString() => 'ApiException($statusCode): $message';
 }
 
+class RateLimitException extends ApiException {
+  const RateLimitException(
+    super.statusCode,
+    super.message, {
+    super.body,
+    required this.retryAfter,
+  });
+
+  final Duration retryAfter;
+
+  @override
+  String toString() =>
+      'RateLimitException($statusCode): $message (retry after ${retryAfter.inSeconds}s)';
+}
 /// Describes a single file to include in a multipart request.
 class MultipartFileInfo {
   const MultipartFileInfo({
@@ -184,44 +198,72 @@ class ApiClient {
 
   // ── Core request execution ────────────────────────────────────────
 
-  Future<http.Response> _execute(
-    Future<http.Response> Function(Map<String, String> headers) fn, {
-    Map<String, String>? additionalHeaders,
-    bool isRetry = false,
-  }) async {
-    // Ensure we have a fresh Firebase token before making the request.
-    if (!isRetry) {
-      await _accessTokenAsync;
-    }
-    final response = await fn(_headers(additionalHeaders: additionalHeaders)).timeout(_timeout);
-
-    if (response.statusCode == 401 && !isRetry) {
-      if (kDebugMode) {
-        developer.log(
-          '[ApiClient] 401 received — attempting token refresh',
-          name: 'ApiClient',
-        );
-      }
-
-      final newToken = await _refreshedToken();
-      if (newToken == null) {
-        throw const ApiAuthException(
-          'Session expired and token refresh failed. Please log in again.',
-        );
-      }
-
-      final retryResponse = await fn(_headers(token: newToken, additionalHeaders: additionalHeaders)).timeout(_timeout);
-      if (retryResponse.statusCode == 401) {
-        throw const ApiAuthException(
-          'Authentication failed after token refresh. Please log in again.',
-        );
-      }
-      return retryResponse;
-    }
-
-    return response;
+Future<http.Response> _execute(
+  Future<http.Response> Function(Map<String, String> headers) fn, {
+  Map<String, String>? additionalHeaders,
+  bool isRetry = false,
+}) async {
+  // Ensure we have a fresh Firebase token before making the request.
+  if (!isRetry) {
+    await _accessTokenAsync;
   }
 
+  final response = await fn(
+    _headers(additionalHeaders: additionalHeaders),
+  ).timeout(_timeout);
+
+  // Existing 401 handling (KEEP THIS)
+  if (response.statusCode == 401 && !isRetry) {
+    if (kDebugMode) {
+      developer.log(
+        '[ApiClient] 401 received — attempting token refresh',
+        name: 'ApiClient',
+      );
+    }
+
+    final newToken = await _refreshedToken();
+    if (newToken == null) {
+      throw const ApiAuthException(
+        'Session expired and token refresh failed. Please log in again.',
+      );
+    }
+
+    final retryResponse = await fn(
+      _headers(
+        token: newToken,
+        additionalHeaders: additionalHeaders,
+      ),
+    ).timeout(_timeout);
+
+    if (retryResponse.statusCode == 401) {
+      throw const ApiAuthException(
+        'Authentication failed after token refresh. Please log in again.',
+      );
+    }
+
+    return retryResponse;
+  }
+
+  // Handle rate limiting (429)
+  if (response.statusCode == 429 && !isRetry) {
+    final retryAfterHeader = response.headers['retry-after'];
+
+    int retrySeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
+
+    // Cap maximum wait time to 30 seconds
+    retrySeconds = retrySeconds.clamp(1, 30);
+
+    await Future.delayed(Duration(seconds: retrySeconds));
+
+    return await _execute(
+      fn,
+      additionalHeaders: additionalHeaders,
+      isRetry: true,
+    );
+  }
+
+  return response;
+}
   // ── URI building and path normalization ───────────────────────────
 
   Uri _buildUri(String path) {
@@ -454,6 +496,19 @@ class ApiClient {
       message = response.reasonPhrase ?? 'Unknown error';
     }
 
+    if (response.statusCode == 429) {
+        final retryAfterHeader = response.headers['retry-after'];
+
+        final retryAfterSeconds =
+            int.tryParse(retryAfterHeader ?? '') ?? 0;
+
+        throw RateLimitException(
+            response.statusCode,
+            message,
+            body: response.body,
+            retryAfter: Duration(seconds: retryAfterSeconds),
+        );
+    }
     throw ApiException(response.statusCode, message, body: response.body);
   }
 }


### PR DESCRIPTION
## Summary

Adds client-side handling for HTTP 429 responses.

### Changes

- Added `RateLimitException` for rate-limited responses.
- Added support for parsing the `Retry-After` header.
- Waits before retrying once when receiving HTTP 429.
- Throws a typed `RateLimitException` if the retry is still rate limited.

Closes #6196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer rate-limit error details, including the recommended retry duration.
  * Requests that encounter temporary rate limits now automatically retry once, waiting up to 30 seconds as indicated by the server.

* **Bug Fixes**
  * Improved handling of rate-limited responses while preserving existing authentication recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->