### PR TITLE
fix(kafka): replay original event from dead letters

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -174,11 +174,28 @@ class OrderConsumer {
 
     for (const entry of pending) {
       const topicHandlers = this.handlers.get(entry.topic) || [];
-      const parsedMessage = entry.message;
+
+      // entry.message is the DLQ wrapper object
+      // ({ topic, message, error, timestamp, retryCount }); its `message` field
+      // holds the JSON-encoded original Kafka value. Handlers are registered
+      // for the original event shape, so replay must feed them the parsed
+      // event, not the wrapper.
+      let parsedMessage;
+      try {
+        const serialized = typeof entry.message === 'string'
+          ? entry.message
+          : entry.message?.message;
+        parsedMessage = JSON.parse(serialized);
+      } catch (error) {
+        logger.error(`Replay failed for dead letter ${entry.id} (${entry.topic}): message is not valid JSON:`, error);
+        await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        results.failed += 1;
+        continue;
+      }
 
       try {
         for (const handler of topicHandlers) {
-          await handler(parsedMessage, { value: parsedMessage?.message });
+          await handler(parsedMessage, { value: parsedMessage });
         }
         await deadLetterRepository.markStatus(entry.id, 'replayed');
         results.succeeded += 1;


### PR DESCRIPTION
﻿## Problem
`replayDeadLetters` fed the dead-letter wrapper (`{ topic, message, error, ... }`) directly into the event handlers, which expect the original event shape, so replays either crashed or were misprocessed.

## Fix
Extract `entry.message.message` (or the string form), `JSON.parse` it back into the original event, and feed the parsed event to the handlers; failures are logged and the entry is marked replayed/pending accordingly.

## Files changed
- `backend/kafka/consumers/order.consumer.js`

## Testing
Replaying a stored dead letter now routes the original event through the handlers; malformed entries are surfaced and marked pending.

Closes #6707
