### PR TITLE
fix: add missing api-service-v2 service and fix VirtualService manifest

### DIFF
--- a/k8s/istio/canary-service.yaml
+++ b/k8s/istio/canary-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service-v2
+  namespace: truxify
+  labels:
+    app: api
+    version: v2
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5000
+    targetPort: 5000
+    protocol: TCP
+    name: http
+  selector:
+    app: api
+    version: v2

--- a/k8s/istio/virtual-service.yaml
+++ b/k8s/istio/virtual-service.yaml
@@ -1,4 +1,3 @@
-﻿apiVersion: networking.istio.io/v1beta1
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -22,7 +21,6 @@ spec:
         port:
           number: 5000
       weight: 10
-
     retries:
       attempts: 3
       perTryTimeout: 2s
@@ -53,4 +51,3 @@ spec:
         host: api-service
         port:
           number: 5000
-


### PR DESCRIPTION
## Description
The Istio `VirtualService` (`k8s/istio/virtual-service.yaml`) was configured to route 10% of `/api/orders` traffic to `api-service-v2:5000`. However, no Kubernetes Service named `api-service-v2` existed, causing 10% of order API requests to fail with `503 Service Unavailable` / `no healthy upstream` errors. Additionally, `virtual-service.yaml` contained a duplicate `apiVersion` header line.
gssoc 26

Changes made:
- Created `k8s/istio/canary-service.yaml` defining `api-service-v2` Service with selector `app: api`, `version: v2` mapping port 5000.
- Cleaned up duplicate `apiVersion` line in `k8s/istio/virtual-service.yaml`.

Closes #7687

## Type of Change
- [x] Bug fix (infrastructure / k8s configuration)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings