### PR TITLE
fix(api): replace fake escrow ABI with real contract getters

### DIFF
--- a/backend/api/src/services/blockchain/batchCallBuilder.js
+++ b/backend/api/src/services/blockchain/batchCallBuilder.js
@@ -1,28 +1,33 @@
 import { ethers } from 'ethers';
 import logger from '../../middleware/logger.js';
 
+// Real getters exposed by blockchain/contracts/TruxifyEscrow.sol.
 const ESCROW_ABI = [
-  'function getPaymentStatus(uint256 bookingId) view returns (uint8)',
-  'function getDriverBalance(address driver) view returns (uint256)',
-  'function getInsuranceCoverage(uint256 claimId) view returns (bool, uint256)',
-  'function getGeofenceStatus(uint256 shipmentId) view returns (bool)',
-  'function getReputationScore(address driver) view returns (uint256)',
+  'function getBooking(uint256 bookingId) view returns (address payable customer, address payable driver, uint256 amount, uint8 status, bool paid, bool started, uint256 createdAt, uint256 disputedAt)',
+  'function pendingWithdrawals(address account) view returns (uint256)',
+];
+
+// Real getter exposed by blockchain/contracts/Reputation.sol.
+const REPUTATION_ABI = [
+  'function getReputation(address driver) view returns (uint256)',
 ];
 
 class BatchCallBuilder {
   constructor(deps = {}) {
     this.escrowAddress = process.env.ESCROW_CONTRACT_ADDRESS;
+    this.reputationAddress = process.env.REPUTATION_CONTRACT_ADDRESS;
     this.provider = deps.provider;
-    this.iface = new ethers.Interface(ESCROW_ABI);
+    this.escrowIface = new ethers.Interface(ESCROW_ABI);
+    this.reputationIface = new ethers.Interface(REPUTATION_ABI);
   }
 
   buildPaymentStatusCall(bookingId) {
     return {
       target: this.escrowAddress,
-      callData: this.iface.encodeFunctionData('getPaymentStatus', [bookingId]),
+      callData: this.escrowIface.encodeFunctionData('getBooking', [bookingId]),
       decodeFn: (data) => {
-        const decoded = this.iface.decodeFunctionResult('getPaymentStatus', data);
-        return { status: decoded[0] };
+        const decoded = this.escrowIface.decodeFunctionResult('getBooking', data);
+        return { status: decoded.status };
       },
     };
   }
@@ -30,65 +35,31 @@ class BatchCallBuilder {
   buildDriverBalanceCall(driver) {
     return {
       target: this.escrowAddress,
-      callData: this.iface.encodeFunctionData('getDriverBalance', [driver]),
+      callData: this.escrowIface.encodeFunctionData('pendingWithdrawals', [driver]),
       decodeFn: (data) => {
-        const decoded = this.iface.decodeFunctionResult('getDriverBalance', data);
+        const decoded = this.escrowIface.decodeFunctionResult('pendingWithdrawals', data);
         return { balance: decoded[0].toString() };
-      },
-    };
-  }
-
-  buildInsuranceCall(claimId) {
-    return {
-      target: this.escrowAddress,
-      callData: this.iface.encodeFunctionData('getInsuranceCoverage', [claimId]),
-      decodeFn: (data) => {
-        const decoded = this.iface.decodeFunctionResult('getInsuranceCoverage', data);
-        return {
-          approved: decoded[0],
-          amount: decoded[1].toString(),
-        };
-      },
-    };
-  }
-
-  buildGeofenceCall(shipmentId) {
-    return {
-      target: this.escrowAddress,
-      callData: this.iface.encodeFunctionData('getGeofenceStatus', [shipmentId]),
-      decodeFn: (data) => {
-        const decoded = this.iface.decodeFunctionResult('getGeofenceStatus', data);
-        return { withinBounds: decoded[0] };
       },
     };
   }
 
   buildReputationCall(driver) {
     return {
-      target: this.escrowAddress,
-      callData: this.iface.encodeFunctionData('getReputationScore', [driver]),
+      target: this.reputationAddress || this.escrowAddress,
+      callData: this.reputationIface.encodeFunctionData('getReputation', [driver]),
       decodeFn: (data) => {
-        const decoded = this.iface.decodeFunctionResult('getReputationScore', data);
+        const decoded = this.reputationIface.decodeFunctionResult('getReputation', data);
         return { score: decoded[0].toString() };
       },
     };
   }
 
   buildShipmentCompletionBatch(shipment) {
-    const calls = [
+    return [
       this.buildPaymentStatusCall(shipment.bookingId),
       this.buildDriverBalanceCall(shipment.driverAddress),
-      this.buildInsuranceCall(shipment.insuranceClaimId),
       this.buildReputationCall(shipment.driverAddress),
     ];
-
-    if (shipment.geofenceIds && Array.isArray(shipment.geofenceIds)) {
-      shipment.geofenceIds.forEach(geofenceId => {
-        calls.push(this.buildGeofenceCall(geofenceId));
-      });
-    }
-
-    return calls;
   }
 
   buildMultiShipmentBatch(shipments) {
@@ -105,18 +76,27 @@ class BatchCallBuilder {
     return allCalls;
   }
 
+  _ifaceFor(target) {
+    if (this.reputationAddress && target === this.reputationAddress) {
+      return this.reputationIface;
+    }
+    return this.escrowIface;
+  }
+
   buildCustomBatch(callDefinitions) {
     return callDefinitions.map(def => {
       try {
         const functionName = def.functionName;
         const args = def.args || [];
+        const target = def.target || this.escrowAddress;
+        const iface = this._ifaceFor(target);
 
         return {
-          target: def.target || this.escrowAddress,
-          callData: this.iface.encodeFunctionData(functionName, args),
+          target,
+          callData: iface.encodeFunctionData(functionName, args),
           decodeFn: (data) => {
             try {
-              const result = this.iface.decodeFunctionResult(functionName, data);
+              const result = iface.decodeFunctionResult(functionName, data);
               return {
                 functionName,
                 result: result[0]?.toString?.() || result[0],
@@ -136,4 +116,5 @@ class BatchCallBuilder {
   }
 }
 
+export { ESCROW_ABI, REPUTATION_ABI };
 export default BatchCallBuilder;

--- a/backend/api/test/unit/batchCallBuilder.test.js
+++ b/backend/api/test/unit/batchCallBuilder.test.js
@@ -1,65 +1,121 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ethers } from 'ethers'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
 
-const { default: BatchCallBuilder } = await import('../../src/services/blockchain/batchCallBuilder.js')
+const { default: BatchCallBuilder, ESCROW_ABI, REPUTATION_ABI } = await import('../../src/services/blockchain/batchCallBuilder.js')
 
-const IFACE = new ethers.Interface([
-  'function getPaymentStatus(uint256 bookingId) view returns (uint8)',
-  'function getDriverBalance(address driver) view returns (uint256)',
-  'function getInsuranceCoverage(uint256 claimId) view returns (bool, uint256)',
-  'function getGeofenceStatus(uint256 shipmentId) view returns (bool)',
-  'function getReputationScore(address driver) view returns (uint256)',
-])
+const ESCROW_IFACE = new ethers.Interface(ESCROW_ABI)
+const REPUTATION_IFACE = new ethers.Interface(REPUTATION_ABI)
+
+const BOOKING_RESULT = {
+  customer: '0x' + 'c'.repeat(40),
+  driver: '0x' + 'd'.repeat(40),
+  amount: 1000n,
+  status: 1,
+  paid: false,
+  started: true,
+  createdAt: 1700000000n,
+  disputedAt: 0n,
+}
+
+const CONTRACT_SOURCES = [
+  ['../../../../blockchain/contracts/TruxifyEscrow.sol', ['function getBooking(uint256 bookingId)', 'mapping(address => uint256) public pendingWithdrawals']],
+  ['../../../../blockchain/contracts/Reputation.sol', ['function getReputation(address driver)']],
+]
 
 describe('BatchCallBuilder', () => {
   let builder
 
   beforeEach(() => {
     process.env.ESCROW_CONTRACT_ADDRESS = '0x0000000000000000000000000000000000000001'
+    process.env.REPUTATION_CONTRACT_ADDRESS = '0x0000000000000000000000000000000000000002'
     builder = new BatchCallBuilder({ provider: null })
   })
 
-  it('builds a payment status call and decodes its result', () => {
-    const call = builder.buildPaymentStatusCall(1)
-    expect(call.target).toBe(process.env.ESCROW_CONTRACT_ADDRESS)
-    const data = IFACE.encodeFunctionResult('getPaymentStatus', [5])
-    expect(call.decodeFn(data)).toEqual({ status: 5n })
-  })
-
-  it('builds a driver balance call and decodes it as a string', () => {
-    const call = builder.buildDriverBalanceCall('0x' + 'a'.repeat(40))
-    const data = IFACE.encodeFunctionResult('getDriverBalance', [1000n])
-    expect(call.decodeFn(data)).toEqual({ balance: '1000' })
-  })
-
-  it('builds an insurance call returning approved and amount', () => {
-    const call = builder.buildInsuranceCall(3)
-    const data = IFACE.encodeFunctionResult('getInsuranceCoverage', [true, 250n])
-    expect(call.decodeFn(data)).toEqual({ approved: true, amount: '250' })
-  })
-
-  it('appends geofence calls when geofenceIds are present', () => {
-    const calls = builder.buildShipmentCompletionBatch({
-      bookingId: 1,
-      driverAddress: '0x' + 'b'.repeat(40),
-      insuranceClaimId: 2,
-      geofenceIds: [10, 11],
+  describe('ABI matches the real contract sources', () => {
+    it.each(CONTRACT_SOURCES)('%s declares every ABI function', (path, signatures) => {
+      const url = new URL(path, import.meta.url)
+      const source = readFileSync(fileURLToPath(url), 'utf8')
+      for (const signature of signatures) {
+        expect(source).toContain(signature)
+      }
     })
-    // base batch (3) + reputation (1) + 2 geofence calls
-    expect(calls.length).toBe(6)
   })
 
-  it('builds a batch without geofence calls when none are present', () => {
-    const calls = builder.buildShipmentCompletionBatch({
-      bookingId: 1,
-      driverAddress: '0x' + 'b'.repeat(40),
-      insuranceClaimId: 2,
+  describe('buildPaymentStatusCall', () => {
+    it('encodes getBooking and decodes the booking status', () => {
+      const call = builder.buildPaymentStatusCall(7)
+      expect(call.target).toBe(process.env.ESCROW_CONTRACT_ADDRESS)
+      expect(call.callData.startsWith(ESCROW_IFACE.encodeFunctionData('getBooking', [7]).slice(0, 10))).toBe(true)
+      const data = ESCROW_IFACE.encodeFunctionResult('getBooking', [
+        BOOKING_RESULT.customer,
+        BOOKING_RESULT.driver,
+        BOOKING_RESULT.amount,
+        BOOKING_RESULT.status,
+        BOOKING_RESULT.paid,
+        BOOKING_RESULT.started,
+        BOOKING_RESULT.createdAt,
+        BOOKING_RESULT.disputedAt,
+      ])
+      expect(call.decodeFn(data)).toEqual({ status: 1n })
     })
-    expect(calls.length).toBe(4)
+  })
+
+  describe('buildDriverBalanceCall', () => {
+    it('encodes pendingWithdrawals and decodes the balance as a string', () => {
+      const driver = '0x' + 'a'.repeat(40)
+      const call = builder.buildDriverBalanceCall(driver)
+      expect(call.target).toBe(process.env.ESCROW_CONTRACT_ADDRESS)
+      const data = ESCROW_IFACE.encodeFunctionResult('pendingWithdrawals', [5000n])
+      expect(call.decodeFn(data)).toEqual({ balance: '5000' })
+    })
+  })
+
+  describe('buildReputationCall', () => {
+    it('targets the reputation contract and decodes getReputation', () => {
+      const driver = '0x' + 'b'.repeat(40)
+      const call = builder.buildReputationCall(driver)
+      expect(call.target).toBe(process.env.REPUTATION_CONTRACT_ADDRESS)
+      const data = REPUTATION_IFACE.encodeFunctionResult('getReputation', [42n])
+      expect(call.decodeFn(data)).toEqual({ score: '42' })
+    })
+
+    it('falls back to the escrow address when no reputation contract is configured', () => {
+      process.env.REPUTATION_CONTRACT_ADDRESS = ''
+      builder = new BatchCallBuilder({ provider: null })
+      const call = builder.buildReputationCall('0x' + 'b'.repeat(40))
+      expect(call.target).toBe(process.env.ESCROW_CONTRACT_ADDRESS)
+    })
+  })
+
+  describe('buildShipmentCompletionBatch', () => {
+    it('builds payment, driver balance and reputation calls only', () => {
+      const calls = builder.buildShipmentCompletionBatch({
+        bookingId: 1,
+        driverAddress: '0x' + 'b'.repeat(40),
+        insuranceClaimId: 2,
+        geofenceIds: [10, 11],
+      })
+      expect(calls.length).toBe(3)
+      expect(calls.every(call => call.callData && call.decodeFn)).toBe(true)
+    })
+  })
+
+  describe('buildMultiShipmentBatch', () => {
+    it('stamps each call with its shipment id', () => {
+      const calls = builder.buildMultiShipmentBatch([
+        { id: 1, bookingId: 1, driverAddress: '0x' + 'b'.repeat(40) },
+        { id: 2, bookingId: 2, driverAddress: '0x' + 'c'.repeat(40) },
+      ])
+      expect(calls.length).toBe(6)
+      expect(calls.slice(0, 3).every(call => call.shipmentId === 1)).toBe(true)
+      expect(calls.slice(3).every(call => call.shipmentId === 2)).toBe(true)
+    })
   })
 
   it('returns an error object for an unknown custom function', () => {


### PR DESCRIPTION
## Problem
`BatchCallBuilder` in `backend/api/src/services/blockchain/batchCallBuilder.js` encoded its batch reads against five ABI functions that do not exist on any deployed contract:

- `getPaymentStatus(uint256)` — not in `TruxifyEscrow.sol`
- `getDriverBalance(address)` — not in `TruxifyEscrow.sol`
- `getInsuranceCoverage(uint256)` — no such getter anywhere
- `getGeofenceStatus(uint256)` — no such getter anywhere
- `getReputationScore(address)` — no such getter anywhere (`Reputation.sol` exposes `getReputation`)

Every batch call therefore targeted a non-existent function selector, so the batch reads reverted or returned no real data.

## Fix
Replaced the fabricated `ESCROW_ABI` with the getters that actually exist on the target contracts, keeping the same high-level builder methods:

- `buildPaymentStatusCall(bookingId)` → encodes `getBooking(bookingId)` and decodes the `Booking` struct's `status` enum field (`TruxifyEscrow.sol`).
- `buildDriverBalanceCall(driver)` → encodes `pendingWithdrawals(address)` (public mapping getter) and returns the driver's withdrawable escrow balance as a string.
- `buildReputationCall(driver)` → encodes `getReputation(driver)` from `Reputation.sol`, targeted at `REPUTATION_CONTRACT_ADDRESS` (falls back to the escrow address only when unset, to keep the builder usable in minimally-configured environments).
- Removed `buildInsuranceCall` / `buildGeofenceCall` — no insurance or geofence getter exists on any contract, so these calls could never return real data; `buildShipmentCompletionBatch` now emits only real calls (payment + driver balance + reputation).
- `buildCustomBatch` now picks the correct interface based on the call's target contract.

The real ABI fragments are exported (`ESCROW_ABI`, `REPUTATION_ABI`) as a single source of truth for the tests.

## Files changed
- `backend/api/src/services/blockchain/batchCallBuilder.js`
- `backend/api/test/unit/batchCallBuilder.test.js`

## Testing
Rewrote the unit test to round-trip against the real ABI:
- The ABI is bound to the actual contract source — the test reads `TruxifyEscrow.sol` and `Reputation.sol` and asserts every ABI function signature is declared there.
- Encode/decode round-trips: `getBooking` → status, `pendingWithdrawals` → balance, `getReputation` → score, including the reputation-contract target and fallback.
- Batch composition assertions updated (payment + driver + reputation, no insurance/geofence calls).

`npx vitest run test/unit/batchCallBuilder.test.js` — all 9 tests pass (plus the pre-existing instance test).

Closes #7731
