### PR TITLE
fix(wasm): clamp haversine a in route matrix

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -23,6 +23,10 @@ pub fn compute_offline_route_matrix(origin_lat: f64, origin_lng: f64, dest_lat: 
 
     let a = (d_lat / 2.0).sin().powi(2)
         + origin_lat.to_radians().cos() * dest_lat.to_radians().cos() * (d_lng / 2.0).sin().powi(2);
+    // Floating-point rounding can push `a` marginally above 1.0 for
+    // near-identical/antipodal pairs; clamp so `(1.0 - a).sqrt()` stays finite
+    // and serde_json can serialize the result.
+    let a = a.clamp(0.0, 1.0);
     let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
     
     // Straight-line distance multiplied by road tortuosity factor (1.25 for highways)


### PR DESCRIPTION
## Problem

The WASM offline route matrix in `wasm/src/lib.rs:26` computes `(1.0 - a).sqrt()` with an unclamped `a`. For near-identical or antipodal coordinate pairs, floating-point rounding can push `a` above `1.0`, making `(1.0 - a)` negative and its square root `NaN`. `serde_json::to_string` refuses to serialize `NaN` and returns `None`, so `unwrap_or_default()` produces an empty string — the `/wasm/route` endpoint responds 200 with an unparseable empty body.

## Fix

Clamp `a` to the valid `[0.0, 1.0]` range before the square root:

```rust
let a = a.clamp(0.0, 1.0);
let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
```

All computed fields remain finite, `serde_json` serializes normally, and callers always receive parseable JSON.

## Files changed

- `wasm/src/lib.rs` — `compute_offline_route_matrix` clamps `a` before computing `(1.0 - a).sqrt()`.

## Testing

- Identical coordinate pairs return `distance_km: 0.0` (no `NaN`).
- Antipodal pairs return a finite great-circle distance.
- Response is always valid serialized JSON (non-empty).

Closes #6842
