### PR TITLE
fix(liquibase): add rollback verb and validate count

### DIFF
--- a/database/liquibase/liquibase.service.js
+++ b/database/liquibase/liquibase.service.js
@@ -71,11 +71,17 @@ class LiquibaseService {
 
     async rollback(rollbackCount = 1) {
         try {
+            const parsedCount = parseInt(rollbackCount, 10);
+            if (!Number.isFinite(parsedCount) || parsedCount < 1) {
+                throw new Error('rollbackCount must be a positive integer');
+            }
+
             const args = [
                 `--changeLogFile=${this.liquibasePath}/changelog-master.xml`,
                 `--url=${this.dbUrl}`,
                 `--username=${this.username}`,
-                `--rollbackCount=${rollbackCount}`,
+                'rollback',
+                `--rollbackCount=${parsedCount}`,
             ];
 
             const { stdout, stderr } = await runLiquibase(args, this.password);
@@ -85,7 +91,7 @@ class LiquibaseService {
                 return { success: false, error: stderr };
             }
 
-            logger.info(`✅ Rollback ${rollbackCount} changes completed`);
+            logger.info(`✅ Rollback ${parsedCount} changes completed`);
             return { success: true, output: stdout };
         } catch (error) {
             logger.error('Rollback failed:', error);


### PR DESCRIPTION
﻿## Problem
The `rollback` service method builds args without the `rollback` command verb, so Liquibase errors out instead of rolling back, and `rollbackCount` is passed through unvalidated.

## Fix
Add the `rollback` verb to the args and validate `rollbackCount` is a positive integer (throwing otherwise).

## Files changed
- `database/liquibase/liquibase.service.js`

## Testing
`rollback` now invokes Liquibase with the `rollback` command; non-numeric or negative counts return an error instead of running.

Closes #6713
