### PR TITLE
fix : added extraction of magic risk thresholds in fraudMiddleware

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -1,6 +1,9 @@
 import fraudDetection from '../services/fraud/FraudDetectionService.js';
 import logger from './logger.js';
 
+const RISK_THRESHOLD_FLAG = 0.7;
+const RISK_THRESHOLD_BLOCK = 0.9;
+
 export const fraudDetectionMiddleware = async (req, res, next) => {
   try {
     const userId = req.user?.id;
@@ -44,7 +47,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
         deviceChanged: req.deviceChanged || false
       });
 
-      if (risk && risk.riskScore > 0.7) {
+      if (risk && risk.riskScore > RISK_THRESHOLD_FLAG) {
         // Flag for review
         await fraudDetection.addToReviewQueue(
           userId,
@@ -53,7 +56,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
         );
 
         // Block high-risk transactions
-        if (risk.riskScore > 0.9) {
+        if (risk.riskScore > RISK_THRESHOLD_BLOCK) {
           return res.status(403).json({
             error: 'Transaction blocked due to suspicious activity',
             riskScore: risk.riskScore,


### PR DESCRIPTION
Closes #6420.

Summary of What Has Been Done:
Extracted the hardcoded risk-score thresholds 0.7 and 0.9 into named constants so risk policy is clearer and easier to tune.

Changes Made:
- backend/api/src/middleware/fraudMiddleware.js: added RISK_THRESHOLD_FLAG and RISK_THRESHOLD_BLOCK.

Impact it Made:
Improves readability and maintainability of the fraud risk policy.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.