### PR TITLE
fix(swap): add getSwapCount/getCrossChainSwapCount to ABI (issue #6834)

### DIFF
--- a/backend/atomic-swap/swap.service.js
+++ b/backend/atomic-swap/swap.service.js
@@ -19,6 +19,8 @@ class AtomicSwapService {
             'function refundCrossChainSwap(uint256 swapId) external',
             'function getSwap(uint256 swapId) external view returns (tuple(uint256,address,address,address,uint256,bytes32,uint256,bool,bool,uint256,bytes32))',
             'function getCrossChainSwap(uint256 swapId) external view returns (tuple(uint256,uint256,uint256,address,address,address,uint256,bytes32,uint256,bool,bool,bytes32,bytes32))',
+            'function getSwapCount() external view returns (uint256)',
+            'function getCrossChainSwapCount() external view returns (uint256)',
             'function isHashLockUsed(bytes32 hashLock) external view returns (bool)'
         ];
 


### PR DESCRIPTION
## Problem

`AtomicSwapService` calls `this.swap.getSwapCount()` / `this.swap.getCrossChainSwapCount()` after creating a swap, but neither function was present in `swapABI`. `AtomicSwap.sol` does implement both (`getSwapCount()`, `getCrossChainSwapCount()`), yet ethers threw `CALL_EXCEPTION` ("cannot call getSwapCount because no function matches") because the ABI was missing the entries. The on-chain swap succeeded, but the service threw, the swap was never persisted, and callers saw a failure.

## Fix

Added the two missing ABI entries to `swapABI` in `swap.service.js`, matching the contract's actual view functions:

- `function getSwapCount() external view returns (uint256)`
- `function getCrossChainSwapCount() external view returns (uint256)`

## Files changed

- `backend/atomic-swap/swap.service.js`

## Testing

- Verified with `node --check` that the service parses successfully.
- `this.swap.getSwapCount()` and `this.swap.getCrossChainSwapCount()` now resolve to functions that exist in the contract (`AtomicSwap.sol:277`, `:281`), so swap creation no longer throws after a successful on-chain swap and `storeSwap`/`storeCrossChainSwap` persist the record.

Closes #6834
