### PR TITLE
fix: use valid notif_type for cold-chain alert

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -90,12 +90,13 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
         user_id: load.customer_id,
         title: 'Temperature Alert',
         body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
-        notif_type: 'cold_chain_alert',
+        notif_type: 'trip_update',
         metadata: {
           load_id: loadId,
           temperature,
           target_temperature_min: load.target_temperature_min,
-          target_temperature_max: load.target_temperature_max
+          target_temperature_max: load.target_temperature_max,
+          cold_chain_alert: true
         }
       }).catch(err => logger.error('Failed to send notification:', err));
     }


### PR DESCRIPTION
## Summary
Fixes the cold-chain temperature alert in `backend/api/src/routes/iotRoutes.js`, which inserted `notif_type: 'cold_chain_alert'` into `notifications` — a value that violates the table's CHECK constraint, so every out-of-range alert silently failed.

## Changes
- Use the valid `notif_type: 'trip_update'` (one of `order_update, payment, load_offer, trip_update, document, system`).
- Preserve the cold-chain signal in `metadata.cold_chain_alert: true` so the alert remains distinguishable.

## Verification
- `node --check backend/api/src/routes/iotRoutes.js` passes.
- `notif_type` matches the `notifications` CHECK constraint in `docs/supabase_setup.sql`.

Closes #6857

GSSOC
