### PR TITLE
fix(security): release gate for SECURITY DEFINER caller verification

### DIFF
--- a/backend/api/test/rpcSecurity.releaseGate.test.js
+++ b/backend/api/test/rpcSecurity.releaseGate.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../../supabase/migrations');
+
+// Any of these markers counts as caller verification / access restriction on a
+// SECURITY DEFINER function. A function with none of them is a privilege-
+// escalation vector (see issue #5890).
+const HARDENING_MARKERS = [
+  'auth.role()',
+  'auth.uid()',
+  'get_profile_id()',
+  'REVOKE EXECUTE',
+  'service_role',
+];
+
+/**
+ * Scans every migration (applied in filename order, oldest → newest) and
+ * returns the LATEST definition of each SECURITY DEFINER function, keyed by
+ * function name, with its full SQL block (from its CREATE statement to the
+ * next CREATE statement or end of file).
+ */
+function latestSecurityDefinerFunctions() {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  const defs = {};
+
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
+    const re = /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+(?:public\.)?(\w+)/g;
+    let match;
+    while ((match = re.exec(sql)) !== null) {
+      const start = match.index;
+      const nextCreate = sql.indexOf('CREATE', start + 1);
+      const block = sql.slice(start, nextCreate === -1 ? sql.length : nextCreate);
+      const headerEnd = block.indexOf('AS $');
+      const header = headerEnd === -1 ? block : block.slice(0, headerEnd);
+      if (!header.includes('SECURITY DEFINER')) continue;
+      defs[match[1]] = { file, block };
+    }
+  }
+
+  return defs;
+}
+
+describe('SECURITY DEFINER release gate (issue #5890)', () => {
+  const defs = latestSecurityDefinerFunctions();
+
+  it('finds SECURITY DEFINER functions in the migrations', () => {
+    expect(Object.keys(defs).length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every SECURITY DEFINER function has caller verification or is revoke-restricted', () => {
+    const unhardened = Object.entries(defs)
+      .filter(([, { block }]) => !HARDENING_MARKERS.some((mk) => block.includes(mk)))
+      .map(([name, { file }]) => `${name} (${file})`);
+    expect(unhardened).toEqual([]);
+  });
+
+  it('update_order_and_load_offer verifies the caller owns the order', () => {
+    const def = defs['update_order_and_load_offer'];
+    expect(def).toBeDefined();
+    expect(def.block).toContain('SET search_path = public, pg_temp');
+    expect(def.block).toMatch(/get_profile_id\(\).*v_customer_id|v_customer_id.*get_profile_id\(\)/);
+    expect(def.block).toContain('REVOKE EXECUTE');
+  });
+
+  it('create_order_tx binds non-service callers to their own profile', () => {
+    const def = defs['create_order_tx'];
+    expect(def).toBeDefined();
+    expect(def.block).toContain('SET search_path = public, pg_temp');
+    expect(def.block).toContain("auth.role() = 'service_role'");
+    expect(def.block).toContain('v_customer_id := get_profile_id()');
+    expect(def.block).toContain('cannot create orders as another customer');
+  });
+});


### PR DESCRIPTION
## Problem

Two SECURITY DEFINER RPCs re-introduced the privilege-escalation class that the earlier RPC-hardening migrations fixed: `update_order_and_load_offer` (created `20260728000000`) had no ownership check and no `SET search_path`, letting any authenticated user rewrite any order's price/route and its `load_offers` row; `create_order_tx` (created `20260723000003`) had no caller verification and could attribute a forged order to an arbitrary `p_customer_id`. `revoke_anon_privileges.sql` only revoked table privileges, not function `EXECUTE`.

## Fix

Both functions are now hardened upstream:

- `update_order_and_load_offer` — `20260802000000_secure_update_order_and_load_offer.sql` adds a `get_profile_id()` ownership guard, `SET search_path = public, pg_temp`, restricts financial columns to `service_role`, and `REVOKE EXECUTE … FROM anon, authenticated`.
- `create_order_tx` — binds any non-`service_role` caller to their own `get_profile_id()`, rejecting attempts to create an order as another customer.

This PR adds the release gate the issue's suggested fix called for (`backend/api/test/rpcSecurity.releaseGate.test.js`):

- Scans every migration (oldest → newest) and captures the latest definition of each SECURITY DEFINER function.
- Asserts every one carries caller verification (`auth.role()` / `auth.uid()` / `get_profile_id()`) or is restricted via `REVOKE EXECUTE` — 13 functions checked, 0 unhardened.
- Pinpoints the two reported RPCs: `update_order_and_load_offer` must verify the caller owns the order and be revoked from `anon`/`authenticated`; `create_order_tx` must bind non-service callers to their own profile.

## Files changed

- `backend/api/test/rpcSecurity.releaseGate.test.js` (new)

## Testing

- `npx vitest run test/rpcSecurity.releaseGate.test.js` — 4 passed.

Closes #5890
