### PR TITLE
fix : added import for DeliveryVerificationService in OracleService.js

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -1,6 +1,7 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { verifyDeliveryOtpHash } from '../services/notificationService.js';
+import { DeliveryVerificationService } from '../services/order/deliveryVerificationService.js';
 
 const DELIVERY_COMPLETED_STATUSES = new Set([
   'delivered',


### PR DESCRIPTION
Closes #7592.

Summary of What Has Been Done:
Added import for `DeliveryVerificationService` in OracleService.js. The `_verifyGPS` method was calling `DeliveryVerificationService.assertDriverAtDropoff()` but the class was never imported, causing a ReferenceError at runtime whenever GPS verification was attempted.

Changes Made:
- backend/api/src/oracle/OracleService.js: Added `import { DeliveryVerificationService } from '../services/order/deliveryVerificationService.js';`

Impact it Made:
- Fixes ReferenceError preventing GPS-based delivery verification from working
- Enables the full 2-of-3 oracle consensus mechanism to function

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).