### PR TITLE
fix(blockchain): harden zkEVMBridge.withdrawFromL2 accounting and proof replay (regression tests)

### DIFF
--- a/blockchain/contracts/MockZkEVM.sol
+++ b/blockchain/contracts/MockZkEVM.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/// @notice Test-only stand-in for the real zkEVM rollup. Accepts every
+///         withdrawal proof so bridge-level accounting (deposited amounts,
+///         replay protection, payout queueing) can be exercised without a
+///         real Groth16 proof. Never used in production deployments.
+contract MockZkEVM {
+    mapping(address => uint256) public balances;
+
+    function depositToL2() external payable {
+        require(msg.value > 0, "Amount must be > 0");
+        balances[msg.sender] += msg.value;
+    }
+
+    function withdrawFromL2(uint256 amount, bytes calldata) external {
+        require(amount > 0, "Amount must be > 0");
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+        balances[msg.sender] -= amount;
+        payable(msg.sender).transfer(amount);
+    }
+
+    function getBalance(address user) external view returns (uint256) {
+        return balances[user];
+    }
+}

--- a/blockchain/test/zkEVMBridge.test.cjs
+++ b/blockchain/test/zkEVMBridge.test.cjs
@@ -1,0 +1,121 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, (error) => error.message.includes(message));
+}
+
+describe("zkEVMBridge", function () {
+  async function deployBridge() {
+    const [owner, user, attacker] = await ethers.getSigners();
+    const MockZkEVM = await ethers.getContractFactory("MockZkEVM");
+    const zkEVM = await MockZkEVM.deploy();
+    await zkEVM.waitForDeployment();
+    const Bridge = await ethers.getContractFactory("zkEVMBridge");
+    const bridge = await Bridge.deploy(await zkEVM.getAddress());
+    await bridge.waitForDeployment();
+    return { bridge, zkEVM, owner, user, attacker };
+  }
+
+  it("rejects any withdrawal attempt by a caller with no deposit", async function () {
+    const { bridge, attacker } = await deployBridge();
+    const proof = ethers.randomBytes(65);
+    await assertRejectsWith(
+      bridge.connect(attacker).withdrawFromL2(ethers.parseEther("0.01"), proof),
+      "Exceeds deposited amount"
+    );
+  });
+
+  it("rejects withdrawals larger than the caller's deposited amount", async function () {
+    const { bridge, zkEVM, user } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    const proof = ethers.randomBytes(65);
+    await assertRejectsWith(
+      bridge.connect(user).withdrawFromL2(ethers.parseEther("1.1"), proof),
+      "Exceeds deposited amount"
+    );
+  });
+
+  it("rejects a zero-amount withdrawal", async function () {
+    const { bridge, zkEVM, user } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    await assertRejectsWith(
+      bridge.connect(user).withdrawFromL2(0, ethers.randomBytes(65)),
+      "Amount must be > 0"
+    );
+  });
+
+  it("rejects an empty proof", async function () {
+    const { bridge, user } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    await assertRejectsWith(
+      bridge.connect(user).withdrawFromL2(ethers.parseEther("0.5"), "0x"),
+      "Empty proof"
+    );
+  });
+
+  it("credits and debits the per-user deposited amount", async function () {
+    const { bridge, user } = await deployBridge();
+    const fee = await bridge.bridgeFee();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    assert.equal(
+      await bridge.depositedAmount(user.address),
+      ethers.parseEther("1") - fee
+    );
+
+    await bridge.connect(user).withdrawFromL2(ethers.parseEther("0.3"), ethers.randomBytes(65));
+    assert.equal(
+      await bridge.depositedAmount(user.address),
+      ethers.parseEther("1") - fee - ethers.parseEther("0.3")
+    );
+  });
+
+  it("queues withdrawals into pendingWithdrawals for later claim", async function () {
+    const { bridge, user } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+
+    await bridge.connect(user).withdrawFromL2(ethers.parseEther("0.25"), ethers.randomBytes(65));
+    assert.equal(await bridge.pendingWithdrawals(user.address), ethers.parseEther("0.25"));
+
+    await bridge.connect(user).claimWithdrawal();
+    assert.equal(await bridge.pendingWithdrawals(user.address), 0n);
+  });
+
+  it("prevents replaying the same proof twice", async function () {
+    const { bridge, user } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("2") });
+    const proof = ethers.randomBytes(65);
+
+    await bridge.connect(user).withdrawFromL2(ethers.parseEther("0.5"), proof);
+    assert.equal(await bridge.usedProofs(ethers.keccak256(proof)), true);
+
+    await assertRejectsWith(
+      bridge.connect(user).withdrawFromL2(ethers.parseEther("0.5"), proof),
+      "Proof already used"
+    );
+  });
+
+  it("only allows the owner to update the bridge fee", async function () {
+    const { bridge, user } = await deployBridge();
+    await assertRejectsWith(
+      bridge.connect(user).setBridgeFee(ethers.parseEther("0.002")),
+      "OwnableUnauthorizedAccount"
+    );
+    await bridge.setBridgeFee(ethers.parseEther("0.002"));
+    assert.equal(await bridge.bridgeFee(), ethers.parseEther("0.002"));
+  });
+
+  it("only allows the owner to sweep accumulated fees", async function () {
+    const { bridge, user, owner } = await deployBridge();
+    await assertRejectsWith(
+      bridge.connect(user).withdrawFees(),
+      "OwnableUnauthorizedAccount"
+    );
+
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    const ownerBefore = await ethers.provider.getBalance(owner.address);
+    await bridge.connect(owner).withdrawFees();
+    const ownerAfter = await ethers.provider.getBalance(owner.address);
+    assert.ok(ownerAfter > ownerBefore, "owner balance should increase");
+  });
+});


