### PR TITLE
fix(blockchain): mount blockchainMonitoringRoutes and attach its req dependencies

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -66,6 +66,7 @@ import demandRoutes from './routes/demandRoutes.js'
 // ============================================================================
 import verificationRoutes from './routes/verificationRoutes.js'
 import oracleRoutes from './routes/oracleRoutes.js'
+import blockchainMonitoringRoutes from './routes/blockchainMonitoringRoutes.js'
 
 // ============================================================================
 // 🆕 GEOGRAPHIC SHARDING ROUTES
@@ -139,6 +140,8 @@ import {
   stopDlqWorker,
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
+import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
+import EscalationHandler from './services/blockchain/escalationHandler.js'
 import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
@@ -166,6 +169,12 @@ try {
 // INITIALIZE DISTRIBUTED CACHE MANAGER
 // ============================================================================
 CacheManager.init(redisClient)
+
+// ============================================================================
+// BLOCKCHAIN MONITORING — singletons shared with blockchainMonitoringRoutes
+// ============================================================================
+const blockchainMetrics = new BlockchainMetrics()
+const escalationHandler = new EscalationHandler({})
 
 // ============================================================================
 // STARTUP VALIDATION — crash fast, not at request time
@@ -493,6 +502,18 @@ app.use('/api/webhooks', webhookRoutes)
 app.use('/api/verify', verificationRoutes)
 app.use('/api/oracle', oracleRoutes)
 app.use('/api/webhooks', webhookRoutes)
+
+// ============================================================================
+// 🆕 BLOCKCHAIN MONITORING ROUTES
+// Attach the monitoring services and service-role client per request so the
+// handlers never fall back to the anon-key client (RLS would hide all rows).
+// ============================================================================
+app.use('/api/blockchain', (req, _res, next) => {
+  req.blockchainMetrics = blockchainMetrics
+  req.escalationHandler = escalationHandler
+  req.supabase = supabaseAdmin
+  next()
+}, blockchainMonitoringRoutes)
 
 // 🆕 Oracle Health Check Endpoint
 app.get('/api/oracle/health', (req, res) => {

--- a/backend/api/src/routes/blockchainMonitoringRoutes.js
+++ b/backend/api/src/routes/blockchainMonitoringRoutes.js
@@ -10,12 +10,7 @@ const router = express.Router();
  */
 router.get('/metrics', authenticate, requireRole(['admin', 'support']), async (req, res) => {
   try {
-    const { data: metrics, error } = await req.blockchainMetrics.getMetrics();
-
-    if (error) {
-      logger.error('Failed to fetch blockchain metrics:', error);
-      return res.status(500).json({ error: 'Failed to fetch metrics' });
-    }
+    const metrics = req.blockchainMetrics.getMetrics();
 
     res.json({
       timestamp: new Date().toISOString(),

--- a/backend/api/test/unit/blockchainMonitoringRoutes.test.js
+++ b/backend/api/test/unit/blockchainMonitoringRoutes.test.js
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for backend/api/src/routes/blockchainMonitoringRoutes.js
+ *
+ * These routes were previously unreachable: the router was never mounted and
+ * its req.* dependencies (blockchainMetrics, escalationHandler, supabase)
+ * were never attached. These tests mount the router with mocked dependencies
+ * and assert every endpoint responds with the expected payload.
+ *
+ * Run with:  npm test -- test/unit/blockchainMonitoringRoutes.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import blockchainMonitoringRoutes from '../../src/routes/blockchainMonitoringRoutes.js';
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => next(),
+  requireRole: () => (_req, _res, next) => next(),
+}));
+
+function buildApp(deps) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/blockchain', (req, _res, next) => {
+    req.blockchainMetrics = deps.blockchainMetrics;
+    req.escalationHandler = deps.escalationHandler;
+    req.supabase = deps.supabase;
+    next();
+  });
+  app.use('/api/blockchain', blockchainMonitoringRoutes);
+  return app;
+}
+
+function buildSupabaseStub() {
+  const calls = [];
+  const chain = {
+    select() { return chain; },
+    order() { return chain; },
+    limit() { return chain; },
+    eq(column, value) {
+      calls.push({ column, value });
+      return chain;
+    },
+    single() { return chain; },
+    then(resolve, reject) {
+      return Promise.resolve(resolve({ data: [], error: null })).catch(reject);
+    },
+  };
+  return {
+    from: vi.fn(() => chain),
+    calls,
+  };
+}
+
+describe('blockchainMonitoringRoutes', () => {
+  let metrics;
+  let escalationHandler;
+  let supabase;
+
+  beforeEach(() => {
+    metrics = {
+      getMetrics: vi.fn(() => ({
+        contractCallSuccessRate: 100,
+        failedTransactionCount: 0,
+      })),
+    };
+    escalationHandler = {
+      getActiveAlerts: vi.fn(async () => [{ alertId: 'abc123', resolved: false }]),
+      resolveAlert: vi.fn(async () => true),
+    };
+    supabase = buildSupabaseStub();
+  });
+
+  it('GET /api/blockchain/metrics returns the metrics payload', async () => {
+    const res = await request(buildApp({ blockchainMetrics: metrics, escalationHandler, supabase }))
+      .get('/api/blockchain/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics.contractCallSuccessRate).toBe(100);
+    expect(res.body.timestamp).toBeTruthy();
+  });
+
+  it('GET /api/blockchain/alerts/active returns active alerts', async () => {
+    const res = await request(buildApp({ blockchainMetrics: metrics, escalationHandler, supabase }))
+      .get('/api/blockchain/alerts/active');
+
+    expect(res.status).toBe(200);
+    expect(res.body.activeAlerts).toEqual([{ alertId: 'abc123', resolved: false }]);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('POST /api/blockchain/alerts/:alertId/resolve resolves an alert', async () => {
+    const res = await request(buildApp({ blockchainMetrics: metrics, escalationHandler, supabase }))
+      .post('/api/blockchain/alerts/abc123/resolve');
+
+    expect(res.status).toBe(200);
+    expect(res.body.alertId).toBe('abc123');
+    expect(escalationHandler.resolveAlert).toHaveBeenCalledWith('abc123');
+  });
+
+  it('GET /api/blockchain/events queries blockchain_monitoring_events through the attached supabase client', async () => {
+    const res = await request(buildApp({ blockchainMetrics: metrics, escalationHandler, supabase }))
+      .get('/api/blockchain/events?type=PAYMENT_RECEIVED&severity=CRITICAL&limit=10');
+
+    expect(res.status).toBe(200);
+    expect(supabase.from).toHaveBeenCalledWith('blockchain_monitoring_events');
+    expect(supabase.calls).toEqual([
+      { column: 'type', value: 'PAYMENT_RECEIVED' },
+      { column: 'severity', value: 'CRITICAL' },
+    ]);
+    expect(res.body.count).toBe(0);
+  });
+
+  it('GET /api/blockchain/escalations/:alertId reads blockchain_escalations through the attached supabase client', async () => {
+    const app = buildApp({ blockchainMetrics: metrics, escalationHandler, supabase });
+    supabase.from.mockImplementationOnce(() => {
+      const chain = {
+        select() { return chain; },
+        eq(column, value) {
+          supabase.calls.push({ column, value });
+          return chain;
+        },
+        single() { return chain; },
+        then(resolve) {
+          return Promise.resolve(resolve({
+            data: { alert_id: 'abc123', resolved: false },
+            error: null,
+          }));
+        },
+      };
+      return chain;
+    });
+
+    const res = await request(app).get('/api/blockchain/escalations/abc123');
+
+    expect(res.status).toBe(200);
+    expect(supabase.from).toHaveBeenCalledWith('blockchain_escalations');
+    expect(res.body.escalation.alert_id).toBe('abc123');
+  });
+});


### PR DESCRIPTION
## Problem

Closes #7324.

`backend/api/src/routes/blockchainMonitoringRoutes.js` defines five admin/support endpoints (`GET /api/blockchain/metrics`, `GET /api/blockchain/alerts/active`, `POST /api/blockchain/alerts/:alertId/resolve`, `GET /api/blockchain/events`, `GET /api/blockchain/escalations/:alertId`) but is **never imported or mounted** in `src/index.js`, so every route returns 404 and the monitoring subsystem is dead code.

Even if it were mounted, the router depends on `req.blockchainMetrics`, `req.escalationHandler`, and `req.supabase`, none of which any middleware or container attaches — every handler would throw `TypeError` on a defined-`req` dependency.

Additionally, `GET /api/blockchain/metrics` destructured `const { data: metrics, error } = await req.blockchainMetrics.getMetrics()`, but `BlockchainMetrics.getMetrics()` returns the metrics object directly (not `{ data, error }`), so the endpoint would always respond with `metrics: undefined`.

## Fix

- `src/index.js`:
  - Import `blockchainMonitoringRoutes`, `BlockchainMetrics`, and `EscalationHandler`.
  - Instantiate `blockchainMetrics` and `escalationHandler` singletons at startup.
  - Mount the router at `/api/blockchain` behind the `/api` middleware chain (next to the oracle/verification mounts) with a per-request middleware that attaches `req.blockchainMetrics`, `req.escalationHandler`, and `req.supabase = supabaseAdmin` (service-role client, so the RLS-protected `blockchain_monitoring_events` / `blockchain_escalations` reads never fall back to the anon-key client).
- `src/routes/blockchainMonitoringRoutes.js`: fix the `/metrics` handler to use `getMetrics()`'s actual return shape.
- `test/unit/blockchainMonitoringRoutes.test.js`: new regression suite that mounts the router with mocked `authenticate`/`requireRole` and stubbed `req.*` dependencies, asserting all five endpoints respond and that the events/escalations queries run through the attached supabase client.

## Files changed

- `backend/api/src/index.js` — import, singletons, mount + dependency-attaching middleware.
- `backend/api/src/routes/blockchainMonitoringRoutes.js` — `/metrics` handler return-shape fix.
- `backend/api/test/unit/blockchainMonitoringRoutes.test.js` — new tests (5/5).

## Testing

- `npm test -- test/unit/blockchainMonitoringRoutes.test.js` — 5/5 pass.
- `npx eslint src/index.js src/routes/blockchainMonitoringRoutes.js test/unit/blockchainMonitoringRoutes.test.js` — clean.
- `node --check src/index.js` — parses.

## Notes

- Full-app integration tests cannot run locally on main due to a pre-existing parse error in `src/routes/orderRoutes.js:185` (`router.post(...)` handler uses `await` at :203 inside a non-async function), which prevents the whole app module graph from loading. Unrelated to this PR.
- `escalationHandler.js` / `blockchainMetrics.js` also write to `blockchain_escalations` / `blockchain_metrics` through the anon `supabase` client (e.g. `storeEscalation`, `aggregateMetrics`); that is outside the scope of this mount fix.
