### PR TITLE
fix : add missing requireRole import in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -146,7 +146,7 @@ import rateLimit from 'express-rate-limit';
 
 import { bidLimiter, userLimiter, userKeyGenerator, podUploadLimiter, createStore } from '../middleware/rateLimiter.js';
 import { mongoDb, supabase, redisClient, createUserClient } from '../config/db.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateDocumentBuffer } from '../lib/documentValidation.js';
 import { scanDocument } from '../lib/malwareScanner.js';


### PR DESCRIPTION
Closes #<none> (pre-existing ESLint fix).

Summary of What Has Been Done:
ESLint no-undef error in orderRoutes.js: requireRole is used on line 1838 but was not imported. Added requireRole to the existing import statement from auth.js.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Added requireRole to the import from ../middleware/auth.js

Impact it Made:
ESLint no-undef error is resolved. The function will no longer throw a runtime ReferenceError when the /:id/pod route is accessed.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted proof-of-delivery uploads to authenticated drivers.
  * Added role-based authorization to help prevent unauthorized uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->