### PR TITLE
fix(kafka): align order stats statuses with real order lifecycle

### DIFF
--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -167,7 +167,10 @@ class OrderReadModel {
   }
 
   async getOrderStats() {
-    const statuses = ['pending', 'accepted', 'in_transit', 'delivered', 'cancelled', 'payment_released'];
+    // These are the status values actually produced by the read-model builder
+    // (event.repository.js getSnapshot). Querying any other values would
+    // always report 0.
+    const statuses = ['created', 'assigned', 'paid', 'in_transit', 'completed', 'settled'];
     const stats = {};
 
     for (const status of statuses) {


### PR DESCRIPTION
﻿## Problem
`getOrderStats` groups orders by statuses that do not match the order lifecycle used by the read model (`created/assigned/paid/in_transit/completed/settled`), so stats return empty/incorrect buckets.

## Fix
Replace the stale status list with the read-model statuses.

## Files changed
- `backend/kafka/cqrs/order.read.model.js`

## Testing
`getOrderStats` now buckets orders under the lifecycle statuses; verified against the status mapping in the snapshot builder.

Closes #6701
