### PR TITLE
fix: return 404 when device token is not found

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -153,15 +153,23 @@ export async function unregisterDeviceToken(req, res, next) {
       });
     }
 
-    const { error: deleteError } = await supabase
+    const { data: deletedRows, error: deleteError } = await supabase
       .from('user_devices')
       .delete()
       .eq('user_id', userId)
-      .eq('fcm_token', fcmToken);
+      .eq('fcm_token', fcmToken)
+      .select('id');
 
     if (deleteError) {
       logger.error('[DeviceController] Failed to remove device token from database:', deleteError.message);
       return next(new AppError('Failed to unregister device', 500));
+    }
+
+    if (!deletedRows || deletedRows.length === 0) {
+      return res.status(404).json({
+        success: false,
+        error: 'Device token not found for this user'
+      });
     }
 
     const { error: profileClearError } = await supabase


### PR DESCRIPTION
## Description

This PR fixes the device unregistration endpoint to accurately report whether a device token was removed.

### Changes made
- Updated the delete operation to return the deleted row(s) using `.select('id')`.
- Added a check to verify whether any device token was actually deleted.
- Return **404 Not Found** when the specified device token does not exist for the authenticated user.
- Preserve the existing success response when a device token is successfully removed.
- Prevent the API from returning misleading success responses when no database changes occur.

---

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

---

## How Has This Been Tested?

**Test Commands:**
- No automated tests were run.

**Test Steps / Prerequisites:**
1. Register a valid device token for a user.
2. Call the unregister endpoint with the registered token and verify a successful response.
3. Call the unregister endpoint again with the same token (or a token that does not belong to the user).
4. Verify the endpoint returns **404 Not Found** instead of a misleading success response.

**Expected Result:**
- Existing device tokens are successfully removed and return `200 OK`.
- Requests for non-existent device tokens return `404 Not Found`.
- The API accurately reflects whether a device token was actually removed.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

---

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/7268

---

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.