### PR TITLE
fix : convert require() to ESM import and fix path in zkp.routes.js

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -1,5 +1,5 @@
-const { authenticate } = require('../middleware/auth.middleware');
 import express from 'express';
+import { authenticate } from '../middleware/auth.js';
 import zkpService from '../services/zkp/zkp.service.js';
 import { LockAcquisitionError } from '../lib/redisLock.js';
 import { redisRateLimiter } from '../middleware/redisRateLimiter.js';


### PR DESCRIPTION
Closes #7357.

Summary of What Has Been Done:
backend/api/src/routes/zkp.routes.js:1 used CommonJS require() in an ESM file alongside ESM import statements. This caused a module-typeless parse error preventing the API server from starting. This fix converts the require() to an ESM import and corrects the import path to '../middleware/auth.js' (matching how all other routes import authenticate).

Changes Made:
- backend/api/src/routes/zkp.routes.js: Replaced const { authenticate } = require('../middleware/auth.middleware') with import { authenticate } from '../middleware/auth.js'.

Impact it Made:
- zkp.routes.js becomes valid ESM and the API server boots cleanly.
- All /api/zkp/* endpoints become functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).