### PR TITLE
test : added unit tests for escrowRelease and markEscrowBookingStarted

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());

--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -24,7 +24,8 @@ import {
   isEscrowEnabled,
   submitEscrowRaiseDispute,
   submitEscrowResolveDispute,
-  submitEscrowResolveDisputeTimeout
+  submitEscrowResolveDisputeTimeout,
+  markEscrowBookingStarted,
 } from '../../src/services/escrow.js'
 
 describe('escrow service — getEscrowBookingId', () => {
@@ -356,5 +357,35 @@ describe('escrow service \u2014 validateEscrowSetup (contract unconfigured)', ()
   it('returns false when ESCROW_CONTRACT_ADDRESS env vars are missing', async () => {
     const result = await validateEscrowSetup()
     expect(result).toBe(false)
+  })
+})
+
+describe('escrow service — escrowRelease (contract unconfigured)', () => {
+  it('returns txHash: null and a valid bookingId when contract is not initialised', async () => {
+    const result = await escrowRelease('#FF20260607')
+    expect(result.txHash).toBeNull()
+    expect(typeof result.bookingId).toBe('string')
+    expect(result.bookingId.startsWith('0x')).toBe(true)
+  })
+
+  it('returns the same bookingId as getEscrowBookingId', async () => {
+    const result = await escrowRelease('#FF20260608')
+    const expected = getEscrowBookingId('#FF20260608')
+    expect(result.bookingId).toBe(expected)
+  })
+})
+
+describe('escrow service — markEscrowBookingStarted (contract unconfigured)', () => {
+  it('returns txHash: null and a valid bookingId when contract is not initialised', async () => {
+    const result = await markEscrowBookingStarted('#FF20260609')
+    expect(result.txHash).toBeNull()
+    expect(typeof result.bookingId).toBe('string')
+    expect(result.bookingId.startsWith('0x')).toBe(true)
+  })
+
+  it('returns the same bookingId as getEscrowBookingId', async () => {
+    const result = await markEscrowBookingStarted('#FF20260610')
+    const expected = getEscrowBookingId('#FF20260610')
+    expect(result.bookingId).toBe(expected)
   })
 })


### PR DESCRIPTION
Closes #6796.

Summary of What Has Been Done:
Added unit tests for escrowRelease and markEscrowBookingStarted functions in escrow.js. Tests cover the contract-unconfigured fallback behavior (returns txHash: null with valid bookingId).

Changes Made:
- backend/api/test/unit/escrow.test.js: Added describe blocks for escrowRelease and markEscrowBookingStarted, each with 2 test cases verifying txHash: null and valid bookingId.

Impact it Made:
- Coverage for previously untested escrow functions.
- Documents expected behavior when contract is not configured.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.