### PR TITLE
fix : use supabaseAdmin for loads board query in loadRoutes

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -50,7 +50,7 @@
  */
 
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
@@ -193,7 +193,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
     const from = (page - 1) * limit;
     const to   = from + limit - 1;
 
-    let query = supabase
+    let query = supabaseAdmin
       .from('load_offers')
       .select('*', { count: 'exact' });
 


### PR DESCRIPTION
Closes #7328.

Summary of What Has Been Done:
backend/api/src/routes/loadRoutes.js queries load_offers via the anon-key supabase client. RLS policies prevent the anon role from reading load_offers, causing the loads board to return empty results for all drivers. This fix uses supabaseAdmin for the load_offers board query.

Changes Made:
- backend/api/src/routes/loadRoutes.js: Changed load_offers board query to use supabaseAdmin

Impact it Made:
- Drivers can see available loads on the board instead of an empty list.

Note: Please assign this PR to the tmdeveloper007 account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).