### PR TITLE
fix : required lat/lng in tracker telemetry and reject null coordinates

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -10,8 +10,8 @@ import { GpsLog } from '../models/GpsLog.js';
 import { ebpfLoader } from '../../../../ebpf/loader.js';
 
 const TELEMETRY_SCHEMA = {
-  lat: { type: 'number', required: false, min: -90, max: 90 },
-  lng: { type: 'number', required: false, min: -180, max: 180 },
+  lat: { type: 'number', required: true, min: -90, max: 90 },
+  lng: { type: 'number', required: true, min: -180, max: 180 },
   latitude: { type: 'number', required: false, min: -90, max: 90 },
   longitude: { type: 'number', required: false, min: -180, max: 180 },
   driver_id: { type: 'string', required: false, minLen: 1, maxLen: 64 },
@@ -750,6 +750,11 @@ export async function handleLocationPing(ws, data, req) {
 
   const lat = data.lat !== undefined ? data.lat : data.latitude;
   const lng = data.lng !== undefined ? data.lng : data.longitude;
+
+  // Reject frames with null or undefined coordinates before validation
+  if (lat === null || lat === undefined || lng === null || lng === undefined) {
+    return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: ['lat and lng are required'] }));
+  }
 
   // Fix 3 + dead-code fix: run the payload through the schema validator/
   const normalizedForValidation = {


### PR DESCRIPTION
Closes #7411.

Summary of What Has Been Done:
Made lat and lng required fields in the TELEMETRY_SCHEMA (changed required: false to required: true) and added an explicit null check after extracting lat/lng from the data. This prevents telemetry frames with null or undefined coordinates from passing validation and being stored in the database.

Changes Made:
- Changed lat and lng schema from required: false to required: true
- Added explicit null/undefined check for lat and lng before validation

Impact it Made:
- Prevents null-location records from entering the database
- Ensures live location broadcasts only contain valid coordinates

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.