### PR TITLE
fix: add retry_count column to sync_events schema

### DIFF
--- a/apps/driver/lib/services/offline_first_sync_service.dart
+++ b/apps/driver/lib/services/offline_first_sync_service.dart
@@ -26,7 +26,7 @@ class OfflineFirstSyncService {
     final dbPath = p.join(dir.path, 'offline_sync.db');
     _db = await openDatabase(
       dbPath,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE sync_events (
@@ -35,9 +35,17 @@ class OfflineFirstSyncService {
             payload TEXT NOT NULL,
             queued_at INTEGER NOT NULL,
             is_synced INTEGER NOT NULL DEFAULT 0,
-            synced_at INTEGER
+            synced_at INTEGER,
+            retry_count INTEGER NOT NULL DEFAULT 0
           )
         ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute(
+            'ALTER TABLE sync_events ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0',
+          );
+        }
       },
     );
     _emitDbSnapshot();


### PR DESCRIPTION
## Problem

`apps/driver/lib/services/offline_first_sync_service.dart` reads and writes a `retry_count` column on the `sync_events` table, but the table schema (created at lines 31–40) had no such column. The failure-retry path does:

```dart
final retries = batch[j]['retry_count'] as int? ?? 0;
if (retries < 3) {
  await db.update('sync_events', {'retry_count': retries + 1}, ...);
}
```

Since `retry_count` was never added to `CREATE TABLE sync_events`, every failed sync batch raised a SQLite `no such column: sync_events.retry_count` error, aborting the whole sync attempt and permanently losing unsynced events.

## Fix

- Added `retry_count INTEGER NOT NULL DEFAULT 0` to the `CREATE TABLE sync_events` schema.
- Bumped the DB version to 2 and added an `onUpgrade` migration that runs `ALTER TABLE sync_events ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0` for existing installs.

## Files changed

- `apps/driver/lib/services/offline_first_sync_service.dart`

## Testing

- Fresh installs create the table with the `retry_count` column.
- Existing installs are migrated via the `ALTER TABLE` in `onUpgrade`.
- Failed events are now retried up to 3 times, then dropped as intended.

Closes #6235
