### PR TITLE
fix(graphql): accurate startup-failure log + syntax gate (issue #6663)

### DIFF
--- a/backend/api/test/unit/graphqlStartupSyntax.test.js
+++ b/backend/api/test/unit/graphqlStartupSyntax.test.js
@@ -1,0 +1,53 @@
+/**
+ * Syntax-gate regression test for GitHub issue #6663.
+ *
+ * `backend/graphql/index.js` previously ended with a dangling promise-chain
+ * continuation that made the module fail to parse (GraphQL gateway would not
+ * boot):
+ *
+ *   startGraphQL();
+ *   .catch(err => console.error("Promise.all failed:", err));
+ *
+ *   node --check backend/graphql/index.js
+ *   SyntaxError: Unexpected token '.'   (graphql/index.js:41)
+ *
+ * The current code re-attaches the `.catch` to the promise returned by
+ * `startGraphQL()` and reports the real source of the failure. This test locks
+ * both properties in place.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexFile = path.resolve(__dirname, '../../../graphql/index.js');
+
+describe('graphql/index.js startup catch (issue #6663)', () => {
+  it('module parses cleanly under `node --check`', () => {
+    const result = spawnSync(process.execPath, ['--check', indexFile], {
+      encoding: 'utf8',
+    });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+
+  it('does not contain the dangling `.catch` continuation or stale message', () => {
+    const source = readFileSync(indexFile, 'utf8');
+    expect(source).not.toContain('startGraphQL();');
+    expect(source).not.toContain('Promise.all failed:');
+  });
+
+  it('attaches a single .catch to the startGraphQL promise with an accurate message', () => {
+    const source = readFileSync(indexFile, 'utf8');
+    const lastLine = source.trim().split('\n').pop();
+
+    expect(lastLine.trim()).toBe(
+      'startGraphQL().catch(err => console.error("startGraphQL failed:", err));',
+    );
+
+    const catchCount = (source.match(/startGraphQL\(\)\.catch/g) ?? []).length;
+    expect(catchCount, 'expected exactly one .catch on the startup promise')
+      .toBe(1);
+  });
+});

--- a/backend/graphql/index.js
+++ b/backend/graphql/index.js
@@ -37,4 +37,4 @@ process.on('SIGINT', async () => {
     process.exit(0);
 });
 
-startGraphQL().catch(err => console.error("Promise.all failed:", err));
+startGraphQL().catch(err => console.error("startGraphQL failed:", err));


### PR DESCRIPTION
## Summary

Closes #6663 — the reported dangling `.catch()` continuation in `backend/graphql/index.js` was already re-attached upstream (`startGraphQL().catch(...)`). This PR makes two changes:

1. **Fix the stale log message** (`backend/graphql/index.js`): the `catch` handler reported `"Promise.all failed:"` — a leftover fragment of the removed `Promise.all(...)` chain. It now logs the real source of the failure:
   ```js
   startGraphQL().catch(err => console.error("startGraphQL failed:", err));
   ```
2. **Regression test** (`backend/api/test/unit/graphqlStartupSyntax.test.js`):
   - runs `node --check` on `graphql/index.js` (catches the original `SyntaxError: Unexpected token '.'`)
   - asserts no dangling `startGraphQL();` continuation or stale `"Promise.all failed:"` message remains
   - asserts a single `.catch` is attached to the startup promise with the corrected message

## Verification

- `node --check backend/graphql/index.js` passes
- `npx vitest run test/unit/graphqlStartupSyntax.test.js` — 3/3 pass
- Full backend unit suite re-run confirms the new test passes alongside existing tests.

## Notes

- The repo-wide `npx hardhat test` (contracts) is unrelated to this PR; it remains blocked by a pre-existing `ZKPrivacy.sol` compile error tracked separately.
