### PR TITLE
fix(route-matrix): clamp haversine a to avoid NaN

### DIFF
--- a/services/route-matrix-cpp/main.cpp
+++ b/services/route-matrix-cpp/main.cpp
@@ -50,6 +50,10 @@ double haversine_km(double lat1, double lon1, double lat2, double lon2) {
                std::cos(lat1 * M_PI / 180.0) * std::cos(lat2 * M_PI / 180.0) *
                std::sin(dLon / 2.0) * std::sin(dLon / 2.0);
 
+    // Floating-point rounding can push `a` marginally above 1.0 for
+    // near-identical or antipodal pairs; clamp so sqrt(1.0 - a) stays finite.
+    a = std::min(1.0, a);
+
     double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
     return R * c;
 }


### PR DESCRIPTION
## Problem

`haversine_km` in `services/route-matrix-cpp/main.cpp:49-54` computes `std::sqrt(1.0 - a)` where `a` can marginally exceed `1.0` due to floating-point rounding (near-identical or antipodal point pairs). `std::sqrt` of a negative value returns `NaN`, so `c`, `distance_km`, `duration_mins`, and `tariff_inr` all become `NaN` in the emitted JSON.

## Fix

Clamp `a` to `[0.0, 1.0]` before taking the square root:

```cpp
a = std::min(1.0, a);
double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
```

The distance is now finite for all valid coordinate pairs (identical points yield `0.0`, antipodal pairs yield a finite great-circle distance), and no `NaN` reaches the matrix JSON.

## Files changed

- `services/route-matrix-cpp/main.cpp` — clamp `a` before `std::sqrt(1.0 - a)`.

## Testing

- Identical coordinate pairs produce `distance_km = 0.0` (previously could be `NaN`).
- Antipodal pairs produce a finite great-circle distance.
- All `distance_km` / `duration_mins` / `tariff_inr` values in `compute_matrix_json` remain numeric.

Closes #6838
