### PR TITLE
fix(notifications): run document-expiry worker with the service-role client (issue #7321)

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -1,4 +1,4 @@
-import { supabase, redisClient } from '../config/db.js';
+import { supabaseAdmin, redisClient } from '../config/db.js';
 import { sendPushNotification } from './notificationService.js';
 import logger from '../middleware/logger.js';
 import crypto from 'crypto';
@@ -59,10 +59,10 @@ function endOfDay(date) {
 }
 
 async function hasExistingNotification(userId, documentId, daysRemaining) {
-  if (!supabase) return false;
+  if (!supabaseAdmin) return false;
   try {
     const cutoff = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
-    const { data, error } = await supabase
+    const { data, error } = await supabaseAdmin
       .from('notifications')
       .select('id, metadata')
       .eq('user_id', userId)
@@ -127,7 +127,7 @@ export async function processDocumentExpiryBatch() {
 
       let documents = [];
       try {
-        const { data, error } = await supabase
+        const { data, error } = await supabaseAdmin
           .from('documents')
           .select('id, user_id, doc_type, valid_until')
           .not('valid_until', 'is', null)

--- a/backend/api/test/unit/documentExpiryService.test.js
+++ b/backend/api/test/unit/documentExpiryService.test.js
@@ -1,31 +1,68 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-const supabaseInsertMock = vi.fn().mockResolvedValue({ error: null });
-const supabaseSelectMock = vi.fn();
-const redisSetMock = vi.fn();
-const redisDelMock = vi.fn();
+const sendPushNotificationMock = vi.fn().mockResolvedValue({ success: true });
 
-function createChainableTerminal(finalFn) {
-  const handler = {
-    get(target, prop) {
-      if (prop === 'then') {
-        return (resolve, reject) => {
-          try {
-            const result = finalFn();
-            return Promise.resolve(result).then(resolve, reject);
-          } catch (e) {
-            reject(e);
-          }
-        };
-      }
-      return new Proxy(() => {}, handler);
-    }
+function makeBuilder(result) {
+  const builder = {
+    select() { return this; },
+    not() { return this; },
+    gte() { return this; },
+    lte() { return this; },
+    eq() { return this; },
+    maybeSingle() { return this; },
+    then(resolve) { return resolve(result); },
   };
-  return new Proxy(() => {}, handler);
+  return builder;
 }
 
+const resultsByTable = {
+  documents: { data: [{ id: 'doc-1', user_id: 'user-1', doc_type: 'rc_book', valid_until: '2099-01-01T00:00:00.000Z' }], error: null },
+  notifications: { data: [], error: null },
+};
+
+const supabaseAdminBuilder = {
+  from: vi.fn((table) => makeBuilder(resultsByTable[table] ?? { data: [], error: null })),
+};
+const supabaseAnonBuilder = {
+  from: vi.fn(() => makeBuilder({ data: [], error: null })),
+};
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: supabaseAnonBuilder,
+  supabaseAdmin: supabaseAdminBuilder,
+  redisClient: {
+    set: vi.fn().mockResolvedValue('OK'),
+    eval: vi.fn().mockResolvedValue(1),
+  },
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: sendPushNotificationMock,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 describe('documentExpiryService', () => {
-  it('should be a placeholder', () => {
-    expect(true).toBe(true);
+  it('routes documents and notifications queries through the service-role client, never the anon client', async () => {
+    const { processDocumentExpiryBatch } = await import('../../src/services/documentExpiryService.js');
+
+    await processDocumentExpiryBatch();
+
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('documents');
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('notifications');
+    expect(supabaseAnonBuilder.from).not.toHaveBeenCalled();
+    expect(sendPushNotificationMock).toHaveBeenCalledWith(
+      'user-1',
+      expect.any(String),
+      expect.any(String),
+      'document',
+      expect.objectContaining({ documentId: 'doc-1', daysRemaining: expect.any(Number) })
+    );
   });
 });


### PR DESCRIPTION
## Problem

`startDocumentExpiryWorker` runs `processDocumentExpiryBatch` (backend/api/src/services/documentExpiryService.js:84), which queries `documents` for rows expiring in the 30/14/7-day windows (:130-135) and checks `notifications` for duplicates (`hasExistingNotification`, :61-82). Both queries use the shared **anon-key** `supabase` client imported at :1. `documents` is RLS-enabled with policies only for `service_role` and the owning `authenticated` user, and `notifications` privileges are revoked from `anon`, so both reads fail or return empty — reminders are never sent.

## Fix

Switch the `documents` and `notifications` queries in documentExpiryService.js to the service-role `supabaseAdmin` client (already exported from `config/db.js`), extending the existing `if (!supabase) return false` guards to `supabaseAdmin`. This mirrors how notificationService.js persists delivery OTPs/notifications with the admin client.

## Files changed

- `backend/api/src/services/documentExpiryService.js`
- `backend/api/test/unit/documentExpiryService.test.js`

## Testing

- Replaced the placeholder unit test with a regression test asserting the `documents` and `notifications` queries route through the service-role client (never the anon client) and that the expiry reminder is sent.
- `npm test -- test/unit/documentExpiryService.test.js` — 1/1 pass.
- `npx eslint` on changed files — clean.

Closes #7321