### PR TITLE
fix: use lowercase truck_assigned status in assignDriver

### DIFF
--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -170,7 +170,7 @@ const resolvers = {
                 .from('orders')
                 .update({
                     driver_id: driverId,
-                    status: 'ASSIGNED',
+                    status: 'truck_assigned',
                     updated_at: new Date().toISOString()
                 })
                 .eq('id', orderId)


### PR DESCRIPTION
## Summary
Fixes the GraphQL `assignDriver` mutation in `backend/graphql/services/driver.service.js`, which wrote `status: 'ASSIGNED'` — violating the `orders.status` CHECK constraint (lowercase `truck_assigned` is the valid value) so every assignment failed.

## Changes
- `status: 'ASSIGNED'` → `status: 'truck_assigned'`, matching the DB CHECK constraint and the REST API convention.

## Verification
- `node --check backend/graphql/services/driver.service.js` passes.
- No other `status: 'ASSIGNED'` writes remain in `backend/graphql/`.
- Value matches the `orders.status` CHECK constraint in `docs/supabase_setup.sql`.

Closes #6860

GSSOC
