### PR TITLE
fix(kyber): derive shared secret from compressed ciphertext so encapsulate/decapsulate agree

### DIFF
--- a/backend/kyber/kyber_core.py
+++ b/backend/kyber/kyber_core.py
@@ -176,8 +176,9 @@ class KyberKEM:
         u_compressed = self._compress(u, 10)
         v_compressed = self._compress(v, 4)
         
-        # Derive shared secret
-        shared_secret = self._derive_secret(u, v)
+        # Derive shared secret from the compressed ciphertext so it matches
+        # decapsulate, which hashes the compressed u/v transmitted in the ciphertext
+        shared_secret = self._derive_secret(u_compressed, v_compressed)
         
         ciphertext = {
             'u': u_compressed.tolist(),

--- a/backend/pqc/kyber.py
+++ b/backend/pqc/kyber.py
@@ -168,9 +168,10 @@ class KyberKEM:
         u_compressed = self._compress(u, 10)
         v_compressed = self._compress(v, 4)
         
-        # Derive shared secret
+        # Derive shared secret from the compressed ciphertext so it matches
+        # decapsulate, which hashes the compressed u/v transmitted in the ciphertext
         shared_secret = hashlib.sha256(
-            np.concatenate([u.flatten(), v.flatten()]).tobytes()
+            np.concatenate([u_compressed.flatten(), v_compressed.flatten()]).tobytes()
         ).digest()
         
         ciphertext = {


### PR DESCRIPTION
﻿Closes #7042

## Summary
aligns the shared-secret derivation between `encapsulate` and `decapsulate` in both Kyber implementations so round-trips produce identical secrets.

## Changes
- `backend/kyber/kyber_core.py`: derive the secret from the compressed ciphertext (`u_compressed`/`v_compressed`) instead of the raw `u`/`v`.
- `backend/pqc/kyber.py`: same change.

## Verification
- `python -m py_compile` passes for both files.
- Round-trip test (keygen -> encapsulate -> decapsulate) before the fix: `enc==dec: False`; after the fix: `enc==dec: True`.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kyber key encapsulation consistency by deriving shared secrets from the same compressed ciphertext representation used during decapsulation.
  * Fixed potential mismatches that could prevent successful shared-secret agreement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->