### PR TITLE
fix(blockchain): pin TruxifyUpgradeable escrow access control (regression tests)

### DIFF
--- a/blockchain/test/TruxifyUpgradeable.accessControl.test.cjs
+++ b/blockchain/test/TruxifyUpgradeable.accessControl.test.cjs
@@ -1,0 +1,88 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, (error) => error.message.includes(message));
+}
+
+describe("TruxifyUpgradeable escrow access control", function () {
+  let truxify;
+  let admin, driver, customer, attacker;
+
+  beforeEach(async function () {
+    [admin, driver, customer, attacker] = await ethers.getSigners();
+
+    const TruxifyUpgradeable = await ethers.getContractFactory("TruxifyUpgradeable");
+    const implementation = await TruxifyUpgradeable.deploy();
+    await implementation.waitForDeployment();
+
+    const UUPSProxy = await ethers.getContractFactory("UUPSProxy");
+    const initializeData = implementation.interface.encodeFunctionData("initialize");
+    const proxy = await UUPSProxy.deploy(await implementation.getAddress(), initializeData);
+    await proxy.waitForDeployment();
+
+    truxify = await ethers.getContractAt("TruxifyUpgradeable", await proxy.getAddress());
+  });
+
+  async function createEscrow() {
+    const amount = ethers.parseEther("1");
+    await truxify.connect(customer).createEscrow(driver.address, amount, { value: amount });
+    return 1;
+  }
+
+  it("grants DEFAULT_ADMIN_ROLE to the initializer only", async function () {
+    const adminRole = await truxify.DEFAULT_ADMIN_ROLE();
+    assert.equal(await truxify.hasRole(adminRole, admin.address), true);
+    assert.equal(await truxify.hasRole(adminRole, attacker.address), false);
+  });
+
+  it("rejects releaseEscrow from a non-admin address", async function () {
+    const escrowId = await createEscrow();
+    await assertRejectsWith(
+      truxify.connect(attacker).releaseEscrow(escrowId),
+      "AccessControl"
+    );
+    const escrow = await truxify.getEscrow(escrowId);
+    assert.equal(escrow.released, false);
+  });
+
+  it("rejects disputeEscrow from a non-admin address", async function () {
+    const escrowId = await createEscrow();
+    await assertRejectsWith(
+      truxify.connect(attacker).disputeEscrow(escrowId),
+      "AccessControl"
+    );
+    const escrow = await truxify.getEscrow(escrowId);
+    assert.equal(escrow.disputed, false);
+  });
+
+  it("rejects releaseEscrow from the customer even though they funded it", async function () {
+    const escrowId = await createEscrow();
+    await assertRejectsWith(
+      truxify.connect(customer).releaseEscrow(escrowId),
+      "AccessControl"
+    );
+  });
+
+  it("allows the admin to release an escrow", async function () {
+    const escrowId = await createEscrow();
+    await truxify.connect(admin).releaseEscrow(escrowId);
+    const escrow = await truxify.getEscrow(escrowId);
+    assert.equal(escrow.released, true);
+  });
+
+  it("allows the admin to dispute an escrow", async function () {
+    const escrowId = await createEscrow();
+    await truxify.connect(admin).disputeEscrow(escrowId);
+    const escrow = await truxify.getEscrow(escrowId);
+    assert.equal(escrow.disputed, true);
+  });
+
+  it("keeps createEscrow permissionless so any customer can lock funds", async function () {
+    const amount = ethers.parseEther("0.5");
+    await truxify.connect(attacker).createEscrow(driver.address, amount, { value: amount });
+    const escrow = await truxify.getEscrow(1);
+    assert.equal(escrow.customer, attacker.address);
+    assert.equal(escrow.amount, amount);
+  });
+});


### PR DESCRIPTION
## Problem

`TruxifyUpgradeable` re-implemented the escrow API without the `onlyOwner` invariant documented in `TruxifyEscrow.sol`: `releaseEscrow`, `disputeEscrow`, and `lockPayment` were permissionless, so any address could force payout of a locked escrow, flip orders into dispute, or lock arbitrary funds — contradicting the documented security invariant.

## Fix

The contract has since been hardened: `releaseEscrow` and `disputeEscrow` are gated with `onlyRole(DEFAULT_ADMIN_ROLE)`, and the payable `lockPayment` function no longer exists — the escrow-locking flow is `createEscrow`, which stays permissionless by design (the caller is the customer whose funds are locked).

This PR adds a dedicated regression suite (`blockchain/test/TruxifyUpgradeable.accessControl.test.cjs`, 7 passing) pinning the invariant so the reported bypass cannot silently regress:

- `DEFAULT_ADMIN_ROLE` is granted to the initializer only
- `releaseEscrow` reverts for non-admin callers (including the funding customer) and leaves the escrow unreleased
- `disputeEscrow` reverts for non-admin callers and leaves the escrow undisputed
- the admin can release and dispute
- `createEscrow` remains permissionless so any customer can lock funds

## Files changed

- `blockchain/test/TruxifyUpgradeable.accessControl.test.cjs` (new)

## Testing

- `npx hardhat test test/TruxifyUpgradeable.accessControl.test.cjs` — 7 passing.
- Note: the repo-wide `npx hardhat test` currently cannot compile because of a pre-existing, unrelated break in `blockchain/contracts/ZKPrivacy.sol` (commit 67d740a9 changed `this.verifySTARK()` to a direct call of an `external` function). The new suite is verified by compiling the escrow + proxy contracts in isolation.

Closes #6009
