### PR TITLE
fix(orders): order wallet transaction update by unique id column (issue #6826)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -511,7 +511,7 @@ export class OrderRepository {
       .eq('driver_id', driverId)
       .eq('order_display_id', orderDisplayId)
       .eq('txn_type', 'credit')
-      .order('created_at', { ascending: false })
+      .order('id', { ascending: false })
       .limit(1), 'updateWalletTransaction');
   }
 


### PR DESCRIPTION
## Problem

`OrderRepository.updateWalletTransaction` orders the target row by `created_at` (a non-unique column) and then applies `.limit(1)`. PostgREST only permits `UPDATE`/`DELETE` with `limit()` when the query is ordered by a unique column (primary key or unique-constrained column), so the request is rejected. Both callers (`orderMilestoneService.js`, `deliveryVerificationService.js`) swallow the failure, so payout-description updates are silently lost.

## Fix

Order the query by the unique `id` column (primary key) before applying `.limit(1)`, which PostgREST accepts, so the driver's most recent credit row is updated and the payout description persists.

## Files changed

- `backend/api/src/repositories/orderRepository.js`

## Testing

- Verified the `updateWalletTransaction` query now orders by the unique `id` column, satisfying PostgREST's unique-order requirement for `UPDATE ... LIMIT`.
- No other code paths are affected; the change is limited to the ordering column.

Closes #6826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet transaction updates by consistently selecting the latest matching transaction, ensuring the correct record is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->