### PR TITLE
fix(iot): mount iotRoutes and route RLS-protected reads through the service-role client

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -46,6 +46,7 @@ import supportRoutes from './routes/supportRoutes.js'
 import profileRoutes from './routes/profileRoutes.js'
 import shipmentRoutes from './routes/shipmentRoutes.js'
 import loadRoutes from './routes/loadRoutes.js'
+import iotRoutes from './routes/iotRoutes.js'
 import deadheadRoutes from './routes/deadheadRoutes.js'
 import truckRoutes from './routes/truckRoutes.js'
 import authRoutes from './routes/authRoutes.js'
@@ -467,6 +468,7 @@ app.use('/api/driver', driverRoutes)
 app.use('/api/earnings', earningsRouter)
 app.use('/api/v1/shipment', shipmentRoutes)
 app.use('/api/loads', loadRoutes)
+app.use('/api/iot', iotRoutes)
 app.use('/api/support', supportRoutes)
 app.use('/api/profile', profileRoutes)
 app.use('/api/users', userRoutes)

--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import { supabase, supabaseAdmin } from '../config/db.js';
+import { supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { paramIdSchema } from '../validation/requestSchemas.js';
 import { authenticate } from '../middleware/auth.js';
@@ -37,8 +37,10 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
     const loadId = req.params.id;
     const { temperature } = parseResult.data;
 
-    // Check if load exists and has cold chain enabled
-    const { data: load, error: loadErr } = await supabase
+    // Check if load exists and has cold chain enabled.
+    // load_offers is RLS-protected (anon revoked), so this read must use the
+    // service-role client; ownership is enforced below against req.user.
+    const { data: load, error: loadErr } = await supabaseAdmin
       .from('load_offers')
       .select('requires_refrigeration, target_temperature_min, target_temperature_max, customer_id')
       .eq('id', loadId)
@@ -63,7 +65,7 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
 
     // Insert telemetry (service-role client: RLS only permits service_role to
     // write temperature_telemetry, so the backend must use supabaseAdmin).
-    const { error: insertErr } = await (supabaseAdmin ?? supabase)
+    const { error: insertErr } = await supabaseAdmin
       .from('temperature_telemetry')
       .insert({
         load_id: loadId,
@@ -86,7 +88,7 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       // For MVP, we'll insert a notification immediately if it's not already spammed.
       // We can use the existing notifications table or system if one exists, but for now we'll just log.
       
-      await (supabaseAdmin ?? supabase).from('notifications').insert({
+      await supabaseAdmin.from('notifications').insert({
         user_id: load.customer_id,
         title: 'Temperature Alert',
         body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
@@ -115,7 +117,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
   const loadId = req.params.id;
 
   try {
-    const { data: load, error: loadErr } = await supabase
+    const { data: load, error: loadErr } = await supabaseAdmin
       .from('load_offers')
       .select('customer_id, order_display_id')
       .eq('id', loadId)
@@ -134,7 +136,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
       let isAuthorized = load.customer_id === req.user.id;
 
       if (!isAuthorized && load.order_display_id) {
-        const { data: order } = await supabase
+        const { data: order } = await supabaseAdmin
           .from('orders')
           .select('driver_id')
           .eq('order_display_id', load.order_display_id)
@@ -149,7 +151,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
       }
     }
 
-    const { data, error } = await (supabaseAdmin ?? supabase)
+    const { data, error } = await supabaseAdmin
       .from('temperature_telemetry')
       .select('*')
       .eq('load_id', loadId)

--- a/backend/api/test/unit/iotRoutes.test.js
+++ b/backend/api/test/unit/iotRoutes.test.js
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for backend/api/src/routes/iotRoutes.js
+ *
+ * The router was previously never mounted (all /api/iot/* endpoints 404) and
+ * its authorization reads used the anon-key supabase client, which RLS hides
+ * from (load_offers / orders are anon-revoked). These tests mount the router
+ * with mocked auth/rate-limiters and assert the write + read paths work and
+ * that every database access goes through the service-role client.
+ *
+ * Run with:  npm test -- test/unit/iotRoutes.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import iotRoutes from '../../src/routes/iotRoutes.js';
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => next(),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  safeIpKeyGenerator: () => 'test-ip',
+  createStore: vi.fn(() => ({})),
+}));
+
+const { anonFrom } = vi.hoisted(() => ({
+  anonFrom: vi.fn(() => {
+    throw new Error('anon supabase must never be used by iotRoutes');
+  }),
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: anonFrom },
+  supabaseAdmin: { from: vi.fn() },
+}));
+
+import { supabaseAdmin } from '../../src/config/db.js';
+
+const adminFrom = supabaseAdmin.from;
+
+function maybeSingleChain(result) {
+  return {
+    select: vi.fn(() => maybeSingleChain(result)),
+    eq: vi.fn(() => maybeSingleChain(result)),
+    in: vi.fn(() => maybeSingleChain(result)),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+  };
+}
+
+function insertStub(error = null) {
+  return {
+    insert: vi.fn(async () => ({ data: null, error })),
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/iot', (req, _res, next) => {
+    req.user = {
+      id: req.headers['x-user-id'],
+      role: req.headers['x-user-role'] || 'customer',
+    };
+    next();
+  });
+  app.use('/api/iot', iotRoutes);
+  return app;
+}
+
+describe('iotRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POST /api/iot/telemetry/:id records telemetry for the owning customer using the service-role client', async () => {
+    const load = { requires_refrigeration: true, target_temperature_min: 0, target_temperature_max: 10, customer_id: 'cust-1' };
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      if (table === 'temperature_telemetry') return insertStub();
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const res = await request(buildApp())
+      .post('/api/iot/telemetry/load-1')
+      .set('x-user-id', 'cust-1')
+      .send({ temperature: 5 });
+
+    expect(res.status).toBe(201);
+    expect(adminFrom).toHaveBeenCalledWith('load_offers');
+    expect(adminFrom).toHaveBeenCalledWith('temperature_telemetry');
+    expect(anonFrom).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/iot/telemetry/:id returns 403 for a non-owning non-admin user', async () => {
+    const load = { requires_refrigeration: true, target_temperature_min: 0, target_temperature_max: 10, customer_id: 'cust-1' };
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const res = await request(buildApp())
+      .post('/api/iot/telemetry/load-1')
+      .set('x-user-id', 'other-user')
+      .send({ temperature: 5 });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('POST /api/iot/telemetry/:id returns 404 when the load does not exist', async () => {
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: null, error: null });
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const res = await request(buildApp())
+      .post('/api/iot/telemetry/load-1')
+      .set('x-user-id', 'cust-1')
+      .send({ temperature: 5 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/iot/telemetry/:id returns telemetry history for the owning customer', async () => {
+    const load = { customer_id: 'cust-1', order_display_id: 'OD-1' };
+    const telemetry = [{ load_id: 'load-1', temperature: 5 }];
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      if (table === 'temperature_telemetry') {
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+          then(resolve) { return Promise.resolve(resolve({ data: telemetry, error: null })); },
+        };
+        return chain;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const res = await request(buildApp())
+      .get('/api/iot/telemetry/load-1')
+      .set('x-user-id', 'cust-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(telemetry);
+    expect(adminFrom).toHaveBeenCalledWith('temperature_telemetry');
+    expect(anonFrom).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/iot/telemetry/:id allows the assigned driver via the orders lookup', async () => {
+    const load = { customer_id: 'cust-1', order_display_id: 'OD-1' };
+    const telemetry = [{ load_id: 'load-1', temperature: 5 }];
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      if (table === 'orders') return maybeSingleChain({ data: { driver_id: 'driver-1' }, error: null });
+      if (table === 'temperature_telemetry') {
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+          then(resolve) { return Promise.resolve(resolve({ data: telemetry, error: null })); },
+        };
+        return chain;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const res = await request(buildApp())
+      .get('/api/iot/telemetry/load-1')
+      .set('x-user-id', 'driver-1');
+
+    expect(res.status).toBe(200);
+    expect(adminFrom).toHaveBeenCalledWith('orders');
+    expect(anonFrom).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Closes #7325.

`backend/api/src/routes/iotRoutes.js` implements the cold-chain telemetry API but is **never imported or mounted** in `src/index.js`, so every `/api/iot/*` endpoint 404s and the whole feature (which ships with the `temperature_telemetry` table and its own rate limiter) is dead.

Additionally, the authorization reads in the router ran through the shared **anon-key** `supabase` client:
- `load_offers` SELECT at the POST handler (load existence + cold-chain flag + owner check)
- `load_offers` SELECT at the GET handler (owner/driver authorization)
- `orders` SELECT at the GET handler (driver-assignment authorization)

`load_offers` and `orders` are RLS-enabled with only `service_role`/`authenticated` policies and all privileges revoked from `anon`, so these reads return permission errors or zero rows. Even mounted, the write path would 500 on the `load_offers` lookup and the read path would 403 for every legitimate owner.

## Fix

- `src/index.js`: import `iotRoutes` and mount it at `/api/iot` behind the `/api` middleware chain (next to `/api/loads`).
- `src/routes/iotRoutes.js`: route all three authorization reads (`load_offers` ×2, `orders`) through `supabaseAdmin` — the service-role client — and drop the unused anon `supabase` import. Ownership/assignment is still enforced in application code against `req.user`, so the service-role reads do not leak data. The telemetry write/read paths already used `(supabaseAdmin ?? supabase)`; since the anon client is no longer imported, those now reference `supabaseAdmin` directly (no silent anon fallback).
- `test/unit/iotRoutes.test.js`: new suite mounting the router with mocked auth/rate-limiters that asserts:
  - an owning customer can record telemetry (201) and that `load_offers` / `temperature_telemetry` go through the service-role client while the anon client is never called;
  - a non-owner is rejected (403);
  - a missing load returns 404;
  - an owner and an assigned driver can read telemetry history (200).

## Files changed

- `backend/api/src/index.js` — import + `app.use('/api/iot', iotRoutes)`.
- `backend/api/src/routes/iotRoutes.js` — service-role reads, removed anon client usage.
- `backend/api/test/unit/iotRoutes.test.js` — new tests (5/5).

## Testing

- `npm test -- test/unit/iotRoutes.test.js` — 5/5 pass.
- `npx eslint src/index.js src/routes/iotRoutes.js test/unit/iotRoutes.test.js` — clean.
- `node --check src/index.js` — parses.

## Notes

- Full-app integration tests cannot run locally on main due to a pre-existing parse error in `src/routes/orderRoutes.js:185` (`await` at :203 inside a non-async handler), which prevents the app module graph from loading. Unrelated to this PR.
- The telemetry write path already used `supabaseAdmin`, matching RLS on `temperature_telemetry` (`20260721000000_add_cold_chain_telemetry.sql`).
