### PR TITLE
fix(graphql): resolve gateway role from profiles, not client-editable user_metadata (#6333)

### DIFF
--- a/backend/api/test/unit/graphqlGatewayAuthContext.test.js
+++ b/backend/api/test/unit/graphqlGatewayAuthContext.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveUserContext,
+  DEFAULT_ROLE,
+} from '../../../../backend/graphql/gateway/authContext.js';
+
+function makeClient({ user = null, getUserError = null, profile = null, profileError = null } = {}) {
+  return {
+    auth: {
+      getUser: async () => ({
+        data: { user },
+        error: getUserError,
+      }),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: profile,
+            error: profileError,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('GraphQL gateway role resolution (issue #6333)', () => {
+  it('resolves the role from profiles, ignoring a self-set user_metadata.role', async () => {
+    // Attacker: token whose user_metadata.role claims "admin", while the
+    // server-side profiles row says "customer".
+    const client = makeClient({
+      user: { id: 'user-1', user_metadata: { role: 'admin' } },
+      profile: { role: 'customer' },
+    });
+
+    const ctx = await resolveUserContext(client, 'Bearer attacker-token');
+
+    expect(ctx).toEqual({ id: 'user-1', role: 'customer' });
+  });
+
+  it('falls back to the least-privilege DEFAULT_ROLE when no profile row resolves', async () => {
+    const client = makeClient({
+      user: { id: 'user-2', user_metadata: { role: 'admin' } },
+      profile: null,
+    });
+
+    const ctx = await resolveUserContext(client, 'Bearer token');
+
+    expect(ctx).toEqual({ id: 'user-2', role: DEFAULT_ROLE });
+  });
+
+  it('returns null when the token cannot be verified', async () => {
+    const client = makeClient({ user: null, getUserError: { message: 'invalid' } });
+
+    expect(await resolveUserContext(client, 'Bearer bogus')).toBeNull();
+  });
+
+  it('returns null when no token is supplied', async () => {
+    const client = makeClient();
+    expect(await resolveUserContext(client, '')).toBeNull();
+    expect(await resolveUserContext(client, undefined)).toBeNull();
+  });
+
+  it('strips a "Bearer " prefix before calling getUser', async () => {
+    let receivedToken = null;
+    const client = {
+      auth: {
+        getUser: async (token) => {
+          receivedToken = token;
+          return { data: { user: { id: 'user-3' } }, error: null };
+        },
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { role: 'driver' }, error: null }),
+          }),
+        }),
+      }),
+    };
+
+    const ctx = await resolveUserContext(client, 'Bearer raw-token');
+
+    expect(receivedToken).toBe('raw-token');
+    expect(ctx).toEqual({ id: 'user-3', role: 'driver' });
+  });
+});

--- a/backend/graphql/gateway/authContext.js
+++ b/backend/graphql/gateway/authContext.js
@@ -1,0 +1,30 @@
+// Role/identity resolution for the GraphQL gateway (issue #6333).
+//
+// The caller's role must come from the server-authoritative `profiles` table,
+// never from the client-editable `user_metadata.role`. Supabase allows clients
+// to self-assign `user_metadata` via auth.updateUser({ data: ... }), so trusting
+// it here would let a customer fabricate `x-user-role: admin` for every subgraph.
+//
+// This module is intentionally dependency-free (the client is injected) so it
+// can be unit-tested without wiring up the Apollo gateway or a real DB client.
+
+export const DEFAULT_ROLE = 'CUSTOMER';
+
+export async function resolveUserContext(supabaseClient, token) {
+  if (!token) return null;
+
+  const stripped = token.startsWith('Bearer ') ? token.slice(7) : token;
+  const { data: { user }, error } = await supabaseClient.auth.getUser(stripped);
+  if (error || !user) return null;
+
+  // profiles.role is column-privilege protected (authenticated users can never
+  // UPDATE it) and RLS only returns the caller's own row. Fall back to the
+  // least-privilege DEFAULT_ROLE when no profile row resolves.
+  const { data: profile } = await supabaseClient
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  return { id: user.id, role: profile?.role || DEFAULT_ROLE };
+}

--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -5,6 +5,7 @@ import { startStandaloneServer } from '@apollo/server/standalone';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
 import logger from '../../api/src/middleware/logger.js';
 import { supabase } from '../../api/src/config/db.js';
