### PR TITLE
fix(api): prevent IDOR on POST /api/verification/documents/check (#6563)

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -101,6 +101,22 @@ router.get('/order/:orderId', orderVerificationLimiter, authenticate, validatePa
 router.post('/documents/check', documentCheckLimiter, authenticate, validateBody(documentCheckSchema), async (req, res) => {
   try {
     const { driverId } = req.body;
+
+    // IDOR guard: a caller may only inspect their own document/KYC status
+    // unless they hold an admin role (mirrors the ownership check used on the
+    // order-scoped verification routes).
+    try {
+      policy.authorize(req.user, 'document:view', { driverId });
+    } catch (error) {
+      if (error instanceof PolicyError) {
+        return res.status(error.status).json({
+          success: false,
+          error: error.message,
+        });
+      }
+      throw error;
+    }
+
     const result = await verificationService.checkDocumentIntegrity(driverId);
 
     res.status(200).json({

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -73,6 +73,7 @@ const POLICIES = {
 
   'driver:view-stats':         { roles: [ROLES.DRIVER] },
   'document:upload':           { roles: [ROLES.DRIVER] },
+  'document:view':             { ownership: (u, r) => r?.driverId && (r.driverId === u.id || u.role === ROLES.ADMIN) },
   'driver:toggle-online':      { roles: [ROLES.DRIVER] },
   'driver:update-hos':         { roles: [ROLES.DRIVER] },
   'driver:view-wallet':        { roles: [ROLES.DRIVER] },

--- a/backend/api/test/integration/oracleVerificationSecurity.test.js
+++ b/backend/api/test/integration/oracleVerificationSecurity.test.js
@@ -120,7 +120,7 @@ const USER_HEADERS = {
 };
 
 const DRIVER_HEADERS = {
-  'x-user-id': 'driver-1',
+  'x-user-id': VALID_DRIVER_ID,
   'x-user-role': 'driver',
 };
 
@@ -463,6 +463,61 @@ describe('Verification Routes — Request Validation', () => {
       .set(DRIVER_HEADERS)
       .send({ driverId: VALID_DRIVER_ID, extra: 'nope' });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('Verification Routes — Document Check IDOR Guard', () => {
+  const OTHER_DRIVER_ID = '770e8400-e29b-41d4-a716-446655440002';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when a driver tries to check another driver\'s documents', async () => {
+    const app = buildVerifyApp();
+    const res = await request(app)
+      .post('/api/verify/documents/check')
+      .set(DRIVER_HEADERS)
+      .send({ driverId: OTHER_DRIVER_ID });
+
+    expect(res.status).toBe(403);
+    expect(mockVerificationService.checkDocumentIntegrity).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when a customer tries to check a driver\'s documents', async () => {
+    const app = buildVerifyApp();
+    const res = await request(app)
+      .post('/api/verify/documents/check')
+      .set(USER_HEADERS)
+      .send({ driverId: VALID_DRIVER_ID });
+
+    expect(res.status).toBe(403);
+    expect(mockVerificationService.checkDocumentIntegrity).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 when a driver checks their own documents', async () => {
+    const app = buildVerifyApp();
+    const res = await request(app)
+      .post('/api/verify/documents/check')
+      .set(DRIVER_HEADERS)
+      .send({ driverId: VALID_DRIVER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockVerificationService.checkDocumentIntegrity).toHaveBeenCalledWith(VALID_DRIVER_ID);
+  });
+
+  it('returns 200 when an admin checks any driver\'s documents', async () => {
+    const app = buildVerifyApp();
+    const res = await request(app)
+      .post('/api/verify/documents/check')
+      .set('x-user-id', 'admin-uuid-999')
+      .set('x-user-role', 'admin')
+      .send({ driverId: OTHER_DRIVER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockVerificationService.checkDocumentIntegrity).toHaveBeenCalledWith(OTHER_DRIVER_ID);
   });
 });
 


### PR DESCRIPTION
## Problem
`POST /api/verification/documents/check` accepted an arbitrary `driverId` from the request body and returned that driver's document/KYC status to any authenticated caller — an IDOR letting any user enumerate driver verification statuses by guessing UUIDs.

## Fix
Enforce authorization before `checkDocumentIntegrity`:
- Added a `document:view` policy action with an ownership check: a caller may only inspect their own documents, or admins may inspect any driver's documents (mirroring the order-scoped verification routes).
- The route returns 403 for unauthorized callers.

## Files changed
- `backend/api/src/routes/verificationRoutes.js`
- `backend/api/src/security/policyEngine.js`
- `backend/api/test/integration/oracleVerificationSecurity.test.js`

## Testing
- Added IDOR regression tests: driver checking another driver's docs -> 403 (service not called), customer checking a driver's docs -> 403, driver checking own docs -> 200, admin checking any driver -> 200.
- Updated `DRIVER_HEADERS` so the existing 200/contract tests use a UUID matching the queried driver.

Closes #6563
