### PR TITLE
fix: Add security headers to API responses

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -11,6 +11,23 @@ export default function securityHeaders(req, res, next) {
     res.setHeader('X-Content-Type-Options', 'nosniff');
   }
 
+  // Prevent clickjacking attacks
+  if (!res.getHeader('X-Frame-Options')) {
+    res.setHeader('X-Frame-Options', 'DENY');
+  }
+
+  // Enable XSS filter in browsers
+  if (!res.getHeader('X-XSS-Protection')) {
+    res.setHeader('X-XSS-Protection', '1; mode=block');
+  }
+
+  // Enforce HTTPS for sensitive headers
+  if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
+    if (!res.getHeader('Strict-Transport-Security')) {
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+  }
+
   // Control referrer information
   if (!res.getHeader('Referrer-Policy')) {
     res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -27,6 +44,11 @@ export default function securityHeaders(req, res, next) {
   // Prevent cross-origin resource abuse
   if (!res.getHeader('Cross-Origin-Resource-Policy')) {
     res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  }
+
+  // Prevent cross-origin embedding
+  if (!res.getHeader('X-Content-Security-Policy')) {
+    res.setHeader('X-Content-Security-Policy', "default-src 'self'");
   }
 
   // Do NOT override an existing CSP


### PR DESCRIPTION
## Issue #1: Missing Security Headers

### Severity: MEDIUM

### Category: Security

### Problem Description
API responses lack comprehensive security headers to protect against common web vulnerabilities.

### Missing Headers
- Content-Security-Policy
- X-Content-Type-Options
- X-Frame-Options
- Strict-Transport-Security

### Solution
Add security headers middleware with recommended headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added security-related response headers to improve protection for application responses.
  * Ensured requests continue through the normal processing flow after headers are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->