### PR TITLE
fix : replace browser window global with module variable in idempotency middleware

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -16,7 +16,8 @@ const EVICTION_BATCH_SIZE = Math.floor(MAX_IN_MEMORY_ENTRIES * 0.1); // evict 10
 // default 120s gives a comfortable margin. Overridable per deployment.
 const LOCK_TTL_MS = Number(process.env.IDEMPOTENCY_LOCK_TTL_MS) || 120_000;
 
-const cleanupTimer = clearInterval(window.__interval); window.__interval = setInterval(() => {
+// Module-level interval ID to avoid browser globals in Node.js environment.
+const _cleanupIntervalId = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of inMemoryStore) {
     if (entry.expiresAt <= now) {
@@ -25,7 +26,7 @@ const cleanupTimer = clearInterval(window.__interval); window.__interval = setIn
   }
 }, CLEANUP_INTERVAL_MS);
 
-cleanupTimer.unref();
+_cleanupIntervalId.unref();
 
 function getFromMemory(key) {
   const entry = inMemoryStore.get(key);


### PR DESCRIPTION
Closes #7221.

Summary of What Has Been Done:
Replaced the browser-specific window.__interval global with a module-level const _cleanupIntervalId in idempotency.js. This fixes the ReferenceError that occurs at module load time in Node.js environments.

Changes Made:
- backend/api/src/middleware/idempotency.js: Replaced window.__interval with module-level _cleanupIntervalId variable, preserving the same cleanup interval behavior.

Impact it Made:
- Fixes the ReferenceError that prevents server boot in Node.js
- Makes the idempotency middleware work correctly in server-side context

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.