### PR TITLE
fix: add metadata column for device registration

### DIFF
--- a/docs/supabase/migrations/20260804120000_add_metadata_to_user_devices.sql
+++ b/docs/supabase/migrations/20260804120000_add_metadata_to_user_devices.sql
@@ -1,0 +1,7 @@
+-- Add metadata column to user_devices.
+-- deviceController.registerDeviceToken has always upserted a `metadata`
+-- field, but the column was never created, so every device registration
+-- failed with a PostgREST "unknown column" error (500).
+
+ALTER TABLE user_devices
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Description

This PR fixes the schema mismatch between the device registration controller and the `user_devices` table by adding the missing `metadata` column.

### Changes made
- Added a new Supabase migration to create the missing `metadata` column on the `user_devices` table.
- Defined `metadata` as a `jsonb` column with a default empty object (`{}`).
- Used `IF NOT EXISTS` to ensure the migration is safe to run multiple times.

This resolves the database error that caused device registration to fail whenever the controller attempted to persist device metadata.

---

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

---

## How Has This Been Tested?

**Test Commands:**
- Applied the migration locally.

**Test Steps / Prerequisites:**
1. Run the new migration.
2. Register a device by sending a request containing `fcmToken`, `platform`, and `metadata`.
3. Verify the request succeeds and the metadata is stored in the `user_devices` table.

**Expected Result:**
- Device registration succeeds without the PostgREST "unknown column `metadata`" error.
- The `metadata` field is successfully persisted.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

---

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/5683

---

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.