### PR TITLE
refactor : added named constants for reputation RPC timeouts

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -98,6 +98,8 @@ initReputationContract();
  */
 const REPUTATION_RETRY_MAX = 3;
 const REPUTATION_RETRY_DELAY_MS = 2000;
+const REPUTATION_RPC_TIMEOUT_MS = 5000;
+const REPUTATION_TX_CONFIRM_TIMEOUT_MS = 60000;
 
 async function retryWithBackoff(fn, maxRetries, baseDelayMs) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -133,7 +135,7 @@ export async function awardReputationPoints(driverWalletAddress, stars) {
     logger.info(`[reputation] increaseReputation tx submitted: ${tx.hash}`);
     await retryWithBackoff(async () => {
       const provider = reputationContract.provider || reputationContract.runner?.provider;
-      const receipt = provider ? await provider.waitForTransaction(tx.hash, 1, 60_000) : await tx?.wait?.(1);
+      const receipt = provider ? await provider.waitForTransaction(tx.hash, 1, REPUTATION_TX_CONFIRM_TIMEOUT_MS) : await tx?.wait?.(1);
       if (!receipt || receipt.status === 0) {
         throw new Error(`increaseReputation transaction ${tx.hash} reverted or was not found on chain.`);
       }
@@ -167,7 +169,7 @@ export async function getDriverReputation(walletAddress) {
     const score = await Promise.race([
       reputationContract.getReputation(walletAddress),
       new Promise((_, reject) => {
-        timeoutId = setTimeout(() => reject(new Error('RPC timeout')), 5000);
+        timeoutId = setTimeout(() => reject(new Error('RPC timeout')), REPUTATION_RPC_TIMEOUT_MS);
       }),
     ]);
     clearTimeout(timeoutId);


### PR DESCRIPTION
Closes #6423.

Summary of What Has Been Done:
Lifted the hardcoded 5s RPC timeout and 60s transaction-confirmation wait into named constants next to the existing retry constants.

Changes Made:
- backend/api/src/services/reputation.js: added REPUTATION_RPC_TIMEOUT_MS and REPUTATION_TX_CONFIRM_TIMEOUT_MS.

Impact it Made:
No behavior change; reputation tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.