### PR TITLE
fix: use CSPRNG-based key-rotation ID instead of Math.random

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
 import { supabase } from '../../config/db.js';
@@ -73,7 +74,7 @@ class KeyRotationService {
 
   async createRotationRecord(userId, walletAddress, reason) {
     try {
-      const rotationId = `rot_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      const rotationId = `rot_${crypto.randomBytes(16).toString('hex')}`;
 
       const { data, error } = await supabase
         .from('key_rotations')


### PR DESCRIPTION
Closes #6519

Rotation IDs were generated with \Date.now()\ + \Math.random()\ and the deprecated \.substr()\, making audit IDs guessable in a security subsystem. Now uses \crypto.randomBytes(16).toString('hex')\.

GSSOC