### PR TITLE
fix(customer): clamp to int in backoff shift

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -168,7 +168,7 @@ class SyncEngine {
   }
 
   Duration _backoffDelay(int retryCount) {
-    final delayMs = 250 * (1 << (retryCount.clamp(0, 5)));
+    final delayMs = 250 * (1 << (retryCount.clamp(0, 5).toInt()));
     return Duration(milliseconds: delayMs > 8000 ? 8000 : delayMs);
   }
 }


### PR DESCRIPTION
## Problem

`apps/customer/lib/core/offline/sync/sync_engine.dart:171` uses `retryCount.clamp(0, 5)` — which returns `num` — inside a left shift:

```dart
final delayMs = 250 * (1 << (retryCount.clamp(0, 5)));
```

`<<` requires an `int` right operand, but `int.clamp` returns `num`. This is a static type error, so the customer app fails to compile (a distinct cause from the missing-import compile issue in the same file).

## Fix

Convert the clamped retry count to `int` before shifting:

```dart
final delayMs = 250 * (1 << (retryCount.clamp(0, 5).toInt()));
```

The customer app compiles and offline-sync backoff is still capped at `2^5` (and `delayMs` at 8000 ms).

## Files changed

- `apps/customer/lib/core/offline/sync/sync_engine.dart` — `.clamp(0, 5).toInt()` in `_backoffDelay`.

## Testing

- Customer app compiles (`flutter analyze`).
- Backoff delay = `250 * 2^min(retryCount, 5)` ms, capped at 8000 ms.

Closes #6846
