### PR TITLE
fix : removed writes to non-existent orders.notification_failed column in order services

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -257,7 +257,6 @@ export class DeliveryVerificationService {
             `[DeliveryVerificationService] Delivery OTP notification failed for order ${orderDisplayId} — FCM error: ${notifResult.fcm?.error || "unknown"}`,
           );
           await this.orderRepository.updateOrder(orderId, {
-            notification_failed: true,
             updated_at: new Date().toISOString(),
           });
         }

--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -138,7 +138,6 @@ export class OrderMilestoneService {
             `[OrderRoutes] Delivery OTP notification failed for order ${order.order_display_id} — FCM error: ${notifResult.fcm?.error || 'unknown'}`
           );
           await this.orderRepository.updateOrder(orderId, {
-            notification_failed: true,
             updated_at: new Date().toISOString()
           });
         }

--- a/backend/api/src/services/order/orderNotificationService.js
+++ b/backend/api/src/services/order/orderNotificationService.js
@@ -136,7 +136,6 @@ export class OrderNotificationService {
       logger.warn(`[OrderNotification] Delivery OTP notification failed for order ${orderDisplayId} — FCM error: ${notifResult.fcm?.error || 'unknown'}`);
       if (type === 'delivery_otp_in_transit') {
         await this.orderRepository.updateOrder(orderId, {
-          notification_failed: true,
           updated_at: new Date().toISOString(),
         });
       }


### PR DESCRIPTION
Closes #7584.

Summary of What Has Been Done:
Removed writes to non-existent `orders.notification_failed` column from orderMilestoneService.js, deliveryVerificationService.js, and orderNotificationService.js. The orders table does not have a notification_failed column, causing Supabase RLS errors on notification writes.

Changes Made:
- backend/api/src/services/order/orderMilestoneService.js: Removed notification_failed from updateOrder payload
- backend/api/src/services/order/deliveryVerificationService.js: Removed notification_failed from updateOrder payload
- backend/api/src/services/order/orderNotificationService.js: Removed notification_failed from updateOrder payload

Impact it Made:
- Fixes Supabase RLS errors on order notification writes
- Prevents notification failures from propagating errors to callers

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).