### PR TITLE
fix(verification): require ML_API_URL and ML_API_KEY for KYC OCR without fallbacks

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -240,11 +240,19 @@ router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticat
     const blob = new Blob([req.file.buffer], { type: req.file.mimetype });
     formData.append('file', blob, req.file.originalname);
 
-    const mlResponse = await fetch('http://127.0.0.1:8000/verify/kyc', {
+    const mlBaseUrl = (process.env.ML_API_URL || process.env.ML_ENGINE_URL || process.env.ML_SERVICE_URL || '').replace(/\/$/, '');
+    const mlApiKey = process.env.ML_API_KEY;
+
+    if (!mlBaseUrl || !mlApiKey) {
+      logger.error('[OCR] ML service URL (ML_API_URL) or API key (ML_API_KEY) not configured');
+      return res.status(503).json({ success: false, error: 'KYC OCR service is unconfigured' });
+    }
+
+    const mlResponse = await fetch(`${mlBaseUrl}/verify/kyc`, {
       method: 'POST',
       body: formData,
       headers: {
-        'X-API-Key': process.env.ML_API_KEY || 'truxify_ml_dev_key',
+        'X-API-Key': mlApiKey,
       },
     });
 


### PR DESCRIPTION
## Description
Resolves issue #7101 where the KYC OCR verification endpoint in `verificationRoutes.js` made outbound requests to a hardcoded `http://127.0.0.1:8000/verify/kyc` address using a fallback default key string (`truxify_ml_dev_key`).
gssoc 26

Key Changes:
- Removed hardcoded local host endpoint and dev fallback API key from `verificationRoutes.js`
- Enforced required configuration via `ML_API_URL` (or fallback engine URL env vars) and `ML_API_KEY`
- Added fail-closed behavior returning `503 Service Unavailable` if ML URL or API key environment variables are missing

Fixes #7101

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security / Hardening

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings