### PR TITLE
fix(sockets): reject WS auth tokens in the URL and keep upgrade limiter fail-closed

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -290,6 +290,8 @@ function getClientIp(request) {
   return request.socket?.remoteAddress || request.connection?.remoteAddress || 'unknown';
 }
 
+export { getClientIp };
+
 // Process-local fallback counter for the per-IP upgrade limit, used when Redis
 // is unavailable so the limit is still enforced instead of failing open.
 const wsUpgradeMemoryLimits = new Map();
@@ -345,6 +347,33 @@ export function rejectWebSocketUpgrade(socket) {
     '\r\n'
   );
   socket.destroy();
+}
+
+/**
+ * Reject a WebSocket connection whose URL carries a `token` query parameter.
+ *
+ * Tokens must only ever arrive via the first-frame `auth` event; a token in
+ * the URL leaks through proxies, CDN/access logs and web analytics. When the
+ * client supplies one, the connection is refused with close code 4001 so the
+ * leak is impossible rather than merely discouraged (issue #5826).
+ *
+ * @param {object} ws     The raw WebSocket connection.
+ * @param {URL}    reqUrl Parsed request URL.
+ * @returns {boolean} true when the connection was rejected (caller should return).
+ */
+export function rejectConnectionWithTokenInUrl(ws, reqUrl) {
+  const urlToken = reqUrl.searchParams.get('token');
+  if (!urlToken) return false;
+  logger.warn(
+    { event: 'WS_TOKEN_IN_URL' },
+    'WebSocket auth token present in URL query string; refusing connection',
+  );
+  ws.send(JSON.stringify({
+    error: 'Unauthorized: auth token must not be sent in the URL query string',
+    code: 4001,
+  }));
+  ws.close(4001, 'Auth token must not be sent in the URL query string');
+  return true;
 }
 
 /**
@@ -514,6 +543,14 @@ export function initWebSocketServer(server, orderRepository) {
         await removeClientFromAllSubscriptions(ws);
       })();
     });
+
+    // A bearer token in the URL query string is a client bug and a credential
+    // leak (issue #5826): it would be written to proxies, CDN/access logs and
+    // web analytics. Refuse the connection loudly instead of silently ignoring
+    // the credential so a future client change cannot reintroduce the leak.
+    if (rejectConnectionWithTokenInUrl(ws, reqUrl)) {
+      return;
+    }
 
     if (bypassAuth) {
       if (process.env.NODE_ENV === 'production') {

--- a/backend/api/test/tracker.wsSecurity.test.js
+++ b/backend/api/test/tracker.wsSecurity.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const db = vi.hoisted(() => ({
+  redis: null,
+}));
+
+vi.mock('../src/config/db.js', () => ({
+  get mongoDb() { return null; },
+  get redisClient() { return db.redis; },
+  get firebaseAdmin() { return null; },
+  get supabase() { return null; },
+}));
+
+vi.mock('../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const {
+  isWebSocketUpgradeAllowed,
+  rejectConnectionWithTokenInUrl,
+  getClientIp,
+  closeWebSocketServer,
+} = await import('../src/sockets/tracker.js');
+
+function makeWs(overrides = {}) {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRequest({ ip = '203.0.113.7', forwardedFor, url = '/ws/tracking' } = {}) {
+  return {
+    headers: forwardedFor ? { 'x-forwarded-for': forwardedFor } : {},
+    socket: { remoteAddress: ip },
+    url,
+  };
+}
+
+describe('issue #5826 — token must never be sent in the URL', () => {
+  it('refuses a connection whose URL carries a token (4001) and reports it', () => {
+    const ws = makeWs();
+    const reqUrl = new URL('http://localhost/ws/tracking?token=eyJhbGciOiJIUzI1NiJ9');
+
+    const rejected = rejectConnectionWithTokenInUrl(ws, reqUrl);
+
+    expect(rejected).toBe(true);
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining('must not be sent in the URL'),
+    );
+    expect(ws.close).toHaveBeenCalledWith(
+      4001,
+      expect.stringContaining('must not be sent in the URL'),
+    );
+  });
+
+  it('accepts connections with no token query parameter', () => {
+    const ws = makeWs();
+    const reqUrl = new URL('http://localhost/ws/tracking');
+
+    expect(rejectConnectionWithTokenInUrl(ws, reqUrl)).toBe(false);
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it('ignores an unrelated query parameter', () => {
+    const ws = makeWs();
+    const reqUrl = new URL('http://localhost/ws/tracking?driver_id=abc');
+
+    expect(rejectConnectionWithTokenInUrl(ws, reqUrl)).toBe(false);
+  });
+});
+
+describe('issue #5826 — getClientIp trusts only the TCP peer', () => {
+  it('ignores a spoofed X-Forwarded-For header', () => {
+    const req = makeRequest({ ip: '203.0.113.7', forwardedFor: '1.2.3.4, 5.6.7.8' });
+    expect(getClientIp(req)).toBe('203.0.113.7');
+  });
+
+  it('falls back to connection.remoteAddress and then unknown', () => {
+    const req1 = {
+      headers: {},
+      socket: { remoteAddress: null },
+      connection: { remoteAddress: '198.51.100.9' },
+    };
+    expect(getClientIp(req1)).toBe('198.51.100.9');
+
+    const req2 = { headers: {} };
+    expect(getClientIp(req2)).toBe('unknown');
+  });
+});
+
+describe('issue #5826 — upgrade limiter fails closed', () => {
+  beforeEach(() => {
+    db.redis = null;
+  });
+
+  it('enforces the per-IP cap via the in-memory fallback when Redis errors (no fail-open)', async () => {
+    db.redis = { incr: vi.fn().mockRejectedValue(new Error('redis down')) };
+    const req = makeRequest();
+
+    for (let i = 0; i < 5; i++) {
+      await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(true);
+    }
+    await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(false);
+  });
+
+  it('enforces the per-IP cap via Redis when available', async () => {
+    let attempts = 0;
+    db.redis = {
+      incr: vi.fn().mockImplementation(() => {
+        attempts++;
+        return Promise.resolve(attempts);
+      }),
+      expire: vi.fn().mockResolvedValue(1),
+      ttl: vi.fn().mockResolvedValue(60),
+    };
+    const req = makeRequest();
+
+    for (let i = 0; i < 5; i++) {
+      await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(true);
+    }
+    await expect(isWebSocketUpgradeAllowed(req)).resolves.toBe(false);
+    expect(db.redis.expire).toHaveBeenCalledWith(expect.stringContaining('ws:upgrade:'), 60);
+  });
+});


### PR DESCRIPTION
## Problem

The driver location WebSocket client embedded the Firebase/JWT auth token (and `driver_id`) in the connection URL query string, and the server read it back from there — leaking credentials into proxy/CDN/access logs and web analytics. In addition, the upgrade rate limiter keyed on the client-supplied `X-Forwarded-For` header (spoofable to mint unlimited keys) and returned `true` when Redis was unavailable or errored, disabling DoS protection exactly when the cache layer was down.

## Fix

The core issues are already fixed upstream — the Dart client sends the token via a first-frame `auth` handshake (no URL parameters), the server only authenticates from that handshake, `getClientIp` trusts only the TCP peer address, and the upgrade limiter falls back to a process-local counter instead of failing open. This PR locks the contract in and adds belt-and-braces hardening:

- `backend/api/src/sockets/tracker.js` — new `rejectConnectionWithTokenInUrl` guard: any connection whose URL carries a `token` query parameter is refused with close code `4001`, so the credential leak can never silently reappear. `getClientIp` is now exported for testability.
- `backend/api/test/tracker.wsSecurity.test.js` (new) — regression suite covering:
  - URL-embedded tokens are rejected (`4001`) and reported; clean URLs and unrelated params are accepted.
  - `getClientIp` ignores a spoofed `X-Forwarded-For` header and falls back to `connection.remoteAddress` / `unknown`.
  - The upgrade limiter enforces the per-IP cap via the in-memory fallback when Redis errors (fail closed, no fail-open) and via Redis when available.

## Files changed

- `backend/api/src/sockets/tracker.js`
- `backend/api/test/tracker.wsSecurity.test.js` (new)

## Testing

- `npx vitest run test/tracker.wsSecurity.test.js` — 7 passed.
- `npx vitest run test/tracker.test.js` — unchanged (4 pre-existing failures, unrelated).
- `node --check backend/api/src/sockets/tracker.js` passes.

Closes #5826
