### PR TITLE
fix: batch-5 issue #7201

### DIFF
--- a/backend/digital-twin/twin_model.py
+++ b/backend/digital-twin/twin_model.py
@@ -167,16 +167,16 @@ class SimulationEngine:
                 if random.random() < 0.1:
                     asset_id = random.choice(list(self.twin.assets.keys()))
                     event_type = random.choice(['pickup', 'dropoff', 'delay', 'arrival'])
-                
-                event = LogisticsEvent(
-                    id=f"sim_{int(datetime.now().timestamp())}_{i}",
-                    type=event_type,
-                    timestamp=datetime.now(),
-                    asset_id=asset_id,
-                    location={'lat': random.uniform(20, 30), 'lng': random.uniform(70, 80)},
-                    metadata={'scenario': scenario_id}
-                )
-                events.append(event)
+
+                    event = LogisticsEvent(
+                        id=f"sim_{int(datetime.now().timestamp())}_{i}",
+                        type=event_type,
+                        timestamp=datetime.now(),
+                        asset_id=asset_id,
+                        location={'lat': random.uniform(20, 30), 'lng': random.uniform(70, 80)},
+                        metadata={'scenario': scenario_id}
+                    )
+                    events.append(event)
         
         # Calculate metrics
         metrics = self._calculate_metrics(events, scenario['params'])


### PR DESCRIPTION
## Fix: digital-twin simulation raises NameError

Closes #7201

**Problem:** In `backend/digital-twin/twin_model.py` the event body used `asset_id`/`event_type` which were only assigned inside the `random.random() < 0.1` branch — so ~90% of simulation iterations raised `NameError`.

**Fix:** moved event selection and construction together inside the random trigger so the fields are always defined before use.

GSSOC
