### PR TITLE
fix: prevent duplicate imports and route insertion in update_backend.py

### DIFF
--- a/update_backend.py
+++ b/update_backend.py
@@ -7,20 +7,24 @@ with open(file_path, 'r', encoding='utf-8') as f:
 # Add import
 import_stmt = "import { checkBypassEligibility } from '../services/weighStationService.js';"
 # insert at top after other imports
-if import_stmt not in content:
-    matches = list(re.finditer(r'^import .*?;$', content, re.MULTILINE))
+import_pattern = re.compile(
+    r"import\s*\{[^}]*\bcheckBypassEligibility\b[^}]*\}\s*from\s*['\"]\.\./services/weighStationService\.js['\"]\s*;",
+    re.MULTILINE | re.DOTALL,
+)
+
+if not import_pattern.search(content):
+    matches = list(re.finditer(r"^import\b[\s\S]*?;$", content, re.MULTILINE))
 
     if matches:
         last = matches[-1]
         content = (
             content[:last.end()]
-            + '\n'
+            + "\n"
             + import_stmt
             + content[last.end():]
         )
     else:
-        content = import_stmt + '\n' + content
-
+        content = import_stmt + "\n" + content
 # Add route
 route = '''
 router.get('/weigh-stations/bypass-status', requireAuth, requireDriver, async (req, res) => {
@@ -38,7 +42,12 @@ router.get('/weigh-stations/bypass-status', requireAuth, requireDriver, async (r
 '''
 
 # insert before export default router;
-if "/weigh-stations/bypass-status" not in content:
+route_pattern = re.compile(
+    r"router\.get\s*\(\s*['\"]/weigh-stations/bypass-status['\"]",
+    re.MULTILINE,
+)
+
+if not route_pattern.search(content):
     content = content.replace(
         'export default router;',
         route + '\nexport default router;'

--- a/update_backend.py
+++ b/update_backend.py
@@ -7,11 +7,19 @@ with open(file_path, 'r', encoding='utf-8') as f:
 # Add import
 import_stmt = "import { checkBypassEligibility } from '../services/weighStationService.js';"
 # insert at top after other imports
-match = re.search(r'import\s+.*?;', content)
-if match:
-    content = content[:match.end()] + '\n' + import_stmt + content[match.end():]
-else:
-    content = import_stmt + '\n' + content
+if import_stmt not in content:
+    matches = list(re.finditer(r'^import .*?;$', content, re.MULTILINE))
+
+    if matches:
+        last = matches[-1]
+        content = (
+            content[:last.end()]
+            + '\n'
+            + import_stmt
+            + content[last.end():]
+        )
+    else:
+        content = import_stmt + '\n' + content
 
 # Add route
 route = '''
@@ -30,8 +38,11 @@ router.get('/weigh-stations/bypass-status', requireAuth, requireDriver, async (r
 '''
 
 # insert before export default router;
-content = content.replace('export default router;', route + '\nexport default router;')
-
+if "/weigh-stations/bypass-status" not in content:
+    content = content.replace(
+        'export default router;',
+        route + '\nexport default router;'
+    )
 with open(file_path, 'w', encoding='utf-8') as f:
     f.write(content)
 print("Done")


### PR DESCRIPTION

## Description

This PR fixes a bug in `update_backend.py` where running the script multiple times could insert duplicate import statements and duplicate route definitions into `driverRoutes.js`.

### Changes Made
- Prevent duplicate import insertion by checking if the import already exists.
- Prevent duplicate route insertion by checking if the route already exists.
- Preserve the existing functionality of the script.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:**
  ```bash
  python update_backend.py
  python update_backend.py
  ```

- **Test Steps / Prerequisites:**
  1. Run the script once.
  2. Verify that the import statement and route are added.
  3. Run the script a second time.
  4. Verify that no duplicate import or route is added.

- **Expected Result:**
  The script should insert the import statement and route only once, even when executed multiple times.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues

Closes #<issue_number>

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
  
## Related Issues

Closes #7639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate service imports when updating backend files.
  * Ensured new imports are placed consistently after existing imports.
  * Prevented duplicate bypass-status routes from being added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->