### PR TITLE
test : add unit tests for sendDeliveryOtpNotification in notificationService

### DIFF
--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import notificationService from '../../src/services/notificationService.js';
+import notificationService, { sendDeliveryOtpNotification } from '../../src/services/notificationService.js';
 import DomainError from '../../src/errors/DomainError.js';
 
 describe('notificationService allowlist validation', () => {
@@ -19,5 +19,28 @@ describe('notificationService allowlist validation', () => {
       // Will attempt supabase call, which might fail or resolve depending on mock, but won't throw DomainError
       await expect(notificationService.sendPushNotification(payload)).resolves.toBeDefined();
     }
+  });
+});
+
+describe('sendDeliveryOtpNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should be defined and callable with valid arguments', async () => {
+    const customerId = 'cust-123';
+    const orderDisplayId = 'ORD-001';
+    const otp = '123456';
+
+    // The function should not throw when called with valid arguments.
+    // It may resolve to an object or throw if external calls fail,
+    // but it should be callable without TypeErrors.
+    await expect(sendDeliveryOtpNotification(customerId, orderDisplayId, otp)).resolves.toBeDefined();
+  });
+
+  it('should accept string customerId and numeric OTP', async () => {
+    await expect(
+      sendDeliveryOtpNotification('user-abc', 'ORD-999', 654321)
+    ).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
Closes #7229.

Summary of What Has Been Done:
Added unit tests for the sendDeliveryOtpNotification function in notificationService.js. Added a test import for the function, a describe block covering basic call-with-valid-arguments scenarios, and two it() cases: one with string customerId and numeric OTP, one with string args.

Changes Made:
- backend/api/test/unit/notificationService.test.js: Added sendDeliveryOtpNotification import and test cases.

Impact it Made:
- Increases test coverage for the notification service
- Ensures sendDeliveryOtpNotification is callable with valid arguments without TypeErrors

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.