### PR TITLE
fix(workers): use allowed lowercase notif_type values for worker notifications

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -114,7 +114,7 @@ async function finalizeOrRevert(order, orderRepository) {
         order.customer_id,
         'Bid Acceptance Expired',
         `The escrow deposit for order ${order.order_display_id} was not completed in time, so the driver is no longer reserved. You can accept a bid again.`,
-        'BID_ACCEPTANCE_EXPIRED',
+        'order_update',
         { orderId: order.id }
       ).catch((err) => logger.error(`[FCM] Failed to notify customer of expired bid acceptance: ${err.message}`));
       logger.info(`[escrow-funding] Order ${order.order_display_id} reverted to pending (funding TTL expired).`);

--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -153,7 +153,7 @@ async function cancelStaleOrder(staleOrder) {
         requiresRefund
           ? `Your order ${current.order_display_id} was cancelled because it was not completed in time. Any escrowed funds are being refunded.`
           : 'Your order was cancelled because it received no accepted bids within 24 hours. Please try posting again.',
-        'ORDER_CANCELLED',
+        'order_update',
         { orderId: current.id, orderDisplayId: current.order_display_id }
       );
       logger.info(`[StaleOrderWorker] Cancelled order ${current.order_display_id} and notified customer ${current.customer_id}.`);


### PR DESCRIPTION
## Summary
The background workers send `notif_type` values that violate the `notifications.notif_type` CHECK constraint: `staleOrderWorker` sends `ORDER_CANCELLED` and `escrowFundingReconciliation` sends `BID_ACCEPTANCE_EXPIRED`. These notifications were silently dropped at the DB layer. Both are normalized to the already-allowed lowercase `order_update` value.

## Changes
- `staleOrderWorker.js`: `ORDER_CANCELLED` -> `order_update`.
- `escrowFundingReconciliation.js`: `BID_ACCEPTANCE_EXPIRED` -> `order_update`.

Closes #7539

GSSOC
