### PR TITLE
fix(customer): reject offline events that exhaust their retry budget (#6282)

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -49,7 +49,26 @@ class SyncEngine {
 
   Future<int> syncPending() async {
     final pending = await db.pendingEvents(limit: batchSize);
-    final eligible = pending.where((event) => event.retryCount < maxRetries).toList();
+    if (pending.isEmpty) {
+      return 0;
+    }
+
+    // Events that exhausted their retry budget must never be silently dropped
+    // forever: mark them rejected with a stored reason the UI can surface.
+    final exhausted = pending
+        .where((event) => event.retryCount >= maxRetries)
+        .toList();
+    if (exhausted.isNotEmpty) {
+      for (final event in exhausted) {
+        await db.markRejected(event.id, reason: 'retry budget exhausted');
+      }
+      developer.log(
+        '[SyncEngine] Rejected ${exhausted.length} offline event(s) that exhausted their retry budget.',
+      );
+    }
+
+    final eligible =
+        pending.where((event) => event.retryCount < maxRetries).toList();
     if (eligible.isEmpty) {
       return 0;
     }

--- a/apps/customer/test/core/offline/sync_engine_test.dart
+++ b/apps/customer/test/core/offline/sync_engine_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:truxify/core/offline/db/offline_event_db.dart';
+import 'package:truxify/core/offline/models/trip_event.dart';
+import 'package:truxify/core/offline/sync/sync_engine.dart';
+
+class FakeOfflineEventDb extends OfflineEventDb {
+  final List<TripEvent> pending = [];
+  final List<Map<String, dynamic>> rejected = [];
+  final List<Map<String, dynamic>> failed = [];
+  final List<String> synced = [];
+
+  @override
+  Future<List<TripEvent>> pendingEvents({int limit = 50}) async =>
+      pending.take(limit).toList();
+
+  @override
+  Future<void> markRejected(String id, {required String reason}) async {
+    rejected.add({'id': id, 'reason': reason});
+  }
+
+  @override
+  Future<void> markFailed(String id, {required int retryCount}) async {
+    failed.add({'id': id, 'retryCount': retryCount});
+  }
+
+  @override
+  Future<void> markSynced(String id) async {
+    synced.add(id);
+  }
+
+  @override
+  Future<void> markSyncing(String id) async {}
+}
+
+void main() {
+  TripEvent event(String id, {int retryCount = 0}) =>
+      TripEvent.gpsUpdate('trip-1', {'lat': 1.0, 'lng': 2.0}, id: id, retryCount: retryCount);
+
+  test('events past maxRetries are rejected with reason, not silently dropped (issue #6282)', () async {
+    final db = FakeOfflineEventDb();
+    db.pending.add(event('evt-1', retryCount: 5));
+    final engine = SyncEngine(
+      db: db,
+      apiBaseUrl: 'http://localhost:8080',
+      maxRetries: 5,
+    );
+
+    final uploaded = await engine.syncPending();
+
+    expect(uploaded, 0);
+    expect(db.rejected, [
+      {'id': 'evt-1', 'reason': 'retry budget exhausted'},
+    ]);
+    expect(db.failed, isEmpty);
+    expect(db.synced, isEmpty);
+  });
+
+  test('exhausted events are rejected while eligible events still retry (issue #6282)', () async {
+    final db = FakeOfflineEventDb();
+    db.pending.add(event('evt-exhausted', retryCount: 5));
+    db.pending.add(event('evt-eligible', retryCount: 0));
+    final engine = SyncEngine(
+      db: db,
+      apiBaseUrl: 'http://localhost:8080',
+      maxRetries: 5,
+    );
+
+    final uploaded = await engine.syncPending();
+
+    expect(uploaded, 0);
+    expect(db.rejected, [
+      {'id': 'evt-exhausted', 'reason': 'retry budget exhausted'},
+    ]);
+    // The eligible event still attempts an upload (which cannot succeed in the
+    // test environment), so it is retried instead of being skipped.
+    expect(db.failed, [
+      {'id': 'evt-eligible', 'retryCount': 1},
+    ]);
+  });
+}


### PR DESCRIPTION
## Problem

`apps/customer/lib/core/offline/sync/sync_engine.dart` `syncPending()` filters pending offline events to those with `retryCount < maxRetries` (line 40). Retryable failures increment `retryCount` via `db.markFailed(...)` (line 63). Once an event reaches `maxRetries` (default 5), it was silently excluded from every future sync pass:

- never uploaded again,
- never marked rejected / surfaced to the user (the `permanentFailure` path only fires on a definitive server rejection),
- never purged,
- and `syncPending()` simply returned 0.

A user who stays offline (or has an expired Supabase token — which makes `_uploadBatch` return `retryableFailure`) for 5 retry attempts lost every queued trip/GPS event permanently with no indication.

## Fix

Added an exhaustion branch in `syncPending()`: when pending events have `retryCount >= maxRetries`, they are marked rejected with the stored reason `'retry budget exhausted'` (mirroring the existing `markRejected` path, which persists `sync_status = 'rejected'` + `sync_error` in the offline DB). A `developer.log` line surfaces the event count. Eligible events still proceed through the normal upload path.

## Files changed

- `apps/customer/lib/core/offline/sync/sync_engine.dart` — exhaustion branch in `syncPending()`
- `apps/customer/test/core/offline/sync_engine_test.dart` — new tests

## Testing

- New unit tests (with a fake `OfflineEventDb`) assert:
  - an event past `maxRetries` is rejected with reason `'retry budget exhausted'` and is neither failed nor synced,
  - in a mixed batch, the exhausted event is rejected while the eligible event still retries (retry count incremented) instead of being skipped.
- No new dependencies; runs in CI via `flutter test`.

Closes #6282
