### PR TITLE
fix: batch-4 issue #7182

### DIFF
--- a/backend/smpc/smpc_service.py
+++ b/backend/smpc/smpc_service.py
@@ -195,10 +195,7 @@ class SMPCProtocol:
             raise
 
     def _sum_shares(self, shares: List[Tuple[int, int]]) -> int:
-        total = 0
-        for x, y in shares:
-            total = (total + y) % self.secret_sharing.prime
-        return total
+        return self.secret_sharing.reconstruct_secret(shares)
 
     def secure_aggregate(self, data_list: List[Any], operation: str = 'sum') -> Any:
         try:


### PR DESCRIPTION
## Fix: SMPC compute_sum returns a meaningless number

Closes #7182

**Problem:** Shamir shares are points on a degree `k-1` polynomial whose constant term is the secret. `_sum_shares` just summed the `y`-values, so `compute_sum`/`compute_average` returned garbage (e.g. `108127999706051085452546860716279783028` instead of `42`).

**Fix:** `_sum_shares` now uses the existing `reconstruct_secret` (Lagrange interpolation at x=0), the same correct path already used by `compute_multiplication`.

**Verified:**
- `reconstruct_secret(shares_of_42) == 42`
- `_sum_shares(shares_of_42) == 42`

GSSOC
