### PR TITLE
fix(tracker): use validated sanitized.bearing instead of undefined sanitized.heading

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -896,7 +896,7 @@ export async function handleLocationPing(ws, data, req) {
     coordinates: [sanitized.lng, sanitized.lat]
   },
   speed_kmh: sanitized.speed ?? 0,
-  bearing_deg: sanitized.heading ?? 0,
+  bearing_deg: sanitized.bearing ?? 0,
     timestamp: deviceTime || new Date(),
     pinged_at: deviceTime || new Date(),
     buffered_at: new Date(),
@@ -916,7 +916,7 @@ export async function handleLocationPing(ws, data, req) {
       const redisKey = `driver:location:${driver_id}`;
       await redisClient.set(
         redisKey,
-        JSON.stringify({ latitude: sanitized.lat, longitude: sanitized.lng, speed: sanitized.speed ?? 0, bearing: sanitized.heading ?? 0, updated_at: new Date(serverNow) }),
+        JSON.stringify({ latitude: sanitized.lat, longitude: sanitized.lng, speed: sanitized.speed ?? 0, bearing: sanitized.bearing ?? 0, updated_at: new Date(serverNow) }),
         'EX',
         120
       );
@@ -936,7 +936,7 @@ export async function handleLocationPing(ws, data, req) {
       lat,
       lng,
       speed: speed || 0,
-      heading: bearing || 0,
+      heading: sanitized.bearing ?? 0,
       timestamp: deviceTime || new Date(serverNow),
       metadata: {
         order_id: orderUUID || null,
@@ -956,7 +956,7 @@ export async function handleLocationPing(ws, data, req) {
       latitude: sanitized.lat,
       longitude: sanitized.lng,
       speed: sanitized.speed ?? 0,
-      bearing: sanitized.heading ?? 0,
+      bearing: sanitized.bearing ?? 0,
       timestamp: new Date(serverNow)
     }
   });


### PR DESCRIPTION
## Description
In `backend/api/src/sockets/tracker.js`, telemetry validation defines the key as `bearing` in `TELEMETRY_SCHEMA`. However, downstream caching, buffering, and WebSocket broadcast routines were reading `sanitized.heading`, which was always `undefined` and defaulted to `0`. Additionally, the MongoDB `GpsLog` entry referenced the unvalidated raw `bearing` field.
gssoc 26
### Changes Made:
- Replaced all references to `sanitized.heading` with `sanitized.bearing` across buffered telemetry, Redis driver cache (`driver:location:*`), and WebSocket `location_update` events.
- Updated MongoDB `GpsLog` creation to use `sanitized.bearing ?? 0` instead of raw client `bearing`.

Fixes #7216

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] Performed self-review of changes
- [x] Telemetry bearing values correctly persist and broadcast