### PR TITLE
fix: bind ZKPrivacy public inputs to transaction parameters and execute payout

### DIFF
--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -136,9 +136,20 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         require(recipient != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be > 0");
 
+        // Verify zk-SNARK proof inputs match transaction parameters
+        require(proof.input.length >= 4, "Invalid proof public inputs length");
+        require(proof.input[0] == uint256(nullifier), "Nullifier mismatch in proof input");
+        require(proof.input[1] == uint256(commitment), "Commitment mismatch in proof input");
+        require(proof.input[2] == uint256(uint160(recipient)), "Recipient mismatch in proof input");
+        require(proof.input[3] == amount, "Amount mismatch in proof input");
+
         // Verify zk-SNARK proof
         bool isValid = IVerifier(verifier).verifyProof(proof.a, proof.b, proof.c, proof.input);
         require(isValid, "Invalid proof");
+
+        // Transfer payout to recipient
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Transfer failed");
 
         // Store transaction
         transactionCounter++;


### PR DESCRIPTION
## Description
`ZKPrivacy.sol`'s `processPrivateTransaction` verified zk-SNARK proofs without validating whether `proof.input` matched the supplied transaction parameters (`nullifier`, `commitment`, `recipient`, `amount`). Additionally, no ETH transfer was executed to `recipient`, allowing arbitrary callers to record unbacked transactions in the privacy ledger.

## Changes Made
- Added explicit assertions checking `proof.input` public arguments against `nullifier`, `commitment`, `recipient`, and `amount`
- Added ETH transfer logic `recipient.call{value: amount}("")` to ensure real funds are transferred on transaction processing
- Fixes #6886

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings