### PR TITLE
fix(api): confirm on-chain release before notifying on stuck-escrow retry

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -562,6 +562,17 @@ export class DeliveryVerificationService {
               ":",
               releaseErr.message,
             );
+            await this.orderRepository
+              .updateOrder(orderId, {
+                escrow_release_error: String(releaseErr.message).slice(0, 1000),
+                updated_at: new Date().toISOString(),
+              })
+              .catch((err) =>
+                logger.warn(
+                  "[escrow] Failed to record release failure:",
+                  err.message,
+                ),
+              );
             throw new DomainError(503, {
               error:
                 "Blockchain escrow release failed. Payment cannot be processed. Please retry.",
@@ -590,14 +601,42 @@ export class DeliveryVerificationService {
             }
           }
         } else if (order.escrow_status === "released") {
-        // 1. Database and Trip State Verification/Execution First
-        if (order.escrow_status === "released") {
           // Release was confirmed in a previous attempt — reuse the persisted hash.
           releaseTxHash = order.release_tx_hash || null;
-        } else {
-          logger.info(
-            `[escrow] Escrow not funded (status: ${order.escrow_status}) — skipping on-chain release.`,
+        }
+
+        // Re-check that the escrow actually released after this attempt. This
+        // is what makes the stuck-escrow retry safe: token revocation and the
+        // "Payment Released" push below only run once releaseTxHash /
+        // escrowAlreadyReleased confirm the on-chain release, or the order was
+        // already "released". If the release failed again, the driver is told
+        // the retry failed instead of being notified that they are paid while
+        // the funds remain stuck on-chain.
+        const releaseConfirmed = Boolean(
+          releaseTxHash ||
+            escrowAlreadyReleased ||
+            order.escrow_status === "released",
+        );
+        if (!releaseConfirmed) {
+          logger.error(
+            `[verify-delivery] On-chain escrow release not confirmed for order ${orderId} (escrow_status=${order.escrow_status}) — aborting before notification.`,
           );
+          await this.orderRepository
+            .updateOrder(orderId, {
+              escrow_release_error: `ESCROW_NOT_RELEASED: on-chain release not confirmed (escrow_status=${order.escrow_status})`,
+              updated_at: new Date().toISOString(),
+            })
+            .catch((err) =>
+              logger.warn(
+                "[escrow] Failed to record unconfirmed release:",
+                err.message,
+              ),
+            );
+          throw new DomainError(503, {
+            error:
+              "On-chain escrow release was not confirmed. Payment cannot be processed. Please retry.",
+            retryable: true,
+          });
         }
 
         // 2. Execute Postgres RPC to complete the trip AFTER blockchain success
@@ -677,8 +716,16 @@ export class DeliveryVerificationService {
           });
         } else {
           logger.info(
-            `[verify-delivery] Retry for stuck escrow for order ${orderId} by driver ${driverId}`,
+            `[verify-delivery] Retry for stuck escrow for order ${orderId} by driver ${driverId} — release confirmed (tx_hash=${releaseTxHash || "alreadyReleased"}).`,
           );
+          // The verified OTP is consumed on the retry path too so it cannot be
+          // replayed by a later attempt. It is only consumed after the release
+          // is confirmed, so a failed release leaves the OTP intact for the
+          // next retry instead of force-rotating it.
+          await this.completeDeliveryOtp({
+            otpRecordId: otpRecord.id,
+            orderId,
+          });
         }
 
         // The trip is complete (payment_released) — kill any active public

--- a/backend/api/test/deliveryVerification.releaseOrder.test.js
+++ b/backend/api/test/deliveryVerification.releaseOrder.test.js
@@ -285,3 +285,126 @@ describe('verifyDelivery payout defense-in-depth (amount integrity)', () => {
     expect(result).toEqual({ escrowUpdateFailed: false });
   });
 });
