### PR TITLE
fix: prune expired timestamps in pruneGeofenceRateEntries to enforce rate tracker bound

### DIFF
--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -302,17 +302,27 @@ func allowGeofence(driverID string) bool {
 	return true
 }
 
-// pruneGeofenceRateEntries removes empty rate entries once the tracker grows
+// pruneGeofenceRateEntries removes expired rate entries once the tracker grows
 // beyond its cap, keeping the in-memory map bounded.
 func pruneGeofenceRateEntries() {
+	cutoff := time.Now().Add(-time.Second)
 	geofenceRateLimit.Range(func(key, value interface{}) bool {
 		e := value.(*rateEntry)
 		e.mu.Lock()
+		kept := e.stamps[:0]
+		for _, t := range e.stamps {
+			if t.After(cutoff) {
+				kept = append(kept, t)
+			}
+		}
+		e.stamps = kept
 		empty := len(e.stamps) == 0
 		e.mu.Unlock()
+
 		if empty {
-			geofenceRateLimit.Delete(key)
-			atomic.AddUint64(&geofenceRateTracked, ^uint64(0))
+			if _, loaded := geofenceRateLimit.LoadAndDelete(key); loaded {
+				atomic.AddUint64(&geofenceRateTracked, ^uint64(0))
+			}
 		}
 		return true
 	})


### PR DESCRIPTION
## Description
`pruneGeofenceRateEntries()` in `services/telemetry-ingestion/main.go` previously only removed tracking entries whose `stamps` slice was already empty without filtering expired timestamps first. This caused `geofenceRateTracked` to remain above `maxRateTracked` under continuous distinct queries, leading to full O(n) map scans on every insert.

gssoc 26

## Changes Made
- Updated `pruneGeofenceRateEntries` to purge expired timestamps (older than 1s window) before checking entry emptiness
- Used `LoadAndDelete` to safely delete empty entries and accurately decrement `geofenceRateTracked`
- Fixes #6881

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings