### PR TITLE
fix: batch-5 issue #7202

### DIFF
--- a/backend/voice/services/voice_ai_service.py
+++ b/backend/voice/services/voice_ai_service.py
@@ -321,7 +321,7 @@ class VoiceAIService:
                 'timestamp': datetime.now().isoformat()
             })
             
-            self.increment_language_usage(detection)
+            self.increment_language_usage(detection['language_code'])
             return {
                 'success': True,
                 'detected_language': detection,


### PR DESCRIPTION
## Fix: voice language usage stats always 0

Closes #7202

**Problem:** `voice_ai_service.py` called `increment_language_usage(detection)` with the whole `detect_language()` dict, so the redis key became `voice:stats:{'language_code': ...}` (dict repr) while `get_language_stats` reads real language codes — every count stayed 0.

**Fix:** pass `detection['language_code']`.

GSSOC
