### PR TITLE
fix(dao): fix treasury proposal execution and allow cancelling passed proposals

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -239,7 +239,7 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
 
     function cancelProposal(uint256 proposalId) external onlyOwner {
         Proposal storage proposal = proposals[proposalId];
-        require(proposal.state == ProposalState.PENDING || proposal.state == ProposalState.ACTIVE, "Cannot cancel");
+        require(proposal.state == ProposalState.PENDING || proposal.state == ProposalState.ACTIVE || proposal.state == ProposalState.PASSED, "Cannot cancel");
         proposal.state = ProposalState.CANCELLED;
         emit ProposalCancelled(proposalId, msg.sender);
     }
@@ -275,13 +275,13 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
         require(recipient != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be > 0");
 
-        bytes memory callData = abi.encodeWithSignature("withdrawTreasury(uint256,address)", amount, recipient);
+        bytes memory callData = "";
 
         return createProposal(
             string(abi.encodePacked("Treasury Withdrawal: ", reason)),
             reason,
             callData,
-            address(this),
+            recipient,
             amount,
             ProposalType.TREASURY
         );


### PR DESCRIPTION
## Description
`treasuryProposal` previously encoded a self-call to `withdrawTreasury(uint256,address)` targeting `address(this)`. When executed via `executeProposal`, this self-call failed because `withdrawTreasury` is protected by `onlyOwner` (`msg.sender` became `address(this)`) and `nonReentrant` (reentering `DAO` during execution). Furthermore, `cancelProposal` disallowed cancelling proposals once they reached the `PASSED` status, leaving failed proposals permanently stuck.
gssoc 26

## Changes Made
- Updated `treasuryProposal` to route `target` directly to the `recipient` with `amount` value and empty `callData`, transferring funds seamlessly upon execution without triggering self-call security guards.
- Updated `cancelProposal` to permit cancelling proposals in `PASSED` state in addition to `PENDING` and `ACTIVE` as an escape hatch.

Fixes #6887

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings