### PR TITLE
fix : passed original event to DLQ handlers instead of wrapper in replayDeadLetters

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());

--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -174,11 +174,23 @@ class OrderConsumer {
 
     for (const entry of pending) {
       const topicHandlers = this.handlers.get(entry.topic) || [];
-      const parsedMessage = entry.message;
+      // entry.message is the serialized original event (stored as-is in kafka_dead_letters.message).
+      // Parse it to recover the original event before replaying.
+      let originalEvent;
+      try {
+        originalEvent = typeof entry.message === 'string'
+          ? JSON.parse(entry.message)
+          : entry.message;
+      } catch (parseErr) {
+        logger.warn({ entryId: entry.id }, 'Failed to parse dead letter message during replay — skipping');
+        await deadLetterRepository.markStatus(entry.id, 'failed');
+        results.failed += 1;
+        continue;
+      }
 
       try {
         for (const handler of topicHandlers) {
-          await handler(parsedMessage, { value: parsedMessage?.message });
+          await handler(originalEvent);
         }
         await deadLetterRepository.markStatus(entry.id, 'replayed');
         results.succeeded += 1;


### PR DESCRIPTION
Closes #6789.

Summary of What Has Been Done:
Fixed replayDeadLetters in order.consumer.js to pass the original deserialized event to handlers instead of the DLQ wrapper object. The handler now receives the properly parsed original event.

Changes Made:
- backend/kafka/consumers/order.consumer.js: After retrieving the DLQ entry, parse entry.message (the serialized original event) to recover the original event object. Pass the original event to handlers instead of the wrapper.

Impact it Made:
- Dead letter replay now correctly processes the original event instead of the DLQ wrapper.
- Failed messages can be retried and applied correctly.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.