### PR TITLE
fix(api): include status in confirm-deposit projection so cancelled guard fires (#6561)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1454,7 +1454,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
   }
 
   try {
-    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance');
+    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, status, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertCustomerOwnership(order, req.user.id);
     orderValidationService.assertEscrowState(order, ['funding'], 'Order is not in funding state');

--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -733,6 +733,30 @@ describe('Bid Routes', () => {
       expect(res.body.error).toBe('Order is not in funding state');
     });
 
+    it('POST /:id/confirm-deposit returns 409 for an order cancelled in funding state', async () => {
+      m.store.orders.push({
+        id: 'order-1',
+        customer_id: 'customer-1',
+        order_display_id: 'OD1',
+        status: 'cancelled',
+        escrow_booking_id: 'escrow:OD1',
+        escrow_status: 'funding',
+      });
+
+      const app = buildApp();
+      const res = await request(app)
+        .post('/api/orders/order-1/confirm-deposit')
+        .set(CUSTOMER)
+        .send({ txHash: '0x' + '1'.repeat(64) });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Order is already cancelled. Cannot confirm deposit.');
+
+      const order = m.store.orders.find(o => o.id === 'order-1');
+      expect(order.escrow_status).toBe('funding');
+      expect(mockRecordDepositTx).not.toHaveBeenCalled();
+    });
+
     it('POST /:id/confirm-deposit returns 422 if recordDepositTx fails', async () => {
       m.store.orders.push({
         id: 'order-1',


### PR DESCRIPTION
## Problem
The confirm-deposit handler's projection did not include `status`, so the `order.status === 'cancelled'` guard never fired and a cancelled order could still have its deposit confirmed.

## Fix
Include `status` as the first column in the confirm-deposit order projection so the cancelled-order 409 guard works as intended.

## Files changed
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/integration/bids.test.js`

## Testing
- Added an integration test: a cancelled order with `escrow_status: 'funding'` returns 409, escrow state is unchanged, and `recordDepositTx` is not called.

Closes #6561
