### PR TITLE
fix(escrow): never finalize refunded without confirmed tx hash (issue #6831)

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -122,15 +122,24 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
 
         if (!refundTxHash) {
           const submitted = await submitEscrowRefund(order.order_display_id);
-          if (submitted.waitForConfirmation) {
-            receipt = await submitted.waitForConfirmation();
-          } else {
-            logger.warn(`[escrow-reconciliation] waitForConfirmation unavailable for ${order.order_display_id} — escrow contract may not be initialized.`);
-            receipt = { hash: submitted.txHash };
+          if (!submitted.waitForConfirmation || !submitted.txHash) {
+            // The on-chain refund was not actually submitted/confirmed
+            // (cancelBooking threw or the contract is not configured). Never
+            // finalize the order as refunded in that case — keep it in
+            // refund_pending/refund_failed so the retry loop can heal it.
+            throw new Error(
+              submitted.error ||
+              `Escrow refund for ${order.order_display_id} could not be submitted on-chain (no confirmation available).`
+            );
           }
+          receipt = await submitted.waitForConfirmation();
           refundTxHash = receipt.hash ?? submitted.txHash;
         } else {
           receipt = await confirmEscrowRefund(refundTxHash);
+        }
+
+        if (!refundTxHash) {
+          throw new Error(`Escrow refund for ${order.order_display_id} has no confirmed on-chain refund transaction hash.`);
         }
 
         const refundedAt = new Date().toISOString();


### PR DESCRIPTION
## Problem

The escrow refund reconciliation could finalize an order as `escrow_status='refunded'` with `refund_tx_hash = null` when the on-chain refund was never confirmed. `submitEscrowRefund` returns without `waitForConfirmation` when `cancelBooking` threw or the contract is not configured (`{ txHash: null, bookingId, error }`). In that path the order was still updated to `refunded`, dropped out of `findPendingEscrowRefunds`, and the on-chain funds remained locked — a silent financial desync.

## Fix

- If `submitEscrowRefund` returns without a confirmation callback or without a `txHash` (submission failed or contract not configured), the worker now **throws** instead of fabricating `{ hash: submitted.txHash }`.
- A final guard throws if `refundTxHash` is still missing before finalizing.
- The thrown error lands in the existing retry handler, which bumps `escrow_refund_attempts` and records `escrow_refund_error`, keeping the order in `refund_pending`/`refund_failed` so the retry loop can heal it later.

## Files changed

- `backend/api/src/services/escrowRefundReconciliation.js`

## Testing

- Confirmed with `node --check` that the service parses successfully.
- Simulated failure path: `submitEscrowRefund` returning `{ txHash: null, bookingId, error }` now throws before the order-update, so `escrow_status` is never set to `refunded`.
- The successful path (submission + `waitForConfirmation` returning a receipt hash) is unchanged.

Closes #6831
