### PR TITLE
Validate LTL route coordinates

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1445,10 +1445,10 @@ router.get('/weigh-stations/bypass-status', authenticate, requirePolicy('driver:
  */
 router.get('/ltl/optimize-route', authenticate, userLimiter, requirePolicy('driver:view-stats'), async (req, res) => {
   try {
-    const lat = parseFloat(req.query.lat);
-    const lng = parseFloat(req.query.lng);
+    const lat = parseCoordinate(req.query.lat);
+    const lng = parseCoordinate(req.query.lng);
 
-    if (Number.isNaN(lat) || Number.isNaN(lng)) {
+    if (!hasValidCoordinates(lat, lng)) {
       return res.status(400).json({ error: 'Valid lat and lng query parameters are required.' });
     }
 

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -41,6 +41,7 @@ describe('Driver Routes', () => {
     m.store.wallet_transactions = [];
     m.store.earnings_daily = [];
     m.store.trucks = [];
+    m.store.orders = [];
     m.calls.length = 0;
   });
 
@@ -109,6 +110,26 @@ describe('Driver Routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.truck.id).toBe('truck-1');
+  });
+
+  it('GET /ltl/optimize-route rejects malformed current coordinates', async () => {
+    const res = await request(buildApp())
+      .get('/api/drivers/ltl/optimize-route?lat=12abc&lng=77.5946')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Valid lat and lng query parameters are required.');
+    expect(m.calls.some((call) => call.table === 'orders')).toBe(false);
+  });
+
+  it('GET /ltl/optimize-route rejects out-of-range current coordinates', async () => {
+    const res = await request(buildApp())
+      .get('/api/drivers/ltl/optimize-route?lat=999&lng=77.5946')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Valid lat and lng query parameters are required.');
+    expect(m.calls.some((call) => call.table === 'orders')).toBe(false);
   });
 
   it('GET /trips enriches escrow_status from the underlying order', async () => {


### PR DESCRIPTION
## Summary
- parse LTL route query coordinates with the strict coordinate parser
- reject malformed and out-of-range current locations before querying active orders
- add route regressions for malformed and out-of-range coordinate input

## Tests
- node --check backend/api/src/routes/driverRoutes.js
- npx vitest run test/integration/driverRoutes.test.js -t ltl/optimize-route

Note: the full driver route file currently has unrelated failures in trips and withdrawal cases on this branch.

Closes #6225