### PR TITLE
feat: export sanitizePrice utility helper in pricing.js

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -17,7 +17,7 @@
 
 import logger from '../middleware/logger.js';
 
-function sanitizePrice(value) {
+export function sanitizePrice(value) {
   const num = Number(value);
   return Number.isFinite(num) && num >= 0 ? Math.round(num) : 0;
 }


### PR DESCRIPTION
## Description
Exported the `sanitizePrice` utility helper function as a named export in `backend/api/src/lib/pricing.js`.
gssoc 26

### Changes Made:
- Added `export` keyword to `sanitizePrice` function definition.
- Allows external modules to perform consistent monetary rounding to non-negative integers (paisa) without duplicating logic.

Fixes #6985

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings