### PR TITLE
fix: batch-5 issue #7203

### DIFF
--- a/backend/traceability/trace.service.js
+++ b/backend/traceability/trace.service.js
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { v4 as uuidv4 } from 'uuid';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
 
@@ -18,7 +17,8 @@ class TraceabilityService {
             'function getProduct(uint256 productId) external view returns (tuple(uint256,string,string,string,address,uint256,uint256,bool,string,bytes32))',
             'function getShipment(uint256 shipmentId) external view returns (tuple(uint256,uint256,address,address,uint256,uint256,string,string,bytes32,bool))',
             'function getProductEvents(uint256 productId) external view returns (tuple(uint256,uint256,uint256,string,string,string,address,uint256,bytes32)[])',
-            'function getProductTrace(uint256 productId) external view returns (tuple(uint256,string,string,string,address,uint256,uint256,bool,string,bytes32), tuple(uint256,uint256,uint256,string,string,string,address,uint256,bytes32)[], tuple(uint256,uint256,address,uint256,bool,string,bytes32)[])'
+            'function getProductTrace(uint256 productId) external view returns (tuple(uint256,string,string,string,address,uint256,uint256,bool,string,bytes32), tuple(uint256,uint256,uint256,string,string,string,address,uint256,bytes32)[], tuple(uint256,uint256,address,uint256,bool,string,bytes32)[])',
+            'event ProductCreated(uint256 indexed productId, string name, address indexed manufacturer)'
         ];
 
         this.contract = new ethers.Contract(this.contractAddress, this.contractABI, this.wallet);
@@ -34,15 +34,6 @@ class TraceabilityService {
                 ethers.toUtf8Bytes(JSON.stringify(productData))
             );
 
-            const productId = uuidv4();
-
-            await this.storeProduct({
-                ...productData,
-                productId,
-                productHash,
-                txHash: ''
-            });
-
             const tx = await this.contract.createProduct(
                 productData.name,
                 productData.description || '',
@@ -53,11 +44,15 @@ class TraceabilityService {
             );
             const receipt = await tx.wait();
 
-            const { error } = await supabase
-                .from('trace_products')
-                .update({ tx_hash: receipt.hash })
-                .eq('product_id', productId);
-            if (error) logger.error('Failed to update txHash:', error);
+            // Use the on-chain productId emitted by ProductCreated instead of fabricating a uuid
+            const productId = this._parseProductCreated(receipt);
+
+            await this.storeProduct({
+                ...productData,
+                productId,
+                productHash,
+                txHash: receipt.hash
+            });
 
             logger.info(`✅ Product created: ${productId}`);
             return {
@@ -70,6 +65,20 @@ class TraceabilityService {
             logger.error('Product creation failed:', error);
             throw error;
         }
+    }
+
+    _parseProductCreated(receipt) {
+        for (const log of receipt.logs) {
+            try {
+                const parsed = this.contract.interface.parseLog(log);
+                if (parsed && parsed.name === 'ProductCreated') {
+                    return parsed.args[0].toString();
+                }
+            } catch (e) {
+                continue;
+            }
+        }
+        throw new Error('ProductCreated event not found in receipt');
     }
 
     // ============ Shipment Management ============


### PR DESCRIPTION
## Fix: traceability products stored under a fabricated id that never exists on-chain

Closes #7203

**Problem:** `createProduct` stored the DB row under a client-side `uuidv4()` while `SupplyChain.sol` derives the id on-chain (`_productCounter`) and emits `ProductCreated(productId, ...)`. All later contract calls (`createShipment`, `getProduct`, `verifyProduct`, `addCustomEvent`) take `uint256 productId`, so the UUID caused reverts/empty results.

**Fix:** call the contract first, parse the `ProductCreated` event from the receipt (event added to the ABI), and store/return the real on-chain id. Removed the now-unused `uuid` import.

GSSOC
