### PR TITLE
fix(api): return numeric amount_inr and order_display_id from confirm-otp (#6560)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1165,7 +1165,7 @@ router.post(
         'total_amount, order_display_id'
       );
       const amountInr = orderForAmount?.total_amount
-        ? (order.total_amount / 100).toFixed(0)
+        ? (orderForAmount.total_amount / 100).toFixed(0)
         : null;
 
       if (escrowUpdateFailed) {
@@ -1184,7 +1184,7 @@ router.post(
         payment_released: true,
         escrow_status: 'released',
         amount_inr: amountInr,
-        order_display_id: order?.order_display_id,
+        order_display_id: orderForAmount?.order_display_id,
       });
     } catch (err) {
       if (err instanceof DomainError) {

--- a/backend/api/test/contracts/delivery.contract.test.js
+++ b/backend/api/test/contracts/delivery.contract.test.js
@@ -279,6 +279,41 @@ describe("POST /api/orders/:id/verify-delivery — delivery verification contrac
     expect(m.calls.find((c) => c.rpc === "complete_trip_tx")).toBeTruthy();
   });
 
+  it("200: confirm-otp returns numeric amount_inr and non-null order_display_id", async () => {
+    escrowReleaseMock.mockResolvedValue({ txHash: "0xrelease" });
+
+    m.store.orders.push({
+      id: "order-cotp-1",
+      driver_id: DRIVER["x-user-id"],
+      order_display_id: "ORD-COTP",
+      status: "arriving",
+      total_amount: 500000,
+      escrow_status: "funded",
+      drop_lat: DROP_LAT,
+      drop_lng: DROP_LNG,
+    });
+    m.store.delivery_otps.push(makeOtpRecord("otp-cotp-1", "order-cotp-1"));
+    seedDriverAtDropOff("order-cotp-1", DRIVER["x-user-id"]);
+    m.store.order_timeline.push({
+      order_display_id: "ORD-COTP",
+      milestone: "Delivered",
+      completed: false,
+    });
+
+    const res = await request(buildApp())
+      .post("/api/orders/order-cotp-1/confirm-otp")
+      .set("X-Idempotency-Key", "cotp-test-1")
+      .set(DRIVER)
+      .send({ otp: "123456" });
+
+    expectContract(res, 200);
+    expect(res.body.payment_released).toBe(true);
+    expect(typeof res.body.amount_inr).toBe("string");
+    expect(Number.isNaN(Number(res.body.amount_inr))).toBe(false);
+    expect(res.body.amount_inr).toBe("5000");
+    expect(res.body.order_display_id).toBe("ORD-COTP");
+  });
+
   it("400: validation error when OTP missing", async () => {
     const res = await request(buildApp())
       .post("/api/orders/order-dv-1/verify-delivery")


### PR DESCRIPTION
## Problem
`POST /api/orders/:id/confirm-otp` returned `amount_inr: NaN` because it read `order.total_amount` instead of the amount returned by the escrow/order lookup (`orderForAmount.total_amount`), and `order_display_id` was null because the projection didn't include it.

## Fix
Compute `amountInr` from `orderForAmount.total_amount` and return `orderForAmount?.order_display_id` in the response.

## Files changed
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/contracts/delivery.contract.test.js`

## Testing
- Added a contract regression test asserting `amount_inr === "5000"`, a non-null `order_display_id`, `payment_released` true, and no `NaN` in the response.

Closes #6560
