### PR TITLE
fix(vector-matcher): bound cosine loop by actual sizes

### DIFF
--- a/services/vector-matcher-cpp/main.cpp
+++ b/services/vector-matcher-cpp/main.cpp
@@ -18,13 +18,16 @@ struct DriverEmbedding {
     std::vector<float> vector;
 };
 
-// Compute Cosine Similarity between two 64-D vectors
+// Compute Cosine Similarity between two vectors. The loop is bounded by the
+// actual vector lengths so shorter embeddings cannot cause an out-of-bounds
+// read.
 float cosine_similarity(const std::vector<float>& v1, const std::vector<float>& v2) {
     float dot = 0.0f;
     float norm_a = 0.0f;
     float norm_b = 0.0f;
 
-    for (int i = 0; i < EMBEDDING_DIM; ++i) {
+    const size_t dim = std::min<size_t>(EMBEDDING_DIM, std::min(v1.size(), v2.size()));
+    for (size_t i = 0; i < dim; ++i) {
         dot += v1[i] * v2[i];
         norm_a += v1[i] * v1[i];
         norm_b += v2[i] * v2[i];


### PR DESCRIPTION
## Problem

`cosine_similarity` in `services/vector-matcher-cpp/main.cpp:22-35` loops to the fixed `EMBEDDING_DIM` (64) with no size guard, reading `v1[i]` / `v2[i]` even when a vector is shorter than 64. ML pipelines can emit embeddings of varying dimensions, so a shorter vector causes an out-of-bounds read into `std::vector` storage — undefined behavior (garbage similarity scores, crashes, or memory disclosure). The `search_top_k` path feeds driver/load embeddings straight into this function.

## Fix

Bound the similarity loop by the actual vector lengths:

```cpp
const size_t dim = std::min<size_t>(EMBEDDING_DIM, std::min(v1.size(), v2.size()));
for (size_t i = 0; i < dim; ++i) {
```

The loop now iterates at most `EMBEDDING_DIM` and never past the end of either input. Mismatched/short embeddings no longer trigger undefined behavior, and a zero-length (or fully zero) vector still returns `0.0f` via the existing norm guard.

## Files changed

- `services/vector-matcher-cpp/main.cpp` — `cosine_similarity` bound by actual vector sizes.

## Testing

- Similarity is computed over `min(EMBEDDING_DIM, v1.size(), v2.size())` elements.
- Zero-length and shorter-than-64 vectors no longer read out of bounds.
- Full-length vectors behave exactly as before.

Closes #6837
