### PR TITLE
[Security] Hash phone login OTPs with a per-record salt instead of bare SHA-256

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -1,0 +1,104 @@
+/**
+ * Shared OTP hashing.
+ *
+ * A 6-digit OTP has a keyspace of 10^6. An unsalted digest of one is not a
+ * meaningful protection: the complete rainbow table computes in well under a
+ * second, so anyone with read access to the OTP table recovers every live
+ * code. Salting per record makes precomputation useless, and scrypt's work
+ * factor makes exhaustive search per record costly.
+ *
+ * This module is shared by the delivery-OTP path (`delivery_otps`) and the
+ * phone login path (`phone_otps`) so the two cannot drift apart again — the
+ * delivery path was migrated to salted scrypt while login was left on bare
+ * SHA-256.
+ */
+import crypto from 'crypto';
+
+/** Salt length in bytes. Hex-encoded on storage, so 32 characters. */
+const SALT_BYTES = 16;
+
+/** scrypt output length in bytes. Hex-encoded on storage, so 128 characters. */
+const KEY_BYTES = 64;
+
+/** A salted scrypt digest, hex-encoded. */
+const SCRYPT_HASH_PATTERN = /^[a-f0-9]{128}$/;
+
+/** A legacy unsalted SHA-256 digest, hex-encoded. */
+const LEGACY_SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+/**
+ * Hash an OTP with scrypt.
+ *
+ * @param {string|number} otp The plaintext OTP.
+ * @param {string} [saltHex] Existing salt for verification, or undefined to
+ *   generate a fresh one for storage.
+ * @returns {{hash: string, salt: string}} Hex-encoded digest and salt.
+ */
+export function hashOtp(otp, saltHex) {
+  const salt = saltHex || crypto.randomBytes(SALT_BYTES).toString('hex');
+  const key = crypto.scryptSync(String(otp), salt, KEY_BYTES);
+  return { hash: key.toString('hex'), salt };
+}
+
+/**
+ * Timing-safe comparison of a submitted OTP against a stored record.
+ *
+ * Records written after the migration carry an `otp_salt` and are compared
+ * with scrypt. Pre-migration rows have no salt and are compared with SHA-256,
+ * so codes already in flight keep working for the remainder of their TTL
+ * rather than locking users out at deploy time.
+ *
+ * Both branches use `crypto.timingSafeEqual`, and both validate the stored
+ * digest's shape first — `timingSafeEqual` throws on a length mismatch, and a
+ * malformed row must fail closed rather than raise.
+ *
+ * @param {string|number} otp The submitted OTP.
+ * @param {{otp_hash?: string, otp_salt?: string}|null|undefined} otpRecord
+ * @returns {boolean} True only on an exact match.
+ */
+export function verifyOtpHash(otp, otpRecord) {
+  if (!otpRecord || typeof otpRecord !== 'object') {
+    return false;
+  }
+
+  const expected = String(otpRecord.otp_hash || '');
+
+  if (otpRecord.otp_salt) {
+    if (!SCRYPT_HASH_PATTERN.test(expected)) {
+      return false;
+    }
+    const { hash: submittedHash } = hashOtp(otp, otpRecord.otp_salt);
+    return crypto.timingSafeEqual(
+      Buffer.from(submittedHash, 'hex'),
+      Buffer.from(expected, 'hex')
+    );
+  }
+
+  // Legacy unsalted row, retained only for the TTL window of codes issued
+  // before the migration. Remove this branch once that window has elapsed.
+  if (LEGACY_SHA256_PATTERN.test(expected)) {
+    const submittedHash = crypto.createHash('sha256').update(String(otp)).digest('hex');
+    return crypto.timingSafeEqual(
+      Buffer.from(submittedHash, 'hex'),
+      Buffer.from(expected, 'hex')
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Whether a stored record still uses the legacy unsalted format.
+ *
+ * Lets callers report how much legacy data remains so the fallback branch
+ * above can be retired with evidence rather than guesswork.
+ *
+ * @param {{otp_hash?: string, otp_salt?: string}|null|undefined} otpRecord
+ * @returns {boolean}
+ */
+export function isLegacyOtpRecord(otpRecord) {
+  if (!otpRecord || typeof otpRecord !== 'object') {
+    return false;
+  }
+  return !otpRecord.otp_salt && LEGACY_SHA256_PATTERN.test(String(otpRecord.otp_hash || ''));
+}

--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -167,6 +167,7 @@ router.get("/session", authenticate, userLimiter, (req, res) => {
 
 import crypto from "crypto";
 import { supabase } from "../config/db.js";
+import { isLegacyOtpRecord, verifyOtpHash } from "../lib/otpHashing.js";
 import { otpSendSchema } from "../validation/requestSchemas.js";
 import { z } from "zod";
 
@@ -206,7 +207,7 @@ router.post("/verify-otp", otpVerificationLimiter, async (req, res) => {
     // Look up the latest unused, unexpired OTP for this phone number
     const { data: otpRecord, error: fetchErr } = await supabase
       .from("phone_otps")
-      .select("id, otp_hash, expires_at, verified")
+      .select("id, otp_hash, otp_salt, expires_at, verified")
       .eq("phone", phone)
       .eq("verified", false)
       .gt("expires_at", new Date().toISOString())
@@ -223,19 +224,18 @@ router.post("/verify-otp", otpVerificationLimiter, async (req, res) => {
       return res.status(400).json({ success: false, error: "OTP not found or has expired." });
     }
 
-    // Timing-safe comparison to prevent timing attacks
-    const submittedHash = crypto.createHash("sha256").update(String(otp)).digest("hex");
-    const storedHash = otpRecord.otp_hash;
-
-    const isMatch =
-      submittedHash.length === storedHash.length &&
-      crypto.timingSafeEqual(
-        Buffer.from(submittedHash, "hex"),
-        Buffer.from(storedHash, "hex"),
-      );
-
-    if (!isMatch) {
+    // Salted scrypt comparison, timing-safe. Falls back to the legacy
+    // unsalted digest for rows written before the salt migration so codes
+    // already in flight are not invalidated mid-window.
+    if (!verifyOtpHash(otp, otpRecord)) {
       return res.status(400).json({ success: false, error: "Invalid OTP." });
+    }
+
+    if (isLegacyOtpRecord(otpRecord)) {
+      logger.warn(
+        { otpId: otpRecord.id },
+        "[auth/verify-otp] Verified a pre-migration unsalted OTP record"
+      );
     }
 
     // Consume the OTP so it cannot be reused

--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -1,6 +1,7 @@
 import { supabase, firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import crypto from 'crypto';
+import { hashOtp, verifyOtpHash } from '../lib/otpHashing.js';
 import { measureExecution } from '../core/performanceMetrics.js';
 
 const TRANSIENT_ERROR_CODES = new Set([
@@ -133,9 +134,7 @@ export async function sendFcmNotification(userId, notification, data = {}) {
  *   and hex-encoded salt.
  */
 export function hashDeliveryOtp(otp, saltHex) {
-  const salt = saltHex || crypto.randomBytes(16).toString('hex');
-  const key = crypto.scryptSync(String(otp), salt, 64);
-  return { hash: key.toString('hex'), salt };
+  return hashOtp(otp, saltHex);
 }
 
 /**
@@ -145,23 +144,16 @@ export function hashDeliveryOtp(otp, saltHex) {
  * are compared with scrypt. Pre-migration rows (no salt) are compared with
  * SHA-256 so in-flight OTPs keep working for their remaining TTL window.
  *
+ * Delegates to the shared implementation in lib/otpHashing.js, which the
+ * phone login path uses too — the two previously diverged, with login left
+ * on bare unsalted SHA-256.
+ *
  * @param {string|number} otp
  * @param {{otp_hash?: string, otp_salt?: string}|null} otpRecord
  * @returns {boolean}
  */
 export function verifyDeliveryOtpHash(otp, otpRecord) {
-  if (!otpRecord) return false;
-  if (otpRecord.otp_salt) {
-    const { hash: submittedHash } = hashDeliveryOtp(otp, otpRecord.otp_salt);
-    const expected = String(otpRecord.otp_hash || '');
-    if (!/^[a-f0-9]{128}$/.test(expected)) return false;
-    return crypto.timingSafeEqual(Buffer.from(submittedHash, 'hex'), Buffer.from(expected, 'hex'));
-  }
-  if (otpRecord.otp_hash && /^[a-f0-9]{64}$/.test(otpRecord.otp_hash)) {
-    const submittedHash = crypto.createHash('sha256').update(String(otp)).digest('hex');
-    return crypto.timingSafeEqual(Buffer.from(submittedHash, 'hex'), Buffer.from(otpRecord.otp_hash, 'hex'));
-  }
-  return false;
+  return verifyOtpHash(otp, otpRecord);
 }
 
 export async function storeDeliveryOtp(orderId, otp, ttlMinutes = 15) {

--- a/backend/api/test/unit/otpHashing.test.js
+++ b/backend/api/test/unit/otpHashing.test.js
@@ -1,0 +1,176 @@
+/**
+ * Coverage for shared OTP hashing.
+ *
+ * Phone login OTPs were stored as bare unsalted SHA-256. A 6-digit code has a
+ * keyspace of 10^6, so the full rainbow table computes in under a second and
+ * any read access to `phone_otps` yielded live login credentials. The delivery
+ * OTP path had already been migrated to salted scrypt; these tests pin the
+ * shared implementation both paths now use.
+ */
+import crypto from 'crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  hashOtp,
+  isLegacyOtpRecord,
+  verifyOtpHash,
+} from '../../src/lib/otpHashing.js';
+
+/** Build a legacy pre-migration record: unsalted SHA-256, no salt column. */
+function legacyRecord(otp) {
+  return {
+    otp_hash: crypto.createHash('sha256').update(String(otp)).digest('hex'),
+  };
+}
+
+/** Build a post-migration record: salted scrypt. */
+function saltedRecord(otp) {
+  const { hash, salt } = hashOtp(otp);
+  return { otp_hash: hash, otp_salt: salt };
+}
+
+describe('hashOtp', () => {
+  it('produces a 128-character hex digest and a 32-character hex salt', () => {
+    const { hash, salt } = hashOtp('123456');
+    expect(hash).toMatch(/^[a-f0-9]{128}$/);
+    expect(salt).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('generates a fresh salt on every call', () => {
+    const a = hashOtp('123456');
+    const b = hashOtp('123456');
+    expect(a.salt).not.toBe(b.salt);
+  });
+
+  it('produces different digests for the same OTP — defeating precomputation', () => {
+    // This is the entire point of the change. Under the old unsalted scheme
+    // these two would have been byte-identical.
+    const a = hashOtp('123456');
+    const b = hashOtp('123456');
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it('is deterministic when the salt is supplied', () => {
+    const { hash, salt } = hashOtp('123456');
+    expect(hashOtp('123456', salt).hash).toBe(hash);
+  });
+
+  it('accepts a numeric OTP as well as a string', () => {
+    const { hash, salt } = hashOtp(123456);
+    expect(hashOtp('123456', salt).hash).toBe(hash);
+  });
+
+  it('produces different digests for different OTPs under one salt', () => {
+    const { salt } = hashOtp('000000');
+    expect(hashOtp('123456', salt).hash).not.toBe(hashOtp('654321', salt).hash);
+  });
+});
+
+describe('verifyOtpHash — salted records', () => {
+  it('accepts the correct OTP', () => {
+    expect(verifyOtpHash('123456', saltedRecord('123456'))).toBe(true);
+  });
+
+  it('rejects an incorrect OTP', () => {
+    expect(verifyOtpHash('654321', saltedRecord('123456'))).toBe(false);
+  });
+
+  it('accepts a numeric submission against a string-hashed OTP', () => {
+    expect(verifyOtpHash(123456, saltedRecord('123456'))).toBe(true);
+  });
+
+  it('rejects when the salt does not match the digest', () => {
+    const record = saltedRecord('123456');
+    record.otp_salt = crypto.randomBytes(16).toString('hex');
+    expect(verifyOtpHash('123456', record)).toBe(false);
+  });
+
+  it('fails closed on a malformed digest rather than throwing', () => {
+    // timingSafeEqual throws on a length mismatch, so shape is validated first.
+    const record = saltedRecord('123456');
+    expect(verifyOtpHash('123456', { ...record, otp_hash: 'deadbeef' })).toBe(false);
+    expect(verifyOtpHash('123456', { ...record, otp_hash: '' })).toBe(false);
+    expect(verifyOtpHash('123456', { ...record, otp_hash: 'z'.repeat(128) })).toBe(false);
+    expect(verifyOtpHash('123456', { ...record, otp_hash: null })).toBe(false);
+  });
+
+  it('rejects an uppercase digest, since storage is lowercase hex', () => {
+    const record = saltedRecord('123456');
+    expect(verifyOtpHash('123456', { ...record, otp_hash: record.otp_hash.toUpperCase() })).toBe(false);
+  });
+});
+
+describe('verifyOtpHash — legacy unsalted records', () => {
+  it('still accepts a correct pre-migration OTP', () => {
+    // In-flight codes issued before the migration must keep working for the
+    // remainder of their TTL, otherwise deploying locks users out.
+    expect(verifyOtpHash('123456', legacyRecord('123456'))).toBe(true);
+  });
+
+  it('rejects an incorrect pre-migration OTP', () => {
+    expect(verifyOtpHash('999999', legacyRecord('123456'))).toBe(false);
+  });
+
+  it('fails closed on a malformed legacy digest', () => {
+    expect(verifyOtpHash('123456', { otp_hash: 'abc' })).toBe(false);
+    expect(verifyOtpHash('123456', { otp_hash: 'g'.repeat(64) })).toBe(false);
+  });
+
+  it('prefers the salted path when a salt is present', () => {
+    // A record carrying both a salt and a legacy-length digest must not fall
+    // through to the SHA-256 branch.
+    const record = { ...legacyRecord('123456'), otp_salt: 'a'.repeat(32) };
+    expect(verifyOtpHash('123456', record)).toBe(false);
+  });
+});
+
+describe('verifyOtpHash — malformed input', () => {
+  it('returns false for null, undefined and non-object records', () => {
+    expect(verifyOtpHash('123456', null)).toBe(false);
+    expect(verifyOtpHash('123456', undefined)).toBe(false);
+    expect(verifyOtpHash('123456', 'not-a-record')).toBe(false);
+    expect(verifyOtpHash('123456', 42)).toBe(false);
+  });
+
+  it('returns false for an empty record', () => {
+    expect(verifyOtpHash('123456', {})).toBe(false);
+  });
+
+  it('returns false rather than throwing for a null OTP', () => {
+    expect(verifyOtpHash(null, saltedRecord('123456'))).toBe(false);
+    expect(verifyOtpHash(undefined, saltedRecord('123456'))).toBe(false);
+  });
+});
+
+describe('isLegacyOtpRecord', () => {
+  it('identifies a pre-migration unsalted record', () => {
+    expect(isLegacyOtpRecord(legacyRecord('123456'))).toBe(true);
+  });
+
+  it('does not flag a salted record', () => {
+    expect(isLegacyOtpRecord(saltedRecord('123456'))).toBe(false);
+  });
+
+  it('does not flag malformed or empty records', () => {
+    expect(isLegacyOtpRecord(null)).toBe(false);
+    expect(isLegacyOtpRecord({})).toBe(false);
+    expect(isLegacyOtpRecord({ otp_hash: 'short' })).toBe(false);
+  });
+});
+
+describe('login and delivery OTP paths share one implementation', () => {
+  it('a digest produced by hashOtp verifies through verifyOtpHash', async () => {
+    const { verifyDeliveryOtpHash } = await import(
+      '../../src/services/notificationService.js'
+    ).catch(() => ({ verifyDeliveryOtpHash: null }));
+
+    const record = saltedRecord('246810');
+    expect(verifyOtpHash('246810', record)).toBe(true);
+
+    // The delivery path delegates to the same function, so if it is importable
+    // in this environment it must agree.
+    if (verifyDeliveryOtpHash) {
+      expect(verifyDeliveryOtpHash('246810', record)).toBe(true);
+      expect(verifyDeliveryOtpHash('000000', record)).toBe(false);
+    }
+  });
+});

--- a/supabase/migrations/20260805120000_add_otp_salt_to_phone_otps.sql
+++ b/supabase/migrations/20260805120000_add_otp_salt_to_phone_otps.sql
@@ -1,0 +1,31 @@
+-- Add a per-record salt to phone login OTPs.
+--
+-- phone_otps.otp_hash was written as a bare, unsalted SHA-256 digest. A
+-- 6-digit OTP has a keyspace of 10^6, so the complete rainbow table computes
+-- in under a second — any read access to this table yielded live login codes.
+-- The delivery_otps table was already migrated to salted scrypt; this brings
+-- the login path in line.
+--
+-- The column is nullable on purpose. Rows written before this migration have
+-- no salt and are verified through the legacy SHA-256 branch in
+-- src/lib/otpHashing.js for the remainder of their TTL, so codes already in
+-- flight are not invalidated at deploy time.
+
+BEGIN;
+
+ALTER TABLE public.phone_otps
+  ADD COLUMN IF NOT EXISTS otp_salt text;
+
+COMMENT ON COLUMN public.phone_otps.otp_salt IS
+  'Hex-encoded 16-byte scrypt salt. NULL only for pre-migration rows, which '
+  'verify via the legacy unsalted SHA-256 path until they expire.';
+
+-- Lookups filter on (phone, verified, expires_at) and take the newest row.
+CREATE INDEX IF NOT EXISTS idx_phone_otps_lookup
+  ON public.phone_otps (phone, verified, expires_at DESC);
+
+-- Supports cleanup of expired rows without scanning the table.
+CREATE INDEX IF NOT EXISTS idx_phone_otps_expires_at
+  ON public.phone_otps (expires_at);
+
+COMMIT;


### PR DESCRIPTION
Fixes #6396

**What is the problem**

`POST /api/auth/verify-otp` hashed phone login OTPs with bare, unsalted SHA-256:

```js
const submittedHash = crypto.createHash("sha256").update(String(otp)).digest("hex");
```

A 6-digit OTP has a keyspace of 10^6. The complete rainbow table for every possible code computes in well under a second, so anyone able to read `phone_otps` recovers live login credentials — retroactively for every code ever issued, and going forward. There is no work factor and no per-record variation to prevent it.

The comparison itself *is* timing-safe, which is correct and is preserved. The defect is the hash construction, not the comparison.

What makes this clearly an oversight rather than a design decision: the **delivery** OTP path in this same codebase was already migrated to salted scrypt. `notificationService.js` has `hashDeliveryOtp` (scrypt + per-record salt), `verifyDeliveryOtpHash` (salted with a documented legacy fallback), and `storeDeliveryOtp` writes both `otp_hash` and `otp_salt`. The login path, living in a different route file against a different table, was simply never swept up in that migration.

**What was changed**

- **`backend/api/src/lib/otpHashing.js`** (new) — the delivery-OTP implementation lifted into a module both paths share, exporting `hashOtp`, `verifyOtpHash` and `isLegacyOtpRecord`. Preserves the salted-then-legacy-fallback semantics and the timing-safe comparison exactly. Hardened slightly: the stored digest's shape is validated *before* `timingSafeEqual`, which throws on a length mismatch — a malformed row must fail closed, not raise.
- **`supabase/migrations/20260805120000_add_otp_salt_to_phone_otps.sql`** (new) — adds a nullable `otp_salt` column, wrapped in `BEGIN; ... COMMIT;` per `CONTRIBUTING.md`, with `IF NOT EXISTS` so it is idempotent. Also adds the `(phone, verified, expires_at DESC)` index matching the query the verify path actually issues, and an expiry index for cleanup.
- **`backend/api/src/routes/authRoutes.js`** — selects `otp_salt` and delegates to `verifyOtpHash`, removing the inline SHA-256 construction. Logs when a pre-migration record is verified, so the legacy branch can eventually be retired against evidence.
- **`backend/api/src/services/notificationService.js`** — `hashDeliveryOtp` and `verifyDeliveryOtpHash` now delegate to the shared module. Their signatures and behaviour are unchanged, so existing callers and tests are unaffected.
- **`backend/api/test/unit/otpHashing.test.js`** (new) — 23 tests.

**Why this approach**

Salting is what actually fixes this. Switching to a stronger unsalted digest would not: the keyspace is 10^6 regardless of algorithm, so a single precomputed table still breaks every record. Per-record salt makes precomputation useless, and scrypt's work factor makes even per-record exhaustive search costly.

The column is **nullable on purpose**. Making it `NOT NULL` would invalidate every OTP currently in flight the moment the migration ran, locking out any user mid-login. The legacy branch verifies pre-migration rows via SHA-256 for the remainder of their TTL — the same backward-compatible shape `verifyDeliveryOtpHash` already used, so this introduces no new pattern.

The logic went into a shared module rather than being copied because copying is precisely how this bug happened. One implementation cannot drift.

**⚠️ This PR does not complete the migration on its own.**

I traced the write path and it does **not exist in this repository** — `phone_otps` is only ever read (line 209) and consumed (line 243) here. Whatever issues login OTPs (a Supabase Edge Function, or the SMS provider integration) lives outside this repo and **must be updated to persist `otp_salt` via `hashOtp`** before newly issued codes are actually salted.

Until that happens, this PR delivers: the column, the shared hardened verifier, backward compatibility, the missing indexes, and test coverage — with new codes still landing on the legacy path. I did not want to imply an end-to-end fix I cannot verify from this repo. If you can point me at where OTPs are issued, I will follow up with that half.

**How to test**

1. Pull this branch, apply the migration (`supabase db push`, or paste the file into the SQL editor).
2. Verify backward compatibility — the critical case: insert a row into `phone_otps` with a SHA-256 `otp_hash` and **no** salt, then `POST /api/auth/verify-otp` with that code. It still verifies, and a warning is logged naming the record.
3. Verify the salted path: insert a row using `hashOtp('123456')` for both `otp_hash` and `otp_salt`, then verify — accepted.
4. Verify rejection: submit a wrong code against either record type — 400 `Invalid OTP.`
5. Verify fail-closed behaviour: corrupt a stored `otp_hash` to a short string; verification returns 400 rather than throwing a 500 from `timingSafeEqual`.
6. Run `npx vitest run test/unit/otpHashing.test.js` — 23 tests pass.

**Edge cases covered**

- Salt uniqueness across calls; identical OTPs producing different digests (the property that defeats precomputation).
- Deterministic re-hash when the salt is supplied; numeric vs string OTP input.
- Salted record with a mismatched salt — rejected.
- Malformed stored digests: too short, empty, non-hex, `null`, uppercase — all fail closed rather than throwing.
- Legacy unsalted record: correct code accepted, incorrect rejected, malformed fails closed.
- A record carrying both a salt and a legacy-length digest — takes the salted path and does not fall through.
- `null`/`undefined`/non-object records, and `null`/`undefined` submitted OTPs.
- `isLegacyOtpRecord` correctly distinguishes the two formats for reporting.

**Screenshots or logs**

```
$ npx vitest run test/unit/otpHashing.test.js
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

Demonstrating the core property — the same OTP now produces different stored digests (actual output from this branch):

```
$ node -e "import('./src/lib/otpHashing.js').then(({hashOtp})=>{ \
    const a=hashOtp('123456'), b=hashOtp('123456'); \
    console.log('a.salt:', a.salt); console.log('a.hash:', a.hash.slice(0,32)+'...'); \
    console.log('b.salt:', b.salt); console.log('b.hash:', b.hash.slice(0,32)+'...'); \
    console.log('identical hashes?', a.hash===b.hash); })"

a.salt: 2a8c4cc9994b0fcdbae054e678e10d2b
a.hash: f467784c775a537969f403d9a3cd7264...
b.salt: fc7aba37d3317967b2d69de22ed727b9
b.hash: a8b2aaafd88fab8d9d7362535bf1104c...
identical hashes? false
```

Under the previous scheme both would have been byte-identical, which is what made one rainbow table sufficient.

**Lines changed**

330 added, 27 removed — 357 total across 5 files.

**Verification checklist**

- [x] Branch fully synced with latest upstream before coding started
- [x] All original existing code preserved — `hashDeliveryOtp`/`verifyDeliveryOtpHash` keep their signatures and behaviour
- [x] PR raised against original upstream repository and not my fork
- [x] Correct issue number tagged with Fixes #6396
- [x] Root cause fully resolved *within this repository* — see the write-path caveat above, which is outside it
- [x] All edge cases and error paths handled
- [x] No regressions introduced — full suite compared against baseline below
- [x] All existing tests pass
- [x] New tests written covering this change
- [x] Code matches project style and conventions throughout
- [x] Total lines changed confirmed at 200 or above
- [x] Not a duplicate of any existing open or closed PR

**Note on the test suite baseline.** `main` is red for unrelated reasons — `@opentelemetry/*` is imported by `src/tracing/tracing.js` but absent from `package.json`, and `profileCache.js` (#6384) and `escrow.js` (#6122) do not parse. Against that baseline:

| | `main` | this branch |
|---|---|---|
| Tests | 119 failed / 1187 passed | 119 failed / **1210** passed |

Identical failure count, +23 passing tests. No regressions.

**Labels:** no `type:security` label exists — closest are `type:bug` + `high` + `backend` + `level:advanced` + `gssoc:approved`. I lack triage permission to apply them.

Please review and merge this under GSSoC 2026.
