### PR TITLE
fix(wasm): filter_drivers applies min_rating

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -28,6 +28,7 @@ pub struct DriverData {
     pub lng: f64,
     pub speed: f64,
     pub status: String,
+    pub rating: f64,
 }
 
 #[wasm_bindgen]
@@ -118,7 +119,7 @@ pub fn validate_otp(input_otp: &str, correct_otp: &str) -> bool {
 pub fn filter_drivers(drivers: Vec<DriverData>, min_rating: f64) -> Vec<DriverData> {
     drivers
         .into_iter()
-        .filter(|d| d.status != "offline")
+        .filter(|d| d.status != "offline" && d.rating >= min_rating)
         .collect()
 }
 


### PR DESCRIPTION
## Problem

WASM edge `filter_drivers` in `wasm/rust/src/lib.rs:117-123` advertises a `min_rating` filter but never uses it — the body only excludes `status == "offline"`. Worse, `DriverData` has no `rating` field at all, so the rating constraint is silently ignored. Dispatcher code calling `filter_drivers(drivers, 4.5)` receives drivers with lower ratings, defeating the caller's intent.

## Fix

- Added a `rating: f64` field to `DriverData`.
- Applied the rating constraint in the filter:

```rust
.filter(|d| d.status != "offline" && d.rating >= min_rating)
```

Drivers whose rating is below `min_rating` are now excluded, and callers can rely on the parameter actually being enforced.

## Files changed

- `wasm/rust/src/lib.rs` — `DriverData.rating` field; `filter_drivers` enforces `d.rating >= min_rating`.

## Testing

- `filter_drivers([driver(status="online", rating=4.8), driver(status="online", rating=3.9)], 4.5)` returns only the 4.8 driver.
- Offline drivers are still excluded regardless of rating.

Closes #6841
