### PR TITLE
fix : replaced invalid BID_ACCEPTANCE_EXPIRED notification type with order_update in escrowFundingReconciliation.js

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -114,7 +114,7 @@ async function finalizeOrRevert(order, orderRepository) {
         order.customer_id,
         'Bid Acceptance Expired',
         `The escrow deposit for order ${order.order_display_id} was not completed in time, so the driver is no longer reserved. You can accept a bid again.`,
-        'BID_ACCEPTANCE_EXPIRED',
+        'order_update',
         { orderId: order.id }
       ).catch((err) => logger.error(`[FCM] Failed to notify customer of expired bid acceptance: ${err.message}`));
       logger.info(`[escrow-funding] Order ${order.order_display_id} reverted to pending (funding TTL expired).`);


### PR DESCRIPTION
Closes #7594.

Summary of What Has Been Done:
Replaced the invalid `notif_type: 'BID_ACCEPTANCE_EXPIRED'` with `notif_type: 'order_update'` in escrowFundingReconciliation.js. The 'BID_ACCEPTANCE_EXPIRED' type violates the notifications.notif_type CHECK constraint.

Changes Made:
- backend/api/src/services/escrowFundingReconciliation.js: Changed 'BID_ACCEPTANCE_EXPIRED' to 'order_update'

Impact it Made:
- Fixes CHECK constraint violations in escrow funding reconciliation notification writes
- Ensures bid acceptance expiry notifications are persisted correctly

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).