### PR TITLE
test : added unit tests for PriceLog model

### DIFF
--- a/backend/api/test/unit/PriceLog.test.js
+++ b/backend/api/test/unit/PriceLog.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { PriceLog } from '../../src/models/PriceLog.js'
+
+describe('PriceLog model', () => {
+  it('accepts a valid price log document', async () => {
+    const doc = new PriceLog({
+      order_id: 'order-1',
+      predicted_price: 1000,
+      accepted_price: 1100,
+      distance_km: 45.5,
+      weight_tonnes: 3.2,
+    })
+    await expect(doc.validate()).resolves.toBeUndefined()
+  })
+
+  it('requires order_id and both prices', async () => {
+    const doc = new PriceLog({ order_id: 'order-1' })
+    await expect(doc.validate()).rejects.toThrow(/predicted_price|accepted_price/)
+  })
+
+  it('defaults created_at to the current date', () => {
+    const doc = new PriceLog({
+      order_id: 'order-1',
+      predicted_price: 100,
+      accepted_price: 100,
+    })
+    expect(doc.created_at).toBeInstanceOf(Date)
+  })
+})


### PR DESCRIPTION
Closes #6435.

Summary of What Has Been Done:
Added vitest coverage for the PriceLog mongoose model, verifying required fields and defaults.

Changes Made:
- backend/api/test/unit/PriceLog.test.js: new test file.

Impact it Made:
Documents and guards the price log schema.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.