### PR TITLE
fix : used supabaseAdmin for loads board query in loadRoutes

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -50,7 +50,7 @@
  */
 
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
@@ -193,7 +193,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
     const from = (page - 1) * limit;
     const to   = from + limit - 1;
 
-    let query = supabase
+    let query = supabaseAdmin
       .from('load_offers')
       .select('*', { count: 'exact' });
 


### PR DESCRIPTION
Closes #7413.

Summary of What Has Been Done:
Changed the loads board endpoint to use supabaseAdmin instead of the anon supabase client for the load_offers query. The anon-key client is blocked by RLS policies, causing the loads board to return empty results.

Changes Made:
- Added supabaseAdmin to the import from '../config/db.js'
- Changed the load_offers query from supabase to supabaseAdmin

Impact it Made:
- Fixes the loads board returning empty results due to RLS restrictions
- Allows the administrative loads view to show all active load offers

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.