### PR TITLE
test : added unit tests for rootController

### DIFF
--- a/backend/api/test/unit/rootController.test.js
+++ b/backend/api/test/unit/rootController.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getRoot, notFound } from '../../src/controllers/rootController.js'
+
+describe('rootController', () => {
+  it('getRoot returns an HTML status page including the websocket URL', () => {
+    const res = { send: vi.fn() }
+    getRoot({ hostname: 'api.example.com' }, res)
+    expect(res.send).toHaveBeenCalledWith(expect.stringContaining('ws://api.example.com'))
+  })
+
+  it('getRoot defaults the port from the PORT environment variable', () => {
+    const original = process.env.PORT
+    process.env.PORT = '8080'
+    const res = { send: vi.fn() }
+    getRoot({ hostname: 'localhost' }, res)
+    expect(res.send).toHaveBeenCalledWith(expect.stringContaining(':8080/ws/tracking'))
+    if (original === undefined) delete process.env.PORT
+    else process.env.PORT = original
+  })
+
+  it('notFound returns a 404 JSON error', () => {
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    }
+    notFound({}, res)
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Endpoint resource not found.' })
+  })
+})


### PR DESCRIPTION
Closes #6450.

Summary of What Has Been Done:
Added vitest coverage for the root controller covering the status HTML page and the 404 not-found handler.

Changes Made:
- backend/api/test/unit/rootController.test.js: new test file.

Impact it Made:
Guards basic API root behavior.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.