### PR TITLE
fix(telemetry): age out rate-limit entries in sweep

### DIFF
--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -367,7 +367,7 @@ func storePing(driverID string, ping TelemetryPing) bool {
 }
 
 // sweepDrivers removes drivers whose last ping is older than the TTL and drops
-// empty rate-limit entries.
+// stale rate-limit entries.
 func sweepDrivers() {
 	now := time.Now()
 
@@ -381,9 +381,15 @@ func sweepDrivers() {
 	pingRateLimit.Range(func(key, value interface{}) bool {
 		e := value.(*rateEntry)
 		e.mu.Lock()
-		empty := len(e.stamps) == 0
+		// Stamps are appended in order and pruned oldest-first, so the last
+		// stamp is the driver's most recent activity. Entries are aged out
+		// once they go quiet for a full driverTTL, not only when empty.
+		stale := true
+		if len(e.stamps) > 0 {
+			stale = now.Sub(e.stamps[len(e.stamps)-1]) > driverTTL
+		}
 		e.mu.Unlock()
-		if empty {
+		if stale {
 			pingRateLimit.Delete(key)
 		}
 		return true


### PR DESCRIPTION
﻿## Problem
`sweepDrivers` only removes a driver when its `pingRateLimit` entry is empty, so stale rate-limit stamps (and their memory) are never cleaned up once a driver has pinged, and re-registered drivers inherit old stamps.

## Fix
Also remove `pingRateLimit` entries whose last stamp is older than `driverTTL`, regardless of whether the entry is empty.

## Files changed
- `services/telemetry-ingestion/main.go`

## Testing
Sweep now drops entries with an expired last stamp; entries with recent stamps are retained.

Closes #6704
