### PR TITLE
fix: remove 30-day post-release withdrawal lock in TruxifyEscrow

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -247,7 +247,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         pendingWithdrawals[driver] += paymentAmount;
 
         // Always extend the timeout to protect newly released funds
-        releaseTimestamps[driver] = block.timestamp + WITHDRAWAL_TIMEOUT;
+        // releaseTimestamps[driver] = block.timestamp + WITHDRAWAL_TIMEOUT; // Removed post-release withdrawal lock
 
         emit WithdrawalReady(bookingId, driver, paymentAmount);
         emit PaymentReleased(bookingId, driver, paymentAmount);
@@ -515,7 +515,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     function withdraw() external nonReentrant whenNotPaused {
         uint256 amount = pendingWithdrawals[msg.sender];
         require(amount > 0, "Nothing to withdraw");
-        require(block.timestamp > releaseTimestamps[msg.sender], "Withdrawal period active");
+        // require(block.timestamp > releaseTimestamps[msg.sender], "Withdrawal period active"); // Immediate withdrawal allowed
 
         pendingWithdrawals[msg.sender] = 0;
         releaseTimestamps[msg.sender] = 0;


### PR DESCRIPTION
## Description
`TruxifyEscrow.sol` previously enforced a 30-day `WITHDRAWAL_TIMEOUT` on drivers attempting to withdraw funds immediately after release, blocking liquidity and contradicting instant-release expectations.
gssoc 26

## Changes made:
- Commented out / removed the assignment of `releaseTimestamps[driver]` upon release.
- Removed the timestamp check in `withdraw()` allowing drivers to pull funds instantly.
- Verified successful compilation and contract test suites.

Fixes #7097

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Driver funds released through escrow can now be withdrawn immediately.
  * Removed the waiting period that previously applied after payment release, providing faster access to available funds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->