### PR TITLE
bug : added support for valid zero coordinates in reverseGeocode

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -12,7 +12,7 @@ const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
  * @returns {Promise<string|null>} Formatted location string or null if failed
  */
 export async function reverseGeocode(lat, lon) {
-  if (!lat || !lon) return null;
+  if (lat == null || lon == null || Number.isNaN(Number(lat)) || Number.isNaN(Number(lon))) return null;
 
   // Round coordinates to ~100m precision (3 decimal places) to maximize cache hits
   const roundedLat = Number(lat).toFixed(3);


### PR DESCRIPTION
Closes #6415.

Summary of What Has Been Done:
Changed the input guard in reverseGeocode so it rejects only null, undefined, and NaN, allowing the valid coordinate pair 0,0 to be geocoded.

Changes Made:
- backend/api/src/lib/reverseGeocode.js: guard against null/undefined/NaN instead of falsy values.

Impact it Made:
Coordinates at 0,0 now geocode instead of silently returning null. Existing reverseGeocode unit tests still pass (12/12).

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.