### PR TITLE
fix : added defensive parsing of HEADER_SIZE_LIMIT in headerSizeMonitor

### DIFF
--- a/backend/api/src/middleware/headerSizeMonitor.js
+++ b/backend/api/src/middleware/headerSizeMonitor.js
@@ -7,7 +7,8 @@ export default function headerSizeMonitor(req, res, next) {
     return next();
   }
 
-  const limit = Number(process.env.HEADER_SIZE_LIMIT || DEFAULT_LIMIT);
+  const configuredLimit = Number(process.env.HEADER_SIZE_LIMIT);
+  const limit = Number.isFinite(configuredLimit) && configuredLimit > 0 ? configuredLimit : DEFAULT_LIMIT;
 
   let totalSize = 0;
 


### PR DESCRIPTION
Closes #6419.

Summary of What Has Been Done:
Hardened the limit parsing in headerSizeMonitor so a non-numeric HEADER_SIZE_LIMIT no longer produces NaN and silently disables monitoring; it falls back to the default.

Changes Made:
- backend/api/src/middleware/headerSizeMonitor.js: use a finite, positive limit or fall back to DEFAULT_LIMIT.

Impact it Made:
Keeps monitoring active even when the env var is malformed. Existing headerSizeMonitor tests pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.