### PR TITLE
fix(pqc): genuine Dilithium signing; keep seed out of public key

### DIFF
--- a/backend/pqc/kyber.py
+++ b/backend/pqc/kyber.py
@@ -265,40 +265,193 @@ class DilithiumSignature:
                 t[i] = (t[i] + KyberKEM._negacyclic_convolve(A[i][j], private_key['s1'][j], n, q)) % q
             t[i] = (t[i] + private_key['s2'][i]) % q
         
+        # The public key carries only the public matrix seed, the matrix and t.
+        # The signing seed must never appear in the public key.
         public_key = {
             'A': A,
             't': t,
-            'seed': private_key['seed'],
             'rho': rho
         }
+        private_key['A'] = A
+        private_key['t'] = t
+        private_key['rho'] = rho
         
         self.private_key = private_key
         self.public_key = public_key
         
         return public_key, private_key
     
+    def _sample_centered(self, rows: int, bound: int) -> np.ndarray:
+        """Sample ``rows*n`` coefficients uniformly from ``[-bound, bound]``.
+
+        Used for the signing masking vector ``y`` (FIPS 204 ``expand_mask``,
+        rejection sampled over ``[-gamma1, gamma1]``).
+        """
+        n = self.params['n']
+        total = rows * n
+        span = 2 * bound + 1
+        bits = span.bit_length()
+        values = np.empty(total, dtype=np.int64)
+        idx = 0
+        while idx < total:
+            candidate = secrets.randbits(bits)
+            if candidate < span:
+                values[idx] = candidate - bound
+                idx += 1
+        return values.reshape((rows, n))
+
+    def _poly_mul(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        """Negacyclic polynomial product ``a*b mod (X^n + 1)`` over Z_q."""
+        return KyberKEM._negacyclic_convolve(a, b, self.params['n'], self.params['q'])
+
+    def _module_mul(self, mat, vec, out_rows: int) -> np.ndarray:
+        """Matrix-vector product over R_q (negacyclic convolution)."""
+        n = self.params['n']
+        q = self.params['q']
+        res = np.zeros((out_rows, n), dtype=np.int64)
+        for i in range(out_rows):
+            for j in range(vec.shape[0]):
+                res[i] = (res[i] + self._poly_mul(mat[i][j], vec[j])) % q
+        return res
+
+    def _decompose(self, r: np.ndarray, alpha: int) -> tuple:
+        """Dilithium ``Decompose``: split ``r`` into ``(r1, r0)`` with centered low bits."""
+        q = self.params['q']
+        r = np.asarray(r, dtype=np.int64) % q
+        r0 = r % alpha
+        r0 = np.where(r0 > (alpha >> 1), r0 - alpha, r0)
+        r1 = (r - r0) // alpha
+        r1, r0 = np.where(r == q - 1, 0, r1), np.where(r == q - 1, 0, r0)
+        return r1, r0
+
+    def _low_bits(self, r: np.ndarray, alpha: int) -> np.ndarray:
+        return self._decompose(r, alpha)[1]
+
+    def _inf_norm_centered(self, arr: np.ndarray) -> int:
+        """Infinite norm of coefficients after centering in (-q/2, q/2]."""
+        q = self.params['q']
+        return int(np.max(np.minimum(arr % q, q - (arr % q))))
+
+    def _sample_in_ball(self, seed: bytes) -> np.ndarray:
+        """Deterministic sparse challenge polynomial ``c`` of hamming weight ``tau``.
+
+        Derives the ``tau`` signed positions from SHAKE256(seed) so both signer
+        and verifier reconstruct the identical challenge from the 32-byte seed.
+        """
+        n = self.params['n']
+        tau = self.params['tau']
+        c = np.zeros(n, dtype=np.int64)
+        counter = 0
+        placed = 0
+        while placed < tau:
+            buf = _shake_bytes(seed, counter, 2)
+            counter += 1
+            index = int.from_bytes(buf, 'big') % n
+            if c[index] != 0:
+                continue
+            sign = 1 if (buf[0] >> 7) & 1 else -1
+            c[index] = sign
+            placed += 1
+        return c
+
+    def _challenge_seed(self, message: bytes, rho: bytes, w1: np.ndarray) -> bytes:
+        """Fiat-Shamir challenge seed from the public matrix seed and ``w1``."""
+        return hashlib.sha256(message + rho + w1.astype('<i4').tobytes() + b'challenge').digest()
+
     def sign(self, message: bytes) -> bytes:
-        """Sign message with Dilithium"""
+        """Sign ``message`` with a genuine FIPS 204-style Dilithium signature.
+
+        Uses the Fiat-Shamir transform over the module lattice: samples the
+        masking vector ``y``, computes ``w = A*y``, derives the challenge ``c``
+        from ``(w1, message)`` and returns ``z = y + c*s1``. The verifier can
+        reconstruct ``w' = A*z - c*t`` purely from public material and re-derive
+        the challenge, so the signing seed is never exposed.
+        """
         if self.private_key is None:
             raise ValueError("Key pair not generated")
-        
-        # Simplified signing
-        # In production: implement full Dilithium signing
-        signature = hashlib.sha256(
-            message + self.private_key['seed'] + b'signature'
-        ).digest()
-        
-        return signature
-    
+        n = self.params['n']
+        q = self.params['q']
+        k = self.params['k']
+        l = self.params['l']
+        gamma1 = self.params['gamma1']
+        gamma2 = self.params['gamma2']
+        beta = self.params['tau'] * self.params['eta']
+        alpha = 2 * gamma2
+
+        A = self.private_key['A']
+        s1 = self.private_key['s1']
+        s2 = self.private_key['s2']
+        rho = self.private_key['rho']
+
+        while True:
+            y = self._sample_centered(l, gamma1)
+            w = self._module_mul(A, y, k)
+            w1 = np.zeros((k, n), dtype=np.int64)
+            w0 = np.zeros((k, n), dtype=np.int64)
+            for i in range(k):
+                w1[i], w0[i] = self._decompose(w[i], alpha)
+
+            challenge_seed = self._challenge_seed(message, rho, w1)
+            c = self._sample_in_ball(challenge_seed)
+
+            z = np.zeros((l, n), dtype=np.int64)
+            for j in range(l):
+                z[j] = (y[j] + self._poly_mul(c, s1[j])) % q
+            if self._inf_norm_centered(z) >= gamma1 - beta:
+                continue
+
+            cs2 = np.zeros((k, n), dtype=np.int64)
+            for i in range(k):
+                cs2[i] = self._poly_mul(c, s2[i])
+            overflow = False
+            for i in range(k):
+                r0 = self._low_bits(w0[i] - cs2[i], alpha)
+                if self._inf_norm_centered(r0) >= gamma2 - beta:
+                    overflow = True
+                    break
+            if overflow:
+                continue
+            break
+
+        z_centered = np.where(z > q // 2, z - q, z)
+        z_bytes = b''.join(int(v).to_bytes(4, 'little', signed=True) for v in z_centered.flatten())
+        return challenge_seed + z_bytes
+
     def verify(self, message: bytes, signature: bytes) -> bool:
-        """Verify Dilithium signature"""
+        """Verify a Dilithium signature produced by :meth:`sign`."""
         if self.public_key is None:
             raise ValueError("Public key not set")
-        
-        # Simplified verification
-        # In production: implement full Dilithium verification
-        expected = hashlib.sha256(
-            message + self.public_key['seed'] + b'signature'
-        ).digest()
-        
-        return signature == expected
+        n = self.params['n']
+        q = self.params['q']
+        k = self.params['k']
+        l = self.params['l']
+        gamma1 = self.params['gamma1']
+        gamma2 = self.params['gamma2']
+        beta = self.params['tau'] * self.params['eta']
+        alpha = 2 * gamma2
+
+        if len(signature) < 32:
+            return False
+        challenge_seed, z_bytes = signature[:32], signature[32:]
+        if len(z_bytes) != l * n * 4:
+            return False
+
+        z = np.frombuffer(z_bytes, dtype='<i4').astype(np.int64).reshape((l, n))
+        if self._inf_norm_centered(z) >= gamma1 - beta:
+            return False
+
+        A = self.public_key['A']
+        t = self.public_key['t']
+        rho = self.public_key['rho']
+
+        c = self._sample_in_ball(challenge_seed)
+        wp = self._module_mul(A, z, k)
+        ct = np.zeros((k, n), dtype=np.int64)
+        for i in range(k):
+            ct[i] = self._poly_mul(c, t[i])
+        wp = (wp - ct) % q
+        w1p = np.zeros((k, n), dtype=np.int64)
+        for i in range(k):
+            w1p[i] = self._decompose(wp[i], alpha)[0]
+
+        return self._challenge_seed(message, rho, w1p) == challenge_seed


### PR DESCRIPTION
## Problem

`backend/pqc/kyber.py` `DilithiumSignature` was forgeable by design. `keygen()` copied the private signing `seed` into the returned public key:

```python
public_key = { 'A': A, 't': t, 'seed': private_key['seed'], 'rho': rho }
```

and `sign`/`verify` were a plain SHA-256 of `message + seed + b'signature'`. Because the seed was public material, any caller holding the public key could compute valid signatures for arbitrary messages (`sha256(msg + pk['seed'] + b'signature')`), completely defeating the purpose of the digital signature.

## Fix

Replaced the placeholder signing/verification with a genuine FIPS 204-style Dilithium construction (Fiat-Shamir with abort over the module lattice):

- The signing seed is **never** placed in the public key; the public key carries only `A` (matrix), `t` (verification key) and `rho` (matrix seed).
- `sign` samples the masking vector `y` uniformly over `[-gamma1, gamma1]`, computes `w = A*y`, derives the challenge seed from `H(message, rho, w1)`, expands the sparse challenge `c` (hamming weight `tau`) deterministically from that seed, and returns `z = y + c*s1` after the standard FIPS 204 rejection checks (`||z||inf` and the hint low-bits bound `gamma2 - beta`).
- `verify` reconstructs `w' = A*z - c*t` purely from public material, re-derives the challenge from `(message, rho, w1')`, and accepts only if it matches — signatures are unforgeable without `s1`/`s2`.
- Challenge expansion (`_sample_in_ball`), `Decompose`/`LowBits`, module multiplication over the negacyclic ring and centered infinity-norm checks are implemented deterministically so signer and verifier agree exactly.

## Files changed

- `backend/pqc/kyber.py` — `DilithiumSignature.keygen`, `sign`, `verify`; added `_sample_centered`, `_module_mul`, `_decompose`, `_low_bits`, `_inf_norm_centered`, `_sample_in_ball`, `_challenge_seed`.

## Testing

- Round-trip sign/verify passes for multiple messages (including empty and long messages).
- Tampered messages and bit-flipped signatures are rejected.
- A legacy-style forgery (`sha256(msg + rho + b'signature')`) using only public-key material is rejected.
- `python -c "import ast; ast.parse(...)"` syntax check passes.

Closes #6835
