### PR TITLE
fix: add missing shard password keys to k8s secrets

### DIFF
--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -13,3 +13,8 @@ data:
   SUPABASE_URL: <base64-encoded-supabase-url>
   SUPABASE_KEY: <base64-encoded-supabase-key>
   JWT_SECRET: <base64-encoded-jwt-secret>
+  SHARD_PASSWORD: <base64-encoded-shard-password>
+  SHARD_NORTH_PASSWORD: <base64-encoded-shard-password>
+  SHARD_SOUTH_PASSWORD: <base64-encoded-shard-password>
+  SHARD_EAST_PASSWORD: <base64-encoded-shard-password>
+  SHARD_WEST_PASSWORD: <base64-encoded-shard-password>


### PR DESCRIPTION
## Description
`ShardManager.js` and database deployment configs rely on shard password secrets (`SHARD_PASSWORD`, `SHARD_NORTH_PASSWORD`, `SHARD_SOUTH_PASSWORD`, `SHARD_EAST_PASSWORD`, `SHARD_WEST_PASSWORD`), but these entries were missing from `k8s/secrets.yaml`.
gssoc 26

Changes made:
- Added missing regional and fallback base64 shard password placeholders to `k8s/secrets.yaml`.
- Ensured environment variable parity between Kubernetes secrets and backend initialization checks.

Fixes #7679

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings