### PR TITLE
fix: confirm-otp returns amount_inr as number instead of string (#6169)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -292,7 +292,7 @@ const handleDeliveryVerification = async (req, res) => {
       'total_amount, order_display_id'
     );
     const amountInr = orderForAmount?.total_amount
-      ? (orderForAmount.total_amount / 100).toFixed(0)
+      ? Math.round(orderForAmount.total_amount / 100)
       : null;
 
     if (escrowUpdateFailed) {

--- a/backend/api/test/contracts/delivery.contract.test.js
+++ b/backend/api/test/contracts/delivery.contract.test.js
@@ -309,9 +309,9 @@ describe("POST /api/orders/:id/verify-delivery — delivery verification contrac
 
     expectContract(res, 200);
     expect(res.body.payment_released).toBe(true);
-    expect(typeof res.body.amount_inr).toBe("string");
-    expect(Number.isNaN(Number(res.body.amount_inr))).toBe(false);
-    expect(res.body.amount_inr).toBe("5000");
+    expect(typeof res.body.amount_inr).toBe("number");
+    expect(Number.isNaN(res.body.amount_inr)).toBe(false);
+    expect(res.body.amount_inr).toBe(5000);
     expect(res.body.order_display_id).toBe("ORD-COTP");
   });
 


### PR DESCRIPTION
## Fixes #6169

Bug fix for Truxify.