### PR TITLE
fix: correct ../api import depth in graphql gateway and services (#6356)

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -3,8 +3,8 @@ import { RemoteGraphQLDataSource } from '@apollo/gateway';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
-import logger from '../api/src/middleware/logger.js';
-import { supabase } from '../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
 
 class GraphQLGateway {
     constructor() {

--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -2,8 +2,8 @@ import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const DISPATCH_ROLES = new Set(['ADMIN', 'admin', 'DISPATCHER', 'dispatcher']);
 

--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -2,8 +2,8 @@ import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const ADMIN_ROLES = new Set(['ADMIN', 'admin']);
 


### PR DESCRIPTION
## Summary

The GraphQL gateway (`backend/graphql/gateway/index.js`) and both subgraph services (`backend/graphql/services/driver.service.js`, `backend/graphql/services/order.service.js`) import from `../api/src/...`, but these files live two levels below `backend/`, so the correct relative path is `../../api/src/...`. The misresolved imports (`../../api/...` from the wrong base) made the gateway and services fail to boot with `ERR_MODULE_NOT_FOUND`.

## Changes
- `backend/graphql/gateway/index.js`: `../api/src/middleware/logger.js` → `../../api/src/middleware/logger.js`, `../api/src/config/db.js` → `../../api/src/config/db.js`.
- `backend/graphql/services/driver.service.js`: same two import paths corrected.
- `backend/graphql/services/order.service.js`: same two import paths corrected.

## Verification
- Both target files resolve: `backend/api/src/config/db.js` and `backend/api/src/middleware/logger.js` exist.

Closes #6356
GSSOC
