### PR TITLE
fix: create drivers view for GraphQL driver subgraph (#6351)

### DIFF
--- a/supabase/migrations/20260805000020_create_drivers_view.sql
+++ b/supabase/migrations/20260805000020_create_drivers_view.sql
@@ -1,0 +1,76 @@
+-- Migration: create drivers view for the GraphQL Driver subgraph
+-- Backs backend/graphql/services/driver.service.js which queries `.from('drivers')`
+-- (5 sites: driver, drivers, nearbyDrivers, updateDriver, updateDriverLocation).
+-- No table/view named `drivers` existed, so every resolver failed with
+-- relation "drivers" does not exist. The view maps the resolvers' columns onto
+-- profiles + driver_details + trucks + driver_locations.
+
+CREATE OR REPLACE VIEW drivers AS
+SELECT
+  dd.id                 AS id,
+  dd.user_id            AS user_id,
+  p.full_name           AS name,
+  p.phone               AS phone,
+  t.truck_type          AS truck_type,
+  t.number_plate        AS truck_number,
+  CASE WHEN dd.is_online THEN 'AVAILABLE' ELSE 'OFFLINE' END AS status,
+  jsonb_build_object(
+    'lat', dl.latitude,
+    'lng', dl.longitude,
+    'address', COALESCE(dl.accuracy::text, '')
+  )                     AS current_location,
+  dd.rating             AS rating,
+  dd.total_trips        AS trips_completed,
+  dd.updated_at         AS updated_at
+FROM driver_details dd
+JOIN profiles p       ON p.id = dd.user_id
+LEFT JOIN trucks t    ON t.id = dd.truck_id
+LEFT JOIN driver_locations dl ON dl.driver_id = dd.user_id AND dl.is_active = true;
+
+-- RLS on views is not enforced by PostgREST for the GraphQL client; keep it simple
+-- and readable. The subgraph service uses the service/client key.
+
+-- ---------------------------------------------------------------------------
+-- Updatable view support for updateDriver / updateDriverLocation mutations
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION sync_drivers_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    UPDATE driver_details
+       SET is_online = (NEW.status = 'AVAILABLE')
+     WHERE id = NEW.id;
+  END IF;
+
+  IF NEW.truck_type IS DISTINCT FROM OLD.truck_type
+     OR NEW.truck_number IS DISTINCT FROM OLD.truck_number THEN
+    UPDATE trucks t
+       SET truck_type   = COALESCE(NEW.truck_type, t.truck_type),
+           number_plate = COALESCE(NEW.truck_number, t.number_plate)
+     WHERE t.driver_id = NEW.user_id;
+  END IF;
+
+  IF NEW.current_location IS DISTINCT FROM OLD.current_location THEN
+    INSERT INTO driver_locations (driver_id, latitude, longitude, accuracy, is_active)
+    VALUES (
+      NEW.user_id,
+      (NEW.current_location ->> 'lat')::numeric(10, 8),
+      (NEW.current_location ->> 'lng')::numeric(11, 8),
+      NULL,
+      true
+    )
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  UPDATE driver_details SET updated_at = now() WHERE id = NEW.id;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER drivers_update_trigger
+  INSTEAD OF UPDATE ON drivers
+  FOR EACH ROW EXECUTE FUNCTION sync_drivers_update();


### PR DESCRIPTION
## Summary

`backend/graphql/services/driver.service.js` queries `.from('drivers')` in five resolvers (`driver`, `drivers`, `nearbyDrivers`, `updateDriver`, `updateDriverLocation`) but no `drivers` table or view existed in the Supabase schema — every resolver failed with `relation "drivers" does not exist`.

This PR adds a `drivers` **view** over the existing `profiles` + `driver_details` + `trucks` + `driver_locations` tables, exposing exactly the columns `mapDriver()` and the resolvers read/write: `id`, `user_id`, `name`, `phone`, `truck_type`, `truck_number`, `status`, `current_location`, `rating`, `trips_completed`, `updated_at`.

Because the resolvers also issue `.update()` calls (status, current_location, truck_type, truck_number), the migration includes an `INSTEAD OF UPDATE` trigger that routes writes back to the underlying tables.

## Changes
- `supabase/migrations/20260805000020_create_drivers_view.sql`:
  - `CREATE OR REPLACE VIEW drivers` joining `driver_details`, `profiles`, `trucks`, and the active `driver_locations` row.
  - `sync_drivers_update()` + `drivers_update_trigger` making the view updatable (persists status → `driver_details.is_online`, truck fields → `trucks`, location → `driver_locations`).

## Verification
- Column names match the `mapDriver()` normalization (`userId`/`user_id`, `truckType`/`truck_type`, `truckNumber`/`truck_number`, `currentLocation`/`current_location`, `tripsCompleted`/`trips_completed`).
- `current_location` is JSONB (`lat`/`lng` keys) matching the `current_location->>lat` / `->>lng` filters used by `drivers` and `nearbyDrivers`.
- `status` matches the `DriverStatus` enum values used (`AVAILABLE`/`OFFLINE`), with `is_online` as the source.

Closes #6351
GSSOC
