### PR TITLE
fix(eventsourcing): add event_store table migration

### DIFF
--- a/supabase/migrations/20260806000000_create_event_store.sql
+++ b/supabase/migrations/20260806000000_create_event_store.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- EVENT SOURCING — Event Store Table
+-- ============================================================================
+-- The eventsourcing module (backend/eventsourcing) persists every domain event
+-- in `event_store` and reads it back for event streams, aggregate-state
+-- rebuilds and projection rebuilds (storeEvent / getEventStream in
+-- event-store.js, plus the POST /eventsourcing/rebuild endpoint in routes.js).
+-- No migration ever created the table, so storeEvent threw
+-- `relation "event_store" does not exist`, handleCommand always failed,
+-- getEventStream returned [] and rebuild returned 500. This migration creates
+-- the table with columns matching the inserts in event-store.js.
+--
+-- SECURITY MODEL:
+--   - Written by backend services and never exposed to clients, so RLS allows
+--     service_role only.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. EVENT STORE TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists event_store (
+  event_id     text not null,          -- event.id (natural key)
+  event_type   text not null,          -- event.type
+  aggregate_id text not null,          -- event.aggregateId
+  payload      jsonb,                  -- event.payload
+  version      integer,                -- event.version
+  timestamp    timestamptz not null,   -- event.timestamp
+  created_at   timestamptz not null default now(),
+  primary key (event_id)
+);
+
+create index if not exists idx_event_store_aggregate
+  on event_store (aggregate_id);
+
+create index if not exists idx_event_store_timestamp
+  on event_store (timestamp);
+
+create index if not exists idx_event_store_aggregate_version
+  on event_store (aggregate_id, version);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table event_store enable row level security;
+
+drop policy if exists "Service role full access on event_store"
+  on event_store;
+create policy "Service role full access on event_store"
+  on event_store
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table event_store from anon, authenticated;


### PR DESCRIPTION
## Problem
The event-sourcing store persists events to an `event_store` table, but that table does not exist in the database, so event writes and the rebuild-from-events flow fail against a missing relation.

## Fix
Add a migration that creates the `event_store` table with service_role-only row level security, matching the existing Supabase migration patterns.

## Files changed
- `supabase/migrations/20260806000000_create_event_store.sql`

## Testing
Migration applies cleanly on a fresh Supabase project; service_role insert/select/delete verified; `anon`/`authenticated` roles revoked.

Closes #6695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent storage for application events, including event metadata, payloads, timestamps, and efficient retrieval by aggregate and chronology.
  * Restricted event data access to authorized service operations for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->