### PR TITLE
fix : use nullish coalescing instead of logical OR in createCacheEvent

### DIFF
--- a/backend/api/src/cache/CacheEvent.js
+++ b/backend/api/src/cache/CacheEvent.js
@@ -43,12 +43,12 @@ export function createCacheEvent(type, opts = {}) {
     id: crypto.randomUUID(),
     type,
     namespace: opts.namespace,
-    key: opts.key || null,
-    pattern: opts.pattern || null,
-    entityId: opts.entityId || null,
-    subKey: opts.subKey || null,
-    originInstanceId: opts.originInstanceId || null,
-    timestamp: opts.timestamp || Date.now(),
+    key: opts.key ?? null,
+    pattern: opts.pattern ?? null,
+    entityId: opts.entityId ?? null,
+    subKey: opts.subKey ?? null,
+    originInstanceId: opts.originInstanceId ?? null,
+    timestamp: opts.timestamp ?? Date.now(),
   };
 }
 


### PR DESCRIPTION
Closes #7220.

Summary of What Has Been Done:
Replaced logical OR (||) with nullish coalescing (??) for optional fields in createCacheEvent. This ensures that falsy values like 0, false, or empty string are preserved, while null/undefined are defaulted to null.

Changes Made:
- backend/api/src/cache/CacheEvent.js: Changed opts.key || null to opts.key ?? null (and same for pattern, entityId, subKey, originInstanceId, timestamp).

Impact it Made:
- Fixes a subtle bug where legitimate falsy values (0, false, '') would be incorrectly replaced with null
- Makes createCacheEvent consistent with other null-safety improvements in the codebase

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.