### PR TITLE
fix(wasm): return edge function result under expected key

### DIFF
--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -79,7 +79,7 @@ class EdgeRuntime {
                 const func = instance.exports[functionName];
                 if (!func) throw new Error('Function ' + functionName + ' not found');
                 const result = func(...params);
-                parentPort.postMessage({ success: true, data: result });
+                parentPort.postMessage({ success: true, result });
             } catch (err) {
                 parentPort.postMessage({ success: false, error: err.message });
             }


### PR DESCRIPTION
﻿## Problem
The worker posts `{ success: true, data: result }`, but the edge function wrappers read `result.result`, so every successful execution returns `null`.

## Fix
Post the result under the `result` key so the wrappers receive what they expect.

## Files changed
- `wasm/edge-runtime.js`

## Testing
Edge functions (calculate_route, calculate_eta, filter_drivers, etc.) now return the actual result instead of `null` on success.

Closes #6719
