### PR TITLE
fix: batch-4 issue #7183

### DIFF
--- a/backend/zkp/zkp.service.js
+++ b/backend/zkp/zkp.service.js
@@ -18,6 +18,7 @@ class ZKPService {
             'function verifySTARK(bytes calldata proof, bytes calldata publicInputs) external view returns (bool)',
             'function createPrivateTransaction(address recipient, uint256 amount, bytes memory encryptedData) external',
             'function getTransaction(bytes32 txId) external view returns (tuple(bytes32,bytes32,address,uint256,uint256,bool))',
+            'function getTransactionCount() external view returns (uint256)',
             'function getMerkleRoot() external view returns (bytes32)',
             'function isNullifierUsed(bytes32 nullifier) external view returns (bool)'
         ];
@@ -175,9 +176,13 @@ class ZKPService {
             );
             const receipt = await tx.wait();
 
-            // Get transaction ID from logs
-            const txId = ethers.keccak256(
-                ethers.toUtf8Bytes(`${Date.now()}:${recipient}:${amount}`)
+            // Reconstruct the on-chain transaction id instead of fabricating one from Date.now()
+            // Contract: txId = keccak256(abi.encodePacked(block.timestamp, transactionCounter))
+            const block = await this.provider.getBlock(receipt.blockNumber);
+            const counter = await this.zkp.getTransactionCount();
+            const txId = ethers.solidityPackedKeccak256(
+                ["uint256", "uint256"],
+                [block.timestamp, counter]
             );
 
             await this.storeTransaction({


### PR DESCRIPTION
## Fix: ZKP service fabricates a txId that never exists on-chain

Closes #7183

**Problem:** `createPrivateTransaction` derived `txId` from `Date.now()`, but `ZKPrivacy.sol` derives it on-chain as `keccak256(abi.encodePacked(block.timestamp, transactionCounter))`. The stored `tx_id` never matched an on-chain transaction, so `getTransaction(txId)` returned an empty struct.

**Fix:** After the receipt is mined, reconstruct the real on-chain id from the receipt block timestamp and `getTransactionCount()` (the counter used by the contract), via `ethers.solidityPackedKeccak256(["uint256","uint256"], [block.timestamp, counter])`. Added `getTransactionCount` to the ABI.

GSSOC
