### PR TITLE
fix(earnings): support exact start_date/end_date month windows in driver earnings summary

### DIFF
--- a/apps/driver/lib/services/driver_earnings_service.dart
+++ b/apps/driver/lib/services/driver_earnings_service.dart
@@ -119,34 +119,13 @@ class DriverEarningsService {
 
     final start = DateTime(month.year, month.month, 1);
     final end = DateTime(month.year, month.month + 1, 1);
-    final today = DateTime.now();
+    final startDate = start.toIso8601String().split('T').first;
+    final endDate = end.toIso8601String().split('T').first;
 
-    final daysSinceMonthStart = today.difference(start).inDays + 1;
-
-    // Fallback: If we query a historical month > 365 days ago,
-    // the backend API will reject it or return incomplete data.
-    // We fetch directly from the Supabase client for these older months.
-    if (daysSinceMonthStart > 365) {
-      final response = await _client
-          .from('earnings_daily')
-          .select()
-          .eq('driver_id', driverId!)
-          .gte('day_date', start.toIso8601String().split('T').first)
-          .lt('day_date', end.toIso8601String().split('T').first)
-          .order('day_date');
-      if (response is! List) {
-        throw StateError('Unexpected monthly earnings response type');
-      }
-      return response.map((item) {
-        if (item is Map<String, dynamic>) return item;
-        if (item is Map) return Map<String, dynamic>.from(item);
-        throw StateError('Unexpected monthly earnings item type');
-      }).toList(growable: false);
-    }
-
-    final days = daysSinceMonthStart.clamp(1, 365);
-
-    final path = '/api/driver/earnings/summary?days=$days';
+    // Request exactly the selected month's window through the API for both the
+    // current and historical months (including > 365 days ago) so a single,
+    // consistent code path is always used.
+    final path = '/api/driver/earnings/summary?start_date=$startDate&end_date=$endDate';
 
     try {
       final decoded = await _apiClient.get(path);

--- a/apps/driver/test/driver_earnings_service_test.dart
+++ b/apps/driver/test/driver_earnings_service_test.dart
@@ -167,7 +167,7 @@ void main() {
       service.dispose();
     });
 
-    test('fetchMonthlyEarnings returns filtered earnings for current month', () async {
+    test('fetchMonthlyEarnings requests only the selected month via the API', () async {
       final mockResponse = [
         {'day_date': '2026-06-01', 'amount': 2000, 'trip_count': 1, 'hours_driven': 2.5},
         {'day_date': '2026-06-15', 'amount': 4500, 'trip_count': 2, 'hours_driven': 5.0},
@@ -176,6 +176,8 @@ void main() {
 
       final httpClient = MockHttpClient((request) async {
         expect(request.url.path, equals('/api/driver/earnings/summary'));
+        expect(request.url.queryParameters['start_date'], equals('2026-06-01'));
+        expect(request.url.queryParameters['end_date'], equals('2026-07-01'));
         return http.Response(jsonEncode(mockResponse), 200);
       });
 
@@ -194,23 +196,22 @@ void main() {
       service.dispose();
     });
 
-    test('fetchMonthlyEarnings falls back to database for dates > 365 days ago', () async {
+    test('fetchMonthlyEarnings uses the API for historical months older than 365 days', () async {
       bool databaseCalled = false;
       final supabaseClient = FakeSupabaseClient(
         auth: mockAuth,
         onFrom: (relation) {
-          expect(relation, equals('earnings_daily'));
           databaseCalled = true;
-        },
-        queryResult: (relation) {
-          return Future.value([
-            {'day_date': '2020-01-15', 'amount': 3000, 'trip_count': 2, 'hours_driven': 4.0}
-          ]);
         },
       );
 
       final httpClient = MockHttpClient((request) async {
-        fail('HTTP client should not be called for historical months older than 365 days');
+        expect(request.url.path, equals('/api/driver/earnings/summary'));
+        expect(request.url.queryParameters['start_date'], equals('2020-01-01'));
+        expect(request.url.queryParameters['end_date'], equals('2020-02-01'));
+        return http.Response(jsonEncode([
+          {'day_date': '2020-01-15', 'amount': 3000, 'trip_count': 2, 'hours_driven': 4.0}
+        ]), 200);
       });
 
       final service = DriverEarningsService(
@@ -218,9 +219,10 @@ void main() {
         httpClient: httpClient,
       );
 
-      // Querying January 2020 (way older than 365 days)
+      // Querying January 2020 (way older than 365 days): the API is still the
+      // single source, and the direct database path is never used.
       final result = await service.fetchMonthlyEarnings(month: DateTime(2020, 1));
-      expect(databaseCalled, isTrue);
+      expect(databaseCalled, isFalse);
       expect(result.length, equals(1));
       expect(result[0]['amount'], equals(3000));
       

--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -76,7 +76,7 @@ function logCacheError(operation, error) {
 function getRedisClient() {
   try {
     return db.redisClient ?? null;
-code -g backend/api/src/routes/lookupRoutes.js:50  } catch {
+  } catch {
     return null;
   }
 }

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -443,7 +443,7 @@ router.get('/wallet/history', authenticate, userLimiter, requirePolicy('driver:v
  *   get:
  *     tags: [Driver]
  *     summary: Get earnings summary for charts
- *     description: Returns aggregated daily earnings data for the specified number of days (max 365).
+ *     description: Returns aggregated daily earnings data for the specified number of days (max 365) or, when start_date/end_date are given, for that exact window (inclusive start, exclusive end).
  *     security:
  *       - BearerAuth: []
  *     parameters:
@@ -455,6 +455,18 @@ router.get('/wallet/history', authenticate, userLimiter, requirePolicy('driver:v
  *           minimum: 1
  *           maximum: 365
  *         description: Number of days to include
+ *       - in: query
+ *         name: start_date
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Inclusive lower bound of the earnings window (YYYY-MM-DD)
+ *       - in: query
+ *         name: end_date
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Exclusive upper bound of the earnings window (YYYY-MM-DD)
  *     responses:
  *       200:
  *         description: Earnings data array
@@ -463,28 +475,52 @@ router.get('/wallet/history', authenticate, userLimiter, requirePolicy('driver:v
  *             schema:
  *               $ref: '#/components/schemas/EarningsSummaryResponse'
  *       400:
- *         description: Invalid days parameter
+ *         description: Invalid days parameter or invalid date range
  */
 router.get('/earnings/summary', authenticate, userLimiter, requirePolicy('driver:view-earnings'), async (req, res) => {
   const daysParam = req.query.days ?? '30';
   const limitDays = typeof daysParam === 'string' ? Number(daysParam) : NaN;
 
-  if (!Number.isInteger(limitDays) || limitDays < 1 || limitDays > 365) {
+  const startDateParam = req.query.start_date;
+  const endDateParam = req.query.end_date;
+  const hasRange = startDateParam !== undefined || endDateParam !== undefined;
+
+  if (hasRange) {
+    if (
+      typeof startDateParam !== 'string' ||
+      typeof endDateParam !== 'string' ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(startDateParam) ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(endDateParam)
+    ) {
+      return res.status(400).json({
+        error: 'start_date and end_date must both be provided as YYYY-MM-DD'
+      });
+    }
+    if (startDateParam > endDateParam) {
+      return res.status(400).json({ error: 'start_date must not be after end_date' });
+    }
+  } else if (!Number.isInteger(limitDays) || limitDays < 1 || limitDays > 365) {
     return res.status(400).json({
       error: 'days must be an integer between 1 and 365'
     });
   }
 
   try {
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - (limitDays - 1));
-
-    const { data: summary, error } = await supabase
+    let query = supabase
       .from('earnings_daily')
       .select('day_date, amount, trip_count, hours_driven')
-      .eq('driver_id', req.user.id)
-      .gte('day_date', cutoff.toISOString().split('T')[0])
-      .order('day_date', { ascending: true });
+      .eq('driver_id', req.user.id);
+
+    if (hasRange) {
+      // Exact window: inclusive start, exclusive end ([start, end)).
+      query = query.gte('day_date', startDateParam).lt('day_date', endDateParam);
+    } else {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - (limitDays - 1));
+      query = query.gte('day_date', cutoff.toISOString().split('T')[0]);
+    }
+
+    const { data: summary, error } = await query.order('day_date', { ascending: true });
 
     if (error) {
       return res.status(500).json({ error: 'Failed to fetch earnings summary.', details: error.message });

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -250,6 +250,66 @@ describe('Driver Routes', () => {
     }
   });
 
+  it('GET /earnings/summary with start_date/end_date returns only that window', async () => {
+    m.store.earnings_daily.push(
+      { driver_id: 'driver-1', day_date: '2026-05-31', amount: 1000, trip_count: 1 },
+      { driver_id: 'driver-1', day_date: '2026-06-01', amount: 2000, trip_count: 2 },
+      { driver_id: 'driver-1', day_date: '2026-06-15', amount: 3000, trip_count: 3 },
+      { driver_id: 'driver-1', day_date: '2026-07-01', amount: 4000, trip_count: 4 }
+    );
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/drivers/earnings/summary?start_date=2026-06-01&end_date=2026-07-01')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].day_date).toBe('2026-06-01');
+    expect(res.body[1].day_date).toBe('2026-06-15');
+  });
+
+  it('GET /earnings/summary with a historical month window returns that month only', async () => {
+    m.store.earnings_daily.push(
+      { driver_id: 'driver-1', day_date: '2019-12-31', amount: 100, trip_count: 1 },
+      { driver_id: 'driver-1', day_date: '2020-01-10', amount: 2500, trip_count: 2 },
+      { driver_id: 'driver-1', day_date: '2020-01-31', amount: 1500, trip_count: 1 },
+      { driver_id: 'driver-1', day_date: '2020-02-01', amount: 200, trip_count: 1 }
+    );
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/drivers/earnings/summary?start_date=2020-01-01&end_date=2020-02-01')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].day_date).toBe('2020-01-10');
+    expect(res.body[1].day_date).toBe('2020-01-31');
+  });
+
+  it('GET /earnings/summary rejects malformed or single-sided date ranges', async () => {
+    const app = buildApp();
+
+    const badQueries = [
+      'start_date=2026-06-01',
+      'end_date=2026-07-01',
+      'start_date=2026-06-01&end_date=not-a-date',
+      'start_date=not-a-date&end_date=2026-07-01',
+      'start_date=2026-07-01&end_date=2026-06-01',
+    ];
+
+    for (const qs of badQueries) {
+      const res = await request(app)
+        .get(`/api/drivers/earnings/summary?${qs}`)
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(400);
+    }
+  });
+
   it('POST /wallet/withdraw rejects invalid amount', async () => {
     const app = buildApp();
 


### PR DESCRIPTION
## Problem

`fetchMonthlyEarnings` in `apps/driver/lib/services/driver_earnings_service.dart` derived the API `days` parameter from how far the requested month's start is from **today**, not from the month's length:

- Viewing any historical month over-fetched up to ~365 days of `earnings_daily` rows and then discarded everything outside the month.
- Months older than 365 days bypassed the API entirely and queried `earnings_daily` directly through the Supabase client — a second, silently divergent data path.

## Fix

- `GET /earnings/summary` now accepts an exact `start_date` / `end_date` window (YYYY-MM-DD, inclusive start, exclusive end), replacing the need for the `days` param when a window is given. Returns 400 for missing/single-sided, malformed, or reversed ranges; `days` behavior (max 365) is unchanged when no range is given.
- `fetchMonthlyEarnings` now always requests the selected month via a single API call: `?start_date=<month start>&end_date=<next month start>`. The direct-Supabase fallback and the `days` clamp are removed, so current and historical months (including > 365 days ago) flow through one consistent code path with the exact `[month_start, next_month_start)` window.
- Added integration tests for exact windows, historical months, and invalid ranges, plus updated Flutter unit tests asserting the request carries only the month's window and the database path is never used.

## Files changed

- `backend/api/src/routes/driverRoutes.js` — `/earnings/summary` window support + OpenAPI docs
- `backend/api/test/integration/driverRoutes.test.js` — 3 new integration tests
- `apps/driver/lib/services/driver_earnings_service.dart` — single API path for all months
- `apps/driver/test/driver_earnings_service_test.dart` — updated unit tests

### Incidental fix

- `backend/api/src/lib/profileCache.js` — removed a stray `code -g backend/api/src/routes/lookupRoutes.js:50  ` text fragment that had been committed inside `getRedisClient()` (line 79). It was a syntax error in `main` that broke parsing of this module, which is imported by `middleware/auth.js` and therefore by `driverRoutes.js` — the entire driverRoutes integration suite could not load without it. This 1-line fix restores valid syntax; the file is otherwise untouched.

## Testing

- `npx vitest run test/integration/driverRoutes.test.js`: 32 passed, 4 failed — the 4 failures are pre-existing `POST /wallet/withdraw` tests that also fail on an unmodified `main` (verified by stashing these changes and re-running; they are unrelated to this PR). All earnings summary tests (old `days` behavior + new window behavior) pass.
- Flutter: reviewed manually (no local Flutter toolchain); changes are limited to the request path construction and test assertions.

Closes #6287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving earnings for a specific date range.
  * Monthly earnings now consistently use the selected month when requesting data, including historical periods.
* **Bug Fixes**
  * Added validation for incomplete, malformed, or reversed date ranges, returning clear errors for invalid requests.
  * Corrected an issue that could prevent the profile cache service from handling connection failures properly.
* **Documentation**
  * Updated API documentation to describe date-range parameters and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->