### PR TITLE
fix : added clearing of circuitBreaker timeout timer

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -46,9 +46,10 @@ export class CircuitBreaker {
       throw new Error(`CircuitBreaker:${this.name} is OPEN`);
     }
 
+    let timer;
     try {
       const timeoutPromise = new Promise((_, reject) => {
-        const timer = setTimeout(() => {
+        timer = setTimeout(() => {
           reject(new Error(`[CircuitBreaker:${this.name}] Request timed out after ${this.requestTimeoutMs}ms`));
         }, this.requestTimeoutMs);
         timer.unref?.();
@@ -59,6 +60,8 @@ export class CircuitBreaker {
       return result;
     } catch (err) {
       return this.onFailure(err, args);
+    } finally {
+      clearTimeout(timer);
     }
   }
 


### PR DESCRIPTION
Closes #6418.

Summary of What Has Been Done:
Cleared the request timeout timer in a finally block so it never fires after the wrapped call has already resolved, avoiding a pending rejection and timer leak.

Changes Made:
- backend/api/src/lib/circuitBreaker.js: hoisted the timer and clearTimeout in finally.

Impact it Made:
Prevents unhandled rejections and timer leaks under normal resolution. circuitBreaker tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.