### PR TITLE
bug : add per-transaction signature/nonce/balance guards to zkEVM executeBatch

### DIFF
--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -166,7 +166,15 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             txHashes[i] = txHash;
 
             require(!processedTxHashes[txHash], "Duplicate transaction");
+            require(!usedNonces[from][nonce], "Nonce already used");
+            require(currentState.balances[from] >= value + gasPrice * gasLimit, "Insufficient balance");
+
+            // Verify signature (same digest as executeTransaction)
+            bytes32 txHashForSig = keccak256(abi.encodePacked(from, to, value, data, nonce, gasPrice, gasLimit));
+            require(_verifySignature(txHashForSig, signature, from), "Invalid signature");
+
             processedTxHashes[txHash] = true;
+            usedNonces[from][nonce] = true;
 
             // Execute
             currentState.balances[from] -= value + gasPrice * gasLimit;


### PR DESCRIPTION
Closes #7746.

Summary of What Has Been Done:
Added per-transaction signature verification, nonce reuse prevention, and sufficient-balance checks to the executeBatch function in zkEVM.sol. The batch processing loop now enforces the same guards as the single-transaction executeTransaction path.

Changes Made:
- blockchain/contracts/zkEVM.sol: Added require(!usedNonces[from][nonce]) nonce guard, require(balance sufficient) balance check, and _verifySignature call with the same digest as executeTransaction in executeBatch

Impact it Made:
- Prevents unsigned transactions from being executed via executeBatch
- Prevents nonce reuse in batch mode
- Ensures balance sufficiency before debit in batch mode
- Eliminates the security gap between single-tx and batch execution paths

Note: Please assign this PR to the `tmdeveloper007` account.

This PR was submitted as part of the GSSOC automation workflow.