### PR TITLE
fix(blockchain): scope IdentityWallet credentialInWallet per wallet owner

### DIFF
--- a/blockchain/contracts/IdentityWallet.sol
+++ b/blockchain/contracts/IdentityWallet.sol
@@ -17,7 +17,7 @@ contract IdentityWallet is Ownable {
     // Mapping
     mapping(address => Wallet) public wallets;
     mapping(address => bool) public hasWallet;
-    mapping(bytes32 => bool) public credentialInWallet;
+    mapping(bytes32 => mapping(address => bool)) public credentialInWallet;
     
     uint256 public totalWallets;
 
@@ -49,10 +49,10 @@ contract IdentityWallet is Ownable {
 
     function addCredential(bytes32 credentialId) external {
         require(hasWallet[msg.sender], "Wallet not found");
-        require(!credentialInWallet[credentialId], "Credential already in wallet");
+        require(!credentialInWallet[credentialId][msg.sender], "Credential already in wallet");
 
         wallets[msg.sender].credentials.push(credentialId);
-        credentialInWallet[credentialId] = true;
+        credentialInWallet[credentialId][msg.sender] = true;
         wallets[msg.sender].updatedAt = block.timestamp;
 
         emit CredentialAdded(msg.sender, credentialId);
@@ -60,7 +60,7 @@ contract IdentityWallet is Ownable {
 
     function removeCredential(bytes32 credentialId) external {
         require(hasWallet[msg.sender], "Wallet not found");
-        require(credentialInWallet[credentialId], "Credential not in wallet");
+        require(credentialInWallet[credentialId][msg.sender], "Credential not in wallet");
 
         Wallet storage wallet = wallets[msg.sender];
         for (uint256 i = 0; i < wallet.credentials.length; i++) {
@@ -71,7 +71,7 @@ contract IdentityWallet is Ownable {
             }
         }
 
-        credentialInWallet[credentialId] = false;
+        credentialInWallet[credentialId][msg.sender] = false;
         wallet.updatedAt = block.timestamp;
 
         emit CredentialRemoved(msg.sender, credentialId);
@@ -101,7 +101,7 @@ contract IdentityWallet is Ownable {
     }
 
     function hasCredential(address owner, bytes32 credentialId) external view returns (bool) {
-        return credentialInWallet[credentialId];
+        return credentialInWallet[credentialId][owner];
     }
 
     function isWalletActive(address owner) external view returns (bool) {

--- a/blockchain/test/IdentityWallet.test.js
+++ b/blockchain/test/IdentityWallet.test.js
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, error => error.message.includes(message));
+}
+
+describe("IdentityWallet credential scoping", function () {
+  async function deployWallet() {
+    const [owner, alice, bob] = await ethers.getSigners();
+    const IdentityWallet = await ethers.getContractFactory("IdentityWallet");
+    const wallet = await IdentityWallet.deploy();
+    await wallet.waitForDeployment();
+    return { wallet, owner, alice, bob };
+  }
+
+  async function createWallet(wallet, signer) {
+    const did = `did:example:${signer.address.toLowerCase()}`;
+    const tx = await wallet.connect(signer).createWallet(did);
+    await tx.wait();
+    return did;
+  }
+
+  const credentialId = ethers.keccak256(ethers.toUtf8Bytes("KYCCredential#12345"));
+
+  it("lets the same credentialId be stored in two different wallets", async function () {
+    const { wallet, alice, bob } = await deployWallet();
+    await createWallet(wallet, alice);
+    await createWallet(wallet, bob);
+
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+    await (await wallet.connect(bob).addCredential(credentialId)).wait();
+
+    assert.equal(await wallet.hasCredential(alice.address, credentialId), true);
+    assert.equal(await wallet.hasCredential(bob.address, credentialId), true);
+  });
+
+  it("still reverts when the same wallet tries to add a credential twice", async function () {
+    const { wallet, alice } = await deployWallet();
+    await createWallet(wallet, alice);
+
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+
+    await assertRejectsWith(
+      wallet.connect(alice).addCredential(credentialId),
+      "Credential already in wallet"
+    );
+  });
+
+  it("removeCredential only clears the caller's own wallet, not other wallets holding the same credential", async function () {
+    const { wallet, alice, bob } = await deployWallet();
+    await createWallet(wallet, alice);
+    await createWallet(wallet, bob);
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+    await (await wallet.connect(bob).addCredential(credentialId)).wait();
+
+    await (await wallet.connect(alice).removeCredential(credentialId)).wait();
+
+    assert.equal(await wallet.hasCredential(alice.address, credentialId), false);
+    assert.equal(await wallet.hasCredential(bob.address, credentialId), true);
+
+    const bobCredentials = await wallet.getCredentials(bob.address);
+    assert.equal(bobCredentials.length, 1);
+    assert.equal(bobCredentials[0], credentialId);
+  });
+
+  it("hasCredential returns the per-owner answer and ignores nothing", async function () {
+    const { wallet, alice, bob } = await deployWallet();
+    await createWallet(wallet, alice);
+    await createWallet(wallet, bob);
+
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+
+    assert.equal(await wallet.hasCredential(alice.address, credentialId), true);
+    assert.equal(await wallet.hasCredential(bob.address, credentialId), false);
+  });
+
+  it("removeCredential reverts for a caller that does not hold the credential", async function () {
+    const { wallet, alice, bob } = await deployWallet();
+    await createWallet(wallet, alice);
+    await createWallet(wallet, bob);
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+
+    await assertRejectsWith(
+      wallet.connect(bob).removeCredential(credentialId),
+      "Credential not in wallet"
+    );
+  });
+
+  it("keeps the wallet credentials array consistent across add/remove", async function () {
+    const { wallet, alice } = await deployWallet();
+    await createWallet(wallet, alice);
+
+    const second = ethers.keccak256(ethers.toUtf8Bytes("DrivingLicence#67890"));
+    await (await wallet.connect(alice).addCredential(credentialId)).wait();
+    await (await wallet.connect(alice).addCredential(second)).wait();
+
+    assert.deepEqual([...await wallet.getCredentials(alice.address)], [credentialId, second]);
+
+    await (await wallet.connect(alice).removeCredential(credentialId)).wait();
+
+    assert.deepEqual([...await wallet.getCredentials(alice.address)], [second]);
+    assert.equal(await wallet.hasCredential(alice.address, second), true);
+    assert.equal(await wallet.hasCredential(alice.address, credentialId), false);
+  });
+});


### PR DESCRIPTION
## Problem

In `blockchain/contracts/IdentityWallet.sol` the `credentialInWallet` mapping is **global across all wallets** instead of being scoped per owner:

- `credentialInWallet` is `mapping(bytes32 => bool)` — a single on-chain flag per `credentialId`.
- `addCredential()` gates on this global flag, so once **any** wallet adds a `credentialId`, every other wallet is locked out of it forever (`"Credential already in wallet"`).
- `removeCredential()` flips the global flag to `false` for **everyone**, so other wallets that still legitimately hold the credential now report it as absent — inconsistent with their `credentials` arrays.
- `hasCredential(owner, credentialId)` **ignores the `owner` argument** and returns the global flag, leaking whether a credential exists anywhere on-chain.

## Fix

- Changed the mapping to be per-owner: `mapping(bytes32 => mapping(address => bool)) public credentialInWallet;` (keyed by `credentialId → owner`, as proposed in the issue).
- `addCredential()` now reads/writes `credentialInWallet[credentialId][msg.sender]` only — the same `credentialId` can be stored in many wallets independently.
- `removeCredential()` now only clears the caller's own entry (`credentialInWallet[credentialId][msg.sender] = false`) and keeps the existing array pop logic, so the array and scoped map stay consistent for every holder.
- `hasCredential(owner, credentialId)` now returns the per-owner answer: `credentialInWallet[credentialId][owner]`.

## Files changed

- `blockchain/contracts/IdentityWallet.sol`
- `blockchain/test/IdentityWallet.test.js` (new)

## Testing

Added `blockchain/test/IdentityWallet.test.js` covering all the issue's required scenarios:

1. The same `credentialId` can be stored in **two different wallets**.
2. Adding the same credential twice to the **same** wallet still reverts with `"Credential already in wallet"`.
3. `removeCredential` only clears the **caller's** wallet — the other wallet holding the same credential is unaffected.
4. `hasCredential` returns the **per-owner** result.
5. `removeCredential` reverts with `"Credential not in wallet"` for a caller that does not hold the credential.
6. The `credentials` array stays consistent across add/remove.

All 6 tests pass (`6 passing`) and the contract compiles cleanly.

Note: the repository's `blockchain` package-lock currently pins a hardhat v2 core with v3-only plugins (`hardhat-verify`, `hardhat-ignition`), so `npx hardhat test` from the `blockchain/` root cannot load plugins on main today. The tests above were verified in an isolated project using the repo's own pinned `hardhat`/`hardhat-ethers`/`hardhat-chai-matchers`/`ethers` versions. This PR does not change the dependency setup; it only fixes the contract and adds the tests.

Closes #7680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Credentials are now tracked independently for each wallet, preventing ownership conflicts between wallets.
  - Credential additions, removals, and lookups now return wallet-specific results.
  - Credential lists remain consistent after credentials are added or removed.

- **Tests**
  - Added coverage for duplicate additions, owner-specific removal, invalid removals, and cross-wallet credential behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->