### PR TITLE
fix(raft): replicate entries to quorum before committing (#6285)

### DIFF
--- a/services/consensus-raft-go/README.md
+++ b/services/consensus-raft-go/README.md
@@ -8,7 +8,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 
 - **Distributed State Machine**: Guarantees linearizable order state transitions (`CREATED` $\rightarrow$ `DISPATCHED` $\rightarrow$ `COMPLETED`) across multi-cloud regions.
 - **Leader Election & Heartbeats**: Nodes start as `FOLLOWER`, campaign for leadership via `RequestVote` RPCs, and keep leadership with `AppendEntries` heartbeats and term bumps (Raft paper §5).
-- **Atomic Log Replication**: Appends transactional state transition entries into an append-only WAL log.
+- **Atomic Log Replication**: Appends transactional state transition entries into an append-only WAL log and replicates them to a quorum of followers (AppendEntries + `nextIndex`/`matchIndex` tracking) before advancing `CommitIndex`. `/commit` returns success only once the entry is replicated to a quorum and committed.
 - **Quorum-Aware Health**: `/api/v1/raft/status` reports `HEALTHY_CLUSTER` only when a leader has quorum; `NO_LEADER`, `ELECTION_IN_PROGRESS`, and `UNHEALTHY_CLUSTER` are reported otherwise.
 
 ---
@@ -18,7 +18,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 | Endpoint | Method | Description |
 | :--- | :--- | :--- |
 | `/api/v1/raft/status` | `GET` | Returns node role, current term, leader id, log length, quorum, and cluster health. |
-| `/api/v1/raft/commit` | `POST` | Commits an order entry. Only the leader may commit; without quorum it returns `503`, and non-leaders return `409` with the current `leader_id`. |
+| `/api/v1/raft/commit` | `POST` | Commits an order entry. The leader appends the entry, replicates it to followers via `AppendEntries`, and advances `CommitIndex` only once a quorum acknowledges it — success is returned only after the entry is committed (and the updated commit index is propagated). Non-leaders return `409` with the current `leader_id`; without quorum it returns `503`. |
 | `/api/v1/raft/vote` | `POST` | Internal Raft `RequestVote` RPC used during elections. |
 | `/api/v1/raft/append` | `POST` | Internal Raft `AppendEntries` (heartbeat) RPC used by the leader. |
 

--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -111,26 +111,28 @@ type AppendEntriesResponse struct {
 }
 
 type RaftNode struct {
-	mu                sync.Mutex
-	NodeID            string     `json:"node_id"`
-	CurrentTerm       uint64     `json:"current_term"`
-	VotedFor          string     `json:"voted_for"`
-	Role              NodeRole   `json:"role"`
-	Log               []LogEntry `json:"log"`
-	CommitIndex       uint64     `json:"commit_index"`
-	LastApplied       uint64     `json:"last_applied"`
-	Peers             []string   `json:"peers"`
-	PeerURLs          []string   `json:"peer_urls"`
-	LeaderID          string     `json:"leader_id"`
+	mu          sync.Mutex
+	NodeID      string     `json:"node_id"`
+	CurrentTerm uint64     `json:"current_term"`
+	VotedFor    string     `json:"voted_for"`
+	Role        NodeRole   `json:"role"`
+	Log         []LogEntry `json:"log"`
+	CommitIndex uint64     `json:"commit_index"`
+	LastApplied uint64     `json:"last_applied"`
+	Peers       []string   `json:"peers"`
+	PeerURLs    []string   `json:"peer_urls"`
+	LeaderID    string     `json:"leader_id"`
 
-	lastLeaderSeen    time.Time
-	electionStarted   time.Time
-	electionTimeout   time.Duration
+	lastLeaderSeen     time.Time
+	electionStarted    time.Time
+	electionTimeout    time.Duration
 	electionTimeoutMin time.Duration
 	electionTimeoutMax time.Duration
-	heartbeatInterval time.Duration
-	peerHeartbeats    map[string]bool
-	httpClient        *http.Client
+	heartbeatInterval  time.Duration
+	peerHeartbeats     map[string]bool
+	nextIndex          map[string]uint64
+	matchIndex         map[string]uint64
+	httpClient         *http.Client
 }
 
 // rng is a source of randomness for election timeouts.
@@ -158,6 +160,8 @@ func NewRaftNode(id string, peers []string, peerURLs []string) *RaftNode {
 		electionTimeoutMax: time.Duration(electionMaxMs) * time.Millisecond,
 		electionTimeout:    time.Duration(electionMinMs) * time.Millisecond,
 		peerHeartbeats:     make(map[string]bool),
+		nextIndex:          make(map[string]uint64),
+		matchIndex:         make(map[string]uint64),
 		httpClient:         &http.Client{Timeout: 500 * time.Millisecond},
 	}
 }
