### PR TITLE
fix : add async keyword to geofence-confirm handler in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -182,7 +182,7 @@ import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 
-router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
+router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);


### PR DESCRIPTION
Closes #7355.

Summary of What Has Been Done:
backend/api/src/routes/orderRoutes.js:185 the geofence-confirm handler used await without async, causing SyntaxError in ESM and preventing the entire orderRoutes module from loading. This fix adds the async keyword.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Changed (req, res) => { to async (req, res) => { on the geofence-confirm handler.

Impact it Made:
- The entire orderRoutes module becomes loadable.
- All /api/orders/* endpoints become functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).