### PR TITLE
fix: report offline dashboard synced events accurately

### DIFF
--- a/apps/customer/lib/core/offline/db/offline_event_db.dart
+++ b/apps/customer/lib/core/offline/db/offline_event_db.dart
@@ -12,11 +12,12 @@ class OfflineDbStats {
 
   static Future<OfflineDbStats> collect(Database db) async {
     final total = Sqflite.firstIntValue(await db.rawQuery('SELECT COUNT(*) FROM trip_events')) ?? 0;
-    final pending = Sqflite.firstIntValue(await db.rawQuery("SELECT COUNT(*) FROM trip_events WHERE sync_status = 'pending'")) ?? 0;
+    final pending = Sqflite.firstIntValue(await db.rawQuery("SELECT COUNT(*) FROM trip_events WHERE sync_status IN ('pending', 'failed')")) ?? 0;
+    final synced = Sqflite.firstIntValue(await db.rawQuery("SELECT COUNT(*) FROM trip_events WHERE sync_status = 'synced'")) ?? 0;
     return OfflineDbStats()
       ..totalEvents = total
       ..pendingEvents = pending
-      ..syncedEvents = total - pending;
+      ..syncedEvents = synced;
   }
 }
 


### PR DESCRIPTION
## Problem

`apps/customer/lib/core/offline/db/offline_event_db.dart` — `OfflineDbStats.collect` computed `syncedEvents = total - pending` where `pending` only counted `sync_status = 'pending'`. But `pendingEvents()` treats both `pending` and `failed` statuses as pending, and `markSyncing` sets `sync_status = 'syncing'`. Events stuck in `syncing` or `failed` were therefore counted as successfully synced — the offline dashboard could report 100% synced while events were never uploaded (e.g. a crash mid-upload leaves rows in `syncing` forever).

## Fix

- `pendingEvents` now counts `sync_status IN ('pending', 'failed')`, matching the status vocabulary of `pendingEvents()` (what the sync loop will actually pick up).
- `syncedEvents` now counts only `sync_status = 'synced'`.
- Events in `syncing`/`rejected` are no longer misreported as synced.

## Files changed

- `apps/customer/lib/core/offline/db/offline_event_db.dart`

## Testing

- Dashboard counts are now consistent: `synced` reflects only uploaded rows, `pending` reflects what the sync loop will pick up, and stuck rows are no longer hidden.

Closes #6239
