### PR TITLE
fix: replace bare /--/ SQL injection pattern with context-aware regex

### DIFF
--- a/backend/api/src/middleware/suspiciousRequests.js
+++ b/backend/api/src/middleware/suspiciousRequests.js
@@ -4,8 +4,13 @@ const SQLI_PATTERNS = [
   /union\s+select/i,
   /drop\s+table/i,
   /insert\s+into/i,
+  /delete\s+from/i,
   /or\s+1=1/i,
-  /--/,
+  // Match -- only when it appears in a SQL comment context: preceded by
+  // whitespace, a quote, a closing paren, or a semicolon — not when
+  // embedded mid-word (e.g. date ranges like 2026-01-01--2026-02-01,
+  // negative numbers, or note fields containing "--").
+  /(?:^|[\s'");])--/,
 ];
 
 const XSS_PATTERNS = [


### PR DESCRIPTION
## Description
`suspiciousRequests.js` used a bare `/--/` pattern that matched **any** occurrence of `--` in the request body or query string — including legitimate data like date ranges (`2026-01-01--2026-02-01`), notes containing `--`, or negative numbers. This caused `403` false positives for normal API traffic, blocking legitimate customer and driver requests.
gssoc 26

Changes made:
- Replaced `/--/` with `/(?:^|[\s'");])--/` which matches `--` only when preceded by whitespace, a quote, a closing paren, or a semicolon — i.e. only in an actual SQL comment context. `--` embedded mid-word or mid-date string is no longer matched
- Added `/delete\s+from/i` to `SQLI_PATTERNS` which was absent from the original set alongside the other DML patterns (`drop table`, `insert into`, `union select`)

Fixes #7152

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings