### PR TITLE
fix(driver): add accessibility Semantics to critical delivery OTP screen flows (#7113)

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -618,9 +618,13 @@ class _GeofenceBadge extends StatelessWidget {
         ? 'You are ${distanceM!.toInt()}m away — Auto-confirm available'
         : 'You are ${distanceM!.toInt()}m away (need <500m for auto-confirm)';
 
-    return GestureDetector(
-      onTap: withinGeofence && !isConfirming ? onAutoConfirm : null,
-      child: AnimatedBuilder(
+    return Semantics(
+      button: true,
+      enabled: withinGeofence && !isConfirming,
+      label: label,
+      child: GestureDetector(
+        onTap: withinGeofence && !isConfirming ? onAutoConfirm : null,
+        child: AnimatedBuilder(
         animation: pulseController,
         builder: (context, child) {
           final opacity =


### PR DESCRIPTION
## Description
`apps/driver/lib/screens/delivery_otp_screen.dart`'s geofence confirmation relied on a naked `GestureDetector` without proper accessibility semantics or button roles, hindering screen reader users (TalkBack/VoiceOver).
gssoc 26
## Changes made:
- Added an explicit `Semantics` widget wrapper with `button: true` and a dynamic descriptive label to the geofence action element.
- Ensured assistive tech can properly identify and trigger primary driver geofence actions.

Fixes #7113

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings