### PR TITLE
fix : reject telemetry events with null or invalid lat/lng in batch sync endpoint

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -287,6 +287,11 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       const lat = event.payload?.lat !== undefined ? Number(event.payload.lat) : null;
       const lng = event.payload?.lng !== undefined ? Number(event.payload.lng) : null;
 
+      if (lat === null || lng === null || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+        logger.warn('[SyncEngine] Skipping event with invalid coordinates:', { eventId: event.id, lat, lng });
+        return null;
+      }
+
       const safeMetadata = deepSanitize(event.payload, SENSITIVE_FIELDS);
 
       return {
@@ -303,11 +308,15 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
     });
 
     // 3. Bulk Insert / Upsert into the trip_events table
+    // Filter out null records (events with invalid coordinates)
+    const validRecords = recordsToInsert.filter(Boolean);
+
+    // 4. Bulk Insert / Upsert into the trip_events table
     // Upsert ensures that if a specific event ID already exists, it just updates it
     // rather than failing the whole batch.
     const { error: insertError } = await supabase
       .from('trip_events')
-      .upsert(recordsToInsert, { onConflict: 'event_id' });
+      .upsert(validRecords, { onConflict: 'event_id' });
 
     if (insertError) {
       logger.error('[SyncEngine] Bulk Insert Failed:', insertError.message);


### PR DESCRIPTION
Closes #7369.

Summary of What Has Been Done:
backend/api/src/routes/tripRoutes.js batch event sync endpoint was accepting telemetry events with null or invalid lat/lng coordinates, inserting null location records into the database and broadcasting null coordinates via WebSocket. This fix validates that lat and lng are present, finite numbers before processing the event, skipping invalid events and filtering them from the bulk upsert.

Changes Made:
- backend/api/src/routes/tripRoutes.js: Added null/invalid coordinate check in the recordsToInsert mapping, and added filtering to exclude null records from the bulk upsert.

Impact it Made:
- No more null location records in the trip_events database.
- Live tracking clients receive only valid coordinates.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).