### PR TITLE
fix(api): stop duplicate timeline rows on change-drop (#6565)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1343,11 +1343,8 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
       return res.status(500).json({ error: 'Failed to update order atomically.', details: updateErr.message });
     }
 
-    try {
-      await orderRepository.insertTimelineEntry({ order_display_id: order.order_display_id, milestone: 'Drop Changed', milestone_time: new Date().toISOString(), completed: true, sort_order: 25 });
-    } catch (timelineErr) {
-      logger.warn('Failed to update timeline for change-drop:', timelineErr.message);
-    }
+    // Single canonical writer for the drop-change event. OrderTimelineService
+    // is the only path that inserts into order_timeline for this milestone.
     await orderTimelineService.insertDropChangedEvent(order.order_display_id);
 
     await expireDeliveryOtps(order.id);

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -2364,6 +2364,11 @@ describe('Customer actions: change-drop and cancel endpoints', () => {
     expect(stored.drop_address).toBe('New Drop Place');
     expect(stored.drop_lat).toBe(22.22);
     expect(stored.drop_lng).toBe(88.88);
+
+    const dropChanged = m.store.order_timeline.filter(
+      t => t.order_display_id === 'OD-CHANGE-1' && t.milestone === 'Drop Changed'
+    );
+    expect(dropChanged).toHaveLength(1);
   });
 
   it('blocks change-drop with 409 when escrow is already funded', async () => {


### PR DESCRIPTION
## Problem
Change-drop inserted the "Drop Changed" milestone twice: once directly via `orderRepository.insertTimelineEntry` and once via `orderTimelineService.insertDropChangedEvent`. Every drop change produced duplicate timeline rows.

## Fix
Removed the direct `insertTimelineEntry` call; `insertDropChangedEvent` is now the single canonical writer for this milestone.

## Files changed
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/integration/orders.test.js`

## Testing
- Extended the change-drop integration test to assert exactly one "Drop Changed" row is written to `order_timeline`.

Closes #6565
