### PR TITLE
fix : reset DLQ event status from processing to pending on retryable failure in dlqService.js

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -127,7 +127,8 @@ export const dlqService = {
             const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
             await dlqDb()
               .from('webhook_failures')
-              .update({ 
+              .update({
+                status: 'pending',
                 retry_count: newRetryCount,
                 next_retry_at: nextRetryAt,
                 error_message: String(procErr.message || procErr).slice(0, 1000),


### PR DESCRIPTION
Closes #7586.

Summary of What Has Been Done:
Added `status: 'pending'` to the retryable failure update in dlqService.js. Previously, when a DLQ retry failed but was still retryable, the code updated retry_count and next_retry_at but left status='processing', preventing the event from being re-picked up by the next DLQ run.

Changes Made:
- backend/api/src/services/webhook/dlqService.js: Added status: 'pending' to the retryable failure update payload

Impact it Made:
- Fixes critical bug where retryable DLQ events were permanently stuck in 'processing' status
- Enables automatic retry of failed webhook deliveries

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).