### PR TITLE
fix(customer): route push notifications to correct tabs

### DIFF
--- a/apps/customer/lib/screens/shell_screen.dart
+++ b/apps/customer/lib/screens/shell_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/app_page_route.dart';
 import 'find_trucks_screen.dart';
 import 'home_screen.dart';
 import 'live_tracking_screen.dart';
+import 'my_documents_screen.dart';
 import 'notifications_screen.dart';
 import 'order_detail_screen.dart';
 import 'orders_screen.dart';
@@ -86,10 +87,29 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
       case NotificationTarget.orderDetail:
         await _navigateToOrderDetail(data);
         break;
+      case NotificationTarget.loadDetail:
+        // A new bid/load offer on one of the customer's posted loads — open
+        // the Orders tab where the load and its bids are visible.
+        _switchTab(2);
+        break;
+      case NotificationTarget.earnings:
+        // Payment released to the customer's wallet — open the Profile tab.
+        _switchTab(3);
+        break;
+      case NotificationTarget.documents:
+        // Document expiring/expired — open the documents screen.
+        _switchTab(3);
+        _profileNavigatorKey.currentState?.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const MyDocumentsScreen(),
+          ),
+        );
+        break;
       case NotificationTarget.notifications:
         _navigateToNotifications();
         break;
-      default:
+      case NotificationTarget.tripDetail:
+      case NotificationTarget.unknown:
         _navigateToNotifications();
         break;
     }


### PR DESCRIPTION
﻿## Problem
The customer app notification switch only handled `orderDetail`/`tripDetail`, so earnings, load detail, and documents notifications fell through to the generic notifications screen instead of navigating to the right tab.

## Fix
Handle `loadDetail` (Orders tab), `earnings` (Profile tab), and `documents` (Profile tab -> MyDocumentsScreen) targets in `_handleNotificationNavigation`, matching the driver app routing; added the missing import for `my_documents_screen.dart`.

## Files changed
- `apps/customer/lib/screens/shell_screen.dart`

## Testing
Verified each `NotificationTarget` resolves to the correct tab/screen; unknown targets still fall back to notifications.

Closes #6705
