### PR TITLE
fix: enforce dropoff geofence validation in OracleService _verifyGPS (#7096)

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -19,7 +19,7 @@ class OracleService {
     const otpResult = await this._verifyOTP(orderId, otp);
     providerResults.push(otpResult);
 
-    const gpsResult = this._verifyGPS(gpsCoordinates);
+    const gpsResult = await this._verifyGPS(orderId, gpsCoordinates);
     providerResults.push(gpsResult);
 
     const statusResult = await this._verifyOrderStatus(orderId);
@@ -77,18 +77,37 @@ class OracleService {
     }
   }
 
-  _verifyGPS(gpsCoordinates) {
+  async _verifyGPS(orderId, gpsCoordinates) {
     const hasValidCoords = gpsCoordinates &&
       typeof gpsCoordinates.lat === 'number' &&
       typeof gpsCoordinates.lng === 'number' &&
       gpsCoordinates.lat >= -90 && gpsCoordinates.lat <= 90 &&
       gpsCoordinates.lng >= -180 && gpsCoordinates.lng <= 180;
 
-    return {
-      confirmed: hasValidCoords === true,
-      provider: 'GPSVerifier',
-      timestamp: new Date().toISOString(),
-    };
+    if (!hasValidCoords) {
+      return {
+        confirmed: false,
+        provider: 'GPSVerifier',
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    try {
+      const verification = await DeliveryVerificationService.assertDriverAtDropoff(orderId, gpsCoordinates);
+      return {
+        confirmed: verification.success || verification.isValid === true,
+        provider: 'GPSVerifier',
+        reason: verification.reason || null,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      return {
+        confirmed: false,
+        provider: 'GPSVerifier',
+        reason: error.message,
+        timestamp: new Date().toISOString(),
+      };
+    }
   }
 
   async _verifyOrderStatus(orderId) {


### PR DESCRIPTION
## Description
`backend/api/src/oracle/OracleService.js`'s `_verifyGPS` previously only checked basic coordinate bounds, allowing oracle GPS verification to succeed for arbitrary locations anywhere on Earth.
gssoc 26

## Changes made:
- Converted `_verifyGPS` to an async method invoking `DeliveryVerificationService.assertDriverAtDropoff` for strict geofence validation.
- Passed `orderId` to `_verifyGPS` to check against the specific order's delivery coordinates and radius.

Fixes #7096

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings