### PR TITLE
fix: remove stray shell command in profileCache getRedisClient (#6384)

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -76,7 +76,7 @@ function logCacheError(operation, error) {
 function getRedisClient() {
   try {
     return db.redisClient ?? null;
-code -g backend/api/src/routes/lookupRoutes.js:50  } catch {
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
## Summary

`backend/api/src/lib/profileCache.js` had a stray shell command (`code -g backend/api/src/routes/lookupRoutes.js:50`) pasted into `getRedisClient()`, replacing the `} catch {` line. This produced a `SyntaxError: Unexpected identifier 'backend'` at load time. Since `profileCache.js` is statically imported by `middleware/auth.js` (used by `orderRoutes`, `authRoutes`, `driverRoutes`, `paymentRoutes`), the whole API server failed to start.

## Changes
- `backend/api/src/lib/profileCache.js`: removed the stray `code -g ...` line, restoring the `} catch {` block.

## Verification
- `node --check backend/api/src/lib/profileCache.js` passes (previously threw `SyntaxError`).

Closes #6384
GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when accessing the profile cache, allowing the application to safely continue when the cache is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->