### PR TITLE
fix: correct inverted congestion metric in ML traffic pipeline

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -199,7 +199,7 @@ class TrafficPipeline:
                     return {
                         'duration': duration,
                         'speed': route.get('distance', {}).get('value', 0) / duration if duration > 0 else 50,
-                        'congestion': 1 - (duration / normal_duration) if normal_duration > 0 else 0
+                        'congestion': (1 - normal_duration / duration) if duration > 0 else 0
                     }
         return {}
     


### PR DESCRIPTION
Closes #6511

The congestion metric was computed as \1 - (duration / normal_duration)\, which goes negative when the trip takes longer than normal (i.e. congested). Switched to \1 - (normal_duration / duration)\, a normalized [0, 1) value where higher = more congested.

GSSOC