### PR TITLE
fix(ml): correct traffic pipeline ETA to use consistent m/m/s units

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -316,7 +316,8 @@ class TrafficPipeline:
                     osrm_data = await self._fetch_osrm_data(current_location, destination)
                     route_distance_m = float(osrm_data.get('distance') or 0)
                     if route_distance_m > 0 and predicted_speed_kmh > 0:
-                        eta_seconds = (route_distance_m / 1000.0) / (predicted_speed_kmh / 3.6)
+                        # distance in metres / speed in metres-per-second (km/h / 3.6) = seconds
+                        eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
                     else:
                         # Fall back to the routing engine's duration estimate.
                         eta_seconds = float(osrm_data.get('duration') or 0)


### PR DESCRIPTION
## Problem

`predict_eta` in `backend/ml/services/traffic_pipeline.py` converted the route distance to kilometres (`route_distance_m / 1000.0`) and the predicted speed from km/h to m/s (`predicted_speed_kmh / 3.6`), then divided the two. Dividing km by m/s produced a value exactly 1000x smaller than the true travel time in seconds, so every ETA returned by `update_eta_realtime` was ~1000x too small (a 10 km trip at 40 km/h reported ~0.9 s instead of ~900 s).

## Fix

Compute the ETA using consistent units: `route_distance_m / (predicted_speed_kmh / 3.6)` (metres divided by metres-per-second = seconds), and document the unit conversion with a comment. A 10 km trip at 40 km/h now correctly reports ~900 seconds (15 minutes).

## Files changed

- `backend/ml/services/traffic_pipeline.py`

## Testing

- Verified the unit math: 10000 m / (40 / 3.6 m/s) = 900 s (15 min), matching the expected behaviour from the issue.
- No new dependencies or runtime behaviour changes beyond the corrected formula.

Closes #7725


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traffic ETA accuracy by correctly converting route distances and predicted speeds during calculation.
  * Prevented inaccurate arrival-time estimates caused by inconsistent measurement units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->