### PR TITLE
fix(iot): allow assigned driver cold-chain telemetry during arrived_pickup/arriving

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -65,11 +65,11 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
     if (req.user.role !== 'admin') {
       let isAuthorized = load.customer_id === req.user.id;
       if (!isAuthorized && load.order_display_id) {
-        const { data: order } = await supabase
+        const { data: order } = await supabaseAdmin
           .from('orders')
           .select('driver_id')
           .eq('order_display_id', load.order_display_id)
-          .in('status', ['truck_assigned', 'en_route_pickup', 'picked_up', 'in_transit'])
+          .in('status', ['truck_assigned', 'en_route_pickup', 'arrived_pickup', 'picked_up', 'in_transit', 'arriving', 'delivered'])
           .maybeSingle();
         isAuthorized = order?.driver_id === req.user.id;
       }
@@ -155,7 +155,7 @@ router.get('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePara
           .from('orders')
           .select('driver_id')
           .eq('order_display_id', load.order_display_id)
-          .in('status', ['truck_assigned', 'en_route_pickup', 'picked_up', 'in_transit'])
+          .in('status', ['truck_assigned', 'en_route_pickup', 'arrived_pickup', 'picked_up', 'in_transit', 'arriving', 'delivered'])
           .maybeSingle();
 
         isAuthorized = order?.driver_id === req.user.id;

--- a/backend/api/test/unit/iotRoutes.test.js
+++ b/backend/api/test/unit/iotRoutes.test.js
@@ -38,7 +38,7 @@ vi.mock('../../src/config/db.js', () => ({
   supabaseAdmin: { from: vi.fn() },
 }));
 
-import { supabaseAdmin } from '../../src/config/db.js';
+import { supabase, supabaseAdmin } from '../../src/config/db.js';
 
 const adminFrom = supabaseAdmin.from;
 
@@ -178,5 +178,83 @@ describe('iotRoutes', () => {
     expect(res.status).toBe(200);
     expect(adminFrom).toHaveBeenCalledWith('orders');
     expect(anonFrom).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/iot/telemetry/:id authorizes the assigned driver across the full active status set', async () => {
+    const load = { requires_refrigeration: true, target_temperature_min: 0, target_temperature_max: 10, customer_id: 'cust-1', order_display_id: 'OD-1' };
+    const statusCalls = [];
+    const ordersChain = {
+      select: vi.fn(() => ordersChain),
+      eq: vi.fn(() => ordersChain),
+      in: vi.fn((col, statuses) => { statusCalls.push({ col, statuses }); return ordersChain; }),
+      maybeSingle: vi.fn(() => Promise.resolve({ data: { driver_id: 'driver-1' }, error: null })),
+    };
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      if (table === 'orders') return ordersChain;
+      if (table === 'temperature_telemetry') return insertStub();
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    for (const status of ['arrived_pickup', 'arriving', 'delivered']) {
+      const res = await request(buildApp())
+        .post('/api/iot/telemetry/load-1')
+        .set('x-user-id', 'driver-1')
+        .send({ temperature: 5 });
+      expect(res.status).toBe(201);
+    }
+
+    expect(statusCalls).toHaveLength(3);
+    const authorizedStatuses = ['truck_assigned', 'en_route_pickup', 'arrived_pickup', 'picked_up', 'in_transit', 'arriving', 'delivered'];
+    for (const call of statusCalls) {
+      expect(call.col).toBe('status');
+      for (const status of authorizedStatuses) {
+        expect(call.statuses).toContain(status);
+      }
+    }
+    expect(anonFrom).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/iot/telemetry/:id authorizes the assigned driver for arrived_pickup/arriving/delivered statuses', async () => {
+    const load = { customer_id: 'cust-1', order_display_id: 'OD-1' };
+    const telemetry = [{ load_id: 'load-1', temperature: 5 }];
+    const statusCalls = [];
+    const ordersChain = {
+      select: vi.fn(() => ordersChain),
+      eq: vi.fn(() => ordersChain),
+      in: vi.fn((col, statuses) => { statusCalls.push({ col, statuses }); return ordersChain; }),
+      maybeSingle: vi.fn(() => Promise.resolve({ data: { driver_id: 'driver-1' }, error: null })),
+    };
+    adminFrom.mockImplementation((table) => {
+      if (table === 'load_offers') return maybeSingleChain({ data: load, error: null });
+      if (table === 'orders') return ordersChain;
+      if (table === 'temperature_telemetry') {
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+          then(resolve) { return Promise.resolve(resolve({ data: telemetry, error: null })); },
+        };
+        return chain;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    for (const status of ['arrived_pickup', 'arriving', 'delivered']) {
+      const res = await request(buildApp())
+        .get('/api/iot/telemetry/load-1')
+        .set('x-user-id', 'driver-1');
+      expect(res.status).toBe(200);
+    }
+
+    expect(statusCalls).toHaveLength(3);
+    const authorizedStatuses = ['truck_assigned', 'en_route_pickup', 'arrived_pickup', 'picked_up', 'in_transit', 'arriving', 'delivered'];
+    for (const call of statusCalls) {
+      expect(call.col).toBe('status');
+      for (const status of authorizedStatuses) {
+        expect(call.statuses).toContain(status);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Problem

The `POST /api/iot/telemetry/:id` cold-chain endpoint only authorized the assigned driver when the order status was one of `truck_assigned`, `en_route_pickup`, `picked_up`, `in_transit`. `arrived_pickup` (loading) and `arriving` (drop-off) were missing from the whitelist — the exact moments the reefer door opens and the cargo is most exposed to ambient temperature — so drivers got `403 Access denied for this load` and temperature excursions during loading/unloading went unrecorded. The POST driver path also referenced an undefined `supabase` client (only `supabaseAdmin` is imported), so it 500'd instead of authorizing.

## Fix

- Expanded the status whitelist (POST and GET, mirrored consistently) to `truck_assigned`, `en_route_pickup`, `arrived_pickup`, `picked_up`, `in_transit`, `arriving`, and `delivered` (final handover), matching the active status set used elsewhere in the API.
- Changed the POST driver-authorization orders lookup from the undefined `supabase` reference to `supabaseAdmin`, mirroring the GET path (which already used the service-role client) and fixing the 500.
- Added regression tests asserting the assigned driver is authorized for `arrived_pickup`, `arriving`, and `delivered` on both POST and GET, and that every authorized status is present in the `.in()` filter.

## Files changed

- `backend/api/src/routes/iotRoutes.js`
- `backend/api/test/unit/iotRoutes.test.js`

## Testing

- `npx vitest run test/unit/iotRoutes.test.js` — all 7 tests pass, including the new driver-status regression tests.

Closes #7730
