### PR TITLE
fix: allow assigned driver to POST cold-chain telemetry in iotRoutes.js

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -40,7 +40,7 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
     // Check if load exists and has cold chain enabled
     const { data: load, error: loadErr } = await supabase
       .from('load_offers')
-      .select('requires_refrigeration, target_temperature_min, target_temperature_max, customer_id')
+      .select('requires_refrigeration, target_temperature_min, target_temperature_max, customer_id, order_display_id')
       .eq('id', loadId)
       .maybeSingle();
 
@@ -57,8 +57,23 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       return res.status(400).json({ error: 'Load does not require refrigeration' });
     }
 
-    if (req.user.role !== 'admin' && load.customer_id !== req.user.id) {
-      return res.status(403).json({ error: 'Access denied for this load' });
+    // Mirror GET authorization: allow the load owner OR the assigned driver.
+    // The driver is the party physically carrying the load and the only person
+    // able to record cold-chain readings in transit.
+    if (req.user.role !== 'admin') {
+      let isAuthorized = load.customer_id === req.user.id;
+      if (!isAuthorized && load.order_display_id) {
+        const { data: order } = await supabase
+          .from('orders')
+          .select('driver_id')
+          .eq('order_display_id', load.order_display_id)
+          .in('status', ['truck_assigned', 'en_route_pickup', 'picked_up', 'in_transit'])
+          .maybeSingle();
+        isAuthorized = order?.driver_id === req.user.id;
+      }
+      if (!isAuthorized) {
+        return res.status(403).json({ error: 'Access denied for this load' });
+      }
     }
 
     // Insert telemetry (service-role client: RLS only permits service_role to


### PR DESCRIPTION
## Description
`POST /api/iot/telemetry/:id` authorized only the load owner (`customer_id`) or an admin to record temperature readings. The assigned driver — the person physically carrying the refrigerated load and the only party able to monitor the cold chain in transit — was rejected with `403 Access denied for this load`.

The `GET` handler for the same resource already authorizes the assigned driver via an `orders` lookup, so the two endpoints were inconsistent.
gssoc 26

Changes made:
- Added `order_display_id` to the `load_offers` SELECT so the driver lookup has the required join key
- Added the same orders lookup used by the GET handler (matching on `order_display_id`, filtering by active transit statuses: `truck_assigned`, `en_route_pickup`, `picked_up`, `in_transit`)
- The load owner OR the assigned driver is now authorized to POST telemetry; all other non-admin callers still receive `403`

Fixes #7153

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings