### PR TITLE
fix(kafka): correct ../api/src import depth in consumers, cqrs, repositories and scripts

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -1,6 +1,6 @@
 import kafka, { TOPICS, CONSUMER_GROUPS } from '../config/kafka.config.js';
 import processedEventRepository from '../repositories/processedEvent.repository.js';
-import logger from '../api/src/middleware/logger.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class OrderConsumer {
   constructor({ eventBus: externalEventBus } = {}) {

--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 import eventRepository from '../repositories/event.repository.js';
 
 class OrderReadModel {

--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class EventRepository {
   async saveEvent(event) {

--- a/backend/kafka/repositories/processedEvent.repository.js
+++ b/backend/kafka/repositories/processedEvent.repository.js
@@ -1,5 +1,5 @@
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 class ProcessedEventRepository {
   /**

--- a/backend/kafka/scripts/init-kafka.js
+++ b/backend/kafka/scripts/init-kafka.js
@@ -2,7 +2,7 @@
 
 import kafka from '../config/kafka.config.js';
 import { TOPICS } from '../config/kafka.config.js';
-import logger from '../api/src/middleware/logger.js';
+import logger from '../../api/src/middleware/logger.js';
 
 async function initKafka() {
   try {


### PR DESCRIPTION
Fixes #6336

## Summary
Corrected the relative import depth of `../api/src/...` → `../../api/src/...` in five files of the `backend/kafka` microservice. From the subdirectories these files live in, `../api/` resolves to `backend/kafka/api/` (which does not exist), so the imports failed at module load and the Kafka service could not start.

## Changes
- `backend/kafka/consumers/order.consumer.js` — `logger` import depth
- `backend/kafka/cqrs/order.read.model.js` — `supabase` + `logger` import depth
- `backend/kafka/repositories/event.repository.js` — `supabase` + `logger` import depth
- `backend/kafka/repositories/processedEvent.repository.js` — `supabase` + `logger` import depth
- `backend/kafka/scripts/init-kafka.js` — `logger` import depth

## Verification
- `node --check` passes on all five modified files
- New paths resolve to `backend/api/src/config/db.js` and `backend/api/src/middleware/logger.js`

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backend event-processing components so database, logging, and messaging integrations resolve correctly.
  * Improved reliability for order event consumption, event storage, and Kafka initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->