### PR TITLE
fix: use CSPRNG multipart boundary for Whisper upload

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -106,7 +106,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
   // Production Whisper call
   let transcript;
   try {
-    const boundary = '----VoiceAIBoundary' + Math.random().toString(16).substring(2);
+    const boundary = '----VoiceAIBoundary' + crypto.randomBytes(16).toString('hex');
     const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename || 'audio.wav'}"\r\nContent-Type: audio/wav\r\n\r\n`;
     const footer = `\r\n--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\nwhisper-1\r\n--${boundary}--`;
     const body = Buffer.concat([


### PR DESCRIPTION
Closes #6587

The multipart boundary for the OpenAI Whisper upload was built with \Math.random()\ (predictable -> boundary injection / request smuggling risk). Now uses \crypto.randomBytes(16).toString('hex')\.

GSSOC