### PR TITLE
fix(did): derive credentialId from CredentialIssued event so verify/revoke work

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -21,7 +21,8 @@ class DIDService {
             'function verifyCredential(bytes32 credentialId) external view returns (bool)',
             'function getDID(string memory did) external view returns (address, string, bool, uint256, uint256)',
             'function getCredential(bytes32 credentialId) external view returns (tuple(bytes32, address, address, string, bytes32, uint256, uint256, bool, bytes32))',
-            'function isDIDActive(string memory did) external view returns (bool)'
+            'function isDIDActive(string memory did) external view returns (bool)',
+            'event CredentialIssued(bytes32 indexed credentialId, address issuer, address subject)'
         ];
 
         this.identityWalletABI = [
@@ -117,13 +118,32 @@ class DIDService {
             );
             const receipt = await tx.wait();
 
-            const blockTimestamp = Math.floor(Date.now() / 1000);
-            const credentialId = ethers.keccak256(
-                ethers.solidityPacked(
-                    ["uint256", "address", "address", "string"],
-                    [blockTimestamp, this.wallet.address, subject, credentialType]
-                )
-            );
+            // Read the exact on-chain credentialId from the CredentialIssued
+            // event so it always matches the contract's own derivation.
+            let credentialId = null;
+            for (const log of receipt.logs) {
+                try {
+                    const parsed = this.didRegistry.interface.parseLog(log);
+                    if (parsed && parsed.name === 'CredentialIssued') {
+                        credentialId = parsed.args[0];
+                        break;
+                    }
+                } catch {
+                    // Not a DIDRegistry log; keep scanning.
+                }
+            }
+
+            if (!credentialId) {
+                // Fallback: reproduce abi.encodePacked(block.timestamp, msg.sender,
+                // subject, credentialType) using the actual block timestamp.
+                const block = await this.provider.getBlock(receipt.blockNumber);
+                credentialId = ethers.keccak256(
+                    ethers.solidityPacked(
+                        ["uint256", "address", "address", "string"],
+                        [block.timestamp, this.wallet.address, subject, credentialType]
+                    )
+                );
+            }
 
             await this.identityWallet.addCredential(credentialId);
 


### PR DESCRIPTION
Fixes #6889

The contract derives credentialId as keccak256(abi.encodePacked(block.timestamp, msg.sender, subject, credentialType)). The backend recomputed it with Math.floor(Date.now()/1000) taken after tx.wait(), which can drift from the on-chain block.timestamp, so the off-chain id never matched the on-chain id and verifyCredential returned empty while revokeCredential reverted with 'Not issuer'.

- Parse the exact credentialId from the CredentialIssued event emitted by DIDRegistry.issueCredential.
- Fall back to reproducing the contract encoding with the receipt block's actual timestamp (provider.getBlock(receipt.blockNumber).timestamp) instead of the wall clock.