### PR TITLE
test : added unit tests for order domainError

### DIFF
--- a/backend/api/test/unit/domainError.test.js
+++ b/backend/api/test/unit/domainError.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { DomainError } from '../../src/services/order/domainError.js'
+
+describe('DomainError', () => {
+  it('carries status and payload', () => {
+    const err = new DomainError(400, { error: 'invalid order' })
+    expect(err.status).toBe(400)
+    expect(err.payload).toEqual({ error: 'invalid order' })
+    expect(err.name).toBe('DomainError')
+    expect(err.message).toBe('invalid order')
+  })
+
+  it('derives the message from payload.message when error is absent', () => {
+    const err = new DomainError(403, { message: 'forbidden' })
+    expect(err.message).toBe('forbidden')
+  })
+
+  it('falls back to a default message', () => {
+    const err = new DomainError(500, {})
+    expect(err.message).toBe('Domain Error')
+  })
+})


### PR DESCRIPTION
Closes #6446.

Summary of What Has Been Done:
Added vitest coverage for the order DomainError class verifying status, payload and message derivation.

Changes Made:
- backend/api/test/unit/domainError.test.js: new test file.

Impact it Made:
Locks in the domain error shape used by order routes.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.