### PR TITLE
fix: OracleService GPS verifier imports and correctly uses DeliveryVerificationService

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -1,6 +1,7 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { verifyDeliveryOtpHash } from '../services/notificationService.js';
+import { DeliveryVerificationService } from '../services/order/deliveryVerificationService.js';
 
 const DELIVERY_COMPLETED_STATUSES = new Set([
   'delivered',
@@ -93,11 +94,30 @@ class OracleService {
     }
 
     try {
-      const verification = await DeliveryVerificationService.assertDriverAtDropoff(orderId, gpsCoordinates);
+      const { data: order, error: orderErr } = await this.supabase
+        .from('orders')
+        .select('id, driver_id, drop_lat, drop_lng')
+        .eq('id', orderId)
+        .maybeSingle();
+
+      if (orderErr || !order) {
+        return {
+          confirmed: false,
+          provider: 'GPSVerifier',
+          reason: orderErr?.message || 'Order not found',
+          timestamp: new Date().toISOString(),
+        };
+      }
+
+      // assertDriverAtDropoff(order, radiusM) resolves when the assigned
+      // driver's latest telemetry is fresh and inside the drop-off geofence;
+      // it throws a DomainError otherwise (missing/stale/out-of-range data).
+      const deliveryVerifier = new DeliveryVerificationService();
+      await deliveryVerifier.assertDriverAtDropoff(order);
+
       return {
-        confirmed: verification.success || verification.isValid === true,
+        confirmed: true,
         provider: 'GPSVerifier',
-        reason: verification.reason || null,
         timestamp: new Date().toISOString(),
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

`OracleService._verifyGPS` called `DeliveryVerificationService.assertDriverAtDropoff(orderId, gpsCoordinates)` without ever importing `DeliveryVerificationService` (ReferenceError), and passed the wrong arguments — the method signature is `assertDriverAtDropoff(order, radiusM)`.

The order is now loaded first and `assertDriverAtDropoff(order)` is invoked on a properly constructed service instance, so valid in-geofence driver telemetry actually confirms the `GPSVerifier` provider.

## Changes

- `backend/api/src/oracle/OracleService.js`
  - Imported `DeliveryVerificationService` from `../services/order/deliveryVerificationService.js`.
  - Loaded the order and called `assertDriverAtDropoff(order)` with the correct signature.
  - Return `confirmed: true` on success (the method resolves on success, throws otherwise).

Fixes #7512

---

This PR is submitted as part of GSSOC.
