### PR TITLE
fix(driver): correct ApiClient import path in delivery_otp_screen.dart

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:geolocator/geolocator.dart';
-import '../core/api_client.dart';
+import '../services/api_client.dart';
 import '../theme/app_theme.dart';
 
 /// DeliveryOtpScreen — shown to the driver when order status is 'arriving'.


### PR DESCRIPTION
Fixes #6340

## Summary
Corrects the `ApiClient` import in the driver app's delivery OTP screen. `api_client.dart` lives in `apps/driver/lib/services/`, not `apps/driver/lib/core/`, so the import pointed at a nonexistent file and broke compilation of the driver app.

## Changes
- `apps/driver/lib/screens/delivery_otp_screen.dart:7` — `../core/api_client.dart` → `../services/api_client.dart`

## Verification
- `apps/driver/lib/services/api_client.dart` exists; `apps/driver/lib/core/` contains no `api_client.dart`

GSSOC
