### PR TITLE
fix(mev): align createEscrow ABI with contract signature (issue #6832)

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -10,7 +10,7 @@ class MEVService {
         this.escrowAddress = process.env.MEV_ESCROW_ADDRESS;
         
         this.escrowABI = [
-            'function createEscrow(address driver, bytes32 commitHash, bytes32 secretHash) external payable',
+            'function createEscrow(address driver, bytes32 secretHash) external payable',
             'function releaseEscrowWithProof(uint256 escrowId, bytes32 secret, bytes calldata proof) external',
             'function disputeEscrowWithProof(uint256 escrowId, bytes calldata proof) external',
             'function createCommitment(bytes32 secretHash) external',
@@ -77,14 +77,12 @@ class MEVService {
                 ethers.toUtf8Bytes(secret + userId)
             );
             
-            // Create escrow with commit hash
-            const commitHash = ethers.keccak256(
-                ethers.toUtf8Bytes(secret + userId + Date.now().toString())
-            );
-            
+            // Create escrow with MEV protection. The contract's createEscrow
+            // takes (address driver, bytes32 secretHash) — the secretHash is
+            // stored on-chain as the escrow's commit hash, so no separate
+            // commit hash argument is passed.
             const tx = await this.escrow.createEscrow(
                 driver,
-                commitHash,
                 secretHash,
                 { 
                     value: ethers.parseEther(amount.toString()),
@@ -101,7 +99,7 @@ class MEVService {
                 customer: this.wallet.address,
                 driver,
                 amount,
-                commitHash,
+                commitHash: secretHash,
                 secretHash,
                 txHash: receipt.hash
             });
@@ -110,7 +108,8 @@ class MEVService {
             return {
                 success: true,
                 escrowId,
-                commitHash,
+                commitHash: secretHash,
+                secretHash,
                 txHash: receipt.hash
             };
         } catch (error) {


### PR DESCRIPTION
## Problem

`MEVService` declared `createEscrow(address, bytes32, bytes32)` (3 args) in its ABI, but `MEVProtectedEscrow.sol` defines `createEscrow(address, bytes32)` (2 args). Every escrow-creation call encoded a selector that does not exist on the contract, so the call fell through to the fallback and always reverted on-chain.

## Fix

- ABI declaration aligned to the contract: `function createEscrow(address driver, bytes32 secretHash) external payable`.
- Call site updated to pass `(driver, secretHash)` only — the contract stores the `secretHash` as the escrow's on-chain commit hash, so the separate fabricated `commitHash` argument (which never matched the commitment) was removed.
- The persisted and returned `commitHash` is now the contract-matching `secretHash`, keeping the `mev_escrows` record consistent with the on-chain escrow.

## Files changed

- `backend/mev/mev.service.js`

## Testing

- Verified with `node --check` that the service parses successfully.
- The `createEscrow` call now encodes the 2-argument selector that matches `MEVProtectedEscrow.createEscrow(address,bytes32)`, so escrow creation no longer reverts with a no-match selector.

Closes #6832
