### PR TITLE
fix(pqc): CSPRNG keygen with spec-conformant sampling (#6284)

### DIFF
--- a/backend/pqc/kyber.py
+++ b/backend/pqc/kyber.py
@@ -4,6 +4,31 @@ from typing import Tuple, Dict, Any
 import numpy as np
 from dataclasses import dataclass
 
+
+def _shake_bytes(seed: bytes, counter: int, length: int) -> bytes:
+    """SHAKE256 expansion of ``seed`` with a 64-bit counter (FIPS 202)."""
+    return hashlib.shake_256(seed + counter.to_bytes(8, 'big')).digest(length)
+
+
+def _rejection_sample_uniform(q: int, count: int, *, seed: bytes, counter: int = 0) -> np.ndarray:
+    """Uniform coefficients in [0, q) via rejection sampling from a SHAKE256 stream.
+
+    Used to expand the public matrix ``A`` deterministically from a public seed
+    (FIPS 203/204 ``rej_uniform``). 16-bit values are rejected unless below ``q``.
+    """
+    samples = []
+    while len(samples) < count:
+        buf = _shake_bytes(seed, counter, 4096)
+        counter += 1
+        for i in range(0, len(buf) - 1, 2):
+            value = buf[i] | (buf[i + 1] << 8)
+            if value < q:
+                samples.append(value)
+                if len(samples) >= count:
+                    break
+    return np.array(samples[:count], dtype=np.int64)
+
+
 @dataclass
 class KyberParams:
     """Kyber KEM Parameters"""
@@ -32,14 +57,36 @@ class KyberKEM:
         return (c_padded[:n] - c_padded[n:]) % q
         
     def _sample_cbd(self, eta: int, size: int) -> np.ndarray:
-        """Sample from centered binomial distribution"""
-        # Simulate CBD sampling
-        samples = np.random.binomial(eta, 0.5, size) - np.random.binomial(eta, 0.5, size)
-        return samples % self.q
+        """Sample from the centered binomial distribution (FIPS 203 Sec 4.1).
+
+        Each coefficient consumes ``2*eta`` uniform bits drawn from ``secrets``
+        (an ``os.urandom``-backed CSPRNG) and is computed as
+        sum(bits[:eta]) - sum(bits[eta:]).
+        """
+        total = size if isinstance(size, int) else int(np.prod(size))
+        samples = np.empty(total, dtype=np.int64)
+        for idx in range(total):
+            bits = secrets.randbits(2 * eta)
+            value = 0
+            for i in range(eta):
+                value += (bits >> i) & 1
+                value -= (bits >> (eta + i)) & 1
+            samples[idx] = value % self.q
+        return samples.reshape(size)
     
     def _sample_uniform(self, size: int) -> np.ndarray:
-        """Sample uniformly from Z_q"""
-        return np.random.randint(0, self.q, size)
+        """Sample uniformly from Z_q via rejection sampling (FIPS 203 Sec 4.1).
+
+        16-bit values are drawn from ``secrets`` and rejected unless they fall
+        below the modulus ``q``.
+        """
+        total = size if isinstance(size, int) else int(np.prod(size))
+        samples = []
+        while len(samples) < total:
+            value = secrets.randbits(16)
+            if value < self.q:
+                samples.append(value)
+        return np.array(samples[:total], dtype=np.int64).reshape(size)
     
     def _compress(self, x: np.ndarray, d: int) -> np.ndarray:
         """Compress coefficients"""
@@ -51,10 +98,18 @@ class KyberKEM:
     
     def keygen(self) -> Tuple[Dict, Dict]:
         """Generate Kyber key pair"""
-        # Sample random matrix A
-        A = self._sample_uniform((self.k, self.k, self.n))
-        
-        # Sample secret s and error e
+        # Public seed for the matrix A (public material, reproducible per spec).
+        rho = secrets.token_bytes(32)
+
+        # Sample the random public matrix A deterministically from rho.
+        A = np.empty((self.k, self.k, self.n), dtype=np.int64)
+        counter = 0
+        for i in range(self.k):
+            for j in range(self.k):
+                A[i][j] = _rejection_sample_uniform(self.q, self.n, seed=rho, counter=counter)
+                counter += 1
+
+        # Sample secret s and error e from a CSPRNG (FIPS 203 CBD).
         s = self._sample_cbd(self.params.eta1, (self.k, self.n))
         e = self._sample_cbd(self.params.eta1, (self.k, self.n))
         
@@ -70,13 +125,15 @@ class KyberKEM:
         
         public_key = {
             't': t_compressed,
-            'A': A  # In production: generate from seed
+            'A': A,
+            'rho': rho
         }
         
         secret_key = {
             's': s,
             't': t,
-            'A': A
+            'A': A,
+            'rho': rho
         }
         
         return public_key, secret_key
@@ -156,6 +213,7 @@ class DilithiumSignature:
             'q': 8380417,
             'd': 13,
             'tau': 39,
+            'eta': 2,
             'gamma1': 131072,
             'gamma2': 95232
         }
