### PR TITLE
fix(ebpf): require auth + ebpf:manage policy for load/unload routes (#6328)

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -104,6 +104,8 @@ const POLICIES = {
 
   'liquibase:migrate':         { roles: [ROLES.ADMIN] },
   'liquibase:rollback':        { roles: [ROLES.ADMIN] },
+
+  'ebpf:manage':               { roles: [ROLES.ADMIN] },
 };
 
 export class PolicyEngine {

--- a/ebpf/routes.js
+++ b/ebpf/routes.js
@@ -3,6 +3,8 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import rateLimit from 'express-rate-limit';
 import logger from '../backend/api/src/middleware/logger.js';
+import { authenticate } from '../backend/api/src/middleware/auth.js';
+import { requirePolicy } from '../backend/api/src/middleware/requirePolicy.js';
 
 const execAsync = promisify(exec);
 const router = express.Router();
@@ -182,8 +184,8 @@ router.get('/ebpf/profile', ebpfMetricsLimiter, async (req, res) => {
 
 // ============ eBPF Load/Unload with Rate Limiting ============
 
-// Load eBPF programs (with rate limiting)
-router.post('/ebpf/load', ebpfActionLimiter, async (req, res) => {
+// Load eBPF programs (admin only, with rate limiting)
+router.post('/ebpf/load', authenticate, requirePolicy('ebpf:manage'), ebpfActionLimiter, async (req, res) => {
     try {
         // Validate request
         const { program } = req.body;
@@ -217,8 +219,8 @@ router.post('/ebpf/load', ebpfActionLimiter, async (req, res) => {
     }
 });
 
-// Unload eBPF programs (with rate limiting)
-router.post('/ebpf/unload', ebpfActionLimiter, async (req, res) => {
+// Unload eBPF programs (admin only, with rate limiting)
+router.post('/ebpf/unload', authenticate, requirePolicy('ebpf:manage'), ebpfActionLimiter, async (req, res) => {
     try {
         // Validate request
         const { program } = req.body;
@@ -252,8 +254,8 @@ router.post('/ebpf/unload', ebpfActionLimiter, async (req, res) => {
     }
 });
 
-// Unload all eBPF programs (with rate limiting)
-router.post('/ebpf/unload-all', ebpfActionLimiter, async (req, res) => {
+// Unload all eBPF programs (admin only, with rate limiting)
+router.post('/ebpf/unload-all', authenticate, requirePolicy('ebpf:manage'), ebpfActionLimiter, async (req, res) => {
     try {
         await execAsync('sudo rm -f /sys/fs/bpf/truxify_*');
         


### PR DESCRIPTION
## Problem

Issue #6328 — `backend/api/src/index.js:530` mounted `ebpfRoutes` at the public `/api` path with only a rate limiter (`5 req / 15 min`) and no `authenticate` / `requirePolicy`. The handlers execute privileged host commands:

- `POST /ebpf/load` — `sudo bpftool prog load ...`
- `POST /ebpf/unload` — `sudo rm -f /sys/fs/bpf/truxify_${program}`
- `POST /ebpf/unload-all` — `sudo rm -f /sys/fs/bpf/truxify_*`

Any anonymous internet user could trigger `sudo` execution on the host and delete **all** eBPF security-monitoring programs (defense evasion / host DoS).

## Fix

- Registered a new admin-only policy `ebpf:manage` in `policyEngine.js` (`{ roles: [admin] }`).
- Added `authenticate` + `requirePolicy('ebpf:manage')` to the three privileged routes in `ebpf/routes.js`, matching the existing `liquibase:migrate` / `liquibase:rollback` pattern.
- The read-only `/ebpf/metrics|syscalls|network|security|profile` endpoints return static placeholder data and are left public (unchanged behavior).

## Files changed

- `backend/api/src/security/policyEngine.js`
- `ebpf/routes.js`

## Testing

- `node --check` passes on both changed files.
- `npx eslint --max-warnings=0` passes on `policyEngine.js` (the root `ebpf/` tree is outside the `backend/api` eslint scope, as it already was).
- Unauthenticated requests now receive `401` from `authenticate`; non-admin authenticated users receive `403` from `requirePolicy`.

Closes #6328
