### PR TITLE
fix: enforce totalTokens cap and bound availableTokens accounting in AssetToken

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -162,6 +162,8 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         uint256 totalCost = (amount * asset.tokenPrice + 1e18 - 1) / 1e18;
         require(msg.value >= totalCost, "Insufficient payment");
 
+        require(totalSupply() + amount <= asset.totalTokens, "Exceeds total token cap");
+
         // Update asset
         asset.availableTokens -= amount;
 
@@ -206,8 +208,11 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         // Update ownership
         ownership.amount -= amount;
 
-        // Update asset — returned fractions re-enter the available pool
+        // Update asset — returned fractions re-enter available pool bounded by totalTokens cap
         assets[assetId].availableTokens += amount;
+        if (assets[assetId].availableTokens > assets[assetId].totalTokens) {
+            assets[assetId].availableTokens = assets[assetId].totalTokens;
+        }
 
         if (ownership.amount == 0) {
             _removeUserAsset(msg.sender, assetId);


### PR DESCRIPTION
## Description
In `blockchain/contracts/AssetToken.sol`, secondary market flows and treasury buy-backs previously allowed `availableTokens` accounting to re-inflate beyond collateral limits, breaking the economic invariant that token supply is strictly backed by `totalTokens`.
gssoc 26

### Changes Made:
- Enforced a hard invariant in `purchaseFraction` ensuring `totalSupply() + amount` never exceeds `asset.totalTokens`.
- Bounded `availableTokens` restoration in `sellFraction` to `asset.totalTokens` cap to ensure primary pool capacity accurately reflects available fractions.

Fixes #7686

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings