### PR TITLE
fix: match active trip status against TripStatusType in trip detail screen

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -36,14 +36,9 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
   final GpsTrackingService _gpsTracking = GpsTrackingService();
   WsConnectionStatus _wsStatus = WsConnectionStatus.disconnected;
 
-  /// Statuses that require live GPS emission (matches LocationService list).
+  /// Statuses that require live GPS emission.
   static const _activeStatuses = {
-    'truck_assigned',
-    'en_route_pickup',
-    'arrived_pickup',
-    'picked_up',
-    'in_transit',
-    'arriving',
+    TripStatusType.active,
   };
 
   @override
@@ -69,9 +64,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
 
   /// Start GPS emission only if this trip is in an active status.
   void _maybeStartGpsTracking() {
-    // TripStatusType is an enum — map to its string key.
-    final statusName = widget.trip.status.name;
-    if (!_activeStatuses.contains(statusName)) return;
+    if (!_activeStatuses.contains(widget.trip.status)) return;
 
     _gpsTracking.connectionStatus.listen((status) {
       if (mounted) setState(() => _wsStatus = status);


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/trip_detail_screen.dart` defines `_activeStatuses` with snake_case strings (`'truck_assigned'`, `'en_route_pickup'`, etc.), but the trip status comes from the `TripStatusType` enum whose `.name` values are `active`, `completed`, `cancelled`. `_maybeStartGpsTracking()` compared `widget.trip.status.name` against the set, which could never match, so live GPS emission for an active trip never started and the backend never received live position for the trip.

## Fix

- Changed `_activeStatuses` to hold `TripStatusType.active`.
- Compare `widget.trip.status` directly against the set instead of its `.name` string.

## Files changed

- `apps/driver/lib/screens/trip_detail_screen.dart`

## Testing

- Active trips now pass the check and call `_gpsTracking.startForTrip(...)`.
- Completed/cancelled trips correctly skip GPS emission.

Closes #6236
