### PR TITLE
fix: event replay publishes to wrong Kafka topic

### DIFF
--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -94,9 +94,15 @@ class EventRepository {
 
   async reemitEvent(event) {
     // Re-emit event to Kafka
-    const kafka = (await import('../config/kafka.config.js')).default;
+    const kafkaModule = await import('../config/kafka.config.js');
+    const kafka = kafkaModule.default;
+    const topic = kafkaModule.TOPICS[event.event_type];
+    if (!topic) {
+      logger.warn(`No Kafka topic mapped for event type ${event.event_type}; skipping replay`);
+      return;
+    }
     await kafka.publishEvent(
-      event.event_type,
+      topic,
       {
         eventId: event.event_id,
         eventType: event.event_type,


### PR DESCRIPTION
## Summary

`reemitEvent` in `backend/kafka/repositories/event.repository.js` published replays using the stored snake_case `event.event_type` (e.g. `ORDER_CREATED`) as the Kafka topic, but consumers subscribe to the dotted `TOPICS` values (e.g. `order.created`) — replayed events landed on a topic nobody reads.

- Map `event.event_type` → `TOPICS[event.event_type]` before publishing; skip with a warning if unmapped.

Verified: `node --check` passes.

Closes #7435

GSSOC
