### PR TITLE
fix(migrations): add missing documents.storage_path column

### DIFF
--- a/supabase/migrations/20260807000060_add_documents_storage_path.sql
+++ b/supabase/migrations/20260807000060_add_documents_storage_path.sql
@@ -1,0 +1,6 @@
+-- Fix #7540: add missing storage_path column to documents.
+-- digilockerService sync writes storage_path on documents, which previously
+-- failed with PGRST204. The other columns it writes (is_govt_verified,
+-- blockchain_tx_hash) already exist via the applied govt-verification migration.
+alter table documents
+  add column if not exists storage_path text;


### PR DESCRIPTION
## Summary
`documents` has no `storage_path` column. The DigiLocker sync in `digilockerService.js` writes `storage_path`, failing with `PGRST204`, so verified documents were never persisted. The other columns it writes (`is_govt_verified`, `blockchain_tx_hash`) already exist.

## Changes
- Add `storage_path text` to `documents`.

Closes #7540

GSSOC
