### PR TITLE
fix : added validation for geofence_radius_m as a positive number in delivery confirm

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1081,6 +1081,15 @@ router.post(
         return res.status(400).json({ error: 'driver_lat and driver_lng must be valid numbers.' });
       }
 
+      if (geofence_radius_m !== undefined) {
+        const parsedRadius = parseFloat(geofence_radius_m);
+        if (!Number.isFinite(parsedRadius) || parsedRadius <= 0) {
+          return res.status(400).json({ error: 'geofence_radius_m must be a positive number.' });
+        }
+        // Only pass the validated radius; the service will apply its own default if undefined.
+        req.body._validatedGeofenceRadiusM = parsedRadius;
+      }
+
       // Verify the order exists and the requesting driver is assigned to it
       const order = await orderValidationService.findOrderByIdOrDisplayId(
         req.params.id,
@@ -1102,7 +1111,7 @@ router.post(
         driverId: req.user.id,
         driverLat: lat,
         driverLng: lng,
-        geofenceRadiusM: geofence_radius_m ? parseFloat(geofence_radius_m) : 500,
+        geofenceRadiusM: req.body._validatedGeofenceRadiusM ?? 500,
       });
 
       return res.json(result);


### PR DESCRIPTION
Closes #6961.

Summary of What Has Been Done:
Added explicit Number.isFinite and positive-value validation for geofence_radius_m body parameter in the geofence-confirm route handler. If geofence_radius_m is provided but parses to NaN or a non-positive number, the API now returns a 400 error instead of passing NaN to the service layer.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Added validation block after driver_lat/lng checks. Uses a validated property on req.body to avoid repeating parseFloat.

Impact it Made:
- Prevents NaN geofence radius from bypassing security enforcement on delivery confirmation.
- API returns clear 400 errors for invalid input instead of silent failures.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).