### PR TITLE
bug : added logging of document expiry supabase lookup failures

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -75,7 +75,8 @@ async function hasExistingNotification(userId, documentId, daysRemaining) {
       (n) => n.metadata?.documentId === documentId &&
              String(n.metadata?.daysRemaining) === String(daysRemaining),
     );
-  } catch {
+  } catch (err) {
+    logger.error({ err, userId, documentId }, '[document-expiry] hasExistingNotification query failed');
     return false;
   }
 }


### PR DESCRIPTION
Closes #6411.

Summary of What Has Been Done:
Added error logging to hasExistingNotification so a supabase query failure is surfaced instead of silently returning false and risking duplicate notifications.

Changes Made:
- backend/api/src/services/documentExpiryService.js: log the caught error with user/document context before returning false.

Impact it Made:
Surfaces DB failures in the document expiry worker for better diagnostics.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.