### PR TITLE
fix: add missing user_devices.metadata migration

### DIFF
--- a/supabase/migrations/20260804120000_add_metadata_to_user_devices.sql
+++ b/supabase/migrations/20260804120000_add_metadata_to_user_devices.sql
@@ -1,0 +1,7 @@
+-- Add metadata column to user_devices.
+-- deviceController.registerDeviceToken has always upserted a `metadata`
+-- field, but the column was never created, so every device registration
+-- failed with a PostgREST "unknown column" error (500).
+
+ALTER TABLE user_devices
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
Adds the missing `metadata` column migration for `user_devices`. `deviceController.registerDeviceToken` upserts a `metadata` field, but the column was never created — a draft migration existed only under `docs/`, so every device registration failed with a PostgREST "unknown column" error (500).

## Changes
- Copy `supabase/migrations/20260804120000_add_metadata_to_user_devices.sql` (previously only `docs/supabase/migrations/20260804120000_add_metadata_to_user_devices.sql`) into the real `supabase/migrations/` directory so it is actually applied.
- Migration: `ALTER TABLE user_devices ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb`.

## Verification
- Migration filename/timestamp is unique in `supabase/migrations/` and idempotent (`IF NOT EXISTS`).
- `metadata` is a `jsonb` column, matching the object `normalizedMetadata` value the controller upserts.

Closes #6852

GSSOC
