### PR TITLE
fix : added async keyword to transaction() method in GlobalStore.js

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -183,7 +183,7 @@ class GlobalStore extends EventEmitter {
     
     // ============ Transaction Support ============
     
-    transaction(fn) {
+    async transaction(fn) {
         if (this.activeTransaction) {
             throw new Error('Nested transactions not supported');
         }


### PR DESCRIPTION
Closes #7579.

Summary of What Has Been Done:
Added the missing `async` keyword to the `transaction(fn)` method in GlobalStore.js. The method contained `await transaction.commit()` in the synchronous code path but was not declared as `async`, causing a SyntaxError that prevented the module from loading.

Changes Made:
- backend/store/GlobalStore.js line 186: Changed `transaction(fn) {` to `async transaction(fn) {`

Impact it Made:
- Fixed SyntaxError preventing GlobalStore module from loading
- Makes the store's transaction support functional
- Verified with `node --check store/GlobalStore.js`

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).