### PR TITLE
Apply material type truck filtering

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -336,6 +336,14 @@ function isLongitude(value) {
   return Number.isFinite(value) && value >= -180 && value <= 180;
 }
 
+const MATERIAL_TRUCK_COMPATIBILITY = Object.freeze({
+  Textile: ['Open Body', 'Closed Body', 'Container'],
+  Electronics: ['Closed Body', 'Container'],
+  Food: ['Closed Body', 'Container', 'Refrigerated'],
+  Machinery: ['Open Body', 'Container'],
+  Furniture: ['Closed Body', 'Container'],
+});
+
 async function canViewTruckNumber(user, truck) {
   if (user.role === 'admin' || truck.driver_id === user.id) {
     return { allowed: true };
@@ -587,7 +595,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     const driverIds = drivers.map(d => d.user_id);
 
     const [trucksRes, profilesRes] = await Promise.all([
-      supabase.from('trucks').select('id, name, number_plate, max_capacity_tons').in('id', truckIds),
+      supabase.from('trucks').select('id, name, truck_type, number_plate, max_capacity_tons').in('id', truckIds),
       supabase.from('profiles').select('id, full_name, avatar_url, is_digilocker_verified').in('id', driverIds),
     ]);
 
@@ -639,6 +647,12 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
       }
       if (truck_type && truck_type !== '') {
         if (truck.truckType !== truck_type) {
+          return false;
+        }
+      }
+      if (material_type && material_type !== '') {
+        const compatibleTypes = MATERIAL_TRUCK_COMPATIBILITY[material_type] || [];
+        if (!compatibleTypes.includes(truck.truckType)) {
           return false;
         }
       }

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -323,6 +323,32 @@ describe('Truck Routes', () => {
       expect(Array.isArray(res.body)).toBe(true);
     });
 
+    it('filters results by material compatibility', async () => {
+      mockTelemetryResults = [
+        { driver_id: 'driver-open' },
+        { driver_id: 'driver-reefer' },
+      ];
+      m.store.trucks = [
+        { id: 'truck-open', name: 'Open Body Truck', truck_type: 'Open Body', number_plate: 'MH12AB0001', max_capacity_tons: 10, owner_id: 'driver-open' },
+        { id: 'truck-reefer', name: 'Cold Chain Truck', truck_type: 'Refrigerated', number_plate: 'MH12AB0002', max_capacity_tons: 10, owner_id: 'driver-reefer' },
+      ];
+      m.store.driver_details = [
+        { user_id: 'driver-open', is_online: true, truck_id: 'truck-open', rating: 4.2, total_trips: 50, completion_rate: 95 },
+        { user_id: 'driver-reefer', is_online: true, truck_id: 'truck-reefer', rating: 4.8, total_trips: 90, completion_rate: 98 },
+      ];
+      m.store.profiles = [
+        { id: 'driver-open', full_name: 'Open Driver' },
+        { id: 'driver-reefer', full_name: 'Cold Driver' },
+      ];
+
+      const res = await request(buildApp())
+        .get(`/api/trucks/search?${SEARCH_PARAMS}&material_type=Food`)
+        .set(CUSTOMER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.map(item => item.truck)).toEqual(['Cold Chain Truck']);
+    });
+
     it('returns empty when no nearby drivers', async () => {
       mockTelemetryResults = [];
       const res = await request(buildApp())


### PR DESCRIPTION
## Summary
- add explicit material-to-truck compatibility rules for search
- select `truck_type` for filtering during truck enrichment
- add coverage for filtering food cargo to compatible truck types

## Validation
- `node --check backend/api/src/routes/truckRoutes.js`
- `npm --prefix backend/api test -- truckRoutes.test.js -t "material compatibility"` is currently blocked by an unrelated parse error in `backend/api/src/lib/profileCache.js` on main.

Closes #6222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Truck search now filters results based on compatibility between truck type and requested cargo material.
  - Material-specific searches return only trucks suitable for transporting that cargo.
  - Truck type information continues to appear in search results.

- **Bug Fixes**
  - Prevented incompatible trucks from appearing in material-filtered searches.

- **Tests**
  - Added coverage confirming compatible refrigerated trucks are returned for food-related searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->