### PR TITLE
fix: guard acceptBid against funded/released/terminal orders (#6278)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -515,15 +515,29 @@ export class OrderRepository {
   // ESCROW
   // ===================================================================
 
-  async updateEscrowBooking(orderId, bookingId, escrowStatus, extra = {}) {
-    return this._retryableQuery(() => this.supabase
-      .from('orders')
-      .update({
-        escrow_booking_id: bookingId,
-        escrow_status: escrowStatus,
-        ...extra,
-      })
-      .eq('id', orderId), 'updateEscrowBooking');
+  async updateEscrowBooking(orderId, bookingId, escrowStatus, extra = {}, filters) {
+    return this._retryableQuery(() => {
+      let query = this.supabase
+        .from('orders')
+        .update({
+          escrow_booking_id: bookingId,
+          escrow_status: escrowStatus,
+          ...extra,
+        })
+        .eq('id', orderId);
+      if (filters) {
+        for (const f of filters) {
+          if (f.op === 'eq') {
+            query = query.eq(f.column, f.value);
+          } else if (f.op === 'is') {
+            query = query.is(f.column, f.value);
+          } else if (f.op === 'or') {
+            query = query.or(f.value);
+          }
+        }
+      }
+      return query.select('id, escrow_status, pending_bid_acceptance').single();
+    }, 'updateEscrowBooking');
   }
 
   async revertEscrowStatus(orderId) {

--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -6,6 +6,20 @@ import { acquireLock, releaseLock } from '../../lib/redisLock.js';
 // Re-export for backward compatibility — prefer importing from domainError.js
 export { DomainError } from './domainError.js';
 
+// Once the escrow money has moved, or the order is finished, a new bid can
+// never be accepted — doing so would orphan the on-chain escrow and the
+// already-assigned driver.
+const BLOCKED_ESCROW_STATUSES = ['funded', 'released', 'refunded'];
+const TERMINAL_ORDER_STATUSES = ['delivered', 'cancelled', 'payment_released'];
+
+// updateEscrowBooking only flips the order to 'funding' while it is still in
+// an accepting state (escrow untouched, no pending acceptance), closing the
+// concurrent double-accept TOCTOU window: the second writer matches no row.
+const ESCROW_RESET_GUARD_FILTERS = [
+  { op: 'or', value: 'escrow_status.is.null,escrow_status.eq.pending' },
+  { op: 'is', column: 'pending_bid_acceptance', value: null },
+];
+
 export class BidAcceptanceService {
   constructor({ orderRepository, buildDepositTxFn, escrowDepositFn, recordDepositTxFn, escrowRefundFn, logger, notificationDispatcher }) {
     this.orderRepository = orderRepository;
@@ -40,6 +54,20 @@ export class BidAcceptanceService {
         if (order.escrow_status === 'funding' && order.pending_bid_acceptance) {
           throw new DomainError(409, {
             error: 'Funding has already been initiated for a bid on this order. Confirm the pending escrow deposit before accepting another bid.'
+          });
+        }
+
+        // Guard: never re-accept once the escrow funds have moved or the order
+        // has reached a terminal state — the funds on-chain and the assigned
+        // driver would be orphaned by resetting the booking to 'funding'.
+        if (BLOCKED_ESCROW_STATUSES.includes(order.escrow_status)) {
+          throw new DomainError(409, {
+            error: `Bid cannot be accepted: escrow is already ${order.escrow_status}.`
+          });
+        }
+        if (TERMINAL_ORDER_STATUSES.includes(order.status)) {
+          throw new DomainError(409, {
+            error: `Bid cannot be accepted: order is already ${order.status}.`
           });
         }
 
@@ -153,14 +181,27 @@ export class BidAcceptanceService {
           version: order.version,
         };
 
-        const { error: escrowUpdateErr } = await this.orderRepository.updateEscrowBooking(orderId, bookingId, 'funding', {
+        const { data: escrowUpdateResult, error: escrowUpdateErr } = await this.orderRepository.updateEscrowBooking(orderId, bookingId, 'funding', {
           escrow_amount_wei: amountWei.toString(),
           escrow_driver_wallet: freshDriverWallet,
           escrow_funding_started_at: new Date().toISOString(),
           pending_bid_acceptance: pendingAcceptance,
-        });
+        }, ESCROW_RESET_GUARD_FILTERS);
         if (escrowUpdateErr) {
+          // No row matched the guard (PGRST116) — a concurrent acceptance or an
+          // escrow that already advanced won the race. Report it as a conflict,
+          // never as a server failure, and never overwrite the existing booking.
+          if (escrowUpdateErr.code === 'PGRST116' || String(escrowUpdateErr.message).includes('no rows')) {
+            throw new DomainError(409, {
+              error: 'This order already has an active escrow flow. Reload the order before accepting another bid.'
+            });
+          }
           throw new DomainError(500, { error: 'Failed to store escrow booking reference.', details: escrowUpdateErr.message });
+        }
+        if (!escrowUpdateResult) {
+          throw new DomainError(409, {
+            error: 'This order already has an active escrow flow. Reload the order before accepting another bid.'
+          });
         }
 
         return {

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -83,6 +83,7 @@ class SupabaseQueryBuilder {
   ilike(col, p) { this._filters.push({ col, op: 'ilike', val: p }); return this; }
   is(col, val)  { this._filters.push({ col, op: 'is', val }); return this; }
   not(col, op, val) { this._filters.push({ col, op: `not:${op}`, val }); return this; }
+  or(spec) { this._filters.push({ col: null, op: 'or', val: spec }); return this; }
   order(col, opts = {}) {
     this._order = { col, ascending: opts.ascending !== false };
     return this;
@@ -100,6 +101,47 @@ class SupabaseQueryBuilder {
   }
   catch(reject) { return this._exec().catch(reject); }
 
+  // Split a PostgREST-style OR spec on top-level commas, respecting and(...)
+  // groups so an inner comma does not break the group.
+  _splitOr(spec) {
+    const parts = [];
+    let depth = 0;
+    let current = '';
+    for (const ch of spec) {
+      if (ch === '(') depth++;
+      if (ch === ')') depth--;
+      if (ch === ',' && depth === 0) {
+        parts.push(current);
+        current = '';
+      } else {
+        current += ch;
+      }
+    }
+    if (current) parts.push(current);
+    return parts;
+  }
+
+  // Parse a single `col.op.value` condition into a { col, op, val } filter.
+  _parseCond(cond) {
+    let opPrefix = '';
+    let rest = cond;
+    if (rest.startsWith('not.')) {
+      opPrefix = 'not:';
+      rest = rest.substring(4);
+    }
+    const firstDot = rest.indexOf('.');
+    const secondDot = rest.indexOf('.', firstDot + 1);
+    const col = rest.slice(0, firstDot);
+    const op = rest.slice(firstDot + 1, secondDot);
+    let val = rest.slice(secondDot + 1);
+    if (op === 'is') {
+      if (val === 'null') val = null;
+      if (val === 'true') val = true;
+      if (val === 'false') val = false;
+    }
+    return { col, op: opPrefix + op, val };
+  }
+
   _matches(row, f) {
     const v = row[f.col];
     let op = f.op;
@@ -112,9 +154,23 @@ class SupabaseQueryBuilder {
     let res;
     switch (op) {
       case 'eq':
-      case 'is':
         isMatched = v === f.val;
         break;
+      case 'is':
+        // Postgres returns NULL for missing/undefined fields; a row without
+        // the column should satisfy an `is null` filter.
+        isMatched = f.val === null ? (v === null || v === undefined) : v === f.val;
+        break;
+      case 'or': {
+        const topLevel = this._splitOr(String(f.val));
+        isMatched = topLevel.some(cond => {
+          if (cond.startsWith('and(') && cond.endsWith(')')) {
+            return this._splitOr(cond.slice(4, -1)).every(part => this._matches(row, this._parseCond(part)));
+          }
+          return this._matches(row, this._parseCond(cond));
+        });
+        break;
+      }
       case 'neq':
         isMatched = v !== f.val;
         break;

--- a/backend/api/test/unit/services/bidAcceptanceService.test.js
+++ b/backend/api/test/unit/services/bidAcceptanceService.test.js
@@ -53,6 +53,8 @@ describe('BidAcceptanceService', () => {
       vehicle_id: null,
       status: 'pending',
       version: 1,
+      escrow_status: null,
+      pending_bid_acceptance: null,
     }];
     supabaseMock.store.load_bids = [{
       id: 'bid-1',
@@ -293,5 +295,247 @@ describe('BidAcceptanceService', () => {
     await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
       status: 502,
     });
+  });
+
+  it('rejects a second bid acceptance after the escrow is already funded', async () => {
+    supabaseMock.store.orders = [{
+      id: 'order-1',
+      order_display_id: 'ORDER-001',
+      customer_id: 'customer-1',
+      driver_id: 'driver-1',
+      vehicle_id: 'truck-1',
+      status: 'active',
+      version: 2,
+      escrow_status: 'funded',
+      pending_bid_acceptance: null,
+      escrow_booking_id: 'escrow:ORDER-001',
+    }];
+    supabaseMock.store.load_bids = [{
+      id: 'bid-1',
+      load_id: 'offer-1',
+      order_id: 'order-1',
+      driver_id: 'driver-1',
+      version: 1,
+      bid_amount: 50000,
+      status: 'pending',
+      created_at: '2024-01-01T00:00:00.000Z',
+    }];
+    supabaseMock.store.load_offers = [{
+      id: 'offer-1',
+      order_display_id: 'ORDER-001',
+    }];
+    supabaseMock.store.profiles = [
+      {
+        id: 'driver-1',
+        full_name: 'Jane Driver',
+        polygon_wallet_address: '0xdriver',
+      },
+      {
+        id: 'customer-1',
+        polygon_wallet_address: '0xcustomer',
+      },
+    ];
+    supabaseMock.store.driver_details = [{
+      user_id: 'driver-1',
+      polygon_wallet_address: '0xdriver',
+      rating: 4.8,
+      truck_id: 'truck-1',
+    }];
+    supabaseMock.store.trucks = [{
+      id: 'truck-1',
+      name: 'Big Rig',
+      number_plate: 'ABC-123',
+    }];
+
+    await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
+      status: 409,
+    });
+
+    // The guard must fire before any mutation: no deposit tx is built and the
+    // funded booking reference is left untouched.
+    expect(escrowDeposit).not.toHaveBeenCalled();
+    expect(supabaseMock.store.orders[0].escrow_status).toBe('funded');
+    expect(supabaseMock.store.orders[0].escrow_booking_id).toBe('escrow:ORDER-001');
+  });
+
+  it('rejects bid acceptance after the escrow has been released', async () => {
+    supabaseMock.store.orders = [{
+      id: 'order-1',
+      order_display_id: 'ORDER-001',
+      customer_id: 'customer-1',
+      driver_id: 'driver-1',
+      vehicle_id: 'truck-1',
+      status: 'payment_released',
+      version: 2,
+      escrow_status: 'released',
+      pending_bid_acceptance: null,
+      escrow_booking_id: 'escrow:ORDER-001',
+    }];
+    supabaseMock.store.load_bids = [{
+      id: 'bid-1',
+      load_id: 'offer-1',
+      order_id: 'order-1',
+      driver_id: 'driver-1',
+      version: 1,
+      bid_amount: 50000,
+      status: 'pending',
+      created_at: '2024-01-01T00:00:00.000Z',
+    }];
+    supabaseMock.store.load_offers = [{
+      id: 'offer-1',
+      order_display_id: 'ORDER-001',
+    }];
+    supabaseMock.store.profiles = [
+      {
+        id: 'driver-1',
+        full_name: 'Jane Driver',
+        polygon_wallet_address: '0xdriver',
+      },
+      {
+        id: 'customer-1',
+        polygon_wallet_address: '0xcustomer',
+      },
+    ];
+    supabaseMock.store.driver_details = [{
+      user_id: 'driver-1',
+      polygon_wallet_address: '0xdriver',
+      rating: 4.8,
+      truck_id: 'truck-1',
+    }];
+    supabaseMock.store.trucks = [{
+      id: 'truck-1',
+      name: 'Big Rig',
+      number_plate: 'ABC-123',
+    }];
+
+    await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
+      status: 409,
+    });
+    expect(escrowDeposit).not.toHaveBeenCalled();
+    expect(supabaseMock.store.orders[0].escrow_status).toBe('released');
+  });
+
+  it('rejects bid acceptance when the order is in a terminal state', async () => {
+    supabaseMock.store.orders = [{
+      id: 'order-1',
+      order_display_id: 'ORDER-001',
+      customer_id: 'customer-1',
+      driver_id: null,
+      vehicle_id: null,
+      status: 'cancelled',
+      version: 1,
+      escrow_status: 'pending',
+      pending_bid_acceptance: null,
+    }];
+    supabaseMock.store.load_bids = [{
+      id: 'bid-1',
+      load_id: 'offer-1',
+      order_id: 'order-1',
+      driver_id: 'driver-1',
+      version: 1,
+      bid_amount: 50000,
+      status: 'pending',
+      created_at: '2024-01-01T00:00:00.000Z',
+    }];
+    supabaseMock.store.load_offers = [{
+      id: 'offer-1',
+      order_display_id: 'ORDER-001',
+    }];
+    supabaseMock.store.profiles = [
+      {
+        id: 'driver-1',
+        full_name: 'Jane Driver',
+        polygon_wallet_address: '0xdriver',
+      },
+      {
+        id: 'customer-1',
+        polygon_wallet_address: '0xcustomer',
+      },
+    ];
+    supabaseMock.store.driver_details = [{
+      user_id: 'driver-1',
+      polygon_wallet_address: '0xdriver',
+      rating: 4.8,
+      truck_id: 'truck-1',
+    }];
+    supabaseMock.store.trucks = [{
+      id: 'truck-1',
+      name: 'Big Rig',
+      number_plate: 'ABC-123',
+    }];
+
+    await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
+      status: 409,
+    });
+    expect(escrowDeposit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a concurrent double-accept that already reserved a bid', async () => {
+    // Simulates the loser of a TOCTOU race: another acceptBid already wrote
+    // pending_bid_acceptance, but this request re-read a stale order with
+    // escrow_status still 'pending'. The conditional UPDATE must match no row
+    // (pending_bid_acceptance is no longer null) instead of overwriting it.
+    supabaseMock.store.orders = [{
+      id: 'order-1',
+      order_display_id: 'ORDER-001',
+      customer_id: 'customer-1',
+      driver_id: null,
+      vehicle_id: null,
+      status: 'pending',
+      version: 1,
+      escrow_status: 'pending',
+      pending_bid_acceptance: {
+        bid_id: 'bid-0',
+        load_id: 'offer-1',
+        driver_id: 'driver-2',
+        version: 1,
+        order_display_id: 'ORDER-001',
+      },
+    }];
+    supabaseMock.store.load_bids = [{
+      id: 'bid-1',
+      load_id: 'offer-1',
+      order_id: 'order-1',
+      driver_id: 'driver-1',
+      version: 1,
+      bid_amount: 50000,
+      status: 'pending',
+      created_at: '2024-01-01T00:00:00.000Z',
+    }];
+    supabaseMock.store.load_offers = [{
+      id: 'offer-1',
+      order_display_id: 'ORDER-001',
+    }];
+    supabaseMock.store.profiles = [
+      {
+        id: 'driver-1',
+        full_name: 'Jane Driver',
+        polygon_wallet_address: '0xdriver',
+      },
+      {
+        id: 'customer-1',
+        polygon_wallet_address: '0xcustomer',
+      },
+    ];
+    supabaseMock.store.driver_details = [{
+      user_id: 'driver-1',
+      polygon_wallet_address: '0xdriver',
+      rating: 4.8,
+      truck_id: 'truck-1',
+    }];
+    supabaseMock.store.trucks = [{
+      id: 'truck-1',
+      name: 'Big Rig',
+      number_plate: 'ABC-123',
+    }];
+
+    await expect(service.acceptBid({ orderId: 'order-1', bidId: 'bid-1', customerId: 'customer-1' })).rejects.toMatchObject({
+      status: 409,
+    });
+
+    // The existing acceptance must not be overwritten.
+    expect(supabaseMock.store.orders[0].pending_bid_acceptance).toMatchObject({ bid_id: 'bid-0' });
+    expect(supabaseMock.store.orders[0].escrow_status).toBe('pending');
+    expect(supabaseMock.calls.some(call => call.rpc === 'accept_bid_tx')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`acceptBid` in `backend/api/src/services/order/bidAcceptanceService.js` had only one escrow-state guard: it rejected a new acceptance when `escrow_status === 'funding' && pending_bid_acceptance`. There was no guard for orders whose escrow was already `funded`, `released`, or `refunded`, and no check on the order status being terminal.

`updateEscrowBooking` then unconditionally overwrote `escrow_status`, `escrow_booking_id`, `escrow_driver_wallet`, and `pending_bid_acceptance` with the new bid's data. So a customer could accept bid A, fund the escrow (`escrow_status = 'funded'`, driver A assigned via `accept_bid_tx`), and then accept bid B — resetting the order to `escrow_status = 'funding'` with a brand-new unfunded booking while driver A stayed assigned and the original escrow still held funds on-chain. The order became inconsistent and could be double-funded.

## Fix

- Added explicit guards in `acceptBid` that reject (409) when the order's `escrow_status` is `funded`/`released`/`refunded` or the order `status` is terminal (`delivered`/`cancelled`/`payment_released`), before any mutation.
- Made the escrow-booking update conditional: `updateEscrowBooking` now accepts optional filters and returns the updated row via `.select().single()`. `acceptBid` passes a guard (`escrow_status IS NULL OR 'pending'` AND `pending_bid_acceptance IS NULL`), so it can never reset an already-advanced escrow. If no row matches (PGRST116 — e.g. a concurrent double-accept won the race), the service returns 409 instead of overwriting the existing booking.

## Files changed

- `backend/api/src/services/order/bidAcceptanceService.js` — state guards + conditional escrow-booking update
- `backend/api/src/repositories/orderRepository.js` — `updateEscrowBooking` supports optional filters and returns the updated row
- `backend/api/test/helpers/supabaseMock.js` — added `.or()` support (PostgREST-style, incl. `and(...)` groups) and NULL handling for `is`
- `backend/api/test/unit/services/bidAcceptanceService.test.js` — regression tests

## Testing

- Added regression tests covering accept-after-funding, accept-after-release, terminal-order rejection, and concurrent double-accept (the losing writer matches no row and must not overwrite the existing `pending_bid_acceptance`).
- Verified the conditional-update semantics against the in-memory Supabase mock (first writer flips to `funding`; second writer gets `PGRST116` no rows).
- Ran `node --check` on all changed files.
- Full suite runs in CI via `npm test`.

Closes #6278