@@ -243,6 +247,14 @@ func (rn *RaftNode) startElection() {
 		rn.Role = Leader
 		rn.LeaderID = rn.NodeID
 		rn.peerHeartbeats = make(map[string]bool, len(rn.PeerURLs))
+		// Per-follower replication state (Raft §5.3): the leader assumes each
+		// follower's log matches its own and works backward from the end.
+		rn.nextIndex = make(map[string]uint64, len(rn.PeerURLs))
+		rn.matchIndex = make(map[string]uint64, len(rn.PeerURLs))
+		for _, url := range rn.PeerURLs {
+			rn.nextIndex[url] = rn.lastLogIndex() + 1
+			rn.matchIndex[url] = 0
+		}
 		log.Printf("🌐 node [%s] elected leader for term %d", rn.NodeID, rn.CurrentTerm)
 	}
 }
@@ -315,8 +327,11 @@ func (rn *RaftNode) callAppend(peerURL string, req AppendEntriesRequest) (Append
 	return resp, err
 }
 
-// sendHeartbeats replicates AppendEntries RPCs to peers and records which
-// peers acknowledge the current leadership, performing HTTP calls outside rn.mu.
+// sendHeartbeats replicates the leader's log to followers and advances
+// CommitIndex once a quorum acknowledges the replicated entries. Each heartbeat
+// sends AppendEntries with the entries a follower is still missing (based on
+// nextIndex), updates matchIndex/nextIndex from the responses, and only then
+// moves CommitIndex/LastApplied forward. HTTP calls run outside rn.mu.
 func (rn *RaftNode) sendHeartbeats() {
 	rn.mu.Lock()
 	if rn.Role != Leader {
@@ -324,34 +339,56 @@ func (rn *RaftNode) sendHeartbeats() {
 		return
 	}
 	term := rn.CurrentTerm
-	req := AppendEntriesRequest{
-		Term:         rn.CurrentTerm,
-		LeaderID:     rn.NodeID,
-		PrevLogIndex: rn.lastLogIndex(),
-		PrevLogTerm:  rn.lastLogTerm(),
-		LeaderCommit: rn.CommitIndex,
-	}
 	rn.peerHeartbeats = make(map[string]bool, len(rn.PeerURLs))
+
+	type peerState struct {
+		url     string
+		request AppendEntriesRequest
+	}
+	states := make([]peerState, 0, len(rn.PeerURLs))
+	for _, url := range rn.PeerURLs {
+		next := rn.nextIndex[url]
+		if next == 0 {
+			next = 1
+		}
+		prevLogIndex := next - 1
+		prevLogTerm := uint64(0)
+		if prevLogIndex > 0 && prevLogIndex <= uint64(len(rn.Log)) {
+			prevLogTerm = rn.Log[prevLogIndex-1].Term
+		}
+		req := AppendEntriesRequest{
+			Term:         term,
+			LeaderID:     rn.NodeID,
+			PrevLogIndex: prevLogIndex,
+			PrevLogTerm:  prevLogTerm,
+			LeaderCommit: rn.CommitIndex,
+		}
+		if next <= uint64(len(rn.Log)) {
+			req.Entries = append(req.Entries, rn.Log[next-1:]...)
+		}
+		states = append(states, peerState{url: url, request: req})
+	}
 	rn.mu.Unlock()
 
 	type result struct {
-		url  string
-		resp AppendEntriesResponse
-		err  error
+		url     string
+		request AppendEntriesRequest
+		resp    AppendEntriesResponse
+		err     error
 	}
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	results := make([]result, 0, len(rn.PeerURLs))
+	results := make([]result, 0, len(states))
 
-	for _, url := range rn.PeerURLs {
+	for _, st := range states {
 		wg.Add(1)
-		go func(peerURL string) {
+		go func(url string, req AppendEntriesRequest) {
 			defer wg.Done()
-			resp, err := rn.callAppend(peerURL, req)
+			resp, err := rn.callAppend(url, req)
 			mu.Lock()
-			results = append(results, result{url: peerURL, resp: resp, err: err})
+			results = append(results, result{url: url, request: req, resp: resp, err: err})
 			mu.Unlock()
-		}(url)
+		}(st.url, st.request)
 	}
 	wg.Wait()
 
@@ -371,8 +408,43 @@ func (rn *RaftNode) sendHeartbeats() {
 			return
 		}
 		if res.resp.Success {
+			// Follower accepted the prefix; record the highest matching index.
+			rn.matchIndex[res.url] = res.request.PrevLogIndex + uint64(len(res.request.Entries))
+			rn.nextIndex[res.url] = rn.matchIndex[res.url] + 1
 			rn.peerHeartbeats[res.url] = true
+		} else if rn.nextIndex[res.url] > 1 {
+			// Log inconsistency: back off and retry from an earlier prefix.
+			rn.nextIndex[res.url]--
 		}
+	}
+
+	rn.advanceCommitIndexLocked()
+}
+
+// advanceCommitIndexLocked advances CommitIndex to the highest index replicated
+// to a quorum of the cluster (including the leader itself) in the current term,
+// then applies committed entries by moving LastApplied forward. Entries from
+// previous terms are only committed indirectly once a current-term entry commits
+// (Raft §5.4.2).
+func (rn *RaftNode) advanceCommitIndexLocked() {
+	last := rn.lastLogIndex()
+	for n := rn.CommitIndex + 1; n <= last; n++ {
+		if rn.Log[n-1].Term != rn.CurrentTerm {
+			continue
+		}
+		acked := 1 // the leader's own log always matches
+		for _, m := range rn.matchIndex {
+			if m >= n {
+				acked++
+			}
+		}
+		if acked < rn.quorum() {
+			break
+		}
+		rn.CommitIndex = n
+	}
+	if rn.CommitIndex > rn.LastApplied {
+		rn.LastApplied = rn.CommitIndex
 	}
 }
 
@@ -614,9 +686,9 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rn.mu.Lock()
-	defer rn.mu.Unlock()
 
 	if rn.Role != Leader {
+		rn.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -628,6 +700,7 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !rn.leaderHasQuorumLocked() {
+		rn.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -645,9 +718,59 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now(),
 	}
 
+	// Append to the local log first. CommitIndex is NOT advanced here: the entry
+	// must first be replicated to a quorum of followers (Raft §5.3).
 	rn.Log = append(rn.Log, entry)
-	rn.CommitIndex = entry.Index
-	rn.LastApplied = entry.Index
+	rn.mu.Unlock()
+
+	// Replicate to followers and wait for a quorum acknowledgement before
+	// treating the entry as committed.
+	rn.sendHeartbeats()
+
+	rn.mu.Lock()
+	if rn.Role != Leader {
+		rn.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success":   false,
+			"error":     "stepped down while replicating entry",
+			"leader_id": rn.LeaderID,
+		})
+		return
+	}
+	committed := rn.CommitIndex >= entry.Index
+	rn.mu.Unlock()
+
+	if !committed {
+		rn.mu.Lock()
+		defer rn.mu.Unlock()
+		if rn.Role != Leader {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success":   false,
+				"error":     "stepped down while replicating entry",
+				"leader_id": rn.LeaderID,
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success":    false,
+			"error":      "entry not yet committed to a quorum of followers",
+			"raft_index": entry.Index,
+		})
+		return
+	}
+
+	// Propagate the updated LeaderCommit to followers so they apply the entry
+	// before the client observes success.
+	rn.sendHeartbeats()
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{

--- a/services/consensus-raft-go/main_test.go
+++ b/services/consensus-raft-go/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -72,5 +74,238 @@ func TestConcurrentVoteRPCNoDeadlock(t *testing.T) {
 
 	if node1.Role != Leader {
 		t.Errorf("expected node1 to become leader, got %s", node1.Role)
+	}
+}
+
+// raftHandlers wires the standard Raft HTTP routes for a node under test.
+func raftHandlers(n *RaftNode) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/raft/status", n.HandleStatus)
+	mux.HandleFunc("/api/v1/raft/commit", n.HandleCommitOrder)
+	mux.HandleFunc("/api/v1/raft/vote", n.HandleVote)
+	mux.HandleFunc("/api/v1/raft/append", n.HandleAppend)
+	return mux
+}
+
+// TestLeaderReplicatesEntryToFollowersBeforeCommit spins up a 3-node cluster
+// over httptest servers, commits an order on the leader, and asserts the entry
+// is present on both followers before the leader returns success.
+func TestLeaderReplicatesEntryToFollowersBeforeCommit(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	node1 := NewRaftNode("node1", []string{"node2", "node3"}, nil)
+	node2 := NewRaftNode("node2", []string{"node1", "node3"}, nil)
+	node3 := NewRaftNode("node3", []string{"node1", "node2"}, nil)
+
+	s1 := httptest.NewServer(raftHandlers(node1))
+	defer s1.Close()
+	s2 := httptest.NewServer(raftHandlers(node2))
+	defer s2.Close()
+	s3 := httptest.NewServer(raftHandlers(node3))
+	defer s3.Close()
+
+	node1.PeerURLs = []string{s2.URL, s3.URL}
+	node2.PeerURLs = []string{s1.URL, s3.URL}
+	node3.PeerURLs = []string{s1.URL, s2.URL}
+
+	node1.mu.Lock()
+	node1.Role = Leader
+	node1.LeaderID = "node1"
+	node1.CurrentTerm = 1
+	node1.nextIndex = map[string]uint64{s2.URL: 1, s3.URL: 1}
+	node1.matchIndex = map[string]uint64{s2.URL: 0, s3.URL: 0}
+	node1.peerHeartbeats = map[string]bool{s2.URL: true, s3.URL: true}
+	node1.mu.Unlock()
+
+	body := strings.NewReader(`{"order_id":"ord-repl-1","command":"CREATED"}`)
+	resp, err := http.Post(s1.URL+"/api/v1/raft/commit", "application/json", body)
+	if err != nil {
+		t.Fatalf("commit request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from leader, got %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Success   bool   `json:"success"`
+		RaftIndex uint64 `json:"raft_index"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decoding commit response: %v", err)
+	}
+	if !payload.Success || payload.RaftIndex != 1 {
+		t.Fatalf("expected success with raft_index 1, got %+v", payload)
+	}
+
+	// The entry must already be replicated AND committed on both followers
+	// before the leader returned success.
+	for name, n := range map[string]*RaftNode{"node2": node2, "node3": node3} {
+		var logLen int
+		var firstOrder string
+		var firstIndex uint64
+		var commit uint64
+		n.mu.Lock()
+		logLen = len(n.Log)
+		if logLen > 0 {
+			firstOrder = n.Log[0].OrderID
+			firstIndex = n.Log[0].Index
+		}
+		commit = n.CommitIndex
+		n.mu.Unlock()
+
+		if logLen != 1 || firstOrder != "ord-repl-1" || firstIndex != 1 {
+			t.Errorf("%s: expected committed entry in log, got len=%d order=%q index=%d",
+				name, logLen, firstOrder, firstIndex)
+		}
+		if commit != 1 {
+			t.Errorf("%s: expected commit_index 1, got %d", name, commit)
+		}
+	}
+}
+
+// TestCommitDoesNotReturnSuccessWithoutQuorumReplication verifies the leader
+// appends the entry locally but does not advance CommitIndex (and returns 503)
+// when followers are unreachable for AppendEntries.
+func TestCommitDoesNotReturnSuccessWithoutQuorumReplication(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	unreachable := []string{"http://127.0.0.1:1", "http://127.0.0.1:2"}
+	node := NewRaftNode("node1", []string{"node2", "node3"}, unreachable)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/raft/commit" {
+			node.HandleCommitOrder(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// Fake acknowledged heartbeats so the liveness pre-check passes, while the
+	// peers themselves remain unreachable for AppendEntries replication.
+	node.mu.Lock()
+	node.Role = Leader
+	node.LeaderID = "node1"
+	node.CurrentTerm = 1
+	node.nextIndex = map[string]uint64{unreachable[0]: 1, unreachable[1]: 1}
+	node.matchIndex = map[string]uint64{unreachable[0]: 0, unreachable[1]: 0}
+	node.peerHeartbeats = map[string]bool{unreachable[0]: true, unreachable[1]: true}
+	node.mu.Unlock()
+
+	body := strings.NewReader(`{"order_id":"ord-lost-1","command":"CREATED"}`)
+	resp, err := http.Post(server.URL+"/api/v1/raft/commit", "application/json", body)
+	if err != nil {
+		t.Fatalf("commit request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 without quorum replication, got %d", resp.StatusCode)
+	}
+
+	node.mu.Lock()
+	defer node.mu.Unlock()
+	if len(node.Log) != 1 || node.Log[0].OrderID != "ord-lost-1" {
+		t.Errorf("expected the entry appended to the local log, got %v", node.Log)
+	}
+	if node.CommitIndex != 0 || node.LastApplied != 0 {
+		t.Errorf("expected commit_index/last_applied 0 without quorum, got commit=%d applied=%d",
+			node.CommitIndex, node.LastApplied)
+	}
+}
+
+// TestHeartbeatBackfillsLaggingFollower verifies the leader replication loop
+// sends missing entries to a follower and advances commit on both nodes.
+func TestHeartbeatBackfillsLaggingFollower(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	now := time.Now()
+	leader := NewRaftNode("node1", []string{"node2"}, nil)
+	leader.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+		{Index: 3, Term: 1, Command: "IN_TRANSIT", OrderID: "ord-1", Timestamp: now},
+	}
+
+	follower := NewRaftNode("node2", []string{"node1"}, nil)
+	follower.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/raft/append" {
+			follower.HandleAppend(w, r)
+		}
+	}))
+	defer server.Close()
+
+	leader.PeerURLs = []string{server.URL}
+	leader.mu.Lock()
+	leader.Role = Leader
+	leader.LeaderID = "node1"
+	leader.CurrentTerm = 1
+	leader.CommitIndex = 2
+	leader.nextIndex = map[string]uint64{server.URL: 2}
+	leader.matchIndex = map[string]uint64{server.URL: 1}
+	leader.peerHeartbeats = map[string]bool{server.URL: true}
+	leader.mu.Unlock()
+
+	leader.sendHeartbeats()
+
+	var logLen int
+	var lastOrder string
+	var commit uint64
+	follower.mu.Lock()
+	logLen = len(follower.Log)
+	if logLen > 0 {
+		lastOrder = follower.Log[logLen-1].OrderID
+	}
+	commit = follower.CommitIndex
+	follower.mu.Unlock()
+
+	if logLen != 3 {
+		t.Errorf("expected follower backfilled to 3 entries, got %d", logLen)
+	}
+	if lastOrder != "ord-1" {
+		t.Errorf("expected last entry order ord-1, got %q", lastOrder)
+	}
+	if commit != 2 {
+		t.Errorf("expected follower commit_index 2, got %d", commit)
+	}
+}
+
+// TestAdvanceCommitIndexRequiresQuorum exercises the quorum rule directly.
+func TestAdvanceCommitIndexRequiresQuorum(t *testing.T) {
+	now := time.Now()
+	leader := NewRaftNode("node1", []string{"node2", "node3"}, []string{"p2", "p3"})
+	leader.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+	}
+	leader.Role = Leader
+	leader.CurrentTerm = 1
+
+	// Only one follower (plus the leader) acknowledges index 1 → quorum is 2,
+	// so index 1 commits but index 2 does not.
+	leader.matchIndex = map[string]uint64{"p2": 1, "p3": 0}
+	leader.advanceCommitIndexLocked()
+	if leader.CommitIndex != 1 {
+		t.Errorf("expected commit_index 1 with partial quorum, got %d", leader.CommitIndex)
+	}
+	if leader.LastApplied != 1 {
+		t.Errorf("expected last_applied 1, got %d", leader.LastApplied)
+	}
+
+	// Both followers acknowledge index 2 → fully committed.
+	leader.matchIndex = map[string]uint64{"p2": 2, "p3": 2}
+	leader.advanceCommitIndexLocked()
+	if leader.CommitIndex != 2 {
+		t.Errorf("expected commit_index 2 with full quorum, got %d", leader.CommitIndex)
+	}
+	if leader.LastApplied != 2 {
+		t.Errorf("expected last_applied 2, got %d", leader.LastApplied)
 	}
 }


### PR DESCRIPTION
## Problem

`HandleCommitOrder` committed order entries on the leader's **local** log only: it appended the entry, set `CommitIndex`/`LastApplied` to it immediately, and returned success — without ever sending `AppendEntries` to any follower. There was no replication loop, no `nextIndex`/`matchIndex`, and no quorum acknowledgement for the entry. On leader failover or partition the "committed" order was absent from every other node, so consensus was never achieved and the same order id could be committed again elsewhere.

## Fix

Implemented the Raft replication path (Raft paper §5.3):

- **Per-follower state**: `RaftNode` now tracks `nextIndex`/`matchIndex` keyed by peer URL, initialized when a node wins an election (`startElection`) and on manual leader setup.
- **Replication on every heartbeat**: `sendHeartbeats` now sends `AppendEntries` carrying the entries each follower is still missing (starting at `nextIndex`, with `PrevLogIndex`/`PrevLogTerm` consistency check), updates `matchIndex`/`nextIndex` from responses, backs off `nextIndex` on log inconsistency, and reuses the existing `HandleAppend`/`appendLogFromLeaderLocked` follower path.
- **Quorum-before-commit**: new `advanceCommitIndexLocked` advances `CommitIndex` only when a majority (`matchIndex >= N` plus the leader itself) acknowledge an entry from the current term, then moves `LastApplied` forward.
- **Commit waits for quorum**: `HandleCommitOrder` appends to the local log, replicates to followers, and only returns success once the entry is committed; if no quorum acknowledges it, it returns `503` and leaves the entry for the heartbeat loop to replicate/commit later. After committing it also propagates the updated `LeaderCommit` to followers before responding.
- README updated to document the new semantics.

## Files changed

- `services/consensus-raft-go/main.go` — `nextIndex`/`matchIndex` fields + init, replication in `sendHeartbeats`, `advanceCommitIndexLocked`, rewritten `HandleCommitOrder`, election-time index init.
- `services/consensus-raft-go/main_test.go` — multi-node integration test (3 nodes over `httptest`) asserting the entry is replicated and committed on both followers before the leader returns; a 503-without-quorum test; a lagging-follower backfill test; a quorum-rule unit test.
- `services/consensus-raft-go/README.md` — documented replication-before-commit semantics.

## Testing

- `go vet ./...` clean.
- `go test ./... -count=1` → all 8 tests pass (`go test -race` unavailable locally: requires cgo).
- `gofmt -l` clean.

Closes #6285
