### PR TITLE
fix : reset DLQ event status to pending on retryable failure in dlqService

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -123,11 +123,12 @@ export const dlqService = {
               .eq('id', event.id);
             logger.warn(`[DLQ] Event ${event.id} marked as failed_permanently`);
           } else {
-            // Schedule next retry
+            // Schedule next retry by resetting status to pending so the event can be re-claimed.
             const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
             await dlqDb()
               .from('webhook_failures')
-              .update({ 
+              .update({
+                status: 'pending',
                 retry_count: newRetryCount,
                 next_retry_at: nextRetryAt,
                 error_message: String(procErr.message || procErr).slice(0, 1000),


### PR DESCRIPTION
Closes #7225.

Summary of What Has Been Done:
When a DLQ event retry fails with a retryable error, dlqService now resets the event status to 'pending' so it can be re-claimed and retried. Previously the event remained stuck at status='processing', making the exponential backoff retry mechanism dead code.

Changes Made:
- backend/api/src/services/webhook/dlqService.js: Added status: 'pending' to the update object in the retryable failure branch.

Impact it Made:
- Fixes the dead retry path where events are claimed but never retried
- Makes the exponential backoff retry mechanism functional
- Prevents events from being permanently lost after a single failed attempt

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.