### PR TITLE
fix: batch-4 issue #7184

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -111,8 +111,10 @@ class HybridCrypto:
             )
             
             # Remove quantum secret from decrypted data
-            # In production: proper separation
-            return decrypted
+            quantum_secret_len = len(quantum_secret)
+            if len(decrypted) < quantum_secret_len:
+                raise ValueError("Decrypted payload is too short to contain the quantum secret")
+            return decrypted[:-quantum_secret_len]
             
         except Exception as e:
             logger.error(f"Hybrid decryption failed: {e}")


### PR DESCRIPTION
## Fix: hybrid_decrypt returns plaintext polluted with the Kyber shared secret

Closes #7184

**Problem:** `hybrid_encrypt` RSA-encrypts `data + quantum_secret`, but `hybrid_decrypt` returned the whole decrypted payload without stripping the appended 32-byte Kyber secret. Every decryption failed the round-trip (e.g. `b'HELLO'` came back as 37 bytes).

**Fix:** `hybrid_decrypt` now strips the trailing quantum shared secret using the actual length of the recovered Kyber secret, with a length sanity check.

GSSOC
