### PR TITLE
Bind voice audio cache to owners

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -81,6 +81,11 @@ router.get('/audio/:id', authenticate, userLimiter, (req, res) => {
   if (!entry) {
     return res.status(404).json({ error: 'Audio not found' });
   }
+
+  if (!entry.userId || (entry.userId !== req.user.id && req.user.role !== 'admin')) {
+    return res.status(403).json({ error: 'Access Denied: You do not have permission to access this audio.' });
+  }
+
   res.set('Content-Type', 'audio/mpeg');
   res.send(entry.buffer);
 });

--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -31,8 +31,8 @@ function trimCache() {
   }
 }
 
-function cacheAudio(id, buffer) {
-  audioCache.set(id, { buffer, timestamp: Date.now() });
+function cacheAudio(id, buffer, userId) {
+  audioCache.set(id, { buffer, userId, timestamp: Date.now() });
   trimCache();
 }
 
@@ -94,7 +94,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     // Generate a dummy silent mp3
     const mockAudio = Buffer.alloc(1000);
     const audioId = crypto.randomUUID();
-    cacheAudio(audioId, mockAudio);
+    cacheAudio(audioId, mockAudio, userId);
 
     return {
       transcript: selected.transcript,
@@ -170,7 +170,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     });
 
     const audioId = crypto.randomUUID();
-    cacheAudio(audioId, Buffer.from(ttsResponse.data));
+    cacheAudio(audioId, Buffer.from(ttsResponse.data), userId);
     audioUrl = `/api/voice/audio/${audioId}`;
   } catch (err) {
     logger.error('ElevenLabs TTS failed:', err.message);

--- a/backend/api/test/integration/voiceAudioAccess.test.js
+++ b/backend/api/test/integration/voiceAudioAccess.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => {
+    const userId = req.get('x-user-id');
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    req.user = {
+      id: userId,
+      role: req.get('x-user-role') || 'customer',
+    };
+    next();
+  },
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const { audioCache } = await import('../../src/services/voiceService.js');
+const { default: voiceRouter } = await import('../../src/routes/voiceRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use('/api/voice', voiceRouter);
+  return app;
+}
+
+describe('Voice audio cache access', () => {
+  beforeEach(() => {
+    audioCache.clear();
+  });
+
+  it('streams cached audio for the owner', async () => {
+    audioCache.set('audio-1', {
+      buffer: Buffer.from('audio bytes'),
+      userId: 'user-1',
+      timestamp: Date.now(),
+    });
+
+    const res = await request(buildApp())
+      .get('/api/voice/audio/audio-1')
+      .set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('audio/mpeg');
+    expect(Buffer.from(res.body).toString()).toBe('audio bytes');
+  });
+
+  it('denies cached audio to another user', async () => {
+    audioCache.set('audio-2', {
+      buffer: Buffer.from('private audio'),
+      userId: 'user-1',
+      timestamp: Date.now(),
+    });
+
+    const res = await request(buildApp())
+      .get('/api/voice/audio/audio-2')
+      .set('x-user-id', 'user-2');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Access Denied: You do not have permission to access this audio.');
+  });
+
+  it('denies cached audio entries without an owner binding', async () => {
+    audioCache.set('legacy-audio', {
+      buffer: Buffer.from('legacy audio'),
+      timestamp: Date.now(),
+    });
+
+    const res = await request(buildApp())
+      .get('/api/voice/audio/legacy-audio')
+      .set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/api/test/unit/services/voiceService.test.js
+++ b/backend/api/test/unit/services/voiceService.test.js
@@ -168,9 +168,10 @@ describe('trimCache Eviction Logic', () => {
     const now = Date.now();
     audioCache.set('expired_old', { buffer: Buffer.from('old'), timestamp: now - CACHE_TTL_MS - 5000 });
 
-    cacheAudio('new_item', Buffer.from('fresh_data'));
+    cacheAudio('new_item', Buffer.from('fresh_data'), 'user-1');
 
     expect(audioCache.has('expired_old')).toBe(false);
     expect(audioCache.has('new_item')).toBe(true);
+    expect(audioCache.get('new_item').userId).toBe('user-1');
   });
 });


### PR DESCRIPTION
﻿## Summary
- store the requesting user id with generated voice audio cache entries
- deny audio downloads when the cache entry owner does not match the requester
- add route coverage for owner access, cross-user denial, and unbound cache entries

## Tests
- node --check backend/api/src/services/voiceService.js
- node --check backend/api/src/routes/voiceRoutes.js
- npx vitest run test/unit/services/voiceService.test.js test/integration/voiceAudioAccess.test.js

Closes #6228
