### PR TITLE
fix(zkid): derive requestId from receipt and stop fabricating verified:true

### DIFF
--- a/backend/zkid/zkid.service.js
+++ b/backend/zkid/zkid.service.js
@@ -159,9 +159,20 @@ class ZKIDService {
             );
             const receipt = await tx.wait();
 
-            const requestId = ethers.keccak256(
-                ethers.toUtf8Bytes(`${identityHash}:${credentialHash}:${Date.now()}`)
-            );
+            // Derive the request id from the on-chain event if present,
+            // otherwise anchor it to the actual transaction hash instead of
+            // fabricating a keccak of a client-side timestamp
+            let requestId = null;
+            for (const log of receipt.logs) {
+                const parsed = this.zkid.interface.parseLog(log);
+                if (parsed && /request/i.test(parsed.name)) {
+                    requestId = parsed.args[0]?.toString?.() ?? null;
+                    break;
+                }
+            }
+            if (!requestId) {
+                requestId = receipt.hash;
+            }
 
             await this.storeVerificationRequest({
                 requestId,
@@ -174,7 +185,6 @@ class ZKIDService {
             return {
                 success: true,
                 requestId,
-                verified: true,
                 txHash: receipt.hash
             };
         } catch (error) {


### PR DESCRIPTION
Closes #7048

## Summary
`requestVerification()` returned `verified: true` unconditionally and fabricated a `requestId` from a client-side `keccak(...:Date.now())`, so callers were told verification succeeded without any actual verification, and the stored id matched no on-chain request.

## Changes
- `backend/zkid/zkid.service.js`: derive the request id from the receipt's request event (falling back to the tx hash) and drop the hardcoded `verified: true`.

## Verification
- `node --check` passes.

GSSOC
