### PR TITLE
fix(api): strip TX- prefix when enriching trips escrow status (#6562)

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -593,20 +593,25 @@ router.get('/trips', authenticate, userLimiter, requirePolicy('driver:view-trips
 
     if (error) return res.status(500).json({ error: 'Failed to fetch trips.', details: error.message });
 
-    // Enrich trips with escrow_status from orders
-    const tripDisplayIds = (trips || []).map(t => t.trip_display_id).filter(Boolean);
+    // Enrich trips with escrow_status from orders. Trip display ids are
+    // prefixed with TX- (trip_display_id := 'TX-' || order_display_id), so
+    // strip the prefix before matching against orders.order_display_id.
+    const stripTripPrefix = (id) => (typeof id === 'string' ? id.replace(/^TX-/, '') : id);
+    const orderDisplayIds = (trips || [])
+      .map(t => stripTripPrefix(t.trip_display_id))
+      .filter(Boolean);
     let escrowMap = {};
-    if (tripDisplayIds.length > 0) {
+    if (orderDisplayIds.length > 0) {
       const { data: orders } = await supabaseAdmin
         .from('orders')
         .select('order_display_id, escrow_status')
-        .in('order_display_id', tripDisplayIds);
+        .in('order_display_id', orderDisplayIds);
       escrowMap = Object.fromEntries((orders || []).map(o => [o.order_display_id, o.escrow_status]));
     }
 
     const enrichedTrips = (trips || []).map(t => ({
       ...t,
-      escrow_status: escrowMap[t.trip_display_id] || 'pending'
+      escrow_status: escrowMap[stripTripPrefix(t.trip_display_id)] || 'pending'
     }));
 
     res.json({

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -111,6 +111,31 @@ describe('Driver Routes', () => {
     expect(res.body.truck.id).toBe('truck-1');
   });
 
+  it('GET /trips enriches escrow_status from the underlying order', async () => {
+    m.store.trips = [{
+      trip_display_id: 'TX-ORD-100',
+      driver_id: 'driver-1',
+      route_label: 'A → B',
+      status: 'active',
+      trip_date: '2026-08-05',
+    }];
+    m.store.orders = [{
+      order_display_id: 'ORD-100',
+      escrow_status: 'funded',
+    }];
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/drivers/trips')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.trips).toHaveLength(1);
+    expect(res.body.trips[0].trip_display_id).toBe('TX-ORD-100');
+    expect(res.body.trips[0].escrow_status).toBe('funded');
+  });
+
   it('PUT /online rejects invalid status', async () => {
     const app = buildApp();
 


### PR DESCRIPTION
## Problem
The driver trips enrichment lookup matched trip ids (`TX-ORD-100`) against order display ids (`ORD-100`) in a `.in('order_display_id', ...)` query, so escrow status was never attached to trips.

## Fix
Strip the `TX-` prefix from trip ids before the order lookup and use the stripped key when reading `escrowMap`, so each trip gets its order's `escrow_status`.

## Files changed
- `backend/api/src/routes/driverRoutes.js`
- `backend/api/test/integration/driverRoutes.test.js`

## Testing
- Added an integration test: a trip `TX-ORD-100` with order `ORD-100` in `funded` escrow yields an enriched trip with `escrow_status === "funded"`.

Closes #6562
