### PR TITLE
fix(liquibase): point PATH at extracted liquibase directory

### DIFF
--- a/database/liquibase/run-migrations.sh
+++ b/database/liquibase/run-migrations.sh
@@ -6,7 +6,7 @@ echo "🚀 Running Liquibase Migrations..."
 if ! command -v liquibase &> /dev/null; then
     echo "Installing Liquibase..."
     curl -L https://github.com/liquibase/liquibase/releases/download/v4.23.0/liquibase-4.23.0.tar.gz | tar xz
-    export PATH=$PWD/liquibase-4.23.0:$PATH
+    export PATH=$PWD/liquibase:$PATH
 fi
 
 # Run migrations


### PR DESCRIPTION
﻿## Problem
The install step extracts the Liquibase tarball (which unpacks into `liquibase/`) but sets `PATH` to `$PWD/liquibase-4.23.0`, so `liquibase` is never found after a fresh install.

## Fix
Export `PATH` with `$PWD/liquibase`, the directory the tarball actually extracts to.

## Files changed
- `database/liquibase/run-migrations.sh`

## Testing
On a machine without liquibase installed, the script now installs and successfully runs the `liquibase` binary from the extracted directory.

Closes #6715
