### PR TITLE
bug : added fail-closed behavior to apiKey middleware

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -14,8 +14,10 @@ export const requireApiKey = (req, res, next) => {
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);
 
   if (validKeys.length === 0) {
-    // If no keys configured, skip verification to avoid breaking local dev
-    return next();
+    logger.error({ ip: req.ip, path: req.originalUrl }, 'API key auth unavailable: VALID_API_KEYS is not configured');
+    return res.status(503).json({
+      error: 'Service Unavailable: API key authentication is not configured.',
+    });
   }
 
   if (!apiKey || !validKeys.includes(apiKey)) {


### PR DESCRIPTION
Closes #6417.

Summary of What Has Been Done:
Changed requireApiKey so that when no valid API keys are configured it fails closed (503) instead of skipping authentication entirely.

Changes Made:
- backend/api/src/middleware/apiKey.js: reject with a 503 when VALID_API_KEYS is empty/unconfigured.

Impact it Made:
Prevents a misconfiguration from silently exposing an endpoint with no authentication.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.