### PR TITLE
fix(shared): clamp to int in backoff shift

### DIFF
--- a/packages/truxify_shared/lib/src/services/resilient_websocket.dart
+++ b/packages/truxify_shared/lib/src/services/resilient_websocket.dart
@@ -134,7 +134,7 @@ class ResilientWebSocket {
     }
 
     // Exponential backoff: 2^attempt seconds, capped at maxDelay
-    final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5));
+    final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5).toInt());
     final capped = Duration(
       milliseconds:
           delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs,


### PR DESCRIPTION
## Problem

`packages/truxify_shared/lib/src/services/resilient_websocket.dart:137` uses `_attempt.clamp(0, 5)` — which returns `num` — as the right-hand operand of `<<`:

```dart
final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5));
```

`int << num` is not valid: the right operand of `<<` must be `int`, and `int.clamp` returns `num`. This is a static type error (`The argument type 'num' can't be assigned to the parameter type 'int'`), breaking the shared package compile and all dependent apps.

## Fix

Convert the clamped attempt count to `int` before shifting:

```dart
final delayMs = initialDelay.inMilliseconds * (1 << _attempt.clamp(0, 5).toInt());
```

The package compiles and exponential backoff is still capped at `2^5`.

## Files changed

- `packages/truxify_shared/lib/src/services/resilient_websocket.dart` — `.clamp(0, 5).toInt()` in the backoff shift.

## Testing

- `truxify_shared` compiles (`dart analyze` / `flutter analyze`).
- Backoff delay = `initialDelay * 2^min(attempt, 5)`, then capped by `maxDelay` as before.

Closes #6845
