### PR TITLE
fix(wasm): compress_data handles empty input

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -137,7 +137,11 @@ pub fn hash_data(data: &str) -> String {
 
 #[wasm_bindgen]
 pub fn compress_data(data: &[u8]) -> Vec<u8> {
-    // Simple compression at edge
+    // Simple compression at edge. Empty input must not underflow data.len()-1.
+    if data.is_empty() {
+        return Vec::new();
+    }
+
     let mut compressed = Vec::new();
     let mut count = 1;
     


### PR DESCRIPTION
## Problem

WASM edge `compress_data` in `wasm/rust/src/lib.rs:138-157` panics on empty input. With `data.is_empty()` the loop body is skipped, but `data[data.len() - 1]` evaluates to `data[usize::MAX]` → index out of bounds → Rust panics → WASM trap → HTTP 500 for every caller passing empty bytes (e.g. empty telemetry payloads).

## Fix

Return an empty output for empty input before reaching the `data.len() - 1` indexing:

```rust
if data.is_empty() {
    return Vec::new();
}
```

Empty input now produces a valid empty `Vec<u8>` instead of trapping. Non-empty input is compressed exactly as before.

## Files changed

- `wasm/rust/src/lib.rs` — `compress_data` early-returns for empty input.

## Testing

- `compress_data(&[])` returns an empty vector without panicking.
- `compress_data(&[1, 1, 2, 3, 3, 3])` still yields the same run-length output as before.

Closes #6840
