### PR TITLE
fix: never restore funds when settlement RPC fails after payout dispatch

### DIFF
--- a/backend/api/src/workers/withdrawalSettlementWorker.js
+++ b/backend/api/src/workers/withdrawalSettlementWorker.js
@@ -4,8 +4,54 @@ import { dispatchPayout, isPayoutProviderConfigured } from '../services/wallet/p
 import { WorkerTracer } from '../core/telemetry/WorkerTracer.js';
 
 const BATCH_LIMIT = 50;
+const SETTLE_RETRY_ATTEMPTS = 3;
+const SETTLE_RETRY_DELAYS_MS = [500, 1500, 3000];
 
 let intervalId = null;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Records that a payout was dispatched for this withdrawal so a crash between
+ * dispatch and the completion RPC is detected and re-settled (not failed) on
+ * the next sweep. Best-effort: failure to record only delays detection.
+ */
+async function recordPayoutAttempted(withdrawalId, settlementRef) {
+  const { error } = await supabaseAdmin
+    .from('wallet_transactions')
+    .update({
+      payout_attempted_at: new Date().toISOString(),
+      settlement_ref: settlementRef,
+    })
+    .eq('id', withdrawalId)
+    .is('payout_attempted_at', null);
+
+  if (error) {
+    logger.warn(`[WithdrawalSettlementWorker] Failed to record payout attempt for ${withdrawalId}: ${error.message}`);
+  }
+}
+
+/**
+ * Marks a pending withdrawal completed. Retried with a bounded backoff because
+ * settle_withdrawal_tx is idempotent and only matches rows still in 'pending'.
+ */
+async function settleWithRetry(withdrawalId, settlementRef) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= SETTLE_RETRY_ATTEMPTS; attempt += 1) {
+    const { error } = await supabaseAdmin.rpc('settle_withdrawal_tx', {
+      p_withdrawal_id: withdrawalId,
+      p_settlement_ref: settlementRef,
+    });
+    if (!error) {
+      return true;
+    }
+    lastError = error;
+    if (attempt < SETTLE_RETRY_ATTEMPTS) {
+      await sleep(SETTLE_RETRY_DELAYS_MS[attempt - 1]);
+    }
+  }
+  throw new Error(`Failed to settle withdrawal ${withdrawalId}: ${lastError.message}`);
+}
 
 /**
  * Settles 'pending' withdrawal wallet_transactions:
@@ -14,6 +60,13 @@ let intervalId = null;
  *   3. marks the withdrawal completed (settle_withdrawal_tx) or failed
  *      (fail_withdrawal_tx) with the reserved funds restored to
  *      wallet_confirmed.
+ *
+ * Failure-mode split (Issue #6274):
+ *   - dispatchPayout failed BEFORE money left the platform -> fail the
+ *     withdrawal and restore the reserved funds to wallet_confirmed;
+ *   - dispatchPayout succeeded but settle_withdrawal_tx failed -> NEVER
+ *     restore funds. The row stays 'pending' with payout_attempted_at set so
+ *     the next sweep detects it and retries the (idempotent) settle call.
  */
 export async function settlePendingWithdrawals() {
   if (!supabaseAdmin) {
@@ -28,7 +81,7 @@ export async function settlePendingWithdrawals() {
 
   const { data: withdrawals, error } = await supabaseAdmin
     .from('wallet_transactions')
-    .select('id, driver_id, amount')
+    .select('id, driver_id, amount, payout_attempted_at, settlement_ref')
     .eq('txn_type', 'withdrawal')
     .eq('status', 'pending')
     .is('settled_at', null)
@@ -45,33 +98,44 @@ export async function settlePendingWithdrawals() {
   }
 
   for (const withdrawal of withdrawals) {
+    let settlementRef = withdrawal.settlement_ref;
+
+    if (!withdrawal.payout_attempted_at) {
+      try {
+        const result = await dispatchPayout({
+          driverId: withdrawal.driver_id,
+          withdrawal,
+        });
+        settlementRef = result.settlementRef;
+
+        // Persist the dispatch outcome BEFORE the completion RPC so a crash in
+        // between is detected and settled (not failed) on the next sweep.
+        await recordPayoutAttempted(withdrawal.id, settlementRef);
+      } catch (err) {
+        // The payout never left the platform — safe to restore the reserved
+        // funds to wallet_confirmed.
+        logger.error(`[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} payout dispatch failed: ${err.message}`);
+
+        const { error: failErr } = await supabaseAdmin.rpc('fail_withdrawal_tx', {
+          p_withdrawal_id: withdrawal.id,
+          p_error: String(err.message || 'Unknown error').slice(0, 1000),
+        });
+
+        if (failErr) {
+          logger.error(`[WithdrawalSettlementWorker] Failed to mark withdrawal ${withdrawal.id} as failed: ${failErr.message}`);
+        }
+        continue;
+      }
+    }
+
+    // The payout has already been dispatched. Never call fail_withdrawal_tx
+    // here — restoring wallet_confirmed would double-pay the driver. Keep the
+    // row 'pending' and let the next sweep retry the idempotent settle call.
     try {
-      const result = await dispatchPayout({
-        driverId: withdrawal.driver_id,
-        withdrawal,
-      });
-
-      const { error: settleErr } = await supabaseAdmin.rpc('settle_withdrawal_tx', {
-        p_withdrawal_id: withdrawal.id,
-        p_settlement_ref: result.settlementRef,
-      });
-
-      if (settleErr) {
-        throw new Error(`Failed to settle withdrawal ${withdrawal.id}: ${settleErr.message}`);
-      }
-
-      logger.info(`[WithdrawalSettlementWorker] Settled withdrawal ${withdrawal.id} (ref: ${result.settlementRef}).`);
+      await settleWithRetry(withdrawal.id, settlementRef);
+      logger.info(`[WithdrawalSettlementWorker] Settled withdrawal ${withdrawal.id} (ref: ${settlementRef}).`);
     } catch (err) {
-      logger.error(`[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} failed: ${err.message}`);
-
-      const { error: failErr } = await supabaseAdmin.rpc('fail_withdrawal_tx', {
-        p_withdrawal_id: withdrawal.id,
-        p_error: String(err.message || 'Unknown error').slice(0, 1000),
-      });
-
-      if (failErr) {
-        logger.error(`[WithdrawalSettlementWorker] Failed to mark withdrawal ${withdrawal.id} as failed: ${failErr.message}`);
-      }
+      logger.error(`[WithdrawalSettlementWorker] Settlement of withdrawal ${withdrawal.id} deferred — payout already dispatched, funds NOT restored: ${err.message}`);
     }
   }
 }

--- a/backend/api/test/unit/withdrawalSettlementWorker.test.js
+++ b/backend/api/test/unit/withdrawalSettlementWorker.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const admin = {
   from: vi.fn(),
@@ -32,6 +32,7 @@ function mockPendingWithdrawals(rows) {
     is: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    update: vi.fn().mockReturnThis(),
   };
   admin.from.mockReturnValue(query);
   return query;
@@ -40,8 +41,13 @@ function mockPendingWithdrawals(rows) {
 describe('Withdrawal Settlement Worker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     isPayoutProviderConfiguredMock.mockReturnValue(true);
     admin.rpc.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('skips the cycle when no payout provider is configured', async () => {
@@ -55,8 +61,8 @@ describe('Withdrawal Settlement Worker', () => {
 
   it('settles pending withdrawals through the payout provider', async () => {
     mockPendingWithdrawals([
-      { id: 'w1', driver_id: 'd1', amount: 1000 },
-      { id: 'w2', driver_id: 'd2', amount: 500 },
+      { id: 'w1', driver_id: 'd1', amount: 1000, payout_attempted_at: null },
+      { id: 'w2', driver_id: 'd2', amount: 500, payout_attempted_at: null },
     ]);
     dispatchPayoutMock
       .mockResolvedValueOnce({ success: true, settlementRef: 'ref-1' })
@@ -73,10 +79,11 @@ describe('Withdrawal Settlement Worker', () => {
       p_withdrawal_id: 'w2',
       p_settlement_ref: 'ref-2',
     });
+    expect(admin.rpc).not.toHaveBeenCalledWith('fail_withdrawal_tx', expect.anything());
   });
 
   it('marks a withdrawal failed and restores funds when the payout dispatch fails', async () => {
-    mockPendingWithdrawals([{ id: 'w1', driver_id: 'd1', amount: 1000 }]);
+    mockPendingWithdrawals([{ id: 'w1', driver_id: 'd1', amount: 1000, payout_attempted_at: null }]);
     dispatchPayoutMock.mockRejectedValue(new Error('bank rejected'));
 
     await settlePendingWithdrawals();
@@ -85,6 +92,44 @@ describe('Withdrawal Settlement Worker', () => {
       p_withdrawal_id: 'w1',
       p_error: 'bank rejected',
     });
+    expect(admin.rpc).not.toHaveBeenCalledWith('settle_withdrawal_tx', expect.anything());
+  });
+
+  it('does not restore funds when settle fails after a successful dispatch', async () => {
+    vi.useFakeTimers();
+    mockPendingWithdrawals([{ id: 'w1', driver_id: 'd1', amount: 1000, payout_attempted_at: null }]);
+    dispatchPayoutMock.mockResolvedValue({ success: true, settlementRef: 'ref-1' });
+    admin.rpc.mockImplementation((name) =>
+      name === 'settle_withdrawal_tx'
+        ? Promise.resolve({ error: { message: 'rpc timeout' } })
+        : Promise.resolve({ error: null })
+    );
+
+    const running = settlePendingWithdrawals();
+    await vi.advanceTimersByTimeAsync(6000);
+    await running;
+
+    // The payout was dispatched — funds must NEVER be restored via
+    // fail_withdrawal_tx.
+    expect(admin.rpc).not.toHaveBeenCalledWith('fail_withdrawal_tx', expect.anything());
+    // The idempotent settle call is retried with a bounded backoff.
+    const settleCalls = admin.rpc.mock.calls.filter(([name]) => name === 'settle_withdrawal_tx');
+    expect(settleCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not re-dispatch a withdrawal whose payout was already attempted', async () => {
+    mockPendingWithdrawals([
+      { id: 'w1', driver_id: 'd1', amount: 1000, payout_attempted_at: '2026-08-04T10:00:00Z', settlement_ref: 'ref-1' },
+    ]);
+
+    await settlePendingWithdrawals();
+
+    expect(dispatchPayoutMock).not.toHaveBeenCalled();
+    expect(admin.rpc).toHaveBeenCalledWith('settle_withdrawal_tx', {
+      p_withdrawal_id: 'w1',
+      p_settlement_ref: 'ref-1',
+    });
+    expect(admin.rpc).not.toHaveBeenCalledWith('fail_withdrawal_tx', expect.anything());
   });
 
   it('does not settle anything when the pending query errors', async () => {

--- a/supabase/migrations/20260805000000_withdrawal_settlement_payout_attempt.sql
+++ b/supabase/migrations/20260805000000_withdrawal_settlement_payout_attempt.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- Withdrawal settlement: payout-attempt tracking (Issue #6274)
+-- -----------------------------------------------------------------------------
+-- Problem:
+--   The settlement worker dispatched the payout first and then marked the
+--   withdrawal completed via settle_withdrawal_tx. If settle_withdrawal_tx
+--   failed (transient Supabase/network error, RPC timeout), the worker's catch
+--   called fail_withdrawal_tx, which restores the withdrawn amount to
+--   wallet_confirmed. Because the payout had ALREADY been dispatched, the
+--   driver received the bank/UPI payout AND got the amount restored to
+--   wallet_confirmed — an unlimited double-payout loop.
+--
+-- Fix:
+--   Track when a payout was actually dispatched (payout_attempted_at) so the
+--   worker can distinguish:
+--     - dispatch failed before money left the platform  -> safe to restore funds
+--     - dispatch succeeded but completion RPC failed     -> never restore funds;
+--       keep the row pending (payout_attempted_at set) so the next sweep detects
+--       it and retries settle_withdrawal_tx (idempotent, matches only pending
+--       rows) instead of failing the withdrawal.
+-- =============================================================================
+
+ALTER TABLE wallet_transactions
+  ADD COLUMN IF NOT EXISTS payout_attempted_at timestamptz;
+
+-- Pending-withdrawal sweep now also targets rows whose payout was dispatched
+-- but never settled (crash between dispatch and settle), so the existing
+-- partial index covers the payout-attempted-but-unsettled rows as well.
+CREATE INDEX IF NOT EXISTS idx_wallet_transactions_payout_attempted_unsettled
+  ON wallet_transactions (payout_attempted_at)
+  WHERE txn_type = 'withdrawal'
+    AND status = 'pending'
+    AND settled_at IS NULL
+    AND payout_attempted_at IS NOT NULL;


### PR DESCRIPTION
## Problem

`backend/api/src/workers/withdrawalSettlementWorker.js` settled each pending withdrawal by (1) dispatching the payout through the provider (`dispatchPayout`), then (2) marking it completed via `settle_withdrawal_tx`. If step 2 failed (transient Supabase/network error, RPC timeout), the `catch` called `fail_withdrawal_tx`, which restores the withdrawn amount to `wallet_confirmed` (`supabase/migrations/20260802060000_withdrawal_settlement.sql`). Because the payout had already been dispatched, the driver received the real bank/UPI payout **and** the balance was restored for a second withdrawal — an unlimited double-payout loop whenever the settle RPC lags after a successful dispatch.

## Fix

Split the worker loop into two distinct failure modes:

- **Payout dispatch failed** before money left the platform → `fail_withdrawal_tx` is still called and the reserved funds are restored to `wallet_confirmed`.
- **`settle_withdrawal_tx` failed after a successful dispatch** → funds are **never** restored. The row stays `pending`, a new `payout_attempted_at` column is recorded right after dispatch, and the idempotent settle call is retried with bounded backoff. If a crash happens between dispatch and settle, the next sweep detects `payout_attempted_at` set, skips re-dispatching, and settles instead of failing.

## Files changed

- `backend/api/src/workers/withdrawalSettlementWorker.js` — split dispatch/settle failure handling, added `recordPayoutAttempted` and `settleWithRetry`, and skipped re-dispatch for already-attempted withdrawals
- `supabase/migrations/20260805000000_withdrawal_settlement_payout_attempt.sql` — new `payout_attempted_at` column on `wallet_transactions` plus a partial index for payout-attempted-but-unsettled rows
- `backend/api/test/unit/withdrawalSettlementWorker.test.js` — updated and extended: dispatch-success + settle-failure asserts `fail_withdrawal_tx` is never called (balance not restored) and settle is retried; payout-attempted rows are not re-dispatched

## Testing

- `node --check` passes on the modified source and tests.
- Updated vitest unit tests cover: normal settle, dispatch failure restores funds, dispatch-success + settle-failure never restores funds and retries settle, and no re-dispatch of already-attempted withdrawals. Note: local `node_modules` are not installed in this workspace, so the vitest suite itself was not executed here; it runs in CI via `npm test`.

Closes #6274
