### PR TITLE
fix : use supabaseAdmin for notifications table inserts in notificationService

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -146,7 +146,7 @@ import rateLimit from 'express-rate-limit';
 
 import { bidLimiter, userLimiter, userKeyGenerator, podUploadLimiter, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateDocumentBuffer } from '../lib/documentValidation.js';
 import { scanDocument } from '../lib/malwareScanner.js';

--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -242,7 +242,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
 
   let dbSuccess = false;
   try {
-    const { error } = await supabase.from('notifications').insert({
+    const { error } = await supabaseAdmin.from('notifications').insert({
       user_id: customerId,
       title,
       body,
@@ -286,9 +286,9 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
 
 export async function sendPushNotification(userId, title, body, notifType, metadata = {}) {
   return measureExecution('NotificationService.sendPushNotification', async () => {
-    if (supabase) {
+    if (supabaseAdmin) {
       try {
-        const { error } = await supabase.from('notifications').insert({
+        const { error } = await supabaseAdmin.from('notifications').insert({
           user_id: userId,
           title,
           body,

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -9,6 +9,7 @@ const firebaseSendMock = vi.fn();
 // Service-role (delivery_otps) mocks — delivery_otps is service-role-write, so
 // all OTP lifecycle calls must flow through supabaseAdmin, never the anon key.
 const adminDeliveryOtpInsertMock = vi.fn().mockResolvedValue({ data: { id: 'otp-uuid-1' }, error: null });
+const adminNotificationInsertMock = vi.fn().mockResolvedValue({ error: null });
 const adminDeliveryOtpSelectMock = vi.fn().mockResolvedValue({ data: null, error: null });
 const adminDeliveryOtpUpdateMock = vi.fn().mockResolvedValue({ data: null, error: null });
 
@@ -49,6 +50,11 @@ vi.mock('../../src/config/db.js', () => ({
   },
   supabaseAdmin: {
     from: table => {
+      if (table === 'notifications') {
+        return {
+          insert: data => adminNotificationInsertMock(table, data)
+        };
+      }
       if (table === 'delivery_otps') {
         return {
           insert: data => ({
@@ -138,8 +144,8 @@ describe('notificationService', () => {
       expect(result.fcm.success).toBe(true);
       expect(result.fcm.messageId).toBe('msg_id_abc');
 
-      expect(supabaseInsertMock).toHaveBeenCalledOnce();
-      const insertArgs = supabaseInsertMock.mock.calls[0][1];
+      expect(adminNotificationInsertMock).toHaveBeenCalledOnce();
+      const insertArgs = adminNotificationInsertMock.mock.calls[0][1];
       expect(insertArgs.user_id).toBe(customerId);
       // OTP is NOT included in the notification body (security fix)
       expect(insertArgs.body).not.toContain(otp);
@@ -160,7 +166,7 @@ describe('notificationService', () => {
         error: null
       });
 
-      supabaseInsertMock.mockResolvedValue({ error: { message: 'DB error' } });
+      adminNotificationInsertMock.mockResolvedValue({ error: { message: 'DB error' } });
       const fcmError = new Error('Firebase error');
       fcmError.code = 'messaging/internal-error';
       firebaseSendMock.mockRejectedValue(fcmError);
@@ -358,7 +364,7 @@ describe('notificationService', () => {
 
       expect(result.success).toBe(true);
       expect(result.fcm.messageId).toBe('msg_id_xyz');
-      expect(supabaseInsertMock).toHaveBeenCalledOnce();
+      expect(adminNotificationInsertMock).toHaveBeenCalledOnce();
     });
 
     it('classifies transient errors and retries', async () => {


### PR DESCRIPTION
Closes #6727.

Summary of What Has Been Done:
sendDeliveryOtpNotification and sendPushNotification in notificationService.js were using the anon supabase client to insert into the notifications table. If the anon key is revoked, these inserts silently fail and no notification record is persisted. Both paths have been switched to use supabaseAdmin (the service-role client) so notifications are written reliably.

Changes Made:
- backend/api/src/services/notificationService.js: changed sendDeliveryOtpNotification to use supabaseAdmin.from('notifications').insert(...) instead of supabase.from('notifications').insert(...)
- backend/api/src/services/notificationService.js: changed sendPushNotification guard from 'if (supabase)' to 'if (supabaseAdmin)' and use supabaseAdmin.from('notifications').insert(...)
- backend/api/test/unit/notificationService.test.js: updated mock to handle supabaseAdmin.from('notifications') insert path and updated assertions

Impact it Made:
- Notifications are persisted reliably even when the anon key is revoked or rate-limited by Supabase.
- Eliminates silent data-loss in the customer-facing notification pipeline.
- All 15 notificationService unit tests pass.

This is a GSSOC contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of notification record persistence for delivery OTP and push notifications.
  * Preserved existing push delivery and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->