### PR TITLE
fix(zk): cap withdrawFees to collected fees and restrict receive (issue #7403)

### DIFF
--- a/blockchain/contracts/zkEVMBridge.sol
+++ b/blockchain/contracts/zkEVMBridge.sol
@@ -15,6 +15,7 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public depositedAmount;
     uint256 public bridgeFee = 0.001 ether;
+    uint256 public collectedFees;
 
     event BridgeDeposit(address indexed user, uint256 amount, uint256 fee);
     event BridgeWithdraw(address indexed user, uint256 amount);
@@ -29,6 +30,7 @@ contract zkEVMBridge is Ownable, ReentrancyGuard {
         uint256 amount = msg.value - bridgeFee;
 
         depositedAmount[msg.sender] += amount;
+        collectedFees += bridgeFee;
 
         // Deposit to L2
         zkEVM.depositToL2{value: amount}();
@@ -73,8 +75,20 @@ function withdrawFromL2(
     }
 
     function withdrawFees() external onlyOwner {
-        payable(owner()).transfer(address(this).balance);
+        // Only ever sweep the fees collected in depositToL2. The contract
+        // balance also holds user funds queued in pendingWithdrawals, so it
+        // must never be transferred in full to the owner.
+        uint256 amount = collectedFees;
+        require(amount > 0, "No fees to withdraw");
+        collectedFees = 0;
+        payable(owner()).transfer(amount);
     }
 
-    receive() external payable {}
+    receive() external payable {
+        // Only the zkEVM rollup sends ETH back to the bridge (the amount
+        // returned during withdrawFromL2, which is queued for the user).
+        // Rejecting arbitrary ETH keeps stray funds from inflating the
+        // balance and being mistaken for user money or fees.
+        require(msg.sender == address(zkEVM), "Only zkEVM can fund the bridge");
+    }
 }

--- a/blockchain/test/zkEVMBridge.test.cjs
+++ b/blockchain/test/zkEVMBridge.test.cjs
@@ -118,4 +118,40 @@ describe("zkEVMBridge", function () {
     const ownerAfter = await ethers.provider.getBalance(owner.address);
     assert.ok(ownerAfter > ownerBefore, "owner balance should increase");
   });
+
+  it("sweeps only the collected fees, not the contract balance", async function () {
+    const { bridge, user, owner } = await deployBridge();
+    const fee = await bridge.bridgeFee();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    assert.equal(await bridge.collectedFees(), fee);
+
+    await bridge.connect(owner).withdrawFees();
+    assert.equal(await bridge.collectedFees(), 0n);
+  });
+
+  it("does not drain pending user withdrawals when sweeping fees", async function () {
+    const { bridge, user, owner } = await deployBridge();
+    await bridge.connect(user).depositToL2({ value: ethers.parseEther("1") });
+    await bridge.connect(user).withdrawFromL2(ethers.parseEther("0.4"), ethers.randomBytes(65));
+
+    const pendingBefore = await bridge.pendingWithdrawals(user.address);
+    assert.equal(pendingBefore, ethers.parseEther("0.4"));
+
+    await bridge.connect(owner).withdrawFees();
+
+    assert.equal(await bridge.pendingWithdrawals(user.address), ethers.parseEther("0.4"));
+    await bridge.connect(user).claimWithdrawal();
+    assert.equal(await bridge.pendingWithdrawals(user.address), 0n);
+  });
+
+  it("rejects arbitrary ETH sent to the bridge via receive()", async function () {
+    const { bridge, user } = await deployBridge();
+    await assert.rejects(
+      user.sendTransaction({
+        to: await bridge.getAddress(),
+        value: ethers.parseEther("1"),
+      }),
+      "Only zkEVM can fund the bridge"
+    );
+  });
 });


### PR DESCRIPTION
## Problem

`blockchain/contracts/zkEVMBridge.sol` `withdrawFees` transfers the **entire** contract balance to the owner:

```solidity
function withdrawFees() external onlyOwner {
    payable(owner()).transfer(address(this).balance);
}
```

The bridge is not a fee-only wallet: `withdrawFromL2` receives ETH back from the zkEVM rollup and credits it to `pendingWithdrawals[msg.sender]` until the user calls `claimWithdrawal()`, and the unrestricted `receive()` lets anyone send stray ETH to the bridge. A single `withdrawFees()` call therefore drains every user's pending withdrawal plus any stray ETH to the owner, breaking the bridge's accounting.

## Fix

- Track collected fees in a dedicated `collectedFees` state variable, incremented by `bridgeFee` in `depositToL2`.
- `withdrawFees()` now transfers only `collectedFees` (reverting with `No fees to withdraw` when zero) and resets it to 0 — user funds sitting in `pendingWithdrawals` are never touched.
- `receive()` is restricted to ETH sent only from the zkEVM rollup (`msg.sender == address(zkEVM)`), which is exactly the refund path used during `withdrawFromL2`; arbitrary ETH can no longer inflate the contract balance.

## Files changed

- `blockchain/contracts/zkEVMBridge.sol`
- `blockchain/test/zkEVMBridge.test.cjs`

## Testing

- The affected contracts compile successfully with Hardhat.
- All 12 bridge tests pass, including 3 new ones:
  - `withdrawFees` sweeps only `collectedFees` and resets it to 0
  - sweeping fees does not drain pending user withdrawals (the user can still claim the full amount afterwards)
  - arbitrary ETH sent to the bridge via `receive()` is rejected
- Existing behavior preserved: owner-only access, deposit/withdraw accounting, replay protection, and the zkEVM refund path still work.

Closes #7403
