### PR TITLE
fix(zkp): enforce fail-closed policy for SNARK proof generation in non-test environments

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -65,16 +65,25 @@ class ZKPService {
   }
 
   async callSnarkJS(driverData, documentHash) {
-    // In production: execute snarkjs via child_process
-    // For now, return mock proof
-    return {
-      proof: {
-        a: ['0x123...', '0x456...'],
-        b: [['0x789...', '0xabc...'], ['0xdef...', '0xghi...']],
-        c: ['0xjkl...', '0xmno...']
-      },
-      publicSignals: [documentHash, '1']
-    };
+    const isMock = process.env.ZKP_MOCK === 'true' || process.env.NODE_ENV === 'test';
+    
+    if (process.env.NODE_ENV === 'production' && !isMock) {
+      throw new Error('[ZKPService] Real SNARK circuit proof execution is required in production. Mock proofs are disallowed.');
+    }
+
+    if (isMock) {
+      logger.warn('[ZKPService] Generating mock ZK proof (ZKP_MOCK or test mode active)');
+      return {
+        proof: {
+          a: ['0x123...', '0x456...'],
+          b: [['0x789...', '0xabc...'], ['0xdef...', '0xghi...']],
+          c: ['0xjkl...', '0xmno...']
+        },
+        publicSignals: [documentHash, '1']
+      };
+    }
+
+    throw new Error('[ZKPService] SNARK proof generation circuit worker is not configured.');
   }
 
   async verifyKYCOnChain(userId, proof) {


### PR DESCRIPTION
## Description
Resolves issue #7100 where `callSnarkJS` in `zkp.service.js` unconditionally returned hardcoded mock SNARK proofs (`0x123...`), allowing unverified mock data to drive verification, DB persistence, and on-chain KYC execution paths.
gssoc 26

Key Changes:
- Enforced strict fail-closed behavior for `callSnarkJS` in non-test environments
- Restricted mock SNARK proof generation solely to environments where `NODE_ENV === 'test'` or `ZKP_MOCK === 'true'`
- Throws explicit operational errors in production when circuit proof execution workers are not configured

Fixes #7100

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security / Hardening

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings