### PR TITLE
fix(driver): restore valid syntax in delivery_otp_screen _confirmOtp (#6327)

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -175,26 +175,26 @@ class _DeliveryOtpScreenState extends State<DeliveryOtpScreen>
 
     try {
       final body = await _apiClient.post(
-        final body = await _apiClient.post(
-  '/api/orders/${widget.orderId}/confirm-otp',
-  body: {'otp': _otp},
-);
+        '/api/orders/${widget.orderId}/confirm-otp',
+        body: {'otp': _otp},
+      );
 
-final amount = body is Map ? (body['amount_inr'] as String?) : null;
-final reconciliationRequired = body is Map && body['reconciliation_required'] == true;
+      final amount = body is Map ? (body['amount_inr'] as String?) : null;
+      final reconciliationRequired =
+          body is Map && body['reconciliation_required'] == true;
 
-if (reconciliationRequired) {
-  if (mounted) {
-    setState(() {
-      _errorMessage =
-          'Delivery confirmed! Your payout of ₹${amount ?? widget.amountInr ?? '...'} '
-          'is pending reconciliation and will be credited shortly.';
-    });
-  }
-  return;
-}
+      if (reconciliationRequired) {
+        if (mounted) {
+          setState(() {
+            _errorMessage =
+                'Delivery confirmed! Your payout of ₹${amount ?? widget.amountInr ?? '...'} '
+                'is pending reconciliation and will be credited shortly.';
+          });
+        }
+        return;
+      }
 
-await _showPaymentReleased(amount ?? widget.amountInr);
+      await _showPaymentReleased(amount ?? widget.amountInr);
     } catch (e) {
       final msg = e.toString().replaceAll('Exception: ', '');
       setState(() => _errorMessage = msg);


### PR DESCRIPTION
## Problem

Issue #6327 — `apps/driver/lib/screens/delivery_otp_screen.dart:177-181` contained a nested duplicate statement:

```dart
final body = await _apiClient.post(
  final body = await _apiClient.post(
'/api/orders/${widget.orderId}/confirm-otp',
body: {'otp': _otp},
);
```

The second `final body = await _apiClient.post(` was inserted inside the first call's argument list with a malformed continuation (lines 179-181). This is invalid Dart, so the file failed to parse and the entire driver app could not compile — every other flow was unreachable.

## Fix

- Deleted the duplicated `final body = await _apiClient.post(` line.
- Restored correct indentation of the `_confirmOtp` body (the post call, amount/reconciliation parsing, and the payout branch are now inside the `try` block).
- Behavior is unchanged: `_confirmOtp` posts `{otp: _otp}` to `/api/orders/{orderId}/confirm-otp`, exactly matching the working `_geofenceConfirm` pattern.
- CI already runs `flutter analyze` in `.github/workflows/flutter_ci.yml` for `apps/driver`, so this class of compile-breaking edit is now caught on PRs.

## Files changed

- `apps/driver/lib/screens/delivery_otp_screen.dart`

## Testing

- The `_confirmOtp` body now matches the parseable `_geofenceConfirm` structure (same file, lines 218-240).
- CI gate: `.github/workflows/flutter_ci.yml` runs `flutter analyze` + `flutter test` for `apps/driver` on every PR. (Dart/Flutter is not installed in the local environment, so it is validated by CI.)

Closes #6327
