### PR TITLE
fix : sanitized origin header string in cors middleware validator

### DIFF
--- a/backend/api/src/middleware/cors.js
+++ b/backend/api/src/middleware/cors.js
@@ -1,34 +1,44 @@
-import cors from 'cors';
+import cors from "cors";
 
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-  .split(',')
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+  .split(",")
   .map((origin) => origin.trim())
   .filter((origin) => {
     if (!origin) return false;
     try {
       const parsed = new URL(origin);
-      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
     } catch {
       return false;
     }
   });
 
-const corsAllowedHeaders = process.env.NODE_ENV === 'production'
-  ? ['Content-Type', 'Authorization']
-  : ['Content-Type', 'Authorization', 'x-user-id', 'x-user-role', 'x-user-name'];
+const corsAllowedHeaders =
+  process.env.NODE_ENV === "production"
+    ? ["Content-Type", "Authorization"]
+    : [
+        "Content-Type",
+        "Authorization",
+        "x-user-id",
+        "x-user-role",
+        "x-user-name",
+      ];
 
 export const corsMiddleware = cors({
   origin: (origin, callback) => {
     if (!origin) return callback(null, true);
-    if (allowedOrigins.includes(origin)) return callback(null, true);
+    const cleanOrigin = typeof origin === "string" ? origin.trim() : origin;
+    if (allowedOrigins.includes(cleanOrigin)) return callback(null, true);
 
-    if (process.env.NODE_ENV !== 'production') {
-      const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+    if (process.env.NODE_ENV !== "production") {
+      const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(
+        origin,
+      );
       if (isLocalhost) return callback(null, true);
     }
 
     return callback(null, false);
   },
-  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   allowedHeaders: corsAllowedHeaders,
 });


### PR DESCRIPTION
Summary of What Has Been Done:
Updated CORS origin matching in `backend/api/src/middleware/cors.js` to trim origin strings before checking white-listed domains.

Changes Made:
- Modified `backend/api/src/middleware/cors.js`: Added string trimming to `origin` check in CORS options callback.

Impact it Made:
- Prevents unexpected CORS rejection when client origins contain trailing whitespace or newline formatting.

Note: Please assign this PR to the `tmdeveloper007` account.

This pull request is submitted as part of GSSOC.