### PR TITLE
feat : added structured logging to bare catch blocks in profileCache

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -11,7 +11,8 @@ async function _publishProfileInvalidation(eventOpts) {
     try {
       const { publishInvalidation } = await import('../cache/CachePublisher.js');
       _publishFn = publishInvalidation;
-    } catch {
+    } catch (err) {
+      logger.warn({ err }, 'Failed to initialize pub/sub publisher — profile invalidation events will not be broadcast.');
       _publishFn = null;
     }
   }
@@ -76,7 +77,8 @@ function logCacheError(operation, error) {
 function getRedisClient() {
   try {
     return db.redisClient ?? null;
-  } catch {
+  } catch (err) {
+    logger.warn({ err }, 'Failed to get Redis client in getRedisClient — falling back to null.');
     return null;
   }
 }


### PR DESCRIPTION
Closes #6960.

Summary of What Has Been Done:
Added structured warn-level logging to two bare catch blocks in profileCache.js: (1) _publishProfileInvalidation() where the optional pub/sub publisher import failure is now logged, and (2) getRedisClient() where Redis client access failures are now logged.

Changes Made:
- backend/api/src/lib/profileCache.js: Added logger.warn calls in both bare catch blocks with error context.

Impact it Made:
- Redis connection failures and optional pub/sub initialization failures are now visible in production logs.
- Easier diagnosis of cache infrastructure issues.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).