### PR TITLE
fix: geofence-confirm handler malformed - orderRoutes fails to parse

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -182,7 +182,7 @@ import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 
-router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
+router.post('/api/deliveries/:id/geofence-confirm', authenticate, async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);
@@ -192,47 +192,45 @@ router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
     return res.status(400).json({ error: 'Invalid driver_lat or driver_lng' });
   }
 
-  if (geofence_radius_m !== undefined) {
-    const radius = parseFloat(geofence_radius_m);
-    if (!Number.isFinite(radius) || radius <= 0) {
-      return res.status(400).json({ error: 'Invalid geofence_radius_m' });
-    }
+  const geofenceRadiusM = geofence_radius_m !== undefined ? parseFloat(geofence_radius_m) : undefined;
+  if (geofence_radius_m !== undefined && (!Number.isFinite(geofenceRadiusM) || geofenceRadiusM <= 0)) {
+    return res.status(400).json({ error: 'Invalid geofence_radius_m' });
   }
 
-      // Verify the order exists and the requesting driver is assigned to it
-      const order = await orderValidationService.findOrderByIdOrDisplayId(
-        req.params.id,
-        'id, driver_id, customer_id'
-      );
-      orderValidationService.assertOrderFound(order);
-      orderValidationService.assertDriverAssignment(order, req.user.id);
+  try {
+    // Verify the order exists and the requesting driver is assigned to it
+    const order = await orderValidationService.findOrderByIdOrDisplayId(
+      req.params.id,
+      'id, driver_id, customer_id'
+    );
+    orderValidationService.assertOrderFound(order);
+    orderValidationService.assertDriverAssignment(order, req.user.id);
 
-      logger.info({
-        event: 'GEOFENCE_CONFIRM_ATTEMPT',
-        orderId: req.params.id,
-        driverId: req.user.id,
-        lat,
-        lng,
-      }, 'Driver geofence confirm attempt');
+    logger.info({
+      event: 'GEOFENCE_CONFIRM_ATTEMPT',
+      orderId: req.params.id,
+      driverId: req.user.id,
+      lat,
+      lng,
+    }, 'Driver geofence confirm attempt');
 
-      const result = await orderLifecycleService.deliveryVerification.geofenceAutoConfirm({
-        orderId: req.params.id,
-        driverId: req.user.id,
-        driverLat: lat,
-        driverLng: lng,
-        geofenceRadiusM,
-      });
+    const result = await orderLifecycleService.deliveryVerification.geofenceAutoConfirm({
+      orderId: req.params.id,
+      driverId: req.user.id,
+      driverLat: lat,
+      driverLng: lng,
+      geofenceRadiusM,
+    });
 
-      return res.json(result);
-    } catch (err) {
-      if (err instanceof DomainError) {
-        return res.status(err.status).json(err.payload);
-      }
-      logger.error('[geofence-confirm] Exception:', err.message);
-      return res.status(500).json({ error: 'Internal Server Error' });
+    return res.json(result);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(err.status).json(err.payload);
     }
+    logger.error('[geofence-confirm] Exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
-);
+});
 
 // ============================================================================
 // 13c. DRIVER OTP CONFIRM ALIAS — POST /api/deliveries/:id/confirm-otp


### PR DESCRIPTION
## Summary

Repairs the malformed `POST /api/deliveries/:id/geofence-confirm` handler in `backend/api/src/routes/orderRoutes.js`:

- Made the handler `async` (it used `await` in a sync callback → `SyntaxError: Unexpected reserved word`, which made the entire Orders router unparseable).
- Added the missing `try` for the orphaned `catch`.
- Declared `geofenceRadiusM` from the validated `geofence_radius_m` (was an undeclared variable).
- Added the `authenticate` middleware (handler read `req.user.id` without it).

Verified: `node --check` passes and the module now parses.

Closes #7428

GSSOC
