### PR TITLE
fix : logged JSON.parse errors in CachePublisher with channel and message preview

### DIFF
--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -162,7 +162,8 @@ export function setupMessageHandler(cacheInvalidator) {
     const event = (() => {
       try {
         return JSON.parse(message);
-      } catch {
+      } catch (err) {
+        logger.warn({ channel, err: err?.message, message: String(message).slice(0, 100) }, '[CachePublisher] Failed to parse message from pub/sub channel.');
         return null;
       }
     })();

--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Closes #6791.

Summary of What Has Been Done:
Fixed CachePublisher.js bare catch block to log JSON.parse failures instead of silently swallowing them. Operators can now diagnose malformed cache invalidation messages in production.

Changes Made:
- backend/api/src/cache/CachePublisher.js: Changed bare catch {} to catch (err) with logger.warn including channel, error message, and a 100-character preview of the message.

Impact it Made:
- Operators can diagnose malformed cache invalidation messages in production.
- Improves observability of the cache invalidation system.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.