### PR TITLE
fix : reset DLQ event status to pending on retryable failure

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -127,11 +127,12 @@ export const dlqService = {
             const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
             await dlqDb()
               .from('webhook_failures')
-              .update({ 
+              .update({
+                status: 'pending',
                 retry_count: newRetryCount,
                 next_retry_at: nextRetryAt,
                 error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString()
+                updated_at: new Date().toISOString(),
               })
               .eq('id', event.id);
           }


### PR DESCRIPTION
Closes #7410.

Summary of What Has Been Done:
Added status: 'pending' to the DLQ event retry update in dlqService.js. Previously, when a DLQ event failed with a retry available, the status was never reset from 'processing' back to 'pending', causing the event to be permanently stuck and never picked up again.

Changes Made:
- Added status: 'pending' to the retry update call in the catch handler

Impact it Made:
- Fixes the DLQ retry mechanism so failed events are actually retried
- Prevents webhook failures from being permanently stuck in processing state

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.