### PR TITLE
fix(orders): deliveryVerificationService used unimported supabase — regression coverage

### DIFF
--- a/backend/api/test/deliveryVerification.init.test.js
+++ b/backend/api/test/deliveryVerification.init.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const db = vi.hoisted(() => ({
+  sentinelSupabase: { name: 'sentinel-supabase-client' },
+}));
+
+vi.mock('../src/config/db.js', () => ({
+  get supabase() { return db.sentinelSupabase; },
+  get supabaseAdmin() { return null; },
+  get redisClient() { return null; },
+  get mongoDb() { return null; },
+  get firebaseAdmin() { return null; },
+}));
+
+vi.mock('../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/core/performanceMetrics.js', () => ({
+  measureExecution: (name, fn) => fn(),
+}));
+
+vi.mock('../src/services/escrow.js', () => ({
+  escrowRelease: vi.fn(),
+}));
+
+// Issue #4513 regression: module load must not throw a ReferenceError on an
+// undefined `supabase` binding, and the default OrderTimelineService must be
+// constructed with the configured Supabase client.
+const { DeliveryVerificationService } = await import(
+  '../src/services/order/deliveryVerificationService.js'
+);
+
+describe('DeliveryVerificationService supabase wiring (issue #4513)', () => {
+  it('module loads without ReferenceError (supabase is imported)', () => {
+    expect(typeof DeliveryVerificationService).toBe('function');
+  });
+
+  it('constructs the default OrderTimelineService with the configured supabase client', () => {
+    const svc = new DeliveryVerificationService(null);
+    expect(svc.orderTimelineService).toBeDefined();
+    expect(svc.orderTimelineService.orderRepository).toBe(db.sentinelSupabase);
+  });
+
+  it('returns a sensible domain error when no order exists (service is functional)', async () => {
+    const svc = new DeliveryVerificationService({
+      findOrderById: () =>
+        Promise.resolve({ data: null, error: null }),
+    });
+    await expect(
+      svc.validateDeliveryOtp({ orderId: 'missing', driverId: 'd-1', otp: 'x' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});


### PR DESCRIPTION
## Problem

`backend/api/src/services/order/deliveryVerificationService.js` constructed its `OrderTimelineService` with a `supabase` binding that was never imported. This raised `ReferenceError: supabase is not defined` at module load time, preventing delivery OTP verification, delivery completion, and escrow release flows from initializing.

## Fix

The Supabase import now exists upstream (`import { supabase, supabaseAdmin, redisClient, mongoDb } from "../../config/db.js"`). This PR adds a regression suite that pins the wiring so the failure cannot silently return:

- Asserts the module loads without a `ReferenceError` (i.e. `supabase` is imported).
- Asserts the default `OrderTimelineService` is constructed with the configured Supabase client.
- Asserts the service remains functional end-to-end (404 for a missing order).

## Files changed

- `backend/api/test/deliveryVerification.init.test.js` (new)

## Testing

- `npx vitest run test/deliveryVerification.init.test.js` — 3 passed.

Closes #4513
