### PR TITLE
fix: resolve IoT telemetry authorization via order_display_id with valid statuses

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -117,7 +117,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
   try {
     const { data: load, error: loadErr } = await supabase
       .from('load_offers')
-      .select('customer_id')
+      .select('customer_id, order_display_id')
       .eq('id', loadId)
       .maybeSingle();
 
@@ -133,12 +133,12 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
     if (req.user.role !== 'admin') {
       let isAuthorized = load.customer_id === req.user.id;
 
-      if (!isAuthorized) {
+      if (!isAuthorized && load.order_display_id) {
         const { data: order } = await supabase
           .from('orders')
           .select('driver_id')
-          .eq('load_offer_id', loadId)
-          .in('status', ['assigned', 'in_progress', 'picked_up', 'delivered'])
+          .eq('order_display_id', load.order_display_id)
+          .in('status', ['truck_assigned', 'en_route_pickup', 'picked_up', 'in_transit'])
           .maybeSingle();
 
         isAuthorized = order?.driver_id === req.user.id;


### PR DESCRIPTION
## Summary
Fixes the IoT telemetry authorization lookup in `backend/api/src/routes/iotRoutes.js`. The code previously queried `orders.load_offer_id` (a column that does not exist) and filtered on `orders.status` values (`assigned`, `in_progress`) that the CHECK constraint can never produce, so driver authorization always failed with a 500/403.

## Changes
- Select `order_display_id` from `load_offers` alongside `customer_id`.
- Resolve the owning order via `orders.order_display_id` (the real link between `load_offers` and `orders`).
- Replace invalid status values (`assigned`, `in_progress`) with the DB-valid statuses (`truck_assigned`, `en_route_pickup`, `picked_up`, `in_transit`).
- Skip the order fallback when the load has no `order_display_id`.

## Verification
- `node --check backend/api/src/routes/iotRoutes.js` passes.
- Status values match the `orders.status` CHECK constraint in `docs/supabase_setup.sql`.
- `orders.order_display_id` ↔ `load_offers.order_display_id` matches the existing link used by `orderRepository.findLoadOfferByOrderDisplayId`.

Closes #6850

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization when viewing telemetry history.
  * Driver access is now correctly verified against the associated order and its current assignment or transit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->