### PR TITLE
fix(security): restrict load_bids RLS to SELECT and verify bid amount in accept_bid_tx

### DIFF
--- a/supabase/migrations/20240101000000_rls.sql
+++ b/supabase/migrations/20240101000000_rls.sql
@@ -229,14 +229,28 @@ CREATE POLICY "Service role full access on load_bids"
 
 DROP POLICY IF EXISTS "Drivers access own bids" ON load_bids;
 CREATE POLICY "Drivers access own bids"
-  ON load_bids FOR ALL TO authenticated
-  USING (driver_id = get_profile_id())
-  WITH CHECK (driver_id = get_profile_id());
+  ON load_bids FOR SELECT TO authenticated
+  USING (driver_id = get_profile_id());
 
 DROP POLICY IF EXISTS "Customers view bids on own load offers" ON load_bids;
 CREATE POLICY "Customers view bids on own load offers"
   ON load_bids FOR SELECT TO authenticated
   USING (load_id IN (SELECT id FROM load_offers WHERE customer_id = get_profile_id()));
+
+-- Drivers may only READ their own bids. Bid creation/status/amount writes are
+-- performed exclusively by the backend (service_role / accept_bid_tx) so a
+-- driver can never inflate bid_amount or flip status (e.g. self-accept) via
+-- PostgREST. A driver may not submit more than one pending bid per load, and
+-- bid amounts must always be positive (paisa).
+CREATE UNIQUE INDEX IF NOT EXISTS load_bids_one_pending_per_driver_per_load
+  ON load_bids (load_id, driver_id)
+  WHERE status = 'pending';
+
+ALTER TABLE load_bids
+  DROP CONSTRAINT IF EXISTS load_bids_bid_amount_positive;
+
+ALTER TABLE load_bids
+  ADD CONSTRAINT load_bids_bid_amount_positive CHECK (bid_amount > 0);
 
 
 -- ─── TRIPS ───

--- a/supabase/migrations/20260802120000_accept_bid_tx_trust_stored_bid.sql
+++ b/supabase/migrations/20260802120000_accept_bid_tx_trust_stored_bid.sql
@@ -51,6 +51,8 @@ DECLARE
   v_driver_rating    numeric;
   v_truck_id         uuid;
   v_truck_number     text;
+  v_pending_acceptance jsonb;
+  v_pending_bid_amount  int;
 BEGIN
   -- Resolve the bid by p_bid_id and derive the load/order chain from it.
   -- The caller-supplied p_load_id/p_order_id/p_order_display_id/p_driver_id/
@@ -74,14 +76,29 @@ BEGIN
     RAISE EXCEPTION 'Load offer is no longer available';
   END IF;
 
-  SELECT customer_id, status, version
-    INTO v_customer_id, v_order_status, v_current_version
+  SELECT customer_id, status, version, pending_bid_acceptance
+    INTO v_customer_id, v_order_status, v_current_version, v_pending_acceptance
     FROM orders
    WHERE order_display_id = v_order_display_id
      FOR UPDATE;
 
   IF v_customer_id IS NULL THEN
     RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  -- The order must carry a two-phase acceptance snapshot. Compare the amount
+  -- the customer agreed to and funded with the amount still stored on the bid
+  -- row. If the bid was rewritten after acceptance (e.g. by a driver inflating
+  -- bid_amount), refuse to finalize so escrow can never pay out more than was
+  -- actually funded.
+  IF v_pending_acceptance IS NULL THEN
+    RAISE EXCEPTION 'Pending bid acceptance snapshot is missing';
+  END IF;
+
+  v_pending_bid_amount := (v_pending_acceptance->>'bid_amount')::int;
+
+  IF v_pending_bid_amount IS NULL OR v_bid_amount <> v_pending_bid_amount THEN
+    RAISE EXCEPTION 'Bid amount was modified after acceptance; refusing to finalize';
   END IF;
 
   IF auth.role() <> 'service_role'


### PR DESCRIPTION
## Problem

A driver could rewrite their own `load_bids` row via PostgREST because `"Drivers access own bids"` was `FOR ALL TO authenticated USING (driver_id = get_profile_id()) WITH CHECK (driver_id = get_profile_id())` (`supabase/migrations/20240101000000_rls.sql:230-234`). Because `accept_bid_tx` trusts the stored `b.bid_amount` and writes it to `orders.total_amount`, a driver could inflate `bid_amount` *after* the customer accepted (escrow funded at the lower snapshot) but *before* the reconciliation worker finalized acceptance — driving the eventual `complete_trip_tx` wallet credit above what was actually paid into escrow. Drivers could also self-accept without funding, sabotage a confirmed acceptance by flipping `status`, and INSERT unlimited duplicate bids.

## Fix

- `supabase/migrations/20240101000000_rls.sql`
  - `"Drivers access own bids"` narrowed from `FOR ALL` to `FOR SELECT` (drivers keep read access to their own bids only; `service_role` retains full access and `accept_bid_tx`/backend remain the only writers).
  - Added partial unique index `load_bids_one_pending_per_driver_per_load` on `(load_id, driver_id) WHERE status = 'pending'` so a driver cannot submit more than one pending bid per load.
  - Added `CHECK (bid_amount > 0)` on `load_bids`.
- `supabase/migrations/20260802120000_accept_bid_tx_trust_stored_bid.sql`
  - `accept_bid_tx` now reads the order's `pending_bid_acceptance` snapshot and refuses to finalize unless the stored `bid_amount` still equals the amount the customer agreed to and funded. If the snapshot is missing or the amounts diverge, the transaction raises and the payout can never exceed the escrowed amount.

## Files changed

- `supabase/migrations/20240101000000_rls.sql`
- `supabase/migrations/20260802120000_accept_bid_tx_trust_stored_bid.sql`

## Testing

- Reviewed both migrations for correctness; the `accept_bid_tx` signature is unchanged (verified against `verify-db-schema.js` RPC list).
- The partial unique index keeps the multi-driver marketplace intact (one pending bid per driver per load — mirroring the backend `assertNoDuplicateBid(loadId, driverId)` check) while closing the duplicate-insert hole.

Closes #6324
