### PR TITLE
fix(devices): prevent false-positive validation when metadata contains error key (#7260)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -17,16 +17,23 @@ function validatePlatform(platform) {
   return VALID_PLATFORMS.includes(platform) ? null : `Platform must be one of: ${VALID_PLATFORMS.join(', ')}`;
 }
 
+/**
+ * Normalizes and validates metadata payload.
+ * Returns an explicit result structure so user payload keys (e.g. { error: "..." }) 
+ * are not confused with validation failures.
+ */
 function normalizeMetadata(metadata) {
-  if (metadata === undefined || metadata === null) return {};
+  if (metadata === undefined || metadata === null) {
+    return { data: {}, error: null };
+  }
   if (typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return { error: 'metadata must be an object' };
+    return { data: null, error: 'metadata must be an object' };
   }
   const prototype = Object.getPrototypeOf(metadata);
   if (prototype !== Object.prototype && prototype !== null) {
-    return { error: 'metadata must be an object' };
+    return { data: null, error: 'metadata must be an object' };
   }
-  return metadata;
+  return { data: metadata, error: null };
 }
 
 /**
@@ -56,9 +63,11 @@ export async function registerDeviceToken(req, res, next) {
       return next(new ValidationError(platErr));
     }
 
-    const normalizedMetadata = normalizeMetadata(metadata);
-    if (normalizedMetadata.error) {
-      return res.status(400).json({ error: normalizedMetadata.error });
+    const { data: normalizedMetadata, error: metadataErr } = normalizeMetadata(metadata);
+    if (metadataErr) {
+      return res.status(400).json(
+        errorResponse('VALIDATION_ERROR', metadataErr)
+      );
     }
 
     const tokenUpdatedAt = new Date().toISOString();


### PR DESCRIPTION
## Description
Refactored the `normalizeMetadata` helper function in the device controller to return an explicit `{ data, error }` result object instead of returning the raw metadata object directly. 

Previously, checking `if (normalizedMetadata.error)` caused valid incoming payloads containing an `"error"` key (e.g. `{ "metadata": { "error": "Location permission denied" } }`) to be mistaken for validation failures and rejected with a `400 Bad Request`. The updated check destructures `metadataErr` explicitly from the validation helper, ensuring user payload data is preserved.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:**
  `npm test`
- **Test Steps / Prerequisites:**
  1. Authenticate a session and issue a `POST /devices/register` request.
  2. Send a valid body containing metadata with an `error` key:
     ```json
     {
       "fcmToken": "valid_fcm_token_1234567890",
       "platform": "android",
       "metadata": { "error": "Permission denied" }
     }
     ```
- **Expected Result:**
  Request returns `200 OK` with `{ "success": true, "message": "Device token registered" }` and stores `{ "error": "Permission denied" }` inside `user_devices.metadata`.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7260

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.