### PR TITLE
fix(driver): handle NaN values in driver earnings aggregation

### DIFF
--- a/backend/api/src/services/driverEarningsService.js
+++ b/backend/api/src/services/driverEarningsService.js
@@ -18,6 +18,16 @@ export const calculateEarningsAggregation = (trips, allCompletedTrips, lifetimeT
   let gross_earnings = 0;
 
   (trips || []).forEach(trip => {
+    let tEarnings = Number(trip.total_earnings);
+    if (Number.isNaN(tEarnings)) {
+      tEarnings = 0;
+    }
+
+    let nEarnings = Number(trip.net_earnings);
+    if (Number.isNaN(nEarnings)) {
+      nEarnings = 0;
+    }
+
     if (trip.trip_date) {
       const tripDate = new Date(trip.trip_date);
       // Only add to weekly chart if within the last 7 days
@@ -26,7 +36,7 @@ export const calculateEarningsAggregation = (trips, allCompletedTrips, lifetimeT
       if (diffDays <= 7) {
         const dayLabel = daysOfWeek[tripDate.getDay()];
         if (weeklyChartMap[dayLabel] !== undefined) {
-          weeklyChartMap[dayLabel] += trip.total_earnings || 0;
+          weeklyChartMap[dayLabel] += tEarnings;
         }
       }
     }
@@ -39,8 +49,8 @@ export const calculateEarningsAggregation = (trips, allCompletedTrips, lifetimeT
       totalKm += distanceNum;
     }
 
-    totalNetEarnings += trip.net_earnings || 0;
-    gross_earnings += trip.total_earnings || 0;
+    totalNetEarnings += nEarnings;
+    gross_earnings += tEarnings;
   });
 
   const weeklyChart = Object.entries(weeklyChartMap).map(([day, earnings]) => ({


### PR DESCRIPTION
## Description

Fixed an issue in `driverEarningsService.aggregateTripEarnings` where invalid trip earnings values could cause `NaN` values to propagate into driver earnings summaries and API responses.

The update validates `total_earnings` and `net_earnings` values before performing calculations, converting invalid numeric values to `0` to ensure stable and accurate earnings aggregation.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:**
  - `npm test backend/api/test/unit/driverEarningsService.test.js`
  - `npm install`

- **Test Steps / Prerequisites:**
  - Updated `driverEarningsService.js` to validate earnings values during aggregation.
  - Tested the driver earnings service unit tests after applying the fix.
  - Verified that invalid earnings inputs no longer propagate `NaN` values.

- **Expected Result:**
  - Earnings aggregation handles null, undefined, and invalid numeric values safely.
  - API responses contain valid numeric values instead of `NaN`.
  - Existing earnings calculations continue to work correctly for valid trip data.

### Test Environment

- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues

Closes #6983

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.