### PR TITLE
bug : added fix of circuit-open detection in osrm getRouteGeometry

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -211,7 +211,7 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
 
   } catch (err) {
     logger.error('[osrm] Fetch error (geometry):', err.message);
-    if (err.message?.includes('Circuit open')) return null;
+    if (err.code === 'EOPENBREAKER' || err.message?.includes('Breaker is open')) return null;
     return null;
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
Closes #6414.

Summary of What Has Been Done:
Fixed the circuit-open detection in getRouteGeometry so it matches opossum's real error instead of a message string that never occurs.

Changes Made:
- backend/api/src/services/osrm.js: check err.code EOPENBREAKER and the actual 'Breaker is open' message.

Impact it Made:
Circuit-open failures are now handled consistently with getRouteEstimate.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.