### PR TITLE
fix: batch-5 issue #7208

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -414,7 +414,7 @@ async def predict_demand_endpoint(input: DemandForecastInput, _auth=Depends(veri
     features = [
         input.hour,
         input.day_of_week,
-        1 if input.day_of_week >= 5 else 0,
+        1 if input.day_of_week in (0, 6) else 0,
         input.temperature,
         input.precipitation,
         input.historical_volume,


### PR DESCRIPTION
## Fix: demand-forecast weekend feature mislabels Friday/Sunday

Closes #7208

**Problem:** `DemandForecastInput.day_of_week` is documented `0=Sunday, 6=Saturday`, but the weekend feature was computed as `day_of_week >= 5` — marking Friday (5) as the weekend while excluding Sunday (0).

**Fix:** weekend is now `day_of_week in (0, 6)`, matching the documented convention.

GSSOC
