### PR TITLE
fix: add ALTER TABLE migration to reconcile duplicate fraud table schemas

### DIFF
--- a/supabase/migrations/20260805000041_fix_fraud_tables_schema.sql
+++ b/supabase/migrations/20260805000041_fix_fraud_tables_schema.sql
@@ -1,0 +1,38 @@
+-- Migration: fix fraud table schema mismatches introduced by the duplicate
+-- 20260804101500_create_fraud_tables.sql migration.
+--
+-- The earlier migration (20260804101500) ran first and its schema won because
+-- both migrations used CREATE TABLE IF NOT EXISTS. This left the tables with
+-- the wrong schema:
+--   • behavioral_profiles.last_activity is bigint — the service writes an ISO
+--     timestamp string, which Postgres rejects with "invalid input syntax for
+--     type bigint".
+--   • fraud_review_queue is missing action, notes, resolved_at, updated_at —
+--     columns the service writes in resolveReview(), so every resolve/dismiss
+--     call fails at runtime.
+--
+-- This migration brings the live schema into line with what FraudDetectionService
+-- actually reads and writes, without dropping and re-creating the tables (which
+-- would lose any data already written and break the RLS policies applied by the
+-- subsequent hardening migrations).
+
+-- Fix behavioral_profiles.last_activity: bigint → timestamptz
+ALTER TABLE behavioral_profiles
+  ALTER COLUMN last_activity TYPE timestamptz
+  USING CASE
+    WHEN last_activity IS NULL THEN NULL
+    ELSE to_timestamp(last_activity / 1000.0)  -- treat existing bigint as epoch-ms
+  END;
+
+-- Add missing columns to fraud_review_queue
+ALTER TABLE fraud_review_queue
+  ADD COLUMN IF NOT EXISTS action      text,
+  ADD COLUMN IF NOT EXISTS notes       text,
+  ADD COLUMN IF NOT EXISTS resolved_at timestamptz,
+  ADD COLUMN IF NOT EXISTS updated_at  timestamptz NOT NULL DEFAULT now();
+
+-- Drop columns that exist in the old schema but not the canonical one,
+-- so the table matches 20260805000040 exactly.
+ALTER TABLE fraud_review_queue
+  DROP COLUMN IF EXISTS reviewed_by,
+  DROP COLUMN IF EXISTS reviewed_at;


### PR DESCRIPTION
## Description
Two migrations both used `CREATE TABLE IF NOT EXISTS` for the fraud tables. The earlier one (`20260804101500`) won, leaving the live schema incompatible with what `FraudDetectionService` actually reads and writes:

- `behavioral_profiles.last_activity` is `bigint` but the service writes an ISO timestamp string — Postgres rejects this with `invalid input syntax for type bigint`, so all behavioral profile upserts fail silently at runtime
- `fraud_review_queue` is missing `action`, `notes`, `resolved_at`, `updated_at` — columns `resolveReview()` writes directly, so every `POST /api/fraud/review/:reviewId/resolve` call errors at runtime

This PR adds a new migration (`20260805000041`) that `ALTER TABLE`s the live tables into the canonical schema defined by `20260805000040`, without dropping and re-creating (which would lose any existing data and break the subsequent RLS hardening migrations):
- `ALTER COLUMN last_activity TYPE timestamptz`, converting any existing `bigint` epoch-ms values via `to_timestamp(last_activity / 1000.0)`
- `ADD COLUMN IF NOT EXISTS action, notes, resolved_at, updated_at` on `fraud_review_queue`
- `DROP COLUMN IF EXISTS reviewed_by, reviewed_at` (old schema only, not in canonical)

Fixes #7151

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fraud detection data compatibility and reliability.
  * Added missing information for fraud review workflows.
  * Removed outdated fraud-related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->