### PR TITLE
fix(webrtc): enforce maxPayload limit on WebRTC signaling server

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -6,7 +6,8 @@ import { supabase, redisClient } from '../../config/db.js';
 
 class WebRTCSignalingServer {
   constructor(server) {
-    this.wss = new WebSocketServer({ server, path: '/webrtc' });
+    const MAX_WS_PAYLOAD_BYTES = parseInt(process.env.WS_MAX_PAYLOAD_BYTES, 10) || 4096;
+    this.wss = new WebSocketServer({ server, path: '/webrtc', maxPayload: MAX_WS_PAYLOAD_BYTES });
     this.redis = redisClient;
     this.peers = new Map(); // peerId -> { ws, location, meshId }
     this.meshes = new Map(); // meshId -> Set of peerIds


### PR DESCRIPTION
## Description
Configured `maxPayload` limit on the `WebSocketServer` instance in `backend/api/src/services/webrtc/WebRTCSignalingServer.js` to protect against memory exhaustion (DoS) attacks via unbounded message payloads.
gssoc 26

### Changes Made:
- Added `maxPayload: MAX_WS_PAYLOAD_BYTES` (default `4096` bytes) to `WebSocketServer` configuration matching `sockets/tracker.js`.

Fixes #7147

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue / security patch)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings