### PR TITLE
fix: add async keyword to GlobalStore transaction method

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -183,7 +183,7 @@ class GlobalStore extends EventEmitter {
     
     // ============ Transaction Support ============
     
-    transaction(fn) {
+    async transaction(fn) {
         if (this.activeTransaction) {
             throw new Error('Nested transactions not supported');
         }


### PR DESCRIPTION
## Description
In `backend/store/GlobalStore.js`, the `transaction` method used `await` within its method body (e.g., `await transaction.commit()`) without being declared as `async`.

gssoc 26

Changes made:
- Added `async` keyword to the `transaction(fn)` method declaration in `GlobalStore`.

Fixes #7424

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings