### PR TITLE
fix: safely reduce order total amounts with null-checks in admin revenue calculation

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -84,7 +84,7 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
       return res.status(500).json({ error: 'Failed to fetch revenue.' });
     }
     
-    const totalRevenue = todayOrders.reduce((sum, order) => sum + (order.total_amount || 0), 0);
+    const totalRevenue = (todayOrders || []).reduce((sum, order) => sum + (Number(order.total_amount) || 0), 0);
 
     res.json({
       active_drivers: activeDrivers || 0,


### PR DESCRIPTION
## PR Description:
markdown
## Description
`adminRoutes.js`'s dashboard revenue calculation previously reduced `todayOrders` without safeguarding against potential null data arrays or unhandled non-numeric field values.
gssoc 26
Changes made:
- Added `(todayOrders || [])` fallback array protection
- Wrapped `order.total_amount` in `Number()` casting with `|| 0` fallback
- Zero new errors introduced

Fixes #7107

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings