### PR TITLE
fix(driver): clamp scale to double in earnings heatmap

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -1365,7 +1365,7 @@ class _EarningsScreenState extends State<EarningsScreen> {
               FontWeight textWeight = FontWeight.normal;
 
               if (earnings > 0) {
-                final double scale = (earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0);
+                final double scale = (earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0).toDouble();
                 final double opacity = 0.15 + (scale * 0.75);
                 cellBgColor = TruxifyColors.accent.withValues(alpha: opacity);
 


### PR DESCRIPTION
## Problem

`apps/driver/lib/screens/earnings_screen.dart:1368` assigns `(earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0)` — a `num` — to a `double` local:

```dart
final double scale = (earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0);
```

`double.clamp(num, num)` returns `num`, which cannot be assigned to a `double` — a static type error that breaks the driver app compile.

## Fix

Convert the clamped scale to `double`:

```dart
final double scale = (earnings / _heatmapMaxDailyEarnings).clamp(0.0, 1.0).toDouble();
```

The driver app compiles and the earnings heatmap scale/opacity work as intended.

## Files changed

- `apps/driver/lib/screens/earnings_screen.dart` — `.clamp(0.0, 1.0).toDouble()` in the heatmap scale computation.

## Testing

- Driver app compiles (`flutter analyze`).
- `scale` stays within `[0.0, 1.0]`; opacity `0.15 + scale * 0.75` stays within `[0.15, 0.9]`.

Closes #6849
