### PR TITLE
fix: correct escrow mock path in escrowRefundReconciliation unit test (#6387)

### DIFF
--- a/backend/api/test/unit/escrowRefundReconciliation.test.js
+++ b/backend/api/test/unit/escrowRefundReconciliation.test.js
@@ -47,8 +47,9 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-vi.mock('./escrow.js', () => ({
+vi.mock('../../src/services/escrow.js', () => ({
   confirmEscrowRefund: vi.fn(),
+  submitEscrowRefund: vi.fn(),
 }));
 
 import { OrderRepository } from '../../src/repositories/orderRepository.js';


### PR DESCRIPTION
## Summary

`backend/api/test/unit/escrowRefundReconciliation.test.js` mocked the escrow module with a path that resolves to a file that does not exist:

```js
vi.mock('./escrow.js', () => ({ confirmEscrowRefund: vi.fn() }));
```

From `test/unit/`, `./escrow.js` resolves to `backend/api/test/unit/escrow.js` (missing). The module under test imports `{ confirmEscrowRefund, submitEscrowRefund } from './escrow.js'` relative to `src/services/`, which is a different module id (`../../src/services/escrow.js` from the test file). The mock factory never matched the real module, so it was silently dropped and the tests exercised the real `escrow.js` instead of the stub. Other mocks in the same file already use the correct `../../src/...` depth (`redisLock.js`, `db.js`, `logger.js`).

## Changes
- `backend/api/test/unit/escrowRefundReconciliation.test.js`: changed `vi.mock('./escrow.js', ...)` → `vi.mock('../../src/services/escrow.js', ...)` and added the missing `submitEscrowRefund` stub (also imported by the module under test).

## Verification
- The mock id now matches the module id the service actually imports, so the stub applies and real on-chain escrow calls are not executed during tests.

Closes #6387
GSSOC
