### PR TITLE
fix: correct api/src import depth in kafka depth-2 modules

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -1,7 +1,7 @@
 import kafka, { TOPICS, CONSUMER_GROUPS } from '../config/kafka.config.js';
 import processedEventRepository from '../repositories/processedEvent.repository.js';
 import deadLetterRepository from '../repositories/deadLetter.repository.js';
-import logger from '../api/src/middleware/logger.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class OrderConsumer {
   constructor({ eventBus: externalEventBus } = {}) {

--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 import eventRepository from '../repositories/event.repository.js';
 
 class OrderReadModel {

--- a/backend/kafka/repositories/deadLetter.repository.js
+++ b/backend/kafka/repositories/deadLetter.repository.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class DeadLetterRepository {
   async store({ topic, message, error, retryCount = 0 }) {

--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class EventRepository {
   async saveEvent(event) {

--- a/backend/kafka/repositories/processedEvent.repository.js
+++ b/backend/kafka/repositories/processedEvent.repository.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class ProcessedEventRepository {
   /**

--- a/backend/kafka/scripts/init-kafka.js
+++ b/backend/kafka/scripts/init-kafka.js
@@ -2,7 +2,7 @@
 
 import kafka from '../config/kafka.config.js';
 import { TOPICS } from '../config/kafka.config.js';
-import logger from '../api/src/middleware/logger.js';
+import logger from '../../api/src/middleware/logger.js';
 
 async function initKafka() {
   try {

--- a/backend/kafka/test/smoke.test.js
+++ b/backend/kafka/test/smoke.test.js
@@ -1,0 +1,80 @@
+/**
+ * Startup smoke test for the Kafka event service import graph.
+ *
+ * Regression test for issue #6286: depth-2 modules under backend/kafka/
+ * (consumers, repositories, cqrs, scripts) used `../api/src/...`, which
+ * resolved to a non-existent `backend/kafka/api/` subtree and crashed the
+ * service with MODULE_NOT_FOUND. This test statically resolves every
+ * `from '.../api/src/...'` import specifier against the real filesystem so
+ * the boot path is verified without needing live Kafka/Supabase.
+ *
+ * Run with:  npm test -- test/smoke.test.js
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const kafkaRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const IMPORT_RE = /from\s+['"]([^'"]+)['"]/g;
+const API_SRC_IMPORT = /^\.{1,2}\/api\/src\//;
+
+function collectApiSrcImports(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const specifiers = [];
+  let match;
+  while ((match = IMPORT_RE.exec(content)) !== null) {
+    if (API_SRC_IMPORT.test(match[1])) {
+      specifiers.push(match[1]);
+    }
+  }
+  return specifiers;
+}
+
+function* listSourceFiles(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* listSourceFiles(full);
+    } else if (entry.name.endsWith('.js')) {
+      yield full;
+    }
+  }
+}
+
+describe('Kafka service import graph', () => {
+  it('every api/src import resolves to an existing file', () => {
+    const failures = [];
+    let checked = 0;
+
+    for (const file of listSourceFiles(kafkaRoot)) {
+      for (const spec of collectApiSrcImports(file)) {
+        checked += 1;
+        const resolved = path.resolve(path.dirname(file), spec);
+        if (!fs.existsSync(resolved)) {
+          failures.push(`${path.relative(kafkaRoot, file)} -> ${spec}`);
+        }
+      }
+    }
+
+    expect(checked).toBeGreaterThan(0);
+    expect(failures).toEqual([]);
+  });
+
+  it('depth-2 modules use the ../../api/src depth', () => {
+    const depthTwoDirs = ['consumers', 'repositories', 'cqrs', 'scripts'];
+    for (const dir of depthTwoDirs) {
+      const dirPath = path.join(kafkaRoot, dir);
+      if (!fs.existsSync(dirPath)) continue;
+      for (const file of listSourceFiles(dirPath)) {
+        for (const spec of collectApiSrcImports(file)) {
+          expect(
+            spec,
+            `${path.relative(kafkaRoot, file)} must import api/src via ../../api/src`
+          ).toMatch(/^\.\.\/\.\.\/api\/src\//);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The Kafka event services cannot boot. `backend/kafka/index.js` imports `./consumers/order.consumer.js`, which imports modules at the wrong relative depth. Files two levels under `backend/kafka/` used `../api/src/...`, which resolves to a non-existent `backend/kafka/api/` subtree:

- `consumers/order.consumer.js` → `../api/src/middleware/logger.js`
- `repositories/event.repository.js`, `repositories/processedEvent.repository.js`, `repositories/deadLetter.repository.js` → `../api/src/config/db.js` / `../api/src/middleware/logger.js`
- `cqrs/order.read.model.js` → `../api/src/config/db.js` / `../api/src/middleware/logger.js`
- `scripts/init-kafka.js` → `../api/src/middleware/logger.js`

Loading `order.consumer.js` throws `MODULE_NOT_FOUND`, so `node index.js` in `backend/kafka` crashes before any consumer is initialized — the whole Kafka stack (CQRS read-model builds, wallet/earnings handling, dead-letter persistence, idempotency registry) is dead on arrival.

## Fix

Correct the relative import depth in all depth-2 modules from `../api/src/...` to `../../api/src/...`, matching the already-correct `config/kafka.config.js`. `backend/kafka/scripts/init-kafka.js` had the same bug and was fixed too. A startup smoke test now statically verifies that every `api/src` import specifier in the kafka package resolves to an existing file, so any future depth regression fails CI.

## Files changed

- `backend/kafka/consumers/order.consumer.js` — import depth fixed
- `backend/kafka/repositories/event.repository.js` — import depth fixed
- `backend/kafka/repositories/processedEvent.repository.js` — import depth fixed
- `backend/kafka/repositories/deadLetter.repository.js` — import depth fixed
- `backend/kafka/cqrs/order.read.model.js` — import depth fixed
- `backend/kafka/scripts/init-kafka.js` — import depth fixed (same bug class)
- `backend/kafka/test/smoke.test.js` — new startup smoke test for the import graph

## Testing

- `node --check` passes on the modified sources and the new test.
- New vitest smoke test (`backend/kafka/test/smoke.test.js`) asserts every `api/src` import across the kafka package resolves to an existing file and that depth-2 modules use the `../../api/src` depth. Note: local `node_modules` are not installed in this workspace, so the vitest suite itself was not executed here; it runs in CI via `npm test`.

Closes #6286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected backend service references so Kafka-based order processing, event handling, and initialization can reliably access shared API services.

- **Tests**
  - Added an automated smoke test to verify service references resolve correctly and help prevent future startup or runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->