### PR TITLE
fix(driver): register background PoD sync task and trigger on connectivity restore (#6281)

### DIFF
--- a/apps/driver/lib/main.dart
+++ b/apps/driver/lib/main.dart
@@ -20,6 +20,8 @@ Future<void> main() async {
   await CrashReportingService.init(appName: 'Driver');
 
   BackgroundSyncService.initialize();
+  BackgroundSyncService.registerSyncTask();
+  BackgroundSyncService.listenForConnectivity();
   FcmService.initialize();
   Firebase.initializeApp();
   FcmService.registerTokenForUser(userId);

--- a/apps/driver/lib/services/background_sync_service.dart
+++ b/apps/driver/lib/services/background_sync_service.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
 import 'dart:io';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:workmanager/workmanager.dart';
@@ -20,6 +23,15 @@ void callbackDispatcher() {
 }
 
 class BackgroundSyncService {
+  static bool _syncTaskRegistered = false;
+  static bool _syncing = false;
+  static StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+
+  /// Test hook: replaces the Workmanager scheduling call so tests can assert
+  /// the task is registered exactly once without a platform channel.
+  @visibleForTesting
+  static void Function()? scheduleTaskOverride;
+
   static void initialize() {
     Workmanager().initialize(
       callbackDispatcher,
@@ -28,6 +40,13 @@ class BackgroundSyncService {
   }
 
   static void registerSyncTask() {
+    if (_syncTaskRegistered) return;
+    _syncTaskRegistered = true;
+    final schedule = scheduleTaskOverride;
+    if (schedule != null) {
+      schedule();
+      return;
+    }
     Workmanager().registerOneOffTask(
       'sync_pods_task',
       syncTaskName,
@@ -37,78 +56,96 @@ class BackgroundSyncService {
     );
   }
 
+  /// Syncs offline-saved pods as soon as connectivity returns, so they do not
+  /// wait for the next OS-scheduled background run.
+  static void listenForConnectivity() {
+    _connectivitySubscription ??= Connectivity()
+        .onConnectivityChanged
+        .listen((results) {
+      if (!results.contains(ConnectivityResult.none)) {
+        syncPods();
+      }
+    });
+  }
+
   static Future<void> syncPods() async {
-    final pendingPods = await podStorageService.getUnsyncedPods();
-    if (pendingPods.isEmpty) return;
-
-    String? token;
+    if (_syncing) return;
+    _syncing = true;
     try {
-      final firebaseUser = FirebaseAuth.instance.currentUser;
-      if (firebaseUser != null) {
-        token = await firebaseUser.getIdToken();
-      } else {
-        token = Supabase.instance.client.auth.currentSession?.accessToken;
-      }
-    } catch (_) {
-      // Firebase/Supabase are not initialized in the background isolate.
-      // Fall back to the auth token persisted by the main isolate in
-      // OS-backed secure storage (issue #5739) — never SharedPreferences.
-      token = await AuthTokenStore.read();
-    }
+      final pendingPods = await podStorageService.getUnsyncedPods();
+      if (pendingPods.isEmpty) return;
 
-    if (token == null || token.isEmpty) return;
-
-    const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
-    final apiBaseUri = Uri.tryParse(envUrl);
-    if (apiBaseUri == null ||
-        !apiBaseUri.hasScheme ||
-        apiBaseUri.host.isEmpty) {
-      stderr.writeln(
-        'TRUXIFY_API_BASE_URL must be set to an absolute URL for background POD sync.',
-      );
-      return;
-    }
-    
-    for (final pod in pendingPods) {
+      String? token;
       try {
-        final uri = apiBaseUri.replace(
-          path: '${apiBaseUri.path}/api/orders/${pod.orderId}/pod'
-              .replaceAll(RegExp(r'/+'), '/'),
-          query: null,
-          fragment: null,
-        );
-        final request = http.MultipartRequest('POST', uri);
-        request.headers['Authorization'] = 'Bearer $token';
-
-        if (pod.signaturePath != null) {
-          final file = File(pod.signaturePath!);
-          if (await file.exists()) {
-            request.files.add(await http.MultipartFile.fromPath(
-              'signature',
-              file.path,
-              contentType: MediaType('image', 'png'),
-            ));
-          }
+        final firebaseUser = FirebaseAuth.instance.currentUser;
+        if (firebaseUser != null) {
+          token = await firebaseUser.getIdToken();
+        } else {
+          token = Supabase.instance.client.auth.currentSession?.accessToken;
         }
-
-        if (pod.photoPath != null) {
-          final file = File(pod.photoPath!);
-          if (await file.exists()) {
-            request.files.add(await http.MultipartFile.fromPath(
-              'photo',
-              file.path,
-              contentType: MediaType('image', 'jpeg'),
-            ));
-          }
-        }
-
-        final response = await request.send();
-        if (response.statusCode >= 200 && response.statusCode < 300) {
-          await podStorageService.markAsSynced(pod.id!);
-        }
-      } catch (e) {
-        // Will retry on next background sync
+      } catch (_) {
+        // Firebase/Supabase are not initialized in the background isolate.
+        // Fall back to the auth token persisted by the main isolate in
+        // OS-backed secure storage (issue #5739) — never SharedPreferences.
+        token = await AuthTokenStore.read();
       }
+
+      if (token == null || token.isEmpty) return;
+
+      const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
+      final apiBaseUri = Uri.tryParse(envUrl);
+      if (apiBaseUri == null ||
+          !apiBaseUri.hasScheme ||
+          apiBaseUri.host.isEmpty) {
+        stderr.writeln(
+          'TRUXIFY_API_BASE_URL must be set to an absolute URL for background POD sync.',
+        );
+        return;
+      }
+      
+      for (final pod in pendingPods) {
+        try {
+          final uri = apiBaseUri.replace(
+            path: '${apiBaseUri.path}/api/orders/${pod.orderId}/pod'
+                .replaceAll(RegExp(r'/+'), '/'),
+            query: null,
+            fragment: null,
+          );
+          final request = http.MultipartRequest('POST', uri);
+          request.headers['Authorization'] = 'Bearer $token';
+
+          if (pod.signaturePath != null) {
+            final file = File(pod.signaturePath!);
+            if (await file.exists()) {
+              request.files.add(await http.MultipartFile.fromPath(
+                'signature',
+                file.path,
+                contentType: MediaType('image', 'png'),
+              ));
+            }
+          }
+
+          if (pod.photoPath != null) {
+            final file = File(pod.photoPath!);
+            if (await file.exists()) {
+              request.files.add(await http.MultipartFile.fromPath(
+                'photo',
+                file.path,
+                contentType: MediaType('image', 'jpeg'),
+              ));
+            }
+          }
+
+          final response = await request.send();
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            await podStorageService.markAsSynced(pod.id!);
+          }
+        } catch (e) {
+          // Will retry on next background sync
+        }
+      }
+    } finally {
+      _syncing = false;
     }
   }
 }

--- a/apps/driver/test/background_sync_service_test.dart
+++ b/apps/driver/test/background_sync_service_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/services/background_sync_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    BackgroundSyncService.scheduleTaskOverride = null;
+  });
+
+  test('registerSyncTask schedules the background sync task exactly once (issue #6281)', () {
+    var scheduleCalls = 0;
+    BackgroundSyncService.scheduleTaskOverride = () => scheduleCalls++;
+
+    BackgroundSyncService.registerSyncTask();
+    BackgroundSyncService.registerSyncTask();
+    BackgroundSyncService.registerSyncTask();
+
+    // Guard against duplicate scheduling: only the first call registers.
+    expect(scheduleCalls, 1);
+  });
+}


### PR DESCRIPTION
## Problem

`BackgroundSyncService.registerSyncTask()` (`apps/driver/lib/services/background_sync_service.dart`) was defined but never called. `main.dart` only invoked `initialize()` (which registers the callback dispatcher), so the Workmanager task that runs `syncPods()` in the background was never scheduled.

`syncPods()` is the only path that uploads pods from `podStorageService` (the `pods_cache.db` table written by `pod_capture_screen.dart`). It was only invoked manually at capture time when the immediate upload failed — if the device was offline then, nothing re-triggered it when connectivity returned, so offline PoDs were silently lost.

## Fix

- `main.dart` now calls `registerSyncTask()` (plus the new connectivity listener) right after `initialize()` at startup.
- `registerSyncTask()` is guarded by a `_syncTaskRegistered` flag so the task is scheduled exactly once per process.
- Added `listenForConnectivity()`: when connectivity returns, `syncPods()` runs immediately so offline PoDs upload without waiting for the next OS-scheduled run.
- `syncPods()` is guarded by a `_syncing` flag to prevent concurrent duplicate uploads when the background task and the connectivity listener fire together.

## Files changed

- `apps/driver/lib/main.dart` — register the sync task and start the connectivity listener at startup
- `apps/driver/lib/services/background_sync_service.dart` — single-schedule guard, connectivity-triggered sync, re-entrancy guard, test hook
- `apps/driver/test/background_sync_service_test.dart` — new test

## Testing

- New unit test asserts `registerSyncTask()` schedules the task exactly once even when called repeatedly (via a test hook that replaces the Workmanager platform call).
- Runs in CI via `flutter test`.

Closes #6281
