### PR TITLE
fix : added NaN guards and safePaisa helper for pricing arithmetic safety

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -94,6 +94,14 @@ export function haversineKm(lat1, lon1, lat2, lon2) {
 }
 
 /**
+ * Guard against NaN and Infinity in numeric pricing fields.
+ * If any arithmetic result is not finite, returns a safe fallback of 0.
+ */
+function safePaisa(value) {
+  return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+/**
  * Compute the canonical pricing for an order.
  *
  * @param {object} input
@@ -128,6 +136,9 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
     tollFactor = 1,
   } = input;
 
+  // Guard tollFactor against NaN/undefined: treat invalid values as 1 (no extra toll).
+  const safeTollFactor = Number.isFinite(tollFactor) && tollFactor >= 0 ? tollFactor : 1;
+
   if (!Number.isFinite(weightTonnes) || weightTonnes <= 0) {
     throw new RangeError(`weightTonnes must be a positive number, got ${weightTonnes}`);
   }
@@ -145,14 +156,14 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
     throw new RangeError(`Computed rate-per-tonne-km must be > 0, got ${rate}`);
   }
 
-  const baseFreight = Math.round(rate * weightTonnes * distanceKm) + rateCard.handlingFee;
-  const tollEstimate = Math.round(rateCard.tollPerKm * distanceKm * tollFactor);
-  const platformFee = Math.round((baseFreight * rateCard.platformFeePct) / 100);
-  const totalAmount = baseFreight + tollEstimate + platformFee;
+  const baseFreight = safePaisa(rate * weightTonnes * distanceKm) + rateCard.handlingFee;
+  const tollEstimate = safePaisa(rateCard.tollPerKm * distanceKm * safeTollFactor);
+  const platformFee = safePaisa((baseFreight * rateCard.platformFeePct) / 100);
+  const totalAmount = safePaisa(baseFreight + tollEstimate + platformFee);
 
   // Driver-side cost / margin hints persisted on load_offers.
-  const fuelCost = Math.round((baseFreight * rateCard.fuelCostPct) / 100);
-  const netProfit = baseFreight - fuelCost - tollEstimate;
+  const fuelCost = safePaisa((baseFreight * rateCard.fuelCostPct) / 100);
+  const netProfit = safePaisa(baseFreight - fuelCost - tollEstimate);
 
   return {
     distanceKm: Math.round(distanceKm * 100 + Number.EPSILON) / 100, // 2-decimal precision

--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Closes #6792.

Summary of What Has Been Done:
Added safePaisa() helper function to prevent NaN/Infinity from propagating into pricing output. Added null guard for tollFactor (defaults to 1 if invalid). All monetary arithmetic now uses safePaisa() for defensive handling.

Changes Made:
- backend/api/src/lib/pricing.js: Added safePaisa() helper that returns 0 for non-finite values. Added safeTollFactor guard. Updated baseFreight, tollEstimate, platformFee, totalAmount, fuelCost, netProfit calculations to use safePaisa().

Impact it Made:
- Prevents NaN prices from being stored or returned to API clients.
- Makes pricing calculations robust against edge-case inputs.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.