### PR TITLE
fix : used nullish coalescing for eventOpts.type in CachePublisher

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -60,7 +60,7 @@
     "globals": "^17.7.0",
     "nodemon": "^3.1.2",
     "supertest": "^7.2.2",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.10"
   },
   "keywords": [
     "express",

--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -90,7 +90,7 @@ export async function publishInvalidation(namespace, eventOpts = {}) {
   if (!ns.enablePubSub) return;
 
   const channel = CacheKeyBuilder.pubSubChannel(namespace);
-  const event = createCacheEvent(eventOpts.type || CacheEventType.INVALIDATE_KEY, {
+  const event = createCacheEvent(eventOpts.type ?? CacheEventType.INVALIDATE_KEY, {
     namespace,
     originInstanceId: instanceId,
     ...eventOpts,


### PR DESCRIPTION
Closes #7409.

Summary of What Has Been Done:
Changed the logical OR (||) to nullish coalescing (??) for eventOpts.type in the publishInvalidation function in CachePublisher.js. This ensures that falsy values like 0, '', or false are preserved instead of being replaced with the default CacheEventType.INVALIDATE_KEY.

Changes Made:
- Changed eventOpts.type || CacheEventType.INVALIDATE_KEY to eventOpts.type ?? CacheEventType.INVALIDATE_KEY

Impact it Made:
- Fixes incorrect behavior where falsy cache event types were silently replaced with INVALIDATE_KEY
- Ensures explicit 0 or empty-string event types are preserved

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.