+
+describe('verifyDelivery stuck-escrow retry release confirmation (issue #7732)', () => {
+  function makeRetryService({ escrowReleaseFn, order = {} }) {
+    const repo = {
+      findOrderById: vi.fn().mockResolvedValue({
+        data: {
+          ...ORDER,
+          status: 'payment_released',
+          escrow_status: 'funded',
+          ...order,
+        },
+        error: null,
+      }),
+      updateOrderGuardStatus: vi.fn().mockResolvedValue({ data: { id: 'order-1' }, error: null }),
+      executeRpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+      updateOrder: vi.fn().mockResolvedValue({ data: { id: 'order-1' }, error: null }),
+      updateWalletTransaction: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const notificationService = {
+      getActiveDeliveryOtp: () => Promise.resolve({ id: 'otp-1' }),
+      verifyDeliveryOtpHash: () => true,
+      verifyDeliveryOtp: vi.fn().mockResolvedValue(true),
+      storeDeliveryOtp: () => Promise.resolve(true),
+      sendDeliveryOtpNotification: () => Promise.resolve({ success: true }),
+    };
+    const svc = new DeliveryVerificationService(null, {
+      notificationService,
+      escrowReleaseFn,
+      trackingTokenService: { revokeAllForOrder: vi.fn().mockResolvedValue() },
+    });
+    svc.orderRepository = repo;
+    return { svc, repo, notificationService };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('aborts with a retryable 503 and records the failure when the on-chain release is not confirmed on retry', async () => {
+    const { svc, repo } = makeRetryService({
+      escrowReleaseFn: () => Promise.resolve({ txHash: null, alreadyReleased: false }),
+    });
+
+    await expect(
+      svc.verifyDelivery({ orderId: 'order-1', driverId: 'driver-1', otp: '123456' }, {}),
+    ).rejects.toMatchObject({ status: 503, payload: { retryable: true } });
+
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      'order-1',
+      expect.objectContaining({
+        escrow_release_error: expect.stringContaining('no transaction hash'),
+      }),
+    );
+    expect(repo.executeRpc).not.toHaveBeenCalled();
+  });
+
+  it('does not revoke tracking tokens or notify when the retry release is not confirmed', async () => {
+    const trackingTokenService = { revokeAllForOrder: vi.fn().mockResolvedValue() };
+    const notificationService = {
+      getActiveDeliveryOtp: () => Promise.resolve({ id: 'otp-1' }),
+      verifyDeliveryOtpHash: () => true,
+      verifyDeliveryOtp: vi.fn().mockResolvedValue(true),
+      storeDeliveryOtp: () => Promise.resolve(true),
+      sendDeliveryOtpNotification: () => Promise.resolve({ success: true }),
+    };
+    const repo = {
+      findOrderById: vi.fn().mockResolvedValue({
+        data: { ...ORDER, status: 'payment_released', escrow_status: 'release_failed' },
+        error: null,
+      }),
+      updateOrder: vi.fn().mockResolvedValue({ data: { id: 'order-1' }, error: null }),
+      updateOrderGuardStatus: vi.fn().mockResolvedValue({ data: { id: 'order-1' }, error: null }),
+      executeRpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+      updateWalletTransaction: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const svc = new DeliveryVerificationService(null, {
+      notificationService,
+      escrowReleaseFn: () => Promise.resolve({ txHash: null, error: 'release reverted' }),
+      trackingTokenService,
+    });
+    svc.orderRepository = repo;
+
+    await expect(
+      svc.verifyDelivery({ orderId: 'order-1', driverId: 'driver-1', otp: '123456' }, {}),
+    ).rejects.toMatchObject({ status: 503, payload: { retryable: true } });
+
+    expect(trackingTokenService.revokeAllForOrder).not.toHaveBeenCalled();
+  });
+
+  it('consumes the OTP only after a confirmed release on the retry path', async () => {
+    const { svc, notificationService } = makeRetryService({
+      escrowReleaseFn: () => Promise.resolve({ txHash: '0xRETRY', alreadyReleased: false }),
+    });
+
+    const result = await svc.verifyDelivery(
+      { orderId: 'order-1', driverId: 'driver-1', otp: '123456' },
+      {},
+    );
+
+    expect(result).toEqual({ escrowUpdateFailed: false });
+    expect(notificationService.verifyDeliveryOtp).toHaveBeenCalledWith('otp-1');
+  });
+
+  it('blocks the trip-completion RPC when escrow was never funded', async () => {
+    const { svc, repo } = makeRetryService({
+      order: { status: 'arriving', escrow_status: 'pending' },
+      escrowReleaseFn: () => Promise.resolve({ txHash: '0xSHOULD-NOT-RUN' }),
+    });
+    svc.assertDriverAtDropoff = vi.fn().mockResolvedValue();
+
+    await expect(
+      svc.verifyDelivery({ orderId: 'order-1', driverId: 'driver-1', otp: '123456' }, {}),
+    ).rejects.toMatchObject({ status: 503, payload: { retryable: true } });
+
+    expect(repo.executeRpc).not.toHaveBeenCalled();
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      'order-1',
+      expect.objectContaining({
+        escrow_release_error: expect.stringContaining('ESCROW_NOT_RELEASED'),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem
In `backend/api/src/services/order/deliveryVerificationService.js`, the stuck-escrow retry branch of `verifyDelivery`:

- Fired the "✅ Payment Released ✓" FCM push and revoked tracking tokens **unconditionally** after the release attempt — even when `releaseTxHash` stayed `null` and `escrow_status` remained `release_failed`/`funded`, so the driver was told they were paid while the funds were still stuck on-chain.
- Never consumed the verified OTP on the retry path (no `completeDeliveryOtp`), leaving it active/replayable.
- On a failed release, the retry error was thrown but `escrow_release_error` was never persisted.

Additionally, the base branch's copy of this file **does not parse** — the `} else if (order.escrow_status === "released") {` block (line 592) was never closed, so the trip-completion RPC, token revocation, notification and escrow-status update code were all nested inside it and silently skipped for `funded`/`release_failed` orders (net +1 brace imbalance; `node --check` fails, and the `deliveryVerificationGeofence` test suite could not load).

## Fix
- Added a `releaseConfirmed` gate right after the release attempt:
  `releaseTxHash || escrowAlreadyReleased || order.escrow_status === "released"`.
  When the release is not confirmed, `verifyDelivery` persists `escrow_release_error` (`ESCROW_NOT_RELEASED: …`) and throws a retryable `503` — before any token revocation or FCM push — so a failed retry tells the driver the retry failed instead of "Payment Released ✓".
- Persist `escrow_release_error` on the release-failure `catch` path (previously the error was only logged).
- Consume the verified OTP via `completeDeliveryOtp` on the retry branch after the release is confirmed, so it cannot be replayed; on failure the OTP is left intact for the next retry.
- Closed the unbalanced `else-if` block, restoring the intended structure so the file parses and the happy-path `complete_trip_tx` RPC runs again for `funded`/`release_failed` orders.

## Files changed
- `backend/api/src/services/order/deliveryVerificationService.js`
- `backend/api/test/deliveryVerification.releaseOrder.test.js` (4 new regression tests)

## Testing
`npx vitest run test/deliveryVerification.releaseOrder.test.js` — all 11 tests pass, including new tests for:
- retry aborts with retryable 503 and records `escrow_release_error` when the release is not confirmed;
- tracking tokens are **not** revoked when the retry release fails;
- the OTP is consumed only after a confirmed release on the retry path;
- the trip-completion RPC is blocked when escrow was never funded.

Pre-existing (unrelated, also failing on `main`): `test/unit/deliveryVerificationGeofence.test.js` has 3 test-file bugs (missing `supabaseAdmin` in its db mock, a stale `escrowReleaseFn` call-signature expectation, and a radius-clamp expectation) — the base file's syntax error previously prevented that suite from loading at all. `test/orderLifecycle.verifyDelivery.test.js` has a pre-existing `newAmountWei` redeclaration syntax error.

Closes #7732
