### PR TITLE
fix(driver): remove dead supabase_service import in chat_screen.dart

### DIFF
--- a/apps/driver/lib/screens/chat_screen.dart
+++ b/apps/driver/lib/screens/chat_screen.dart
@@ -3,7 +3,6 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:truxify_shared/truxify_shared.dart';
 import '../models/app_models.dart';
 import '../theme/app_theme.dart';
-import '../services/supabase_service.dart';
 
 class ChatScreen extends StatefulWidget {
   final Trip trip;


### PR DESCRIPTION
Fixes #6342

## Summary
Removes a dead import of `../services/supabase_service.dart` in the driver app's `chat_screen.dart`. The file only exists in the customer app, so the import pointed at a nonexistent path and broke the driver app build; the screen never uses any symbol from it (all Supabase access is via `Supabase.instance` from `supabase_flutter`).

## Changes
- `apps/driver/lib/screens/chat_screen.dart` — removed the unused, nonexistent `supabase_service.dart` import

## Verification
- No references to symbols from `supabase_service` remain in `chat_screen.dart`
- `apps/driver/lib/services/` contains no `supabase_service.dart`

GSSOC
