### PR TITLE
fix: update FCM token regex to allow v1 characters (#7266)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -8,7 +8,8 @@ const VALID_PLATFORMS = ['android', 'ios', 'web'];
 function validateFcmToken(token) {
   if (!token || typeof token !== 'string') return 'fcmToken must be a non-empty string';
   if (token.length < 10 || token.length > 4096) return 'fcmToken length must be between 10 and 4096';
-  if (!/^[a-zA-Z0-9\-_:]+$/.test(token)) return 'fcmToken contains invalid characters';
+  // Allow standard FCM v1 token characters including ., %, /, +, =
+  if (!/^[a-zA-Z0-9\-_:.%/+=]+$/.test(token)) return 'fcmToken contains invalid characters';
   return null;
 }
 


### PR DESCRIPTION
## Fix #7266

FCM token validation regex was rejecting valid FCM v1 tokens containing `.`, `%`, `/`, `+`, or `=`.

**Fix**: Updated regex to allow standard FCM v1 token characters.