### PR TITLE
fix: match reverse-geocode cache key precision and bound cache size

### DIFF
--- a/apps/customer/lib/services/location_service.dart
+++ b/apps/customer/lib/services/location_service.dart
@@ -25,6 +25,13 @@ class LocationService {
     _searchCache[query.toLowerCase().trim()] = results;
   }
 
+  static void _cacheReverse(String key, String address) {
+    if (_reverseCache.length >= _maxCacheSize) {
+      _reverseCache.remove(_reverseCache.keys.first);
+    }
+    _reverseCache[key] = address;
+  }
+
   Future<List<LocationSuggestion>> searchPlaces(String query) async {
     final trimmed = query.trim();
     if (trimmed.length < 3) {
@@ -86,7 +93,7 @@ class LocationService {
   }
 
   Future<String> resolveAddress(LatLng point) async {
-    final cacheKey = '${point.latitude.toStringAsFixed(4)},${point.longitude.toStringAsFixed(4)}';
+    final cacheKey = '${point.latitude.toStringAsFixed(6)},${point.longitude.toStringAsFixed(6)}';
     if (_reverseCache.containsKey(cacheKey)) {
       return _reverseCache[cacheKey]!;
     }
@@ -115,7 +122,7 @@ class LocationService {
     if (decoded is! Map<String, dynamic>) throw Exception('Reverse lookup failed: unexpected response type');
     final displayName = (decoded['display_name'] as String?)?.trim();
     if (displayName != null && displayName.isNotEmpty) {
-      _reverseCache[cacheKey] = displayName;
+      _cacheReverse(cacheKey, displayName);
       return displayName;
     }
 


### PR DESCRIPTION
## Problem

`apps/customer/lib/services/location_service.dart` — `resolveAddress` built the reverse-geocode cache key rounded to 4 decimals but sent the full 6 decimals to the API:

```dart
final cacheKey = '${point.latitude.toStringAsFixed(4)},${point.longitude.toStringAsFixed(4)}';
...
'lat': point.latitude.toStringAsFixed(6),
'lon': point.longitude.toStringAsFixed(6),
```

4 decimal places ≈ 11 m at the equator. Any two points within the same 4-decimal cell (up to ~11 m apart) shared a cache key, so the second lookup returned the first point's cached address — wrong for positions only metres apart (common in truck docks and loading bays). The reverse cache was also unbounded, unlike the 200-entry `_searchCache`.

## Fix

- Use the same precision for the key as the request (6 decimals):

```dart
final cacheKey = '${point.latitude.toStringAsFixed(6)},${point.longitude.toStringAsFixed(6)}';
```

- Added `_cacheReverse` which evicts the reverse cache past `_maxCacheSize`, mirroring `_searchCache`, so the map no longer grows without bound.

## Files changed

- `apps/customer/lib/services/location_service.dart`

## Testing

- Distinct coordinates within ~11 m no longer collide on one cache key.
- The reverse cache is now bounded to the same max size as the search cache.

Closes #6241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved reverse location lookup efficiency with bounded caching.
  * Increased coordinate precision for cached location results.
  * Added automatic removal of the oldest cached entries when the cache reaches capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->