### PR TITLE
test : added unit tests for EventSubscriber

### DIFF
--- a/backend/api/test/unit/EventSubscriber.test.js
+++ b/backend/api/test/unit/EventSubscriber.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventSubscriber } from '../../src/core/events/EventSubscriber.js'
+
+describe('EventSubscriber', () => {
+  it('subscribe throws until implemented by an adapter', async () => {
+    const subscriber = new EventSubscriber()
+    await expect(subscriber.subscribe('x', vi.fn())).rejects.toThrow(/must be implemented/)
+  })
+
+  it('unsubscribe throws until implemented by an adapter', async () => {
+    const subscriber = new EventSubscriber()
+    await expect(subscriber.unsubscribe('x', vi.fn())).rejects.toThrow(/must be implemented/)
+  })
+
+  it('has the default connection state', () => {
+    const subscriber = new EventSubscriber()
+    expect(subscriber.isConnected).toBe(false)
+  })
+
+  it('subscribeAll subscribes each handler', async () => {
+    const subscribed = []
+    class FakeSubscriber extends EventSubscriber {
+      async subscribe(eventType) {
+        subscribed.push(eventType)
+      }
+    }
+    await new FakeSubscriber().subscribeAll({ a: vi.fn(), b: vi.fn() })
+    expect(subscribed).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
Closes #6444.

Summary of What Has Been Done:
Added vitest coverage for the EventSubscriber base interface, including subscribeAll behavior.

Changes Made:
- backend/api/test/unit/EventSubscriber.test.js: new test file.

Impact it Made:
Documents the subscriber adapter contract.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.