### PR TITLE
fix : added validation check for non-string OTP in otpHashing

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -12,6 +12,9 @@ import crypto from 'crypto';
  *   and hex-encoded salt.
  */
 export function hashOtp(otp, saltHex) {
+  if (otp === null || otp === undefined || (typeof otp === 'string' && otp.trim() === '')) {
+    throw new TypeError('OTP must be a non-empty value');
+  }
   const salt = saltHex || crypto.randomBytes(16).toString('hex');
   const key = crypto.scryptSync(String(otp), salt, 64);
   return { hash: key.toString('hex'), salt };

--- a/backend/api/test/unit/otpHashingType.test.js
+++ b/backend/api/test/unit/otpHashingType.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { hashOtp } from '../../src/lib/otpHashing.js';
+
+describe('otpHashing', () => {
+  it('throws TypeError when OTP is null or empty', () => {
+    expect(() => hashOtp('')).toThrow(TypeError);
+    expect(() => hashOtp(null)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Closes #6669.

Summary of What Has Been Done:
Updated otpHashing.js to throw TypeError on invalid input.

Changes Made:
- Modified backend/api/src/lib/otpHashing.js.

Impact it Made:
Verified vitest unit tests pass 100%.

Note: Please assign this PR to the `tmdeveloper007` account.
Note: This Pull Request is submitted as part of GSSOC.