### PR TITLE
fix: quote wildcard host in global-loadbalancer.yaml (#7121)

### DIFF
--- a/k8s/multi-region/global-loadbalancer.yaml
+++ b/k8s/multi-region/global-loadbalancer.yaml
@@ -34,7 +34,7 @@ spec:
   tls:
   - hosts:
     - truxify.com
-    - *.truxify.com
+    - "*.truxify.com"
     secretName: truxify-tls
   rules:
   - host: truxify.com


### PR DESCRIPTION
## Description
`k8s/multi-region/global-loadbalancer.yaml` utilized a bare `*.truxify.com` wildcard host. Since YAML treats `*` as an anchor/alias indicator, the parser fails while scanning aliases, causing global ingress deployment failures.
gssoc 26

## Changes made:
- Wrapped `*.truxify.com` in double quotes (`"*.truxify.com"`) to prevent YAML parsing errors.
- Validated the multi-document YAML manifest successfully via Python loader.

Fixes #7121

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings