### PR TITLE
perf(api): add redis cache storage for truck search results (fixes #6250)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -647,6 +647,14 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
 
     const responseResults = filteredResults.map(({ capacityTons, truckType, ...rest }) => rest);
 
+    if (redisClient) {
+      try {
+        await redisClient.set(cacheKey, JSON.stringify(responseResults), 'EX', 300);
+      } catch (cacheErr) {
+        logger.warn({ err: cacheErr.message }, 'Redis cache write error during search');
+      }
+    }
+
     res.json(responseResults);
   } catch (err) {
     logger.error('Truck search error:', err.message);


### PR DESCRIPTION
## Description
This PR addresses the issue where the truck search API (`GET /api/trucks/search`) successfully generated results but failed to write them to the Redis cache. The changes implement a non-blocking cache write with a 5-minute TTL (Time-To-Live) to temporarily store search results, effectively bypassing heavy database querying and ML pricing generation on subsequent identical requests.

Changes:
- Modified `backend/api/src/routes/truckRoutes.js` to securely persist the `responseResults` to Redis if the `redisClient` is available.
- Added a non-blocking `try...catch` wrapper around the cache write operation to ensure the primary search response is not disrupted in case of cache write failures.
- Added a `logger.warn` statement to log any cache write errors.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `npm start` or equivalent API start script, then test with a search request.
- **Test Steps / Prerequisites:**
  1. Make an initial valid `GET /api/trucks/search` request with matching parameters (e.g., `pickup_lat`, `pickup_lng`, `weight_tonnes`).
  2. Verify that the response returns the computed estimates and drivers successfully.
  3. Execute the exact same request again within 5 minutes.
  4. Verify the logs indicate that the truck search results are now being successfully served from the Redis cache (`Serving truck search results from Redis cache`).
- **Expected Result:** The second identical search request is much faster, logs a cache hit, and does not trigger DB or ML operations, while cache write failures are safely logged without returning a 500 status.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #6250

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.