### PR TITLE
fix(trucks): route driver-search reads through the service-role client

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -80,7 +80,7 @@
  */
 
 import express from 'express';
-import { supabase, mongoDb, redisClient } from '../config/db.js';
+import { supabase, supabaseAdmin, mongoDb, redisClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
@@ -588,7 +588,10 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
       return res.json([]);
     }
 
-    const { data: drivers, error: driversErr } = await supabase
+    // driver_details / trucks / profiles are RLS-protected with all anon
+    // privileges revoked, so the marketplace search must use the service-role
+    // client (scope is enforced by the search criteria, never the raw anon key).
+    const { data: drivers, error: driversErr } = await supabaseAdmin
       .from('driver_details')
       .select('user_id, rating, total_trips, completion_rate, truck_id')
       .eq('is_online', true)
@@ -608,8 +611,8 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     const driverIds = drivers.map(d => d.user_id);
 
     const [trucksRes, profilesRes] = await Promise.all([
-      supabase.from('trucks').select('id, name, truck_type, number_plate, max_capacity_tons').in('id', truckIds),
-      supabase.from('profiles').select('id, full_name, avatar_url, is_digilocker_verified').in('id', driverIds),
+      supabaseAdmin.from('trucks').select('id, name, truck_type, number_plate, max_capacity_tons').in('id', truckIds),
+      supabaseAdmin.from('profiles').select('id, full_name, avatar_url, is_digilocker_verified').in('id', driverIds),
     ]);
 
     if (trucksRes.error) {

--- a/backend/api/test/integration/truckRoutes.test.js
+++ b/backend/api/test/integration/truckRoutes.test.js
@@ -9,6 +9,7 @@ let mockTelemetryResults = [];
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
+  supabaseAdmin: m.supabase,
   firebaseAdmin: null,
   redisClient: null,
   mongoDb: {

--- a/backend/api/test/integration/truckSearchCache.test.js
+++ b/backend/api/test/integration/truckSearchCache.test.js
@@ -13,6 +13,7 @@ let mockTelemetryResults = [];
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
+  supabaseAdmin: m.supabase,
   firebaseAdmin: null,
   redisClient,
   mongoDb: {

--- a/backend/api/test/unit/truckSearchServiceRole.test.js
+++ b/backend/api/test/unit/truckSearchServiceRole.test.js
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for the /api/trucks/search driver-search read path
+ * (issue #7327).
+ *
+ * The driver_details / trucks / profiles reads previously ran through the
+ * shared anon-key supabase client. Those tables are RLS-enabled with all anon
+ * privileges revoked, so the search always errored or returned empty. These
+ * tests prove the search runs through the service-role client and that the
+ * anon client is never consulted.
+ *
+ * Run with:  npm test -- test/unit/truckSearchServiceRole.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
+const m = createSupabaseMock();
+
+let mockTelemetryResults = [];
+
+const { anonFrom } = vi.hoisted(() => ({
+  anonFrom: vi.fn(() => {
+    throw new Error('anon supabase must never be used by the truck search path');
+  }),
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: anonFrom, rpc: vi.fn() },
+  supabaseAdmin: m.supabase,
+  firebaseAdmin: null,
+  redisClient: null,
+  mongoDb: {
+    collection: () => ({
+      find: () => ({
+        toArray: () => Promise.resolve(mockTelemetryResults),
+      }),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/osrm.js', () => ({
+  getRouteEstimate: vi.fn().mockResolvedValue({ distanceKm: 10, durationSeconds: 1200 }),
+}));
+vi.mock('../../src/lib/pricing.js', () => ({
+  computeOrderPricing: vi.fn().mockReturnValue({
+    baseFreight: 1000,
+    tollEstimate: 100,
+    platformFee: 50,
+    totalAmount: 1150,
+    distanceKm: 10,
+  }),
+}));
+vi.mock('../../src/services/ml.js', () => ({
+  predictPrice: vi.fn().mockResolvedValue({ estimated_price: 0 }),
+}));
+vi.mock('../../src/services/trafficService.js', () => ({
+  getLiveTrafficMultiplier: vi.fn().mockResolvedValue(1),
+}));
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = {
+      id: req.get('x-user-id') || 'customer-uuid-123',
+      role: req.get('x-user-role') || 'customer',
+    };
+    next();
+  },
+}));
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}));
+
+const { default: truckRouter } = await import('../../src/routes/truckRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/trucks', truckRouter);
+  return app;
+}
+
+const SEARCH_PARAMS = 'pickup_lat=19.0760&pickup_lng=72.8777&drop_lat=28.6139&drop_lng=77.2090&weight_tonnes=5';
+
+describe('GET /api/trucks/search — service-role client', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+    m.store.trucks = [
+      { id: 'truck-open', name: 'Open Body Truck', number_plate: 'MH12AB0001', max_capacity_tons: 10, owner_id: 'driver-uuid-456' },
+    ];
+    m.store.driver_details = [
+      { user_id: 'driver-uuid-456', is_online: true, truck_id: 'truck-open', rating: 4.5, total_trips: 100, completion_rate: 95 },
+    ];
+    m.store.profiles = [
+      { id: 'driver-uuid-456', full_name: 'Ravi Kumar' },
+    ];
+    mockTelemetryResults = [{ driver_id: 'driver-uuid-456' }];
+    m.calls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('returns matching drivers enriched with truck and profile data', async () => {
+    const res = await request(buildApp())
+      .get(`/api/trucks/search?${SEARCH_PARAMS}`)
+      .set('x-user-id', 'customer-uuid-123')
+      .set('x-user-role', 'customer');
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].driver).toBe('Ravi Kumar');
+    expect(res.body[0].truck).toBe('Open Body Truck');
+  });
+
+  it('runs driver_details, trucks, and profiles reads through the service-role client only', async () => {
+    const res = await request(buildApp())
+      .get(`/api/trucks/search?${SEARCH_PARAMS}`)
+      .set('x-user-id', 'customer-uuid-123')
+      .set('x-user-role', 'customer');
+
+    expect(res.status).toBe(200);
+    expect(anonFrom).not.toHaveBeenCalled();
+
+    const readTables = m.calls.map(c => c.table);
+    expect(readTables).toEqual(expect.arrayContaining(['driver_details', 'trucks', 'profiles']));
+    const driverDetailsCall = m.calls.find(c => c.table === 'driver_details');
+    expect(driverDetailsCall.filters).toEqual([
+      { col: 'is_online', op: 'eq', val: true },
+      { col: 'truck_id', op: 'not:is', val: null },
+      { col: 'user_id', op: 'in', val: ['driver-uuid-456'] },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #7327.

The driver-search endpoints in `backend/api/src/routes/truckRoutes.js` ran their `driver_details`, `trucks`, and `profiles` queries through the shared **anon-key** `supabase` client:
- `driver_details` SELECT (truckRoutes.js:591-596) — filtered by `is_online`, `truck_id`, `user_id`
- `trucks` SELECT (truckRoutes.js:611)
- `profiles` SELECT (truckRoutes.js:612)

All three tables are RLS-enabled with policies only for `service_role` and the owning `authenticated` user, and all privileges are revoked from `anon`. Because the shared client has no user session, the `driver_details` query runs as the anon role → `driversErr` is set and `GET /api/trucks/search` returns `500 Failed to search trucks` (or, without the revoke, an empty list). The driver-search / load-to-driver matching feature never returns real results.

## Fix

- `truckRoutes.js`: route the three driver-search reads (`driver_details`, `trucks`, `profiles`) through `supabaseAdmin` (service-role client). This is a marketplace search that must see all matching drivers, so the service-role client is used and scoping is done entirely by the search criteria — never the raw anon key.
- `test/integration/truckRoutes.test.js` + `test/integration/truckSearchCache.test.js`: the `config/db.js` mock now also exports `supabaseAdmin` (bound to the same in-memory mock), so the search reads keep exercising the store.
- `test/unit/truckSearchServiceRole.test.js`: new regression suite that binds the store-bearing client as `supabaseAdmin` and makes the anon `supabase` client throw on any `from()` call. It asserts `GET /api/trucks/search` returns enriched results and that the anon client is never consulted, and inspects the recorded query to confirm `driver_details` is filtered by `is_online = true`, `truck_id not is null`, `user_id in (...)`, all via the service-role client.

## Files changed

- `backend/api/src/routes/truckRoutes.js` — service-role client for the three search reads.
- `backend/api/test/integration/truckRoutes.test.js` — db mock gains `supabaseAdmin`.
- `backend/api/test/integration/truckSearchCache.test.js` — db mock gains `supabaseAdmin`.
- `backend/api/test/unit/truckSearchServiceRole.test.js` — new regression tests (2/2).

## Testing

- `npm test -- test/unit/truckSearchServiceRole.test.js` — 2/2 pass.
- `npm test -- test/integration/truckRoutes.test.js test/integration/truckSearchCache.test.js` — search tests pass; the 7 failures in `truckRoutes.test.js` are pre-existing on clean main (POST /api/trucks registration + GET /api/trucks ownership, unrelated to the search path and to this change).
- `npx eslint src/routes/truckRoutes.js test/integration/truckRoutes.test.js test/integration/truckSearchCache.test.js test/unit/truckSearchServiceRole.test.js` — clean.

## Notes

- The other `supabase` usages in `truckRoutes.js` (own-truck registration/list, per-driver reads) were intentionally left unchanged: they are outside the scope of this issue's driver-search path.
