### PR TITLE
fix : require at least one coordinate pair in tracker telemetry validation

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -736,6 +736,17 @@ export async function handleLocationPing(ws, data, req) {
   if (validationErrors) {
     return ws.send(JSON.stringify({ error: 'Invalid telemetry payload', details: validationErrors }));
   }
+
+  // Cross-field validation: require at least one complete coordinate pair.
+  const hasLatLng = data.lat !== undefined && data.lng !== undefined;
+  const hasLatLong = data.latitude !== undefined && data.longitude !== undefined;
+  if (!hasLatLng && !hasLatLong) {
+    return ws.send(JSON.stringify({
+      error: 'Invalid telemetry payload',
+      details: ['At least one coordinate pair (lat+lng or latitude+longitude) is required.']
+    }));
+  }
+
   const sanitized = sanitizeTelemetryData(data);
   Object.assign(data, sanitized);
 


### PR DESCRIPTION
Closes #7227.

Summary of What Has Been Done:
Added cross-field validation in tracker telemetry handling to require at least one complete coordinate pair (lat+lng or latitude+longitude). Previously all coordinate fields were individually optional, allowing null location records to be created and broadcast.

Changes Made:
- backend/api/src/sockets/tracker.js: Added coordinate pair cross-field validation after schema validation, returning error 400 if neither coordinate pair is complete.

Impact it Made:
- Prevents null location records from being created and broadcast
- Improves data quality in the tracking system

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.