### PR TITLE
fix(consul): implement real round-robin service selection

### DIFF
--- a/backend/consul/consul.service.js
+++ b/backend/consul/consul.service.js
@@ -145,7 +145,10 @@ class ConsulService {
         }
 
         // Round-robin load balancing
-        const service = services[Math.floor(Math.random() * services.length)];
+        if (this._rrIndex == null) {
+            this._rrIndex = 0;
+        }
+        const service = services[this._rrIndex++ % services.length];
         return `${service.address}:${service.port}`;
     }
 


### PR DESCRIPTION
Closes #7046

## Summary
`getServiceAddress()` claimed "Round-robin load balancing" but picked services with `Math.random()`, so the documented round-robin behavior was never implemented.

## Changes
- `backend/consul/consul.service.js`: added a round-robin index counter; consecutive calls now cycle deterministically through the healthy services.

## Verification
- `node --check` passes.

GSSOC
