### PR TITLE
fix : added type validation guards to idempotency middleware key and TTL

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -60,16 +60,19 @@ function readAndParse(str) {
 }
 
 export function requireIdempotency(ttlSeconds = 3600) {
-  const ttlMs = ttlSeconds * 1000;
+  // Guard against invalid TTL: use default of 3600 if not a positive integer.
+  const safeTtlSeconds = Number.isInteger(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds : 3600;
+  const ttlMs = safeTtlSeconds * 1000;
 
   return async function idempotencyMiddleware(req, res, next) {
     const idempotencyKey = req.headers['x-idempotency-key'];
 
-    if (!idempotencyKey) {
+    // Guard against non-string idempotency key: return 400 if not a string.
+    if (typeof idempotencyKey !== 'string' || !idempotencyKey) {
       if (process.env.NODE_ENV === 'test') {
         return next();
       }
-      return res.status(400).json({ error: 'X-Idempotency-Key header is required for this action.' });
+      return res.status(400).json({ error: 'X-Idempotency-Key must be a non-empty string.' });
     }
 
     const key = cacheKey(req, idempotencyKey);

--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Closes #6802.

Summary of What Has Been Done:
Added type guards to the idempotency middleware. The idempotency key is now validated as a non-empty string before use. The TTL parameter is validated as a positive integer with fallback to the default (3600s).

Changes Made:
- backend/api/src/middleware/idempotency.js: Added typeof check for idempotencyKey, returning 400 if not a string. Added safeTtlSeconds with Number.isInteger validation and fallback to 3600.

Impact it Made:
- Prevents type coercion bugs from invalid idempotency keys.
- Returns meaningful 400 error for invalid keys instead of silent cache misses.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.