### PR TITLE
fix(escrow): run reconciliation workers with service-role client (issue #6830)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -22,8 +22,9 @@ import securityHeaderDuplicates from './middleware/securityHeaderDuplicates.js';
 import cookieSecurityValidator from './middleware/cookieSecurityValidator.js';
 import maintenancePhotoRoutes from './routes/maintenancePhotoRoutes.js'
 
-import { closeDbConnections, waitForMongoDb, validateConfig, redisClient } from './config/db.js'
+import { closeDbConnections, waitForMongoDb, validateConfig, redisClient, supabaseAdmin } from './config/db.js'
 import { orderRepository } from './core/container.js'
+import { OrderRepository } from './repositories/orderRepository.js'
 import { CacheManager } from './cache/CacheManager.js'
 import { closeWebSocketServer, initWebSocketServer, __testing as wsTesting } from './sockets/tracker.js'
 import { initLocationServer, closeLocationServer } from './sockets/locationServer.js'
@@ -657,9 +658,15 @@ server.listen(PORT, () => {
   logger.info(`🆕 ZK-Proof KYC Verification enabled with contract: ${process.env.KYC_VERIFIER_CONTRACT || 'not-deployed'}`)
 
 
-  startEscrowRefundReconciliation(orderRepository)
+  // Reconciliation workers sweep `orders` for stuck funding/refund states.
+  // They must run with the service-role client: the anon client has no RLS
+  // read access to `orders`, so an anon-backed repository would silently no-op.
+  const escrowReconciliationOrderRepository = supabaseAdmin
+    ? new OrderRepository(supabaseAdmin)
+    : orderRepository;
+  startEscrowRefundReconciliation(escrowReconciliationOrderRepository)
   startEscrowReleaseReconciliation()
-  startEscrowFundingReconciliation(orderRepository)
+  startEscrowFundingReconciliation(escrowReconciliationOrderRepository)
   startReputationReconciliation(orderRepository)
   startDlqWorker()
   startStaleOrderWorker()


### PR DESCRIPTION
## Problem

The escrow funding and refund reconciliation workers were started with the anonymous `OrderRepository` (built on the anon Supabase client). RLS grants `orders` access only to `service_role` and authenticated owners, and anon privileges are revoked — so `findStaleFundingOrders` and `findPendingEscrowRefunds` returned zero rows (or permission denied), and both workers silently no-op'd every 60s. Stuck `funding` orders were never reverted and `refund_pending`/`refund_failed` orders were never refunded.

## Fix

In `backend/api/src/index.js`, the refund and funding reconciliation workers now receive an `OrderRepository` built on the service-role `supabaseAdmin` client (matching the sibling `escrowReleaseReconciliation` worker), so they can read and heal `orders`. If the admin client is unavailable, it falls back to the existing repository rather than crashing.

## Files changed

- `backend/api/src/index.js`

## Testing

- Verified with `node --check` that `index.js` parses successfully.
- `startEscrowRefundReconciliation` and `startEscrowFundingReconciliation` now receive an `OrderRepository(supabaseAdmin)` instance with RLS read access to `orders`.
- No other workers are affected; `startReputationReconciliation(orderRepository)` is unchanged.

Closes #6830
