### PR TITLE
fix : export LayoutEngine class instead of singleton instance

### DIFF
--- a/backend/layout/LayoutEngine.js
+++ b/backend/layout/LayoutEngine.js
@@ -73,4 +73,4 @@ class LayoutEngine {
     }
 }
 
-export default new LayoutEngine();
+export default LayoutEngine;


### PR DESCRIPTION
Closes #7352.

Summary of What Has Been Done:
backend/layout/LayoutEngine.js was exporting a singleton instance (export default new LayoutEngine()) but backend/layout/routes.js constructs it with new LayoutEngine(), which throws TypeError on a non-constructor. This fix changes the export to export the class itself.

Changes Made:
- backend/layout/LayoutEngine.js: Changed export default new LayoutEngine() to export default LayoutEngine.

Impact it Made:
- backend/layout/routes.js can now construct LayoutEngine instances cleanly.
- GET /layout/tree and /layout/metrics endpoints become functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).