### PR TITLE
fix(wasm): remove trivially bypassable /wasm/otp validator (#6331)

### DIFF
--- a/backend/api/test/unit/wasmOtpRoutes.test.js
+++ b/backend/api/test/unit/wasmOtpRoutes.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import wasmRoutes from '../../../../wasm/routes.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', wasmRoutes);
+  return app;
+}
+
+describe('POST /api/wasm/otp (issue #6331)', () => {
+  it('cannot be used to validate an OTP with a client-controlled reference value', async () => {
+    const app = buildApp();
+
+    // The route used to accept inputOTP + correctOTP from the request body
+    // and return success whenever the two strings matched. It must no longer
+    // exist on the public API surface.
+    const res = await request(app)
+      .post('/api/wasm/otp')
+      .send({ inputOTP: '123456', correctOTP: '123456' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).not.toHaveProperty('success');
+  });
+});

--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -47,7 +47,6 @@ class EdgeRuntime {
                     exports: {
                         calculate_route: (params) => ({ distance_km: params.distance || 15.4, eta_mins: 28, cost: 450 }),
                         calculate_eta: (dist, speed, traffic) => (dist / (speed || 40)) * 60 * (traffic || 1.1),
-                        validate_otp: (input, correct) => input === correct,
                         get_stats: () => ({ memory_used_mb: 4.2, active_functions: 6 })
                     }
                 });
@@ -173,13 +172,10 @@ class EdgeRuntime {
         return null;
     }
 
-    async validateOTP(inputOTP, correctOTP) {
-        const result = await this.executeEdgeFunction('validate_otp', [inputOTP, correctOTP]);
-        if (result.success) {
-            return result.result;
-        }
-        return null;
-    }
+    // validateOTP removed (#6331): the endpoint passed the client-supplied
+    // reference value straight into the sandbox (input === correct), making
+    // it a trivially bypassable OTP validator on the public API. OTP
+    // validation lives server-side against stored, hashed OTPs instead.
 
     async filterDrivers(drivers, minRating) {
         const result = await this.executeEdgeFunction('filter_drivers', [drivers, minRating]);

--- a/wasm/routes.js
+++ b/wasm/routes.js
@@ -102,28 +102,10 @@ router.post('/wasm/eta', async (req, res) => {
     }
 });
 
-// Validate OTP
-router.post('/wasm/otp', async (req, res) => {
-    try {
-        const { inputOTP, correctOTP } = req.body;
-        if (!inputOTP || !correctOTP) {
-            return res.status(400).json({
-                success: false,
-                error: 'inputOTP and correctOTP required'
-            });
-        }
-        
-        const result = await edgeRuntime.validateOTP(inputOTP, correctOTP);
-        res.json({
-            success: true,
-            data: result,
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('OTP validation error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
+// Validate OTP removed (#6331): it accepted the reference value from the
+// client (validate_otp => input === correct), a trivially bypassable OTP
+// validator on the public API. OTP validation must happen server-side
+// against a stored, hashed OTP — never a client-supplied reference.
 
 // Get stats
 router.get('/wasm/stats', async (req, res) => {


### PR DESCRIPTION
## Problem

Issue #6331 — `backend/api/src/index.js:532` mounted `wasmRoutes` at the public `/api` path. `wasm/routes.js:106-126` (`POST /wasm/otp`) was unauthenticated and accepted the reference value from the request body:

```js
const { inputOTP, correctOTP } = req.body;
...
const result = await edgeRuntime.validateOTP(inputOTP, correctOTP);
```

`wasm/edge-runtime.js` fell back to `validate_otp: (input, correct) => input === correct`, so any caller could submit `inputOTP` and `correctOTP` as equal strings and receive a success result — a ready-made, trivially bypassable "OTP validator" on the public API surface.

## Fix

- **Deleted** the `POST /wasm/otp` route.
- **Removed** the now-dead `validateOTP` method from `edge-runtime.js` and the `validate_otp: (input, correct) => input === correct` fallback export, so the bypass primitive no longer exists anywhere in the runtime (nothing else referenced it).
- OTP validation remains server-side only, against stored, hashed OTPs (see the delivery-OTP lifecycle in `notificationService.js` / `deliveryVerificationService.js`).

## Files changed

- `wasm/routes.js`
- `wasm/edge-runtime.js`
- `backend/api/test/unit/wasmOtpRoutes.test.js` (new)

## Testing

- `node --check` passes on both changed source files.
- New regression test `wasmOtpRoutes.test.js`: asserts `POST /api/wasm/otp` with equal `inputOTP`/`correctOTP` returns `404` and no success payload — the endpoint can no longer be used to validate an OTP with a client-controlled reference value. `npx vitest run test/unit/wasmOtpRoutes.test.js` passes.

Closes #6331
