### PR TITLE
fix: map GraphQL order mutations to real orders columns

### DIFF
--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -4,6 +4,7 @@ import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
 import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
+import { generateOrderDisplayId } from '../../api/src/lib/orderDisplayId.js';
 
 const ADMIN_ROLES = new Set(['ADMIN', 'admin']);
 
@@ -25,7 +26,19 @@ function mapOrder(row) {
         ...row,
         customerId: row.customerId ?? row.customer_id,
         driverId: row.driverId ?? row.driver_id,
-        cargoType: row.cargoType ?? row.cargo_type,
+        cargoType: row.cargoType ?? row.goods_type,
+        weight: row.weight ?? row.weight_tonnes,
+        amount: row.amount ?? row.total_amount,
+        pickup: {
+            lat: row.pickup_lat,
+            lng: row.pickup_lng,
+            address: row.pickup_address,
+        },
+        dropoff: {
+            lat: row.drop_lat,
+            lng: row.drop_lng,
+            address: row.drop_address,
+        },
         createdAt: row.createdAt ?? row.created_at,
         updatedAt: row.updatedAt ?? row.updated_at,
     };
@@ -196,12 +209,17 @@ const resolvers = {
                 .from('orders')
                 .insert([{
                     customer_id: customerId,
-                    pickup: input.pickup,
-                    dropoff: input.dropoff,
-                    weight: input.weight,
-                    distance: input.distance,
-                    cargo_type: input.cargoType,
-                    amount: input.amount,
+                    order_display_id: generateOrderDisplayId(),
+                    pickup_address: input.pickup?.address,
+                    pickup_lat: input.pickup?.lat,
+                    pickup_lng: input.pickup?.lng,
+                    drop_address: input.dropoff?.address,
+                    drop_lat: input.dropoff?.lat,
+                    drop_lng: input.dropoff?.lng,
+                    goods_type: input.cargoType,
+                    weight_tonnes: input.weight,
+                    total_amount: input.amount,
+                    pickup_date: new Date().toISOString().slice(0, 10),
                     status: toDbStatus(input.status) || 'pending',
                     created_at: new Date().toISOString()
                 }])
@@ -215,8 +233,12 @@ const resolvers = {
             const currentUser = requireUser(user);
             const updates = {
                 status: toDbStatus(input.status),
-                pickup: input.pickup || undefined,
-                dropoff: input.dropoff || undefined,
+                pickup_address: input.pickup?.address ?? undefined,
+                pickup_lat: input.pickup?.lat ?? undefined,
+                pickup_lng: input.pickup?.lng ?? undefined,
+                drop_address: input.dropoff?.address ?? undefined,
+                drop_lat: input.dropoff?.lat ?? undefined,
+                drop_lng: input.dropoff?.lng ?? undefined,
                 updated_at: new Date().toISOString()
             };
 


### PR DESCRIPTION
## Summary
Fixes the GraphQL `createOrder`/`updateOrder` mutations in `backend/graphql/services/order.service.js`, which inserted non-existent `orders` columns (`pickup`, `dropoff`, `weight`, `distance`, `cargo_type`, `amount`), causing every mutation to fail with a PostgREST "column does not exist" error.

## Changes
- `createOrder` now inserts the real columns: `pickup_address/pickup_lat/pickup_lng`, `drop_address/drop_lat/drop_lng` (from `LocationInput`), `goods_type`, `weight_tonnes`, `total_amount`, a generated `order_display_id`, and a default `pickup_date`.
- `updateOrder` maps `LocationInput` fields to the real `pickup_*` / `drop_*` columns instead of the phantom `pickup`/`dropoff` columns.
- `mapOrder` now reads `goods_type` → `cargoType`, `weight_tonnes` → `weight`, `total_amount` → `amount`, and builds `pickup`/`dropoff` `Location` objects from the real coordinate columns.

## Verification
- `node --check backend/graphql/services/order.service.js` passes.
- All written columns match the `orders` schema in `docs/supabase_setup.sql`.
- `generateOrderDisplayId` reuses the existing `backend/api/src/lib/orderDisplayId.js` util, consistent with the REST flow.

Closes #6859

GSSOC
