### PR TITLE
fix: declare missing active-trip fields in driver home screen

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -149,6 +149,9 @@ class _HomeScreenState extends State<HomeScreen> {
   String _activeTruckLabel = '';
   String _activeTripDistance = '';
   String _activeTripDuration = '';
+  String _activeTripEta = '';
+  double _activeTripProgress = 0.0;
+  String _activeTripStatus = '';
   String _activeTripPayout = '';
   /// Number of stops not yet completed on the active trip.
   int _activeTripStopsRemaining = 0;


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/home_screen.dart` reads three state fields that are never declared anywhere in the class, which is a Dart compile error, so the driver app cannot build:

- `_activeTripEta` — assigned at lines 824, 876, 984, read at 876–878
- `_activeTripProgress` — assigned at 825, 877, 985
- `_activeTripStatus` — assigned at 826, 842, 878, 986, 1452

There is no field declaration for any of them, so the active-trip widget cannot update.

## Fix

Added the three missing field declarations next to the existing active-trip fields:

```dart
String _activeTripEta = '';
double _activeTripProgress = 0.0;
String _activeTripStatus = '';
```

## Files changed

- `apps/driver/lib/screens/home_screen.dart`

## Testing

- Confirmed the three fields are now declared and every assignment/read site resolves.
- Existing active-trip state handling (reset, milestone updates) continues to compile and work.

Closes #6232
