### PR TITLE
fix(migrations): add missing orders.notification_failed column

### DIFF
--- a/supabase/migrations/20260807000000_add_orders_notification_failed.sql
+++ b/supabase/migrations/20260807000000_add_orders_notification_failed.sql
@@ -1,0 +1,5 @@
+-- Fix #7529: add missing notification_failed column to orders.
+-- orderNotificationService, orderMilestoneService and deliveryVerificationService
+-- write notification_failed on orders, which previously failed with PGRST204.
+alter table orders
+  add column if not exists notification_failed boolean not null default false;


### PR DESCRIPTION
## Summary
`orders.notification_failed` does not exist in the schema. Three services write it via PostgREST (`orderNotificationService`, `orderMilestoneService`, `deliveryVerificationService`), and every write failed with `PGRST204`. This migration adds the missing column.

## Changes
- Add `notification_failed boolean NOT NULL DEFAULT false` to `orders`.

Closes #7529

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added order notification failure tracking, defaulting to “not failed” for existing and new orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->