### PR TITLE
fix : used nullish coalescing instead of logical OR for type default in CachePublisher.js

### DIFF
--- a/backend/api/src/cache/CachePublisher.js
+++ b/backend/api/src/cache/CachePublisher.js
@@ -90,7 +90,7 @@ export async function publishInvalidation(namespace, eventOpts = {}) {
   if (!ns.enablePubSub) return;
 
   const channel = CacheKeyBuilder.pubSubChannel(namespace);
-  const event = createCacheEvent(eventOpts.type || CacheEventType.INVALIDATE_KEY, {
+  const event = createCacheEvent(eventOpts.type ?? CacheEventType.INVALIDATE_KEY, {
     namespace,
     originInstanceId: instanceId,
     ...eventOpts,


### PR DESCRIPTION
Closes #7590.

Summary of What Has Been Done:
Changed `eventOpts.type || CacheEventType.INVALIDATE_KEY` to `eventOpts.type ?? CacheEventType.INVALIDATE_KEY` in CachePublisher.publishInvalidation. Logical OR treats 0, false, and empty string as falsy defaults, which could incorrectly override an intentional type value. Nullish coalescing is the semantically correct operator.

Changes Made:
- backend/api/src/cache/CachePublisher.js line 93: Changed `||` to `??`

Impact it Made:
- Fixes a subtle bug where falsy-but-valid type values would be overridden
- Improves semantic correctness of cache event type handling

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).