### PR TITLE
fix(ml): recommendLoads never sends the HTTP request — regression coverage

### DIFF
--- a/backend/api/test/ml.recommendLoads.test.js
+++ b/backend/api/test/ml.recommendLoads.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+process.env.ML_API_KEY = 'test-ml-key';
+process.env.ML_ENGINE_URL = 'http://ml.test:8001';
+
+vi.mock('../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { recommendLoads, recommendTrucks } = await import('../src/services/ml.js');
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+describe('ml.recommendLoads (issue #4512)', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ recommendations: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('actually performs the HTTP POST (regression: previously returned before fetch)', async () => {
+    await recommendLoads({ userId: 'u-1', topN: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts to /recommend/loads with the correct headers and payload', async () => {
+    await recommendLoads({
+      userId: 'u-1',
+      bookingHistory: ['b-1'],
+      ratedDrivers: ['d-9'],
+      topN: 3,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://ml.test:8001/recommend/loads');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.headers['X-API-Key']).toBe('test-ml-key');
+    expect(JSON.parse(init.body)).toEqual({
+      user_id: 'u-1',
+      booking_history: ['b-1'],
+      rated_drivers: ['d-9'],
+      top_n: 3,
+    });
+    expect(init.signal).toBeDefined();
+  });
+
+  it('parses the engine response through handleResponse', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ recommendations: [{ load_id: 'l-1' }] }),
+    );
+
+    const result = await recommendLoads({ userId: 'u-1' });
+
+    expect(result).toEqual({ recommendations: [{ load_id: 'l-1' }] });
+  });
+
+  it('propagates non-OK responses as errors instead of returning undefined', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'boom' }, 500));
+
+    await expect(recommendLoads({ userId: 'u-1' })).rejects.toThrow(
+      /Request failed \(500\)/,
+    );
+  });
+
+  it('sends a different payload shape than recommendTrucks', async () => {
+    await recommendLoads({ userId: 'u-1', ratedDrivers: ['d-9'] });
+    await recommendTrucks({ userId: 'u-1', ratedLoads: ['l-9'] });
+
+    const loadsBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const trucksBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(loadsBody).toHaveProperty('rated_drivers');
+    expect(loadsBody).not.toHaveProperty('rated_loads');
+    expect(trucksBody).toHaveProperty('rated_loads');
+    expect(trucksBody).not.toHaveProperty('rated_drivers');
+  });
+});


### PR DESCRIPTION
## Problem

`backend/api/src/services/ml.js` — `recommendLoads` built its `payload` and computed `url` but never called `fetch()`, then executed `handleResponse(response)` with an undefined `response`, throwing `ReferenceError: response is not defined` on every invocation. The entire "recommend loads" ML feature was non-functional.

## Fix

The `fetch()` call now exists upstream (the function posts to `${ML_ENGINE_URL}/recommend/loads` and awaits `handleResponse`). This PR adds a regression test suite that pins the contract so the bug cannot silently return:

- Asserts the HTTP POST is actually performed (no early return before `fetch`).
- Asserts the URL, method, headers (`X-API-Key`, `Content-Type`), and payload shape (`user_id`, `booking_history`, `rated_drivers`, `top_n`) are correct.
- Asserts engine responses are parsed through `handleResponse` and non-OK responses are propagated as errors rather than returning `undefined`.
- Asserts `recommendLoads` uses a distinct payload (`rated_drivers`) from `recommendTrucks` (`rated_loads`).

## Files changed

- `backend/api/test/ml.recommendLoads.test.js` (new)

## Testing

- `npx vitest run test/ml.recommendLoads.test.js` — 5 passed.

Closes #4512
