### PR TITLE
perf(widgets): add missing const keywords for widget constructors (fi…

### DIFF
--- a/apps/customer/lib/screens/about_screen.dart
+++ b/apps/customer/lib/screens/about_screen.dart
@@ -127,19 +127,19 @@ class AboutScreen extends StatelessWidget {
 
             const SizedBox(height: 12),
 
-            _ContactRow(
+            const _ContactRow(
               icon: Icons.email_rounded,
               label: 'Email',
               value: 'support@truxify.com',
             ),
             const SizedBox(height: 12),
-            _ContactRow(
+            const _ContactRow(
               icon: Icons.phone_rounded,
               label: 'Phone',
               value: '+91 1800-TRUCK-1',
             ),
             const SizedBox(height: 12),
-            _ContactRow(
+            const _ContactRow(
               icon: Icons.public_rounded,
               label: 'Website',
               value: 'www.truxify.com',
@@ -177,6 +177,7 @@ class AboutScreen extends StatelessWidget {
 
 class _ContactRow extends StatelessWidget {
   const _ContactRow({
+    super.key,
     required this.icon,
     required this.label,
     required this.value,
@@ -228,7 +229,7 @@ class _ContactRow extends StatelessWidget {
 }
 
 class _SocialIcon extends StatelessWidget {
-  const _SocialIcon({required this.icon});
+  const _SocialIcon({super.key, required this.icon});
 
   final IconData icon;
 

--- a/apps/customer/lib/widgets/map_placeholder.dart
+++ b/apps/customer/lib/widgets/map_placeholder.dart
@@ -31,7 +31,7 @@ class MapPlaceholder extends StatelessWidget {
         children: [
           Positioned.fill(
             child: CustomPaint(
-              painter: _MapGridPainter(),
+              painter: const _MapGridPainter(),
               child: Container(
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
@@ -158,6 +158,7 @@ class _MapPin extends StatelessWidget {
 }
 
 class _MapGridPainter extends CustomPainter {
+  const _MapGridPainter();
   @override
   void paint(Canvas canvas, Size size) {
     final gridPaint = Paint()


### PR DESCRIPTION
# perf(widgets): add missing const keywords for widget constructors (fixes #78)

## Description
This PR addresses issue #78 by adding missing `const` keywords to stateless widget instantiations and constructors where applicable. Specifically, it updates custom stateless widgets (`_MapGridPainter`, `_ContactRow`, and `_SocialIcon`) in `about_screen.dart` and `map_placeholder.dart`. This allows Flutter to perform compile-time optimizations, preventing unnecessary rebuilds and object allocations in the widget tree, which mildly improves overall rendering performance.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `flutter analyze lib/screens/about_screen.dart lib/widgets/map_placeholder.dart`
- **Test Steps / Prerequisites:** Run the static analyzer to ensure no `prefer_const_constructors` warnings remain for the updated widgets. Compile the app and navigate to the About Screen and Truck Results/Live Tracking screens to verify the UI renders correctly without issues.
- **Expected Result:** The static analysis passes without warnings regarding these widgets, and the UI layout remains completely unchanged while benefiting from `const` widget caching.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #78

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
