### PR TITLE
fix: add cookie security validator middleware referenced by docs and tests (#6358)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -18,6 +18,7 @@ import tripRoutes from './routes/tripRoutes.js'
 import deviceRoutes from './routes/deviceRoutes.js'
 import documentRoutes from './routes/documentRoutes.js'
 import securityHeaderDuplicates from './middleware/securityHeaderDuplicates.js';
+import cookieSecurityValidator from './middleware/cookieSecurityValidator.js';
 import maintenancePhotoRoutes from './routes/maintenancePhotoRoutes.js'
 
 import { closeDbConnections, waitForMongoDb, validateConfig, redisClient } from './config/db.js'
@@ -302,6 +303,7 @@ app.set('trust proxy', trustProxy)
 // Resolves missing security headers from Issues #361 and #944
 // ============================================================================
 app.use(securityHeaderDuplicates);
+app.use(cookieSecurityValidator);
 app.use(helmet({
   // Content Security Policy (CSP) - Prevents XSS and data injection
   contentSecurityPolicy: {

--- a/backend/api/src/middleware/cookieSecurityValidator.js
+++ b/backend/api/src/middleware/cookieSecurityValidator.js
@@ -1,0 +1,42 @@
+import logger from './logger.js';
+
+const RECOMMENDED_ATTRIBUTES = ['HttpOnly', 'SameSite', 'Path'];
+
+export default function cookieSecurityValidator(req, res, next) {
+  if (process.env.NODE_ENV === 'production') {
+    return next();
+  }
+
+  const originalSetHeader = res.setHeader.bind(res);
+
+  res.setHeader = (name, value) => {
+    if (String(name).toLowerCase() === 'set-cookie') {
+      validateCookies(req, value);
+    }
+    return originalSetHeader(name, value);
+  };
+
+  next();
+}
+
+function validateCookies(req, value) {
+  const cookies = Array.isArray(value) ? value : [value];
+
+  for (const cookie of cookies) {
+    const cookieValue = String(cookie);
+    const missingAttributes = RECOMMENDED_ATTRIBUTES.filter(
+      (attribute) => !cookieValue.includes(attribute)
+    );
+
+    if (missingAttributes.length === 0) continue;
+
+    logger.warn(
+      {
+        method: req.method,
+        path: req.originalUrl,
+        missingAttributes,
+      },
+      'Cookie missing recommended security attributes'
+    );
+  }
+}


### PR DESCRIPTION
## Summary

`docs/COOKIE_SECURITY_VALIDATOR.md` describes a development-only `cookieSecurityValidator` middleware and `backend/api/test/cookieSecurityValidator.test.js` exercises it, but `backend/api/src/middleware/cookieSecurityValidator.js` did not exist and was never registered — the test suite could not resolve the module (`ERR_MODULE_NOT_FOUND`) and the documented dev-time cookie checks never ran.

## Changes
- `backend/api/src/middleware/cookieSecurityValidator.js` (new): dev-only middleware that intercepts `Set-Cookie` response headers, checks each cookie for `HttpOnly`, `SameSite`, and `Path`, and logs a warning with `{ method, path, missingAttributes }` when any are missing. No-op in `NODE_ENV=production`, never modifies cookies.
- `backend/api/src/index.js`: import + `app.use(cookieSecurityValidator)` alongside the other security middleware (`securityHeaderDuplicates`, `headerSizeMonitor`).

## Verification
- Behavior matches `cookieSecurityValidator.test.js` exactly: no log when no cookies / all attributes present, single warning object with `missingAttributes` when attributes are missing, no log in production.
- Warning message and shape match the doc (`Cookie missing recommended security attributes`, Method / Path / Missing Attributes).
- Import path corrected in the test file was handled by #6357; this PR provides the module it imports.

Closes #6358
GSSOC
