### PR TITLE
fix: update is_claimed column on route_map_points

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -868,7 +868,7 @@ router.patch(
 
       const { data: updated, error: updateError } = await supabase
         .from('route_map_points')
-        .update({ claimed })
+        .update({ is_claimed: claimed })
         .eq('id', id)
         .select('*')
         .maybeSingle();


### PR DESCRIPTION
## Summary
Fixes `backend/api/src/routes/driverRoutes.js` route-point claim handler, which updated a `claimed` column that does not exist on `route_map_points`.

## Changes
- `.update({ claimed })` → `.update({ is_claimed: claimed })`, matching the actual column `is_claimed boolean not null default false` in `docs/supabase_setup.sql`.

## Verification
- `node --check backend/api/src/routes/driverRoutes.js` passes.
- Grep confirms no other `.update({ claimed })` / `.eq('claimed')` references remain in `backend/`.

Closes #6855

GSSOC
