### PR TITLE
fix(api): re-read cache before reprocessing on idempotency lock release

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -121,7 +121,12 @@ export function requireIdempotency(ttlSeconds = 3600) {
 
             const lockStillHeld = await redisClient.get(lockKey);
             if (!lockStillHeld) {
-              break; // Lock released but cache empty
+              const finalRaw = await redisClient.get(key);
+              const finalCached = finalRaw ? readAndParse(finalRaw) : null;
+              if (finalCached) {
+                return res.status(finalCached.statusCode).json(finalCached.body);
+              }
+              break; // Lock released but cache genuinely empty
             }
 
             retries--;


### PR DESCRIPTION
## Description
When a polling request observed that `lockStillHeld` became false, it immediately broke out of the polling loop and proceeded to re-acquire the lock and reprocess the request. Because `releaseLock` runs on `res.once('finish')`, a race condition occurred where the lock was freed in the same tick as or right before the cache write finished, causing concurrent requests to treat in-flight requests as crashed and execute them twice.

### Changes Made:
- Added a final cache check (`redisClient.get(key)`) immediately after detecting that `lockStillHeld` is false.
- If cached response exists, returns the cached status code and payload directly.
- Only breaks out to re-acquire the lock and reprocess if the cache is genuinely empty (handling actual crashed requests).

Fixes #6898

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings