### PR TITLE
fix(payments): enforce neq escrow-status filter on deposit confirmation

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -149,6 +149,8 @@ export class OrderRepository {
         for (const f of filters) {
           if (f.op === 'eq') {
             query = query.eq(f.column, f.value);
+          } else if (f.op === 'neq') {
+            query = query.neq(f.column, f.value);
           } else if (f.op === 'not') {
             query = query.not(f.column, f.operator, f.value);
           } else if (f.op === 'in') {

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -283,7 +283,7 @@ router.post(
       logger.info(`[payments] Deposit verified on-chain for ${order.order_display_id}`);
 
       // 6. Update escrow_status → funded
-      const { error: updateErr } = await orderRepository.updateOrder(
+      const { error: updateErr } = await orderRepository.updateOrderWithFilter(
         order.id,
         {
           escrow_status: 'funded',

--- a/backend/api/test/unit/orderRepository.test.js
+++ b/backend/api/test/unit/orderRepository.test.js
@@ -11,6 +11,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { OrderRepository } from '../../src/repositories/orderRepository.js';
 
+vi.mock('../../src/core/telemetry/SpanFactory.js', () => ({
+  default: {
+    getActiveSpan: vi.fn(() => ({
+      setAttributes: vi.fn(),
+    })),
+    startWorkerSpan: vi.fn(() => ({
+      setAttributes: vi.fn(),
+    })),
+    end: vi.fn(),
+  },
+}));
+
 function buildStubSupabase(rowByQuery) {
   return {
     from: vi.fn((table) => {
@@ -79,5 +91,59 @@ describe('OrderRepository.findOrderByIdOrDisplayId', () => {
     await repo.findOrderByIdOrDisplayId(UUID, 'id');
 
     expect(spy).toHaveBeenCalledWith(UUID, 'id');
+  });
+});
+
+describe('OrderRepository.updateOrderWithFilter', () => {
+  function buildUpdateStub({ calls, result }) {
+    return {
+      from: vi.fn(() => {
+        const chain = {
+          eq(column, value) {
+            calls.push({ op: 'eq', column, value });
+            return chain;
+          },
+          neq(column, value) {
+            calls.push({ op: 'neq', column, value });
+            return chain;
+          },
+          not(column, operator, value) {
+            calls.push({ op: 'not', column, operator, value });
+            return chain;
+          },
+          in(column, value) {
+            calls.push({ op: 'in', column, value });
+            return chain;
+          },
+          select() { return chain; },
+          single() { return chain; },
+          then(resolve) { return Promise.resolve(resolve(result)); },
+        };
+        return {
+          update: vi.fn(() => chain),
+        };
+      }),
+    };
+  }
+
+  it('applies a neq filter to the update query', async () => {
+    const calls = [];
+    const supabase = buildUpdateStub({
+      calls,
+      result: { data: { id: UUID, escrow_status: 'funded' }, error: null },
+    });
+    const repo = new OrderRepository(supabase);
+
+    const result = await repo.updateOrderWithFilter(
+      UUID,
+      { escrow_status: 'funded' },
+      [{ op: 'neq', column: 'escrow_status', value: 'funded' }],
+    );
+
+    expect(result.error).toBeNull();
+    expect(calls).toEqual([
+      { op: 'eq', column: 'id', value: UUID },
+      { op: 'neq', column: 'escrow_status', value: 'funded' },
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

Closes #7323.

In `backend/api/src/routes/paymentRoutes.js` the deposit-confirmation flow marked the order as `funded` via `orderRepository.updateOrder(order.id, { escrow_status: 'funded', ... })`. `updateOrder()` (orderRepository.js:136) ignores any filters and unconditionally updates the row, so the intended safety guard — only update when `escrow_status` is **not** already `funded` — was silently dropped. A duplicated/retried deposit confirmation would rewrite escrow fields on an already-funded order.

Separately, `updateOrderWithFilter()` (orderRepository.js:145) had no `neq` branch, so the `{ op: 'neq', column: 'escrow_status', value: 'funded' }` filter passed by the route could not be applied even if the route had used the filtered method.

## Fix

- `orderRepository.js`: add a `neq` branch to `updateOrderWithFilter` so `filters` entries with `op: 'neq'` translate to `query.neq(f.column, f.value)`.
- `paymentRoutes.js`: switch the deposit-confirmed update from `updateOrder(...)` to `updateOrderWithFilter(order.id, payload, [{ op: 'neq', column: 'escrow_status', value: 'funded' }])`, keeping the exact same payload and the already-intended `neq` filter.

## Files changed

- `backend/api/src/repositories/orderRepository.js` — `neq` filter support in `updateOrderWithFilter`.
- `backend/api/src/routes/paymentRoutes.js` — deposit-confirmation update now applies the `neq` escrow-status guard.
- `backend/api/test/unit/orderRepository.test.js` — regression test asserting the `eq(id)` + `neq(escrow_status, 'funded')` chain is built for the update query.

## Testing

- `npm test -- test/unit/orderRepository.test.js` — 5/5 pass (including the new `neq` regression test).
- `npx eslint src/repositories/orderRepository.js src/routes/paymentRoutes.js test/unit/orderRepository.test.js` — clean.

## Notes

- The test file gained a `vi.mock` for `src/core/telemetry/SpanFactory.js` (same pattern already used by `test/unit/staleOrderWorker.test.js`) so the file can load — `retry.js` imports `SpanFactory`, which transitively imports `tracing.js` → `@opentelemetry/sdk-trace-node`, a package missing from the local install. Pre-existing on main, unrelated to this change.
- `test/integration/bids.test.js` cannot run locally on main due to a pre-existing parse error (`orderRoutes.js:203` top-level `await`) — unrelated to this PR.
