### PR TITLE
fix(workers): run stale-order worker with the service-role client (issue #7319)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -670,7 +670,7 @@ server.listen(PORT, () => {
   startEscrowFundingReconciliation(escrowReconciliationOrderRepository)
   startReputationReconciliation(orderRepository)
   startDlqWorker()
-  startStaleOrderWorker()
+  startStaleOrderWorker(escrowReconciliationOrderRepository)
   startDocumentExpiryWorker()
   startWithdrawalSettlementWorker()
 

--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -1,19 +1,31 @@
 import cron from 'node-cron';
 import logger from '../middleware/logger.js';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { sendPushNotification } from '../services/notificationService.js';
 import { submitEscrowRefund, confirmEscrowRefund } from '../services/escrow.js';
 import { WorkerTracer } from '../core/telemetry/WorkerTracer.js';
 import spanFactory from '../core/telemetry/SpanFactory.js';
 
 let staleOrderWorkerTask = null;
+let staleOrderClient = null;
 
 const STALE_ORDER_CANCELLATION_REASON = 'Stale order: no accepted bid within 24 hours.';
 
-export const startStaleOrderWorker = () => {
+export const startStaleOrderWorker = (orderRepository) => {
   if (staleOrderWorkerTask) {
     logger.info('[StaleOrderWorker] Stale order cleanup cron job already scheduled.');
     return staleOrderWorkerTask;
+  }
+
+  if (orderRepository) {
+    staleOrderClient = orderRepository.supabase;
+  } else if (supabaseAdmin) {
+    staleOrderClient = supabaseAdmin;
+  } else {
+    staleOrderClient = supabase;
+    logger.warn(
+      '[StaleOrderWorker] Service-role client not configured - falling back to the anon-key client. RLS will block stale-order reads/writes.'
+    );
   }
 
   const tracedHandler = WorkerTracer.wrapCronJob('stale-order-worker', async () => {
@@ -22,7 +34,7 @@ export const startStaleOrderWorker = () => {
       const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
       // Find all pending orders created more than 24 hours ago
-      const { data: staleOrders, error: fetchError } = await supabase
+      const { data: staleOrders, error: fetchError } = await staleOrderClient
         .from('orders')
         .select('id, customer_id, order_display_id')
         .eq('status', 'pending')
@@ -99,7 +111,7 @@ async function cancelStaleOrder(staleOrder) {
   try {
     // Re-fetch the order inside the loop with a status filter to close the
     // window between the batch SELECT and the per-order UPDATE.
-    const { data: current, error: refetchErr } = await supabase
+    const { data: current, error: refetchErr } = await staleOrderClient
       .from('orders')
       .select('id, customer_id, order_display_id, escrow_status, refund_tx_hash, escrow_refund_attempts')
       .eq('id', staleOrder.id)
@@ -140,7 +152,7 @@ async function cancelStaleOrder(staleOrder) {
 
     // Cancel associated load offers (guarded on nothing — the order is now
     // cancelled, so its offers can never be fulfilled).
-    await supabase
+    await staleOrderClient
       .from('load_offers')
       .update({ status: 'cancelled' })
       .eq('order_display_id', current.order_display_id);
@@ -173,7 +185,7 @@ async function cancelStaleOrder(staleOrder) {
  * @returns {Promise<boolean>} true when the order was actually cancelled
  */
 async function cancelPlain(current) {
-  const { data: cancelled, error: updateErr } = await supabase
+  const { data: cancelled, error: updateErr } = await staleOrderClient
     .from('orders')
     .update({
       status: 'cancelled',
@@ -209,7 +221,7 @@ async function cancelWithRefund(current, escrowStatus) {
   // Guarded transition: only an order that is STILL pending AND in the exact
   // escrow state we observed may enter refund reconciliation. This is the
   // serialisation point that prevents two workers from double-refunding.
-  const { data: pendingOrder, error: pendingErr } = await supabase
+  const { data: pendingOrder, error: pendingErr } = await staleOrderClient
     .from('orders')
     .update({
       status: 'cancelled',
@@ -251,7 +263,7 @@ async function cancelWithRefund(current, escrowStatus) {
     }
 
     const refundedAt = new Date().toISOString();
-    const { error: finalErr } = await supabase
+    const { error: finalErr } = await staleOrderClient
       .from('orders')
       .update({
         status: 'cancelled',
@@ -273,7 +285,7 @@ async function cancelWithRefund(current, escrowStatus) {
   } catch (refundErr) {
     const failedAt = new Date().toISOString();
     const nextEscrowStatus = refundTxHash ? 'refund_pending' : 'refund_failed';
-    await supabase
+    await staleOrderClient
       .from('orders')
       .update({
         status: 'cancelled',

--- a/backend/api/test/unit/staleOrderWorker.test.js
+++ b/backend/api/test/unit/staleOrderWorker.test.js
@@ -11,6 +11,7 @@ vi.mock('node-cron', () => ({
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: {},
+  supabaseAdmin: null,
 }));
 
 vi.mock('../../src/services/notificationService.js', () => ({

--- a/backend/api/test/unit/staleOrderWorkerRace.test.js
+++ b/backend/api/test/unit/staleOrderWorkerRace.test.js
@@ -10,6 +10,8 @@ const submitEscrowRefundMock = vi.fn();
 const confirmEscrowRefundMock = vi.fn();
 const ordersUpdateCalls = [];
 let scriptedResponses = [];
+const supabaseAdminBuilder = { from: vi.fn(makeBuilder) };
+const supabaseBuilder = { from: vi.fn(makeBuilder) };
 
 function makeBuilder(table) {
   const builder = {
@@ -86,9 +88,8 @@ vi.mock('../../src/core/telemetry/SpanFactory.js', () => ({
 }));
 
 vi.mock('../../src/config/db.js', () => ({
-  supabase: {
-    from: vi.fn(makeBuilder),
-  },
+  supabase: supabaseBuilder,
+  supabaseAdmin: supabaseAdminBuilder,
 }));
 
 describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
@@ -100,12 +101,23 @@ describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
     sendPushNotificationMock.mockReset();
     submitEscrowRefundMock.mockReset();
     confirmEscrowRefundMock.mockReset();
+    supabaseBuilder.from.mockClear();
+    supabaseAdminBuilder.from.mockClear();
     vi.resetModules();
     const { startStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
     startStaleOrderWorker();
   });
 
   const staleOrder = { id: 'order-1', customer_id: 'customer-1', order_display_id: 'disp-1' };
+
+  it('routes orders queries through the service-role client, never the anon client', async () => {
+    scriptedResponses = [{ data: [], error: null }];
+
+    await scheduledHandler();
+
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('orders');
+    expect(supabaseBuilder.from).not.toHaveBeenCalled();
+  });
 
   function stillPending(overrides = {}) {
     return {


### PR DESCRIPTION
## Problem

`startStaleOrderWorker` (backend/api/src/workers/staleOrderWorker.js) queries every `orders`/`load_offers` table through the shared **anon-key** `supabase` client. `orders` is RLS-enabled with policies only for `service_role` and `authenticated`, and all privileges are revoked from `anon`, so the SELECT at staleOrderWorker.js:25 returns a permission error and the worker returns — stale orders are never cancelled, escrow is never refunded, and no cancellation push is sent.

## Fix

Follow the pattern already used for the escrow reconciliation workers in index.js:665-667. The worker now accepts a service-role-backed `OrderRepository` (index.js passes `escrowReconciliationOrderRepository`), otherwise uses `supabaseAdmin`, and only falls back to the anon client when the service-role client is unavailable (with a warning logged). All `orders`/`load_offers` reads and writes route through the resolved service-role client.

## Files changed

- `backend/api/src/workers/staleOrderWorker.js`
- `backend/api/src/index.js`
- `backend/api/test/unit/staleOrderWorker.test.js`
- `backend/api/test/unit/staleOrderWorkerRace.test.js`

## Testing

- Added a regression test asserting orders queries route through the service-role client and never the anon client.
- `npm test -- test/unit/staleOrderWorker.test.js test/unit/staleOrderWorkerRace.test.js` — 8/8 pass.
- `npx eslint` on changed files — clean.

Closes #7319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-order processing by using the appropriate privileged database connection when available.
  * Ensured stale-order queries and updates consistently use the selected connection.
  * Added coverage to verify that stale-order processing uses the privileged connection and avoids unintended fallback access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->