### PR TITLE
refactor : added removal of dead clamp helper in pricing

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -17,11 +17,6 @@
 
 import logger from '../middleware/logger.js';
 
-function clamp(value, min, max) {
-  if (typeof value !== 'number' || isNaN(value)) return min || 0;
-  return Math.max(min || 0, Math.min(max || Infinity, value));
-}
-
 function sanitizePrice(value) {
   const num = Number(value);
   return Number.isFinite(num) && num >= 0 ? Math.round(num) : 0;


### PR DESCRIPTION
Closes #6425.

Summary of What Has Been Done:
Removed the unused clamp helper from pricing.js, which had no call sites and a subtly incorrect falsy-min fallback.

Changes Made:
- backend/api/src/lib/pricing.js: deleted the dead clamp function.

Impact it Made:
Removes dead code and potential confusion. pricing tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.