### PR TITLE
fix : make rollback idempotent in GlobalStore transaction

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -78,7 +78,7 @@ class StoreTransaction {
     
     async rollback() {
         if (!this.isActive) {
-            throw new Error('Transaction not active');
+            return { id: this.id, duration: 0, error: 'already rolled back' };
         }
         
         if (this.snapshot) {


### PR DESCRIPTION
Closes #7224.

Summary of What Has Been Done:
Changed StoreTransaction.rollback() to return early (instead of throwing) when called on an already-inactive transaction. This makes rollback() idempotent and prevents error masking when GlobalStore.transaction() catches an execute() error.

Changes Made:
- backend/store/GlobalStore.js: Changed rollback() to return a diagnostic object when isActive is false, instead of throwing Error('Transaction not active').

Impact it Made:
- Fixes error masking where callers see 'Transaction not active' instead of the real operation error
- Makes rollback() safe to call multiple times

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.