### PR TITLE
fix(zk): make placeholder Verifier.verifyProof fail closed (issue #7402)

### DIFF
--- a/blockchain/contracts/verifier.sol
+++ b/blockchain/contracts/verifier.sol
@@ -5,36 +5,20 @@ pragma solidity ^0.8.0;
 // It contains the verifier contract for ZK-SNARKs
 // NOTE: Regenerate via `circom kyc_verification.circom --r1cs --wasm --json`
 // after fixing circuits/kyc_verification.circom to produce the real Verifier.sol.
-// Until the real verifier is generated, this placeholder REJECTS zero, empty,
-// and malformed proofs instead of accepting every proof.
+// Until the real Groth16 verifier is generated, verifyProof FAILS CLOSED: it
+// rejects every proof instead of accepting fabricated ones, so KYC and zkEVM
+// callers can never be tricked into trusting a proof that was never verified.
 
 contract Verifier {
-    uint256 constant BN254_GX = 1;
-    uint256 constant BN254_GY = 2;
-    uint256 constant BN254_P = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
-
     function verifyProof(
         uint[2] memory a,
         uint[2][2] memory b,
         uint[2] memory c,
         uint[2] memory input
     ) public view returns (bool r) {
-        require(input[0] != 0 || input[1] != 0, "Empty public input");
-        require(_isOnBn254(a[0], a[1]), "Invalid G1 point in proof (a)");
-        require(_isOnBn254(c[0], c[1]), "Invalid G1 point in proof (c)");
-        require(_isOnBn254(b[0][0], b[0][1]), "Invalid G2 point in proof (b[0])");
-        for (uint i = 0; i < input.length; i++) {
-            require(input[i] < BN254_P, "Public input exceeds field modulus");
-        }
-        r = true;
-    }
-
-    function _isOnBn254(uint256 x, uint256 y) internal pure returns (bool) {
-        if (x == 0 && y == 0) return false; // point at infinity is never a valid proof point
-        if (x >= BN254_P || y >= BN254_P) return false;
-        uint256 lhs = mulmod(y, y, BN254_P);
-        uint256 rhs = mulmod(mulmod(x, x, BN254_P), x, BN254_P);
-        rhs = addmod(rhs, 3, BN254_P);
-        return lhs == rhs;
+        // No real circuit / verification key exists yet, so no proof can be
+        // accepted. Replace this with the snarkjs pairing verifier once the
+        // kyc circuit and trusted setup have been generated.
+        return false;
     }
 }

--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -152,7 +152,7 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
         require(transactionsData.length > 0, "Empty batch");
         require(transactionsData.length <= MAX_BATCH_SIZE, "Batch too large");
 
-        // Verify proof; zero, empty, and malformed proofs are rejected
+        // Verify proof — fails closed until a real Groth16 verifier is deployed
         require(_verifyProof(proof), "Invalid proof");
 
         // Process transactions
@@ -228,7 +228,7 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
         require(amount > 0, "Amount must be > 0");
         require(currentState.balances[msg.sender] >= amount, "Insufficient balance");
 
-        // Verify withdrawal proof; zero, empty, and malformed proofs are rejected
+        // Verify withdrawal proof — fails closed until a real Groth16 verifier is deployed
         require(_verifyProof(proof), "Invalid proof");
 
         currentState.balances[msg.sender] -= amount;

--- a/blockchain/test/zkVerifier.test.js
+++ b/blockchain/test/zkVerifier.test.js
@@ -26,17 +26,27 @@ describe("ZK proof verification", function () {
 
   it("rejects an all-zero proof in Verifier.verifyProof", async function () {
     const { verifier } = await deployZkEVM();
-    await assertRejectsWith(
-      verifier.verifyProof([0, 0], [[0, 0], [0, 0]], [0, 0], [1, 1]),
-      "Invalid G1 point in proof (a)"
+    assert.equal(
+      await verifier.verifyProof([0, 0], [[0, 0], [0, 0]], [0, 0], [1, 1]),
+      false
     );
   });
 
   it("rejects an empty public input in Verifier.verifyProof", async function () {
     const { verifier } = await deployZkEVM();
-    await assertRejectsWith(
-      verifier.verifyProof([1, 2], [[1, 2], [1, 2]], [1, 2], [0, 0]),
-      "Empty public input"
+    assert.equal(
+      await verifier.verifyProof([1, 2], [[1, 2], [1, 2]], [1, 2], [0, 0]),
+      false
+    );
+  });
+
+  it("rejects a fabricated on-curve proof in Verifier.verifyProof", async function () {
+    const { verifier } = await deployZkEVM();
+    // (1,2) is a valid point on the BN254 curve, so the old placeholder
+    // accepted it; verifyProof must now fail closed for every proof.
+    assert.equal(
+      await verifier.verifyProof([1, 2], [[1, 2], [1, 2]], [1, 2], [1, 1]),
+      false
     );
   });
 
@@ -94,5 +104,17 @@ describe("ZK proof verification", function () {
       kycVerifier.connect(admin).verifyKYC([0, 0], [[0, 0], [0, 0]], [0, 0], [0, 0], user.address),
       "Zero proof rejected"
     );
+  });
+
+  it("does not mark a user verified with a fabricated proof in KYCVerifier", async function () {
+    const kycVerifier = await (await ethers.getContractFactory("KYCVerifier")).deploy();
+    await kycVerifier.waitForDeployment();
+    const [admin, user] = await ethers.getSigners();
+
+    const verified = await kycVerifier
+      .connect(admin)
+      .verifyKYC.staticCall([1, 2], [[1, 2], [1, 2]], [1, 2], [1, 1], user.address);
+    assert.equal(verified, false);
+    assert.equal(await kycVerifier.isVerified(user.address), false);
   });
 });


### PR DESCRIPTION
## Problem

`blockchain/contracts/verifier.sol` is a placeholder Groth16 verifier whose `verifyProof` performs no pairing check and returns `true` for any non-zero on-curve BN254 points. Anyone can fabricate a proof with arbitrary public inputs and have it accepted:

- `KYCVerifier.sol` marks `verifiedUsers[user] = true` based on it.
- `zkEVM.sol` `_verifyProof` accepts it for batch and withdrawal proofs.
- `zkEVMBridge.sol` passes user proofs through `zkEVM.withdrawFromL2`.

The zero-knowledge security control therefore verifies nothing.

## Fix

A real `Verifier.sol` cannot be generated yet — `circuits/kyc_verification.circom` is itself a placeholder (its `Poseidon` template is not a real hash and no trusted setup/verification key exists). Following the issue's guidance, the placeholder verifier now **fails closed**:

- `verifyProof` returns `false` for every input instead of `true`; the header comment documents why.
- `zkEVM.sol` comments at `executeBatch` and `withdrawFromL2` updated to reflect that proof verification fails closed until a real Groth16 verifier is deployed; the existing `require(_verifyProof(proof), "Invalid proof")` guards now revert for all proofs instead of accepting fabricated ones.
- `KYCVerifier.verifyKYC` branches on the verifier result, so it now returns `false` and can never mark a user as verified with a fabricated proof.
- `zkEVMBridge` inherits the same fail-closed behavior through `zkEVM.withdrawFromL2`.

## Files changed

- `blockchain/contracts/verifier.sol`
- `blockchain/contracts/zkEVM.sol`
- `blockchain/test/zkVerifier.test.js`

## Testing

- The affected contracts (`verifier.sol`, `zkEVM.sol`, `KYCVerifier.sol`, `zkEVMBridge.sol`) compile successfully with Hardhat.
- `zkVerifier.test.js` updated to the fail-closed contract and extended with:
  - fabricated on-curve BN254 proof `(1, 2)` → `false` (was `true` before)
  - all-zero and empty-input proofs → `false`
  - `zkEVM` batches and withdrawals still revert with `Invalid proof`
  - `KYCVerifier.verifyKYC` does not mark a user verified with a fabricated proof (via staticCall)
- All zk verification tests pass (10/10) against the compiled contracts.

Closes #7402
