### PR TITLE
fix : correct route_map_points update from claimed to is_claimed

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -868,7 +868,7 @@ router.patch(
 
       const { data: updated, error: updateError } = await supabase
         .from('route_map_points')
-        .update({ claimed })
+        .update({ is_claimed: claimed })
         .eq('id', id)
         .select('*')
         .maybeSingle();


### PR DESCRIPTION
Closes #6932.

Summary of What Has Been Done:
The POST /api/drivers/route-map/:id/claim endpoint writes to a column named claimed, but the route_map_points table has is_claimed as the boolean column. This caused every claim/unclaim action to 500 due to a PostgREST column-not-found error.

Changes Made:
- backend/api/src/routes/driverRoutes.js: changed .update({ claimed }) to .update({ is_claimed: claimed })

Impact it Made:
- Drivers can now successfully claim and unclaim route-map points
- Fixes silent 500 errors on every route claim action

Note: This is a GSSOC contribution.