### PR TITLE
fix: increase OSRM cache key coordinate precision from 6 to 8 decimal places

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -39,7 +39,7 @@ function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
 }
 
 function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng }) {
-  const r = (n) => Number(n.toFixed(6));
+  const r = (n) => Number(n.toFixed(8));
   return `osrm:route:v2:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
 }
 


### PR DESCRIPTION
## Description
`buildCacheKey` in `backend/api/src/services/osrm.js` rounded coordinate values to 6 decimal places when constructing Redis cache keys for route estimates.
gssoc 26

Changes made:
- Updated coordinate rounding precision from `toFixed(6)` to `toFixed(8)`.
- Better aligns cache keys with mobile GPS device precision (~1.1mm accuracy) and improves hit fidelity.

Fixes #7650

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings