### PR TITLE
fix: remove OTP from FCM data payload in notification service

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -271,7 +271,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     fcmResult = await sendFcmNotification(
       customerId,
       { title, body },
-      { orderDisplayId, notifType: 'delivery_otp', deliveryOtp: String(otp) }
+      { orderDisplayId, notifType: 'delivery_otp',  }
     );
   } catch (err) {
     logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');


### PR DESCRIPTION
## Description
`sendDeliveryOtpNotification` in `notificationService.js` previously included `deliveryOtp: String(otp)` in the unencrypted FCM `data` payload. FCM data payloads can be logged or read by other apps on the device. Since the OTP is already provided securely via `notification.body` for visual display, removing it from the raw data object eliminates the risk of OTP interception.
gssoc 26

Changes made:
- Removed `deliveryOtp` from the FCM `data` object in `backend/api/src/services/notificationService.js`.

Closes #7649

## Type of Change
- [x] Security / Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings