### PR TITLE
fix(telemetry): validate non-empty JWT sub and enforce caller_id binding

### DIFF
--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -211,7 +211,11 @@ func authorizeGeofence(claims jwtClaims, driverID string) bool {
 // the driver role. On success it returns the authenticated subject (driver id).
 func authenticateDriver(w http.ResponseWriter, r *http.Request) (string, bool) {
 	if bypassAuth {
-		return r.Header.Get("X-Driver-ID"), true
+		sub := r.Header.Get("X-Driver-ID")
+		if sub == "" {
+			sub = "dev-driver"
+		}
+		return sub, true
 	}
 
 	if len(jwtSecret) == 0 {
@@ -233,6 +237,11 @@ func authenticateDriver(w http.ResponseWriter, r *http.Request) (string, bool) {
 
 	if claims.Role != "driver" {
 		http.Error(w, "forbidden: driver role required", http.StatusForbidden)
+		return "", false
+	}
+
+	if claims.Sub == "" {
+		http.Error(w, "invalid token: subject required", http.StatusUnauthorized)
 		return "", false
 	}
 
@@ -426,7 +435,7 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if callerID != "" && callerID != ping.DriverID {
+	if callerID != ping.DriverID {
 		http.Error(w, "driver_id does not match authenticated caller", http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
## Description
`authenticateDriver` previously returned empty JWT subjects (or missing `X-Driver-ID` headers in bypass mode) without validation. When `handlePing` checked `callerID != "" && callerID != ping.DriverID`, an empty subject silently bypassed the check, allowing unauthorized callers to submit telemetry pings under arbitrary `driver_id`s.
gssoc 26

## Changes Made
- Added non-empty subject claim validation in `authenticateDriver`, rejecting tokens with empty `sub` as `401 Unauthorized`.
- Added fallback to `"dev-driver"` when `X-Driver-ID` is omitted in `bypassAuth` mode, aligning with the behavior of `authenticate()`.
- Updated `handlePing` to unconditionally enforce `callerID != ping.DriverID`.

Fixes #6880

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication fallback behavior when no driver identity is provided.
  * Rejected JWT-authenticated requests with missing identity information.
  * Enforced driver identity matching for all telemetry ping requests, including bypass-auth scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->