### PR TITLE
feat : added structured logging to bare catch in CachePublisher message handler

### DIFF
--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -162,7 +162,8 @@ export function setupMessageHandler(cacheInvalidator) {
     const event = (() => {
       try {
         return JSON.parse(message);
-      } catch {
+      } catch (err) {
+        logger.warn({ err, channel, messagePreview: message.slice(0, 100) }, '[CachePublisher] Failed to parse event from Redis channel.');
         return null;
       }
     })();


### PR DESCRIPTION
Closes #6959.

Summary of What Has Been Done:
Added structured warn-level logging to the bare catch block in the Redis subscriber message handler in CachePublisher.js. When JSON.parse fails on a Redis pub/sub message, the error is now logged with channel name and message preview instead of being silently discarded.

Changes Made:
- backend/api/src/cache/CachePublisher.js: Added logger.warn with error, channel, and message preview in the bare catch block of the subscriber message handler.

Impact it Made:
- Redis pub/sub parse failures are now visible in production logs with enough context to diagnose the issue.
- Operators can set up alerts on warn-level CachePublisher messages.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).