### PR TITLE
fix : passed pre_data to CausalImpact for accurate counterfactual baseline

### DIFF
--- a/backend/ai/causal_inference.py
+++ b/backend/ai/causal_inference.py
@@ -179,14 +179,16 @@ class CausalImpact:
     def measure_impact(self, pre_data: np.ndarray, post_data: np.ndarray, intervention_point: int) -> Dict:
         """Measure impact of intervention"""
         try:
-            # Pre-intervention period
-            pre_period = [0, intervention_point - 1]
-            post_period = [intervention_point, len(post_data) - 1]
-            
+            # Concatenate pre and post data into a single series for the causalimpact library.
+            # The library expects a single array and period indices that point into it.
+            full_data = np.concatenate([pre_data, post_data])
+            pre_period = [0, len(pre_data) - 1]
+            post_period = [len(pre_data), len(full_data) - 1]
+
             # Calculate counterfactual
             from causalimpact import CausalImpact
-            
-            impact = CausalImpact(post_data, pre_period, post_period)
+
+            impact = CausalImpact(full_data, pre_period, post_period)
             impact.run()
             
             summary = impact.summary()

--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Closes #6788.

Summary of What Has Been Done:
Fixed CausalImpact.measure_impact to concatenate pre_data and post_data into a single series before passing to the causalimpact library. The pre_period is now correctly computed against the full pre-intervention data.

Changes Made:
- backend/ai/causal_inference.py: Changed to use np.concatenate([pre_data, post_data]) as the full_data series. Pre_period is now [0, len(pre_data)-1] and post_period is [len(pre_data), len(full_data)-1].

Impact it Made:
- Accurate causal impact measurement using actual pre-intervention baseline data.
- The endpoint no longer silently computes on post-only data.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.