### PR TITLE
fix(driver): clamp progress value to double

### DIFF
--- a/apps/driver/lib/widgets/common_widgets.dart
+++ b/apps/driver/lib/widgets/common_widgets.dart
@@ -689,7 +689,7 @@ class StackedCapacityBar extends StatelessWidget {
               color: TruxifyColors.subtleBorder,
             ),
             LinearProgressIndicator(
-              value: thisLoad.clamp(0.0, 1.0),
+              value: thisLoad.clamp(0.0, 1.0).toDouble(),
               minHeight: 12,
               backgroundColor: Colors.transparent,
               color: TruxifyColors.accent,


### PR DESCRIPTION
## Problem

`apps/driver/lib/widgets/common_widgets.dart:692` passes `thisLoad.clamp(0.0, 1.0)` — a `num` — to `LinearProgressIndicator(value:)` which expects `double?`:

```dart
LinearProgressIndicator(
  value: thisLoad.clamp(0.0, 1.0),
  ...
)
```

`num.clamp(num, num)` returns `num`, so this is a static type error and the driver app fails to compile.

## Fix

Convert the clamped load fraction to `double`:

```dart
LinearProgressIndicator(
  value: thisLoad.clamp(0.0, 1.0).toDouble(),
  ...
)
```

The driver app compiles and the load indicator renders with a clamped `[0.0, 1.0]` value.

## Files changed

- `apps/driver/lib/widgets/common_widgets.dart` — `.clamp(0.0, 1.0).toDouble()` for the `LinearProgressIndicator` value.

## Testing

- Driver app compiles (`flutter analyze`).
- Progress value stays within `[0.0, 1.0]`.

Closes #6851
