### PR TITLE
fix : add integer cursor validation to GET /orders/history

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -529,6 +529,13 @@ router.get('/history', authenticate, userLimiter, requirePolicy('order:view-hist
       return res.status(400).json({ error: 'limit must be between 1 and 100' });
     }
 
+    if (cursor !== undefined) {
+      const cursorNum = Number(cursor);
+      if (!Number.isInteger(cursorNum) || cursorNum < 1) {
+        return res.status(400).json({ error: 'cursor must be a positive integer' });
+      }
+    }
+
     const result = await orderLifecycleService.getOrderHistory(req.user.id, cursor, limit);
     res.json(result);
   } catch (err) {


### PR DESCRIPTION
Closes #6935.

Summary of What Has Been Done:
GET /api/orders/history passed the client-supplied cursor directly to PostgREST range() without validation. Non-numeric cursor values caused PostgREST to return a 400 error instead of a clear application-level validation message.

Changes Made:
- backend/api/src/routes/orderRoutes.js: added validation that cursor (if provided) is a positive integer, returning 400 with a clear error if not

Impact it Made:
- API returns a meaningful 400 error for invalid cursor values
- Prevents cryptic PostgREST errors from leaking to clients

Note: This is a GSSOC contribution.