### PR TITLE
fix(migrations): widen notifications.notif_type CHECK for bid/payment types

### DIFF
--- a/supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql
+++ b/supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql
@@ -1,0 +1,17 @@
+-- Fix #7538: widen notifications.notif_type CHECK to accept the values sent
+-- by the bid/payment notification flows. sendPushNotification inserts
+-- 'bid_accepted', 'new_bid', 'payment_locked' and 'payment_released', all of
+-- which previously violated the CHECK and were silently dropped.
+
+-- Drop the existing CHECK constraint (auto-named by Postgres from the inline
+-- definition in supabase_setup.sql).
+alter table notifications
+  drop constraint if exists notifications_notif_type_check;
+
+-- Re-add with the full set of allowed values.
+alter table notifications
+  add constraint notifications_notif_type_check
+  check (notif_type in (
+    'order_update','payment','load_offer','trip_update','document','system',
+    'bid_accepted','new_bid','payment_locked','payment_released'
+  ));


### PR DESCRIPTION
## Summary
`notifications.notif_type` has a CHECK constraint allowing only `order_update`, `payment`, `load_offer`, `trip_update`, `document`, `system`. The order/payment flows send `bid_accepted`, `new_bid`, `payment_locked` and `payment_released`, which violated the CHECK and were silently dropped. This widens the constraint.

## Changes
- Widen `notifications_notif_type_check` to also allow `bid_accepted`, `new_bid`, `payment_locked`, `payment_released`.

Closes #7538

GSSOC
