### PR TITLE
fix : added range validation to iot telemetry schema

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -11,7 +11,7 @@ import { z } from 'zod';
 const router = express.Router();
 
 const telemetrySchema = z.object({
-  temperature: z.number()
+  temperature: z.number().finite().min(-100).max(200)
 });
 const telemetryHistoryLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,


### PR DESCRIPTION
Closes #6429.

Summary of What Has Been Done:
Hardened the telemetry schema to require a finite temperature within a sane range (-100..200) instead of accepting any number.

Changes Made:
- backend/api/src/routes/iotRoutes.js: z.number().finite().min(-100).max(200).

Impact it Made:
Prevents invalid telemetry values from being recorded for cold-chain loads.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.