### PR TITLE
fix: use valid document notif_type for expiry alerts

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -183,7 +183,7 @@ export async function processDocumentExpiryBatch() {
         };
 
         try {
-          await sendPushNotification(doc.user_id, title, body, 'document_expiry', metadata);
+          await sendPushNotification(doc.user_id, title, body, 'document', metadata);
           totalNotificationsSent++;
           logger.info(`[document-expiry] Sent ${window.label} expiry alert for ${docLabel} (doc: ${doc.id}) to user ${doc.user_id}`);
         } catch (err) {


### PR DESCRIPTION
## Summary
Fixes the document-expiry reminder in `backend/api/src/services/documentExpiryService.js`, which passed `notif_type: 'document_expiry'` — a value that violates the `notifications` CHECK constraint, so expiry reminders were never persisted/delivered.

## Changes
- `sendPushNotification(..., 'document_expiry', ...)` → `sendPushNotification(..., 'document', ...)`.
- The `metadata.type: 'document_expiry'` field is kept, so the specific alert kind remains distinguishable.

## Verification
- `node --check backend/api/src/services/documentExpiryService.js` passes.
- `notif_type` now matches the `notifications` CHECK constraint in `docs/supabase_setup.sql`.

Closes #6858

GSSOC
