### PR TITLE
fix: secure ZKP routes with authentication middleware and remount under /api/zkp (#7095)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -579,7 +579,7 @@ app.get('/api/fraud/health', (req, res) => {
 // ============================================================================
 // 🆕 ZK-PROOFS FOR DRIVER KYC ROUTES
 // ============================================================================
-app.use('/api', zkpRoutes)
+app.use('/api/zkp', zkpRoutes)
 
 // 🆕 ZK-Proof Health Check Endpoint
 app.get('/api/zkp/health', (req, res) => {

--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -1,3 +1,4 @@
+const { authenticate } = require('../middleware/auth.middleware');
 import express from 'express';
 import zkpService from '../services/zkp/zkp.service.js';
 import { LockAcquisitionError } from '../lib/redisLock.js';
@@ -43,7 +44,7 @@ const zkpVerifyLimiter = redisRateLimiter({
  *   zkpVerifyLimiter caps each user to 5 attempts/hour (sliding window).
  *   Excess requests receive 429 before reaching the blockchain layer.
  */
-router.post('/verify', zkpVerifyLimiter, async (req, res) => {
+router.post('/verify', authenticate, zkpVerifyLimiter, async (req, res) => {
   try {
     const {
       userId,
@@ -97,7 +98,7 @@ router.post('/verify', zkpVerifyLimiter, async (req, res) => {
  * GET /zkp/status/:userId
  * Returns the KYC verification status for a driver.
  */
-router.get('/status/:userId', async (req, res) => {
+router.get('/status/:userId', authenticate, async (req, res) => {
   try {
     const { userId } = req.params;
     const verified = await zkpService.isVerified(userId);
@@ -112,7 +113,7 @@ router.get('/status/:userId', async (req, res) => {
  * GET /zkp/stats
  * Returns aggregate KYC verification counts.
  */
-router.get('/stats', async (req, res) => {
+router.get('/stats', authenticate, async (req, res) => {
   try {
     const stats = await zkpService.getVerificationStats();
     return res.status(200).json({ success: true, ...stats });


### PR DESCRIPTION
## Description
`backend/api/src/routes/zkp.routes.js` exposed sensitive zero-knowledge proof verification (`/verify`), status lookup (`/status/:userId`), and statistics (`/stats`) endpoints with rate limiting only, lacking authentication middleware and allowing unauthenticated access to submit verification payloads or query arbitrary user statuses.
gssoc 26

## Changes made:
- Imported and applied `authenticate` middleware across all ZKP endpoints (`/verify`, `/status/:userId`, `/stats`).
- Remounted ZKP routes under the `/api/zkp` prefix in `backend/api/src/index.js` instead of root `/api`.
- Ensured proper access control enforcement against unauthenticated requests.

Fixes #7095

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings