### PR TITLE
fix: remove verification_status from client profile update request schema

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -285,7 +285,6 @@ export const updateProfileSchema = z.object({
   language: z.string().min(2, 'Invalid language code').max(10, 'Invalid language code').refine((v) => VALID_LANGUAGES.includes(v), { message: 'Unsupported language code' }).optional(),
   dark_mode: z.boolean().optional(),
   is_online: z.boolean().optional(),
-  verification_status: z.enum(['pending', 'verified', 'rejected']).optional(),
 }).strict();
 
 // ── Oracle & Verification schemas ───────────────────────────────────────


### PR DESCRIPTION
## Description
`updateProfileSchema` in `requestSchemas.js` previously accepted `verification_status` from client payloads. Although current handlers may ignore it, retaining it in client-facing validation schemas creates a latent privilege-escalation risk.
gssoc 26
## Changes made:
- Removed `verification_status` from client profile update validation schemas.
- Reserved status mutation paths strictly for admin schemas and controllers.

Fixes #7112

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security hardening

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings