### PR TITLE
fix : allowed assigned driver to view shipment details

### DIFF
--- a/backend/api/src/controllers/shipmentController.js
+++ b/backend/api/src/controllers/shipmentController.js
@@ -21,8 +21,10 @@ export const getShipmentDetails = async (req, res) => {
 
     // Authorization check: Verify if the authenticated user is the owner (customer) or driver
     // The issue states: "matches the ownerId of the requested shipment"
-    // In our context, customer_id represents the owner.
-    if (shipment.customer_id !== req.user.id) {
+    // In our context, customer_id represents the owner, and driver_id is the assigned driver.
+    const isOwner = shipment.customer_id === req.user.id;
+    const isAssignedDriver = shipment.driver_id === req.user.id;
+    if (!isOwner && !isAssignedDriver) {
       logger.warn({ userId: req.user.id, shipmentId }, 'Unauthorized access attempt to shipment details');
       return res.status(403).json({ error: 'Forbidden: You do not have access to this shipment.' });
     }

--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Closes #6786.

Summary of What Has Been Done:
Fixed getShipmentDetails in shipmentController.js to allow both customers and assigned drivers to view shipment details. Previously only customers (customer_id) could access shipments, causing all driver requests to return 403 Forbidden.

Changes Made:
- backend/api/src/controllers/shipmentController.js: Added isAssignedDriver check alongside isOwner check. Both customer and assigned driver can now access shipment details.

Impact it Made:
- Assigned drivers can now view shipment details for shipments they are actively completing.
- Fixes broken authorization flow that blocked legitimate driver access.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.