### PR TITLE
fix : validate geofence_radius_m is a positive number before use in delivery confirm

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1081,6 +1081,13 @@ router.post(
         return res.status(400).json({ error: 'driver_lat and driver_lng must be valid numbers.' });
       }
 
+      if (geofence_radius_m !== undefined) {
+        const radiusM = parseFloat(geofence_radius_m);
+        if (!Number.isFinite(radiusM) || radiusM <= 0) {
+          return res.status(400).json({ error: 'geofence_radius_m must be a positive number' });
+        }
+      }
+
       // Verify the order exists and the requesting driver is assigned to it
       const order = await orderValidationService.findOrderByIdOrDisplayId(
         req.params.id,

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -383,6 +383,14 @@ export class DeliveryVerificationService {
       });
     }
 
+    // Guard against NaN/Infinity: NaN ?? fallback still evaluates to NaN in JS,
+    // making distanceM > NaN always false and bypassing the proximity check.
+    if (radiusM !== undefined && (!Number.isFinite(radiusM) || radiusM <= 0)) {
+      throw new DomainError(400, {
+        error: "geofence_radius_m must be a positive number.",
+      });
+    }
+
     if (!mongoDb) {
       throw new DomainError(503, {
         error: "Telemetry database not available.",


### PR DESCRIPTION
Closes #6936.

Summary of What Has Been Done:
POST /api/deliveries/:id/geofence-confirm parsed geofence_radius_m with parseFloat but never validated the result. parseFloat('abc') returns NaN; NaN ?? 500 evaluates to NaN in JavaScript, making the distance check distanceM > NaN always false. This silently bypassed the driver-at-dropoff proximity requirement.

Changes Made:
- backend/api/src/routes/orderRoutes.js: added validation that geofence_radius_m (if provided) is a positive finite number, returning 400 with a clear error if invalid
- backend/api/src/services/order/deliveryVerificationService.js: added a defensive guard in assertDriverAtDropoff to reject non-finite radiusM values early

Impact it Made:
- Invalid geofence_radius_m values now return a 400 error instead of silently bypassing the proximity check
- Defense-in-depth prevents forged proximity confirmations

Note: This is a GSSOC contribution.