### PR TITLE
fix : added logging of malformed idempotency cached payload

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -53,7 +53,8 @@ function cacheKey(req, idempotencyKey) {
 function readAndParse(str) {
   try {
     return JSON.parse(str);
-  } catch {
+  } catch (err) {
+    logger.warn({ err }, 'Malformed idempotency cached payload');
     return null;
   }
 }


### PR DESCRIPTION
Closes #6427.

Summary of What Has Been Done:
Added a warning log in readAndParse so a corrupted idempotency cached payload is surfaced instead of silently returning null.

Changes Made:
- backend/api/src/middleware/idempotency.js: log parse failures.

Impact it Made:
Makes corrupted idempotency entries diagnosable. idempotency tests still pass.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.