### PR TITLE
fix: add comment to empty catch block for jwt.decode in auth middleware

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -30,7 +30,9 @@ export async function verifyAuthToken(token) {
   let decoded;
   try {
     decoded = jwt.decode(token);
-  } catch (err) {}
+  } catch (err) {
+    // jwt.decode returns null for malformed or invalid tokens, which is handled in subsequent checks
+  }
 
   const isSupabaseToken =
     decoded &&


### PR DESCRIPTION
## Description
`jwt.decode(token)` in `backend/api/src/middleware/auth.js` contained an empty `catch` block that lacked documentation explaining why exceptions were ignored.
gssoc 26

Changes made:
- Added an explanatory inline comment inside the `catch` block of `verifyAuthToken`.
- Documented that `jwt.decode` returns `null` for malformed/invalid tokens, which is safely validated by subsequent conditional checks.

Fixes #7643

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication handling when decoding a token fails.
  * Added context explaining that subsequent validation handles invalid tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->