### PR TITLE
fix: wrap driver earnings test body in async it() (SyntaxError)

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -48,6 +48,7 @@ describe('GET /api/driver/:id/earnings', () => {
     vi.clearAllMocks();
   });
 
+  it('computes weekly earnings with deadhead savings', async () => {
     let deadheadChain = null;
     
     // Track which 'from' was called


### PR DESCRIPTION
Closes #6585

The test body used \wait\ directly inside the non-async \describe\ callback (\SyntaxError: Unexpected reserved word\). Wrapped it in an \it('computes weekly earnings with deadhead savings', async () => { ... })\.

GSSOC