### PR TITLE
fix(liquibase): protect status/validate routes with auth

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -128,6 +128,8 @@ const POLICIES = {
   'demand:view-heatmap':       { roles: [ROLES.DRIVER, ROLES.ADMIN] },
   'liquibase:migrate':         { roles: [ROLES.ADMIN] },
   'liquibase:rollback':        { roles: [ROLES.ADMIN] },
+  'liquibase:status':          { roles: [ROLES.ADMIN] },
+  'liquibase:validate':        { roles: [ROLES.ADMIN] },
 
   'ebpf:manage':               { roles: [ROLES.ADMIN] },
   'snyk:manage':               { roles: [ROLES.ADMIN] },

--- a/database/liquibase/routes.js
+++ b/database/liquibase/routes.js
@@ -37,8 +37,8 @@ router.post('/liquibase/rollback', authenticate, requirePolicy('liquibase:rollba
     }
 });
 
-// Get status
-router.get('/liquibase/status', async (req, res) => {
+// Get status (admin only)
+router.get('/liquibase/status', authenticate, requirePolicy('liquibase:status'), async (req, res) => {
     try {
         const result = await liquibaseService.getStatus();
         res.json({
@@ -52,8 +52,8 @@ router.get('/liquibase/status', async (req, res) => {
     }
 });
 
-// Validate changelog
-router.post('/liquibase/validate', async (req, res) => {
+// Validate changelog (admin only)
+router.post('/liquibase/validate', authenticate, requirePolicy('liquibase:validate'), async (req, res) => {
     try {
         const result = await liquibaseService.validate();
         res.json({


### PR DESCRIPTION
﻿## Problem
`GET /liquibase/status` and `POST /liquibase/validate` are unauthenticated while `/migrate` and `/rollback` require auth, leaving migration metadata and changelog validation exposed.

## Fix
Guard both routes with `authenticate` and `requirePolicy` (new admin-only `liquibase:status` and `liquibase:validate` policies), matching the migrate/rollback routes.

## Files changed
- `database/liquibase/routes.js`
- `backend/api/src/security/policyEngine.js`

## Testing
Requests without a valid token/role now get 401/403; admin users can still read status and validate the changelog.

Closes #6712
