### PR TITLE
fix: batch-5 issue #7206

### DIFF
--- a/backend/eventsourcing/divergence_detector.js
+++ b/backend/eventsourcing/divergence_detector.js
@@ -10,8 +10,8 @@ export class DivergenceDetector {
   processIncomingFrame(driverId, sequenceNumber, payload) {
     const lastSeq = this.driverSequences.get(driverId) || 0;
 
-    if (sequenceNumber !== lastSeq + 1) {
-      // Divergence detected (gap or out-of-order frame)
+    if (sequenceNumber > lastSeq && sequenceNumber !== lastSeq + 1) {
+      // Divergence detected (gap in the sequence)
       const divergenceEvent = {
         driverId,
         expectedSeq: lastSeq + 1,
@@ -23,7 +23,8 @@ export class DivergenceDetector {
       console.warn(`[DivergenceDetector] Gap detected for ${driverId}: expected ${lastSeq + 1}, got ${sequenceNumber}`);
     }
 
-    this.driverSequences.set(driverId, sequenceNumber);
+    // Never regress the watermark on out-of-order or duplicate frames
+    this.driverSequences.set(driverId, Math.max(lastSeq, sequenceNumber));
     return {
       driverId,
       isDivergent: sequenceNumber !== lastSeq + 1,


### PR DESCRIPTION
## Fix: divergence detector never recovers after an out-of-order frame

Closes #7206

**Problem:** `DivergenceDetector` unconditionally overwrote the watermark, so an out-of-order frame (e.g. `1,3,2,4`) regressed it and every subsequent frame was flagged divergent (plus spurious negative gaps on duplicates).

**Fix:** only log a gap when the frame is ahead of the watermark, and never regress it (`Math.max(lastSeq, sequenceNumber)`).

**Verified:** with frames `1,3,2,4,5` only 1 divergence is logged (the real gap at 3) and the watermark reaches 5.

GSSOC
