### PR TITLE
test : added unit tests for redisRateLimiter middleware

### DIFF
--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const client = vi.hoisted(() => ({
+  pipeline: vi.fn(),
+  zrange: vi.fn(),
+}))
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+}))
+
+vi.mock('../../src/config/db.js', () => ({ redisClient: client }))
+vi.mock('../../src/middleware/logger.js', () => ({ default: mockLogger }))
+
+const { redisRateLimiter } = await import('../../src/middleware/redisRateLimiter.js')
+
+function makePipeline(execResult) {
+  const p = {}
+  p.zremrangebyscore = vi.fn(() => p)
+  p.zcard = vi.fn(() => p)
+  p.zadd = vi.fn(() => p)
+  p.pexpire = vi.fn(() => p)
+  p.exec = vi.fn().mockResolvedValue(execResult)
+  return p
+}
+
+function makeRes() {
+  return {
+    set: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  }
+}
+
+function makeReq() {
+  return { ip: '1.2.3.4', user: { id: 'u1' } }
+}
+
+describe('redisRateLimiter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    client.zrange.mockResolvedValue(['member-1', String(Date.now())])
+  })
+
+  it('records the request and calls next when below the limit', async () => {
+    client.pipeline.mockImplementation(() => makePipeline([[null, '0'], [null, 1]]))
+    const next = vi.fn()
+    const res = makeRes()
+    await redisRateLimiter({ routeKey: 'r', limit: 5, windowMs: 1000 })(makeReq(), res, next)
+    expect(next).toHaveBeenCalled()
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('returns 429 when at the limit', async () => {
+    client.pipeline.mockImplementation(() => makePipeline([[null, '0'], [null, 5]]))
+    const next = vi.fn()
+    const res = makeRes()
+    await redisRateLimiter({ routeKey: 'r', limit: 5, windowMs: 1000 })(makeReq(), res, next)
+    expect(res.status).toHaveBeenCalledWith(429)
+    expect(res.set).toHaveBeenCalledWith('Retry-After', expect.any(Number))
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('fails open to next when zcard reports an error', async () => {
+    client.pipeline.mockImplementation(() => makePipeline([[null, '0'], [new Error('zcard down'), null]]))
+    const next = vi.fn()
+    const res = makeRes()
+    await redisRateLimiter({ routeKey: 'r', limit: 5, windowMs: 1000 })(makeReq(), res, next)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('fails open to next when redis throws', async () => {
+    client.pipeline.mockImplementation(() => { throw new Error('redis down') })
+    const next = vi.fn()
+    const res = makeRes()
+    await redisRateLimiter({ routeKey: 'r', limit: 5, windowMs: 1000 })(makeReq(), res, next)
+    expect(next).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #6454.

Summary of What Has Been Done:
Added vitest coverage for redisRateLimiter covering below-limit recording, 429 at-limit, and fail-open paths for zcard errors and redis outages.

Changes Made:
- backend/api/test/unit/redisRateLimiter.test.js: new test file with a mocked redis client.

Impact it Made:
Guards the sliding-window rate limit behavior.

This pull request is being made as part of GSSOC.

Note: Please assign this PR to the `tmdeveloper007` account.