### PR TITLE
fix(shared): clamp to int in 429 retry

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -270,7 +270,7 @@ Future<http.Response> _execute(
     int retrySeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
 
     // Cap maximum wait time to 30 seconds
-    retrySeconds = retrySeconds.clamp(1, 30);
+    retrySeconds = retrySeconds.clamp(1, 30).toInt();
 
     await Future.delayed(Duration(seconds: retrySeconds));
 


### PR DESCRIPTION
## Problem

`packages/truxify_shared/lib/src/services/api_client.dart:273` assigns the result of `retrySeconds.clamp(1, 30)` — which returns `num` — back to an `int` variable:

```dart
int retrySeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
retrySeconds = retrySeconds.clamp(1, 30);   // num → int assignment
```

`int.clamp(num, num)` returns `num` in Dart, so this is a static type error (`A value of type 'num' can't be assigned to a variable of type 'int'`), breaking the shared package compile and everything depending on it. `Duration(seconds:)` also requires an `int`.

## Fix

Convert the clamped value back to `int`:

```dart
retrySeconds = retrySeconds.clamp(1, 30).toInt();
```

The package compiles and the 429 retry wait is still capped at 30s.

## Files changed

- `packages/truxify_shared/lib/src/services/api_client.dart` — `.clamp(1, 30).toInt()`.

## Testing

- `truxify_shared` compiles (`dart analyze` / `flutter analyze`).
- `retryAfterHeader` values above 30 are capped to 30 seconds; values below 1 are raised to 1.

Closes #6844
