### PR TITLE
fix: use CSPRNG-based StoreTransaction id

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import crypto from 'crypto';
 import logger from '../api/src/middleware/logger.js';
 
 class StoreTransaction {
@@ -10,7 +11,7 @@ class StoreTransaction {
         this.error = null;
         this.startTime = null;
         this.endTime = null;
-        this.id = `tx_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        this.id = `tx_${crypto.randomBytes(16).toString('hex')}`;
     }
     
     begin() {


### PR DESCRIPTION
Closes #6589

\StoreTransaction.id\ was generated with \Date.now()\ + \Math.random()\ and the deprecated \.substr\. Now generated from \crypto.randomBytes(16).toString('hex')\.

GSSOC