### PR TITLE
fix(api): honor per-request geofence radius in geofenceAutoConfirm (#6566)

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -294,9 +294,11 @@ export class DeliveryVerificationService {
    * @param {string} params.driverId   - Driver's Supabase user ID
    * @param {number} params.driverLat  - Driver's claimed latitude (audit only)
    * @param {number} params.driverLng  - Driver's claimed longitude (audit only)
+   * @param {number} [params.geofenceRadiusM] - Per-request geofence radius in
+   *   meters, overriding the env default when provided.
    * @returns {Promise<{autoConfirmed: boolean, message: string}>}
    */
-  async geofenceAutoConfirm({ orderId, driverId, driverLat, driverLng }) {
+  async geofenceAutoConfirm({ orderId, driverId, driverLat, driverLng, geofenceRadiusM }) {
     return measureExecution(
       "DeliveryVerificationService.geofenceAutoConfirm",
       async () => {
@@ -327,7 +329,10 @@ export class DeliveryVerificationService {
         // The release gate must never be satisfied by self-reported coordinates.
         // assertDriverAtDropoff() proves physical presence using only telemetry
         // that was authenticated at ingestion and bound to this driver/order.
-        await this.assertDriverAtDropoff(order);
+        await this.assertDriverAtDropoff(
+          order,
+          geofenceRadiusM ?? DELIVERY_GEOFENCE_RADIUS_KM * 1000,
+        );
 
         // Record the geofence confirmation and the (non-authoritative) claimed
         // position for audit. This is a flag only — escrow is not released here.
@@ -366,10 +371,12 @@ export class DeliveryVerificationService {
    * callers from substituting another driver's (or a fabricated) location.
    *
    * @param {object} order - Order row with id/driver_id/drop_lat/drop_lng.
+   * @param {number} [radiusM] - Optional geofence radius in meters; falls back
+   *   to the env default (DELIVERY_GEOFENCE_RADIUS_KM) when not provided.
    * @throws {DomainError} 400 missing drop coords, 503 store unavailable,
    *                       409 no/invalid/stale/out-of-range telemetry.
    */
-  async assertDriverAtDropoff(order) {
+  async assertDriverAtDropoff(order, radiusM) {
     if (!order.drop_lat || !order.drop_lng) {
       throw new DomainError(400, {
         error: "Order is missing drop-off coordinates.",
@@ -421,9 +428,10 @@ export class DeliveryVerificationService {
     const distanceM =
       haversineKm(lat, lng, Number(order.drop_lat), Number(order.drop_lng)) *
       1000;
-    if (distanceM > DELIVERY_GEOFENCE_RADIUS_KM * 1000) {
+    const effectiveRadiusM = radiusM ?? DELIVERY_GEOFENCE_RADIUS_KM * 1000;
+    if (distanceM > effectiveRadiusM) {
       throw new DomainError(409, {
-        error: `Driver is ${(distanceM / 1000).toFixed(2)}km from the drop-off location. Must be within ${DELIVERY_GEOFENCE_RADIUS_KM * 1000}m to confirm delivery.`,
+        error: `Driver is ${(distanceM / 1000).toFixed(2)}km from the drop-off location. Must be within ${effectiveRadiusM}m to confirm delivery.`,
       });
     }
 

--- a/backend/api/test/unit/deliveryVerificationGeofence.test.js
+++ b/backend/api/test/unit/deliveryVerificationGeofence.test.js
@@ -239,6 +239,73 @@ describe("DeliveryVerificationService.assertDriverAtDropoff", () => {
   });
 });
 
+describe("DeliveryVerificationService.geofenceAutoConfirm radius override", () => {
+  // 0.004 deg lng at this latitude ≈ 390m east of the drop; inside the env
+  // default (500m) but outside a 200m override.
+  it("rejects a driver just outside a small per-request radius override", async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.213)];
+    const { service } = makeService();
+    const err = await captureDomainError(
+      service.geofenceAutoConfirm({
+        orderId: "order-geo-1",
+        driverId: "driver-1",
+        driverLat: 28.6139,
+        driverLng: 77.213,
+        geofenceRadiusM: 200,
+      }),
+    );
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+    expect(err.payload.error).toMatch(/must be within 200m/i);
+  });
+
+  it("passes the same position when no override is given (env default applies)", async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.213)];
+    const { service, repo } = makeService();
+    const result = await service.geofenceAutoConfirm({
+      orderId: "order-geo-1",
+      driverId: "driver-1",
+      driverLat: 28.6139,
+      driverLng: 77.213,
+    });
+    expect(result.autoConfirmed).toBe(true);
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      "order-geo-1",
+      expect.objectContaining({ geofence_confirmed: true }),
+    );
+  });
+
+  // 0.007 deg lng at this latitude ≈ 685m east of the drop; outside the env
+  // default (500m) but inside a 1000m override.
+  it("accepts a driver outside the env radius when a larger override is provided", async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.216)];
+    const { service } = makeService();
+    const result = await service.geofenceAutoConfirm({
+      orderId: "order-geo-1",
+      driverId: "driver-1",
+      driverLat: 28.6139,
+      driverLng: 77.216,
+      geofenceRadiusM: 1000,
+    });
+    expect(result.autoConfirmed).toBe(true);
+  });
+
+  it("rejects the same driver without the larger override", async () => {
+    mockTelemetryRecords = [makeTelemetry(28.6139, 77.216)];
+    const { service } = makeService();
+    const err = await captureDomainError(
+      service.geofenceAutoConfirm({
+        orderId: "order-geo-1",
+        driverId: "driver-1",
+        driverLat: 28.6139,
+        driverLng: 77.216,
+      }),
+    );
+    expect(err).toBeInstanceOf(DomainError);
+    expect(err.status).toBe(409);
+  });
+});
+
 describe("DeliveryVerificationService.verifyDelivery geofence gating", () => {
   it("releases escrow only after the geofence check passes", async () => {
     mockTelemetryRecords = [makeTelemetry(DROP_LAT, DROP_LNG)];


### PR DESCRIPTION
## Problem
The route parsed and passed `geofence_radius_m`, but `geofenceAutoConfirm` dropped it and always enforced the global `DELIVERY_GEOFENCE_RADIUS_KM` (default 0.5 km), silently ignoring the documented per-request override.

## Fix
- Destructured `geofenceRadiusM` in `geofenceAutoConfirm` and pass `geofenceRadiusM ?? DELIVERY_GEOFENCE_RADIUS_KM * 1000` into `assertDriverAtDropoff`.
- `assertDriverAtDropoff(order, radiusM)` now uses the provided radius when given, falling back to the env default otherwise (OTP/verifyDelivery path unchanged).

## Files changed
- `backend/api/src/services/order/deliveryVerificationService.js`
- `backend/api/test/unit/deliveryVerificationGeofence.test.js`

## Testing
- Added regression tests: a 200m override rejects a driver ~390m away (same position passes with the env default), and a 1000m override accepts a driver ~685m away (same position rejected without it). All new tests pass; the one pre-existing failure in this file (missing `supabaseAdmin` in the test mock) is unchanged and unrelated.

Closes #6566
