### PR TITLE
fix(escrow): rebalance change-drop escrow_amount_wei with the canonical paisa-to-wei rate (issue #7322)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -176,7 +176,7 @@ import {
   submitEscrowRefund,
   confirmEscrowRefund,
 } from '../core/container.js';
-import { getEscrowBookingId } from '../services/escrow.js';
+import { getEscrowBookingId, paisaToMaticWei } from '../services/escrow.js';
 import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 
@@ -430,7 +430,7 @@ router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, req
     // displayed price, the on-chain payout, and any refund all stay in sync.
     // escrow_amount_wei is the authoritative payout figure (verified against
     // at deposit time and read on release), so it must track total_amount.
-    const newAmountWei = BigInt(Math.round(pricing.totalAmount * 1e16));
+    const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
     const updates = {
       drop_address,

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -7,10 +7,10 @@ import { supabaseAdmin } from '../../config/db.js';
 import {
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
   getEscrowBookingId,
+  paisaToMaticWei,
 } from '../escrow.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
 import { getRouteEstimate } from '../osrm.js';
@@ -572,7 +572,7 @@ export class OrderLifecycleService {
           throw new DomainError(400, { error: 'Unable to compute new pricing for the requested drop.', details: pricingErr.message });
         }
 
-        const newAmountWei = BigInt(Math.round(pricing.totalAmount * 1e16));
+        const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {
           drop_address,

--- a/backend/api/test/changeDrop.escrowRebalance.test.js
+++ b/backend/api/test/changeDrop.escrowRebalance.test.js
@@ -51,6 +51,7 @@ vi.mock('../src/services/escrow.js', () => ({
   submitEscrowCancelWithPenalty: vi.fn(),
   confirmEscrowRefund: vi.fn(),
   getEscrowBookingId: vi.fn(),
+  paisaToMaticWei: vi.fn((paisa) => BigInt(Math.round(paisa * 4e12))),
 }));
 
 vi.mock('../src/services/osrm.js', () => ({
@@ -121,8 +122,9 @@ describe('changeDrop escrow rebalance (issue #5825)', () => {
     const [name, params] = repo.executeRpc.mock.calls[0];
     expect(name).toBe('update_order_and_load_offer');
     const { total_amount, escrow_amount_wei } = params.p_order_updates;
-    // escrow payout figure must track the advertised total (wei = paisa * 1e16).
-    expect(escrow_amount_wei).toBe(BigInt(Math.round(total_amount * 1e16)).toString());
+    // escrow payout figure must track the advertised total via the canonical
+    // paisa -> wei converter (wei = paisa * 4e12, see escrow.js paisaToMaticWei).
+    expect(escrow_amount_wei).toBe(BigInt(Math.round(total_amount * 4e12)).toString());
   });
 
   it('rejects change-drop once escrow funding has started or completed', async () => {
@@ -178,6 +180,6 @@ describe('RPC/route persist escrow_amount_wei (issue #5825)', () => {
       src.indexOf('// ============================================================================\n// 16.'),
     );
     expect(changeDropSection).toContain('escrow_amount_wei: newAmountWei.toString()');
-    expect(changeDropSection).toContain('BigInt(Math.round(pricing.totalAmount * 1e16))');
+    expect(changeDropSection).toContain('BigInt(paisaToMaticWei(pricing.totalAmount))');
   });
 });


### PR DESCRIPTION
## Problem

The change-drop flow writes `orders.escrow_amount_wei` with an inline conversion that disagrees with the canonical converter `paisaToMaticWei` (backend/api/src/services/escrow.js:152) by a factor of **2500**:

- backend/api/src/routes/orderRoutes.js:433 → `BigInt(Math.round(pricing.totalAmount * 1e16))`
- backend/api/src/services/order/orderLifecycleService.js → `BigInt(Math.round(pricing.totalAmount * 1e16))`

`pricing.totalAmount` is in **paisa** (backend/api/src/lib/pricing.js). `paisaToMaticWei` computes `paisa * 4e12` wei, so `totalAmount * 1e16` is 2500× too large. The deposit is funded for `bid_amount * 4e12`, so funding-confirmation fails with "Existing booking is underfunded for the expected escrow amount of this order" — payment verification is permanently blocked for any order that used change-drop. The inline path also bypasses the `MAX_ESCROW_MATIC` safety cap.

## Fix

Replace both inline computations with the canonical converter: `const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount))`, importing `paisaToMaticWei` from `services/escrow.js`, so deposit, verification, and payout share one rate. Also removed a duplicate `submitEscrowRefund` import specifier in the same import block (a pre-existing parse error).

## Files changed

- `backend/api/src/routes/orderRoutes.js`
- `backend/api/src/services/order/orderLifecycleService.js`
- `backend/api/test/changeDrop.escrowRebalance.test.js`

## Testing

- Updated `test/changeDrop.escrowRebalance.test.js` to assert `escrow_amount_wei` stays consistent with `paisaToMaticWei` (and that the route handler uses the canonical converter).
- `npm test -- test/changeDrop.escrowRebalance.test.js` — 5/5 pass.
- `npx eslint` on the changed source/test files — the only remaining error (`orderRoutes.js:203` top-level await) is pre-existing on `main`.

Closes #7322