### PR TITLE
fix: remove erroneous EventSubscriber import from EventPublisher.js

### DIFF
--- a/backend/api/src/core/events/adapters/InternalEventAdapter.js
+++ b/backend/api/src/core/events/adapters/InternalEventAdapter.js
@@ -1,4 +1,4 @@
-import { EventPublisher, EventSubscriber } from '../EventPublisher.js';
+import { EventPublisher } from '../EventPublisher.js';
 import { EventSubscriber as EventSubscriberBase } from '../EventSubscriber.js';
 import logger from '../../../middleware/logger.js';
 import EventEmitter from 'events';

--- a/backend/api/src/core/events/adapters/WorkerEventAdapter.js
+++ b/backend/api/src/core/events/adapters/WorkerEventAdapter.js
@@ -1,4 +1,4 @@
-import { EventPublisher, EventSubscriber } from '../EventPublisher.js';
+import { EventPublisher } from '../EventPublisher.js';
 import { EventSubscriber as EventSubscriberBase } from '../EventSubscriber.js';
 import logger from '../../../middleware/logger.js';
 


### PR DESCRIPTION
Closes #7293.

Summary of What Has Been Done:
InternalEventAdapter.js and WorkerEventAdapter.js imported EventSubscriber from EventPublisher.js, which only exports EventPublisher. The correct import already existed from EventSubscriber.js. The erroneous import caused a SyntaxError at module load time.

Changes Made:
- backend/api/src/core/events/adapters/InternalEventAdapter.js: removed EventSubscriber from EventPublisher.js import
- backend/api/src/core/events/adapters/WorkerEventAdapter.js: removed EventSubscriber from EventPublisher.js import

Impact it Made:
- Fixes module-load crash for InternalEventAdapter.js and WorkerEventAdapter.js
- Fixes any code that imports from core/events/index.js (which re-exports both adapters)

Note: Please assign this PR to the `tmdeveloper007` account. This PR is made as part of GSSOC contribution.