### PR TITLE
test : added unit tests for apiResponse util

### DIFF
--- a/backend/api/test/unit/apiResponse.test.js
+++ b/backend/api/test/unit/apiResponse.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { errorResponse } from '../../src/utils/apiResponse.js'
+
+describe('errorResponse', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development'
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('returns a non-success response with code and message', () => {
+    const res = errorResponse(400, 'Bad Request')
+    expect(res.success).toBe(false)
+    expect(res.error.code).toBe(400)
+    expect(res.error.message).toBe('Bad Request')
+  })
+
+  it('includes details when not in production', () => {
+    const res = errorResponse(400, 'Bad Request', { field: 'name' })
+    expect(res.error.details).toEqual({ field: 'name' })
+  })
+
+  it('omits details in production', () => {
+    process.env.NODE_ENV = 'production'
+    const res = errorResponse(500, 'Server Error', { field: 'x' })
+    expect(res.error.details).toBeUndefined()
+  })
+
+  it('does not add a details key when details is undefined', () => {
+    const res = errorResponse(404, 'Not Found')
+    expect('details' in res.error).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #6431.

Summary of What Has Been Done:
Added vitest coverage for the apiResponse errorResponse helper, including production mode details handling.

Changes Made:
- backend/api/test/unit/apiResponse.test.js: new test file covering code/message/details behavior.

Impact it Made:
Documents and guards the API error response shape.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.