### PR TITLE
fix: correct ../api import depth in graphql trip.service.js (#6385)

### DIFF
--- a/backend/graphql/services/trip.service.js
+++ b/backend/graphql/services/trip.service.js
@@ -3,8 +3,8 @@ import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
 import DataLoader from 'dataloader';
-import { supabase } from '../api/src/config/db.js';
-import logger from '../api/src/middleware/logger.js';
+import { supabase } from '../../api/src/config/db.js';
+import logger from '../../api/src/middleware/logger.js';
 
 const typeDefs = gql`
     extend type Query {


### PR DESCRIPTION
## Summary

`backend/graphql/services/trip.service.js` imported from `../api/src/...`, but the file lives in `backend/graphql/services/`, so that resolves to the nonexistent `backend/graphql/api/src/...`. The GraphQL gateway boots the three subgraph services with `Promise.all([... startTripService()])` and calls `process.exit(1)` on failure, so the `ERR_MODULE_NOT_FOUND` from this import took the whole gateway down. Its siblings (`driver.service.js`, `order.service.js`) already use the correct `../../api/` depth.

## Changes
- `backend/graphql/services/trip.service.js`: `../api/src/config/db.js` → `../../api/src/config/db.js`, `../api/src/middleware/logger.js` → `../../api/src/middleware/logger.js`.

## Verification
- Both target files resolve from the new depth (`backend/api/src/config/db.js`, `backend/api/src/middleware/logger.js` exist).

Closes #6385
GSSOC
