### PR TITLE
fix: container.js duplicate import prevents backend boot

### DIFF
--- a/backend/api/src/core/container.js
+++ b/backend/api/src/core/container.js
@@ -18,7 +18,6 @@ import {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 } from '../services/escrow.js';
 
@@ -83,6 +82,5 @@ export {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 };


### PR DESCRIPTION
## Summary

Removes the duplicate `submitEscrowRefund` import in `backend/api/src/core/container.js` that caused the module to fail loading with `SyntaxError: Identifier 'submitEscrowRefund' has already been declared`, blocking backend startup.

Verified: dynamic import no longer throws the duplicate-identifier error.

Closes #7425

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused escrow refund service export.
  * No end-user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->