### PR TITLE
fix : added logging of subscriber.quit failure in CachePublisher

### DIFF
--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -240,7 +240,8 @@ export async function closeCachePublisher() {
   if (subscriber) {
     try {
       await subscriber.quit();
-    } catch {
+    } catch (err) {
+      logger.warn({ err }, '[CachePublisher] subscriber.quit failed, falling back to disconnect');
       subscriber.disconnect();
     }
     subscriber = null;


### PR DESCRIPTION
Closes #6430.

Summary of What Has Been Done:
Logged the error when subscriber.quit() fails during cache publisher shutdown before falling back to disconnect().

Changes Made:
- backend/api/src/cache/CachePublisher.js: added logger.warn in the quit catch.

Impact it Made:
Shutdown failures are now diagnosable.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.