### PR TITLE
fix: remove orphaned .catch() after export default in keda.service.js

### DIFF
--- a/k8s/keda/keda.service.js
+++ b/k8s/keda/keda.service.js
@@ -179,4 +179,3 @@ class KEDAService {
 }
 
 export default new KEDAService();
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Closes #7290.

Summary of What Has Been Done:
k8s/keda/keda.service.js ended with an orphaned .catch() chained onto the export default statement. There is no promise on the left of .catch, causing SyntaxError: Unexpected token '.' at parse time. The trailing .catch was leftover from a mis-moved Promise.all() guard.

Changes Made:
- k8s/keda/keda.service.js: removed the orphaned .catch(err => console.error(...)) line

Impact it Made:
- Fixes module-load SyntaxError for k8s/keda/keda.service.js
- Fixes module-load failure for k8s/keda/routes.js which imports it

Note: Please assign this PR to the `tmdeveloper007` account. This PR is made as part of GSSOC contribution.