### PR TITLE
fix(api): update KYC verification rows by user_id

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -186,7 +186,7 @@ router.post('/kyc/upload', upload.single('image'), authenticate, async (req, res
     const { error: updateError } = await supabase
       .from('driver_details')
       .update({ kyc_status: 'Pending KYC' })
-      .eq('driver_id', userId);
+      .eq('user_id', userId);
 
     if (updateError) {
       logger.warn({ updateError }, 'Failed to set pending status, but continuing with OCR');
@@ -218,14 +218,14 @@ router.post('/kyc/upload', upload.single('image'), authenticate, async (req, res
           kyc_status: 'Verified',
           kyc_doc_number: ocrData.extracted_number
         })
-        .eq('driver_id', userId);
+        .eq('user_id', userId);
 
       if (verifyError) throw verifyError;
     } else {
        const { error: rejectError } = await supabase
         .from('driver_details')
         .update({ kyc_status: 'Rejected' })
-        .eq('driver_id', userId);
+        .eq('user_id', userId);
 
       if (rejectError) throw rejectError;
     }


### PR DESCRIPTION
﻿## Problem
The KYC verification routes update `driver_details` filtering on a `driver_id` column, but the table keys on `user_id` (per `docs/supabase_setup.sql`), so verification updates match zero rows and silently no-op.

## Fix
Filter the three KYC updates (pending, verified, rejected) on `user_id` instead of `driver_id`.

## Files changed
- `backend/api/src/routes/verificationRoutes.js`

## Testing
KYC status updates now match and update the intended `driver_details` row; invalid ids no longer no-op silently.

Closes #6703
