### PR TITLE
fix: match off-chain credentialId generation with on-chain ABI encoding in did.service.js

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -117,8 +117,12 @@ class DIDService {
             );
             const receipt = await tx.wait();
 
+            const blockTimestamp = Math.floor(Date.now() / 1000);
             const credentialId = ethers.keccak256(
-                ethers.toUtf8Bytes(`${Date.now()}:${this.wallet.address}:${subject}:${credentialType}`)
+                ethers.solidityPacked(
+                    ["uint256", "address", "address", "string"],
+                    [blockTimestamp, this.wallet.address, subject, credentialType]
+                )
             );
 
             await this.identityWallet.addCredential(credentialId);


### PR DESCRIPTION
## Description
`did.service.js` previously computed `credentialId` using string concatenation and UTF-8 conversion, whereas `DIDRegistry.sol` generates it using Solidity packed encoding (`abi.encodePacked`). This mismatch caused verification and revocation to fail.
gssoc 26

## Changes made:
- Updated off-chain `credentialId` calculation in `backend/did/did.service.js` to use `ethers.solidityPacked` with types `["uint256", "address", "address", "string"]`.
- Ensured parity with on-chain `keccak256(abi.encodePacked(block.timestamp, msg.sender, subject, credentialType))`.

Fixes #6889

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings