### PR TITLE
Cache truck search results

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -478,7 +478,20 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     return res.status(400).json({ error: 'min_capacity must be less than or equal to max_capacity' });
   }
 
-  const cacheKey = `truck_search:${numPickupLat},${numPickupLng}:${numDropLat},${numDropLng}:${numWeightTonnes}:${parseBoolean(is_fragile)}:${parseBoolean(is_stackable)}`;
+  const searchCacheFilters = {
+    pickupLat: numPickupLat,
+    pickupLng: numPickupLng,
+    dropLat: numDropLat,
+    dropLng: numDropLng,
+    weightTonnes: numWeightTonnes,
+    isFragile: fragileFilter.value,
+    isStackable: stackableFilter.value,
+    truckType: truck_type || '',
+    minCapacity: minCapFilter.value ?? '',
+    maxCapacity: maxCapFilter.value ?? '',
+    materialType: material_type || '',
+  };
+  const cacheKey = `truck_search:${JSON.stringify(searchCacheFilters)}`;
 
   if (redisClient) {
     try {
@@ -646,6 +659,14 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     });
 
     const responseResults = filteredResults.map(({ capacityTons, truckType, ...rest }) => rest);
+
+    if (redisClient) {
+      try {
+        await redisClient.set(cacheKey, JSON.stringify(responseResults), 'EX', 60);
+      } catch (err) {
+        logger.warn({ err: err.message }, 'Redis cache write error during search');
+      }
+    }
 
     res.json(responseResults);
   } catch (err) {

--- a/backend/api/test/integration/truckSearchCache.test.js
+++ b/backend/api/test/integration/truckSearchCache.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+const redisClient = {
+  get: vi.fn(),
+  set: vi.fn(),
+};
+
+let mockTelemetryResults = [];
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: m.supabase,
+  firebaseAdmin: null,
+  redisClient,
+  mongoDb: {
+    collection: () => ({
+      find: () => ({
+        toArray: () => Promise.resolve(mockTelemetryResults),
+      }),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/osrm.js', () => ({ getRouteEstimate: vi.fn().mockResolvedValue({ distanceKm: 10, durationSeconds: 1200 }) }));
+vi.mock('../../src/lib/pricing.js', () => ({ computeOrderPricing: vi.fn().mockReturnValue({ baseFreight: 1000, tollEstimate: 100, platformFee: 50, totalAmount: 1150, distanceKm: 10 }) }));
+vi.mock('../../src/services/ml.js', () => ({ predictPrice: vi.fn().mockResolvedValue({ estimated_price: 0 }) }));
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => {
+    req.user = {
+      id: req.get('x-user-id') || 'customer-uuid-123',
+      role: req.get('x-user-role') || 'customer',
+      fullName: req.get('x-user-name') || 'Test Customer',
+    };
+    next();
+  },
+}));
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (req, res, next) => next(),
+}));
+
+const { default: truckRouter } = await import('../../src/routes/truckRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/trucks', truckRouter);
+  return app;
+}
+
+describe('truck search caching', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.trucks = [
+      { id: 'truck-open', name: 'Open Body Truck', number_plate: 'MH12AB0001', max_capacity_tons: 10, owner_id: 'driver-uuid-456' },
+    ];
+    m.store.driver_details = [
+      { user_id: 'driver-uuid-456', is_online: true, truck_id: 'truck-open', rating: 4.5, total_trips: 100, completion_rate: 95 },
+    ];
+    m.store.profiles = [
+      { id: 'driver-uuid-456', full_name: 'Ravi Kumar' },
+    ];
+    m.calls.length = 0;
+    mockTelemetryResults = [{ driver_id: 'driver-uuid-456' }];
+    redisClient.get.mockResolvedValue(null);
+    redisClient.set.mockResolvedValue('OK');
+    vi.clearAllMocks();
+  });
+
+  it('stores computed results with a key that includes search filters', async () => {
+    const res = await request(buildApp())
+      .get('/api/trucks/search?pickup_lat=19.0760&pickup_lng=72.8777&drop_lat=28.6139&drop_lng=77.2090&weight_tonnes=5&truck_type=Open%20Body&material_type=Textile')
+      .set({
+        'x-user-id': 'customer-uuid-123',
+        'x-user-role': 'customer',
+        'x-user-name': 'Test Customer',
+      });
+
+    expect(res.status).toBe(200);
+    expect(redisClient.set).toHaveBeenCalledTimes(1);
+    const [cacheKey, cachedPayload, mode, ttl] = redisClient.set.mock.calls[0];
+    expect(cacheKey).toContain('"truckType":"Open Body"');
+    expect(cacheKey).toContain('"materialType":"Textile"');
+    expect(JSON.parse(cachedPayload)).toEqual(res.body);
+    expect(mode).toBe('EX');
+    expect(ttl).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- add Redis writes for computed truck search results
- include optional search filters in the cache key
- add focused coverage for cache writes and cached payload shape

## Validation
- `node --check backend/api/src/routes/truckRoutes.js`
- `npm --prefix backend/api test -- truckSearchCache.test.js`

Closes #6221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved truck search result caching so different filters return accurate results.
  - Updated cache expiration to refresh search results more frequently.
  - Improved resilience when saving search results to the cache.

- **Tests**
  - Added integration coverage validating filtered truck searches and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->