### PR TITLE
fix : replace invalid document_expiry notif_type with document

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -66,7 +66,7 @@ async function hasExistingNotification(userId, documentId, daysRemaining) {
       .from('notifications')
       .select('id, metadata')
       .eq('user_id', userId)
-      .eq('notif_type', 'document_expiry')
+      .eq('notif_type', 'document')
       .gte('created_at', cutoff);
 
     if (error || !data || data.length === 0) return false;
@@ -183,7 +183,7 @@ export async function processDocumentExpiryBatch() {
         };
 
         try {
-          await sendPushNotification(doc.user_id, title, body, 'document_expiry', metadata);
+          await sendPushNotification(doc.user_id, title, body, 'document', metadata);
           totalNotificationsSent++;
           logger.info(`[document-expiry] Sent ${window.label} expiry alert for ${docLabel} (doc: ${doc.id}) to user ${doc.user_id}`);
         } catch (err) {


### PR DESCRIPTION
Closes #6933.

Summary of What Has Been Done:
documentExpiryService sends push notifications with notif_type 'document_expiry', which violates the notifications table CHECK constraint (only order_update, payment, load_offer, trip_update, document, system are allowed). Every document expiry alert was silently failing to insert.

Changes Made:
- backend/api/src/services/documentExpiryService.js: changed 'document_expiry' to 'document' in both the hasExistingNotification query (line 69) and the sendPushNotification call (line 186)

Impact it Made:
- Document expiry notifications are now correctly persisted and delivered
- Fixes silent insert failures on every document expiry event

Note: This is a GSSOC contribution.