### PR TITLE
fix(ml): invalidate demand forecast model cache after retraining

### DIFF
--- a/backend/ml/app/models/demand_forecast.py
+++ b/backend/ml/app/models/demand_forecast.py
@@ -60,6 +60,7 @@ FEATURE_NAMES = [
 
 
 def train_demand_forecast_model() -> dict:
+    global _model_cache
     X, y = generate_synthetic_demand_data()
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
@@ -89,6 +90,9 @@ def train_demand_forecast_model() -> dict:
     }
 
     save_model((model, scaler), MODEL_NAME, metrics)
+    # Invalidate the in-memory cache so the next predict_demand call reloads the
+    # freshly trained model instead of continuing to score with the stale one.
+    _model_cache = None
     logger.info("Demand forecast model trained. R2: %.3f, MAE: %.3f", r2, mae)
     return metrics
 


### PR DESCRIPTION
## Problem

`backend/ml/app/models/demand_forecast.py` caches the trained model in a module-level `_model_cache`. `train_demand_forecast_model()` re-trains and re-saves the model to disk but never resets `_model_cache`, so after a `/train` call every subsequent `predict_demand` kept scoring with the stale in-memory model until the worker restarted. The retrain had no observable effect on running instances.

## Fix

- Declare `global _model_cache` in `train_demand_forecast_model()` and set `_model_cache = None` immediately after `save_model(...)`.
- The next `predict_demand` call now reloads the freshly trained model (with the existing guarded reload on load failure intact), so retraining takes effect without a process restart.

## Files changed

- `backend/ml/app/models/demand_forecast.py`

## Testing

- `python -m py_compile` passes.
- The existing `predict_demand` load-failure guard (re-training and reloading when `load_model` returns `None`) is preserved, so a partially-trained reload cannot crash prediction.

Closes #7727
