### PR TITLE
fix: throw error if RELAYER_WALLET_PRIVATE_KEY is missing

### DIFF
--- a/backend/mev/flashbots_relayer.js
+++ b/backend/mev/flashbots_relayer.js
@@ -41,7 +41,12 @@ export class FlashbotsRelayerService {
   }
 }
 
+const relayerPrivateKey = process.env.RELAYER_WALLET_PRIVATE_KEY;
+if (!relayerPrivateKey) {
+  throw new Error('RELAYER_WALLET_PRIVATE_KEY environment variable is required');
+}
+
 export const mevRelayer = new FlashbotsRelayerService(
   process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
-  process.env.RELAYER_WALLET_PRIVATE_KEY || '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+  relayerPrivateKey
 );


### PR DESCRIPTION
## Description
`backend/mev/flashbots_relayer.js` previously fell back to a hardcoded private key (`0x0123456789abcdef...`) when `RELAYER_WALLET_PRIVATE_KEY` was missing from environment variables, posing a security risk of known-key signing.
gssoc 26

Changes made:
- Removed fallback hardcoded private key from `FlashbotsRelayerService` initialization
- Added explicit validation error when `RELAYER_WALLET_PRIVATE_KEY` environment variable is not defined

Fixes #7104

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings