### PR TITLE
fix : removed incorrect EventSubscriber import from EventPublisher.js in event adapters

### DIFF
--- a/backend/api/src/core/events/adapters/InternalEventAdapter.js
+++ b/backend/api/src/core/events/adapters/InternalEventAdapter.js
@@ -1,4 +1,4 @@
-import { EventPublisher, EventSubscriber } from '../EventPublisher.js';
+import { EventPublisher } from '../EventPublisher.js';
 import { EventSubscriber as EventSubscriberBase } from '../EventSubscriber.js';
 import logger from '../../../middleware/logger.js';
 import EventEmitter from 'events';

--- a/backend/api/src/core/events/adapters/WorkerEventAdapter.js
+++ b/backend/api/src/core/events/adapters/WorkerEventAdapter.js
@@ -1,4 +1,4 @@
-import { EventPublisher, EventSubscriber } from '../EventPublisher.js';
+import { EventPublisher } from '../EventPublisher.js';
 import { EventSubscriber as EventSubscriberBase } from '../EventSubscriber.js';
 import logger from '../../../middleware/logger.js';
 


### PR DESCRIPTION
Closes #7412.

Summary of What Has Been Done:
Removed the incorrect import of EventSubscriber from EventPublisher.js in both InternalEventAdapter.js and WorkerEventAdapter.js. EventPublisher.js only exports EventPublisher class, not EventSubscriber. The adapters already correctly import EventSubscriber from EventSubscriber.js (as EventSubscriberBase).

Changes Made:
- InternalEventAdapter.js: removed EventSubscriber from EventPublisher.js import
- WorkerEventAdapter.js: removed EventSubscriber from EventPublisher.js import

Impact it Made:
- Fixes module load errors in both event bus adapters
- Enables the EventBus to use InternalEventAdapter and WorkerEventAdapter correctly

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.