### PR TITLE
fix : add async keyword to GlobalStore transaction method

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -183,7 +183,7 @@ class GlobalStore extends EventEmitter {
     
     // ============ Transaction Support ============
     
-    transaction(fn) {
+    async transaction(fn) {
         if (this.activeTransaction) {
             throw new Error('Nested transactions not supported');
         }


### PR DESCRIPTION
Closes #7353.

Summary of What Has Been Done:
backend/store/GlobalStore.js:228 uses await inside the transaction() method but the method was not declared async, causing SyntaxError in ESM. This fix adds the async keyword to the transaction() method declaration.

Changes Made:
- backend/store/GlobalStore.js: Changed transaction(fn) to async transaction(fn).

Impact it Made:
- The GlobalStore module loads cleanly without SyntaxError.
- backend/store/routes.js becomes functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).