### PR TITLE
fix: release usedHashLocks on refund in AtomicSwap.sol

### DIFF
--- a/blockchain/contracts/AtomicSwap.sol
+++ b/blockchain/contracts/AtomicSwap.sol
@@ -67,6 +67,7 @@ contract AtomicSwap is ReentrancyGuard {
         require(msg.sender == swap.sender, "Only sender can refund");
 
         swap.refunded = true;
+        usedHashLocks[swap.hashLock] = false;
         (bool sent, ) = swap.sender.call{value: swap.amount}("");
         require(sent, "Refund transfer failed");
 


### PR DESCRIPTION
## Description
`AtomicSwap.sol` previously set `usedHashLocks[hashLock] = true` on creation without ever clearing it during refunds (`refundSwap`). This enabled a permanent DoS/griefing vector where an attacker could front-run a swap creation, forcing a refund while keeping the hashLock permanently consumed.
gssoc 26

## Changes made:
- Added `usedHashLocks[swap.hashLock] = false;` inside `refundSwap` after a swap is successfully marked refunded.
- Ensured hashLocks can be reused safely if a previous swap attempt expires and gets refunded.
- Verified compilation and test suite execution.

Fixes #6893

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings