### PR TITLE
fix(cache): use nullish coalescing operator for option defaults in createCacheEvent (#7168)

### DIFF
--- a/backend/api/src/cache/CacheEvent.js
+++ b/backend/api/src/cache/CacheEvent.js
@@ -6,7 +6,7 @@
  * published on the namespace-specific Redis Pub/Sub channel.
  *
  * Event types:
- *   - INVALIDATE_KEY   : delete a single key
+ *   - INVALIDATE_KEY     : delete a single key
  *   - INVALIDATE_PATTERN : delete all keys matching a glob
  *   - INVALIDATE_NAMESPACE : delete all keys in a namespace
  *   - BUMP_VERSION     : increment version counter, invalidating all versioned keys
@@ -43,12 +43,12 @@ export function createCacheEvent(type, opts = {}) {
     id: crypto.randomUUID(),
     type,
     namespace: opts.namespace,
-    key: opts.key || null,
-    pattern: opts.pattern || null,
-    entityId: opts.entityId || null,
-    subKey: opts.subKey || null,
-    originInstanceId: opts.originInstanceId || null,
-    timestamp: opts.timestamp || Date.now(),
+    key: opts.key ?? null,
+    pattern: opts.pattern ?? null,
+    entityId: opts.entityId ?? null,
+    subKey: opts.subKey ?? null,
+    originInstanceId: opts.originInstanceId ?? null,
+    timestamp: opts.timestamp ?? Date.now(),
   };
 }
 


### PR DESCRIPTION
## Description
Replaced the logical OR operator (`||`) with the nullish coalescing operator (`??`) when assigning default values for optional properties in `createCacheEvent`. This ensures explicitly passed valid falsy values (such as `timestamp: 0`) are preserved rather than overridden by fallbacks like `Date.now()`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `npm test`
- **Test Steps / Prerequisites:**
  1. Call `const event = createCacheEvent(CacheEventType.REFRESH, { namespace: 'users', timestamp: 0 });`
  2. Check `event.timestamp`.
  3. Verify `event.timestamp` equals `0` instead of `Date.now()`.
- **Expected Result:** Explicitly provided falsy options are preserved in the returned event object.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`)

## Related Issues
Closes #7168

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.