### PR TITLE
fix: scope gps_offline_data RLS to the owner

### DIFF
--- a/supabase/migrations/20260804100500_create_gps_offline_data.sql
+++ b/supabase/migrations/20260804100500_create_gps_offline_data.sql
@@ -13,11 +13,14 @@ CREATE INDEX IF NOT EXISTS gps_offline_data_peer_idx
   ON gps_offline_data ("peerId");
 
 -- Service uses the anon client on behalf of authenticated users.
+-- Ownership is scoped to the caller via get_profile_id() so that users can
+-- only read/write their own offline GPS rows (see 20240101000000_rls.sql).
 ALTER TABLE gps_offline_data ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY gps_offline_data_authenticated_all
+DROP POLICY IF EXISTS gps_offline_data_authenticated_all ON gps_offline_data;
+CREATE POLICY gps_offline_data_owner
   ON gps_offline_data
   FOR ALL
   TO authenticated
-  USING (true)
-  WITH CHECK (true);
+  USING ("peerId" = get_profile_id()::text)
+  WITH CHECK ("peerId" = get_profile_id()::text);


### PR DESCRIPTION
## Problem

`supabase/migrations/20260804100500_create_gps_offline_data.sql` — the RLS policy granted every `authenticated` user full read/write over **all** drivers' offline GPS history:

```sql
CREATE POLICY gps_offline_data_authenticated_all
  ON gps_offline_data
  FOR ALL
  TO authenticated
  USING (true)
  WITH CHECK (true);
```

The table stores per-driver offline GPS payloads scoped by `peerId`, but the policy had no ownership scoping. Any logged-in user could `SELECT`, `UPDATE`, or `DELETE` any other driver's location history via PostgREST — a privacy/DoS issue and cross-tenant data exposure.

## Fix

Scoped the policy to the caller using the canonical `get_profile_id()` pattern:

```sql
DROP POLICY IF EXISTS gps_offline_data_authenticated_all ON gps_offline_data;
CREATE POLICY gps_offline_data_owner
  ON gps_offline_data
  FOR ALL
  TO authenticated
  USING ("peerId" = get_profile_id()::text)
  WITH CHECK ("peerId" = get_profile_id()::text);
```

## Files changed

- `supabase/migrations/20260804100500_create_gps_offline_data.sql`

## Testing

- Authenticated users can only access rows whose `peerId` matches their own profile id.
- The overly-broad `gps_offline_data_authenticated_all` policy is dropped.

Closes #6244
