### PR TITLE
fix(raft): never clear VotedFor in current term

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -605,7 +605,13 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 	if req.Term == rn.CurrentTerm {
 		rn.Role = Follower
 		rn.LeaderID = req.LeaderID
-		rn.VotedFor = ""
+		// Never clear VotedFor in the current term: a node must vote at most
+		// once per term. Record the acknowledged leader as this term's vote
+		// when none has been cast yet, so a later candidate in the same term
+		// cannot obtain a second vote.
+		if rn.VotedFor == "" || rn.VotedFor == req.LeaderID {
+			rn.VotedFor = req.LeaderID
+		}
 		rn.lastLeaderSeen = time.Now()
 
 		if rn.appendLogFromLeaderLocked(req) {


### PR DESCRIPTION
## Problem

`HandleAppend` in `services/consensus-raft-go/main.go:605-609` cleared `rn.VotedFor = ""` on every AppendEntries heartbeat from the current-term leader. In Raft a node must vote at most once per term; by erasing the recorded vote, a node that already voted for a candidate could later grant a second vote to a different candidate in the same term — allowing two leaders to each win a majority in one term (a safety violation).

## Fix

Stop clearing `VotedFor` in the AppendEntries handler. Instead, record the acknowledged current-term leader as this term's vote when none has been cast (or when it already matches), so a later candidate in the same term cannot obtain a second vote:

```go
if req.Term == rn.CurrentTerm {
    rn.Role = Follower
    rn.LeaderID = req.LeaderID
    if rn.VotedFor == "" || rn.VotedFor == req.LeaderID {
        rn.VotedFor = req.LeaderID
    }
    rn.lastLeaderSeen = time.Now()
    ...
```

`VotedFor` is now reset only via `stepDownLocked` (when a higher term is observed) and set only through the RequestVote path or this acknowledgment — preserving the at-most-once-per-term guarantee.

## Files changed

- `services/consensus-raft-go/main.go` — AppendEntries no longer clears `VotedFor`.

## Testing

- After a node votes for candidate X in term T and receives AppendEntries from X (term T), `VotedFor` remains X.
- A RequestVote from a different candidate Y in term T is rejected (`rn.VotedFor != "" && != Y`).
- A RequestVote in a higher term still proceeds via `stepDownLocked`, which resets `VotedFor` for the new term.

Closes #6843
