### PR TITLE
fix(cache): throw error on invalid non-object input in serializeCacheEvent

### DIFF
--- a/backend/api/src/cache/CacheEvent.js
+++ b/backend/api/src/cache/CacheEvent.js
@@ -98,63 +98,9 @@ export function createCacheEvent(type, opts = {}) {
  * @returns {string}
  */
 export function serializeCacheEvent(event) {
-  return JSON.stringify(event);
-}
-
-/**
- * Deserialize a JSON string back into a cache event object.
- * Returns null if parsing fails.
- *
- * @param {string} json
- * @returns {object|null}
- */
-export function deserializeCacheEvent(json) {
-  try {
-    const event = JSON.parse(json);
-    if (!event || !event.type || !event.namespace) return null;
-    return event;
-  } catch (err) {
-    logger.warn('[CacheEvent] Deserialization failed:', err?.message);
-    return null;
+  if (!event || typeof event !== 'object') {
+    throw new TypeError('Cache event must be a non-null object.');
   }
-}
-
-export default { CacheEventType, createCacheEvent, serializeCacheEvent, deserializeCacheEvent };
-/**
- * Create a cache invalidation event.
- *
- * @param {string} type — one of CacheEventType values
- * @param {object} opts
- * @param {string} opts.namespace — target namespace
- * @param {string} [opts.key] — specific Redis key (for INVALIDATE_KEY)
- * @param {string} [opts.pattern] — glob pattern (for INVALIDATE_PATTERN)
- * @param {string} [opts.entityId] — entity identifier
- * @param {string} [opts.subKey] — sub-entity key
- * @param {string} [opts.originInstanceId] — ID of the instance that originated the event
- * @param {number} [opts.timestamp] — event creation time (auto-set if omitted)
- * @returns {object} serialized event ready for JSON.stringify
- */
-export function createCacheEvent(type, opts = {}) {
-  return {
-    id: crypto.randomUUID(),
-    type,
-    namespace: opts.namespace,
-    key: opts.key || null,
-    pattern: opts.pattern || null,
-    entityId: opts.entityId || null,
-    subKey: opts.subKey || null,
-    originInstanceId: opts.originInstanceId || null,
-    timestamp: opts.timestamp || Date.now(),
-  };
-}
-
-/**
- * Serialize a cache event to a JSON string for Pub/Sub publishing.
- *
- * @param {object} event — as returned by createCacheEvent
- * @returns {string}
- */
-export function serializeCacheEvent(event) {
   return JSON.stringify(event);
 }
 

--- a/backend/api/test/unit/cacheEvent.test.js
+++ b/backend/api/test/unit/cacheEvent.test.js
@@ -202,6 +202,13 @@ describe('serializeCacheEvent', () => {
     expect(roundTrip.pattern).toBe(event.pattern);
     expect(roundTrip.originInstanceId).toBe(event.originInstanceId);
   });
+
+  it('throws TypeError when input is undefined, null, or non-object', () => {
+    expect(() => serializeCacheEvent(undefined)).toThrow(TypeError);
+    expect(() => serializeCacheEvent(null)).toThrow(TypeError);
+    expect(() => serializeCacheEvent('not-an-object')).toThrow(TypeError);
+    expect(() => serializeCacheEvent(123)).toThrow(TypeError);
+  });
 });
 
 describe('deserializeCacheEvent', () => {


### PR DESCRIPTION
## Description
Updated `serializeCacheEvent` in `backend/api/src/cache/CacheEvent.js` to validate that the `event` parameter is a non-null object before attempting serialization with `JSON.stringify`. Passing `undefined` or primitive non-object types now throws a clear `TypeError` instead of returning JavaScript `undefined` or invalid strings that disrupt Redis pub/sub operations.
gssoc 26
### Changes Made:
- Added `!event || typeof event !== 'object'` guard throwing `TypeError` in `serializeCacheEvent`.
- Removed duplicate function declarations from `backend/api/src/cache/CacheEvent.js`.
- Added unit tests in `backend/api/test/unit/cacheEvent.test.js` to verify `TypeError` throwing behavior for `undefined`, `null`, string, and numeric inputs.

Fixes #7214

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings