### PR TITLE
fix: use CSPRNG-based fallback node id

### DIFF
--- a/backend/layout/LayoutNode.js
+++ b/backend/layout/LayoutNode.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import crypto from 'crypto';
 import logger from '../api/src/middleware/logger.js';
 
 class LayoutNode extends EventEmitter {
@@ -6,7 +7,7 @@ class LayoutNode extends EventEmitter {
         super();
         
         // Node properties
-        this.id = config.id || `node_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        this.id = config.id || `node_${crypto.randomBytes(8).toString('hex')}`;
         this.type = config.type || 'container';
         this.parent = config.parent || null;
         this.children = [];


### PR DESCRIPTION
Closes #6605

\LayoutNode.id\ fell back to \Date.now()\ + \Math.random()\ with the deprecated \.substr\. Now uses \crypto.randomBytes(8).toString('hex')\.

GSSOC