### PR TITLE
fix(driver): clamp alpha to double for withValues

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1927,7 +1927,7 @@ class _HomeScreenState extends State<HomeScreen> {
         circles.add(CircleMarker(
           point: ll.LatLng(coords[1], coords[0]),
           // Fill: zone colour with intensity-scaled alpha for depth effect
-          color: zoneColor.withValues(alpha: (intensity * 0.45).clamp(0.08, 0.45)),
+          color: zoneColor.withValues(alpha: (intensity * 0.45).clamp(0.08, 0.45).toDouble()),
           borderColor: zoneColor.withValues(alpha: 0.6),
           borderStrokeWidth: 1.0,
           useRadiusInMeter: true,


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/home_screen.dart:1930` passes `(intensity * 0.45).clamp(0.08, 0.45)` — a `num` — to `withValues(alpha: ...)` which requires a `double`:

```dart
color: zoneColor.withValues(alpha: (intensity * 0.45).clamp(0.08, 0.45)),
```

`double.clamp(num, num)` returns `num`, so this is a static type error and the driver app fails to compile (a distinct location from the checkpoint clamp error in the same file).

## Fix

Convert the clamped alpha to `double`:

```dart
color: zoneColor.withValues(alpha: (intensity * 0.45).clamp(0.08, 0.45).toDouble()),
```

The driver app compiles and the heatmap alpha is clamped to `[0.08, 0.45]`.

## Files changed

- `apps/driver/lib/screens/home_screen.dart` — `.clamp(0.08, 0.45).toDouble()` for the heatmap marker alpha.

## Testing

- Driver app compiles (`flutter analyze`).
- Heatmap marker alpha stays within `[0.08, 0.45]`.

Closes #6848