@@ -163,27 +221,55 @@ class DilithiumSignature:
         self.public_key = None
     
     def keygen(self) -> Tuple[Dict, Dict]:
-        """Generate Dilithium key pair"""
-        # Simplified key generation
+        """Generate Dilithium key pair (FIPS 204 conformant sampling)"""
+        n = self.params['n']
+        q = self.params['q']
+        eta = self.params['eta']
+
+        # Eta-bounded secret coefficients drawn from a CSPRNG with rejection
+        # sampling, uniform over [-eta, eta] (FIPS 204, Algorithm 1).
+        def _sample_eta_bounded(rows: int) -> np.ndarray:
+            total = rows * n
+            span = 2 * eta + 1
+            bits = span.bit_length()
+            values = np.empty(total, dtype=np.int64)
+            idx = 0
+            while idx < total:
+                candidate = secrets.randbits(bits)
+                if candidate < span:
+                    values[idx] = (candidate - eta) % q
+                    idx += 1
+            return values.reshape((rows, n))
+
+        # Public seed for the matrix A (public material, reproducible per spec).
+        rho = secrets.token_bytes(32)
+
         private_key = {
-            's1': np.random.randint(0, self.params['q'], (self.params['l'], self.params['n'])),
-            's2': np.random.randint(0, self.params['q'], (self.params['k'], self.params['n'])),
+            's1': _sample_eta_bounded(self.params['l']),
+            's2': _sample_eta_bounded(self.params['k']),
             'seed': secrets.token_bytes(32)
         }
         
-        # Compute public key
-        A = np.random.randint(0, self.params['q'], (self.params['k'], self.params['l'], self.params['n']))
+        # Expand the public matrix A deterministically from the public seed rho.
+        A = np.empty((self.params['k'], self.params['l'], n), dtype=np.int64)
+        counter = 0
+        for i in range(self.params['k']):
+            for j in range(self.params['l']):
+                A[i][j] = _rejection_sample_uniform(q, n, seed=rho, counter=counter)
+                counter += 1
+
         t = np.zeros((self.params['k'], self.params['n']))
         
         for i in range(self.params['k']):
             for j in range(self.params['l']):
-                t[i] = (t[i] + KyberKEM._negacyclic_convolve(A[i][j], private_key['s1'][j], self.params['n'], self.params['q'])) % self.params['q']
-            t[i] = (t[i] + private_key['s2'][i]) % self.params['q']
+                t[i] = (t[i] + KyberKEM._negacyclic_convolve(A[i][j], private_key['s1'][j], n, q)) % q
+            t[i] = (t[i] + private_key['s2'][i]) % q
         
         public_key = {
             'A': A,
             't': t,
-            'seed': private_key['seed']
+            'seed': private_key['seed'],
+            'rho': rho
         }
         
         self.private_key = private_key

