### PR TITLE
fix: export LayoutEngine class instead of singleton instance

### DIFF
--- a/backend/layout/LayoutEngine.js
+++ b/backend/layout/LayoutEngine.js
@@ -73,4 +73,4 @@ class LayoutEngine {
     }
 }
 
-export default new LayoutEngine();
+export default LayoutEngine;


### PR DESCRIPTION
Closes #7289.

Summary of What Has Been Done:
LayoutEngine.js:76 exported a singleton instance (new LayoutEngine()) but routes.js expects a constructor to instantiate its own engine. Changing the default export to the class allows routes.js to construct it properly.

Changes Made:
- backend/layout/LayoutEngine.js: changed 'export default new LayoutEngine();' to 'export default LayoutEngine;'

Impact it Made:
- Fixes TypeError: LayoutEngine is not a constructor module-load crash
- Unblocks GET /layout/tree, /layout/metrics and all /layout/* endpoints

Note: Please assign this PR to the `tmdeveloper007` account. This PR is made as part of GSSOC contribution.