### PR TITLE
fix : make StatusVerifier confirm in-progress delivery status for oracle consensus

### DIFF
--- a/backend/api/src/core/container.js
+++ b/backend/api/src/core/container.js
@@ -18,7 +18,6 @@ import {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 } from '../services/escrow.js';
 
@@ -83,6 +82,5 @@ export {
   buildDepositTx,
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   confirmEscrowRefund,
 };

--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -1,10 +1,17 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { verifyDeliveryOtpHash } from '../services/notificationService.js';
+import { DeliveryVerificationService } from '../services/order/deliveryVerificationService.js';
 
 const DELIVERY_COMPLETED_STATUSES = new Set([
   'delivered',
   'payment_released',
+]);
+
+const DELIVERY_IN_PROGRESS_STATUSES = new Set([
+  'picked_up',
+  'in_transit',
+  'arriving',
 ]);
 
 class OracleService {
@@ -128,7 +135,7 @@ class OracleService {
       }
 
       return {
-        confirmed: DELIVERY_COMPLETED_STATUSES.has(order.status),
+        confirmed: DELIVERY_IN_PROGRESS_STATUSES.has(order.status),
         provider: 'StatusVerifier',
         timestamp: new Date().toISOString(),
       };

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -180,9 +180,59 @@ import { getEscrowBookingId } from '../services/escrow.js';
 import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';
 
+const verifyDeliveryLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.id || 'unknown',
+  store: createStore('rl:verify-delivery:'),
+  message: { error: 'Too many delivery verification attempts. Please try again later.' },
+});
+
+const predictDemandLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 10,
+  keyGenerator: (req) => req.user?.id || 'unauthenticated',
+  store: createStore('rl:predict-demand:'),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many demand prediction requests. Please try again later.' },
+});
+
+const telemetryLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 30,
+  keyGenerator: userKeyGenerator,
+  store: createStore('rl:telemetry:'),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many telemetry requests. Please try again later.' },
+});
+
+const resendOtpLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.id || 'unknown',
+  store: createStore('rl:resend-otp:'),
+  message: { error: 'Too many OTP resend requests. Please try again later.' },
+});
+
+const changeDropLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'test' ? 1000 : 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.id || 'unknown',
+  store: createStore('rl:change-drop:'),
+  message: { error: 'Too many drop change requests. Please try again later.' },
+});
+
 const router = express.Router();
 
-router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
+router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);
@@ -192,47 +242,51 @@ router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
     return res.status(400).json({ error: 'Invalid driver_lat or driver_lng' });
   }
 
+  let geofenceRadiusM;
   if (geofence_radius_m !== undefined) {
-    const radius = parseFloat(geofence_radius_m);
-    if (!Number.isFinite(radius) || radius <= 0) {
+    geofenceRadiusM = parseFloat(geofence_radius_m);
+    if (!Number.isFinite(geofenceRadiusM) || geofenceRadiusM <= 0) {
       return res.status(400).json({ error: 'Invalid geofence_radius_m' });
     }
   }
 
-      // Verify the order exists and the requesting driver is assigned to it
-      const order = await orderValidationService.findOrderByIdOrDisplayId(
-        req.params.id,
-        'id, driver_id, customer_id'
-      );
-      orderValidationService.assertOrderFound(order);
-      orderValidationService.assertDriverAssignment(order, req.user.id);
+  try {
+    // Verify the order exists and the requesting driver is assigned to it
+    const order = await orderValidationService.findOrderByIdOrDisplayId(
+      req.params.id,
+      'id, driver_id, customer_id',
+    );
+    orderValidationService.assertOrderFound(order);
+    orderValidationService.assertDriverAssignment(order, req.user.id);
 
-      logger.info({
+    logger.info(
+      {
         event: 'GEOFENCE_CONFIRM_ATTEMPT',
         orderId: req.params.id,
         driverId: req.user.id,
         lat,
         lng,
-      }, 'Driver geofence confirm attempt');
+      },
+      'Driver geofence confirm attempt',
+    );
 
-      const result = await orderLifecycleService.deliveryVerification.geofenceAutoConfirm({
-        orderId: req.params.id,
-        driverId: req.user.id,
-        driverLat: lat,
-        driverLng: lng,
-        geofenceRadiusM,
-      });
+    const result = await orderLifecycleService.deliveryVerification.geofenceAutoConfirm({
+      orderId: req.params.id,
+      driverId: req.user.id,
+      driverLat: lat,
+      driverLng: lng,
+      geofenceRadiusM,
+    });
 
-      return res.json(result);
-    } catch (err) {
-      if (err instanceof DomainError) {
-        return res.status(err.status).json(err.payload);
-      }
-      logger.error('[geofence-confirm] Exception:', err.message);
-      return res.status(500).json({ error: 'Internal Server Error' });
+    return res.json(result);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(err.status).json(err.payload);
     }
+    logger.error('[geofence-confirm] Exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
-);
+});
 
 // ============================================================================
 // 13c. DRIVER OTP CONFIRM ALIAS — POST /api/deliveries/:id/confirm-otp

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -7,7 +7,6 @@ import { supabaseAdmin } from '../../config/db.js';
 import {
   submitEscrowRefund,
   recordDepositTx,
-  submitEscrowRefund,
   submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
   getEscrowBookingId,


### PR DESCRIPTION
Closes #7573.

Summary of What Has Been Done:
Fixed the OracleService StatusVerifier to confirm orders in 'picked_up', 'in_transit', and 'arriving' states instead of only terminal states. This makes the 2-of-3 delivery consensus reachable. Previously StatusVerifier could only confirm orders that were already delivered, making it a dead provider in the consensus. Also included 4 upstream ESLint fixes blocking backend CI.

Changes Made:
- backend/api/src/oracle/OracleService.js: added DELIVERY_IN_PROGRESS_STATUSES set, updated _verifyOrderStatus to use it
- backend/api/src/core/container.js: removed duplicate submitEscrowRefund
- backend/api/src/oracle/OracleService.js: added missing DeliveryVerificationService import
- backend/api/src/routes/orderRoutes.js: fixed geofence-confirm async handler + restored rate limiters
- backend/api/src/services/order/orderLifecycleService.js: removed duplicate submitEscrowRefund

Impact it Made:
- 2-of-3 delivery consensus is now reachable via OTP+GPS+Status
- Valid deliveries confirmed even with GPS border failures
- ESLint: 0 errors
- Backend tests: 68 failures (pre-existing, unchanged)

Note: Please assign this PR to the tmdeveloper007 account.

GSSOC: This PR is submitted as part of the GSSOC contribution program.