### PR TITLE
fix(middleware): replace window global with module-scoped timer in idempotency middleware

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -16,7 +16,7 @@ const EVICTION_BATCH_SIZE = Math.floor(MAX_IN_MEMORY_ENTRIES * 0.1); // evict 10
 // default 120s gives a comfortable margin. Overridable per deployment.
 const LOCK_TTL_MS = Number(process.env.IDEMPOTENCY_LOCK_TTL_MS) || 120_000;
 
-const cleanupTimer = clearInterval(window.__interval); window.__interval = setInterval(() => {
+let cleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of inMemoryStore) {
     if (entry.expiresAt <= now) {


### PR DESCRIPTION
## Description
`backend/api/src/middleware/idempotency.js` attempted to clean up and set `window.__interval` at top-level module load. Since `window` is a browser-only global and unavailable in Node.js, importing this middleware threw a `ReferenceError: window is not defined` and prevented the API server from starting up.
gssoc 26
### Changes Made:
- Removed `window.__interval` reference.
- Replaced timer initialization with a standard module-scoped `cleanupTimer`.

Fixes #7192

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] Server boots up without throwing ReferenceError on module load
- [x] Performed self-review of changes