### PR TITLE
fix(wasi): pass real instanceId to WASI wrappers

### DIFF
--- a/wasi/routes.js
+++ b/wasi/routes.js
@@ -32,7 +32,7 @@ router.post('/wasi/load', wasiActionLimiter, async (req, res) => {
 router.post('/wasi/file/read', wasiActionLimiter, async (req, res) => {
     try {
         const { instanceId, path } = req.body;
-        const content = await wasiRuntime.readFile(path);
+        const content = await wasiRuntime.readFile(instanceId, path);
         res.json({ success: true, data: { content } });
     } catch (error) {
         logger.error('Read error:', error);
@@ -43,7 +43,7 @@ router.post('/wasi/file/read', wasiActionLimiter, async (req, res) => {
 router.post('/wasi/file/write', wasiActionLimiter, async (req, res) => {
     try {
         const { instanceId, path, content } = req.body;
-        const result = await wasiRuntime.writeFile(path, content);
+        const result = await wasiRuntime.writeFile(instanceId, path, content);
         res.json({ success: true, data: { result } });
     } catch (error) {
         logger.error('Write error:', error);
@@ -54,7 +54,7 @@ router.post('/wasi/file/write', wasiActionLimiter, async (req, res) => {
 router.post('/wasi/file/list', wasiActionLimiter, async (req, res) => {
     try {
         const { instanceId, path } = req.body;
-        const files = await wasiRuntime.listDirectory(path);
+        const files = await wasiRuntime.listDirectory(instanceId, path);
         res.json({ success: true, data: { files } });
     } catch (error) {
         logger.error('List error:', error);
@@ -65,8 +65,8 @@ router.post('/wasi/file/list', wasiActionLimiter, async (req, res) => {
 // Network operations
 router.post('/wasi/http', wasiActionLimiter, async (req, res) => {
     try {
-        const { url, method, headers, body } = req.body;
-        const response = await wasiRuntime.httpRequest(url, method, headers, body);
+        const { instanceId, url, method, headers, body } = req.body;
+        const response = await wasiRuntime.httpRequest(instanceId, url, method, headers, body);
         res.json({ success: true, data: response });
     } catch (error) {
         logger.error('HTTP error:', error);
@@ -77,8 +77,9 @@ router.post('/wasi/http', wasiActionLimiter, async (req, res) => {
 // Time operations
 router.get('/wasi/time', async (req, res) => {
     try {
-        const time = await wasiRuntime.getTime();
-        const timeMs = await wasiRuntime.getTimeMs();
+        const { instanceId } = req.query;
+        const time = await wasiRuntime.getTime(instanceId);
+        const timeMs = await wasiRuntime.getTimeMs(instanceId);
         res.json({ success: true, data: { time, timeMs } });
     } catch (error) {
         logger.error('Time error:', error);
@@ -89,8 +90,9 @@ router.get('/wasi/time', async (req, res) => {
 // System operations
 router.get('/wasi/system', async (req, res) => {
     try {
-        const pid = await wasiRuntime.getProcessId();
-        const cwd = await wasiRuntime.getCurrentDir();
+        const { instanceId } = req.query;
+        const pid = await wasiRuntime.getProcessId(instanceId);
+        const cwd = await wasiRuntime.getCurrentDir(instanceId);
         res.json({ success: true, data: { pid, cwd } });
     } catch (error) {
         logger.error('System error:', error);

--- a/wasi/wasi-runtime.js
+++ b/wasi/wasi-runtime.js
@@ -127,65 +127,65 @@ class WASIRuntime {
         }
     }
 
-    async readFile(path) {
+    async readFile(instanceId, path) {
         this.validatePath(path);
-        const result = await this.executeFunction('wasi_read_file', path);
+        const result = await this.executeFunction(instanceId, 'wasi_read_file', path);
         return result;
     }
 
-    async writeFile(path, content) {
+    async writeFile(instanceId, path, content) {
         this.validatePath(path);
-        const result = await this.executeFunction('wasi_write_file', path, content);
+        const result = await this.executeFunction(instanceId, 'wasi_write_file', path, content);
         return result;
     }
 
-    async listDirectory(path) {
+    async listDirectory(instanceId, path) {
         this.validatePath(path);
-        const result = await this.executeFunction('wasi_list_directory', path);
+        const result = await this.executeFunction(instanceId, 'wasi_list_directory', path);
         return JSON.parse(result);
     }
 
-    async createDirectory(path) {
+    async createDirectory(instanceId, path) {
         this.validatePath(path);
-        const result = await this.executeFunction('wasi_create_directory', path);
+        const result = await this.executeFunction(instanceId, 'wasi_create_directory', path);
         return result;
     }
 
-    async deleteFile(path) {
+    async deleteFile(instanceId, path) {
         this.validatePath(path);
-        const result = await this.executeFunction('wasi_delete_file', path);
+        const result = await this.executeFunction(instanceId, 'wasi_delete_file', path);
         return result;
     }
 
-    async httpRequest(url, method, headers, body) {
+    async httpRequest(instanceId, url, method, headers, body) {
         this.validateUrl(url);
         const request = JSON.stringify({ url, method, headers, body });
-        const result = await this.executeFunction('wasi_http_request', request);
+        const result = await this.executeFunction(instanceId, 'wasi_http_request', request);
         return JSON.parse(result);
     }
 
-    async getTime() {
-        return await this.executeFunction('wasi_get_time');
+    async getTime(instanceId) {
+        return await this.executeFunction(instanceId, 'wasi_get_time');
     }
 
-    async getTimeMs() {
-        return await this.executeFunction('wasi_get_time_ms');
+    async getTimeMs(instanceId) {
+        return await this.executeFunction(instanceId, 'wasi_get_time_ms');
     }
 
-    async sleep(ms) {
-        return await this.executeFunction('wasi_sleep', ms);
+    async sleep(instanceId, ms) {
+        return await this.executeFunction(instanceId, 'wasi_sleep', ms);
     }
 
-    async getProcessId() {
-        return await this.executeFunction('wasi_get_process_id');
+    async getProcessId(instanceId) {
+        return await this.executeFunction(instanceId, 'wasi_get_process_id');
     }
 
-    async getEnvVar(name) {
-        return await this.executeFunction('wasi_get_env_var', name);
+    async getEnvVar(instanceId, name) {
+        return await this.executeFunction(instanceId, 'wasi_get_env_var', name);
     }
 
-    async getCurrentDir() {
-        return await this.executeFunction('wasi_get_current_dir');
+    async getCurrentDir(instanceId) {
+        return await this.executeFunction(instanceId, 'wasi_get_current_dir');
     }
 
     validatePath(path) {


### PR DESCRIPTION
﻿## Problem
Every WASI wrapper passes the export function name (e.g. `wasi_read_file`) as the `instanceId`, and the routes never forward the real `instanceId`, so `executeFunction` looks up a non-existent instance and every endpoint returns 500 "Instance not found".

## Fix
Have the wrappers accept and forward the real `instanceId` to `executeFunction`, and update the routes to pass `instanceId` from the request body (query param for GET routes).

## Files changed
- `wasi/wasi-runtime.js`
- `wasi/routes.js`

## Testing
WASI endpoints now execute against the loaded instance returned by `/wasi/load`; unknown instance ids still 404/500 with the instance-not-found error.

Closes #6714
