### PR TITLE
fix(security): never classify deposits as large withdrawals or lock accounts

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -23,11 +23,21 @@ class AnomalyDetectionService {
     this.keyRotationService = deps.keyRotationService;
   }
 
+  isWithdrawalDirection(transaction) {
+    return String(transaction?.type || '').toLowerCase() === 'withdrawal';
+  }
+
   async analyzeTransaction(userId, walletAddress, transaction) {
     return measureExecution('AnomalyDetectionService.analyzeTransaction', async () => {
       const anomalies = [];
 
-      const largeWithdrawal = await this.detectLargeWithdrawal(userId, walletAddress, transaction);
+      // Large-withdrawal scoring only applies to withdrawals. Deposits/credits
+      // must never be compared against the user's withdrawal statistics, and
+      // must never trigger an account lock.
+      let largeWithdrawal = null;
+      if (this.isWithdrawalDirection(transaction)) {
+        largeWithdrawal = await this.detectLargeWithdrawal(userId, walletAddress, transaction);
+      }
       if (largeWithdrawal) anomalies.push(largeWithdrawal);
 
       const unusualTime = this.detectUnusualTime(transaction);
@@ -53,6 +63,12 @@ class AnomalyDetectionService {
 
   async detectLargeWithdrawal(userId, walletAddress, transaction) {
     try {
+      // Defense-in-depth: even if a caller forgets to check the direction,
+      // never score a non-withdrawal transaction as a LARGE_WITHDRAWAL.
+      if (!this.isWithdrawalDirection(transaction)) {
+        return null;
+      }
+
       const amount = parseFloat(transaction.amount || 0);
 
       if (amount < ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL) {

--- a/backend/api/test/unit/anomalyDetectionService.test.js
+++ b/backend/api/test/unit/anomalyDetectionService.test.js
@@ -154,4 +154,18 @@ describe('AnomalyDetectionService', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('detectLargeWithdrawal', () => {
+    it('never scores a deposit/credit transaction as LARGE_WITHDRAWAL', async () => {
+      const transaction = { type: 'deposit', amount: 50000 };
+      const result = await service.detectLargeWithdrawal('user-1', 'wallet-1', transaction);
+      expect(result).toBeNull();
+    });
+
+    it('never scores a credit/refund transaction as LARGE_WITHDRAWAL', async () => {
+      const transaction = { type: 'credit', amount: 50000 };
+      const result = await service.detectLargeWithdrawal('user-1', 'wallet-1', transaction);
+      expect(result).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`analyzeTransaction` ran `detectLargeWithdrawal` for every transaction regardless of direction. A legitimate deposit/credit whose amount exceeded the user's (small) withdrawal history by more than 3 std-dev was classified as `LARGE_WITHDRAWAL`, causing `shouldBlockTransaction` to return true and `handleAnomalies` to lock the account.

## Fix

- `analyzeTransaction` now only runs `detectLargeWithdrawal` when the transaction direction is a withdrawal (`isWithdrawalDirection` checks `transaction.type === 'withdrawal'`).
- Added a defense-in-depth guard inside `detectLargeWithdrawal` that returns `null` for any non-withdrawal transaction, even if a caller forgets to check direction.
- Deposits/credits can no longer produce a `LARGE_WITHDRAWAL` anomaly, so they never reach the auto-lock path (`shouldBlockTransaction` only blocks on `CRITICAL` or `LARGE_WITHDRAWAL`).

## Files changed

- `backend/api/src/services/security/anomalyDetectionService.js`
- `backend/api/test/unit/anomalyDetectionService.test.js`

## Testing

- `npx vitest run test/unit/anomalyDetectionService.test.js` — all 17 tests pass, including two new ones asserting that `deposit`/`credit` transactions of a large amount are never scored as `LARGE_WITHDRAWAL`.

Closes #7729
