### PR TITLE
test : added unit tests for LocalEventEmitterAdapter

### DIFF
--- a/backend/api/test/unit/LocalEventEmitterAdapter.test.js
+++ b/backend/api/test/unit/LocalEventEmitterAdapter.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { LocalEventEmitterAdapter } from '../../src/core/events/adapters/LocalEventEmitterAdapter.js'
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+describe('LocalEventEmitterAdapter', () => {
+  it('publishes an event through the event bus', async () => {
+    const emitSafe = vi.fn()
+    const adapter = new LocalEventEmitterAdapter({ emitSafe })
+    await adapter.publish({ eventType: 'order.created' })
+    expect(emitSafe).toHaveBeenCalledWith('order.created', { eventType: 'order.created' })
+  })
+
+  it('rethrows when the event bus publish fails', async () => {
+    const emitSafe = vi.fn(() => { throw new Error('bus fail') })
+    const adapter = new LocalEventEmitterAdapter({ emitSafe })
+    await expect(adapter.publish({ eventType: 'x' })).rejects.toThrow('bus fail')
+  })
+})


### PR DESCRIPTION
Closes #6445.

Summary of What Has Been Done:
Added vitest coverage for LocalEventEmitterAdapter verifying it publishes through the event bus and rethrows on failures.

Changes Made:
- backend/api/test/unit/LocalEventEmitterAdapter.test.js: new test file.

Impact it Made:
Guards the local event adapter contract.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.