### PR TITLE
fix: remove duplicate close() that overrides safe cleanup in TrafficPipeline

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -96,11 +96,6 @@ class TrafficPipeline:
             logger.info("Creating new LSTM model")
             return self._create_lstm_model()
 
-    def close(self):
-        """Dispose database connections and close Redis connection."""
-        self.engine.dispose()
-        self.redis.close()
-    
     def _create_lstm_model(self):
         """Create LSTM model for ETA prediction"""
         model = models.Sequential([


### PR DESCRIPTION
Closes #6513

The second \close()\ (defined later in the class) overrides the idempotent guarded version, dropping the \_closed\ guard, error handling and \__del__\ safety. Removed the duplicate so the safe implementation is the effective one.

GSSOC