### PR TITLE
fix: create support_ticket_comments table (#6349)

### DIFF
--- a/supabase/migrations/20260805000000_create_support_ticket_comments.sql
+++ b/supabase/migrations/20260805000000_create_support_ticket_comments.sql
@@ -1,0 +1,54 @@
+-- Migration: create support_ticket_comments table
+-- Backs POST/GET /api/support/tickets/:id/comments in backend/api/src/routes/supportRoutes.js
+-- (inserts at line 860, selects at line 973). Columns match what the route reads/writes.
+CREATE TABLE IF NOT EXISTS support_ticket_comments (
+  id         uuid primary key default gen_random_uuid(),
+  ticket_id  uuid not null,                          -- support_tickets.id
+  user_id    uuid not null,                          -- profiles.id
+  user_name  text not null,
+  message    text not null,
+  created_at timestamptz not null default now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_support_ticket_comments_ticket
+  ON support_ticket_comments (ticket_id);
+
+CREATE INDEX IF NOT EXISTS idx_support_ticket_comments_user
+  ON support_ticket_comments (user_id);
+
+ALTER TABLE support_ticket_comments
+  ADD CONSTRAINT support_ticket_comments_ticket_id_fkey
+  FOREIGN KEY (ticket_id) REFERENCES support_tickets(id)
+  ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE support_ticket_comments
+  ADD CONSTRAINT support_ticket_comments_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES profiles(id)
+  ON UPDATE CASCADE ON DELETE RESTRICT;
+
+-- RLS: users may see/add comments on their own tickets; admins manage all.
+ALTER TABLE support_ticket_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role full access on support_ticket_comments"
+  ON support_ticket_comments FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+CREATE POLICY "users view comments on own tickets"
+  ON support_ticket_comments FOR SELECT
+  TO authenticated
+  USING (
+    ticket_id IN (
+      SELECT id FROM support_tickets WHERE user_id = get_profile_id()
+    )
+  );
+
+CREATE POLICY "users insert comments on own tickets"
+  ON support_ticket_comments FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = get_profile_id()
+    AND ticket_id IN (
+      SELECT id FROM support_tickets WHERE user_id = get_profile_id()
+    )
+  );


### PR DESCRIPTION
## Summary

Adds a proper migration in `supabase/migrations/` creating the `support_ticket_comments` table, which `backend/api/src/routes/supportRoutes.js` reads/writes (insert at line 860, select at line 973) but which no applied migration ever created.

The only prior SQL for this table lived in the legacy `docs/supabase/migrations/003_support_ticket_comments.sql` folder, which is not applied by `supabase db push` — so POST/GET `/api/support/tickets/:id/comments` returned 500 with `relation "support_ticket_comments" does not exist`.

Columns, foreign keys, indexes, and RLS policies mirror exactly what the route uses and what the old docs migration defined.

## Changes
- `supabase/migrations/20260805000000_create_support_ticket_comments.sql`: new migration creating the table (`id`, `ticket_id`, `user_id`, `user_name`, `message`, `created_at`), FKs to `support_tickets`/`profiles`, indexes, and RLS (service_role full access; authenticated users can view/insert comments on their own tickets).

## Verification
- Columns match the `.select()`/`.insert()` calls in `supportRoutes.js`.
- Foreign keys reference existing tables (`support_tickets`, `profiles`).
- `get_profile_id()` helper already exists in the schema.

Closes #6349
GSSOC
