### PR TITLE
chore: remove unused getSentryLevel function from sentry middleware

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -11,11 +11,6 @@ export function shouldIgnoreError(err) {
   return SENTRY_ERROR_FILTERS.some((f) => err.code === f.code);
 }
 
-function getSentryLevel(err) {
-  const filter = SENTRY_ERROR_FILTERS.find((f) => err.code === f.code);
-  return filter ? filter.level : "error";
-}
-
 export function initSentry() {
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return;


### PR DESCRIPTION
## Description
The `getSentryLevel` helper function in `backend/api/src/middleware/sentry.js` was defined but not referenced anywhere in the project.

gssoc 26

Changes made:
- Removed unused `getSentryLevel` function definition to eliminate dead code.

Fixes #7645

## Type of Change
- [x] Code refactor / cleanup (non-breaking change)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings