### PR TITLE
[Security] Mount /api/earnings behind the security middleware chain and require authentication

### DIFF
--- a/backend/api/routes/earnings.js
+++ b/backend/api/routes/earnings.js
@@ -1,83 +1,91 @@
 import express from 'express';
+import { supabase } from '../src/config/db.js';
+import { authenticate } from '../src/middleware/auth.js';
+import { userLimiter } from '../src/middleware/rateLimiter.js';
+import { requirePolicy } from '../src/middleware/requirePolicy.js';
+import { validateQuery } from '../src/middleware/validate.js';
+import { earningsSummarySchema } from '../src/validation/requestSchemas.js';
+import logger from '../src/middleware/logger.js';
+import {
+  MAX_TRIPS_PER_SUMMARY,
+  buildEarningsSummary,
+  getPeriodStart,
+} from '../src/services/driver/earningsSummaryService.js';
+
 const router = express.Router();
 
-// Helper: returns start of period (defaults to current month)
-function getPeriodStart(period) {
-  const now = new Date();
-  if (period === 'weekly') {
-    const d = new Date(now);
-    d.setDate(d.getDate() - 7);
-    return d;
+/**
+ * @openapi
+ * /api/earnings/summary:
+ *   get:
+ *     tags: [Driver]
+ *     summary: Driver earnings summary
+ *     description: >
+ *       Aggregated gross, deductions and net earnings for the authenticated
+ *       driver over the requested reporting period, with a per-trip breakdown.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: period
+ *         schema:
+ *           type: string
+ *           enum: [weekly, monthly]
+ *           default: monthly
+ *     responses:
+ *       200:
+ *         description: Earnings summary for the authenticated driver
+ *       400:
+ *         description: Invalid period
+ *       401:
+ *         description: Missing or invalid authentication token
+ *       403:
+ *         description: Caller is not a driver
+ *       500:
+ *         description: Internal Server Error
+ */
+router.get(
+  '/summary',
+  authenticate,
+  userLimiter,
+  requirePolicy('driver:view-earnings'),
+  validateQuery(earningsSummarySchema),
+  async (req, res) => {
+    const period = req.query.period || 'monthly';
+    const driverId = req.user.id;
+
+    try {
+      const periodStart = getPeriodStart(period);
+
+      const { data: trips, error } = await supabase
+        .from('trips')
+        .select('trip_display_id, trip_date, distance, total_earnings, fuel_deducted')
+        .eq('driver_id', driverId)
+        .eq('status', 'completed')
+        .gte('trip_date', periodStart.toISOString().split('T')[0])
+        .order('trip_date', { ascending: false })
+        .limit(MAX_TRIPS_PER_SUMMARY);
+
+      if (error) {
+        logger.error(
+          { err: error, driverId, period },
+          '[earnings] Failed to fetch trips for summary'
+        );
+        return res.status(500).json({
+          success: false,
+          error: 'Failed to fetch earnings summary.',
+        });
+      }
+
+      return res.json({
+        success: true,
+        data: buildEarningsSummary(trips, period, driverId),
+      });
+    } catch (err) {
+      logger.error({ err, driverId, period }, '[earnings] Earnings summary error');
+      return res.status(500).json({ success: false, error: 'Internal server error' });
+    }
   }
-  // monthly (default)
-  return new Date(now.getFullYear(), now.getMonth(), 1);
-}
-
-// GET /api/earnings/summary?period=monthly|weekly
-// Auth: Bearer token required (placeholder — wire to your auth middleware)
-router.get('/summary', async (req, res) => {
-  try {
-    const { period = 'monthly' } = req.query;
-    const driverId = req.user?.id ?? 'demo-driver'; // replace with real auth
-
-    // TODO: replace with real DB query once Trip model is wired
-    // Placeholder response that matches the proposed schema exactly
-    const mockTrips = [
-      {
-        _id: 'trip_001',
-        completedAt: new Date(),
-        freightValue: 12000,
-        fuelCost: 2000,
-        tollCost: 300,
-        distance: 420,
-      },
-      {
-        _id: 'trip_002',
-        completedAt: new Date(Date.now() - 86400000),
-        freightValue: 9500,
-        fuelCost: 1800,
-        tollCost: 200,
-        distance: 310,
-      },
-    ];
-
-    const periodStart = getPeriodStart(period);
-    const trips = mockTrips.filter(
-      (t) => new Date(t.completedAt) >= periodStart
-    );
-
-    const totalGross = trips.reduce((sum, t) => sum + t.freightValue, 0);
-    const totalDeductions = trips.reduce(
-      (sum, t) => sum + t.fuelCost + t.tollCost,
-      0
-    );
-
-    const summary = {
-      period,
-      driverId,
-      totalGross,
-      totalDeductions,
-      netEarnings: totalGross - totalDeductions,
-      tripCount: trips.length,
-      brokerSavingsPercent:
-        totalGross > 0
-          ? Math.round(((totalGross * 0.35) / totalGross) * 100)
-          : 35, // 35% = typical broker commission saved
-      trips: trips.map((t) => ({
-        id: t._id,
-        date: t.completedAt,
-        distance: t.distance,
-        gross: t.freightValue,
-        deductions: t.fuelCost + t.tollCost,
-        net: t.freightValue - t.fuelCost - t.tollCost,
-      })),
-    };
-
-    res.json({ success: true, data: summary });
-  } catch (err) {
-    console.error('Earnings summary error:', err);
-    res.status(500).json({ success: false, error: 'Internal server error' });
-  }
-});
+);
 
 export default router;

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -364,8 +364,6 @@ if (process.env.NODE_ENV === 'production') {
   })
 }
 
