### PR TITLE
fix: batch-5 issue #7207

### DIFF
--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -51,7 +51,7 @@ const ORDER_STATUS_TO_DB = {
     IN_TRANSIT: 'in_transit',
     COMPLETED: 'delivered',
     CANCELLED: 'cancelled',
-    DISPUTED: 'cancelled',
+    DISPUTED: 'disputed',
 };
 
 function toDbStatus(status) {


### PR DESCRIPTION
## Fix: order DISPUTED status is lost (mapped to 'cancelled')

Closes #7207

**Problem:** `ORDER_STATUS_TO_DB` mapped `DISPUTED: 'cancelled'`, so disputes were persisted as cancelled and the GraphQL `OrderStatus.DISPUTED` value could never be stored or queried — disputed orders were indistinguishable from cancelled ones.

**Fix:** map `DISPUTED` to its own DB status `'disputed'`.

GSSOC
