### PR TITLE
fix: remove duplicate PriorityNames export

### DIFF
--- a/backend/scheduler/RenderScheduler.js
+++ b/backend/scheduler/RenderScheduler.js
@@ -487,4 +487,3 @@ class RenderScheduler extends EventEmitter {
 }
 
 export default RenderScheduler;
-export { Priority, PriorityNames };


### PR DESCRIPTION
## Description

This PR fixes an ES module export issue in `RenderScheduler.js` that prevented the module from being imported successfully.

### Changes made
- Removed the duplicate named export of `PriorityNames`.
- Kept `Priority` and `PriorityNames` exported via their original `export const` declarations.
- Retained `RenderScheduler` as the default export.
- Resolved the `SyntaxError: Duplicate export of 'PriorityNames'` caused by exporting the same binding twice.

---

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

---

## How Has This Been Tested?

**Test Commands:**
- No automated tests were run.

**Test Steps / Prerequisites:**
1. Import `backend/scheduler/RenderScheduler.js` as an ES module.
2. Verify the module loads successfully without syntax errors.
3. Confirm `Priority`, `PriorityNames`, and the default `RenderScheduler` export remain accessible.

**Expected Result:**
- The module imports successfully without `Duplicate export of 'PriorityNames'`.
- Existing exports remain available and function as expected.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

---

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/7286

---

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.