### PR TITLE
fix: batch-5 issue #7197

### DIFF
--- a/backend/layout/LayoutEngine.js
+++ b/backend/layout/LayoutEngine.js
@@ -68,4 +68,9 @@ class LayoutEngine {
         
         // Use microtask for immediate scheduling
         Promise.resolve().then(() => {
-        .catch(err => console.error(err))
+            this.isProcessing = false;
+        }).catch(err => console.error(err));
+    }
+}
+
+export default new LayoutEngine();


### PR DESCRIPTION
## Fix: LayoutEngine module cannot load

Closes #7197

**Problem:** `backend/layout/LayoutEngine.js` ended mid-statement — `scheduleLayout` had an unclosed `.then(() => {` with an orphaned `.catch(...)`, and the class/export were missing. Importing the module threw `SyntaxError: Unexpected token '.'`.

**Fix:** completed `scheduleLayout` (reset `isProcessing` in the microtask), closed the class, and added `export default`.

**Verified:** module now imports past syntax (only a missing `pino` dependency remains, which is unrelated to this file).

GSSOC
