### PR TITLE
fix: convert change-drop total from paise to rupees for display

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -663,8 +663,8 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                               );
 
                               final pricing = resp['pricing'];
-                              final total = pricing != null ? pricing['total_amount'] : null;
-                              setModalState(() => pricingText = total != null ? 'New estimated price: ₹${total.toString()}' : 'Price updated');
+                              final total = pricing != null ? pricing['total_amount'] as num? : null;
+                              setModalState(() => pricingText = total != null ? 'New estimated price: ₹${(total / 100).toStringAsFixed(0)}' : 'Price updated');
 
                               // refresh outer order state
                               await _loadOrder();


### PR DESCRIPTION
## Problem

`apps/customer/lib/screens/live_tracking_screen.dart` (lines 665–667) displayed the change-drop repricing `total_amount` without converting paise to rupees:

```dart
final pricing = resp['pricing'];
final total = pricing != null ? pricing['total_amount'] : null;
setModalState(() => pricingText = total != null ? 'New estimated price: ₹${total.toString()}' : 'Price updated');
```

Everywhere else in the codebase `total_amount` is paise and divided by 100 before display (e.g. `shell_screen.dart:116-117`, `orders_screen.dart:160-161`, and `order_service.dart:260` documents that `estimatePriceRange` returns the price in paise). This screen showed the raw paise value as rupees, inflating the shown price 100x.

## Fix

Convert before display:

```dart
final total = pricing != null ? pricing['total_amount'] as num? : null;
pricingText = total != null ? 'New estimated price: ₹${(total / 100).toStringAsFixed(0)}' : 'Price updated';
```

## Files changed

- `apps/customer/lib/screens/live_tracking_screen.dart`

## Testing

- The change-drop modal now displays `₹` + (total_amount / 100), matching the rest of the codebase.

Closes #6238
