### PR TITLE
fix: add 0x prefix to generateSecret in swap.service.js

### DIFF
--- a/backend/atomic-swap/swap.service.js
+++ b/backend/atomic-swap/swap.service.js
@@ -34,7 +34,7 @@ class AtomicSwapService {
     }
 
     generateSecret() {
-        return crypto.randomBytes(32).toString('hex');
+        return '0x' + crypto.randomBytes(32).toString('hex');
     }
 
     // ============ Swap Operations ============


### PR DESCRIPTION
## Description
`swap.service.js` previously returned `generateSecret()` as a plain 64-character hex string without the `0x` prefix. In ethers v6, passing this to a `bytes32` parameter caused ethers to treat it as a UTF-8 string, leading to an encoding crash before transaction submission.
gssoc 26

## Changes made:
- Updated `generateSecret()` in `backend/atomic-swap/swap.service.js` to prepend `'0x'` to the random hex bytes.

Fixes #6890

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings