### PR TITLE
fix : use supabaseAdmin for FCM token queries in notificationService

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -28,9 +28,9 @@ function calculateRetryBackoff(attempt) {
 }
 
 async function getUserFcmToken(userId) {
-  if (!supabase) return null;
+  if (!supabaseAdmin) return null;
   try {
-    const { data, error } = await supabase.from('profiles').select('fcm_token').eq('id', userId).maybeSingle();
+    const { data, error } = await supabaseAdmin.from('profiles').select('fcm_token').eq('id', userId).maybeSingle();
     if (error || !data?.fcm_token) return null;
     return data.fcm_token;
   } catch (err) {
@@ -40,9 +40,9 @@ async function getUserFcmToken(userId) {
 }
 
 async function clearInvalidToken(userId) {
-  if (!supabase) return;
+  if (!supabaseAdmin) return;
   try {
-    await supabase
+    await supabaseAdmin
       .from('profiles')
       .update({
         fcm_token: null,


### PR DESCRIPTION
Closes #7320.

Summary of What Has Been Done:
backend/api/src/services/notificationService.js reads profiles.fcm_token via the anon-key supabase client in getUserFcmToken and clearInvalidToken. RLS policies prevent the anon role from reading profiles, so push notifications fail silently. This fix uses supabaseAdmin for both queries.

Changes Made:
- backend/api/src/services/notificationService.js: Changed getUserFcmToken and clearInvalidToken to use supabaseAdmin

Impact it Made:
- Push notifications are sent successfully instead of silently failing.

Note: Please assign this PR to the tmdeveloper007 account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).