### PR TITLE
fix : added missing async keyword to geofence-confirm route handler in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -182,7 +182,7 @@ import { computeOrderPricing } from '../lib/pricing.js';
 
 const router = express.Router();
 
-router.post('/api/deliveries/:id/geofence-confirm', (req, res) => {
+router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);


### PR DESCRIPTION
Closes #7576.

Summary of What Has Been Done:
Added the missing `async` keyword to the `router.post('/api/deliveries/:id/geofence-confirm')` handler callback. The handler used `await` internally but was declared without `async`, causing a SyntaxError that prevented all /api/deliveries routes from loading.

Changes Made:
- backend/api/src/routes/orderRoutes.js line 185: Changed `(req, res) => {` to `async (req, res) => {`

Impact it Made:
- Fixed SyntaxError that killed all /api/deliveries routes on server boot
- Makes geofence confirmation endpoint functional

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).