### PR TITLE
fix(driver): clamp to int for checkpoint Set<int>

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1572,7 +1572,7 @@ class _HomeScreenState extends State<HomeScreen> {
     final indexes = <int>{};
     for (var step = 1; step <= 3; step++) {
       indexes.add(
-          ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1));
+          ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1).toInt());
     }
 
     return indexes.map((index) => routePoints[index]).toList(growable: false);


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/home_screen.dart:1575` adds the result of `(...).clamp(1, totalSegments - 1)` — a `num` — to a `Set<int>`:

```dart
indexes.add(
    ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1));
```

`int.round()` returns `int`, but `int.clamp(num, num)` returns `num`, and `Set<int>.add` requires an `int` argument — a static type error that breaks the driver app compile.

## Fix

Convert the clamped checkpoint index back to `int`:

```dart
indexes.add(
    ((totalSegments * step) / 4).round().clamp(1, totalSegments - 1).toInt());
```

The driver app compiles and checkpoint indices are computed correctly.

## Files changed

- `apps/driver/lib/screens/home_screen.dart` — `.clamp(1, totalSegments - 1).toInt()` in `_buildCheckpointPoints`.

## Testing

- Driver app compiles (`flutter analyze`).
- Checkpoint indices remain clamped to `[1, totalSegments - 1]` and are valid `int` members of the set.

Closes #6847
