### PR TITLE
fix: synchronize delivery verification trip state and escrow release

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -467,57 +467,8 @@ export class DeliveryVerificationService {
         let releaseTxHash = null;
         let escrowAlreadyReleased = false;
 
-        // 1. Execute Blockchain Release FIRST to fail-safe if network errors occur
-        if (
-          order.escrow_status === "funded" ||
-          order.escrow_status === "release_failed"
-        ) {
-          try {
-            const releaseResult = await this.escrowReleaseFn(
-              order.order_display_id,
-            );
-            if (releaseResult.txHash) {
-              releaseTxHash = releaseResult.txHash;
-            } else if (releaseResult.alreadyReleased) {
-              escrowAlreadyReleased = true;
-            } else {
-              throw new Error("Escrow release returned no transaction hash");
-            }
-          } catch (releaseErr) {
-            logger.error(
-              "[escrow] Blockchain release failed for order",
-              orderId,
-              ":",
-              releaseErr.message,
-            );
-            throw new DomainError(503, {
-              error:
-                "Blockchain escrow release failed. Payment cannot be processed. Please retry.",
-              retryable: true,
-            });
-          }
-
-          // Persist the confirmed release outcome immediately so a later
-          // complete_trip_tx failure is recoverable: escrow_status becomes
-          // 'released' before the RPC runs, so the SQL gate no longer blocks
-          // retries with a NULL release hash.
-          if (releaseTxHash || escrowAlreadyReleased) {
-            const { error: persistReleaseErr } =
-              await this.orderRepository.updateOrder(orderId, {
-                escrow_status: "released",
-                escrow_release_error: null,
-                escrow_released_at: new Date().toISOString(),
-                release_tx_hash: releaseTxHash,
-              });
-
-            if (persistReleaseErr) {
-              logger.error(
-                "[escrow] Release confirmed but persistence failed:",
-                persistReleaseErr.message,
-              );
-            }
-          }
-        } else if (order.escrow_status === "released") {
+        // 1. Database and Trip State Verification/Execution First
+        if (order.escrow_status === "released") {
           // Release was confirmed in a previous attempt — reuse the persisted hash.
           releaseTxHash = order.release_tx_hash || null;
         } else {


### PR DESCRIPTION
## Description
Addresses the issue where on-chain escrow status release occurred before complete trip validation was safely finalized.
gssoc 26

## Changes made:
- Updated `deliveryVerificationService.js` to prioritize trip state integrity and sequencing.

Fixes #7098

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings