### PR TITLE
bug : add balance-sum invariant to StateChannel initiateUnilateralExit

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -61,6 +61,7 @@ contract StateChannel is ReentrancyGuard {
         require(!channel.isClosed, "Channel closed");
         require(msg.sender == channel.userA || msg.sender == channel.userB, "Not participant");
         require(sequence >= channel.sequence, "Stale sequence");
+        require(balanceA + balanceB == channel.balanceA + channel.balanceB, "Invalid balance sum");
 
         bytes32 stateHash = keccak256(abi.encodePacked(channelId, sequence, balanceA, balanceB)).toEthSignedMessageHash();
         


### PR DESCRIPTION
Closes #7747.

Summary of What Has Been Done:
Added the balance-sum invariant check to initiateUnilateralExit in StateChannel.sol, matching the guard already present in cooperativeClose. This prevents invalid balance sums from being submitted in a unilateral exit, which would otherwise cause finalizeExit to permanently lock funds.

Changes Made:
- blockchain/contracts/StateChannel.sol: Added require(balanceA + balanceB == channel.balanceA + channel.balanceB) before marking channel disputed in initiateUnilateralExit

Impact it Made:
- Prevents permanently stuck channels due to invalid unilateral exit states
- Ensures both cooperative and unilateral close paths enforce the same balance invariant
- Prevents fund loss due to incorrect balance sums

Note: Please assign this PR to the `tmdeveloper007` account.

This PR was submitted as part of the GSSOC automation workflow.