### PR TITLE
Fix truck type search filter

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -587,7 +587,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     const driverIds = drivers.map(d => d.user_id);
 
     const [trucksRes, profilesRes] = await Promise.all([
-      supabase.from('trucks').select('id, name, number_plate, max_capacity_tons').in('id', truckIds),
+      supabase.from('trucks').select('id, name, truck_type, number_plate, max_capacity_tons').in('id', truckIds),
       supabase.from('profiles').select('id, full_name, avatar_url, is_digilocker_verified').in('id', driverIds),
     ]);
 

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -302,15 +302,26 @@ describe('Truck Routes', () => {
       expect(res.body.length).toBe(0);
     });
 
-    it('filters by truck_type using name match', async () => {
-      seedSearchData();
+    it('filters by truck_type using the stored truck type', async () => {
+      mockTelemetryResults = [{ driver_id: 'driver-uuid-456' }];
+      m.store.trucks = [
+        { id: 'truck-reefer', name: 'Tata 407', truck_type: 'Refrigerated', number_plate: 'MH12AB0001', max_capacity_tons: 10, owner_id: 'driver-uuid-456' },
+      ];
+      m.store.driver_details = [
+        { user_id: 'driver-uuid-456', is_online: true, truck_id: 'truck-reefer', rating: 4.5, total_trips: 100, completion_rate: 95 },
+      ];
+      m.store.profiles = [
+        { id: 'driver-uuid-456', full_name: 'Ravi Kumar' },
+      ];
+
       const res = await request(buildApp())
         .get(`/api/trucks/search?${SEARCH_PARAMS}&truck_type=Refrigerated`)
         .set(CUSTOMER_HEADERS);
 
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body)).toBe(true);
-      expect(res.body.length).toBe(0);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].truck).toBe('Tata 407');
     });
 
     it('accepts valid optional filters without errors', async () => {


### PR DESCRIPTION
## Summary
- include `truck_type` in truck enrichment during search
- keep filtering based on the stored truck type
- update the regression case so a matching type is returned even when the truck name does not contain the type text

## Validation
- `node --check backend/api/src/routes/truckRoutes.js`

Closes #6220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Truck search results now include truck type information, enabling accurate filtering by truck type.
  * Improved search behavior for refrigerated trucks and verified matching results.

* **Tests**
  * Updated integration coverage to validate truck type filtering and returned truck details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->