### PR TITLE
fix: return 404 when unregisterDeviceToken deletes 0 rows (#7268)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -147,6 +147,14 @@ export async function unregisterDeviceToken(req, res, next) {
       return next(new AppError('Failed to unregister device', 500));
     }
 
+    // If no rows were deleted, the token was not registered for this user
+    if (!deletedRows || deletedRows.length === 0) {
+      return res.status(404).json({
+        success: false,
+        error: 'Device token not found'
+      });
+    }
+
     // Query remaining device tokens for this user to fallback
     const { data: remainingDevice, error: remainingError } = await supabase
       .from('user_devices')

--- a/backend/api/test/unit/deviceController.test.js
+++ b/backend/api/test/unit/deviceController.test.js
@@ -16,7 +16,7 @@ vi.mock('../../src/middleware/logger.js', () => ({
   },
 }));
 
-const { registerDeviceToken } = await import('../../src/controllers/deviceController.js');
+const { registerDeviceToken, unregisterDeviceToken } = await import('../../src/controllers/deviceController.js');
 
 function makeResponse() {
   return {
@@ -100,5 +100,51 @@ describe('registerDeviceToken', () => {
       }),
     );
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('unregisterDeviceToken', () => {
+  beforeEach(() => {
+    supabaseMock.reset();
+  });
+
+  it('returns 404 when the device token is not registered for the user', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      body: { fcmToken: 'valid_token_12345' },
+    };
+    const res = makeResponse();
+    const next = vi.fn();
+
+    await unregisterDeviceToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Device token not found',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('deletes the token and returns success when a matching row exists', async () => {
+    supabaseMock.store.user_devices = [
+      { id: 'row-1', user_id: 'user-1', fcm_token: 'valid_token_12345' },
+    ];
+
+    const req = {
+      user: { id: 'user-1' },
+      body: { fcmToken: 'valid_token_12345' },
+    };
+    const res = makeResponse();
+    const next = vi.fn();
+
+    await unregisterDeviceToken(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Device token unregistered',
+    });
+    expect(supabaseMock.calls.some((call) => call.table === 'user_devices' && call.mode === 'delete')).toBe(true);
   });
 });


### PR DESCRIPTION
## Fix #7268

`unregisterDeviceToken` returns 200 OK even when 0 rows are deleted.

**Fix**: Added count check to return 404 when no rows are deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device-token removal now returns a clear “not found” response when the token is not registered to the authenticated account.
  * Prevented unnecessary fallback processing when an invalid device token is submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->