### PR TITLE
fix(orders): validate and clamp geofence_radius_m (issue #6828)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1081,6 +1081,15 @@ router.post(
         return res.status(400).json({ error: 'driver_lat and driver_lng must be valid numbers.' });
       }
 
+      let geofenceRadiusM = 500;
+      if (geofence_radius_m !== undefined && geofence_radius_m !== null && geofence_radius_m !== '') {
+        const parsedRadius = parseFloat(geofence_radius_m);
+        if (!Number.isFinite(parsedRadius) || parsedRadius <= 0) {
+          return res.status(400).json({ error: 'geofence_radius_m must be a finite positive number.' });
+        }
+        geofenceRadiusM = parsedRadius;
+      }
+
       // Verify the order exists and the requesting driver is assigned to it
       const order = await orderValidationService.findOrderByIdOrDisplayId(
         req.params.id,
@@ -1102,7 +1111,7 @@ router.post(
         driverId: req.user.id,
         driverLat: lat,
         driverLng: lng,
-        geofenceRadiusM: geofence_radius_m ? parseFloat(geofence_radius_m) : 500,
+        geofenceRadiusM,
       });
 
       return res.json(result);

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -329,10 +329,16 @@ export class DeliveryVerificationService {
         // The release gate must never be satisfied by self-reported coordinates.
         // assertDriverAtDropoff() proves physical presence using only telemetry
         // that was authenticated at ingestion and bound to this driver/order.
-        await this.assertDriverAtDropoff(
-          order,
-          geofenceRadiusM ?? DELIVERY_GEOFENCE_RADIUS_KM * 1000,
-        );
+        // The radius is clamped to the server default so a client-supplied
+        // NaN/negative/oversized value can never bypass the distance check.
+        const maxRadiusM = DELIVERY_GEOFENCE_RADIUS_KM * 1000;
+        const radiusM =
+          geofenceRadiusM != null &&
+          Number.isFinite(geofenceRadiusM) &&
+          geofenceRadiusM > 0
+            ? Math.min(geofenceRadiusM, maxRadiusM)
+            : maxRadiusM;
+        await this.assertDriverAtDropoff(order, radiusM);
 
         // Record the geofence confirmation and the (non-authoritative) claimed
         // position for audit. This is a flag only — escrow is not released here.


### PR DESCRIPTION
## Problem

`geofence_radius_m` was parsed with `parseFloat` and never validated. `parseFloat("abc")` yields `NaN`, and `distanceM > NaN` is always `false`, so the "driver inside geofence" assertion never threw — delivery was auto-confirmed even when the driver was kilometres away. Negative or oversized radii bypassed the distance check too.

## Fix

- Route (`orderRoutes.js`): `geofence_radius_m` is now rejected with `400` unless it parses to a finite positive number.
- Service (`deliveryVerificationService.js`): the geofence radius is sanitized and clamped to the server default (`DELIVERY_GEOFENCE_RADIUS_KM * 1000`) before the distance assertion, so a NaN/negative/oversized radius can never bypass the driver-at-dropoff check.

## Files changed

- `backend/api/src/routes/orderRoutes.js`
- `backend/api/src/services/order/deliveryVerificationService.js`

## Testing

- `geofence_radius_m=abc` → `400` with a clear error.
- `geofence_radius_m=-5` and `geofence_radius_m=0` → `400`.
- Omitted `geofence_radius_m` → falls back to the 500m server default.
- Oversized radius (e.g. `1000000000`) → clamped to the server default so the physical-presence check still applies.

Closes #6828
