### PR TITLE
security: prevent WASI path traversal sandbox escape in host filesystem operations

### DIFF
--- a/wasi/src/lib.rs
+++ b/wasi/src/lib.rs
@@ -114,16 +114,40 @@ pub fn wasi_delete_file(path: &str) -> Result<(), String> {
     }
 }
 
+use std::path::{Component, Path, PathBuf};
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if let Some(Component::Normal(_)) = components.last() {
+                    components.pop();
+                } else {
+                    components.push(component);
+                }
+            }
+            _ => components.push(component),
+        }
+    }
+    components.iter().collect()
+}
+
 fn is_path_allowed(path: &str) -> bool {
     // Capability-based security: only allow specific paths
-    let allowed_prefixes = vec![
-        "/tmp/truxify/",
-        "./data/",
-        "/var/truxify/",
+    let allowed_roots = vec![
+        "/tmp/truxify",
+        "./data",
+        "/var/truxify",
     ];
-    
-    for prefix in allowed_prefixes {
-        if path.starts_with(prefix) {
+
+    let p = Path::new(path);
+    let normalized = normalize_path(p);
+
+    for root in allowed_roots {
+        let root_path = normalize_path(Path::new(root));
+        if normalized.starts_with(&root_path) {
             return true;
         }
     }

--- a/wasi/wasi-runtime.js
+++ b/wasi/wasi-runtime.js
@@ -52,9 +52,12 @@ class WASIRuntime {
         try {
             await this.initialize();
             
-            // Path traversal protection
-            const normalized = path.normalize(wasmPath).replace(/^(\.\.[\/\\])+/, '');
-            const resolvedPath = path.resolve(normalized);
+            // Path traversal protection: resolve full path and ensure it stays inside allowed base directory
+            const resolvedPath = path.resolve(wasmPath);
+            const allowedBaseDir = path.resolve(process.cwd());
+            if (!resolvedPath.startsWith(allowedBaseDir + path.sep) && resolvedPath !== allowedBaseDir) {
+                throw new Error('Security Error: Path traversal outside allowed runtime sandbox directory');
+            }
             if (!resolvedPath.endsWith('.wasm')) {
                 throw new Error('Security Error: Only .wasm files are permitted');
             }


### PR DESCRIPTION
## Description
`wasi/src/lib.rs` previously performed a raw string prefix check (`starts_with`) on input file paths without lexical normalization or canonicalization, allowing directory traversal sequences (e.g., `/tmp/truxify/../../etc/passwd`) to escape the sandbox. Furthermore, `wasi/wasi-runtime.js` relied on a single regex replacement (`replace(/^(\.\.[\/\\])+/, '')`) that failed to block nested or internal `..` traversal segments when loading WASM modules.
gssoc 26

### Changes Made:
- **Rust WASI Library (`wasi/src/lib.rs`)**: Implemented `normalize_path` to resolve `.` and `..` path components before performing root prefix checks in `is_path_allowed`.
- **Node.js Runtime (`wasi/wasi-runtime.js`)**: Hardened `loadWasiModule` by resolving full target paths and validating that they remain within the allowed sandbox directory boundaries before execution.

Fixes #7684

## Type of Change
- [x] Security fix (non-breaking change which fixes a vulnerability)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings