### PR TITLE
fix(atomic-swap): make redesigned contract compile

### DIFF
--- a/blockchain/contracts/AtomicSwap.sol
+++ b/blockchain/contracts/AtomicSwap.sol
@@ -29,6 +29,8 @@ contract AtomicSwap is ReentrancyGuard {
 
     mapping(bytes32 => Swap) public swaps;
 
+    mapping(bytes32 => bool) public usedHashLocks;
+
     event SwapOpened(bytes32 indexed swapId, address indexed sender, address indexed recipient, uint256 amount, bytes32 hashLock, uint256 lockTime);
     event SwapClaimed(bytes32 indexed swapId, bytes preimage);
     event SwapRefunded(bytes32 indexed swapId);
@@ -87,7 +89,8 @@ contract AtomicSwap is ReentrancyGuard {
 
         emit SwapRefunded(swapId);
     }
-}
+
     function getUserSwaps(address user) external view returns (SwapReference[] memory) {
         return userSwaps[user];
     }
+}


### PR DESCRIPTION
Closes #6891, #6892, #6893

The merged swap redesign already resolved all three issues:
- #6891: userSwaps stores tagged SwapReference{swapId, isCrossChain} entries and swap ids are caller-supplied with a uniqueness check, so regular and cross-chain ids no longer collide.
- #6892: claimSwap is callable by anyone holding the preimage - no counterparty-only execution gate.
- #6893: refundSwap clears usedHashLocks[swap.hashLock], releasing the reservation.

But the merged file did not compile: usedHashLocks was referenced without a declaration and getUserSwaps sat outside the contract body.

- Declare the usedHashLocks mapping.
- Move getUserSwaps back inside the contract.

Verified with solc 0.8.26 (compile clean).