### PR TITLE
fix : removed deliveryVerificationService writes to non-existent geofence_* columns on orders

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -344,10 +344,6 @@ export class DeliveryVerificationService {
         // position for audit. This is a flag only — escrow is not released here.
         await this.orderRepository
           .updateOrder(orderId, {
-            geofence_confirmed: true,
-            geofence_confirmed_at: new Date().toISOString(),
-            geofence_driver_lat: driverLat,
-            geofence_driver_lng: driverLng,
             updated_at: new Date().toISOString(),
           })
           .catch((err) =>


### PR DESCRIPTION
Closes #7583.

Summary of What Has Been Done:
Removed writes to non-existent `geofence_confirmed`, `geofence_confirmed_at`, `geofence_driver_lat`, and `geofence_driver_lng` columns from deliveryVerificationService.geofenceAutoConfirm(). These columns do not exist in the orders table, causing Supabase RLS errors on every geofence confirmation.

Changes Made:
- backend/api/src/services/order/deliveryVerificationService.js: Removed geofence_confirmed, geofence_confirmed_at, geofence_driver_lat, geofence_driver_lng from the updateOrder payload

Impact it Made:
- Fixes Supabase RLS errors on geofence confirmation
- Prevents errors from blocking the delivery confirmation flow

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).