### PR TITLE
fix : removed duplicate submitEscrowRefund import in container.js

### DIFF
--- a/backend/api/src/core/container.js
+++ b/backend/api/src/core/container.js
@@ -18,7 +18,6 @@ import {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 } from '../services/escrow.js';
 
@@ -83,6 +82,5 @@ export {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 };


### PR DESCRIPTION
Closes #7406.

Summary of What Has Been Done:
Removed the duplicate submitEscrowRefund named import from '../services/escrow.js' in container.js. There were two occurrences of the import - one in the OrderLifecycleService imports block and one in a separate block.

Changes Made:
- Removed duplicate submitEscrowRefund from both import blocks in container.js

Impact it Made:
- Fixes a SyntaxError: Duplicate export of 'submitEscrowRefund' that prevented the API server from booting
- Verified with node --check

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.