### PR TITLE
fix(api): use polygon_wallet_address instead of phantom wallet_address on profiles

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -288,7 +288,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
   try {
     const { data: existing, error: checkErr } = await supabase
       .from('profiles')
-      .select('wallet_address, polygon_wallet_address')
+      .select('polygon_wallet_address')
       .eq('id', userId)
       .maybeSingle();
 
@@ -298,7 +298,6 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
     const { error: updateErr } = await supabase
       .from('profiles')
       .update({
-        wallet_address: normalized,
         polygon_wallet_address: normalized,
       })
       .eq('id', userId);


### PR DESCRIPTION
## Summary
The wallet endpoint in `profileRoutes.js` selects and updates `profiles.wallet_address`, a column that does not exist (only `profiles.polygon_wallet_address` does). Both the SELECT and the UPDATE failed with `PGRST204`, so users could not read or update their wallet address.

## Changes
- `profileRoutes.js`: select only `polygon_wallet_address` from `profiles`.
- `profileRoutes.js`: update only `polygon_wallet_address` (drop the phantom `wallet_address` write).

Closes #7534

GSSOC
