### PR TITLE
fix(k8s): correct region service import filename in multi-region routes

### DIFF
--- a/k8s/multi-region/routes.js
+++ b/k8s/multi-region/routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import regionService from './region.service.js';
+import regionService from './region-service.js';
 import logger from '../../backend/api/src/middleware/logger.js';
 
 const router = express.Router();


### PR DESCRIPTION
Fixes #6344

## Summary
Fixes the import specifier in `k8s/multi-region/routes.js` to match the actual filename. The file imports `./region.service.js` (dot) but the real module is `region-service.js` (hyphen), so the import failed with `ERR_MODULE_NOT_FOUND`.

## Changes
- `k8s/multi-region/routes.js:2` — `./region.service.js` → `./region-service.js`

## Verification
- `node --check` passes
- `region-service.js` exists in the same directory and exports `default new RegionService()`

GSSOC
