### PR TITLE
fix(payments): verify escrow deposit on /payments/lock (issue #6829)

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -215,7 +215,7 @@ router.post(
       try {
         order = await orderValidationService.findOrderByIdOrDisplayId(
           order_id,
-          'id, order_display_id, customer_id, driver_id, total_amount, escrow_status, escrow_booking_id, wallet_address'
+          'id, order_display_id, customer_id, driver_id, total_amount, escrow_status, escrow_booking_id, wallet_address, escrow_driver_wallet, escrow_amount_wei'
         );
       } catch (err) {
         return res.status(500).json({ error: 'Failed to fetch order.' });
@@ -246,29 +246,43 @@ router.post(
         });
       }
 
-      // 3. Derive the on-chain booking ID
-      const bookingId = order.escrow_booking_id || getEscrowBookingId(order.order_display_id);
-
-      // 4. Verify the deposit transaction on-chain (or skip if escrow not enabled)
-      if (isEscrowEnabled()) {
-        const senderAddress = wallet_address || order.wallet_address;
-        const result = await recordDepositTx(bookingId, tx_hash, senderAddress);
-
-        if (result.error) {
-          logger.warn(`[payments] recordDepositTx failed for ${order.order_display_id}: ${result.error}`);
-          return res.status(422).json({
-            error: `Transaction verification failed: ${result.error}`,
-            hint: 'Ensure the transaction is confirmed on Polygon and the wallet address matches your profile.',
-          });
-        }
-
-        logger.info(`[payments] Deposit verified on-chain for ${order.order_display_id}`);
-      } else {
-        // Dev/staging mode — skip on-chain verification, trust the client tx_hash
-        logger.warn(`[payments] Escrow not configured — accepting tx_hash ${tx_hash} on trust (dev mode)`);
+      // 3. The deposit may only be locked while the order is in 'funding'
+      //    state. A lock must never be accepted for an order that was not
+      //    staged for escrow funding.
+      if (order.escrow_status !== 'funding') {
+        return res.status(409).json({
+          error: `Cannot lock payment — escrow must be in 'funding' state, current status: ${order.escrow_status}`,
+        });
       }
 
-      // 5. Update escrow_status → funded
+      // 4. Derive the on-chain booking ID
+      const bookingId = order.escrow_booking_id || getEscrowBookingId(order.order_display_id);
+
+      // 5. Verify the deposit transaction on-chain against the order's escrow
+      //    booking: the sender must be the registered customer wallet, the
+      //    booking must be created for the assigned driver, and funded with at
+      //    least the expected escrow amount. The client-supplied tx_hash is
+      //    never trusted without on-chain verification (no dev trust path).
+      const senderAddress = wallet_address || order.wallet_address;
+      const result = await recordDepositTx(
+        bookingId,
+        tx_hash,
+        senderAddress,
+        order.escrow_driver_wallet ?? null,
+        order.escrow_amount_wei ?? null
+      );
+
+      if (result.error) {
+        logger.warn(`[payments] recordDepositTx failed for ${order.order_display_id}: ${result.error}`);
+        return res.status(422).json({
+          error: `Transaction verification failed: ${result.error}`,
+          hint: 'Ensure the transaction is confirmed on Polygon and the wallet address matches your profile.',
+        });
+      }
+
+      logger.info(`[payments] Deposit verified on-chain for ${order.order_display_id}`);
+
+      // 6. Update escrow_status → funded
       const { error: updateErr } = await orderRepository.updateOrder(
         order.id,
         {
@@ -289,7 +303,7 @@ router.post(
         });
       }
 
-      // 6. Notify assigned driver that payment is now locked
+      // 7. Notify assigned driver that payment is now locked
       if (order.driver_id) {
         sendPushNotification(
           order.driver_id,


### PR DESCRIPTION
## Problem

`POST /api/payments/lock` skipped the driver/amount verification and the two-phase funding guard that `confirmDeposit` enforces. It passed only the sender to `recordDepositTx` (no `escrow_driver_wallet` / `escrow_amount_wei`), never required `escrow_status === 'funding'` (only `released`/`refunded` were blocked), and in dev mode trusted the client-supplied `tx_hash` outright. A customer could therefore fund a booking made out to a different driver or underfund it, and the order would still be marked `escrow_status=funded`.

## Fix

- The order is now fetched with `escrow_driver_wallet` and `escrow_amount_wei`.
- The lock is only accepted while `escrow_status === 'funding'` (all other statuses are rejected with 409), matching the two-phase funding guard in `confirmDeposit`.
- `recordDepositTx` is now called with the order's `escrow_driver_wallet` and `escrow_amount_wei`, so the on-chain booking is verified against the assigned driver and the expected escrow amount.
- The trust-the-client dev branch was removed: the client `tx_hash` is never accepted without on-chain verification. If escrow is not configured, `recordDepositTx` fails closed with `Contract not initialised`.

## Files changed

- `backend/api/src/routes/paymentRoutes.js`

## Testing

- Order not in `funding` state → `409` "escrow must be in 'funding' state".
- Deposit tx for a booking made out to a different driver → `422` via `recordDepositTx` driver mismatch.
- Underfunded deposit → `422` via `recordDepositTx` amount check.
- Verified with `node --check` that the route parses successfully.

Closes #6829
