### PR TITLE
fix: chain .catch onto startGraphQL() call (SyntaxError)

### DIFF
--- a/backend/graphql/index.js
+++ b/backend/graphql/index.js
@@ -37,5 +37,4 @@ process.on('SIGINT', async () => {
     process.exit(0);
 });
 
-startGraphQL();
-.catch(err => console.error("Promise.all failed:", err));
+startGraphQL().catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Closes #6584

\startGraphQL();\ ended with a semicolon, making the trailing \.catch(...)\ an invalid statement and leaving the startup error handler dead. Merged into a single chained call.

GSSOC