### PR TITLE
fix: batch-5 issue #7204

### DIFF
--- a/backend/dao/dao.service.js
+++ b/backend/dao/dao.service.js
@@ -17,7 +17,7 @@ class DAOService {
             'function castVote(uint256 proposalId, bool support) external',
             'function executeProposal(uint256 proposalId) external',
             'function treasuryProposal(address recipient, uint256 amount, string memory reason) external returns (uint256)',
-            'function getProposal(uint256 proposalId) external view returns (tuple(uint256,address,string,string,bytes,address,uint256,uint256,uint256,uint256,uint256,bool,bool,uint8,uint8))',
+            'function getProposal(uint256 proposalId) external view returns (tuple(uint256,address,string,string,bytes,address,uint256,uint256,uint256,uint256,uint256,uint256,bool,bool,uint8,uint8))',
             'function getMember(address member) external view returns (tuple(address,uint256,uint256,bool,uint256,uint256))',
             'function getTotalProposals() external view returns (uint256)',
             'function getTotalMembers() external view returns (uint256)',


### PR DESCRIPTION
## Fix: DAO getProposal cannot decode the on-chain Proposal struct

Closes #7204

**Problem:** The `getProposal` ABI tuple (15 fields) was missing `uint256 abstainVotes` — the contract's `Proposal` struct has 16 fields (`DAO.sol` lines 15-32). ethers v6 fails to decode a 16-slot struct against a 15-field tuple, so every `getProposal` call threw and the DAO service returned `null` for every proposal.

**Fix:** added the missing `uint256` (abstainVotes) to the ABI tuple.

GSSOC
