### PR TITLE
fix(otp): delivery-OTP lifecycle on service role; cancel-guard via user client (#6326)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -486,8 +486,8 @@ export class OrderRepository {
   // DELIVERY OTPS
   // ===================================================================
 
-  async findVerifiedDeliveryOtp(orderId) {
-    return this._retryableQuery(() => this.supabase
+  async findVerifiedDeliveryOtp(orderId, client) {
+    return this._retryableQuery(() => (client ?? this.supabase)
       .from('delivery_otps')
       .select('id')
       .eq('order_id', orderId)

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1403,7 +1403,12 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
  */
 router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cancel'), auditLog({ action: 'order:cancel', resourceType: 'order' }), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(cancelOrderSchema), async (req, res) => {
   try {
-    const result = await orderLifecycleService.cancelOrder(req.params.id, req.user.id, req.body.reason);
+    const result = await orderLifecycleService.cancelOrder(
+      req.params.id,
+      req.user.id,
+      req.body.reason,
+      req.token ? createUserClient(req.token) : undefined
+    );
     return res.status(result.status).json(result.body);
   } catch (err) {
     if (err instanceof DomainError) {

--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -1,4 +1,4 @@
-import { supabase, firebaseAdmin } from '../config/db.js';
+import { supabase, supabaseAdmin, firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import crypto from 'crypto';
 import { measureExecution } from '../core/performanceMetrics.js';
@@ -166,10 +166,14 @@ export function verifyDeliveryOtpHash(otp, otpRecord) {
 
 export async function storeDeliveryOtp(orderId, otp, ttlMinutes = 15) {
   return measureExecution('NotificationService.storeDeliveryOtp', async () => {
+    if (!supabaseAdmin) {
+      logger.error('[NotificationService] Service-role client not configured — cannot store OTP.');
+      return null;
+    }
     const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
     const { hash: otpHash, salt: otpSalt } = hashDeliveryOtp(otp);
 
-    const { data, error } = await supabase
+    const { data, error } = await supabaseAdmin
       .from('delivery_otps')
       .insert({
         order_id: orderId,
@@ -193,7 +197,11 @@ export async function storeDeliveryOtp(orderId, otp, ttlMinutes = 15) {
 
 export async function getActiveDeliveryOtp(orderId) {
   return measureExecution('NotificationService.getActiveDeliveryOtp', async () => {
-    const { data, error } = await supabase
+    if (!supabaseAdmin) {
+      logger.error('[NotificationService] Service-role client not configured — cannot read OTP.');
+      return null;
+    }
+    const { data, error } = await supabaseAdmin
       .from('delivery_otps')
       .select('id, otp_hash, otp_salt, expires_at')
       .eq('order_id', orderId)
@@ -218,7 +226,11 @@ export async function verifyDeliveryOtp(otpId) {
     // unverified OTPs for an order. This ensures only the matched OTP
     // (which was validated by the caller via timing-safe hash comparison)
     // is consumed, preventing any future caller from bypassing verification.
-    const { data, error } = await supabase
+    if (!supabaseAdmin) {
+      logger.error('[NotificationService] Service-role client not configured — cannot verify OTP.');
+      return false;
+    }
+    const { data, error } = await supabaseAdmin
       .from('delivery_otps')
       .update({
         verified: true,
@@ -245,7 +257,11 @@ export async function verifyDeliveryOtp(otpId) {
 
 export async function expireDeliveryOtps(orderId) {
   return measureExecution('NotificationService.expireDeliveryOtps', async () => {
-    const { error } = await supabase
+    if (!supabaseAdmin) {
+      logger.error('[NotificationService] Service-role client not configured — cannot expire OTPs.');
+      return;
+    }
+    const { error } = await supabaseAdmin
       .from('delivery_otps')
       .update({ expires_at: new Date().toISOString() })
       .eq('order_id', orderId)

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -636,7 +636,7 @@ export class OrderLifecycleService {
     });
   }
 
-  async cancelOrder(orderId, customerId, reason) {
+  async cancelOrder(orderId, customerId, reason, userClient) {
     return measureExecution('OrderLifecycleService.cancelOrder', async () => {
       const { data: order, error: orderErr } = await this.orderRepository.findOrderByAnyId(orderId, '*');
       if (orderErr) throw new DomainError(500, { error: 'Failed to fetch order.', details: orderErr.message });
@@ -655,7 +655,11 @@ export class OrderLifecycleService {
         if (currentOrderErr) throw new DomainError(500, { error: 'Failed to fetch order.', details: currentOrderErr.message });
         if (!currentOrder) throw new DomainError(404, { error: 'Order not found.' });
 
-        const { data: otpCheck } = await this.orderRepository.findVerifiedDeliveryOtp(currentOrder.id);
+        // Runs under the caller's identity so RLS resolves get_profile_id() to
+        // the customer; the shared anon-key client always returns null here
+        // (drivers cannot read delivery_otps, and unauthenticated RLS yields
+        // no rows), which would silently disable the guard below.
+        const { data: otpCheck } = await this.orderRepository.findVerifiedDeliveryOtp(currentOrder.id, userClient);
         if (otpCheck) {
           throw new DomainError(409, { error: 'Cannot cancel: delivery OTP has already been verified.' });
         }

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -6,6 +6,12 @@ const supabaseInsertMock = vi.fn().mockResolvedValue({ error: null });
 const supabaseSelectMock = vi.fn();
 const firebaseSendMock = vi.fn();
 
+// Service-role (delivery_otps) mocks — delivery_otps is service-role-write, so
+// all OTP lifecycle calls must flow through supabaseAdmin, never the anon key.
+const adminDeliveryOtpInsertMock = vi.fn().mockResolvedValue({ data: { id: 'otp-uuid-1' }, error: null });
+const adminDeliveryOtpSelectMock = vi.fn().mockResolvedValue({ data: null, error: null });
+const adminDeliveryOtpUpdateMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
 vi.mock('../../src/config/db.js', () => ({
   supabase: {
     from: table => {
@@ -41,6 +47,54 @@ vi.mock('../../src/config/db.js', () => ({
       }
     }
   },
+  supabaseAdmin: {
+    from: table => {
+      if (table === 'delivery_otps') {
+        return {
+          insert: data => ({
+            select: fields => ({
+              single: () => adminDeliveryOtpInsertMock(table, data, fields)
+            })
+          }),
+          select: fields => ({
+            eq: (col, val) => ({
+              eq: (col2, val2) => ({
+                gte: (col3, val3) => ({
+                  order: (col4, opts) => ({
+                    limit: n => ({
+                      maybeSingle: () => adminDeliveryOtpSelectMock(table, fields, col, val, col2, val2, col3, val3, col4, opts, n)
+                    })
+                  })
+                })
+              })
+            })
+          }),
+          update: data => ({
+            eq: (col, val) => ({
+              eq: (col2, val2) => {
+                // Thenable so the no-.select path (expireDeliveryOtps) can be
+                // awaited directly, while verifyDeliveryOtp can keep chaining.
+                const tail = {
+                  select: fields => ({
+                    maybeSingle: () => adminDeliveryOtpUpdateMock(table, data, col, val, col2, val2, fields)
+                  })
+                };
+                tail.then = resolve => {
+                  adminDeliveryOtpUpdateMock(table, data, col, val, col2, val2, null);
+                  resolve({ error: null });
+                };
+                return tail;
+              },
+              select: fields => ({
+                maybeSingle: () => adminDeliveryOtpUpdateMock(table, data, col, val, null, null, fields)
+              })
+            })
+          })
+        };
+      }
+      return {};
+    }
+  },
   firebaseAdmin: {
     messaging: () => ({
       send: firebaseSendMock
@@ -52,7 +106,10 @@ const {
   sendDeliveryOtpNotification,
   sendPushNotification,
   sendFcmNotification,
+  storeDeliveryOtp,
+  getActiveDeliveryOtp,
   verifyDeliveryOtp,
+  expireDeliveryOtps,
   hashDeliveryOtp,
   verifyDeliveryOtpHash
 } = await import('../../src/services/notificationService.js');
@@ -129,8 +186,8 @@ describe('notificationService', () => {
   });
 
   describe('verifyDeliveryOtp', () => {
-    it('marks a specific OTP record as verified by ID', async () => {
-      supabaseUpdateMock.mockResolvedValue({
+    it('marks a specific OTP record as verified by ID via the service-role client', async () => {
+      adminDeliveryOtpUpdateMock.mockResolvedValue({
         data: { id: 'otp-uuid-123' },
         error: null
       });
@@ -138,9 +195,9 @@ describe('notificationService', () => {
       const result = await verifyDeliveryOtp('otp-uuid-123');
 
       expect(result).toBe(true);
-      expect(supabaseUpdateMock).toHaveBeenCalledOnce();
+      expect(adminDeliveryOtpUpdateMock).toHaveBeenCalledOnce();
 
-      const [table, data, col, val] = supabaseUpdateMock.mock.calls[0];
+      const [table, data, col, val] = adminDeliveryOtpUpdateMock.mock.calls[0];
       expect(table).toBe('delivery_otps');
       expect(data.verified).toBe(true);
       expect(data.verified_at).toBeDefined();
@@ -149,7 +206,7 @@ describe('notificationService', () => {
     });
 
     it('returns false when Supabase update fails', async () => {
-      supabaseUpdateMock.mockResolvedValue({
+      adminDeliveryOtpUpdateMock.mockResolvedValue({
         data: null,
         error: { message: 'DB error' }
       });
@@ -159,13 +216,67 @@ describe('notificationService', () => {
     });
 
     it('returns false when no OTP record is found or already verified', async () => {
-      supabaseUpdateMock.mockResolvedValue({
+      adminDeliveryOtpUpdateMock.mockResolvedValue({
         data: null,
         error: null
       });
 
       const result = await verifyDeliveryOtp('nonexistent-otp-id');
       expect(result).toBe(false);
+    });
+  });
+
+  describe('delivery OTP lifecycle (service-role writes, issue #6326)', () => {
+    it('stores, reads, and consumes an OTP row end-to-end through the service-role client', async () => {
+      adminDeliveryOtpInsertMock.mockResolvedValue({
+        data: { id: 'otp-uuid-endtoend' },
+        error: null
+      });
+      adminDeliveryOtpSelectMock.mockResolvedValue({
+        data: { id: 'otp-uuid-endtoend', otp_hash: 'a'.repeat(128), otp_salt: 'b'.repeat(32), expires_at: '2099-01-01T00:00:00.000Z' },
+        error: null
+      });
+      adminDeliveryOtpUpdateMock.mockResolvedValue({
+        data: { id: 'otp-uuid-endtoend' },
+        error: null
+      });
+
+      const stored = await storeDeliveryOtp('order-uuid-1', '654321', 15);
+      expect(stored).toEqual({ id: 'otp-uuid-endtoend' });
+      expect(adminDeliveryOtpInsertMock).toHaveBeenCalledOnce();
+      const insertArgs = adminDeliveryOtpInsertMock.mock.calls[0][1];
+      expect(insertArgs.order_id).toBe('order-uuid-1');
+      expect(insertArgs.otp_hash).toMatch(/^[a-f0-9]{128}$/);
+      expect(insertArgs.otp_salt).toMatch(/^[a-f0-9]{32}$/);
+      expect(insertArgs.verified).toBe(false);
+      // The raw OTP is never persisted — only the salted digest.
+      expect(JSON.stringify(insertArgs)).not.toContain('654321');
+
+      const active = await getActiveDeliveryOtp('order-uuid-1');
+      expect(active?.id).toBe('otp-uuid-endtoend');
+      expect(adminDeliveryOtpSelectMock).toHaveBeenCalledOnce();
+      const [table, fields, col, val] = adminDeliveryOtpSelectMock.mock.calls[0];
+      expect(table).toBe('delivery_otps');
+      expect(col).toBe('order_id');
+      expect(val).toBe('order-uuid-1');
+
+      const consumed = await verifyDeliveryOtp('otp-uuid-endtoend');
+      expect(consumed).toBe(true);
+      expect(adminDeliveryOtpUpdateMock).toHaveBeenCalledOnce();
+      const [, updateData, upCol, upVal] = adminDeliveryOtpUpdateMock.mock.calls[0];
+      expect(updateData.verified).toBe(true);
+      expect(upCol).toBe('id');
+      expect(upVal).toBe('otp-uuid-endtoend');
+    });
+
+    it('expires unverified OTPs for an order via the service-role client', async () => {
+      await expireDeliveryOtps('order-uuid-2');
+      expect(adminDeliveryOtpUpdateMock).toHaveBeenCalledOnce();
+      const [table, data, col, val] = adminDeliveryOtpUpdateMock.mock.calls[0];
+      expect(table).toBe('delivery_otps');
+      expect(data.expires_at).toBeDefined();
+      expect(col).toBe('order_id');
+      expect(val).toBe('order-uuid-2');
     });
   });
 


### PR DESCRIPTION
## Problem

Issue #6326 — The delivery-OTP lifecycle in `backend/api/src/services/notificationService.js` ran entirely on the shared anon-keyed Supabase client. But `delivery_otps` RLS grants `INSERT`/`UPDATE` only to `service_role`, `SELECT` only to the order's customer (drivers explicitly denied), and `revoke_anon_privileges.sql` revokes all anon privileges on the table.

Consequences:
- `storeDeliveryOtp` failed → OTP generation for the "In Transit" milestone failed.
- `getActiveDeliveryOtp` returned null → delivery verification threw `OTP not available or has expired`.
- `findVerifiedDeliveryOtp` (the **cannot cancel after OTP verified** guard) ran on the anon client and always returned null — the guard could never fire, opening a refund-after-delivery window during the `complete_trip_tx` commit window.

## Fix

- **`notificationService.js`**: `storeDeliveryOtp`, `getActiveDeliveryOtp`, `verifyDeliveryOtp`, and `expireDeliveryOtps` now run through `supabaseAdmin` (service role), with null-guards when the service key is not configured.
- **`orderRepository.js`**: `findVerifiedDeliveryOtp(orderId, client)` accepts an optional client so the cancel-guard can run under the caller's identity.
- **`orderLifecycleService.js`**: `cancelOrder` accepts a `userClient` and passes it to the guard read, so RLS resolves `get_profile_id()` to the customer instead of the anon identity.
- **`orderRoutes.js`**: the `POST /:id/cancel` route passes `createUserClient(req.token)` — matching the `executeRpc(..., userClient)` pattern used in `deliveryVerificationService.js`.
- **Regression test**: added an end-to-end test asserting an OTP row is created, read, and consumed through the service-role client (store → get → verify → expire), including that only the salted digest is persisted.

## Files changed

- `backend/api/src/services/notificationService.js`
- `backend/api/src/repositories/orderRepository.js`
- `backend/api/src/services/order/orderLifecycleService.js`
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/unit/notificationService.test.js`

## Testing

- `npx vitest run test/unit/notificationService.test.js` — 15/15 pass.
- `npx eslint --max-warnings=0` passes on all changed files except a pre-existing duplicate-`const order` parse error in `orderRoutes.js:1163` (present on `main`, unrelated to this issue).

Closes #6326
