### PR TITLE
fix(otp): make complete_trip_tx authorization fail closed and service-role-only (#6332)

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { supabase, redisClient, mongoDb } from "../../config/db.js";
+import { supabase, supabaseAdmin, redisClient, mongoDb } from "../../config/db.js";
 import { DomainError } from "./domainError.js";
 import { measureExecution } from "../../core/performanceMetrics.js";
 import { haversineKm } from "../../lib/pricing.js";
@@ -543,7 +543,7 @@ export class DeliveryVerificationService {
               p_otp_id: otpRecord.id,
               p_release_tx_hash: releaseTxHash,
             },
-            userClient,
+            supabaseAdmin,
           );
           tripData = rpcResult.data;
 

--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import {
   sendDeliveryOtpNotification,
   storeDeliveryOtp,
@@ -244,7 +244,7 @@ export class OrderMilestoneService {
           p_otp_id: otpRecord.id,
           p_release_tx_hash: releaseTxHash
         },
-        userClient
+        supabaseAdmin
       );
       if (rpcErr) {
         logger.error('complete_trip_tx RPC failed:', rpcErr.message);

--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -360,3 +360,30 @@ describe('Service-level RPC calls carry an authenticated client (issue #5737)', 
     expect(driverRoutesContent).not.toMatch(/createUserClient\(req\.token\) \? [^;]* : supabase/);
   });
 });
+
+describe('complete_trip_tx — authorization is not NULL-bypassable and is service-role-only (issue #6332)', () => {
+  let content;
+
+  beforeAll(async () => {
+    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260805120000_secure_complete_trip_tx_auth.sql');
+    content = await fs.readFile(p, 'utf8');
+  });
+
+  it('does not use the NULL-bypassable guard (auth.uid() is not null and get_profile_id() <>)', () => {
+    expect(/auth\.uid\(\)\s+is not null\s+and\s+get_profile_id\(\)\s+<>/.test(content)).toBe(false);
+  });
+
+  it('fails closed: non-service_role callers must resolve to the assigned driver (auth.role() + IS DISTINCT FROM)', () => {
+    expect(/coalesce\(auth\.role\(\),\s*''\)\s+<> 'service_role'/.test(content)).toBe(true);
+    expect(/get_profile_id\(\)\s+is distinct from\s+v_order\.driver_id/.test(content)).toBe(true);
+    expect(/raise exception 'Unauthorized: you can only complete trips you are assigned to'/.test(content)).toBe(true);
+  });
+
+  it('revokes EXECUTE from PUBLIC, anon and authenticated so PostgREST clients cannot invoke it directly', () => {
+    expect(/revoke execute on function complete_trip_tx\(uuid,\s*uuid,\s*text\)\s+from public,\s*anon,\s*authenticated/i.test(content)).toBe(true);
+  });
+
+  it('grants EXECUTE to service_role only', () => {
+    expect(/grant execute on function complete_trip_tx\(uuid,\s*uuid,\s*text\)\s+to service_role/i.test(content)).toBe(true);
+  });
+});

