### PR TITLE
fix: OracleService status verifier confirms in-progress deliveries

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -2,9 +2,15 @@ import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { verifyDeliveryOtpHash } from '../services/notificationService.js';
 
-const DELIVERY_COMPLETED_STATUSES = new Set([
-  'delivered',
-  'payment_released',
+// Statuses that indicate a delivery is currently in progress and therefore
+// eligible for verification. Terminal states ('delivered', 'payment_released')
+// must NOT be used here: confirmDelivery runs BEFORE the order is marked
+// delivered, so a status check against those states could never confirm and
+// the 2-of-3 provider consensus would be unreachable.
+const DELIVERY_IN_PROGRESS_STATUSES = new Set([
+  'picked_up',
+  'in_transit',
+  'arriving',
 ]);
 
 class OracleService {
@@ -128,7 +134,7 @@ class OracleService {
       }
 
       return {
-        confirmed: DELIVERY_COMPLETED_STATUSES.has(order.status),
+        confirmed: DELIVERY_IN_PROGRESS_STATUSES.has(order.status),
         provider: 'StatusVerifier',
         timestamp: new Date().toISOString(),
       };


### PR DESCRIPTION
## Summary

`OracleService._verifyOrderStatus` only confirmed terminal order states (`delivered`, `payment_released`), but `confirmDelivery` runs before the order is marked delivered. The `StatusVerifier` provider could therefore never cast a confirming vote and the 2-of-3 provider consensus was unreachable whenever GPS could not be verified.

The status check now confirms in-progress delivery states (`picked_up`, `in_transit`, `arriving`).

## Changes

- `backend/api/src/oracle/OracleService.js`
  - Replaced `DELIVERY_COMPLETED_STATUSES` with `DELIVERY_IN_PROGRESS_STATUSES`.
  - `_verifyOrderStatus` now confirms in-progress deliveries.

Fixes #7511

---

This PR is submitted as part of GSSOC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery status verification by recognizing orders that are picked up, in transit, or arriving as actively progressing.
  * Prevented completed statuses from being incorrectly used when confirming delivery progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->