### PR TITLE
fix: create vehicle_types and regions reference tables (#6354)

### DIFF
--- a/supabase/migrations/20260805000050_create_vehicle_types_regions.sql
+++ b/supabase/migrations/20260805000050_create_vehicle_types_regions.sql
@@ -1,0 +1,61 @@
+-- Migration: create vehicle_types and regions reference tables
+-- Backs backend/api/src/routes/lookupRoutes.js which serves GET /vehicle-types
+-- and GET /regions from `.from('vehicle_types').select('*')` and
+-- `.from('regions').select('*')`. Neither table existed, so both endpoints
+-- returned 500 for every request.
+-- The RLS policies below use the exact names asserted by
+-- backend/api/test/unit/rlsSecurity.test.js.
+
+-- ============ vehicle_types ============
+create table if not exists vehicle_types (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null unique,
+  max_capacity_tons numeric(8,2),
+  min_capacity_tons numeric(8,2),
+  length_ft   numeric(6,2),
+  is_active   boolean not null default true,
+  sort_order  int not null default 0,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_vehicle_types_active on vehicle_types (is_active, sort_order);
+
+-- Seed with the same truck_type values the trucks table accepts.
+insert into vehicle_types (name, is_active, sort_order)
+select v.name, true, v.sort_order
+from (values
+  ('Open Body', 1),
+  ('Closed Body', 2),
+  ('Container', 3),
+  ('Refrigerated', 4)
+) as v(name, sort_order)
+where not exists (select 1 from vehicle_types where vehicle_types.name = v.name);
+
+-- ============ regions ============
+create table if not exists regions (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null unique,
+  state       text,
+  country     text not null default 'IN',
+  latitude    double precision,
+  longitude   double precision,
+  radius_km   double precision not null default 50,
+  is_active   boolean not null default true,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_regions_active on regions (is_active);
+
+-- ============ RLS: anon + authenticated can read reference data ============
+alter table vehicle_types enable row level security;
+alter table regions enable row level security;
+
+create policy "Anyone can view vehicle types"
+  on vehicle_types for select
+  to anon, authenticated
+  using (is_active = true);
+
+create policy "Anyone can view regions"
+  on regions for select
+  to anon, authenticated
+  using (is_active = true);


### PR DESCRIPTION
## Summary

`backend/api/src/routes/lookupRoutes.js` serves `GET /vehicle-types` and `GET /regions` from `vehicle_types` and `regions`, but neither table existed — both endpoints returned `500 Failed to fetch vehicle types/regions` on every request. `backend/api/test/unit/rlsSecurity.test.js` also asserts anon/authenticated read policies on both tables that could never pass.

## Changes
- `supabase/migrations/20260805000050_create_vehicle_types_regions.sql`:
  - `vehicle_types`: `id`, `name` (unique), `max_capacity_tons`, `min_capacity_tons`, `length_ft`, `is_active`, `sort_order`, `created_at`, seeded with the same four values the `trucks.truck_type` check constraint accepts (`Open Body`, `Closed Body`, `Container`, `Refrigerated`).
  - `regions`: `id`, `name` (unique), `state`, `country`, `latitude`, `longitude`, `radius_km`, `is_active`, `created_at`.
  - RLS policies with the exact names asserted by the test suite:
    - `"Anyone can view vehicle types" ON vehicle_types FOR SELECT TO anon, authenticated`
    - `"Anyone can view regions" ON regions FOR SELECT TO anon, authenticated`

## Verification
- Policy names/roles match `rlsSecurity.test.js:95-99` regexes verbatim.
- `select('*')` in both lookup endpoints now resolves.

Closes #6354
GSSOC
