### PR TITLE
fix: remove duplicate _buildHeatmapLayer and _openGoogleMapsRoute in driver home screen

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -241,68 +241,6 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
-  /// Builds a [MarkerLayer] with colour-coded circles for each demand zone.
-  ///
-  /// Expected backend shape (from [MarketplaceRepository.fetchDemandHeatmap]):
-  /// ```json
-  /// {
-  ///   "zones": [
-  ///     { "lat": 28.6, "lng": 77.2, "demand": 0.85 },
-  ///     ...
-  ///   ]
-  /// }
-  /// ```
-  /// `demand` is a normalised value in [0.0, 1.0]:
-  ///   ≥ 0.70  → red   (high demand)
-  ///   ≥ 0.40  → orange (medium demand)
-  ///   < 0.40  → green  (low demand)
-  Widget? _buildHeatmapLayer() {
-    final data = _heatmapData;
-    if (data == null) return null;
-
-    final rawZones = data['zones'];
-    if (rawZones == null || rawZones is! List || rawZones.isEmpty) return null;
-
-    final markers = <Marker>[];
-    for (final zone in rawZones) {
-      if (zone is! Map) continue;
-      final lat = (zone['lat'] as num?)?.toDouble();
-      final lng = (zone['lng'] as num?)?.toDouble();
-      final demand = (zone['demand'] as num?)?.toDouble() ?? 0.0;
-      if (lat == null || lng == null) continue;
-
-      final Color fillColor;
-      if (demand >= 0.70) {
-        fillColor = Colors.red.withValues(alpha: 0.45);
-      } else if (demand >= 0.40) {
-        fillColor = Colors.orange.withValues(alpha: 0.40);
-      } else {
-        fillColor = Colors.green.withValues(alpha: 0.35);
-      }
-
-      markers.add(
-        Marker(
-          point: ll.LatLng(lat, lng),
-          width: 64,
-          height: 64,
-          child: Container(
-            decoration: BoxDecoration(
-              color: fillColor,
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: fillColor.withValues(alpha: 0.7),
-                width: 1.5,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    if (markers.isEmpty) return null;
-    return MarkerLayer(markers: markers);
-  }
-
   // ── Battery monitoring ─────────────────────────────────────────────────────
 
   void _initBatteryMonitoring() {
@@ -1007,21 +945,6 @@ class _HomeScreenState extends State<HomeScreen> {
       }
     } catch (e) {
       debugPrint('Error checking pending PoDs: $e');
-    }
-  }
-
-  // ── Google Maps deep-link ──────────────────────────────────────────────────
-
-  Future<void> _openGoogleMapsRoute() async {
-    final dest = _destination;
-    if (dest == null) return;
-    final uri = Uri.parse(
-      'https://www.google.com/maps/dir/?api=1'
-      '&destination=${dest.point.latitude},${dest.point.longitude}'
-      '&travelmode=driving',
-    );
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/home_screen.dart` declares two methods twice, which is a Dart compile error (duplicate definition), so the driver app cannot build:

- `Widget? _buildHeatmapLayer()` declared at line 259 and again at line 1978
- `Future<void> _openGoogleMapsRoute()` declared at line 1015 and again at line 2061

The duplicated `_buildHeatmapLayer` and `_openGoogleMapsRoute` are orphaned earlier copies that are never reached; Dart emits "The name '_buildHeatmapLayer' is already defined" and "The name '_openGoogleMapsRoute' is already defined" for both duplicates.

## Fix

Deleted the orphaned earlier copies and kept the single live declarations. Call sites continue to work unchanged.

## Files changed

- `apps/driver/lib/screens/home_screen.dart`

## Testing

- Confirmed each method is now declared exactly once (no more duplicate-definition compile errors).
- Confirmed existing call sites still reference the kept declarations.

Closes #6231
