### PR TITLE
fix(mev): commit secret hash of raw secret so releaseEscrow can verify

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -36,9 +36,10 @@ class MEVService {
 
     async createCommitment(secret, userId) {
         try {
-            // Hash secret with user address
+            // Hash secret (the exact bytes revealed at release time, so the
+            // on-chain keccak(preimage) == secretHash check can pass)
             const secretHash = ethers.keccak256(
-                ethers.toUtf8Bytes(secret + userId)
+                ethers.toUtf8Bytes(secret)
             );
             
             const tx = await this.escrow.createCommitment(secretHash, {
@@ -72,9 +73,9 @@ class MEVService {
             // Create commitment first
             const commitment = await this.createCommitment(secret, userId);
             
-            // Hash secret for escrow
+            // Hash secret for escrow (same bytes as release reveals: plain secret)
             const secretHash = ethers.keccak256(
-                ethers.toUtf8Bytes(secret + userId)
+                ethers.toUtf8Bytes(secret)
             );
             
             // Create escrow with commit hash


### PR DESCRIPTION
Closes #7047

## Summary
`createEscrow`/`createCommitment` committed `keccak(secret + userId)` as the secret hash, but `releaseEscrow` reveals only the raw `secret`. The on-chain `keccak(preimage) == secretHash` check could therefore never pass and escrow release always failed.

## Changes
- `backend/mev/mev.service.js`: hash the plain `secret` (the exact bytes revealed at release time) on both the commitment and escrow sides.

## Verification
- `node --check` passes.

GSSOC
