### PR TITLE
fix : remove orphaned .catch() after export default in keda.service.js

### DIFF
--- a/k8s/keda/keda.service.js
+++ b/k8s/keda/keda.service.js
@@ -179,4 +179,3 @@ class KEDAService {
 }
 
 export default new KEDAService();
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Closes #7351.

Summary of What Has Been Done:
k8s/keda/keda.service.js ended with an orphaned .catch() chained onto the export default statement. There is no promise on the left of .catch, which causes SyntaxError: Unexpected token '.' in Node.js. This fix removes the trailing .catch() line.

Changes Made:
- k8s/keda/keda.service.js: Removed the orphaned .catch(err => console.error("Promise.all failed:", err)) line.

Impact it Made:
- The module now parses cleanly and can be loaded.
- k8s/keda/routes.js can import and use the service.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).