### PR TITLE
fix: mount routeRoutes at /api/routes in index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -465,6 +465,7 @@ app.use('/api/driver', driverRoutes)
 // content-type enforcement, fraud detection and the /api rate limiter.
 // Registering it earlier silently bypasses every one of them.
 app.use('/api/earnings', earningsRouter)
+app.use('/api/routes', routeRoutes)
 app.use('/api/v1/shipment', shipmentRoutes)
 app.use('/api/loads', loadRoutes)
 app.use('/api/support', supportRoutes)


### PR DESCRIPTION
Closes #7326.

Summary of What Has Been Done:
routeRoutes was imported at index.js:52 but never mounted, causing GET /api/routes/estimate to always 404. The router is now mounted at /api/routes behind the full middleware chain consistent with other REST routes.

Changes Made:
- backend/api/src/index.js: added app.use('/api/routes', routeRoutes) mount

Impact it Made:
- Unblocks GET /api/routes/estimate endpoint for route estimation
- Consistent with other REST routes in terms of middleware application

Note: Please assign this PR to the `tmdeveloper007` account. This PR is made as part of GSSOC contribution.