### PR TITLE
fix: add async keyword to geofence-confirm handler (#7292)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -182,7 +182,7 @@ import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 
-router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
+router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);


### PR DESCRIPTION
## Fix #7292

The `/api/deliveries/:id/geofence-confirm` handler was using `await` without `async`, causing a SyntaxError that killed the entire `/api/orders` module.

**Fix**: Added `async` keyword to the handler.