### PR TITLE
test : add edge-case tests for predictPrice in ml service

### DIFF
--- a/backend/api/test/unit/ml.test.js
+++ b/backend/api/test/unit/ml.test.js
@@ -360,6 +360,41 @@ describe('ml service — predictPrice', () => {
     expect(result.estimated_price).toBe(3000);
     expect(result.currency).toBe('INR');
   });
+
+  it('rejects response where estimated_price is a string', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ estimated_price: 'five thousand', currency: 'INR' })),
+    });
+
+    await expect(predictPrice({ distanceKm: 100, cargoWeightKg: 500 }))
+      .rejects
+      .toThrow('[ML] Invalid prediction');
+  });
+
+  it('rejects response with invalid currency code', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ estimated_price: 3000, currency: 'EUR' })),
+    });
+
+    await expect(predictPrice({ distanceKm: 100, cargoWeightKg: 500 }))
+      .rejects
+      .toThrow('[ML] Invalid prediction');
+  });
+
+  it('uses default truck type medium_truck when undefined is passed explicitly', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ estimated_price: 3000, currency: 'INR' })),
+    });
+
+    await predictPrice({ distanceKm: 50, cargoWeightKg: 200, truckType: undefined });
+
+    const [, opts] = mockFetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.truck_type).toBe('medium_truck');
+  });
 });
 
 describe('ml service — predictEta', () => {


### PR DESCRIPTION
Closes #7233.

Summary of What Has Been Done:
Added three additional edge-case tests to the predictPrice describe block in ml.test.js: rejects string estimated_price, rejects invalid currency code, and verifies default truckType behavior when undefined is passed explicitly.

Changes Made:
- backend/api/test/unit/ml.test.js: Added 3 new it() cases for edge-case predictPrice scenarios.

Impact it Made:
- Increases test coverage for the ML price prediction service
- Catches additional malformed ML engine responses at the unit-test level

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.