### PR TITLE
fix: correct import depth in top-level security middleware tests (#6357)

### DIFF
--- a/backend/api/test/authFailureMonitor.test.js
+++ b/backend/api/test/authFailureMonitor.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import authFailureMonitor from '../../src/middleware/authFailureMonitor.js';
+import authFailureMonitor from '../src/middleware/authFailureMonitor.js';
 
 function createApp(statusCode = 401) {
   const app = express();

--- a/backend/api/test/cacheControlVerifier.test.js
+++ b/backend/api/test/cacheControlVerifier.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import cacheControlVerifier from '../../src/middleware/cacheControlVerifier.js';
+import cacheControlVerifier from '../src/middleware/cacheControlVerifier.js';
 
 function createApp(headers = {}) {
   const app = express();

--- a/backend/api/test/cookieSecurityValidator.test.js
+++ b/backend/api/test/cookieSecurityValidator.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import cookieSecurityValidator from '../../src/middleware/cookieSecurityValidator.js';
+import cookieSecurityValidator from '../src/middleware/cookieSecurityValidator.js';
 
 function createApp(setCookieValue) {
   const app = express();

--- a/backend/api/test/headerSizeMonitor.test.js
+++ b/backend/api/test/headerSizeMonitor.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import headerSizeMonitor from '../../src/middleware/headerSizeMonitor.js';
+import headerSizeMonitor from '../src/middleware/headerSizeMonitor.js';
 
 function createApp(headers = {}) {
   const app = express();

--- a/backend/api/test/securityHeaderDuplicates.test.js
+++ b/backend/api/test/securityHeaderDuplicates.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import securityHeaderDuplicates from '../../src/middleware/securityHeaderDuplicates.js';
+import securityHeaderDuplicates from '../src/middleware/securityHeaderDuplicates.js';
 
 function createApp(handler) {
   const app = express();

--- a/backend/api/test/securityHeadersVerifier.test.js
+++ b/backend/api/test/securityHeadersVerifier.test.js
@@ -4,13 +4,13 @@ import request from 'supertest';
 
 const warnMock = vi.fn();
 
-vi.mock('../../src/middleware/logger.js', () => ({
+vi.mock('../src/middleware/logger.js', () => ({
   default: {
     warn: warnMock,
   },
 }));
 
-import securityHeadersVerifier from '../../src/middleware/securityHeadersVerifier.js';
+import securityHeadersVerifier from '../src/middleware/securityHeadersVerifier.js';
 
 function createApp(setHeaders = true) {
   const app = express();


### PR DESCRIPTION
## Summary

Six top-level test files in `backend/api/test/` import from `../../src/...`, but these files live directly under `test/`, so the correct relative path is `../src/...`. The over-deepened imports resolve to `backend/src/` (which does not exist), so every run of these tests failed with `ERR_MODULE_NOT_FOUND`. (The `test/unit/` and `test/integration/` suites are one level deeper and correctly use `../../src/`.)

## Changes
- `backend/api/test/authFailureMonitor.test.js`: `../src/middleware/logger.js`, `../src/middleware/authFailureMonitor.js`
- `backend/api/test/cacheControlVerifier.test.js`: `../src/middleware/logger.js`, `../src/middleware/cacheControlVerifier.js`
- `backend/api/test/cookieSecurityValidator.test.js`: `../src/middleware/logger.js`, `../src/middleware/cookieSecurityValidator.js`
- `backend/api/test/headerSizeMonitor.test.js`: `../src/middleware/logger.js`, `../src/middleware/headerSizeMonitor.js`
- `backend/api/test/securityHeaderDuplicates.test.js`: `../src/middleware/logger.js`, `../src/middleware/securityHeaderDuplicates.js`
- `backend/api/test/securityHeadersVerifier.test.js`: `../src/middleware/logger.js`, `../src/middleware/securityHeadersVerifier.js`

Both the `vi.mock(...)` and the static `import ... from` references were corrected in each file.

## Verification
- `rg "\.\./\.\./src/" backend/api/test/*.test.js` now returns no matches; all remaining `../../src/` usages are inside `test/unit/`/`test/integration/` where the depth is correct.
- All six middleware modules exist under `backend/api/src/middleware/`.

Closes #6357
GSSOC
