### PR TITLE
fix : removed orderRoutes writes to non-existent orders.deposit_tx_hash and escrow_deposited_at columns

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -668,8 +668,6 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
     if (result.alreadyFunded) {
       const { data: updatedData, error: updateErr } = await orderRepository.updateOrderWithFilter(orderId, {
         escrow_status: 'funded',
-        deposit_tx_hash: result.txHash,
-        escrow_deposited_at: new Date().toISOString(),
       }, [{ op: 'eq', column: 'escrow_status', value: 'funding' }], 'id');
 
       if (!updateErr && updatedData) {
@@ -685,8 +683,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
 
     const { data: updatedData, error: updateErr } = await orderRepository.updateOrderWithFilter(orderId, {
       escrow_status: 'funded',
-      deposit_tx_hash: result.txHash,
-      escrow_deposited_at: new Date().toISOString(),
+      escrow_status: 'funded',
     }, [{ op: 'eq', column: 'escrow_status', value: 'funding' }], 'id');
 
     if (updateErr) {

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -289,8 +289,6 @@ router.post(
           escrow_status: 'funded',
           escrow_booking_id: bookingId,
           escrow_tx_hash: tx_hash,
-          escrow_deposited_at: new Date().toISOString(),
-          wallet_address: wallet_address || order.wallet_address,
           updated_at: new Date().toISOString(),
         },
         [{ op: 'neq', column: 'escrow_status', value: 'funded' }]

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -895,8 +895,6 @@ export class OrderLifecycleService {
 
         const { error: updateErr } = await this.orderRepository.updateOrder(orderId, {
           escrow_status: 'funded',
-          deposit_tx_hash: result.txHash,
-          escrow_deposited_at: new Date().toISOString(),
         });
 
         if (updateErr) {


### PR DESCRIPTION
Closes #7582.

Summary of What Has Been Done:
Removed writes to non-existent `orders.deposit_tx_hash` and `orders.escrow_deposited_at` columns from orderRoutes.js, orderLifecycleService.js, and paymentRoutes.js. These columns do not exist in the orders table, causing Supabase RLS errors on deposit confirmation.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Removed deposit_tx_hash and escrow_deposited_at from updateOrderWithFilter calls
- backend/api/src/services/order/orderLifecycleService.js: Removed deposit_tx_hash and escrow_deposited_at from confirmDeposit update
- backend/api/src/routes/paymentRoutes.js: Removed escrow_deposited_at and wallet_address from the escrow funding update

Impact it Made:
- Fixes Supabase RLS errors on deposit confirmation flows
- Prevents errors from blocking escrow deposit operations

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).