### PR TITLE
fix : added logging of malformed lookup cache payload

### DIFF
--- a/backend/api/src/routes/lookupRoutes.js
+++ b/backend/api/src/routes/lookupRoutes.js
@@ -47,8 +47,8 @@ async function getCachedOrFetch(key, fetchFn) {
               setL1(key, data, now + L1_TTL_MS);
               return data;
             }
-          } catch {
-            // fall through to fetch on malformed cached payload
+          } catch (err) {
+            logger.warn({ err, key }, 'Malformed cached payload in lookupRoutes; refetching from source');
           }
         }
       } catch (err) {


### PR DESCRIPTION
Closes #6426.

Summary of What Has Been Done:
Logged a warning when a cached payload in lookupRoutes fails JSON.parse, instead of silently dropping it and refetching.

Changes Made:
- backend/api/src/routes/lookupRoutes.js: added a logger.warn with the error and cache key.

Impact it Made:
Surfaces corrupt cache entries for diagnosis.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.