### PR TITLE
fix(orders): validate cursor on GET /orders/history (issue #6827)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -521,9 +521,14 @@ router.get('/load-offers/en-route', authenticate, userLimiter, async (req, res) 
  */
 router.get('/history', authenticate, userLimiter, requirePolicy('order:view-history'), async (req, res) => {
   try {
-    const cursor = req.query.cursor;
+    const cursorParam = req.query.cursor ?? '1';
+    const cursor = typeof cursorParam === 'string' ? Number(cursorParam) : NaN;
     const limitParam = req.query.limit ?? '10';
     const limit = typeof limitParam === 'string' ? Number(limitParam) : NaN;
+
+    if (!Number.isInteger(cursor) || cursor < 1) {
+      return res.status(400).json({ error: 'cursor must be an integer >= 1' });
+    }
 
     if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
       return res.status(400).json({ error: 'limit must be between 1 and 100' });


### PR DESCRIPTION
## Problem

`GET /api/orders/history` passes the client-supplied `cursor` straight through as the PostgREST `page` without validation. `cursor=0` produces a negative `.range()`, causing a PostgREST 400, and `cursor=abc` becomes `NaN`, producing broken/non-deterministic results.

## Fix

Parse and validate the `cursor` the same way `limit` is validated on the same route: it must be an integer >= 1, otherwise the endpoint returns `400` with a clear error instead of forwarding an invalid page to PostgREST.

## Files changed

- `backend/api/src/routes/orderRoutes.js`

## Testing

- Verified `cursor=0` and `cursor=abc` are rejected with `400 { error: 'cursor must be an integer >= 1' }`.
- Verified valid cursors (e.g. `cursor=1`, `cursor=10`) pass through unchanged and return the page.
- Existing `limit` validation behavior is unchanged.

Closes #6827
