### PR TITLE
fix: batch-5 issue #7199

### DIFF
--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -54,5 +54,19 @@ class StateChannelService {
             });
             const channelId = eventLog
                 ? this.channel.interface.parseLog(eventLog).args[0].toString()
-                : (await this.getUserChannels(participantA).then(ch => {
-                .catch(err => console.error(err))
+                : (await this.getUserChannels(participantA))[0]?.toString() ?? null;
+
+            logger.info(`✅ Channel opened: ${channelId}`);
+            return {
+                success: true,
+                channelId,
+                txHash: receipt.hash
+            };
+        } catch (error) {
+            logger.error('Channel open failed:', error);
+            throw error;
+        }
+    }
+}
+
+export default new StateChannelService();


### PR DESCRIPTION
## Fix: state-channels module cannot load

Closes #7199

**Problem:** `backend/state-channels/channel.service.js` ended mid-statement — `openChannel` had an unclosed `.then(ch => {` with an orphaned `.catch(...)`, and the class/export were missing. Importing the module threw `SyntaxError: Unexpected token '.'`.

**Fix:** completed `openChannel` (parse `ChannelOpened` event for the channel id, fall back to `getUserChannels` first entry), closed the class, and added `export default`.

**Verified:** module now imports past syntax (only a missing `ethers` dependency remains, which is unrelated to this file).

GSSOC
