### PR TITLE
bug : added removal of stray shell command from getRedisClient in profileCache

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -76,7 +76,7 @@ function logCacheError(operation, error) {
 function getRedisClient() {
   try {
     return db.redisClient ?? null;
-code -g backend/api/src/routes/lookupRoutes.js:50  } catch {
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
Closes #6409.

Summary of What Has Been Done:
Removed a stray shell command string that had been pasted into the catch clause of getRedisClient() in profileCache.js. The stray text broke the module's syntax, so the backend could not parse or boot.

Changes Made:
- backend/api/src/lib/profileCache.js: restored the intended `} catch {` block by deleting the accidental `code -g ...` shell text.

Impact it Made:
- Fixes the module parse error and lets the server boot. Verified with node --check.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.