### PR TITLE
fix: add missing findOrderByIdOrDisplayId to orderRepository

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -81,6 +81,10 @@ export class OrderRepository {
     return this.findOrderByDisplayId(id, columns);
   }
 
+  async findOrderByIdOrDisplayId(id, columns = '*') {
+    return this.findOrderByAnyId(id, columns);
+  }
+
   async findOrdersByCustomer(customerId, columns, statuses, orderColumn, ascending, pagination) {
     return this._retryableQuery(() => {
       let query = this.supabase

--- a/backend/api/test/unit/orderRepository.test.js
+++ b/backend/api/test/unit/orderRepository.test.js
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for backend/api/src/repositories/orderRepository.js
+ *
+ * Coverage:
+ *   - findOrderByIdOrDisplayId resolves a UUID via findOrderById
+ *   - findOrderByIdOrDisplayId resolves a display id via findOrderByDisplayId
+ *   - findOrderByIdOrDisplayId delegates to findOrderByAnyId
+ *
+ * Run with:  npm test -- test/unit/orderRepository.test.js
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { OrderRepository } from '../../src/repositories/orderRepository.js';
+
+function buildStubSupabase(rowByQuery) {
+  return {
+    from: vi.fn((table) => {
+      if (table !== 'orders') {
+        throw new Error(`Unexpected table "${table}"`);
+      }
+      return {
+        select: vi.fn((columns) => ({
+          eq: vi.fn((column, value) => ({
+            maybeSingle: vi.fn(() => {
+              const row = rowByQuery[`${column}:${value}`];
+              return Promise.resolve(row ?? { data: null, error: null });
+            }),
+          })),
+        })),
+      };
+    }),
+  };
+}
+
+const UUID = '11111111-2222-3333-4444-555555555555';
+const DISPLAY_ID = '#FF20260521';
+
+describe('OrderRepository.findOrderByIdOrDisplayId', () => {
+  it('resolves a UUID order id through findOrderById', async () => {
+    const supabase = buildStubSupabase({
+      [`id:${UUID}`]: { data: { id: UUID, order_display_id: DISPLAY_ID }, error: null },
+    });
+    const repo = new OrderRepository(supabase);
+
+    const result = await repo.findOrderByIdOrDisplayId(UUID, 'id, order_display_id');
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ id: UUID, order_display_id: DISPLAY_ID });
+  });
+
+  it('resolves a display id through findOrderByDisplayId', async () => {
+    const supabase = buildStubSupabase({
+      [`order_display_id:${DISPLAY_ID}`]: { data: { id: UUID, order_display_id: DISPLAY_ID }, error: null },
+    });
+    const repo = new OrderRepository(supabase);
+
+    const result = await repo.findOrderByIdOrDisplayId(DISPLAY_ID, 'id, order_display_id');
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ id: UUID, order_display_id: DISPLAY_ID });
+  });
+
+  it('returns null when the order is not found by either id', async () => {
+    const supabase = buildStubSupabase({});
+    const repo = new OrderRepository(supabase);
+
+    const result = await repo.findOrderByIdOrDisplayId('missing-order', 'id');
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeNull();
+  });
+
+  it('delegates to findOrderByAnyId for the lookup', async () => {
+    const supabase = buildStubSupabase({
+      [`id:${UUID}`]: { data: { id: UUID, order_display_id: DISPLAY_ID }, error: null },
+    });
+    const repo = new OrderRepository(supabase);
+    const spy = vi.spyOn(repo, 'findOrderByAnyId');
+
+    await repo.findOrderByIdOrDisplayId(UUID, 'id');
+
+    expect(spy).toHaveBeenCalledWith(UUID, 'id');
+  });
+});


### PR DESCRIPTION
## Problem

`backend/api/src/routes/paymentRoutes.js` (the `/api/payments/upi-intent`, `/api/payments/lock` and `/api/payments/charge-and-lock` handlers) and `backend/api/src/routes/orderRoutes.js:1163` (the confirm-OTP handler) all call `orderRepository.findOrderByIdOrDisplayId(...)`, but `backend/api/src/repositories/orderRepository.js` only defines `findOrderById`, `findOrderByDisplayId` and `findOrderByAnyId`. At runtime `orderRepository.findOrderByIdOrDisplayId is not a function` throws inside the handler and the endpoint returns HTTP 500 for every request, breaking the UPI payment flow (`apps/customer/lib/screens/booking_confirmation_screen.dart` drives the entire payment flow through `/api/payments/upi-intent`).

## Fix

Add the missing `findOrderByIdOrDisplayId(identifier, columns)` method to `OrderRepository`, delegating to the existing `findOrderByAnyId` (which already resolves a UUID via `findOrderById` and falls back to `findOrderByDisplayId`). This keeps the `{ data, error }` result convention used by all four call sites, so no route logic needs to change and order lookups resolve by UUID or display id as expected.

## Files changed

- `backend/api/src/repositories/orderRepository.js` — added `findOrderByIdOrDisplayId` (delegates to `findOrderByAnyId`)
- `backend/api/test/unit/orderRepository.test.js` — new unit tests asserting UUID resolution, display-id resolution, not-found handling and delegation to `findOrderByAnyId`

## Testing

- `node --check` on the modified source and test files passes.
- New vitest unit tests (`test/unit/orderRepository.test.js`) cover resolution by UUID, by display id, the not-found path, and that the method delegates to `findOrderByAnyId`. Note: local `node_modules` are not installed in this workspace, so the vitest suite itself was not executed here; it runs in CI via `npm test`.

Closes #6276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order lookup so orders can be found using either their internal ID or display ID.
  * Preserved support for selecting specific order fields.
* **Tests**
  * Added coverage for successful lookups, missing orders, and field-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->