### PR TITLE
fix: create trip_events table (#6350)

### DIFF
--- a/supabase/migrations/20260805000010_create_trip_events.sql
+++ b/supabase/migrations/20260805000010_create_trip_events.sql
@@ -1,0 +1,45 @@
+-- Migration: create trip_events table
+-- Backs POST /api/trips/events/batch and GET /api/trips/:id/events in
+-- backend/api/src/routes/tripRoutes.js (upsert at line 309, select at line 462).
+-- Columns match exactly what the route reads/writes.
+CREATE TABLE IF NOT EXISTS trip_events (
+  event_id        TEXT PRIMARY KEY,
+  user_id         UUID NOT NULL,                     -- uploading user (driver or customer)
+  trip_id         UUID NULL,                         -- order/trip identifier
+  event_type      TEXT NOT NULL,
+  event_timestamp TIMESTAMPTZ NOT NULL,
+  latitude        DOUBLE PRECISION NULL,
+  longitude       DOUBLE PRECISION NULL,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- GET /:id/events filters/sorts by trip_id + event_timestamp
+CREATE INDEX IF NOT EXISTS idx_trip_events_trip_id_timestamp
+  ON trip_events (trip_id, event_timestamp);
+
+-- Ownership checks in POST /events/batch look up by user_id
+CREATE INDEX IF NOT EXISTS idx_trip_events_user_id
+  ON trip_events (user_id);
+
+-- GET /:id/events supports ?type= filtering
+CREATE INDEX IF NOT EXISTS idx_trip_events_event_type
+  ON trip_events (event_type);
+
+-- RLS: service role manages all rows; users can only read/write their own events.
+ALTER TABLE trip_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role full access on trip_events"
+  ON trip_events FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+CREATE POLICY "users read own trip_events"
+  ON trip_events FOR SELECT
+  TO authenticated
+  USING (user_id = get_profile_id());
+
+CREATE POLICY "users insert own trip_events"
+  ON trip_events FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = get_profile_id());


### PR DESCRIPTION
## Summary

Adds a proper migration in `supabase/migrations/` creating the `trip_events` table, which `backend/api/src/routes/tripRoutes.js` reads/writes (upsert at line 309, select at line 462) but which no applied migration ever created.

The only prior SQL for this table lived in the legacy `docs/supabase/migrations/004_create_trip_events.sql` folder, which is not applied by `supabase db push` — so POST `/api/trips/events/batch` and GET `/api/trips/:id/events` returned 500 (`TRIP_EVENTS_FETCH_ERROR`) with `relation "trip_events" does not exist`.

## Changes
- `supabase/migrations/20260805000010_create_trip_events.sql`: new migration creating the table (`event_id TEXT PK`, `user_id`, `trip_id`, `event_type`, `event_timestamp`, `latitude`, `longitude`, `metadata JSONB`, `created_at`), indexes on `(trip_id, event_timestamp)`, `user_id`, and `event_type`, plus RLS (service_role full access; authenticated users read/insert their own events).

## Verification
- Columns match the `.upsert()` records and `.select()` field list in `tripRoutes.js`.
- `event_id` is the upsert conflict target (`onConflict: 'event_id'`).
- `get_profile_id()` helper already exists in the schema.

Closes #6350
GSSOC
