### PR TITLE
fix: Kafka resetConsumerOffsets calls nonexistent admin API

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -269,20 +269,29 @@ class KafkaConfig {
         logger.warn(`Topic ${topic} not found in consumer group offsets`);
         return;
       }
-      
+
+      const endOffsets = await admin.fetchTopicOffsets(topic);
+      const endByPartition = new Map(endOffsets.map(o => [o.partition, o.high]));
+
+      const partitions = [];
       for (const entry of topicData.partitions) {
         if (Number.isNaN(entry.partition) || entry.partition < 0) {
           logger.warn(`Skipping invalid partition: ${entry.partition}`);
           continue;
         }
-        await admin.setConsumerGroupOffset(
-          groupId,
-          { topic, partition: entry.partition },
-          'latest'
-        );
+        const offset = endByPartition.get(entry.partition);
+        if (offset === undefined) {
+          logger.warn(`No end offset found for partition ${entry.partition}, skipping`);
+          continue;
+        }
+        partitions.push({ partition: entry.partition, offset: String(offset) });
       }
-      
-      logger.info(`✅ Consumer offsets reset for ${groupId}`);
+
+      if (partitions.length > 0) {
+        await admin.setOffsets({ groupId, topic, partitions });
+      }
+
+      logger.info(`Consumer offsets reset for ${groupId}`);
     } finally {
       await admin.disconnect();
     }


### PR DESCRIPTION
## Summary

`resetConsumerOffsets` in `backend/kafka/config/kafka.config.js` called `admin.setConsumerGroupOffset`, which does not exist in KafkaJS v2 — any call threw `TypeError: admin.setConsumerGroupOffset is not a function`.

- Replaced it with the supported `admin.fetchTopicOffsets` + `admin.setOffsets({ groupId, topic, partitions })` flow, resetting each partition to its latest (end) offset.

Verified: `node --check` passes.

Closes #7434

GSSOC
