### PR TITLE
fix(store): prevent double-rollback in GlobalStore transaction catch handler

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -210,7 +210,9 @@ class GlobalStore extends EventEmitter {
                         return res;
                     })
                     .catch(async (error) => {
-                        await transaction.rollback();
+                        if (transaction.isActive) {
+                            await transaction.rollback();
+                        }
                         this.activeTransaction = null;
                         this.transactionHistory.push({
                             id: transaction.id,
@@ -234,7 +236,9 @@ class GlobalStore extends EventEmitter {
             return result;
             
         } catch (error) {
-            await transaction.rollback();
+            if (transaction.isActive) {
+                await transaction.rollback();
+            }
             this.activeTransaction = null;
             this.transactionHistory.push({
                 id: transaction.id,


### PR DESCRIPTION
## Description
When a transaction operation fails inside `StoreTransaction.execute()`, `execute()` rolls back the transaction and rethrows the original error. Subsequently, `GlobalStore.transaction()` caught the rethrown error and unconditionally invoked `await transaction.rollback()`. Because `isActive` was already set to `false` during the first rollback, this threw `Error('Transaction not active')`, masking the original operation error and bypassing `this.activeTransaction = null`.
gssoc 26
### Changes Made:
- Wrapped `transaction.rollback()` calls inside `GlobalStore.transaction()` catch blocks (both async promise rejection and sync try-catch) with `if (transaction.isActive)`.
- Ensures the original error thrown by the operation propagates to the caller.
- Guarantees `this.activeTransaction` is always reset to `null` on failure, preventing stuck transaction states and enabling subsequent transactions.

Fixes #7209

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings