### PR TITLE
fix(orders): rebalance escrow booking on change-drop to stop payout/price desync

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1308,6 +1308,12 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
       return res.status(400).json({ error: 'Unable to compute new pricing for the requested drop.', details: pricingErr.message });
     }
 
+    // Rebalance the escrow booking alongside the re-priced total so the
+    // displayed price, the on-chain payout, and any refund all stay in sync.
+    // escrow_amount_wei is the authoritative payout figure (verified against
+    // at deposit time and read on release), so it must track total_amount.
+    const newAmountWei = BigInt(Math.round(pricing.totalAmount * 1e16));
+
     const updates = {
       drop_address,
       drop_lat: Number(drop_lat),
@@ -1316,6 +1322,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
       toll_estimate: pricing.tollEstimate,
       platform_fee: pricing.platformFee,
       total_amount: pricing.totalAmount,
+      escrow_amount_wei: newAmountWei.toString(),
       updated_at: new Date().toISOString(),
     };
 

--- a/backend/api/test/changeDrop.escrowRebalance.test.js
+++ b/backend/api/test/changeDrop.escrowRebalance.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const MIGRATION_PATH = path.join(
+  REPO_ROOT,
+  'supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql',
+);
+const ROUTE_PATH = path.join(REPO_ROOT, 'backend/api/src/routes/orderRoutes.js');
+
+const mocks = vi.hoisted(() => ({
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+  getRouteEstimate: vi.fn(),
+}));
+
+vi.mock('../src/lib/redisLock.js', () => ({
+  acquireLock: mocks.acquireLock,
+  releaseLock: mocks.releaseLock,
+}));
+
+vi.mock('../src/config/db.js', () => ({
+  get supabase() { return null; },
+  get supabaseAdmin() { return null; },
+  get redisClient() { return null; },
+  get mongoDb() { return null; },
+  get firebaseAdmin() { return null; },
+}));
+
+vi.mock('../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/core/performanceMetrics.js', () => ({
+  measureExecution: (name, fn) => fn(),
+}));
+
+vi.mock('../src/core/events/index.js', () => ({
+  eventBus: { emit: vi.fn(), on: vi.fn(), once: vi.fn() },
+  EventBus: class {},
+}));
+
+vi.mock('../src/services/escrow.js', () => ({
+  escrowRelease: vi.fn(),
+  escrowRefund: vi.fn(),
+  recordDepositTx: vi.fn(),
+  submitEscrowRefund: vi.fn(),
+  submitEscrowCancelWithPenalty: vi.fn(),
+  confirmEscrowRefund: vi.fn(),
+  getEscrowBookingId: vi.fn(),
+}));
+
+vi.mock('../src/services/osrm.js', () => ({
+  getRouteEstimate: (...args) => mocks.getRouteEstimate(...args),
+}));
+
+const { OrderLifecycleService } = await import(
+  '../src/services/order/orderLifecycleService.js'
+);
+
+const BASE_ORDER = {
+  id: 'order-1',
+  order_display_id: 'OD-1',
+  customer_id: 'customer-1',
+  driver_id: null,
+  status: 'pending',
+  escrow_status: null,
+  escrow_amount_wei: null,
+  weight_tonnes: 2,
+  pickup_lat: 19.0,
+  pickup_lng: 72.8,
+  pickup_address: 'Pune',
+  drop_lat: 19.0,
+  drop_lng: 72.8,
+  drop_address: 'Old Drop',
+};
+
+function makeRepo(order = BASE_ORDER) {
+  return {
+    findOrderByAnyId: () => Promise.resolve({ data: { id: order.id }, error: null }),
+    findOrderById: () => Promise.resolve({ data: order, error: null }),
+    executeRpc: vi.fn().mockResolvedValue({
+      data: { id: order.id, base_freight: 1, toll_estimate: 1, platform_fee: 1, total_amount: 1 },
+      error: null,
+    }),
+  };
+}
+
+function makeService(repo) {
+  return new OrderLifecycleService({
+    orderRepository: repo,
+    orderTimelineService: { insertEntry: vi.fn() },
+    deliveryVerificationService: { verifyDelivery: vi.fn() },
+  });
+}
+
+describe('changeDrop escrow rebalance (issue #5825)', () => {
+  beforeEach(() => {
+    mocks.acquireLock.mockReset();
+    mocks.releaseLock.mockReset();
+    mocks.getRouteEstimate.mockReset();
+    mocks.acquireLock.mockResolvedValue('lock-owner-1');
+    mocks.releaseLock.mockResolvedValue(true);
+    mocks.getRouteEstimate.mockResolvedValue({ distanceKm: 500 });
+  });
+
+  it('sends an escrow_amount_wei matching the re-priced total to the RPC', async () => {
+    const repo = makeRepo();
+    const svc = makeService(repo);
+
+    await svc.changeDrop(
+      'order-1',
+      'customer-1',
+      { drop_address: 'Mumbai', drop_lat: 19.076, drop_lng: 72.877 },
+      {},
+    );
+
+    const [name, params] = repo.executeRpc.mock.calls[0];
+    expect(name).toBe('update_order_and_load_offer');
+    const { total_amount, escrow_amount_wei } = params.p_order_updates;
+    // escrow payout figure must track the advertised total (wei = paisa * 1e16).
+    expect(escrow_amount_wei).toBe(BigInt(Math.round(total_amount * 1e16)).toString());
+  });
+
+  it('rejects change-drop once escrow funding has started or completed', async () => {
+    for (const escrow_status of ['funding', 'funded']) {
+      const repo = makeRepo({ ...BASE_ORDER, escrow_status });
+      const svc = makeService(repo);
+
+      await expect(
+        svc.changeDrop(
+          'order-1',
+          'customer-1',
+          { drop_address: 'Mumbai', drop_lat: 19.076, drop_lng: 72.877 },
+          {},
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+
+      expect(repo.executeRpc).not.toHaveBeenCalled();
+    }
+  });
+
+  it('applies the escrow rebalance inside the per-order lock', async () => {
+    const repo = makeRepo();
+    const svc = makeService(repo);
+
+    await svc.changeDrop(
+      'order-1',
+      'customer-1',
+      { drop_address: 'Mumbai', drop_lat: 19.076, drop_lng: 72.877 },
+      {},
+    );
+
+    expect(mocks.acquireLock).toHaveBeenCalledWith('escrow_lock:order-1', 30000);
+    expect(mocks.releaseLock).toHaveBeenCalledWith('escrow_lock:order-1', 'lock-owner-1');
+  });
+});
+
+describe('RPC/route persist escrow_amount_wei (issue #5825)', () => {
+  it('the RPC migration writes escrow_amount_wei in the service_role branch', () => {
+    const sql = fs.readFileSync(MIGRATION_PATH, 'utf8');
+    expect(sql).toContain(
+      "escrow_amount_wei = COALESCE(p_order_updates->>'escrow_amount_wei', escrow_amount_wei)",
+    );
+    // The key must be written alongside the other financial columns.
+    expect(
+      sql.indexOf('escrow_amount_wei = COALESCE(p_order_updates->'),
+    ).toBeGreaterThan(sql.indexOf('total_amount  = COALESCE'));
+  });
+
+  it('the change-drop route handler rebalances escrow_amount_wei', () => {
+    const src = fs.readFileSync(ROUTE_PATH, 'utf8');
+    const changeDropSection = src.slice(
+      src.indexOf("router.put('/:id/change-drop'"),
+      src.indexOf('// ============================================================================\n// 16.'),
+    );
+    expect(changeDropSection).toContain('escrow_amount_wei: newAmountWei.toString()');
+    expect(changeDropSection).toContain('BigInt(Math.round(pricing.totalAmount * 1e16))');
+  });
+});

--- a/supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql
+++ b/supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql
@@ -1,0 +1,108 @@
+-- =============================================================================
+-- Migration: Persist escrow_amount_wei rebalance on change-drop (Issue #5825)
+-- =============================================================================
+-- Problem:
+--   change-drop reprices the order (base_freight, toll_estimate,
+--   platform_fee, total_amount) and the backend sends an escrow_amount_wei
+--   matching the new total, but update_order_and_load_offer never wrote that
+--   key. escrow_amount_wei is the authoritative payout figure (validated at
+--   deposit-confirm time and read on release), so it drifted from the
+--   displayed price: a longer drop under-paid the driver, a shorter drop
+--   never refunded the difference.
+--
+-- Fix:
+--   In the service_role branch (the only caller that may rewrite pricing),
+--   persist escrow_amount_wei from p_order_updates alongside the other
+--   financial columns. It is a TEXT column so it is written as text, not
+--   numeric. The change-drop gate already rejects escrow_status 'funding'
+--   and 'funded', so only pre-funding drops can be repriced here.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION update_order_and_load_offer(
+  p_order_id UUID,
+  p_order_display_id TEXT,
+  p_order_updates JSONB,
+  p_offer_updates JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_updated_order JSONB;
+  v_customer_id   UUID;
+BEGIN
+  -- Resolve the owning customer of the order for the ownership guard.
+  SELECT customer_id INTO v_customer_id
+  FROM orders
+  WHERE id = p_order_id;
+
+  IF v_customer_id IS NULL THEN
+    RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  -- Ownership guard: an authenticated caller may only update their own order.
+  -- get_profile_id() maps the Firebase JWT sub to profiles.id, which is what
+  -- orders.customer_id actually stores (auth.uid() is the Firebase UID and
+  -- would never match).
+  IF auth.uid() IS NOT NULL AND get_profile_id() <> v_customer_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only update your own orders';
+  END IF;
+
+  -- Only the backend (service_role) may rewrite pricing/payout math.
+  -- Financial columns are server-computed and must never be supplied by a
+  -- client; authenticated callers are limited to the change-drop set.
+  IF auth.role() <> 'service_role' THEN
+    UPDATE orders
+    SET
+      drop_address = COALESCE(p_order_updates->>'drop_address', drop_address),
+      drop_lat     = COALESCE((p_order_updates->>'drop_lat')::NUMERIC, drop_lat),
+      drop_lng     = COALESCE((p_order_updates->>'drop_lng')::NUMERIC, drop_lng),
+      updated_at   = COALESCE((p_order_updates->>'updated_at')::TIMESTAMPTZ, updated_at)
+    WHERE id = p_order_id
+    RETURNING row_to_json(orders.*) INTO v_updated_order;
+
+    UPDATE load_offers
+    SET
+      drop_address     = COALESCE(p_offer_updates->>'drop_address', drop_address),
+      drop_lat         = COALESCE((p_offer_updates->>'drop_lat')::NUMERIC, drop_lat),
+      drop_lng         = COALESCE((p_offer_updates->>'drop_lng')::NUMERIC, drop_lng),
+      route_label      = COALESCE(p_offer_updates->>'route_label', route_label),
+      extra_distance_km = COALESCE((p_offer_updates->>'extra_distance_km')::NUMERIC, extra_distance_km)
+    WHERE order_display_id = p_order_display_id;
+  ELSE
+    UPDATE orders
+    SET
+      drop_address  = COALESCE(p_order_updates->>'drop_address', drop_address),
+      drop_lat      = COALESCE((p_order_updates->>'drop_lat')::NUMERIC, drop_lat),
+      drop_lng      = COALESCE((p_order_updates->>'drop_lng')::NUMERIC, drop_lng),
+      base_freight  = COALESCE((p_order_updates->>'base_freight')::NUMERIC, base_freight),
+      toll_estimate = COALESCE((p_order_updates->>'toll_estimate')::NUMERIC, toll_estimate),
+      platform_fee  = COALESCE((p_order_updates->>'platform_fee')::NUMERIC, platform_fee),
+      total_amount  = COALESCE((p_order_updates->>'total_amount')::NUMERIC, total_amount),
+      escrow_amount_wei = COALESCE(p_order_updates->>'escrow_amount_wei', escrow_amount_wei),
+      updated_at    = COALESCE((p_order_updates->>'updated_at')::TIMESTAMPTZ, updated_at)
+    WHERE id = p_order_id
+    RETURNING row_to_json(orders.*) INTO v_updated_order;
+
+    UPDATE load_offers
+    SET
+      drop_address      = COALESCE(p_offer_updates->>'drop_address', drop_address),
+      drop_lat          = COALESCE((p_offer_updates->>'drop_lat')::NUMERIC, drop_lat),
+      drop_lng          = COALESCE((p_offer_updates->>'drop_lng')::NUMERIC, drop_lng),
+      route_label       = COALESCE(p_offer_updates->>'route_label', route_label),
+      freight_value     = COALESCE((p_offer_updates->>'freight_value')::NUMERIC, freight_value),
+      fuel_cost         = COALESCE((p_offer_updates->>'fuel_cost')::NUMERIC, fuel_cost),
+      toll_cost         = COALESCE((p_offer_updates->>'toll_cost')::NUMERIC, toll_cost),
+      net_profit        = COALESCE((p_offer_updates->>'net_profit')::NUMERIC, net_profit),
+      extra_distance_km = COALESCE((p_offer_updates->>'extra_distance_km')::NUMERIC, extra_distance_km)
+    WHERE order_display_id = p_order_display_id;
+  END IF;
+
+  RETURN v_updated_order;
+END;
+$$;
+
+-- Only the backend service may invoke this RPC; revoke direct client access.
+REVOKE EXECUTE ON FUNCTION public.update_order_and_load_offer(UUID, TEXT, JSONB, JSONB) FROM anon, authenticated;


### PR DESCRIPTION
## Problem

Change-drop repriced the order (`base_freight`, `toll_estimate`, `platform_fee`, `total_amount`) but never rebalanced the escrow booking. `escrow_amount_wei` is the authoritative payout figure — validated at deposit-confirm time (`deliveryVerificationService` reads it as the payout reference) — so it drifted from the displayed price:

- A farther/longer drop raised `total_amount` while the escrow stayed funded at the original bid → driver under-paid.
- A nearer/shorter drop lowered `total_amount` while the escrow stayed at the old amount → customer never refunded the difference.

The live route handler (`backend/api/src/routes/orderRoutes.js` change-drop) did not send `escrow_amount_wei`, and the `update_order_and_load_offer` RPC had no escrow column at all, silently dropping the key even when provided.

## Fix

- `backend/api/src/routes/orderRoutes.js` — the change-drop handler now sends `escrow_amount_wei` rebalanced to the new `total_amount` (`BigInt(Math.round(totalAmount * 1e16))`, matching the conversion used at bid acceptance), alongside the other financial columns.
- `supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql` (new) — `update_order_and_load_offer` now persists `escrow_amount_wei` (TEXT column) in the `service_role` branch, so the rebalance actually lands in `orders` instead of being dropped. Authenticated callers remain limited to the change-drop set and can never write pricing/escrow fields.
- The existing change-drop gate already rejects `escrow_status` `funding`/`funded`, so rebalancing only ever applies to pre-funding drops (a fresh booking then uses the re-priced amount).

## Files changed

- `backend/api/src/routes/orderRoutes.js`
- `supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql` (new)
- `backend/api/test/changeDrop.escrowRebalance.test.js` (new)

## Testing

- `npx vitest run test/changeDrop.escrowRebalance.test.js` — 5 passed.
- Tests assert: `escrow_amount_wei` in the RPC payload always equals `total_amount * 1e16`; change-drop is rejected once escrow is `funding`/`funded`; the rebalance runs inside the per-order lock; the migration writes the key in the `service_role` branch; and the route handler includes the rebalance in its payload.
- `node --check backend/api/src/routes/orderRoutes.js` passes.

Closes #5825
