### PR TITLE
fix : mount iotRoutes at /api/iot in index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -60,6 +60,7 @@ import paymentRoutes from './routes/paymentRoutes.js'
 import userRoutes from './routes/userRoutes.js'
 import voiceRoutes from './routes/voiceRoutes.js'
 import demandRoutes from './routes/demandRoutes.js'
+import iotRoutes from './routes/iotRoutes.js'
 
 // ============================================================================
 // 🆕 MULTI-PROVIDER ORACLE & VERIFICATION ROUTES
@@ -481,6 +482,8 @@ app.use('/api/v1/admin', adminRoutes)
 app.use('/api/v1/admin/audit-logs', auditRoutes)
 app.use('/api/voice', voiceRoutes)
 app.use('/api/demand-heatmap', demandRoutes)
+app.use('/api/routes', routeRoutes)
+app.use('/api/iot', iotRoutes)
 
 // ============================================================================
 // WEBHOOK ROUTES


### PR DESCRIPTION
Closes #7349.

Summary of What Has Been Done:
backend/api/src/routes/iotRoutes.js was neither imported nor mounted in backend/api/src/index.js. This fix adds the import and app.use('/api/iot', iotRoutes) mount so the cold-chain telemetry API becomes functional.

Changes Made:
- backend/api/src/index.js: Added import for iotRoutes and mounted it at /api/iot in the REST routing section.

Impact it Made:
- POST /api/iot/telemetry/:id and telemetry history endpoints become reachable.
- Cold-chain temperature monitoring for IoT sensors becomes functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).