### PR TITLE
fix: correct misleading weight validation error message in truck routes

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -447,7 +447,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
   }
 
   if (numWeightTonnes <= 0 || numWeightTonnes > 50) {
-    return res.status(400).json({ error: 'Weight must be between 0 and 50 tonnes' });
+    return res.status(400).json({ error: 'Weight must be greater than 0 and at most 50 tonnes' });
   }
   const fragileFilter = parseBoolean(is_fragile);
   if (fragileFilter.error) {


### PR DESCRIPTION
## Description
The weight validation logic in `truckRoutes.js` rejects values `<= 0`, but the previous error message claimed `'Weight must be between 0 and 50 tonnes'`, which falsely implied that 0 was a valid weight input.

gssoc 26

Changes made:
- Updated the validation error message in `backend/api/src/routes/truckRoutes.js` to `'Weight must be greater than 0 and at most 50 tonnes'`.

Closes #7648

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings