### PR TITLE
fix: run trip batch ownership validation before the idempotency short-circuit

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -226,22 +226,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
   }
 
   try {
-    // 1. Check Idempotency (Prevent double processing)
-    // We check if this exact batch has already been processed recently.
-    const { data: existingBatch } = await supabase
-      .from('processed_batches')
-      .select('id')
-      .eq('idempotency_key', idempotencyKey)
-      .eq('user_id', userId)
-      .maybeSingle();
-
-    if (existingBatch) {
-      logger.info('[SyncEngine] Ignored duplicate batch:', idempotencyKey);
-      // Return 202 Accepted so the Flutter app marks them as synced locally
-      return res.status(202).json({ error: 'Batch already processed.' });
-    }
-
-    // 2. Validate per-event-type payloads and strip sensitive fields
+    // 1. Validate per-event-type payloads and strip sensitive fields
     for (const event of events) {
       const result = validateEventPayload(event.type, event.payload || {});
       if (!result.success) {
@@ -253,8 +238,10 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       }
     }
 
-    // 2b. Ownership check: events may only be attached to trips (orders) the
+    // 2. Ownership check: events may only be attached to trips (orders) the
     // caller owns or is assigned to. Never trust a client-supplied trip_id.
+    // This runs BEFORE the idempotency short-circuit below, otherwise a
+    // replayed batch would return 202 and skip authorization entirely.
     if (req.user.role !== 'admin') {
       const tripIds = [...new Set(events.map(event => event.trip_id).filter(Boolean))];
 
@@ -281,6 +268,21 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
           }
         }
       }
+    }
+
+    // 3. Check Idempotency (Prevent double processing)
+    // We check if this exact batch has already been processed recently.
+    const { data: existingBatch } = await supabase
+      .from('processed_batches')
+      .select('id')
+      .eq('idempotency_key', idempotencyKey)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (existingBatch) {
+      logger.info('[SyncEngine] Ignored duplicate batch:', idempotencyKey);
+      // Return 202 Accepted so the Flutter app marks them as synced locally
+      return res.status(202).json({ error: 'Batch already processed.' });
     }
 
     const recordsToInsert = events.map(event => {


### PR DESCRIPTION
## Summary

In `POST /events/batch`, the idempotency dedupe ran before the per-trip ownership validation. A replayed batch (already in `processed_batches`) returned `202` immediately, so the ownership check never ran and a user could replay events for trips they do not own without a `403`.

Ownership validation now runs before the idempotency short-circuit.

## Changes

- `backend/api/src/routes/tripRoutes.js`
  - Moved the per-trip ownership check ahead of the `processed_batches` idempotency check in the `/events/batch` handler.

Fixes #7514

---

This PR is submitted as part of GSSOC.
