### PR TITLE
fix: query past A/B test rows in get_active_test

### DIFF
--- a/backend/ml/services/ab_testing.py
+++ b/backend/ml/services/ab_testing.py
@@ -156,7 +156,7 @@ class ABTestModel:
         session = self.Session()
         try:
             recent = session.query(ABTestMetrics).filter(
-                ABTestMetrics.timestamp >= datetime.utcnow()
+                ABTestMetrics.timestamp <= datetime.utcnow()
             ).order_by(ABTestMetrics.timestamp.desc()).first()
 
             if recent:


### PR DESCRIPTION
## Problem

`backend/ml/services/ab_testing.py` — `get_active_test` (lines 154–174) filtered for rows whose timestamp is **in the future**:

```python
recent = session.query(ABTestMetrics).filter(
    ABTestMetrics.timestamp >= datetime.utcnow()
).order_by(ABTestMetrics.timestamp.desc()).first()
```

All rows are written with `datetime.utcnow()`, i.e. always in the past, so this query never matched anything and always returned `None`. The active-test lookup — the switch that lets the shadow deployment serve traffic — was permanently dead, so `get_model_for_request` silently served production 100% of the time and shadow/rollback logic never engaged.

## Fix

Inverted the comparison to return the most recent row in the past:

```python
recent = session.query(ABTestMetrics).filter(
    ABTestMetrics.timestamp <= datetime.utcnow()
).order_by(ABTestMetrics.timestamp.desc()).first()
```

## Files changed

- `backend/ml/services/ab_testing.py`

## Testing

- `get_active_test` now returns the latest stored A/B test instead of always `None`, so shadow routing and rollback logic can engage.

Closes #6243