+import { resolveUserContext, DEFAULT_ROLE } from './authContext.js';
 
 class GraphQLGateway {
     constructor() {
@@ -43,9 +44,16 @@ class GraphQLGateway {
                             request.http.headers.set('authorization', authorization);
                         }
 
+                        // Strip any client-supplied identity headers so subgraph
+                        // authorization can only ever come from the gateway's
+                        // verified context (profiles-backed role), never from a
+                        // forged x-user-id/x-user-role on the raw client request.
+                        request.http.headers.delete('x-user-id');
+                        request.http.headers.delete('x-user-role');
+
                         if (context?.user?.id) {
                             request.http.headers.set('x-user-id', context.user.id);
-                            request.http.headers.set('x-user-role', context.user.role || 'CUSTOMER');
+                            request.http.headers.set('x-user-role', context.user.role || DEFAULT_ROLE);
                         }
 
                         logger.debug(`GraphQL ${name} request sent`);
@@ -336,13 +344,12 @@ class GraphQLGateway {
         if (!token) return null;
 
         try {
-            const stripped = token.startsWith('Bearer ') ? token.slice(7) : token;
-            const { data: { user }, error } = await supabase.auth.getUser(stripped);
-            if (error || !user) {
-                logger.warn('[GraphQL Gateway] Invalid auth token:', error?.message || 'no user');
+            const user = await resolveUserContext(supabase, token);
+            if (!user) {
+                logger.warn('[GraphQL Gateway] Invalid auth token: no user');
                 return null;
             }
-            return { id: user.id, role: user.user_metadata?.role || 'CUSTOMER' };
+            return user;
         } catch (err) {
             logger.warn('[GraphQL Gateway] Token verification failed:', err.message);
             return null;


### PR DESCRIPTION
## Problem

Issue #6333 — `backend/graphql/gateway/index.js` resolved the caller's role from token **user metadata**:

```js
const { data: { user }, error } = await supabase.auth.getUser(stripped);
return { id: user.id, role: user.user_metadata?.role || 'CUSTOMER' };
```

and `willSendRequest` (index.js:46-49) forwarded it to every subgraph:

```js
request.http.headers.set('x-user-id', context.user.id);
request.http.headers.set('x-user-role', context.user.role || 'CUSTOMER');
```

Supabase `user_metadata` is client-editable via `auth.updateUser({ data: {...} })`. A customer could set `user_metadata.role = 'admin'` and the gateway would inject `x-user-role: admin` (and `x-user-id`) into every downstream subgraph request — admin privilege escalation from a normal account. A client could additionally forge `x-user-id`/`x-user-role` directly on unauthenticated requests, and the gateway would forward those untouched when `context.user` was null.

## Fix

- **New `backend/graphql/gateway/authContext.js`** — a dependency-free `resolveUserContext(supabaseClient, token)` that resolves the role from the server-authoritative `profiles.role` column by `user.id` and falls back to the least-privilege `DEFAULT_ROLE` (`CUSTOMER`) only when no profile row resolves. `user_metadata.role` is never consulted.
  - `profiles` RLS restricts the query to the caller's own row (`firebase_uid = auth.jwt() ->> 'sub'`), and the `role` column is `REVOKE UPDATE`-protected from `anon`/`authenticated` — so this value cannot be self-edited.
- **`willSendRequest`** now *strips* any client-supplied `x-user-id`/`x-user-role` from the subgraph request and re-sets them only from the verified context, so forged identity headers cannot reach subgraphs even on unauthenticated requests.
- **`getUserFromToken`** delegates to `resolveUserContext`.

## Files changed

- `backend/graphql/gateway/authContext.js` (new)
- `backend/graphql/gateway/index.js`
- `backend/api/test/unit/graphqlGatewayAuthContext.test.js` (new)

## Testing

- New unit tests prove a self-set `user_metadata.role = 'admin'` is ignored when `profiles.role = 'customer'`, the least-privilege fallback, null on invalid/missing tokens, and Bearer-prefix stripping. `npx vitest run test/unit/graphqlGatewayAuthContext.test.js` → 5 passed.
- `node --check` passes on both gateway files; `npx eslint --max-warnings=0` passes on the new test.

Closes #6333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved GraphQL gateway authentication and identity verification.
  * Server-verified user roles now override client-supplied role information.
  * Invalid, missing, or malformed tokens are rejected safely.
  * Users without a stored profile role receive the default Customer role.
  * Added automated coverage for authentication and role-resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->