### PR TITLE
fix: advance the terminal cursor past unchanged pixels in dirty rects

### DIFF
--- a/backend/renderer/DirtyRenderer.js
+++ b/backend/renderer/DirtyRenderer.js
@@ -281,14 +281,17 @@ class DirtyRenderer {
                 if (pixel) {
                     // Check if pixel changed from previous frame
                     const prevPixel = this.previousFrame.getPixel(x, y);
-                    if (!prevPixel || prevPixel.char !== pixel.char || 
-                        prevPixel.fg !== pixel.fg || prevPixel.bg !== pixel.bg || 
-                        prevPixel.style !== pixel.style) {
-                        output += this.getAnsiSequence(pixel);
-                        output += pixel.char;
-                    } else {
-                        // Skip unchanged pixel
-                    }
+                        if (!prevPixel || prevPixel.char !== pixel.char || 
+                            prevPixel.fg !== pixel.fg || prevPixel.bg !== pixel.bg || 
+                            prevPixel.style !== pixel.style) {
+                            output += this.getAnsiSequence(pixel);
+                            output += pixel.char;
+                        } else {
+                            // Skip the unchanged pixel, but still advance the
+                            // cursor past it so subsequent changed pixels in
+                            // this row keep their correct column position.
+                            output += '\x1b[C';
+                        }
                 }
             }
         }


### PR DESCRIPTION
## Summary

`DirtyRenderer.renderRect` emitted nothing for unchanged pixels inside a dirty rect. Since each emitted character advances the terminal cursor by one column but skipped pixels do not, every changed pixel after a skipped one was written at a shifted (left) column, producing garbled output on partial redraws.

Unchanged pixels now emit a cursor-forward escape so later changed pixels keep their correct column positions.

## Changes

- `backend/renderer/DirtyRenderer.js`
  - In `renderRect`, emit `\x1b[C` for skipped unchanged pixels instead of nothing.

Fixes #7516

---

This PR is submitted as part of GSSOC.
