### PR TITLE
fix(ml): classify Sunday and Saturday as weekend in demand forecast

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -414,7 +414,7 @@ async def predict_demand_endpoint(input: DemandForecastInput, _auth=Depends(veri
     features = [
         input.hour,
         input.day_of_week,
-        1 if input.day_of_week >= 5 else 0,
+        1 if input.day_of_week in (0, 6) else 0,
         input.temperature,
         input.precipitation,
         input.historical_volume,


### PR DESCRIPTION
## Description
In `backend/ml/main.py`, the `DemandForecastInput.day_of_week` schema defines `0=Sunday, 6=Saturday`. However, the weekend feature calculation used `1 if input.day_of_week >= 5 else 0`, which incorrectly categorized Friday (5) as a weekend day while excluding Sunday (0).
gssoc 26
### Changes Made:
- Updated the weekend feature calculation to `1 if input.day_of_week in (0, 6) else 0`.
- Aligned weekend feature logic with the documented `0=Sunday` convention across demand forecasting predictions.

Fixes #7208

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] Performed self-review of changes