### PR TITLE
fix: persist Kafka dead letters and add replay support

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -1,5 +1,6 @@
 import kafka, { TOPICS, CONSUMER_GROUPS } from '../config/kafka.config.js';
 import processedEventRepository from '../repositories/processedEvent.repository.js';
+import deadLetterRepository from '../repositories/deadLetter.repository.js';
 import logger from '../api/src/middleware/logger.js';
 
 class OrderConsumer {
@@ -104,6 +105,7 @@ class OrderConsumer {
             await handler(message, rawMessage);
           } catch (error) {
             logger.error(`Handler error for ${topic}:`, error);
+            await this.storeDeadLetter(topic, rawMessage, error);
           }
         }
       }
@@ -137,14 +139,58 @@ class OrderConsumer {
   }
 
   async storeDeadLetter(topic, message, error) {
+    const rawValue = message?.value;
+    const serialized = Buffer.isBuffer(rawValue)
+      ? rawValue.toString()
+      : rawValue != null
+        ? String(rawValue)
+        : null;
+
     const dlqEntry = {
       topic,
-      message: message.value.toString(),
+      message: serialized,
       error: error.message,
       timestamp: new Date().toISOString(),
       retryCount: 0,
     };
-    logger.info(`📦 Dead letter stored for ${topic}`, dlqEntry);
+
+    const stored = await deadLetterRepository.store({
+      topic,
+      message: dlqEntry,
+      error: error.message,
+      retryCount: 0,
+    });
+
+    if (stored) {
+      logger.info(`📦 Dead letter persisted for ${topic} (id: ${stored.id})`);
+    } else {
+      logger.error(`📦 Dead letter for ${topic} could NOT be persisted — message dropped`, dlqEntry);
+    }
+  }
+
+  async replayDeadLetters({ topic = null, limit = 50 } = {}) {
+    const pending = await deadLetterRepository.listPending({ topic, limit });
+    const results = { attempted: pending.length, succeeded: 0, failed: 0 };
+
+    for (const entry of pending) {
+      const topicHandlers = this.handlers.get(entry.topic) || [];
+      const parsedMessage = entry.message;
+
+      try {
+        for (const handler of topicHandlers) {
+          await handler(parsedMessage, { value: parsedMessage?.message });
+        }
+        await deadLetterRepository.markStatus(entry.id, 'replayed');
+        results.succeeded += 1;
+      } catch (error) {
+        logger.error(`Replay failed for dead letter ${entry.id} (${entry.topic}):`, error);
+        await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        results.failed += 1;
+      }
+    }
+
+    logger.info(`♻️ Dead letter replay complete`, results);
+    return results;
   }
 
   async startAllConsumers() {

--- a/backend/kafka/repositories/deadLetter.repository.js
+++ b/backend/kafka/repositories/deadLetter.repository.js
@@ -1,0 +1,77 @@
+import { supabase } from '../api/src/config/db.js';
+import logger from '../api/src/middleware/logger.js';
+
+class DeadLetterRepository {
+  async store({ topic, message, error, retryCount = 0 }) {
+    try {
+      const { data, error: dbError } = await supabase
+        .from('kafka_dead_letters')
+        .insert({
+          topic,
+          message,
+          error,
+          retry_count: retryCount,
+          status: 'pending',
+        })
+        .select('id')
+        .single();
+
+      if (dbError) throw dbError;
+      return data;
+    } catch (err) {
+      logger.error(`Failed to persist dead letter for ${topic}:`, err);
+      return null;
+    }
+  }
+
+  async listPending({ topic = null, limit = 50 } = {}) {
+    try {
+      let query = supabase
+        .from('kafka_dead_letters')
+        .select('*')
+        .eq('status', 'pending')
+        .order('created_at', { ascending: true })
+        .limit(limit);
+
+      if (topic) query = query.eq('topic', topic);
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data || [];
+    } catch (err) {
+      logger.error('Failed to list pending dead letters:', err);
+      throw err;
+    }
+  }
+
+  async markStatus(id, status, { incrementRetry = false } = {}) {
+    try {
+      const update = {
+        status,
+        replayed_at: status === 'replayed' ? new Date().toISOString() : null,
+      };
+
+      if (incrementRetry) {
+        const { data: current, error: fetchError } = await supabase
+          .from('kafka_dead_letters')
+          .select('retry_count')
+          .eq('id', id)
+          .single();
+        if (fetchError) throw fetchError;
+        update.retry_count = (current?.retry_count || 0) + 1;
+      }
+
+      const { error } = await supabase
+        .from('kafka_dead_letters')
+        .update(update)
+        .eq('id', id);
+
+      if (error) throw error;
+    } catch (err) {
+      logger.error(`Failed to update dead letter ${id} status to ${status}:`, err);
+      throw err;
+    }
+  }
+}
+
+export default new DeadLetterRepository();

--- a/docs/supabase/migrations/005_create_kafka_dead_letters.sql
+++ b/docs/supabase/migrations/005_create_kafka_dead_letters.sql
@@ -1,0 +1,20 @@
+-- Dead-letter store for failed Kafka message handlers.
+-- Mirrors kafka_processed_events' role: durable record of what Kafka delivered,
+-- so failures can be audited and replayed instead of silently dropped.
+
+create table if not exists kafka_dead_letters (
+  id uuid primary key default gen_random_uuid(),
+  topic text not null,
+  message jsonb not null,
+  error text not null,
+  retry_count int not null default 0,
+  status text not null default 'pending', -- pending | replayed | discarded
+  created_at timestamptz not null default now(),
+  replayed_at timestamptz
+);
+
+create index if not exists idx_kafka_dead_letters_status
+  on kafka_dead_letters (status, created_at);
+
+create index if not exists idx_kafka_dead_letters_topic
+  on kafka_dead_letters (topic);


### PR DESCRIPTION
## Description

This PR fixes the Kafka dead-letter queue so failed messages are durably persisted instead of only being logged.

### Changes made
- Persist dead-letter entries to a new `kafka_dead_letters` table via `DeadLetterRepository`.
- Added a new Supabase migration (`005_create_kafka_dead_letters.sql`) to create the required table and indexes.
- Updated `storeDeadLetter()` to serialize and store failed Kafka messages instead of only logging them.
- Added replay support for pending dead-letter entries through `replayDeadLetters()`.
- Added retry tracking and status updates (`pending` / `replayed`) for replayed messages.

This prevents silent loss of failed Kafka messages and provides a durable audit trail with the ability to replay failed events.

---

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

---

## How Has This Been Tested?

**Test Commands:**
- No automated tests were added.

**Test Steps / Prerequisites:**
1. Trigger a Kafka consumer handler failure.
2. Verify a record is created in the `kafka_dead_letters` table.
3. Verify pending dead letters can be replayed using `replayDeadLetters()`.
4. Verify successful replay updates the status to `replayed`.
5. Verify failed replay increments the retry count.

**Expected Result:**
- Failed Kafka messages are persisted instead of being lost.
- Dead-letter entries can be replayed and tracked correctly.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed Kafka messages are now durably recorded for later review and retry.
  * Added support for replaying pending failed messages, with configurable topic filtering and retry limits.
  * Replay results now report attempted, successful, and failed message counts.

* **Bug Fixes**
  * Improved handling of message-processing errors by safely preserving failure details and tracking replay status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->