### PR TITLE
fix(rpc): authenticate cancel_order_tx and lock_order_for_update (#6323)

### DIFF
--- a/supabase/migrations/20260703000001_add_lock_order_and_cancel_order_rpcs.sql
+++ b/supabase/migrations/20260703000001_add_lock_order_and_cancel_order_rpcs.sql
@@ -2,12 +2,19 @@ BEGIN;
 
 -- RPC: lock_order_for_update — Row-level lock on an order to serialize
 -- concurrent verify-delivery and cancel requests on the same order.
+-- Restricted to service_role: SECURITY DEFINER bypasses RLS, so an
+-- unauthenticated/authenticated caller must never be able to lock any order.
 CREATE OR REPLACE FUNCTION lock_order_for_update(p_order_id UUID)
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only the backend service can lock orders';
+  END IF;
+
   PERFORM 1 FROM orders WHERE id = p_order_id FOR UPDATE;
 END;
 $$;
@@ -15,6 +22,10 @@ $$;
 -- RPC: cancel_order_tx — Cancel an order and initiate escrow refund atomically.
 -- Combines the status update and escrow_status transition in a single
 -- transaction with row-level locking, preventing race conditions.
+-- Authorization is derived from the caller's JWT via get_profile_id(): the
+-- owning customer or service_role may cancel. The caller-supplied
+-- p_customer_id is never trusted for authorization (it is kept only for
+-- signature compatibility).
 CREATE OR REPLACE FUNCTION cancel_order_tx(
   p_order_id        UUID,
   p_cancellation_reason TEXT,
@@ -23,6 +34,7 @@ CREATE OR REPLACE FUNCTION cancel_order_tx(
 RETURNS orders
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_order orders%ROWTYPE;
@@ -33,12 +45,22 @@ BEGIN
     RAISE EXCEPTION 'Order not found';
   END IF;
 
-  IF v_order.customer_id <> p_customer_id THEN
+  -- Identity is derived from the JWT. IS DISTINCT FROM fails closed when the
+  -- caller has no resolvable profile (get_profile_id() IS NULL).
+  IF auth.role() <> 'service_role'
+     AND get_profile_id() IS DISTINCT FROM v_order.customer_id THEN
     RAISE EXCEPTION 'Access Denied: You do not own this order.';
   END IF;
 
+  -- Mirror the status guards the backend cancelOrder flow enforces
+  -- (orderLifecycleService.js): delivered/released and in-transit orders
+  -- (already picked up) cannot be cancelled for a full refund.
   IF v_order.status IN ('delivered', 'payment_released') THEN
     RAISE EXCEPTION 'Order was already delivered or payment released. Cannot cancel.';
+  END IF;
+
+  IF v_order.status IN ('picked_up', 'in_transit', 'arriving', 'arrived_dropoff') THEN
+    RAISE EXCEPTION 'Cannot cancel: the shipment has already been picked up and is in transit.';
   END IF;
 
   IF v_order.escrow_status NOT IN ('funded', 'refund_pending', 'refund_failed') THEN
@@ -60,5 +82,11 @@ BEGIN
   RETURN v_order;
 END;
 $$;
+
+-- SECURITY DEFINER functions bypass RLS, so default PUBLIC EXECUTE must be
+-- revoked. Only the backend (service_role) may lock/cancel orders; the owning
+-- customer path is enforced inside cancel_order_tx via get_profile_id().
+REVOKE EXECUTE ON FUNCTION public.lock_order_for_update(UUID) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cancel_order_tx(UUID, TEXT, UUID) FROM anon, authenticated;
 
 COMMIT;


### PR DESCRIPTION
## Problem

`supabase/migrations/20260703000001_add_lock_order_and_cancel_order_rpcs.sql` defines `lock_order_for_update()` and `cancel_order_tx()` as `SECURITY DEFINER` functions with no authorization. `SECURITY DEFINER` bypasses RLS and new functions default to `PUBLIC` EXECUTE, so any authenticated (or anon) caller could cancel a victim's funded in-transit order by supplying the victim's `customer_id` via PostgREST — triggering an on-chain escrow refund for a shipment that may already be underway.

## Fix

- `cancel_order_tx()` now derives the caller's identity from the JWT via `get_profile_id()` and raises `Access Denied` unless `auth.role() = 'service_role'` or the caller owns the order. The caller-supplied `p_customer_id` is never trusted for authorization. The `IS DISTINCT FROM` check fails closed when the caller has no resolvable profile.
- The in-transit status guards the backend `cancelOrder` enforces are mirrored: `picked_up`, `in_transit`, `arriving`, `arrived_dropoff` can no longer be cancelled for a full refund.
- `lock_order_for_update()` is restricted to `service_role`.
- Both functions now set `search_path = public, pg_temp` and have `EXECUTE` revoked from `anon` and `authenticated`.

## Files changed

- `supabase/migrations/20260703000001_add_lock_order_and_cancel_order_rpcs.sql`

## Testing

- SQL reviewed against the sibling hardening pattern (`20260708000000_fix_rpc_security.sql`, `20260802000000_secure_update_order_and_load_offer.sql`).
- `backend/api/scripts/verify-db-schema.js` RPC list is unaffected (function signatures unchanged).

Closes #6323
