### PR TITLE
fix: remove duplicate unclosed 403 block in requireRole (SyntaxError)

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -492,9 +492,6 @@ export function requireRole(allowedRoles) {
       return res.status(403).json({
         error: 'Forbidden: Insufficient privileges.',
         details: `Your account role '${req.user.role}' is not authorized to access this resource.`
-      return res.status(403).json({
-        error: "Forbidden: Insufficient privileges.",
-        details: `Your account role '${req.user.role}' is not authorized to access this resource.`,
       });
     }
 


### PR DESCRIPTION
Closes #6581

Removed the duplicated, unclosed \es.status(403).json({ ... })\ block in \equireRole\ that produced \SyntaxError: Unexpected token 'return'\ and prevented the auth middleware (and the whole backend) from loading.

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the formatting of forbidden-role responses without changing their behavior or content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->