### PR TITLE
fix(migrations): add missing driver_details.polygon_wallet_address column

### DIFF
--- a/supabase/migrations/20260807000010_add_driver_details_polygon_wallet.sql
+++ b/supabase/migrations/20260807000010_add_driver_details_polygon_wallet.sql
@@ -1,0 +1,5 @@
+-- Fix #7532: add missing polygon_wallet_address column to driver_details.
+-- orderRepository, driverRoutes, profileRoutes and bidAcceptanceService read/write
+-- driver_details.polygon_wallet_address, which previously failed with PGRST204.
+alter table driver_details
+  add column if not exists polygon_wallet_address text;


### PR DESCRIPTION
## Summary
`driver_details.polygon_wallet_address` does not exist in the schema. `orderRepository`, `driverRoutes`, `profileRoutes` and `bidAcceptanceService` read/write it, and every such call failed with `PGRST204`. This migration adds the missing column so the driver escrow wallet flow works.

## Changes
- Add `polygon_wallet_address text` to `driver_details`.

Closes #7532

GSSOC
