### PR TITLE
fix : added extraction of magic rush-hour surge literals in trafficService

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -1,5 +1,13 @@
 import logger from '../middleware/logger.js';
 
+const RUSH_HOUR_START_AM = 7;
+const RUSH_HOUR_END_AM = 10;
+const RUSH_HOUR_START_PM = 16;
+const RUSH_HOUR_END_PM = 19;
+const MIN_SURGE_MULTIPLIER = 1.2;
+const MAX_SURGE_MULTIPLIER = 2.5;
+const SURGE_PEAK_AMPLITUDE = 1.3;
+
 /**
  * Fetches live traffic congestion metrics.
  * Uses a mock implementation for TomTom / Google Maps Distance Matrix.
@@ -25,12 +33,14 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
     // Mocking a live traffic integration:
     // If it's rush hour, dynamically generate a surge multiplier (1.2 to 2.5) based on coordinates hash to simulate localized congestion
     const hour = new Date().getHours();
-    const isRushHour = (hour >= 7 && hour <= 10) || (hour >= 16 && hour <= 19);
+    const isRushHour =
+      (hour >= RUSH_HOUR_START_AM && hour <= RUSH_HOUR_END_AM) ||
+      (hour >= RUSH_HOUR_START_PM && hour <= RUSH_HOUR_END_PM);
 
     if (isRushHour) {
       // sin(x) + cos(y) ranges over [-2, 2], so after Math.abs it's [0, 2] — normalize to [0, 1] before scaling
       const geoHash = Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng)) / 2;
-      const surgeMultiplier = Math.min(2.5, Math.max(1.2, 1.2 + (geoHash * 1.3))); // clamped to 1.2–2.5
+      const surgeMultiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(MIN_SURGE_MULTIPLIER, MIN_SURGE_MULTIPLIER + (geoHash * SURGE_PEAK_AMPLITUDE))); // clamped to 1.2–2.5
       logger.info(`[TrafficService] Live traffic surge detected at ${pickupLat},${pickupLng}: x${surgeMultiplier.toFixed(2)}`);
       return Number(surgeMultiplier.toFixed(2));
     }


### PR DESCRIPTION
Closes #6416.

Summary of What Has Been Done:
Extracted the hardcoded rush-hour windows and surge multiplier clamps in trafficService into named constants, improving readability without changing behavior.

Changes Made:
- backend/api/src/services/trafficService.js: added named constants for rush hour windows and surge clamp values.

Impact it Made:
Clearer, configurable traffic surge logic. Existing trafficService tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.