### PR TITLE
fix : removed profileRoutes writes to non-existent profiles.wallet_address column

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -288,7 +288,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
   try {
     const { data: existing, error: checkErr } = await supabase
       .from('profiles')
-      .select('wallet_address, polygon_wallet_address')
+      .select('polygon_wallet_address')
       .eq('id', userId)
       .maybeSingle();
 
@@ -298,7 +298,6 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
     const { error: updateErr } = await supabase
       .from('profiles')
       .update({
-        wallet_address: normalized,
         polygon_wallet_address: normalized,
       })
       .eq('id', userId);


### PR DESCRIPTION
Closes #7580.

Summary of What Has Been Done:
Removed all writes and reads of the `profiles.wallet_address` column in profileRoutes.js. This column does not exist in the profiles table (only `polygon_wallet_address` exists), causing Supabase RLS errors on every wallet update.

Changes Made:
- backend/api/src/routes/profileRoutes.js: Changed select() from 'wallet_address, polygon_wallet_address' to just 'polygon_wallet_address'
- backend/api/src/routes/profileRoutes.js: Removed wallet_address from the update() payload (kept only polygon_wallet_address)

Impact it Made:
- Fixes Supabase RLS errors on wallet address update operations
- Ensures wallet_address writes go to the correct existing column

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).