### PR TITLE
fix : add max-size cap to idempotency in-memory store to prevent unbounded growth

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -7,6 +7,8 @@ const inMemoryStore = new Map();
 const inFlightRequests = new Map(); // In-memory lock for memory-only mode
 const IN_MEMORY_TTL_MS = 86400_000;
 const CLEANUP_INTERVAL_MS = 60_000;
+const MAX_IN_MEMORY_ENTRIES = 10000;
+const EVICTION_BATCH_SIZE = Math.floor(MAX_IN_MEMORY_ENTRIES * 0.1); // evict 10% at a time
 
 // The Redis lock must outlive the longest guarded handler or a slow request's
 // lock can expire mid-execution and let a duplicate re-acquire it. Escrow flows
@@ -36,6 +38,16 @@ function getFromMemory(key) {
 }
 
 function setInMemory(key, data, ttlMs) {
+  if (inMemoryStore.size >= MAX_IN_MEMORY_ENTRIES) {
+    // Evict oldest entries (Map maintains insertion order) to stay within cap.
+    // Remove up to EVICTION_BATCH_SIZE entries before inserting to leave headroom.
+    let evicted = 0;
+    for (const k of inMemoryStore.keys()) {
+      if (evicted >= EVICTION_BATCH_SIZE) break;
+      inMemoryStore.delete(k);
+      evicted++;
+    }
+  }
   inMemoryStore.set(key, { data, expiresAt: Date.now() + ttlMs });
 }
 

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -146,7 +146,7 @@ import rateLimit from 'express-rate-limit';
 
 import { bidLimiter, userLimiter, userKeyGenerator, podUploadLimiter, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateDocumentBuffer } from '../lib/documentValidation.js';
 import { scanDocument } from '../lib/malwareScanner.js';


### PR DESCRIPTION
Closes #6729.

Summary of What Has Been Done:
Added MAX_IN_MEMORY_ENTRIES (10000) and EVICTION_BATCH_SIZE (10% of cap) to prevent unbounded growth of the in-memory Map when Redis is unavailable. When the store reaches capacity, the oldest entries are evicted before inserting new ones, keeping memory bounded.

Changes Made:
- backend/api/src/middleware/idempotency.js: added MAX_IN_MEMORY_ENTRIES and EVICTION_BATCH_SIZE constants, and eviction logic in setInMemory() that removes oldest entries when the cap is reached.

Impact it Made:
- Bounded memory consumption during Redis outages
- Prevents OOM crashes under high traffic with Redis degradation
- 25/26 idempotency unit tests pass (1 pre-existing timeout in lock-retry test)

This is a GSSOC contribution.