-app.use('/api/earnings', earningsRouter);
-
 // Payload parsers
 const jsonBodyLimit =
   process.env.JSON_BODY_LIMIT || '1mb';
@@ -451,6 +449,11 @@ app.use('/api/payments', paymentRoutes)
 app.use('/api/driver', deadheadRoutes)
 app.use('/api/orders', trackingRoutes)
 app.use('/api/driver', driverRoutes)
+// Mounted here, with the other REST routes, so it sits behind the full
+// middleware chain — body parsers, correlation/request IDs, HPP protection,
+// content-type enforcement, fraud detection and the /api rate limiter.
+// Registering it earlier silently bypasses every one of them.
+app.use('/api/earnings', earningsRouter)
 app.use('/api/v1/shipment', shipmentRoutes)
 app.use('/api/loads', loadRoutes)
 app.use('/api/support', supportRoutes)

--- a/backend/api/src/services/driver/earningsSummaryService.js
+++ b/backend/api/src/services/driver/earningsSummaryService.js
@@ -1,0 +1,89 @@
+/**
+ * Driver earnings summary aggregation.
+ *
+ * Kept free of Express, Supabase and middleware imports so the arithmetic is
+ * unit-testable in isolation, per the layered architecture in CONTRIBUTING.md
+ * (routes stay thin; business logic lives in a service).
+ */
+
+/**
+ * Typical broker commission this platform removes from the chain, expressed
+ * as a fraction of gross freight value. Surfaced to drivers as the saving
+ * they make by booking directly.
+ */
+export const BROKER_COMMISSION_RATE = 0.35;
+
+/**
+ * Upper bound on rows read for a single summary. A driver cannot complete
+ * more trips than this in either reporting window, so the cap only ever
+ * engages on anomalous data — it exists so the query can never become
+ * unbounded as trip history grows.
+ */
+export const MAX_TRIPS_PER_SUMMARY = 500;
+
+/**
+ * Start of the requested reporting period.
+ *
+ * @param {'weekly'|'monthly'} period
+ * @returns {Date} Inclusive lower bound for `trip_date`.
+ */
+export function getPeriodStart(period) {
+  const now = new Date();
+  if (period === 'weekly') {
+    const d = new Date(now);
+    d.setDate(d.getDate() - 7);
+    return d;
+  }
+  // monthly (default) — from the first of the current month
+  return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+
+/**
+ * Coerce a possibly-null numeric column to a finite number.
+ *
+ * `total_earnings` and `fuel_deducted` are both nullable, and a null
+ * propagating into the reduce would turn a whole summary into NaN.
+ *
+ * @param {unknown} value
+ * @returns {number}
+ */
+function toAmount(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Build the summary payload from a driver's completed trips.
+ *
+ * @param {Array<object>|null|undefined} trips Completed trips in the window.
+ * @param {string} period
+ * @param {string} driverId
+ * @returns {object} Summary in the shape the driver app already consumes.
+ */
+export function buildEarningsSummary(trips, period, driverId) {
+  const rows = Array.isArray(trips) ? trips : [];
+
+  const totalGross = rows.reduce((sum, t) => sum + toAmount(t.total_earnings), 0);
+  const totalDeductions = rows.reduce((sum, t) => sum + toAmount(t.fuel_deducted), 0);
+
+  return {
+    period,
+    driverId,
+    totalGross,
+    totalDeductions,
+    netEarnings: totalGross - totalDeductions,
+    tripCount: rows.length,
+    // Expressed as a percentage of gross. Constant by definition, but kept in
+    // the payload because the driver app renders it directly.
+    brokerSavingsPercent: Math.round(BROKER_COMMISSION_RATE * 100),
+    brokerSavingsAmount: Math.round(totalGross * BROKER_COMMISSION_RATE),
+    trips: rows.map((t) => ({
+      id: t.trip_display_id,
+      date: t.trip_date,
+      distance: t.distance,
+      gross: toAmount(t.total_earnings),
+      deductions: toAmount(t.fuel_deducted),
+      net: toAmount(t.total_earnings) - toAmount(t.fuel_deducted),
+    })),
+  };
+}

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -241,6 +241,16 @@ export const driverStatementSchema = z.object({
   sort_by: z.enum(['pickup_date', 'net_earnings', 'base_freight']).optional(),
 }).strict();
 
+/**
+ * Reporting window for the driver earnings summary.
+ *
+ * `.strict()` rejects unknown query keys so a typo surfaces as a 400 rather
+ * than silently falling back to the default period.
+ */
+export const earningsSummarySchema = z.object({
+  period: z.enum(['weekly', 'monthly']).optional(),
+}).strict();
+
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
 // e.g. MH12AB1234 or DL01C1234
 const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;

--- a/backend/api/test/unit/earningsSummary.test.js
+++ b/backend/api/test/unit/earningsSummary.test.js
@@ -1,0 +1,165 @@
+/**
+ * Unit coverage for the driver earnings summary aggregation.
+ *
+ * The router previously returned a hardcoded `mockTrips` array attributed to
+ * a `demo-driver` placeholder. These tests pin the real aggregation, with
+ * particular attention to the nullable monetary columns — `total_earnings`
+ * and `fuel_deducted` are both nullable in the schema, and a null propagating
+ * into the reduce turns an entire summary into NaN.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildEarningsSummary,
+  getPeriodStart,
+} from '../../src/services/driver/earningsSummaryService.js';
+
+const DRIVER = '22222222-2222-2222-2222-222222222222';
+
+function trip(overrides = {}) {
+  return {
+    trip_display_id: 'TRP-001',
+    trip_date: '2026-08-01',
+    distance: '420 km',
+    total_earnings: 12000,
+    fuel_deducted: 2000,
+    ...overrides,
+  };
+}
+
+describe('getPeriodStart', () => {
+  it('returns seven days back for the weekly window', () => {
+    const start = getPeriodStart('weekly');
+    const diffDays = Math.round((Date.now() - start.getTime()) / 86_400_000);
+    expect(diffDays).toBe(7);
+  });
+
+  it('returns the first of the current month for the monthly window', () => {
+    const start = getPeriodStart('monthly');
+    expect(start.getDate()).toBe(1);
+    expect(start.getMonth()).toBe(new Date().getMonth());
+  });
+
+  it('defaults to the monthly window for an unrecognised period', () => {
+    // Validation rejects these before the handler runs; this is defence in depth.
+    expect(getPeriodStart(undefined).getDate()).toBe(1);
+    expect(getPeriodStart('yearly').getDate()).toBe(1);
+  });
+});
+
+describe('buildEarningsSummary', () => {
+  it('aggregates gross, deductions and net across trips', () => {
+    const summary = buildEarningsSummary(
+      [
+        trip({ total_earnings: 12000, fuel_deducted: 2000 }),
+        trip({ trip_display_id: 'TRP-002', total_earnings: 9500, fuel_deducted: 1800 }),
+      ],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.totalGross).toBe(21500);
+    expect(summary.totalDeductions).toBe(3800);
+    expect(summary.netEarnings).toBe(17700);
+    expect(summary.tripCount).toBe(2);
+  });
+
+  it('attributes the summary to the authenticated driver', () => {
+    const summary = buildEarningsSummary([trip()], 'monthly', DRIVER);
+    expect(summary.driverId).toBe(DRIVER);
+    // The placeholder identity the endpoint used to fall back to.
+    expect(summary.driverId).not.toBe('demo-driver');
+  });
+
+  it('returns a zeroed summary for a driver with no trips', () => {
+    const summary = buildEarningsSummary([], 'weekly', DRIVER);
+
+    expect(summary.totalGross).toBe(0);
+    expect(summary.totalDeductions).toBe(0);
+    expect(summary.netEarnings).toBe(0);
+    expect(summary.tripCount).toBe(0);
+    expect(summary.trips).toEqual([]);
+  });
+
+  it('treats a null total_earnings as zero rather than producing NaN', () => {
+    const summary = buildEarningsSummary(
+      [trip({ total_earnings: null }), trip({ total_earnings: 5000, fuel_deducted: 500 })],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.totalGross).toBe(5000);
+    expect(Number.isNaN(summary.netEarnings)).toBe(false);
+  });
+
+  it('treats a null fuel_deducted as zero', () => {
+    const summary = buildEarningsSummary(
+      [trip({ total_earnings: 8000, fuel_deducted: null })],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.totalDeductions).toBe(0);
+    expect(summary.netEarnings).toBe(8000);
+  });
+
+  it('ignores non-numeric monetary values instead of corrupting the total', () => {
+    const summary = buildEarningsSummary(
+      [trip({ total_earnings: 'not-a-number', fuel_deducted: undefined })],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.totalGross).toBe(0);
+    expect(summary.totalDeductions).toBe(0);
+  });
+
+  it('handles a null or non-array trips argument', () => {
+    expect(buildEarningsSummary(null, 'monthly', DRIVER).tripCount).toBe(0);
+    expect(buildEarningsSummary(undefined, 'monthly', DRIVER).tripCount).toBe(0);
+  });
+
+  it('computes per-trip net from that trip alone', () => {
+    const summary = buildEarningsSummary(
+      [trip({ total_earnings: 12000, fuel_deducted: 2300 })],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.trips[0]).toMatchObject({
+      id: 'TRP-001',
+      gross: 12000,
+      deductions: 2300,
+      net: 9700,
+    });
+  });
+
+  it('reports broker savings against gross', () => {
+    const summary = buildEarningsSummary(
+      [trip({ total_earnings: 10000, fuel_deducted: 0 })],
+      'monthly',
+      DRIVER
+    );
+
+    expect(summary.brokerSavingsPercent).toBe(35);
+    expect(summary.brokerSavingsAmount).toBe(3500);
+  });
+
+  it('reports zero broker savings when there is no gross', () => {
+    const summary = buildEarningsSummary([], 'monthly', DRIVER);
+    expect(summary.brokerSavingsAmount).toBe(0);
+    // Percentage is a constant rate, so it stays meaningful at zero gross.
+    expect(summary.brokerSavingsPercent).toBe(35);
+  });
+
+  it('echoes the requested period back to the client', () => {
+    expect(buildEarningsSummary([], 'weekly', DRIVER).period).toBe('weekly');
+    expect(buildEarningsSummary([], 'monthly', DRIVER).period).toBe('monthly');
+  });
+
+  it('does not return fabricated placeholder trips', () => {
+    const summary = buildEarningsSummary([], 'monthly', DRIVER);
+    const ids = summary.trips.map((t) => t.id);
+    expect(ids).not.toContain('trip_001');
+    expect(ids).not.toContain('trip_002');
+  });
+});

--- a/backend/api/test/unit/middlewareOrder.test.js
+++ b/backend/api/test/unit/middlewareOrder.test.js
@@ -1,0 +1,137 @@
+/**
+ * Guards the registration order of the Express middleware chain.
+ *
+ * Express matches middleware positionally, so mounting a router before the
+ * security stack silently disables it for that path — no error, no warning.
+ * `/api/earnings` was registered ahead of the body parsers, HPP protection,
+ * content-type enforcement, fraud detection and the rate limiter, which meant
+ * every request to it bypassed all of them.
+ *
+ * These assertions read src/index.js as text rather than booting the app,
+ * because importing it starts servers, workers and reconciliation cron jobs.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const INDEX = path.resolve(__dirname, '../../src/index.js');
+
+/** Middleware every /api route must sit behind, with the marker that registers it. */
+const REQUIRED_BEFORE_ROUTES = [
+  { name: 'JSON body parser', marker: 'express.json(' },
+  { name: 'urlencoded body parser', marker: 'express.urlencoded(' },
+  { name: 'correlation ID', marker: 'app.use(correlationIdMiddleware)' },
+  { name: 'request ID', marker: 'app.use(requestIdMiddleware)' },
+  { name: 'request logger', marker: 'app.use(requestLogger)' },
+  { name: 'HPP protection', marker: 'app.use(hppProtection)' },
+  { name: 'suspicious requests', marker: 'app.use(suspiciousRequests)' },
+  { name: 'content-type enforcement', marker: 'app.use(requireJsonContent)' },
+  { name: 'fraud detection', marker: 'app.use(fraudDetectionMiddleware)' },
+  { name: 'global rate limiter', marker: "app.use('/api/', globalLimiter)" },
+];
+
+describe('express middleware registration order', () => {
+  let source;
+
+  beforeAll(async () => {
+    source = await fs.readFile(INDEX, 'utf8');
+  });
+
+  it('registers every security middleware exactly once', () => {
+    for (const { name, marker } of REQUIRED_BEFORE_ROUTES) {
+      const occurrences = source.split(marker).length - 1;
+      expect(occurrences, `${name} should be registered exactly once`).toBe(1);
+    }
+  });
+
+  it('mounts /api/earnings behind the full middleware chain', () => {
+    const mount = source.indexOf("app.use('/api/earnings'");
+    expect(mount, '/api/earnings should be mounted').toBeGreaterThan(-1);
+
+    for (const { name, marker } of REQUIRED_BEFORE_ROUTES) {
+      const registered = source.indexOf(marker);
+      expect(registered, `${name} should be registered`).toBeGreaterThan(-1);
+      expect(
+        registered,
+        `/api/earnings is mounted before ${name} — that path would bypass it`
+      ).toBeLessThan(mount);
+    }
+  });
+
+  it('mounts no /api router ahead of the global rate limiter', () => {
+    const limiter = source.indexOf("app.use('/api/', globalLimiter)");
+    expect(limiter).toBeGreaterThan(-1);
+
+    // Health is deliberately mounted earlier with its own dedicated limiter
+    // so uptime probes are not throttled by the global bucket.
+    const ALLOWED_BEFORE_LIMITER = ['/api/health', '/api/v1/health'];
+
+    const earlyMounts = [...source.slice(0, limiter).matchAll(/app\.use\(\s*'(\/api[^']*)'/g)]
+      .map((match) => match[1])
+      .filter((route) => !ALLOWED_BEFORE_LIMITER.includes(route));
+
+    expect(
+      earlyMounts,
+      `These /api routers are mounted before the global rate limiter and bypass it: ${earlyMounts.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('keeps the earnings mount alongside the other REST routes', () => {
+    const earnings = source.indexOf("app.use('/api/earnings'");
+    const orders = source.indexOf("app.use('/api/orders', orderRoutes)");
+    const profile = source.indexOf("app.use('/api/profile'");
+
+    expect(earnings).toBeGreaterThan(orders);
+    expect(earnings).toBeLessThan(profile);
+  });
+});
+
+describe('earnings route protection', () => {
+  let source;
+
+  beforeAll(async () => {
+    source = await fs.readFile(
+      path.resolve(__dirname, '../../routes/earnings.js'),
+      'utf8'
+    );
+  });
+
+  it('requires authentication', () => {
+    expect(source).toMatch(/authenticate/);
+  });
+
+  it('enforces the driver earnings policy', () => {
+    expect(source).toMatch(/requirePolicy\(\s*['"]driver:view-earnings['"]\s*\)/);
+  });
+
+  it('applies a per-user rate limit', () => {
+    expect(source).toMatch(/userLimiter/);
+  });
+
+  it('validates the query string', () => {
+    expect(source).toMatch(/validateQuery\(\s*earningsSummarySchema\s*\)/);
+  });
+
+  it('reads the driver id from the authenticated user, not a placeholder', () => {
+    expect(source).toMatch(/req\.user\.id/);
+    expect(source).not.toMatch(/demo-driver/);
+    expect(source).not.toMatch(/req\.user\?\.id\s*\?\?/);
+  });
+
+  it('no longer serves hardcoded mock trips', () => {
+    expect(source).not.toMatch(/mockTrips/);
+    expect(source).not.toMatch(/trip_001/);
+  });
+
+  it('uses the project logger rather than console', () => {
+    expect(source).toMatch(/logger\.error/);
+    expect(source).not.toMatch(/console\.(error|log)/);
+  });
+
+  it('bounds the trips query', () => {
+    expect(source).toMatch(/\.limit\(\s*MAX_TRIPS_PER_SUMMARY\s*\)/);
+  });
+});


### PR DESCRIPTION
Fixes #6394

**What is the problem**

`/api/earnings` was mounted at `src/index.js:367`, before the body parsers, correlation/request-ID middleware, HPP protection, content-type enforcement, fraud detection and the `/api` rate limiter were registered. Express matches middleware positionally, so registering a router above the stack silently disables the entire stack for that path — no error, no warning, nothing in review that looks wrong.

The handler compounded it. It had no `authenticate` middleware, and read its identity as `req.user?.id ?? 'demo-driver'`. Since nothing upstream ever populated `req.user`, the fallback was not a fallback — it was the only branch that executed. It then returned a hardcoded `mockTrips` array as though it were real earnings.

The net effect: an unauthenticated, unrate-limited, fraud-invisible endpoint serving fabricated financial figures.

**What was changed**

- **`backend/api/src/index.js`** — removed the line-367 mount and re-registered `/api/earnings` alongside the other REST routes, between `/api/driver` and `/api/v1/shipment`, so it inherits the complete chain. Added a comment recording *why* the position matters, since that is the part that was invisible.
- **`backend/api/routes/earnings.js`** — added `authenticate`, `userLimiter` and `requirePolicy('driver:view-earnings')`, matching the existing `GET /api/driver/earnings/summary`. Replaced the mock array with a real Supabase query against `trips` filtered by `driver_id` and `status = 'completed'`, bounded by the reporting window and an explicit row cap. Reads `req.user.id`; the `demo-driver` fallback is gone. Swapped `console.error` for the project `logger` with structured context. Added the OpenAPI block the other routes carry.
- **`backend/api/src/services/driver/earningsSummaryService.js`** (new) — the aggregation, extracted per the layered architecture in `CONTRIBUTING.md` (routes stay thin, logic lives in a service). Also makes the arithmetic testable without booting Express. Handles the nullable monetary columns explicitly.
- **`backend/api/src/validation/requestSchemas.js`** — added `earningsSummarySchema`, a `.strict()` enum for `period`, so validation is shared rather than inlined and an unknown query key returns 400 instead of silently defaulting.
- **`backend/api/test/unit/earningsSummary.test.js`** (new) — 15 tests over the aggregation.
- **`backend/api/test/unit/middlewareOrder.test.js`** (new) — 12 tests over registration order and route protection.

**Why this approach**

Fixing only the missing `authenticate` would have left the real defect in place: the path would still bypass rate limiting, HPP protection, fraud detection and correlation logging, and the next router mounted in that region would inherit the same invisible hole. Moving the mount fixes the class of problem.

The mock data is removed rather than left behind a guard because serving invented earnings figures is its own defect in a product whose stated purpose is transparent driver pay.

The aggregation went into a service because the route file could not otherwise be tested — importing it pulls in the auth middleware chain, which currently reaches `profileCache.js` (broken by #6384). Extracting the logic follows the documented architecture and sidesteps that coupling, so these tests pass today rather than being blocked on an unrelated fix.

Nullable-column coercion was added because `total_earnings` and `fuel_deducted` are both nullable; a single null would have turned an entire summary into `NaN` once the query returned real rows instead of the mock array.

**How to test**

1. Pull this branch and run the backend.
2. Reproduce the original problem on `main`: `curl [link removed for security] with **no** Authorization header returns HTTP 200 and a full earnings payload, with no `RateLimit-*` and no `X-Request-Id` headers. On this branch the same request returns **401**.
3. Verify the fix: repeat with a valid driver token — HTTP 200 with real trips, and the response now carries `RateLimit-*` and `X-Request-Id` headers, proving the request traversed the full chain.
4. Verify authorisation: repeat with a valid **customer** token — HTTP **403** from the policy engine.
5. Verify validation: `?period=yearly` returns **400**; `?perid=weekly` (typo) also returns **400** rather than silently defaulting to monthly.
6. Run `npx vitest run test/unit/earningsSummary.test.js test/unit/middlewareOrder.test.js` — 27 tests pass.

**Edge cases covered**

- Driver with zero completed trips — zeroed summary, empty trips array, no crash.
- `total_earnings` null, `fuel_deducted` null, both null — coerced to 0 rather than producing `NaN` totals.
- Non-numeric and `undefined` monetary values — coerced to 0.
- `trips` returned as `null` or a non-array — handled without throwing.
- Zero gross — `brokerSavingsAmount` is 0 while the constant percentage stays meaningful.
- Supabase query error — logged with context and surfaced as 500 without leaking the driver id or DB internals to the client.
- Unknown `period` value, unknown query key, and omitted `period` (defaults to monthly).
- Weekly boundary at exactly 7 days; monthly boundary at the first of the month.
- Health routes remain deliberately mounted ahead of the global limiter with their own limiter — the order test allowlists them explicitly rather than failing.

**Screenshots or logs**

Before, on `main` — no token, no rate-limit headers:

```
$ curl -i [link removed for security]
HTTP/1.1 200 OK
{"success":true,"data":{"driverId":"demo-driver","totalGross":21500,...}}
```

After, on this branch:

```
$ curl -i [link removed for security]
HTTP/1.1 401 Unauthorized
{"error":"Access Denied. No token provided."}
```

Test run:

```
$ npx vitest run test/unit/earningsSummary.test.js test/unit/middlewareOrder.test.js
 Test Files  2 passed (2)
      Tests  27 passed (27)
```

**Lines changed**

488 added, 76 removed — 564 total across 6 files.

**Verification checklist**

- [x] Branch fully synced with latest upstream before coding started
- [x] All original existing code preserved — the response shape the driver app consumes is retained, including `brokerSavingsPercent`
- [x] PR raised against original upstream repository and not my fork
- [x] Correct issue number tagged with Fixes #6394
- [x] Root cause fully resolved — mount position fixed, not just the missing auth call
- [x] All edge cases and error paths handled
- [x] No regressions introduced — full suite compared against baseline below
- [x] All existing tests pass
- [x] New tests written covering this change
- [x] Code matches project style and conventions throughout
- [x] Total lines changed confirmed at 200 or above
- [x] Not a duplicate of any existing open or closed PR

**Note on the test suite baseline.** `main` is currently red for reasons unrelated to this change — `@opentelemetry/*` is imported by `src/tracing/tracing.js` but absent from `package.json`, and `profileCache.js` (#6384) and `escrow.js` (#6122) do not parse. Measured on this branch against that baseline:

| | `main` | this branch |
|---|---|---|
| Test files | 57 failed / 75 passed | 57 failed / **77** passed |
| Tests | 119 failed / 1187 passed | 119 failed / **1214** passed |

Identical failure counts, +27 passing tests. No regressions introduced.

**Labels:** the repository has no `type:security` label — closest existing are `type:bug` + `critical` + `backend` + `level:advanced` + `gssoc:approved`. I don't have triage permission to apply them.

Please review and merge this under GSSoC 2026.

> ⚠️ **Security Notice:** Links posted by non-contributors have been automatically removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated driver earnings summaries for weekly and monthly periods.
  * Summaries now include gross earnings, deductions, net earnings, trip counts, broker savings, and per-trip details.
  * Earnings data is based on completed trips for the selected reporting period.
  * Added validation for supported reporting periods.

* **Bug Fixes**
  * Removed placeholder trip data and improved handling of empty or incomplete earnings records.
  * Added safeguards to keep earnings requests secure and within supported limits.

* **Tests**
  * Added coverage for calculations, reporting periods, access controls, and earnings data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->