### PR TITLE
feat : exported shouldIgnoreError filter helper in sentry middleware

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -1,19 +1,19 @@
-import * as Sentry from '@sentry/node';
-import logger from './logger.js';
+import * as Sentry from "@sentry/node";
+import logger from "./logger.js";
 
 const SENTRY_ERROR_FILTERS = [
-  { code: 'ECONNRESET', level: 'warn' },
-  { code: 'ECONNREFUSED', level: 'warn' },
-  { code: 'ETIMEDOUT', level: 'warn' },
+  { code: "ECONNRESET", level: "warn" },
+  { code: "ECONNREFUSED", level: "warn" },
+  { code: "ETIMEDOUT", level: "warn" },
 ];
 
-function shouldIgnoreError(err) {
-  return SENTRY_ERROR_FILTERS.some(f => err.code === f.code);
+export function shouldIgnoreError(err) {
+  return SENTRY_ERROR_FILTERS.some((f) => err.code === f.code);
 }
 
 function getSentryLevel(err) {
-  const filter = SENTRY_ERROR_FILTERS.find(f => err.code === f.code);
-  return filter ? filter.level : 'error';
+  const filter = SENTRY_ERROR_FILTERS.find((f) => err.code === f.code);
+  return filter ? filter.level : "error";
 }
 
 export function initSentry() {
@@ -22,7 +22,7 @@ export function initSentry() {
 
   Sentry.init({
     dsn,
-    environment: process.env.NODE_ENV || 'development',
+    environment: process.env.NODE_ENV || "development",
     beforeSend(event) {
       if (event.exception?.values?.[0]?.value) {
         const err = new Error(event.exception.values[0].value);
@@ -31,7 +31,7 @@ export function initSentry() {
       return event;
     },
   });
-  logger.info('Sentry error tracking initialized.');
+  logger.info("Sentry error tracking initialized.");
 }
 
 export async function flushSentry(timeoutMs = 2000) {
@@ -39,7 +39,7 @@ export async function flushSentry(timeoutMs = 2000) {
   try {
     await Sentry.flush(timeoutMs);
   } catch (err) {
-    logger.warn({ err }, 'Sentry.flush failed during teardown');
+    logger.warn({ err }, "Sentry.flush failed during teardown");
   }
 }
 


### PR DESCRIPTION
Summary of What Has Been Done:
Exported `shouldIgnoreError` error filter helper from `backend/api/src/middleware/sentry.js`.

Changes Made:
- Modified `backend/api/src/middleware/sentry.js`: Exported `shouldIgnoreError(err)` function.

Impact it Made:
- Enables unit testing and external inspection of Sentry network error ignore filters (ECONNRESET, ETIMEDOUT).

Note: Please assign this PR to the `tmdeveloper007` account.

This pull request is submitted as part of GSSOC.