### PR TITLE
fix : use nullish coalescing instead of logical OR for eventOpts.type default in CachePublisher

### DIFF
--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -90,7 +90,7 @@ export async function publishInvalidation(namespace, eventOpts = {}) {
   if (!ns.enablePubSub) return;
 
   const channel = CacheKeyBuilder.pubSubChannel(namespace);
-  const event = createCacheEvent(eventOpts.type || CacheEventType.INVALIDATE_KEY, {
+  const event = createCacheEvent(eventOpts.type ?? CacheEventType.INVALIDATE_KEY, {
     namespace,
     originInstanceId: instanceId,
     ...eventOpts,


### PR DESCRIPTION
Closes #7367.

Summary of What Has Been Done:
backend/api/src/cache/CachePublisher.js used logical OR (||) for the eventOpts.type default value in the publishInvalidation function. This caused falsy but valid type values (like empty string) to be replaced with the default. This fix uses nullish coalescing (??) so only null or undefined triggers the default.

Changes Made:
- backend/api/src/cache/CachePublisher.js: Changed eventOpts.type || CacheEventType.INVALIDATE_KEY to eventOpts.type ?? CacheEventType.INVALIDATE_KEY.

Impact it Made:
- Falsy but intentional event type values are no longer incorrectly replaced with the default.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).