### PR TITLE
fix : added extraction of magic literals in UpiPaymentService

### DIFF
--- a/backend/api/src/services/payment/UpiPaymentService.js
+++ b/backend/api/src/services/payment/UpiPaymentService.js
@@ -1,5 +1,13 @@
 import logger from '../../middleware/logger.js';
 
+const PAYOUT_SIMULATED_DELAY_MS = 200;
+const UTR_MIN = 100000000000;
+const UTR_RANGE = 900000000000;
+
+function generateUtr() {
+  return (UTR_MIN + Math.floor(Math.random() * UTR_RANGE)).toString();
+}
+
 class UpiPaymentService {
   constructor() {
     this.gatewayName = process.env.UPI_GATEWAY || 'Razorpay (Mock)';
@@ -21,12 +29,12 @@ class UpiPaymentService {
   async processDriverPayout(driverUpiId, amountPaisa) {
     logger.info(`[UPI Payout] Initiating driver payout via ${this.gatewayName} to ${driverUpiId}, amount: ${amountPaisa} paisa`);
     // Simulate payout API delay
-    await new Promise(resolve => setTimeout(resolve, 200));
+    await new Promise(resolve => setTimeout(resolve, PAYOUT_SIMULATED_DELAY_MS));
 
     return {
       payout_id: `pout_${Math.random().toString(36).substring(2, 15)}`,
       status: 'processed',
-      utr: Math.floor(100000000000 + Math.random() * 900000000000).toString(),
+      utr: generateUtr(),
       processed_at: new Date().toISOString()
     };
   }


### PR DESCRIPTION
Closes #6421.

Summary of What Has Been Done:
Extracted the simulated payout delay and UTR generation literals into named constants and a helper for readability.

Changes Made:
- backend/api/src/services/payment/UpiPaymentService.js: added PAYOUT_SIMULATED_DELAY_MS, UTR_MIN/UTR_RANGE and generateUtr().

Impact it Made:
Clearer mock payout logic and easier tuning of simulation parameters.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.