### PR TITLE
fix(driver): align chat channel id with customer order_display_id (#6558)

### DIFF
--- a/apps/driver/lib/screens/chat_screen.dart
+++ b/apps/driver/lib/screens/chat_screen.dart
@@ -28,7 +28,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   void _setupSupabaseChannel() {
-    final orderId = widget.trip.id;
+    final orderId = widget.trip.id.replaceFirst(RegExp(r'^TX-'), '');
     _channel = Supabase.instance.client.channel('chat_$orderId');
 
     _channel!


### PR DESCRIPTION
## Problem
Driver and customer chat channels are built from different id spaces. The driver app used `trip_display_id` (e.g. `TX-ORD-100`) to build `chat_$orderId`, while the customer app used `order_display_id` (e.g. `ORD-100`). The two apps never joined the same Supabase Realtime channel, so driver-customer chat silently broke.

## Fix
Strip the `TX-` prefix from the trip id when building the driver's channel key, so both apps subscribe to `chat_ORD-100`. Reused the `tripId -> orderDisplayId` relationship created by the trip-on-assignment migration (`v_trip_display_id := 'TX-' || NEW.order_display_id`).

## Files changed
- `apps/driver/lib/screens/chat_screen.dart`

## Testing
- Confirmed the channel id derivation now matches the customer side (`order_display_id`).
- No app unit tests cover this screen; verified by tracing both code paths.

Closes #6558