--- a/backend/pqc/test_kyber.py
+++ b/backend/pqc/test_kyber.py
@@ -1,0 +1,124 @@
+"""Tests for CSPRNG-based key generation in backend/pqc/kyber.py.
+
+Run with: python -m pytest backend/pqc/test_kyber.py
+"""
+
+import hashlib
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+from kyber import KyberKEM, DilithiumSignature, _rejection_sample_uniform
+
+
+def _module_dir() -> str:
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def test_kyber_secret_keys_not_reproducible_from_numpy_seed():
+    """Seeding numpy's PRNG must not reproduce Kyber secret keys."""
+    np.random.seed(12345)
+    kem = KyberKEM()
+    _, sk1 = kem.keygen()
+    np.random.seed(12345)
+    _, sk2 = kem.keygen()
+    assert not np.array_equal(sk1['s'], sk2['s'])
+    assert not np.array_equal(sk1['t'], sk2['t'])
+
+
+def test_dilithium_secret_keys_not_reproducible_from_numpy_seed():
+    """Seeding numpy's PRNG must not reproduce Dilithium secret keys."""
+    np.random.seed(12345)
+    d1 = DilithiumSignature()
+    _, sk1 = d1.keygen()
+    np.random.seed(12345)
+    d2 = DilithiumSignature()
+    _, sk2 = d2.keygen()
+    assert not np.array_equal(sk1['s1'], sk2['s1'])
+    assert not np.array_equal(sk1['s2'], sk2['s2'])
+
+
+def test_kyber_keys_differ_between_generations():
+    """Consecutive keygen calls must produce fresh secrets."""
+    kem = KyberKEM()
+    pk1, sk1 = kem.keygen()
+    pk2, sk2 = kem.keygen()
+    assert not np.array_equal(sk1['s'], sk2['s'])
+    assert not np.array_equal(pk1['t'], pk2['t'])
+    assert not np.array_equal(sk1['A'], sk2['A'])
+
+
+def test_dilithium_secrets_eta_bounded():
+    """s1/s2 coefficients must lie in [-eta, eta] (stored mod q)."""
+    d = DilithiumSignature()
+    _, sk = d.keygen()
+    eta = d.params['eta']
+    q = d.params['q']
+    assert sk['s1'].shape == (d.params['l'], d.params['n'])
+    assert sk['s2'].shape == (d.params['k'], d.params['n'])
+    for arr in (sk['s1'], sk['s2']):
+        assert np.all((arr <= eta) | (arr >= q - eta))
+
+
+def test_sample_uniform_in_range():
+    """Rejection-sampled uniform coefficients stay in [0, q)."""
+    kem = KyberKEM()
+    samples = kem._sample_uniform((50, 50))
+    assert samples.shape == (50, 50)
+    assert np.all(samples >= 0)
+    assert np.all(samples < kem.q)
+
+
+def test_sample_cbd_range():
+    """CBD(eta) coefficients stay within [-eta, eta] (stored mod q)."""
+    kem = KyberKEM()
+    samples = kem._sample_cbd(2, (100,))
+    assert np.all((samples <= 2) | (samples >= kem.q - 2))
+
+
+def test_public_matrix_deterministic_from_public_seed():
+    """A must be reproducible from the public seed rho while secrets are not."""
+    d = DilithiumSignature()
+    pk, _ = d.keygen()
+    A = np.empty((d.params['k'], d.params['l'], d.params['n']), dtype=np.int64)
+    counter = 0
+    for i in range(d.params['k']):
+        for j in range(d.params['l']):
+            A[i][j] = _rejection_sample_uniform(
+                d.params['q'], d.params['n'], seed=pk['rho'], counter=counter
+            )
+            counter += 1
+    assert np.array_equal(A, pk['A'])
+
+
+def test_rejection_sample_uniform_is_deterministic():
+    """The same seed+counter must reproduce the same stream."""
+    seed = bytes(range(32))
+    a = _rejection_sample_uniform(8380417, 100, seed=seed)
+    b = _rejection_sample_uniform(8380417, 100, seed=seed)
+    assert np.array_equal(a, b)
+
+
+def test_secret_keys_differ_across_processes():
+    """Secrets must differ between independent interpreter runs (restarts),
+    proving they are not derived from any reproducible seed."""
+    hashes = []
+    for _ in range(2):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import hashlib; import numpy as np; from kyber import KyberKEM; "
+                "np.random.seed(999); k = KyberKEM(); _, sk = k.keygen(); "
+                "print(hashlib.sha256(sk['s'].tobytes()).hexdigest())",
+            ],
+            cwd=_module_dir(),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        hashes.append(proc.stdout.strip())
+    assert len(hashes) == 2
+    assert hashes[0] != hashes[1]


### PR DESCRIPTION
## Problem

`backend/pqc/kyber.py` generated all secret material with NumPy's default PRNG (Mersenne Twister), which is not cryptographically secure:

- `KyberKEM._sample_cbd` used `np.random.binomial(eta, 0.5, size)`
- `KyberKEM._sample_uniform` used `np.random.randint(0, q, size)`
- `DilithiumSignature.keygen` drew `s1`/`s2` uniformly over the full modulus `q = 8380417`, whereas FIPS 204 requires small η-bounded secret coefficients

Any seeding (`np.random.seed`) or statistical recovery could recover secret keys, and the Dilithium keys were non-conformant with the spec.

## Fix

- `_sample_cbd` now draws `2*eta` uniform bits per coefficient from `secrets` (an `os.urandom`-backed CSPRNG) and computes `sum(bits[:eta]) - sum(bits[eta:])` per FIPS 203 §4.1.
- `_sample_uniform` now uses FIPS-style rejection sampling: 16-bit CSPRNG values rejected unless below `q`.
- `DilithiumSignature.keygen` samples `s1`/`s2` via rejection sampling from the CSPRNG, uniform over `[-eta, eta]` (FIPS 204 Algorithm 1), with an efficient acceptance rate (`span = 2*eta+1`, `bits = span.bit_length()`).
- The public matrix `A` (Kyber and Dilithium) is now expanded deterministically from a public seed `rho` via SHAKE256 with rejection sampling (`_rejection_sample_uniform`), per spec — only public material is reproducible; secrets remain CSPRNG-derived.

## Files changed

- `backend/pqc/kyber.py` — CSPRNG/rejection-sampling rewrite of `_sample_cbd`, `_sample_uniform`, and `DilithiumSignature.keygen`; new `_shake_bytes` / `_rejection_sample_uniform` helpers; `rho` public seed added to both keypairs.
- `backend/pqc/test_kyber.py` — new pytest suite (9 tests): secrets not reproducible from a `np.random` seed, keys differ between generations and across processes/restarts, η-bounded Dilithium secrets, uniform/CBD coefficient ranges, and deterministic public-matrix-from-`rho`.

## Testing

- `python -m pytest backend/pqc/test_kyber.py` → 9 passed.
- `py_compile` clean.

Note: the `/pqc` endpoints are not exercised end-to-end here because `backend/pqc/hybrid_crypto.py` already fails to import at runtime on `main` (missing `from typing import Dict`); that pre-existing defect is out of scope for this issue. Also observed (pre-existing, out of scope): `KyberKEM.encapsulate`/`decapsulate` hash different arrays (uncompressed vs compressed `v`), so they never agreed on a shared secret even before this change.

Closes #6284
