### PR TITLE
test : added NaN and Infinity edge case tests for buildPagination

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());

--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -140,3 +140,21 @@ describe('Pagination Middleware', () => {
     expect(req.query.offset).toBe(40); // (3-1) * 20
   });
 });
+
+describe('pagination — NaN and edge case handling', () => {
+  it('buildPagination handles NaN page by defaulting to 1', () => {
+    const result = buildPagination({ page: NaN });
+    expect(result.page).toBe(1);
+    expect(result.offset).toBe(0);
+  });
+
+  it('buildPagination handles NaN limit by defaulting to 20', () => {
+    const result = buildPagination({ limit: NaN });
+    expect(result.limit).toBe(20);
+  });
+
+  it('buildPagination handles Infinity page by defaulting to 1', () => {
+    const result = buildPagination({ page: Infinity });
+    expect(result.page).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #6804.

Summary of What Has Been Done:
Added NaN and Infinity edge case tests for buildPagination. Tests cover NaN page defaults to 1, NaN limit defaults to 20, and Infinity page defaults to 1.

Changes Made:
- backend/api/test/unit/pagination.test.js: Added 3 new test cases for NaN/Infinity handling.

Impact it Made:
- Documents expected behavior for edge-case pagination inputs.
- Prevents regression in boundary handling.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.