### PR TITLE
fix(db): add key_rotations table migration

### DIFF
--- a/supabase/migrations/20260806050000_create_key_rotations_table.sql
+++ b/supabase/migrations/20260806050000_create_key_rotations_table.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- KEY ROTATION RECORDS — wallet key rotation history
+-- ============================================================================
+-- Backend services (keyRotationService.js) record each wallet key rotation here
+-- so the rotation lifecycle (in_progress -> completed/failed) can be tracked and
+-- audited, and so rotation policies can be enforced from history.
+--
+-- SECURITY MODEL:
+--   - Written by backend services using the service_role key and never exposed
+--     to clients, so RLS allows service_role only.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. KEY ROTATIONS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists key_rotations (
+  rotation_id    varchar(255) primary key,  -- service-generated id (e.g. rot_<hex>)
+  user_id        uuid not null,
+  wallet_address varchar(255) not null,
+  reason         varchar(100),              -- 'routine', 'security_breach', 'device_compromise'
+  status         varchar(50),               -- 'in_progress', 'completed', 'failed'
+  new_key_id     uuid,
+  initiated_at   timestamptz not null default now(),
+  completed_at   timestamptz
+);
+
+create index if not exists idx_rotations_user_wallet
+  on key_rotations (user_id, wallet_address);
+
+create index if not exists idx_rotations_initiated_at
+  on key_rotations (initiated_at);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table key_rotations enable row level security;
+
+drop policy if exists "Service role full access on key_rotations"
+  on key_rotations;
+create policy "Service role full access on key_rotations"
+  on key_rotations
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table key_rotations from anon, authenticated;


### PR DESCRIPTION
﻿## Problem
`keyRotationService` records rotation lifecycle rows into `key_rotations`, but the table does not exist in the database, so rotations fail on insert and history/policy checks fail on select.

## Fix
Add a migration creating `key_rotations` per `docs/secure-key-management.md` (rotation_id, user_id, wallet_address, reason, status, new_key_id, initiated_at, completed_at) with service_role-only RLS.

## Files changed
- `supabase/migrations/20260806050000_create_key_rotations_table.sql`

## Testing
Migration applies cleanly; service_role insert/update/select verified; `anon`/`authenticated` roles revoked.

Closes #6717
