### PR TITLE
fix(driver): pass real order id to PoD upload from home screen (#6559)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -146,6 +146,9 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _showStatusCard = true;
   final TripService _tripService = TripService();
   String? _activeTripId;
+  /// Order id (orders.id UUID) served by the active trip, used for
+  /// order-scoped uploads such as proof of delivery.
+  String? _activeOrderId;
   String _activeTruckLabel = '';
   String _activeTripDistance = '';
   String _activeTripDuration = '';
@@ -700,6 +703,7 @@ class _HomeScreenState extends State<HomeScreen> {
             '';
 
         await prefs.setString('cached_trip_id', tripId);
+        await prefs.setString('cached_order_id', activeTrip['order_id']?.toString() ?? '');
         await prefs.setString('cached_truck_label', truckLabel);
         await prefs.setString('cached_distance', distanceStr);
         await prefs.setString('cached_duration', durationStr);
@@ -719,6 +723,7 @@ class _HomeScreenState extends State<HomeScreen> {
         setState(() {
           _isOffline = false;
           _activeTripId = tripId;
+          _activeOrderId = activeTrip['order_id']?.toString();
           _activeTruckLabel = truckLabel;
           _activeTripDistance = distanceStr;
           _activeTripDuration = durationStr;
@@ -755,10 +760,12 @@ class _HomeScreenState extends State<HomeScreen> {
       } else {
         final prefs = await SharedPreferences.getInstance();
         await prefs.remove('cached_trip_id');
+        await prefs.remove('cached_order_id');
         if (mounted) {
           setState(() {
             _isOffline = false;
             _activeTripId = null;
+            _activeOrderId = null;
             _isTripStarted = false;
             _destination = null;
             _routeFuture = null;
@@ -775,6 +782,7 @@ class _HomeScreenState extends State<HomeScreen> {
         setState(() {
           _isOffline = true;
           _activeTripId = prefs.getString('cached_trip_id');
+          _activeOrderId = prefs.getString('cached_order_id');
           _activeTruckLabel = prefs.getString('cached_truck_label') ?? '';
           _activeTripDistance = prefs.getString('cached_distance') ?? '';
           _activeTripDuration = prefs.getString('cached_duration') ?? '';
@@ -811,6 +819,7 @@ class _HomeScreenState extends State<HomeScreen> {
         if (mounted) {
           setState(() {
             _activeTripId = null;
+            _activeOrderId = null;
             _isTripStarted = false;
             _destination = null;
             _routeFuture = null;
@@ -2115,7 +2124,7 @@ class _HomeScreenState extends State<HomeScreen> {
             if (_isTripStarted && _activeTripId != null) ...[
               ElevatedButton.icon(
                 onPressed: () async {
-                  await Navigator.push(context, MaterialPageRoute(builder: (_) => PodCaptureScreen(orderId: _activeTripId!)));
+                  await Navigator.push(context, MaterialPageRoute(builder: (_) => PodCaptureScreen(orderId: _activeOrderId ?? _activeTripId!)));
                   _checkPendingPods();
                 },
                 icon: const Icon(Icons.camera_alt),


### PR DESCRIPTION
## Problem
The PoD (proof-of-delivery) upload button on the home screen passed the trip's `TX-` prefixed display id as the order id. `POST /api/orders/:id/pod` resolves `:id` against the orders UUID/display-id namespace (`findOrderByIdOrDisplayId`), so it never matched and PoD uploads from the home screen failed.

## Fix
Track the active trip's real `order_id` alongside the trip id. `_activeOrderId` is captured when the active trip is loaded (mirroring the pattern in `trips_screen.dart`), cached in SharedPreferences as `cached_order_id`, and passed to `PodCaptureScreen` (falling back to the trip id only if unavailable).

## Files changed
- `apps/driver/lib/screens/home_screen.dart`

## Testing
- Traced `_loadActiveTrip` -> PoD button -> `PodCaptureScreen`/`SyncService.uploadPodFiles` to confirm the order UUID is now used.
- The offline retry path (`background_sync_service.dart`) already persists whatever id was passed at capture, so it inherits the fix.

Closes #6559
