### PR TITLE
fix: orderLifecycleService duplicate import prevents module load

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -7,7 +7,6 @@ import { supabaseAdmin } from '../../config/db.js';
 import {
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
   getEscrowBookingId,


### PR DESCRIPTION
## Summary

Removes the duplicate `submitEscrowRefund` import in `backend/api/src/services/order/orderLifecycleService.js` that caused the module to fail loading with `SyntaxError: Identifier 'submitEscrowRefund' has already been declared`, breaking order/payment route wiring via the container.

Verified: dynamic import no longer throws the duplicate-identifier error.

Closes #7426

GSSOC
