### PR TITLE
fix : use updateOrderWithFilter for escrow_status guard in payment funding update

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -153,6 +153,8 @@ export class OrderRepository {
             query = query.not(f.column, f.operator, f.value);
           } else if (f.op === 'in') {
             query = query.in(f.column, f.value);
+          } else if (f.op === 'neq') {
+            query = query.not(f.column, 'neq', f.value);
           }
         }
       }

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -283,7 +283,7 @@ router.post(
       logger.info(`[payments] Deposit verified on-chain for ${order.order_display_id}`);
 
       // 6. Update escrow_status → funded
-      const { error: updateErr } = await orderRepository.updateOrder(
+      const { error: updateErr } = await orderRepository.updateOrderWithFilter(
         order.id,
         {
           escrow_status: 'funded',


### PR DESCRIPTION
Closes #7323.

Summary of What Has Been Done:
backend/api/src/routes/paymentRoutes.js called orderRepository.updateOrder() with a guard filter neq(escrow_status, funded), but updateOrder() ignores guard filters. This fix calls updateOrderWithFilter() instead, which properly applies the guard filter. Also added neq operator support to updateOrderWithFilter() in orderRepository.

Changes Made:
- backend/api/src/repositories/orderRepository.js: Added neq operator support to updateOrderWithFilter filters
- backend/api/src/routes/paymentRoutes.js: Changed updateOrder() to updateOrderWithFilter() for the escrow_status=funded guard

Impact it Made:
- Concurrent or stale deposit confirmations can no longer overwrite a different escrow state.

Note: Please assign this PR to the tmdeveloper007 account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).