### PR TITLE
fix(escrow): single pull-based payout in releasePayment and cancelBooking (#6322)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -226,21 +226,22 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     {
         Booking storage booking = bookings[bookingId];
 
-        // CHECKS
-        require(booking.delivered, "Delivery not confirmed");
-        require(!booking.paid, "Already paid");
-        require(!booking.cancelled, "Booking cancelled");
-        require(booking.amount > 0, "No funds in escrow");
+        require(
+            booking.status == BookingStatus.Active,
+            "TruxifyEscrow: Booking not active"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(booking.amount > 0, "TruxifyEscrow: Nothing to release");
 
-        uint256 amount = booking.amount;
-        address payable driver = booking.driver;
+        // ── CHECKS done above ─────────────────────────────────────────────
+
+        // ── EFFECTS: Update state BEFORE external call (CEI pattern) ──────
+        uint256 paymentAmount   = booking.amount;
+        address payable driver  = booking.driver;
 
         booking.paid    = true;                      // ← committed first
         booking.amount  = 0;                         // ← zero out
         booking.status  = BookingStatus.Delivered;   // ← status updated
-
-        (bool success, ) = driver.call{value: amount}("");
-        require(success, "Transfer failed");
 
         // ── INTERACTIONS: Add to pending withdrawal instead of direct transfer ──
         pendingWithdrawals[driver] += paymentAmount;
@@ -298,10 +299,13 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     {
         Booking storage booking = bookings[bookingId];
 
-        require(!booking.delivered, "Already delivered");
-        require(!booking.paid, "Already paid");
-        require(!booking.cancelled, "Already cancelled");
-        require(booking.amount > 0, "No funds to refund");
+        require(
+            booking.customer != address(0) && booking.status == BookingStatus.Active,
+            "TruxifyEscrow: Cannot cancel - booking not active"
+        );
+        require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(!booking.started, "TruxifyEscrow: Trip already started");
+        require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
 
         // ── EFFECTS ───────────────────────────────────────────────────────
         uint256 refundAmount    = booking.amount;
@@ -310,10 +314,6 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         booking.amount  = 0;
         booking.paid    = true;
         booking.status  = BookingStatus.Cancelled;
-
-        // INTERACTIONS
-        (bool success, ) = customer.call{value: amount}("");
-        require(success, "Refund failed");
 
         // ── INTERACTIONS: Add to pending withdrawal instead of direct transfer ──
         pendingWithdrawals[customer] += refundAmount;


### PR DESCRIPTION
## Problem

`blockchain/contracts/TruxifyEscrow.sol` `releasePayment()` and `cancelBooking()` pay out **twice**: they transfer ETH directly via `.call{value: ...}` and then also credit the same recipient through `pendingWithdrawals`. Both functions also reference symbols that do not exist (`booking.delivered`, `booking.cancelled`, `paymentAmount`, `amount`), so the contract does not compile against the `Booking` struct, and if the undefined references are "fixed" the double-payout logic would silently pay every driver / cancelled customer twice.

## Fix

Restore the valid status-based guards (checked against the `BookingStatus` enum) in `releasePayment()` and `cancelBooking()`, remove the direct ETH `.call{}` transfers so the payout happens **exactly once** through the pull-based `pendingWithdrawals` bucket, and use the correctly defined `paymentAmount` / `refundAmount` locals. The `ReentrancyGuard` / CEI pattern is preserved.

## Files changed

- `blockchain/contracts/TruxifyEscrow.sol`

## Testing

- `blockchain/contracts/TruxifyEscrow.sol` compiles cleanly against the `Booking` struct.
- Existing `blockchain/test/TruxifyEscrow.test.js` assertions (single payout, pull-only withdrawal, status-transition reverts) match the restored logic.

Closes #6322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment release validation to ensure bookings are active before funds are released.
  * Updated cancellation handling to restrict refunds to eligible, unpaid, and unstarted bookings.
  * Payments and refunds are now routed through pending withdrawals for safer processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->