### PR TITLE
chore: remove unused safeAdd and safeSubtract functions from reputation service

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -25,15 +25,7 @@ import { measureExecution } from "../core/performanceMetrics.js";
 
 // Safe math utilities for reputation calculations.
 // Boundary clamping (0–MAX_REPUTATION) is handled by clampReputation.
-function safeAdd(a, b) {
-  const result = Number(a) + Number(b);
-  return Number.isFinite(result) ? result : 0;
-}
 
-function safeSubtract(a, b) {
-  const result = Number(a) - Number(b);
-  return Number.isFinite(result) ? result : 0;
-}
 
 /** @type {number} Must match Reputation.sol MAX_REPUTATION constant */
 const MAX_REPUTATION = 10000;


### PR DESCRIPTION
## Description
The `reputation.js` service defined `safeAdd` and `safeSubtract` utility functions that were not referenced anywhere in the service or codebase.

gssoc 26

Changes made:
- Removed unused `safeAdd` and `safeSubtract` dead code functions from `backend/api/src/services/reputation.js`.

Closes #7646

## Type of Change
- [x] Maintenance / Refactoring (non-breaking code cleanup)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings