### PR TITLE
fix(notifications): resolve FCM tokens via the service-role client (issue #7320)

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -1,4 +1,4 @@
-import { supabase, supabaseAdmin, firebaseAdmin } from '../config/db.js';
+import { supabaseAdmin, firebaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import crypto from 'crypto';
 import { measureExecution } from '../core/performanceMetrics.js';
@@ -28,9 +28,9 @@ function calculateRetryBackoff(attempt) {
 }
 
 async function getUserFcmToken(userId) {
-  if (!supabase) return null;
+  if (!supabaseAdmin) return null;
   try {
-    const { data, error } = await supabase.from('profiles').select('fcm_token').eq('id', userId).maybeSingle();
+    const { data, error } = await supabaseAdmin.from('profiles').select('fcm_token').eq('id', userId).maybeSingle();
     if (error || !data?.fcm_token) return null;
     return data.fcm_token;
   } catch (err) {
@@ -40,9 +40,9 @@ async function getUserFcmToken(userId) {
 }
 
 async function clearInvalidToken(userId) {
-  if (!supabase) return;
+  if (!supabaseAdmin) return;
   try {
-    await supabase
+    await supabaseAdmin
       .from('profiles')
       .update({
         fcm_token: null,


### PR DESCRIPTION
## Problem

`getUserFcmToken` (backend/api/src/services/notificationService.js:30-40) selects `profiles.fcm_token` through the shared **anon-key** `supabase` client, which has no user session. `profiles` is RLS-enabled with policies only for `service_role` and the owning `authenticated` user, and ALL privileges are revoked from `anon`. The SELECT returns a permission error (or no rows), so `getUserFcmToken` returns `null` and every push is silently dropped. `clearInvalidToken` (:42-55) is equally dead — its UPDATE on `profiles` is blocked.

## Fix

Use the already-imported `supabaseAdmin` (service-role) client in `getUserFcmToken` and `clearInvalidToken`, keeping the existing null-guards for when the admin client is unconfigured. This matches the pattern already used for delivery-OTP storage/read/verify and notification inserts in the same file. The now-unused anon `supabase` import was removed.

## Files changed

- `backend/api/src/services/notificationService.js`

## Testing

- `npx eslint` on the changed file — clean.
- Note: `test/unit/notificationService.test.js` was already failing on `main` before this change (the module has no `default` export while the test uses one); it is out of scope for this issue and unaffected by it.

Closes #7320