### PR TITLE
fix: replace phantom order statuses in cancellation logic

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -667,14 +667,14 @@ export class OrderLifecycleService {
         // The driver has already started the trip — a full-refund cancellation is
         // no longer possible. On-chain, cancelBooking / cancelWithPenalty revert
         // once the booking has been marked as started, so reject here first.
-        if (['picked_up', 'in_transit', 'arriving', 'arrived_dropoff'].includes(currentOrder.status)) {
+        if (['picked_up', 'in_transit', 'arriving', 'delivered'].includes(currentOrder.status)) {
           throw new DomainError(409, { error: 'Cannot cancel: the shipment has already been picked up and is in transit.' });
         }
 
         const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(currentOrder.escrow_status);
-        const penaltyBps = currentOrder.status === 'assigned'
+        const penaltyBps = currentOrder.status === 'truck_assigned'
           ? 1000
-          : ['arrived_pickup', 'picked_up', 'in_transit', 'arrived_dropoff'].includes(currentOrder.status)
+          : ['arrived_pickup', 'picked_up', 'in_transit', 'delivered'].includes(currentOrder.status)
             ? 5000
             : 0;
         const cancellationFee = currentOrder.total_amount && penaltyBps > 0


### PR DESCRIPTION
## Summary
Fixes cancellation-fee/refund logic in `backend/api/src/services/order/orderLifecycleService.js` that compared against phantom order statuses the DB CHECK constraint can never produce.

## Changes
- `arrived_dropoff` → `delivered` in the "already picked up / in transit" cancellation gate (the real terminal status).
- `assigned` → `truck_assigned` in the penalty-bps branch (the real post-assignment status).
- `arrived_dropoff` → `delivered` in the 5000 bps penalty tier list.

## Verification
- `node --check backend/api/src/services/order/orderLifecycleService.js` passes.
- All statuses now match the `orders.status` CHECK constraint: `pending, truck_assigned, en_route_pickup, arrived_pickup, picked_up, in_transit, arriving, delivered, cancelled, payment_released`.
- No remaining `assigned`, `arrived_dropoff`, or `in_progress` references in the file.

Closes #6853

GSSOC
