### PR TITLE
fix(api): harden /api/verification/kyc/upload against unbounded uploads (#6564)

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -10,6 +10,8 @@ import logger from '../middleware/logger.js';
 import { verifyOrderParamsSchema, documentCheckSchema } from '../validation/requestSchemas.js';
 import { PolicyError, policy } from '../security/policyEngine.js';
 import digilockerService from '../services/verification/DigilockerService.js';
+import { validateDocumentBuffer, DocumentValidationError } from '../lib/documentValidation.js';
+import { scanDocument, MalwareScanError } from '../lib/malwareScanner.js';
 
 const router = express.Router();
 const orderVerificationLimiter = rateLimit({
@@ -42,6 +44,17 @@ const digilockerLimiter = rateLimit({
   keyGenerator: safeIpKeyGenerator,
   validate: { keyGeneratorIpFallback: false },
   store: createStore('rl:digilocker:'),
+  message: { error: 'Rate limit exceeded', retryAfter: 900 },
+});
+
+const kycUploadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: safeIpKeyGenerator,
+  validate: { keyGeneratorIpFallback: false },
+  store: createStore('rl:kyc-upload:'),
   message: { error: 'Rate limit exceeded', retryAfter: 900 },
 });
 
@@ -157,13 +170,44 @@ router.post('/digilocker/verify', digilockerLimiter, authenticate, async (req, r
   }
 });
 
-const upload = multer({ storage: multer.memoryStorage() });
+const KYC_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png'];
+const KYC_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
-router.post('/kyc/upload', upload.single('image'), authenticate, async (req, res) => {
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: KYC_MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (KYC_ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(null, false);
+    }
+  },
+});
+
+router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {
       return res.status(400).json({ success: false, error: 'No image uploaded' });
+    }
+
+    // Validate magic bytes and malware-scan before the buffer is forwarded to
+    // the ML endpoint (same hardening as the PoD upload at orderRoutes).
+    try {
+      validateDocumentBuffer(req.file.buffer, req.file.mimetype);
+      const scanResult = await scanDocument(req.file.buffer, req.file.originalname);
+      if (!scanResult.clean) {
+        return res.status(422).json({ success: false, error: 'Uploaded image failed malware scanning.' });
+      }
+    } catch (error) {
+      if (error instanceof DocumentValidationError) {
+        return res.status(422).json({ success: false, error: error.message });
+      }
+      if (error instanceof MalwareScanError) {
+        return res.status(422).json({ success: false, error: error.message });
+      }
+      throw error;
     }
 
     // Set status to pending

--- a/backend/api/test/integration/kycUploadSecurity.test.js
+++ b/backend/api/test/integration/kycUploadSecurity.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: m.supabase,
+  firebaseAdmin: null,
+  redisClient: null,
+  mongoDb: null,
+}));
+
+vi.mock('../../src/lib/malwareScanner.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    scanDocument: vi.fn().mockResolvedValue({ clean: true, engine: 'mock' }),
+  };
+});
+
+const { default: verificationRouter } = await import('../../src/routes/verificationRoutes.js');
+const { scanDocument } = await import('../../src/lib/malwareScanner.js');
+const { errorHandler } = await import('../../src/middleware/errorHandler.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/verify', verificationRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const DRIVER_HEADERS = {
+  'x-user-id': 'kyc-driver-uuid-123',
+  'x-user-role': 'driver',
+  'x-user-name': 'Test Driver',
+};
+
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+const EXECUTABLE_RENAMED_AS_JPG = Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00]);
+const KYC_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+describe('KYC Upload Route Security Tests', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.driver_details = [
+      { driver_id: 'kyc-driver-uuid-123', kyc_status: 'Not Submitted' },
+    ];
+    m.calls.length = 0;
+    scanDocument.mockResolvedValue({ clean: true, engine: 'mock' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 413 for an oversized image', async () => {
+    const oversized = Buffer.alloc(KYC_MAX_FILE_SIZE + 1024, 0xff);
+
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', oversized, { filename: 'big.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/File upload error/);
+  });
+
+  it('rejects a disallowed MIME type (400, file is skipped by fileFilter)', async () => {
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', Buffer.from('GIF89a-not-an-image'), { filename: 'doc.gif', contentType: 'image/gif' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No image uploaded');
+    expect(scanDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects an executable renamed to .jpg with 422 and never forwards to the ML endpoint', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', EXECUTABLE_RENAMED_AS_JPG, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/Invalid document type/);
+    expect(fetchMock).not.toHaveBeenCalled();
+    const row = m.store.driver_details.find((d) => d.driver_id === 'kyc-driver-uuid-123');
+    expect(row.kyc_status).toBe('Not Submitted');
+  });
+
+  it('rejects a file whose real content does not match its declared Content-Type', async () => {
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', JPEG_BYTES, { filename: 'id.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/does not match declared type/);
+  });
+
+  it('rejects a valid-looking image when the malware scanner flags it (422)', async () => {
+    const { MalwareScanError } = await import('../../src/lib/malwareScanner.js');
+    scanDocument.mockRejectedValue(new MalwareScanError('Uploaded file is infected: TestVirus'));
+
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', JPEG_BYTES, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/infected|TestVirus/i);
+  });
+
+  it('accepts a real JPEG and forwards it to the ML endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ verified: true, extracted_number: 'DL-12345678' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await request(buildApp())
+      .post('/api/verify/kyc/upload')
+      .set(DRIVER_HEADERS)
+      .attach('image', JPEG_BYTES, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:8000/verify/kyc');
+
+    const row = m.store.driver_details.find((d) => d.driver_id === 'kyc-driver-uuid-123');
+    expect(row.kyc_status).toBe('Verified');
+    expect(row.kyc_doc_number).toBe('DL-12345678');
+  });
+});


### PR DESCRIPTION
## Problem
`POST /api/verification/kyc/upload` used an unbounded `multer.memoryStorage()` with no file-size cap, no MIME allow-list, no malware scan, and no rate limiter. Large requests fully buffered in server RAM and were forwarded to the internal ML endpoint.

## Fix
Applied the same hardening as the PoD upload:
- `limits.fileSize` capped at 10MB.
- `fileFilter` allow-list restricted to `image/jpeg` and `image/png`.
- Reused `validateDocumentBuffer` (magic bytes) and `scanDocument` (malware) before forwarding to the ML endpoint; invalid/flagged files return 422.
- Added a `kycUploadLimiter` (mirrors `documentCheckLimiter`/`digilockerLimiter`).

## Files changed
- `backend/api/src/routes/verificationRoutes.js`
- `backend/api/test/integration/kycUploadSecurity.test.js` (new)

## Testing
- New integration tests: oversized file -> 413, disallowed MIME -> 400, executable renamed to .jpg -> 422 (never forwarded), declared-type mismatch -> 422, malware-flagged -> 422, and a valid JPEG -> 200 that reaches the ML endpoint.

Closes #6564
