### PR TITLE
fix : added extraction of magic literals in weighStationService

### DIFF
--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -4,15 +4,19 @@
  * to check carrier credentials and safety scores against the specific weigh station.
  */
 
+const SIMULATED_NETWORK_DELAY_MS = 800;
+const PULL_IN_PROBABILITY = 0.2;
+const STATION_ID_RANGE = 1000;
+
 const checkBypassEligibility = async (driverId, lat, lng) => {
   // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 800));
+  await new Promise(resolve => setTimeout(resolve, SIMULATED_NETWORK_DELAY_MS));
 
   // Determine bypass (80% chance) vs pull in (20% chance)
-  const isBypass = Math.random() > 0.2;
+  const isBypass = Math.random() > PULL_IN_PROBABILITY;
   
   // Randomly assign an ID for the station for logging
-  const stationId = 'WS-' + Math.floor(Math.random() * 1000);
+  const stationId = 'WS-' + Math.floor(Math.random() * STATION_ID_RANGE);
 
   return {
     action: isBypass ? 'BYPASS' : 'PULL_IN',


### PR DESCRIPTION
Closes #6422.

Summary of What Has Been Done:
Extracted the hardcoded network delay, pull-in probability and station ID range into named constants for readability.

Changes Made:
- backend/api/src/services/weighStationService.js: added SIMULATED_NETWORK_DELAY_MS, PULL_IN_PROBABILITY, STATION_ID_RANGE.

Impact it Made:
No behavior change; weighStationService tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.