### PR TITLE
fix(escrow): use escrow_refund_attempts column instead of non-existent escrow_refund_retry_count

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -562,7 +562,7 @@ export class OrderRepository {
   async findPendingEscrowRefunds() {
     return this._retryableQuery(() => this.supabase
       .from('orders')
-      .select('id, order_display_id, refund_tx_hash, escrow_status, escrow_refund_retry_count, updated_at')
+      .select('id, order_display_id, refund_tx_hash, escrow_status, escrow_refund_attempts, updated_at')
       .in('escrow_status', ['refund_pending', 'refund_failed'])
       .limit(50), 'findPendingEscrowRefunds');
   }

--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -66,7 +66,7 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
     }
 
     for (const order of pendingOrders ?? []) {
-      const retryCount = order.escrow_refund_retry_count ?? 0;
+      const retryCount = order.escrow_refund_attempts ?? 0;
 
       // Exponential backoff logic based on updated_at
       if (retryCount > 0 && order.updated_at) {
@@ -96,7 +96,7 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
       }
 
       try {
-        const retryCount = order.escrow_refund_retry_count ?? 0;
+        const retryCount = order.escrow_refund_attempts ?? 0;
         if (retryCount >= MAX_RETRIES) {
           logger.warn(`[escrow-reconciliation] Order ${order.order_display_id} exceeded max retries (${MAX_RETRIES}), escalating.`);
           continue;
@@ -151,9 +151,9 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
           );
         }
       } catch (err) {
-        const newRetryCount = (order.escrow_refund_retry_count ?? 0) + 1;
+        const newRetryCount = (order.escrow_refund_attempts ?? 0) + 1;
         await orderRepository.updateOrder(order.id, {
-          escrow_refund_retry_count: newRetryCount,
+          escrow_refund_attempts: newRetryCount,
           escrow_refund_error: err.message,
           reconciled_by: null,
           updated_at: new Date().toISOString(),

--- a/backend/api/test/unit/escrowRefundReconciliation.test.js
+++ b/backend/api/test/unit/escrowRefundReconciliation.test.js
@@ -114,7 +114,7 @@ describe('reconcilePendingEscrowRefunds', () => {
     configureBuilder([{
       id: 'oB',
       order_display_id: 'OB',
-      escrow_refund_retry_count: 2,
+      escrow_refund_attempts: 2,
       updated_at: recentUpdate
     }]);
 


### PR DESCRIPTION
Fixes #5677

## Summary
Replaced the non-existent `escrow_refund_retry_count` column with the real schema column `escrow_refund_attempts` (defined in `docs/supabase_setup.sql`, `docs/migration_add_escrow.sql`, and `supabase/migrations/20260624233000_track_escrow_refund_reconciliation.sql`) in the escrow-refund reconciliation read, compare, and update paths.

## Changes
- `backend/api/src/repositories/orderRepository.js:565` — `findPendingEscrowRefunds()` select now reads `escrow_refund_attempts`
- `backend/api/src/services/escrowRefundReconciliation.js:69,99,154,156` — backoff, max-retry, and retry-count update now use `escrow_refund_attempts`
- `backend/api/test/unit/escrowRefundReconciliation.test.js:117` — mock row updated to match the real column so the backoff-skip test still exercises the retry logic

## Verification
- `node --check` passes on both modified source files
- `escrow_refund_retry_count` no longer appears anywhere in the repo

GSSOC
