### PR TITLE
fix(security): restrict payments RLS policies to specific roles

### DIFF
--- a/supabase/migrations/20260805000030_create_payments_table.sql
+++ b/supabase/migrations/20260805000030_create_payments_table.sql
@@ -37,12 +37,18 @@ alter table payments enable row level security;
 
 drop policy if exists payments_service_policy on payments;
 create policy payments_service_policy on payments
-  for all using (true) with check (true);
+  for all
+  to service_role
+  using (true) with check (true);
 
 drop policy if exists payments_owner_read_policy on payments;
 create policy payments_owner_read_policy on payments
-  for select using (user_id = get_profile_id());
+  for select
+  to authenticated
+  using (user_id = get_profile_id());
 
 drop policy if exists payments_owner_insert_policy on payments;
 create policy payments_owner_insert_policy on payments
-  for insert with check (user_id = get_profile_id());
+  for insert
+  to authenticated
+  with check (user_id = get_profile_id());


### PR DESCRIPTION
## Description
Updated `supabase/migrations/20260805000030_create_payments_table.sql` to explicitly specify target roles for RLS policies on the `payments` table. Without explicit `TO <role>` clauses, policies default to `PUBLIC`, allowing holders of the public `anon` key full read/write access.
gssoc 26

### Changes Made:
- Added `TO service_role` to `payments_service_policy`.
- Added `TO authenticated` to `payments_owner_read_policy` and `payments_owner_insert_policy`.

Fixes #7145

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue / security patch)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings