### PR TITLE
fix: submitBid never releases its Redis lock

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -301,8 +301,8 @@ export class OrderLifecycleService {
   async submitBid(loadOfferId, driverId, bidAmount) {
     return measureExecution('OrderLifecycleService.submitBid', async () => {
       const lockKey = `lock:submitBid:${driverId}:${loadOfferId}`;
-      const acquired = await acquireLock(lockKey, 5000);
-      if (!acquired) throw new DomainError(409, { error: 'Duplicate bid submission in progress.' });
+      const lockValue = await acquireLock(lockKey, 5000);
+      if (!lockValue) throw new DomainError(409, { error: 'Duplicate bid submission in progress.' });
 
       try {
         const { data: offer, error: offerErr } = await this.orderRepository.findLoadOfferById(loadOfferId, 'id, status, customer_id');
@@ -341,7 +341,7 @@ export class OrderLifecycleService {
 
         return { message: 'Bid submitted successfully.', bid };
       } finally {
-        await releaseLock(lockKey);
+        await releaseLock(lockKey, lockValue);
       }
     });
   }


### PR DESCRIPTION
## Summary

`submitBid` in `backend/api/src/services/order/orderLifecycleService.js` acquired a Redis lock but called `releaseLock(lockKey)` without the owner token. `releaseLock` no-ops when the token is missing (redisLock.js:109-110), so the lock survived its 5s TTL and produced spurious `409 Duplicate bid submission in progress` responses.

- Capture the owner token from `acquireLock` and pass it to `releaseLock`, matching the pattern already used by the other 4 call sites in the same file.

Closes #7431

GSSOC
