### PR TITLE
fix(sgx): use CSPRNG for secure_random instead of random.randint

### DIFF
--- a/backend/sgx/sgx_service.py
+++ b/backend/sgx/sgx_service.py
@@ -207,9 +207,9 @@ class SGXService:
                 return {'success': False, 'error': 'Enclave not initialized'}
             
             # In production: call ecall_secure_random
-            # For demo: generate random
-            import random
-            random_num = random.randint(0, 2**32 - 1)
+            # For demo: use a CSPRNG instead of the predictable Mersenne Twister
+            import secrets
+            random_num = secrets.randbits(32)
             
             return {
                 'success': True,


### PR DESCRIPTION
Closes #7045

## Summary
`secure_random()` in the SGX service generated the "secure random number" with the non-cryptographic Mersenne Twister (`random.randint`).

## Changes
- `backend/sgx/sgx_service.py`: use `secrets.randbits(32)` (CSPRNG) instead of `random.randint`.

## Verification
- `python -m py_compile` passes.

GSSOC