--- a/supabase/migrations/20260805120000_secure_complete_trip_tx_auth.sql
+++ b/supabase/migrations/20260805120000_secure_complete_trip_tx_auth.sql
@@ -1,0 +1,223 @@
+-- =============================================================================
+-- Migration: complete_trip_tx authorization is NULL-bypassable and the RPC
+-- remains callable by the authenticated role (#6332)
+-- =============================================================================
+-- Problem:
+--   1. The pre-fix guard combined an auth.uid() non-NULL probe with a
+--      get_profile_id() inequality against v_order.driver_id, which SQL
+--      three-valued logic made NULL-bypassable: get_profile_id() returns NULL
+--      when the JWT `sub` has no matching profiles.firebase_uid row, so the
+--      comparison evaluated to NULL and the IF was skipped — any authenticated
+--      caller without a resolvable profile bypassed the driver-assignment
+--      check. The guard was also skipped wholesale for tokens with no `sub`
+--      (auth.uid() IS NULL).
+--   2. Only `REVOKE EXECUTE ... FROM anon` was issued (20260803100000). The
+--      default EXECUTE grant to PUBLIC (of which anon/authenticated are members)
+--      remained, so the `authenticated` role could still invoke the RPC directly
+--      via PostgREST with an arbitrary p_order_id/p_otp_id, marking the OTP row
+--      verified and triggering the wallet credit without ever validating the OTP
+--      value.
+--
+-- Fix:
+--   - Rewrite the guard to fail closed: any non-service_role caller must have a
+--     profile that resolves to the order's assigned driver. A NULL role or NULL
+--     get_profile_id() result now rejects instead of skipping the check.
+--   - Revoke EXECUTE from PUBLIC (the default grant) plus anon/authenticated, and
+--     grant it explicitly to service_role only — the backend invokes this RPC via
+--     the service key (deliveryVerificationService/orderMilestoneService switched
+--     from the per-user client), while the app layer enforces driver assignment,
+--     OTP hashing, lockout and geofence before calling it.
+-- =============================================================================
+
+create or replace function complete_trip_tx(
+  p_order_id uuid,
+  p_otp_id uuid,
+  p_release_tx_hash text default null
+)
+returns table(driver_id uuid)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_order record;
+  v_trip_display_id text;
+  v_updated_count int;
+  v_otp_updated int;
+begin
+  -- Use FOR UPDATE to lock the order row and prevent concurrent modifications
+  select * into v_order from orders where id = p_order_id for update;
+
+  if not found then
+    raise exception 'Order not found';
+  end if;
+
+  -- Verify the caller is the driver assigned to this order. get_profile_id()
+  -- maps the Firebase JWT sub to profiles.id, which is what orders.driver_id
+  -- stores (auth.uid() is the Firebase UID and would never match). Fail closed:
+  -- when the role cannot be established (coalesce(auth.role(), '') <> 'service_role')
+  -- OR the caller's profile does not resolve to the assigned driver
+  -- (get_profile_id() IS DISTINCT FROM v_order.driver_id, true when NULL), the
+  -- RPC rejects. service_role (the backend) is exempt because the app layer
+  -- already enforces driver assignment, OTP hashing, lockout and geofence.
+  if coalesce(auth.role(), '') <> 'service_role'
+     and get_profile_id() is distinct from v_order.driver_id then
+    raise exception 'Unauthorized: you can only complete trips you are assigned to';
+  end if;
+
+  if v_order.driver_id is null then
+    raise exception 'No driver assigned to this order';
+  end if;
+
+  -- Idempotency guard: check if the order status is already payment_released
+  if v_order.status = 'payment_released' then
+    driver_id := v_order.driver_id;
+    return next;
+    return;
+  end if;
+
+  update delivery_otps
+  set verified = true,
+      verified_at = now()
+  where id = p_otp_id
+    and order_id = p_order_id
+    and verified = false
+    and expires_at >= now();
+
+  get diagnostics v_otp_updated = row_count;
+  if v_otp_updated <> 1 then
+    raise exception 'Delivery OTP is invalid, expired, or already verified';
+  end if;
+
+  -- Check if the order was cancelled
+  if v_order.status = 'cancelled' then
+    raise exception 'Order has been cancelled — cannot complete trip';
+  end if;
+
+  -- Check if the order was already delivered — prevents double-processing
+  if v_order.status = 'delivered' then
+    raise exception 'Order has already been delivered';
+  end if;
+
+  -- Fail closed (restored from 20260802130000_complete_trip_tx_require_funded_escrow.sql):
+  -- credit the driver wallet ONLY when the escrow was actually funded and released
+  -- on-chain (`escrow_status = 'released'` or a release tx hash is supplied), or
+  -- when the order is explicitly marked `escrow_disabled`. Any ambiguous/unfunded
+  -- state raises instead of crediting.
+  if not v_order.escrow_disabled
+     and coalesce(v_order.escrow_status, '') <> 'released'
+     and p_release_tx_hash is null then
+    raise exception 'Blockchain escrow release must complete before crediting driver wallet';
+  end if;
+
+  -- Finalize the active trip that actually served THIS order (restored from
+  -- 20260802060000_link_trips_to_orders.sql: selecting by driver_id could
+  -- complete the wrong trip when a driver has several active trips, and it
+  -- silently skipped trip finalization when the driver had no active trip).
+  -- When no linked trip exists the order is still finalized below so the
+  -- driver payout is never lost (#6325).
+  select trip_display_id into v_trip_display_id
+  from trips
+  where order_id = p_order_id
+    and status = 'active'
+  order by created_at
+  limit 1;
+
+  if v_trip_display_id is not null then
+    -- Update trip record
+    update trips
+    set status = 'completed',
+        end_time = to_char(now(), 'HH24:MI'),
+        updated_at = now()
+    where trip_display_id = v_trip_display_id;
+
+    -- Update trip items to delivered
+    update trip_items
+    set is_delivered = true
+    where trip_display_id = v_trip_display_id;
+
+    -- Update trip stops to completed/delivered
+    update trip_stops
+    set is_completed = true,
+        is_current = false,
+        status_label = 'Delivered',
+        updated_at = now()
+    where trip_display_id = v_trip_display_id;
+  end if;
+
+  -- Update order status and escrow details. Escrow fields are only synced for
+  -- escrow-backed orders (the fail-closed guard above guarantees the escrow was
+  -- released on-chain); escrow-disabled orders never enter the escrow lifecycle,
+  -- so their escrow_status must not be rewritten to 'released'.
+  if v_order.escrow_disabled then
+    update orders
+    set status = 'payment_released',
+        blockchain_tx_hash = coalesce(p_release_tx_hash, blockchain_tx_hash),
+        updated_at = now()
+    where id = p_order_id
+      and status != 'cancelled'
+      and status != 'payment_released';
+  else
+    update orders
+    set status = 'payment_released',
+        escrow_status = 'released',
+        escrow_released_at = now(),
+        blockchain_tx_hash = coalesce(p_release_tx_hash, blockchain_tx_hash),
+        updated_at = now()
+    where id = p_order_id
+      and status != 'cancelled'
+      and status != 'payment_released';
+  end if;
+
+  -- Verify the update actually affected a row
+  get diagnostics v_updated_count = row_count;
+  if v_updated_count = 0 then
+    raise exception 'Order status changed during processing — possible concurrent cancellation';
+  end if;
+
+  -- Update order timeline milestone 'Delivered'
+  update order_timeline
+  set completed = true,
+      milestone_time = now()
+  where order_display_id = v_order.order_display_id and milestone = 'Delivered';
+
+  -- Update driver's wallet
+  update driver_details
+  set
+    total_trips = total_trips + 1,
+    wallet_confirmed = wallet_confirmed + v_order.total_amount,
+    wallet_total = wallet_total + v_order.total_amount,
+    updated_at = now()
+  where user_id = v_order.driver_id;
+
+  -- Log wallet transaction
+  insert into wallet_transactions (
+    driver_id, order_display_id, amount, txn_type, status, description
+  ) values (
+    v_order.driver_id,
+    v_order.order_display_id,
+    v_order.total_amount,
+    'credit',
+    'confirmed',
+    'Payout for Order ' || v_order.order_display_id
+  );
+
+  -- Update daily earnings summary
+  insert into earnings_daily (driver_id, day_date, amount, trip_count)
+  values (v_order.driver_id, current_date, v_order.total_amount, 1)
+  on conflict (driver_id, day_date)
+  do update set
+    amount = earnings_daily.amount + excluded.amount,
+    trip_count = earnings_daily.trip_count + 1;
+
+  driver_id := v_order.driver_id;
+  return next;
+end;
+$$;
+
+-- Only service_role (the backend) may invoke this RPC. Revoke the default
+-- PUBLIC grant (anon/authenticated are members of PUBLIC) as well as the
+-- explicit anon/authenticated grants so direct PostgREST invocation is
+-- impossible; then grant execution to service_role explicitly.
+REVOKE EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) TO service_role;


### PR DESCRIPTION
## Problem

Issue #6332 — `supabase/migrations/20260803100000_update_complete_trip_tx.sql` guards driver-assignment authorization with:

```sql
if auth.uid() is not null and get_profile_id() <> v_order.driver_id then
  raise exception 'Unauthorized: you can only complete trips you are assigned to';
end if;
```

Two defects:

1. **NULL-bypass.** `get_profile_id()` returns `NULL` when the JWT `sub` has no matching `profiles.firebase_uid` row. In SQL three-valued logic `NULL <> v_order.driver_id` evaluates to `NULL`, so the `IF` is skipped — any authenticated caller without a resolvable profile bypasses the driver-assignment check entirely. The guard is also skipped wholesale for tokens with no `sub`.
2. **Still callable by `authenticated`.** The migration only issued `REVOKE EXECUTE ... FROM anon`. The default EXECUTE grant to PUBLIC (of which `anon`/`authenticated` are members) remained, so `authenticated` clients could invoke `complete_trip_tx` directly via PostgREST with an arbitrary `p_order_id`/`p_otp_id`. Because the RPC marks the OTP row verified without ever checking the OTP value (that check lives in the app layer), a direct caller could complete another driver's order and trigger the wallet credit / earnings insert.

## Fix

- **Rewrite the guard to fail closed** in `complete_trip_tx(uuid, uuid, text)`:
  ```sql
  if coalesce(auth.role(), '') <> 'service_role'
     and get_profile_id() is distinct from v_order.driver_id then
    raise exception 'Unauthorized: you can only complete trips you are assigned to';
  end if;
  ```
  A non-service_role caller must resolve to the assigned driver; a NULL role or NULL `get_profile_id()` now rejects instead of skipping. `service_role` is exempt because the app layer already enforces driver assignment, OTP hashing, lockout and geofence before invoking the RPC.
- **Close the privilege hole**: `REVOKE EXECUTE ... FROM PUBLIC, anon, authenticated` (PUBLIC is the default grant) and `GRANT EXECUTE ... TO service_role`.
- **Switch the backend callers** (`deliveryVerificationService.js`, `orderMilestoneService.js`) from the per-user client to `supabaseAdmin` (service key), since clients can no longer invoke the RPC and the driver-assignment check is enforced at the app layer.
- New migration timestamp `20260805120000` supersedes the `20260805090000` definition (issue #6325, PR #6481) — the function keeps the orphaned-order finalization fallback while gaining the fail-closed guard.

## Files changed

- `supabase/migrations/20260805120000_secure_complete_trip_tx_auth.sql` (new)
- `backend/api/src/services/order/deliveryVerificationService.js`
- `backend/api/src/services/order/orderMilestoneService.js`
- `backend/api/test/unit/rlsSecurity.test.js` (regression tests)

## Testing

- New `rlsSecurity.test.js` block asserts: the NULL-bypass guard is gone, the guard fails closed (`auth.role()` + `IS DISTINCT FROM`), EXECUTE is revoked from PUBLIC/anon/authenticated, and granted to `service_role`. `npx vitest run test/unit/rlsSecurity.test.js` → 129 passed.
- `node --check` + `npx eslint --max-warnings=0` pass on the changed backend files.

> Note: integration suites that import `orderRoutes.js` remain unable to load due to a pre-existing duplicate `order` declaration at `orderRoutes.js:1163` (separate from this issue).

Closes #6332