### PR DESCRIPTION
## Problem

`zkEVMBridge.withdrawFromL2` was reported as a critical loss-of-funds bug: it was a public function whose only gate was `proof.length > 0`, paying `bridgeBalance / 100` to any caller with any non-empty byte string. There was no proof verification, no per-user accounting, and no replay protection — an attacker could drain the bridge to insolvency with repeated calls.

## Fix

The current `withdrawFromL2(uint256 amount, bytes calldata proof)` already enforces the security model described in the report (per-user `depositedAmount` cap, `usedProofs` replay guard, proof verification delegated to the zkEVM rollup, `nonReentrant`). This PR locks that contract down with a regression suite so the reported drain can never silently regress:

- `blockchain/contracts/MockZkEVM.sol` — test-only stand-in for the rollup so bridge-level accounting and replay protection can be exercised without a real Groth16 proof (never used in production deployments).
- `blockchain/test/zkEVMBridge.test.cjs` — new regression tests pinning:
  - a caller with no deposit cannot withdraw anything (the old 1%-drain vector)
  - withdrawals cannot exceed the caller's deposited amount
  - zero-amount and empty-proof withdrawals are rejected
  - `depositedAmount` is credited on deposit and debited on withdrawal, and payouts queue into `pendingWithdrawals` for later `claimWithdrawal`
  - the same proof cannot be replayed (`usedProofs`)
  - `setBridgeFee` and `withdrawFees` remain owner-only

## Files changed

- `blockchain/contracts/MockZkEVM.sol` (new, test-only)
- `blockchain/test/zkEVMBridge.test.cjs` (new)

## Testing

- `npx hardhat test test/zkEVMBridge.test.cjs` — 9 passing.
- Note: the repo-wide `npx hardhat test` currently cannot compile because of a pre-existing, unrelated break in `blockchain/contracts/ZKPrivacy.sol` (commit 67d740a9 changed `this.verifySTARK()` to a direct call of an `external` function). The new suite is verified by compiling the bridge contracts in isolation.

Closes #6007
