### PR TITLE
test : added error path tests for sendDeliveryOtpNotification

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -377,4 +377,68 @@ describe('notificationService', () => {
       expect(firebaseSendMock).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('sendDeliveryOtpNotification — error paths', () => {
+    it('returns success=false when DB insert fails but FCM succeeds', async () => {
+      // Reset mocks
+      supabaseInsertMock.mockReset();
+      firebaseSendMock.mockReset();
+
+      // DB insert fails
+      supabaseInsertMock.mockResolvedValueOnce({ error: { message: 'DB connection error' } });
+      // FCM succeeds
+      firebaseSendMock.mockResolvedValue({ messageId: 'msg_from_fcm' });
+
+      const result = await sendDeliveryOtpNotification(
+        'customer_uuid_001',
+        'ORD-001',
+        '123456'
+      );
+
+      expect(result.success).toBe(true); // FCM succeeded so overall success is true
+      expect(result.fcm.success).toBe(true);
+      expect(supabaseInsertMock).toHaveBeenCalledOnce();
+    });
+
+    it('returns success=false when both DB and FCM fail', async () => {
+      supabaseInsertMock.mockReset();
+      firebaseSendMock.mockReset();
+
+      // DB insert fails
+      supabaseInsertMock.mockRejectedValueOnce(new Error('DB connection error'));
+      // FCM also fails
+      const fcmErr = new Error('FCM unreachable');
+      fcmErr.code = 'messaging/unavailable';
+      firebaseSendMock.mockRejectedValue(fcmErr);
+
+      const result = await sendDeliveryOtpNotification(
+        'customer_uuid_002',
+        'ORD-002',
+        '654321'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.fcm.success).toBe(false);
+    });
+
+    it('returns success=false when only FCM fails', async () => {
+      supabaseInsertMock.mockReset();
+      firebaseSendMock.mockReset();
+
+      // DB succeeds
+      supabaseInsertMock.mockResolvedValueOnce({ error: null });
+      // FCM fails
+      const fcmErr = new Error('FCM error');
+      firebaseSendMock.mockRejectedValue(fcmErr);
+
+      const result = await sendDeliveryOtpNotification(
+        'customer_uuid_003',
+        'ORD-003',
+        '111222'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.fcm.success).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Closes #6797.

Summary of What Has Been Done:
Added unit tests for sendDeliveryOtpNotification error paths: DB insert failure with FCM success, both DB and FCM failure, and FCM-only failure.

Changes Made:
- backend/api/test/unit/notificationService.test.js: Added 3 new test cases covering DB insert failure, DB+FCM failure, and FCM-only failure scenarios.

Impact it Made:
- Documents expected failure behavior for notification service.
- Ensures graceful degradation on partial failures.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.