### PR TITLE
fix(migrations): add missing orders refund tx columns

### DIFF
--- a/supabase/migrations/20260807000030_add_orders_refund_tx_columns.sql
+++ b/supabase/migrations/20260807000030_add_orders_refund_tx_columns.sql
@@ -1,0 +1,7 @@
+-- Fix #7536: add missing escrow refund columns to orders.
+-- escrowWebhookProcessor selects/updates refund_tx_hash and escrow_refunded_at
+-- on orders, which previously failed with PGRST204.
+-- (Previously only defined in the unapplied docs/migration_add_escrow.sql.)
+alter table orders
+  add column if not exists refund_tx_hash     text,
+  add column if not exists escrow_refunded_at timestamptz;


### PR DESCRIPTION
## Summary
`orders` has no `refund_tx_hash` or `escrow_refunded_at` columns. `escrowWebhookProcessor` selects and updates them on the booking-cancelled path, failing with `PGRST204` and preventing escrow refunds from being recorded. The columns were only defined in the unapplied `docs/migration_add_escrow.sql`.

## Changes
- Add `refund_tx_hash text` and `escrow_refunded_at timestamptz` to `orders`.

Closes #7536

GSSOC
