### PR TITLE
fix : defined missing mockTrips and mockAllTrips in driverEarnings integration test

### DIFF
--- a/backend/api/test/integration/driverEarnings.test.js
+++ b/backend/api/test/integration/driverEarnings.test.js
@@ -38,6 +38,37 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (req, res, next) => next()
 }));
 
+// Shared mock trip data
+const mockTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    total_earnings: 1000,
+    net_earnings: 800,
+    distance: '50 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    total_earnings: 500,
+    net_earnings: 400,
+    distance: '30.5 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
+const mockAllTrips = [
+  {
+    trip_date: new Date().toISOString(),
+    distance: '25 km',
+    route_label: 'Mumbai-Pune',
+  },
+  {
+    trip_date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    distance: '40 km',
+    route_label: 'Delhi-Jaipur',
+  },
+];
+
 // Setup app
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
Summary of What Has Been Done:
Fixed pre-existing ESLint error in test/integration/driverEarnings.test.js. The variables mockTrips and mockAllTrips were referenced in the supabase.from mock callback but were not defined in module scope. Added mock trip data definitions at module level.

Changes Made:
- backend/api/test/integration/driverEarnings.test.js: Added mockTrips and mockAllTrips as module-level const arrays with realistic trip data.

Impact it Made:
- ESLint now passes on the integration test file.
- Backend ESLint CI will transition from RED to GREEN.

This is a GSSOC (GirlScript Summer of Code) contribution.

Note: Please assign this PR to the `tmdeveloper007` account.