### PR TITLE
fix : add user_id filter to getDevicePlatforms query to avoid fetching entire table

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -221,9 +221,11 @@ export async function unregisterAllDeviceTokens(userId) {
  */
 export async function getDevicePlatforms(req, res, next) {
   try {
+    const userId = req.user?.id;
     const { data, error } = await supabase
       .from('user_devices')
-      .select('platform');
+      .select('platform')
+      .eq('user_id', userId);
 
     if (error) {
       logger.error('[DeviceController] Failed to query device platforms:', error.message);


### PR DESCRIPTION
Closes #7363.

Summary of What Has Been Done:
backend/api/src/controllers/deviceController.js getDevicePlatforms() did .select('platform') without any .eq() filter, loading all rows from user_devices into memory before extracting unique platforms. This fix adds an .eq('user_id', userId) filter so only the current user's devices are queried.

Changes Made:
- backend/api/src/controllers/deviceController.js: Added userId from req.user and .eq('user_id', userId) to the supabase query.

Impact it Made:
- Reduced memory usage and network transfer for the platforms endpoint.
- Better performance as the table grows.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).