### PR TITLE
fix: normalize error response shapes in deviceController.js to use {error: string} wrapper

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -43,12 +43,7 @@ export async function registerDeviceToken(req, res, next) {
 
     const tokenErr = validateFcmToken(fcmToken);
     if (tokenErr) {
-      return res.status(400).json(
-        errorResponse(
-          'VALIDATION_ERROR',
-          tokenErr
-        )
-      );
+      return res.status(400).json({ error: tokenErr });
     }
 
     const platErr = validatePlatform(platform);


### PR DESCRIPTION
## Description
`registerDeviceToken` in `backend/api/src/controllers/deviceController.js` previously used `errorResponse('VALIDATION_ERROR', tokenErr)` for FCM token validation errors, resulting in an inconsistent response body shape compared to other endpoints in the same controller.
gssoc 26

Changes made:
- Updated `tokenErr` validation handler in `registerDeviceToken` to return `res.status(400).json({ error: tokenErr })`.
- Standardized error response structure across all device controller validation paths.

Fixes #7588

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid FCM token error responses by returning clearer, direct error details.
  * Removed unnecessary response wrapping for this error case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->