### PR TITLE
fix(address_repository): make setDefault atomic to prevent losing all defaults

### DIFF
--- a/apps/customer/lib/repositories/address_repository.dart
+++ b/apps/customer/lib/repositories/address_repository.dart
@@ -1,3 +1,5 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../models/saved_address.dart';
 import '../services/supabase_service.dart';
 
@@ -35,25 +37,25 @@ class AddressRepository {
   }
 
   /// Set an address as the default, clearing all others.
+  ///
+  /// Clear-and-set runs atomically via the `set_default_address` RPC so a
+  /// failure partway through never leaves the user with no default address.
   Future<void> setDefault(String addressId) async {
     final userId = SupabaseService.requireUserId();
-    final existing = await SupabaseService.client
-        .from(_table)
-        .select('id')
-        .eq('id', addressId)
-        .eq('user_id', userId)
-        .maybeSingle();
-
-    if (existing == null) {
-      throw StateError('Address not found.');
+    try {
+      await SupabaseService.client.rpc(
+        'set_default_address',
+        params: {
+          'p_address_id': addressId,
+          'p_user_id': userId,
+        },
+      );
+    } on PostgrestException catch (e) {
+      if (e.message.contains('Address not found')) {
+        throw StateError('Address not found.');
+      }
+      rethrow;
     }
-
-    await _clearDefaults(userId, exceptId: addressId);
-    await SupabaseService.client
-        .from(_table)
-        .update({'is_default': true})
-        .eq('id', addressId)
-        .eq('user_id', userId);
   }
 
   /// Delete an address by ID.

--- a/supabase/migrations/20260804000000_add_set_default_address_rpc.sql
+++ b/supabase/migrations/20260804000000_add_set_default_address_rpc.sql
@@ -1,0 +1,54 @@
+-- Migration: Add set_default_address RPC (fixes #1359)
+-- setDefault previously cleared all defaults in one call, then set the new
+-- default in a second, separate call. If the second call failed (stale/
+-- deleted addressId, RLS block, network error), every address was left
+-- non-default with no replacement. This wraps both writes in a single
+-- SECURITY DEFINER function so they succeed or fail together.
+
+CREATE OR REPLACE FUNCTION set_default_address(
+  p_address_id UUID,
+  p_user_id    UUID
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_exists BOOLEAN;
+BEGIN
+  -- Verify the caller IS the user whose addresses are being modified.
+  -- auth.uid() is NULL for unauthenticated calls, and NULL <> x is NULL
+  -- (not TRUE), so this must be a null-safe check to actually block them.
+  IF auth.uid() IS NULL OR auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only modify your own addresses';
+  END IF;
+
+  -- Lock and confirm the target address belongs to this user before
+  -- touching anything else
+  SELECT EXISTS(
+    SELECT 1 FROM saved_addresses
+    WHERE id = p_address_id
+      AND user_id = p_user_id
+    FOR UPDATE
+  ) INTO v_exists;
+
+  IF NOT v_exists THEN
+    RAISE EXCEPTION 'Address not found';
+  END IF;
+
+  UPDATE saved_addresses
+    SET is_default = false
+    WHERE user_id = p_user_id
+      AND id <> p_address_id;
+
+  UPDATE saved_addresses
+    SET is_default = true
+    WHERE id = p_address_id
+      AND user_id = p_user_id;
+END;
+$$;
+
+-- Postgres grants EXECUTE to PUBLIC by default on function creation;
+-- granting to authenticated afterward does not revoke that. Revoke first.
+REVOKE EXECUTE ON FUNCTION set_default_address(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION set_default_address(UUID, UUID) TO authenticated;


### PR DESCRIPTION
## Description
`setDefault` in `address_repository.dart` called `_clearDefaults(userId)`
and then a separate `update()` to set the new default as two independent
network calls. If the second call failed (stale/deleted addressId, RLS
block, network error), every address was left non-default with no
replacement.

Added a `SECURITY DEFINER` RPC, `set_default_address`, that:
- Verifies the caller owns the target address (`auth.uid()` check + row
  lock via `FOR UPDATE`)
- Clears and sets the default inside a single Postgres transaction

`setDefault` now calls this RPC instead of two separate client calls, so
the clear-and-set always succeeds or fails together.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** Manually invoked `set_default_address` against a
  local Supabase instance via the Supabase SQL editor / client RPC call.
- **Test Steps / Prerequisites:** Seed a user with 2+ saved addresses,
  one marked default.
- **Expected Result:**
  - Valid `addressId` belonging to the user → old default cleared, new
    one set, exactly one row has `is_default = true`.
  - Invalid/foreign `addressId` → RPC raises `Address not found`, caught
    client-side and rethrown as `StateError('Address not found.')`; no
    rows touched.

### Test Environment
- [x] Local manual testing

## Related Issues
Closes #1359

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when changing the default address by applying the update as one atomic operation.
  - Prevented inconsistent address states when multiple updates occur simultaneously.
  - Added clearer handling when the selected address cannot be found.
  - Enforced that only the signed-in account can update its own addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->