### PR TITLE
Skip invalid LTL order coordinates

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -156,6 +156,10 @@ function parseIntegerQuery(value) {
 }
 
 function parseCoordinate(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
   if (typeof value !== 'string' || value.trim().length === 0) {
     return null;
   }
@@ -1465,9 +1469,13 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requirePolicy('driv
     const tasks = [];
     for (const order of activeOrders || []) {
       const needsPickup = ['truck_assigned', 'en_route_pickup', 'arrived_pickup'].includes(order.status);
-      
-      const hasPickupCoords = hasValidCoordinates(order.pickup_lat, order.pickup_lng);
-      const hasDropCoords = hasValidCoordinates(order.drop_lat, order.drop_lng);
+
+      const pickupLat = parseCoordinate(order.pickup_lat);
+      const pickupLng = parseCoordinate(order.pickup_lng);
+      const dropLat = parseCoordinate(order.drop_lat);
+      const dropLng = parseCoordinate(order.drop_lng);
+      const hasPickupCoords = hasValidCoordinates(pickupLat, pickupLng);
+      const hasDropCoords = hasValidCoordinates(dropLat, dropLng);
 
       if (needsPickup && (!hasPickupCoords || !hasDropCoords)) {
         logger.warn(`[LTL Route] Excluding active order ${order.id} due to missing/invalid coordinates (requires both pickup and dropoff).`);
@@ -1486,8 +1494,8 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requirePolicy('driv
           orderDisplayId: order.order_display_id,
           type: 'pickup',
           address: order.pickup_address,
-          lat: order.pickup_lat,
-          lng: order.pickup_lng
+          lat: pickupLat,
+          lng: pickupLng
         });
       }
       tasks.push({
@@ -1496,8 +1504,8 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requirePolicy('driv
         orderDisplayId: order.order_display_id,
         type: 'dropoff',
         address: order.drop_address,
-        lat: order.drop_lat,
-        lng: order.drop_lng
+        lat: dropLat,
+        lng: dropLng
       });
     }
 

--- a/backend/api/test/integration/driverRoutes.test.js
+++ b/backend/api/test/integration/driverRoutes.test.js
@@ -41,6 +41,7 @@ describe('Driver Routes', () => {
     m.store.wallet_transactions = [];
     m.store.earnings_daily = [];
     m.store.trucks = [];
+    m.store.orders = [];
     m.calls.length = 0;
   });
 
@@ -109,6 +110,46 @@ describe('Driver Routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.truck.id).toBe('truck-1');
+  });
+
+  it('GET /ltl/optimize-route excludes active orders with invalid coordinates', async () => {
+    m.store.orders.push(
+      {
+        id: 'order-valid',
+        order_display_id: 'ORD-VALID',
+        driver_id: 'driver-1',
+        status: 'truck_assigned',
+        pickup_address: 'Warehouse',
+        pickup_lat: '12.9716',
+        pickup_lng: '77.5946',
+        drop_address: 'Customer',
+        drop_lat: '13.0827',
+        drop_lng: '80.2707',
+      },
+      {
+        id: 'order-invalid',
+        order_display_id: 'ORD-INVALID',
+        driver_id: 'driver-1',
+        status: 'truck_assigned',
+        pickup_address: 'Bad pickup',
+        pickup_lat: null,
+        pickup_lng: '77.5946',
+        drop_address: 'Bad drop',
+        drop_lat: '13abc',
+        drop_lng: '80.2707',
+      }
+    );
+
+    const res = await request(buildApp())
+      .get('/api/drivers/ltl/optimize-route?lat=12.9&lng=77.5')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body.optimized_route.map((task) => task.orderId)).toEqual([
+      'order-valid',
+      'order-valid',
+    ]);
+    expect(res.body.optimized_route.every((task) => typeof task.lat === 'number' && typeof task.lng === 'number')).toBe(true);
   });
 
   it('GET /trips enriches escrow_status from the underlying order', async () => {


### PR DESCRIPTION
﻿## Summary
- normalize active order coordinates before LTL route optimization
- skip active orders with missing, malformed, or out-of-range pickup/dropoff coordinates
- add a route regression that verifies invalid orders are excluded and valid tasks use numeric coordinates

## Tests
- node --check backend/api/src/routes/driverRoutes.js
- npx vitest run test/integration/driverRoutes.test.js -t "excludes active orders"

Closes #6226
