### PR TITLE
fix: FHE decrypt ignores secret key - any key decrypts

### DIFF
--- a/backend/fhe-ai/fhe_inference.py
+++ b/backend/fhe-ai/fhe_inference.py
@@ -1,22 +1,43 @@
 import math
 import hashlib
+import secrets
+
+
+def _derive_public_key(secret_key: str) -> str:
+    """Simulated key-pair derivation: public key is a digest of the secret key."""
+    return hashlib.sha256(("truxify-fhe-key-pair:" + secret_key).encode()).hexdigest()
+
 
 class HomomorphicTensor:
     """Simulated CKKS / BFV Homomorphic Encrypted Tensor representation."""
-    def __init__(self, encrypted_vector: list, scale: float = 1000.0):
+
+    def __init__(self, encrypted_vector: list, scale: float = 1000.0, public_key: str = None):
         self.encrypted_vector = encrypted_vector
         self.scale = scale
+        self.public_key = public_key
 
     def decrypt_evaluate(self, secret_key: str) -> list:
         """Decrypts evaluation ciphertext using matching secret key."""
-        key_hash = int(hashlib.md5(secret_key.encode()).hexdigest(), 16) % 1000
+        if self.public_key is not None:
+            derived_public_key = _derive_public_key(secret_key)
+            if derived_public_key != self.public_key:
+                raise ValueError("Decryption failed: secret key does not match the encryption public key.")
         return [v / self.scale for v in self.encrypted_vector]
+
 
 class FhePriceInferenceEngine:
     """
     Fully Homomorphic Encryption (FHE) Load Price Inference Engine.
     Executes matrix operations directly on homomorphically encrypted cargo features.
     """
+
+    @staticmethod
+    def generate_key_pair():
+        """Generates a simulated (public_key, secret_key) pair bound to each other."""
+        secret_key = secrets.token_hex(16)
+        public_key = _derive_public_key(secret_key)
+        return public_key, secret_key
+
     def __init__(self):
         # Default pricing weights: [distance_weight, weight_weight, volume_weight]
         self.weights = [2.5, 1.2, 0.8]
@@ -26,13 +47,14 @@ class FhePriceInferenceEngine:
         """Encrypts client input vector using public key."""
         scale = 1000.0
         encrypted = [int(f * scale) for f in features]
-        return HomomorphicTensor(encrypted, scale)
+        return HomomorphicTensor(encrypted, scale, public_key)
 
     def predict_encrypted_price(self, encrypted_tensor: HomomorphicTensor) -> HomomorphicTensor:
         """Evaluates linear regression directly on encrypted ciphertext."""
         scaled_bias = int(self.bias * encrypted_tensor.scale)
         dot_product = sum(int(f * w) for f, w in zip(encrypted_tensor.encrypted_vector, self.weights))
         encrypted_result = [dot_product + scaled_bias]
-        return HomomorphicTensor(encrypted_result, encrypted_tensor.scale)
+        return HomomorphicTensor(encrypted_result, encrypted_tensor.scale, encrypted_tensor.public_key)
+
 
 fhe_engine = FhePriceInferenceEngine()

--- a/backend/fhe-ai/test_fhe.py
+++ b/backend/fhe-ai/test_fhe.py
@@ -7,8 +7,7 @@ class TestFheInference(unittest.TestCase):
 
     def test_encrypted_prediction(self):
         features = [100.0, 10.0, 5.0] # 100km, 10 tons, 5 m^3
-        pub_key = "PUB_KEY_DEMO_123"
-        sec_key = "SEC_KEY_DEMO_123"
+        pub_key, sec_key = FhePriceInferenceEngine.generate_key_pair()
 
         encrypted_input = self.engine.encrypt_features(features, pub_key)
         encrypted_price = self.engine.predict_encrypted_price(encrypted_input)
@@ -17,6 +16,17 @@ class TestFheInference(unittest.TestCase):
         expected_price = (100.0 * 2.5) + (10.0 * 1.2) + (5.0 * 0.8) + 50.0
 
         self.assertAlmostEqual(decrypted_price, expected_price, places=2)
+
+    def test_wrong_key_fails(self):
+        features = [100.0, 10.0, 5.0]
+        pub_key, _ = FhePriceInferenceEngine.generate_key_pair()
+        wrong_key = "THIS_IS_NOT_THE_SECRET_KEY"
+
+        encrypted_input = self.engine.encrypt_features(features, pub_key)
+        encrypted_price = self.engine.predict_encrypted_price(encrypted_input)
+
+        with self.assertRaises(ValueError):
+            encrypted_price.decrypt_evaluate(wrong_key)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

`HomomorphicTensor.decrypt_evaluate` in `backend/fhe-ai/fhe_inference.py` computed `key_hash` from the secret key but never used it — any key decrypted the ciphertext (verified: correct and wrong keys produced identical output).

- Ciphertexts now carry the public key used at encryption.
- `decrypt_evaluate` derives the public key from the secret key and raises `ValueError` on mismatch, so only the matching secret key decrypts.
- Added `generate_key_pair()` and updated `test_fhe.py` (correct key round-trips, wrong key fails).

Verified: `python -m py_compile` and both unit tests pass.

Closes #7432

GSSOC
