### PR TITLE
fix(migrations): add missing orders deposit tx columns

### DIFF
--- a/supabase/migrations/20260807000040_add_orders_deposit_tx_columns.sql
+++ b/supabase/migrations/20260807000040_add_orders_deposit_tx_columns.sql
@@ -1,0 +1,7 @@
+-- Fix #7537: add missing escrow deposit columns to orders.
+-- The confirm-deposit flow writes deposit_tx_hash and escrow_deposited_at
+-- on orders, which previously failed with PGRST204.
+-- (Previously only defined in the unapplied docs/migration_add_escrow.sql.)
+alter table orders
+  add column if not exists deposit_tx_hash     text,
+  add column if not exists escrow_deposited_at timestamptz;


### PR DESCRIPTION
## Summary
`orders` has no `deposit_tx_hash` or `escrow_deposited_at` columns. The confirm-deposit flow writes both, failing with `PGRST204` so the order never leaves `funding` state. The columns were only defined in the unapplied `docs/migration_add_escrow.sql`.

## Changes
- Add `deposit_tx_hash text` and `escrow_deposited_at timestamptz` to `orders`.

Closes #7537

GSSOC
