### PR TITLE
fix: import dart:io in driver sync engine

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';


### PR DESCRIPTION
## Problem

`apps/driver/lib/services/sync_engine.dart` uses `Platform.isAndroid` at line 24 but never imports `dart:io`. The import list contains only `dart:convert`, `sqflite`, `path`, `connectivity_plus`, `http`, `firebase_auth`, `uuid`, and `flutter/foundation` — none of which export the `Platform` class. This is a Dart compile error ("Undefined name 'Platform'"), so the driver app cannot build.

## Fix

Added `import 'dart:io';` at the top of `sync_engine.dart` so `Platform.isAndroid` resolves and returns the Android emulator loopback host on Android.

## Files changed

- `apps/driver/lib/services/sync_engine.dart`

## Testing

- Confirmed `dart:io` is now imported and `Platform.isAndroid` resolves.
- No other changes made.

Closes #6234
