### PR TITLE
fix(k8s): wire api-service-account SA into Istio auth policy and remove blanket deny-all

### DIFF
--- a/.github/scripts/check-istio-principals.js
+++ b/.github/scripts/check-istio-principals.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const path = require('path');
+
+const K8S_DIR = 'k8s';
+
+function walkYamlFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkYamlFiles(full));
+    } else if (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractMeta(lines) {
+  let kind = null;
+  let name = null;
+  let ns = null;
+  let inMeta = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed === '---') continue;
+
+    const m = /^kind:\s*(\S+)/.exec(trimmed);
+    if (m) {
+      kind = m[1];
+      continue;
+    }
+
+    if (trimmed === 'metadata:') {
+      inMeta = true;
+      continue;
+    }
+    if (inMeta && !/^\s/.test(line)) {
+      inMeta = false;
+    }
+    if (inMeta) {
+      const mName = /^name:\s*(\S+)/.exec(trimmed);
+      if (mName && name === null) name = mName[1];
+      const mNs = /^namespace:\s*(\S+)/.exec(trimmed);
+      if (mNs && ns === null) ns = mNs[1];
+    }
+  }
+
+  return { kind, name, ns: ns || 'default' };
+}
+
+function splitDocs(lines) {
+  const docs = [];
+  let current = [];
+  for (const line of lines) {
+    if (line.trim() === '---') {
+      docs.push(current);
+      current = [];
+    } else {
+      current.push(line);
+    }
+  }
+  docs.push(current);
+  return docs.filter(d => d.some(l => l.trim() !== ''));
+}
+
+const serviceAccounts = new Set(); // `${ns}/${name}`
+const refs = []; // {file, line, ns, name, principal}
+
+for (const file of walkYamlFiles(K8S_DIR)) {
+  const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+
+  for (const doc of splitDocs(lines)) {
+    const { kind, name, ns } = extractMeta(doc);
+
+    if (kind === 'ServiceAccount' && name) {
+      serviceAccounts.add(`${ns}/${name}`);
+    }
+
+    const docNs = ns;
+    for (let i = 0; i < doc.length; i++) {
+      const line = doc[i].trimStart();
+      if (line.startsWith('#')) continue;
+
+      const saRef = /^serviceAccountName:\s*(\S+)/.exec(line);
+      if (saRef) {
+        refs.push({ file, line: i + 1, ns: docNs, name: saRef[1] });
+        continue;
+      }
+
+      const principal = /^-\s+cluster\.local\/ns\/([^/]+)\/sa\/(\S+)/.exec(line);
+      if (principal) {
+        refs.push({ file, line: i + 1, ns: principal[1], name: principal[2] });
+      }
+    }
+  }
+}
+
+let failed = false;
+
+for (const ref of refs) {
+  if (!serviceAccounts.has(`${ref.ns}/${ref.name}`)) {
+    console.error(
+      `ServiceAccount "${ref.name}" (namespace "${ref.ns}") referenced by ${ref.file}:${ref.line} has no matching ServiceAccount manifest (expected kind: ServiceAccount with name "${ref.name}" in namespace "${ref.ns}")`
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+console.log('All serviceAccountName usages and Istio principals reference ServiceAccounts defined in k8s manifests.');

--- a/.github/workflows/k8s-istio-principals.yml
+++ b/.github/workflows/k8s-istio-principals.yml
@@ -1,0 +1,24 @@
+name: K8s Istio ServiceAccount Reference Validation
+
+on:
+  pull_request:
+    paths:
+      - 'k8s/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'k8s/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-istio-principals:
+    name: Validate Istio principals against k8s ServiceAccounts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check ServiceAccount references
+        run: node .github/scripts/check-istio-principals.js

--- a/k8s/authorization/api-service-account.yaml
+++ b/k8s/authorization/api-service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-service-account
+  namespace: truxify
+  labels:
+    app: truxify
+    component: api

--- a/k8s/deployements/api-deployement.yaml
+++ b/k8s/deployements/api-deployement.yaml
@@ -18,6 +18,7 @@ spec:
         app: truxify
         component: api
     spec:
+      serviceAccountName: api-service-account
       containers:
       - name: api
         image: truxify/api:latest

--- a/k8s/istio/authorization-policy.yaml
+++ b/k8s/istio/authorization-policy.yaml
@@ -1,8 +1,4 @@
-
-﻿apiVersion: security.istio.io/v1beta1
-
 apiVersion: security.istio.io/v1beta1
-
 kind: AuthorizationPolicy
 metadata:
   name: truxify-auth-policy
@@ -27,18 +23,12 @@ spec:
         namespaces: ["istio-system"]
     to:
     - operation:
+        methods: ["GET", "POST", "PUT", "DELETE"]
+        paths: ["/api/*"]
+    - operation:
         methods: ["GET"]
         paths: ["/health", "/metrics"]
----
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: deny-all
-  namespace: truxify
-spec:
-  action: DENY
-  rules:
-  - from:
-    - source:
-        notPrincipals: ["*"]
 
+  - to:
+    - operation:
+        ports: ["15020", "15021"]


### PR DESCRIPTION
## Problem

`k8s/istio/authorization-policy.yaml` installs a deny-all posture for the whole `truxify` namespace that no running workload can satisfy:

- The ALLOW policy (`truxify-auth-policy`) only permits the SPIFFE principal `cluster.local/ns/truxify/sa/api-service-account`, but **no ServiceAccount or Deployment with that name exists** (zero `serviceAccountName` occurrences anywhere under `k8s/`), so the ALLOW rule can never match.
- A second policy (`deny-all`) is `action: DENY` with `from.source.notPrincipals: ["*"]`, which matches **every** principal — even ignoring the first policy, this alone rejects every request (including `/health`, `/metrics`, and ingress gateway traffic).
- Result: once applied, all traffic into the namespace is denied with 403/RBAC errors.

## Fix

- **Created the missing ServiceAccount** `k8s/authorization/api-service-account.yaml` (`api-service-account` in namespace `truxify`).
- **Wired it to the API workload**: added `serviceAccountName: api-service-account` to the API pod template in `k8s/deployements/api-deployement.yaml`, so the ALLOW principal now matches a real workload identity (mTLS is `STRICT` for `app: truxify`, so the principal is present).
- **Removed the blanket `deny-all` policy**. Since an ALLOW policy now exists for `app: truxify`, Istio's default-deny behavior already denies anything not explicitly allowed — the `notPrincipals: ["*"]` policy was both redundant and destructive.
- **Added allow rules for the ingress identity and health checks**:
  - traffic from the `istio-system` namespace (ingress gateway, Prometheus) on `/api/*` and on `GET /health`, `GET /metrics`;
  - the Istio sidecar health-check/status ports `15020`/`15021` (covers kubelet probes via Istio's default probe rewriting).
  - Requests from the API's own service account for `/api/*` (existing rule, now effective).
- **Added CI guard** (`.github/workflows/k8s-istio-principals.yml` + `.github/scripts/check-istio-principals.js`) that fails any PR touching `k8s/**` where a `serviceAccountName` usage or an Istio `principals`/`notPrincipals` entry references a ServiceAccount that is not defined by a manifest under `k8s/` — so a policy pointing at a nonexistent identity can never be merged again.

## Files changed

- `k8s/authorization/api-service-account.yaml` (new)
- `k8s/deployements/api-deployement.yaml`
- `k8s/istio/authorization-policy.yaml`
- `.github/workflows/k8s-istio-principals.yml` (new)
- `.github/scripts/check-istio-principals.js` (new)

## Testing

- Ran the new `check-istio-principals.js` guard — all `serviceAccountName` usages and Istio principals resolve to ServiceAccounts defined in the `k8s/` manifests.
- Manually traced the trust path: `api-service-account` ServiceAccount (created) → `serviceAccountName` on the API pod → mTLS principal `cluster.local/ns/truxify/sa/api-service-account` → ALLOW rule now matches.
- The `authorization-policy.yaml` is written as a single YAML document with no duplicate top-level keys and no UTF-8 BOM, consistent with the `k8s/istio` manifest lint added in #7678.
- Health/probe traffic is covered via the `15020`/`15021` sidecar ports rule plus the API's own service account on `/api/*` (probe paths are `/api/health/live|ready|startup`).

Closes #7681
