### PR TITLE
fix: use connectivity_plus v7 list API in driver services

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -72,8 +72,8 @@ class SyncEngine {
 
     debugPrint('[SyncEngine] Queued $eventType for trip $tripId.');
     
-    final connectivityResult = await Connectivity().checkConnectivity();
-    if (connectivityResult != ConnectivityResult.none) {
+    final connectivityResults = await Connectivity().checkConnectivity();
+    if (!connectivityResults.contains(ConnectivityResult.none)) {
       await attemptSync();
     }
   }
@@ -81,8 +81,8 @@ class SyncEngine {
   /// Flushes the queue to the backend.
   static Future<void> attemptSync() async {
     if (_isSyncing) return;
-    final connectivityResult = await Connectivity().checkConnectivity();
-    if (connectivityResult == ConnectivityResult.none) return;
+    final connectivityResults = await Connectivity().checkConnectivity();
+    if (connectivityResults.contains(ConnectivityResult.none)) return;
 
     final db = await database;
     final events = await db.query('sync_queue', orderBy: 'occurred_at ASC');

--- a/apps/driver/lib/services/trip_service.dart
+++ b/apps/driver/lib/services/trip_service.dart
@@ -186,8 +186,8 @@ class TripService {
     String stopId,
     String tripDisplayId,
   ) async {
-    final connectivityResult = await Connectivity().checkConnectivity();
-    if (connectivityResult == ConnectivityResult.none) {
+    final connectivityResults = await Connectivity().checkConnectivity();
+    if (connectivityResults.contains(ConnectivityResult.none)) {
       await SyncEngine.queueEvent(
         tripId: tripDisplayId,
         eventType: 'markStopCompleted',


### PR DESCRIPTION
## Problem

The project uses `connectivity_plus ^7.2.0`, where `checkConnectivity()` returns `List<ConnectivityResult>`, not a single value. Comparing the returned `List` to a single `ConnectivityResult` enum is always `false`, so the offline branches were dead code:

- `apps/driver/lib/services/trip_service.dart` `markStopCompleted()` — `connectivityResult == ConnectivityResult.none` was never true, so offline stops were not queued and the network call threw.
- `apps/driver/lib/services/sync_engine.dart` lines 75–78 (`connectivityResult != ConnectivityResult.none`) and 84–85 (`== ConnectivityResult.none`) — sync attempts ran while offline and threw, losing events.

## Fix

Use the v7 list API with `contains()` checks in all three call sites:

```dart
final connectivityResults = await Connectivity().checkConnectivity();
if (connectivityResults.contains(ConnectivityResult.none)) { ... }
```

## Files changed

- `apps/driver/lib/services/trip_service.dart`
- `apps/driver/lib/services/sync_engine.dart`

## Testing

- Offline devices now route `markStopCompleted` and sync attempts through the offline queue.
- `sync_service.dart` already used the correct list API and was left unchanged.

Closes #6237
