### PR TITLE
fix : replaced invalid notification types with valid notif_type values in multiple services

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -652,7 +652,7 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
         pending.driver_id,
         'Bid Accepted!',
         `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
-        'bid_accepted',
+        'order_update',
         { orderId, orderDisplayId: pending.order_display_id }
       ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
     };

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -309,7 +309,7 @@ router.post(
           order.driver_id,
           '💰 Payment Locked',
           `Customer payment for order ${order.order_display_id} is now locked in escrow. Proceed with delivery.`,
-          'payment_locked',
+          'payment',
           { order_display_id: order.order_display_id, tx_hash }
         ).catch(err => logger.warn('[payments] Driver FCM push failed:', err.message));
       }

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -71,7 +71,7 @@ async function finalizeOrRevert(order, orderRepository) {
           pending.driver_id,
           'Bid Accepted!',
           `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
-          'bid_accepted',
+          'order_update',
           { orderId: order.id, orderDisplayId: pending.order_display_id }
         ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
       }

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -624,7 +624,7 @@ export class DeliveryVerificationService {
             resolvedDriverIdForPush,
             "✅ Payment Released",
             `Payment Released ✓ ${amountInr} credited for order ${order.order_display_id}`,
-            "payment_released",
+            "payment",
             {
               order_display_id: order.order_display_id,
               release_tx_hash: releaseTxHash || "",

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -335,7 +335,7 @@ export class OrderLifecycleService {
           offer.customer_id,
           'New Bid Received',
           `A driver has submitted a bid of ₹${bidAmount} for your order.`,
-          'new_bid',
+          'order_update',
           { loadOfferId, bidId: bid.id }
         ).catch(err => logger.error(`[FCM] Failed to notify customer of new bid: ${err.message}`));
 
@@ -941,7 +941,7 @@ export class OrderLifecycleService {
             pending.driver_id,
             'Bid Accepted!',
             `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
-            'bid_accepted',
+            'order_update',
             { orderId, orderDisplayId: pending.order_display_id }
           ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
         }


### PR DESCRIPTION
Closes #7538.

Summary of What Has Been Done:
Replaced invalid `notif_type` values with valid values that satisfy the notifications.notif_type CHECK constraint. The invalid types 'bid_accepted', 'new_bid', 'payment_locked', and 'payment_released' were causing PGRST204 check violations, silently dropping notifications.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Changed 'bid_accepted' to 'order_update'
- backend/api/src/services/escrowFundingReconciliation.js: Changed 'bid_accepted' to 'order_update'
- backend/api/src/services/order/orderLifecycleService.js: Changed 'bid_accepted' and 'new_bid' to 'order_update'
- backend/api/src/routes/paymentRoutes.js: Changed 'payment_locked' to 'payment'
- backend/api/src/services/order/deliveryVerificationService.js: Changed 'payment_released' to 'payment'

Impact it Made:
- Fixes PGRST204 check violations for bid, payment, and delivery notifications
- Ensures notifications are persisted correctly in the database

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).