### PR TITLE
fix: trigger the full-frame render on the actual first frame

### DIFF
--- a/backend/renderer/DirtyRenderer.js
+++ b/backend/renderer/DirtyRenderer.js
@@ -137,8 +137,9 @@ class DirtyRenderer {
     
     shouldFullRender() {
         // Full render if:
-        // - First frame
-        if (this.stats.frames === 0) return true;
+        // - First frame (render() increments stats.frames before calling this,
+        //   so the very first render is observed as frames === 1)
+        if (this.stats.frames === 1) return true;
         
         // - Too many dirty rects (> 20)
         if (this.dirtyRects.length > 20) return true;


### PR DESCRIPTION
## Summary

`render()` increments `stats.frames` before calling `shouldFullRender()`, which checked `stats.frames === 0`. That condition could never be true, so the intended first-frame full render (with terminal reset `\x1b[H`) never fired — the first frame was always rendered as partial dirty rects, leaving stale terminal content.

The check now tests `stats.frames === 1`, so the actual first frame triggers a full render while subsequent frames stay partial.

## Changes

- `backend/renderer/DirtyRenderer.js`
  - `shouldFullRender()` first-frame condition: `stats.frames === 0` → `stats.frames === 1`.

Fixes #7517

---

This PR is submitted as part of GSSOC.
