### PR TITLE
fix : added netProfit toll double-counting fix in pricing.js

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -162,8 +162,10 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
   const totalAmount = safePaisa(baseFreight + tollEstimate + platformFee);
 
   // Driver-side cost / margin hints persisted on load_offers.
+  // tollEstimate is already included in totalAmount (customer-facing price),
+  // so it must not be subtracted from netProfit to avoid double-counting.
   const fuelCost = safePaisa((baseFreight * rateCard.fuelCostPct) / 100);
-  const netProfit = safePaisa(baseFreight - fuelCost - tollEstimate);
+  const netProfit = safePaisa(baseFreight - fuelCost);
 
   return {
     distanceKm: Math.round(distanceKm * 100 + Number.EPSILON) / 100, // 2-decimal precision

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -89,7 +89,9 @@ describe('Pricing Service Unit Tests', () => {
       expect(result.platformFee).toBe(4000);
       expect(result.totalAmount).toBe(104000);
       expect(result.fuelCost).toBe(36000);
-      expect(result.netProfit).toBe(24000);
+
+      // netProfit = baseFreight - fuelCost (toll is a pass-through included in totalAmount, not a cost)
+      expect(result.netProfit).toBe(44000);
     });
 
     it('applies fragile multiplier correctly', () => {
@@ -194,6 +196,18 @@ describe('Pricing Service Unit Tests', () => {
       expect(Number.isFinite(result.totalAmount)).toBe(true);
       expect(Number.isFinite(result.fuelCost)).toBe(true);
       expect(Number.isFinite(result.netProfit)).toBe(true);
+    });
+
+    it('netProfit does not subtract tollEstimate since toll is a pass-through in totalAmount', () => {
+      // Using defaultInput: baseFreight=80000, fuelCost=36000, tollEstimate=20000
+      // totalAmount = 80000 + 20000 + 4000 = 104000 (toll included)
+      // netProfit should = baseFreight - fuelCost = 80000 - 36000 = 44000
+      // NOT baseFreight - fuelCost - tollEstimate = 80000 - 36000 - 20000 = 24000
+      const result = computeOrderPricing(defaultInput, mockRateCard);
+      expect(result.netProfit).toBe(44000);
+      expect(result.netProfit).toBe(result.baseFreight - result.fuelCost);
+      // Verify toll is still in totalAmount
+      expect(result.totalAmount).toBe(result.baseFreight + result.tollEstimate + result.platformFee);
     });
   });
 


### PR DESCRIPTION
Closes #7756.

Summary of What Has Been Done:
Fixed netProfit calculation in backend/api/src/lib/pricing.js to not subtract tollEstimate, since tollEstimate is already included in totalAmount (the customer-facing price). The toll is a pass-through cost borne by the customer, not an operator expense. Also updated the existing test and added a new test case verifying netProfit = baseFreight - fuelCost regardless of tollEstimate.

Changes Made:
- backend/api/src/lib/pricing.js: Changed netProfit from baseFreight - fuelCost - tollEstimate to baseFreight - fuelCost
- backend/api/test/unit/pricing.test.js: Updated expected netProfit in standard pricing test, added dedicated test for toll pass-through behavior

Impact it Made:
- Valid loads now correctly show positive profit margins
- Pricing engine ranks loads by accurate profitability
- Drivers and dispatchers see accurate earnings estimates

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).