### PR TITLE
fix(vdf): verify() must recompute and check y = x^(2^T) mod N against output_data

### DIFF
--- a/backend/vdf/vdf_core.py
+++ b/backend/vdf/vdf_core.py
@@ -143,18 +143,22 @@ class VDF:
             # Parse proof
             proof_json = json.loads(proof_data.decode())
             
-            # Verify proof
-            # In production: implement proper verification
-            # For demo: verify hash matches
-            
+            # Recompute the VDF output: y' = x^(2^T) mod N
             x = self._hash_to_point(input_data)
-            y = int(proof_json['output'], 16)
-            
-            # Verify elapsed time
-            elapsed_time = proof_json.get('elapsed_time', 0)
-            if elapsed_time < 0.1:  # Minimum time
+            modulus = int(proof_json['modulus'], 16)
+            iterations = int(proof_json.get('iterations', self.iterations))
+            y = x
+            for _ in range(iterations):
+                y = self._square_mod(y, modulus)
+
+            # The recomputed output must match the claimed output in the proof
+            if int(proof_json['output'], 16) != y:
                 return False
-            
+
+            # And the caller-provided expected output, when given
+            if output_data and output_data != y.to_bytes(32, 'big'):
+                return False
+
             return True
             
         except Exception as e:


### PR DESCRIPTION
Closes #7049

## Summary
`VDF.verify()` accepted any proof carrying `output`/`elapsed_time >= 0.1` without recomputing the VDF output or checking `output_data`, so forged proofs always verified.

## Changes
- `backend/vdf/vdf_core.py`: recompute `y = x^(2^T) mod N` (using the proof's modulus/iterations) and require it to match the proof's `output` and the caller-provided `output_data`.

## Verification
- `python -m py_compile` passes.
- Round-trip: `verify(valid) == True`, `verify(wrong input) == False`, `verify(forged output) == False`, `verify(wrong output_data) == False`.

GSSOC
