### PR TITLE
feat(api): extend redis idempotency middleware coverage to all critical state-mutating routes #7301

### DIFF
--- a/backend/api/src/middleware/index.js
+++ b/backend/api/src/middleware/index.js
@@ -4,3 +4,4 @@ export { default as suspiciousRequests } from './suspiciousRequests.js';
 export { default as responseSanitizer } from './responseSanitizer.js';
 export { requirePolicy } from './requirePolicy.js';
 export { authenticate, requireRole } from './auth.js';
+export { requireIdempotency } from './idempotency.js';

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -154,6 +154,7 @@ import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';
 import { auditLog } from '../middleware/auditLog.js';
+import { requireIdempotency } from '../middleware/idempotency.js';
 const router = express.Router();
 router.use(userLimiter);
 const hosStatusSchema = z.object({
@@ -964,7 +965,7 @@ router.get('/bids', authenticate, userLimiter, requirePolicy('driver:view-bids')
  *       400:
  *         description: Insufficient balance or validation error
  */
-router.post('/wallet/withdraw', authenticate, userLimiter, requirePolicy('driver:withdraw'), auditLog({ action: 'driver:withdraw', resourceType: 'wallet_withdrawal' }), validateBody(withdrawSchema), async (req, res) => {
+router.post('/wallet/withdraw', authenticate, userLimiter, requirePolicy('driver:withdraw'), auditLog({ action: 'driver:withdraw', resourceType: 'wallet_withdrawal' }), requireIdempotency(86400), validateBody(withdrawSchema), async (req, res) => {
   const { amount } = req.body; // in paisa
 
   try {

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -399,7 +399,7 @@ router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requ
  *       429:
  *         description: Rate limited
  */
-router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, requirePolicy('order:change-drop'), auditLog({ action: 'order:change-drop', resourceType: 'order' }), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
+router.put('/:id/change-drop', authenticate, userLimiter, changeDropLimiter, requirePolicy('order:change-drop'), auditLog({ action: 'order:change-drop', resourceType: 'order' }), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(changeDropSchema), async (req, res) => {
   const { id: orderId } = req.params;
   const { drop_address, drop_lat, drop_lng } = req.body;
   try {
@@ -570,7 +570,7 @@ router.post('/:id/cancel', authenticate, userLimiter, requirePolicy('order:cance
  *       200:
  *         description: Deposit confirmed
  */
-router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('order:confirm-deposit'), auditLog({ action: 'order:confirm-deposit', resourceType: 'order' }), validateParams(paramIdSchema), validateBody(
+router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('order:confirm-deposit'), auditLog({ action: 'order:confirm-deposit', resourceType: 'order' }), requireIdempotency(86400), validateParams(paramIdSchema), validateBody(
   z.object({ txHash: z.string().regex(/^0x([A-Fa-f0-9]{64})$/, 'Invalid transaction hash') }),
 ), async (req, res) => {
   const orderId = req.params.id;
@@ -973,7 +973,7 @@ async function validateAndScanPodFile(file, label) {
 // PoD uploads are rate-limited per driver + order: each request may carry up to
 // 20MB and triggers a malware scan, so without a limiter a driver could exhaust
 // storage, RAM (multer memoryStorage), and scan CPU with an unbounded stream.
-router.post('/:id/pod', authenticate, requireRole(['driver']), podUploadLimiter, podUpload.fields([{ name: 'signature', maxCount: 1 }, { name: 'photo', maxCount: 1 }]), async (req, res) => {
+router.post('/:id/pod', authenticate, requireRole(['driver']), podUploadLimiter, requireIdempotency(86400), podUpload.fields([{ name: 'signature', maxCount: 1 }, { name: 'photo', maxCount: 1 }]), async (req, res) => {
   try {
     const orderId = req.params.id;
     const { data: order, error: orderErr } = await orderRepository.findOrderById(orderId);

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -99,6 +99,7 @@ router.post(
   '/upi-intent',
   authenticate,
   lockLimiter,
+  requireIdempotency(3600),
   validateBody(upiIntentSchema),
   async (req, res) => {
     try {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR. -->

Extends the existing Redis-backed idempotency middleware (`requireIdempotency`) coverage to all critical state-mutating API routes that were previously unprotected against network retries and duplicate requests.

The idempotency middleware itself (`backend/api/src/middleware/idempotency.js`) already existed with full Redis-backed caching, distributed locking, in-memory fallback, and LRU eviction. This PR closes the coverage gap by injecting `requireIdempotency()` into five additional high-risk routes across three route files, and re-exports the middleware from the barrel `index.js` for consistency.

**Routes now guarded (newly added):**

| Route | File | TTL | Risk Mitigated |
|---|---|---|---|
| `PUT /:id/change-drop` | `orderRoutes.js` | 86400s | Duplicate repricing + escrow rebalance |
| `POST /:id/confirm-deposit` | `orderRoutes.js` | 86400s | Double escrow funding on-chain |
| `POST /:id/pod` | `orderRoutes.js` | 86400s | Duplicate proof-of-delivery uploads |
| `POST /upi-intent` | `paymentRoutes.js` | 3600s | Duplicate UPI payment intent generation |
| `POST /wallet/withdraw` | `driverRoutes.js` | 86400s | **Double-withdrawal of driver funds** |

**Routes already guarded (no changes):**
- `POST /:id/confirm-otp` — `orderRoutes.js` (86400s)
- `POST /:id/cancel` — `orderRoutes.js` (86400s)
- `POST /lock` — `paymentRoutes.js` (3600s)

## Type of Change
<!-- Select all that apply: -->
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- **Test Commands:**
  - `npm run lint` — ESLint passes with zero errors
  - `npm test` — All existing test suites pass (idempotency middleware unit tests validate Redis and in-memory paths)
- **Test Steps / Prerequisites:**
  1. Ensure `REDIS_URL` is configured in `.env` (middleware falls back to in-memory store if Redis is unavailable)
  2. Send a `POST /api/payments/upi-intent` request with `X-Idempotency-Key: test-key-1` — should return the UPI intent
  3. Replay the same request with the same `X-Idempotency-Key` — should return the **cached** response (HTTP 200, same body)
  4. Send a `POST /api/driver/wallet/withdraw` without `X-Idempotency-Key` header — should return HTTP 400 with `"X-Idempotency-Key must be a non-empty string."`
  5. Repeat for `PUT /:id/change-drop`, `POST /:id/confirm-deposit`, and `POST /:id/pod`
- **Expected Result:** Duplicate requests within the TTL window return the original cached response. Requests missing the `X-Idempotency-Key` header are rejected with HTTP 400.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
<!-- Link the issue(s) resolved or referenced by this PR. -->
<!-- Examples: Closes #1234, Related to #5678 -->
Closes #7301

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards against duplicate wallet withdrawals.
  * Prevented duplicate order updates, deposit confirmations, and proof-of-delivery submissions.
  * Prevented duplicate UPI payment intent generation.
  * Requests are protected for up to 24 hours, or 1 hour for UPI intent generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->