### PR TITLE
fix: batch-5 issue #7209

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -183,7 +183,7 @@ class GlobalStore extends EventEmitter {
     
     // ============ Transaction Support ============
     
-    transaction(fn) {
+    async transaction(fn) {
         if (this.activeTransaction) {
             throw new Error('Nested transactions not supported');
         }
@@ -210,7 +210,9 @@ class GlobalStore extends EventEmitter {
                         return res;
                     })
                     .catch(async (error) => {
-                        await transaction.rollback();
+                        if (transaction.isActive) {
+                            await transaction.rollback();
+                        }
                         this.activeTransaction = null;
                         this.transactionHistory.push({
                             id: transaction.id,
@@ -234,7 +236,9 @@ class GlobalStore extends EventEmitter {
             return result;
             
         } catch (error) {
-            await transaction.rollback();
+            if (transaction.isActive) {
+                await transaction.rollback();
+            }
             this.activeTransaction = null;
             this.transactionHistory.push({
                 id: transaction.id,


### PR DESCRIPTION
## Fix: GlobalStore double-rollback masks errors and leaves a stuck transaction

Closes #7209

**Problem:** `StoreTransaction.execute()` rolls back then rethrows on failure, but `GlobalStore.transaction()`'s catch handlers rolled back again — throwing `Transaction not active`, masking the real error and leaving `activeTransaction` set (so every later `transaction()` failed with `Nested transactions not supported`). The method was also non-async while using `await`, a latent syntax error.

**Fix:** make `transaction()` async, and only roll back in the catch handlers when the transaction is still active.

**Verified:** a failing operation now propagates the original error (`boom`), and a subsequent `transaction()` succeeds — the store no longer gets stuck.

GSSOC
