### PR TITLE
fix: mark FrameBuffer dirty when clear() resets pixel styling

### DIFF
--- a/backend/renderer/FrameBuffer.js
+++ b/backend/renderer/FrameBuffer.js
@@ -160,13 +160,19 @@ class FrameBuffer {
         let changed = false;
         for (let y = 0; y < this.height; y++) {
             for (let x = 0; x < this.width; x++) {
-                if (this.buffer[y][x].char !== character) {
-                    this.buffer[y][x].char = character;
+                const pixel = this.buffer[y][x];
+                // Clear the styling too. Any change to the char OR the styling
+                // must mark the frame dirty and bump the version; otherwise a
+                // clear() that only resets colors/styles is never redrawn and
+                // the old styling stays visible on the terminal.
+                if (pixel.char !== character ||
+                    pixel.fg !== null || pixel.bg !== null || pixel.style !== null) {
+                    pixel.char = character;
+                    pixel.fg = null;
+                    pixel.bg = null;
+                    pixel.style = null;
                     changed = true;
                 }
-                this.buffer[y][x].fg = null;
-                this.buffer[y][x].bg = null;
-                this.buffer[y][x].style = null;
             }
         }
         


### PR DESCRIPTION
## Summary

`FrameBuffer.clear()` reset every pixel's `fg`/`bg`/`style` to `null` unconditionally but only marked the frame dirty when a character changed. Clearing a screen whose characters already matched the clear char left stale colors/styles visible on the terminal (buffer mutated, but no dirty rect/version bump so the renderer never redrew).

Styling changes now count as changes, so `clear()` marks the frame dirty and bumps the version whenever anything (char or styling) actually changes.

## Changes

- `backend/renderer/FrameBuffer.js`
  - `clear()` now tracks `fg`/`bg`/`style` changes alongside the character change.

Fixes #7520

---

This PR is submitted as part of GSSOC.
