### PR TITLE
fix : replace invalid cold_chain_alert notif_type with system

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -90,7 +90,7 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
         user_id: load.customer_id,
         title: 'Temperature Alert',
         body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
-        notif_type: 'cold_chain_alert',
+        notif_type: 'system',
         metadata: {
           load_id: loadId,
           temperature,


### PR DESCRIPTION
Closes #6934.

Summary of What Has Been Done:
The cold-chain temperature alert in iotRoutes inserts notif_type 'cold_chain_alert' which violates the notifications CHECK constraint. Every out-of-range temperature event was silently failing to insert, meaning all cold-chain alerts were lost.

Changes Made:
- backend/api/src/routes/iotRoutes.js: changed notif_type: 'cold_chain_alert' to notif_type: 'system'

Impact it Made:
- Cold-chain temperature alerts are now correctly persisted and delivered
- IoT temperature monitoring becomes operational for cold-chain shipments

Note: This is a GSSOC contribution.