### PR TITLE
fix : added model cache invalidation after demand forecast retraining

### DIFF
--- a/backend/ml/app/models/demand_forecast.py
+++ b/backend/ml/app/models/demand_forecast.py
@@ -15,6 +15,12 @@ MODEL_NAME = "demand_forecast"
 # Module-level cache to avoid reloading from disk on every call
 _model_cache = None
 
+
+def reset_model_cache():
+    """Reset the in-memory model cache so the next prediction loads from disk."""
+    global _model_cache
+    _model_cache = None
+
 # NOTE: This module currently trains on synthetic (randomly generated) data
 # as a placeholder. Replace generate_synthetic_demand_data() with a real
 # data pipeline that loads historical trip/demand data from PostgreSQL or
@@ -90,9 +96,9 @@ def train_demand_forecast_model() -> dict:
     }
 
     save_model((model, scaler), MODEL_NAME, metrics)
-    # Invalidate the in-memory cache so the next predict_demand call reloads the
-    # freshly trained model instead of continuing to score with the stale one.
-    _model_cache = None
+    # Invalidate the in-memory cache so the next predict_demand call
+    # loads the newly trained model instead of the stale cached copy
+    reset_model_cache()
     logger.info("Demand forecast model trained. R2: %.3f, MAE: %.3f", r2, mae)
     return metrics
 

--- a/backend/ml/tests/test_demand_forecast.py
+++ b/backend/ml/tests/test_demand_forecast.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for backend/ml/app/models/demand_forecast.py
+
+Run with: python3 -m pytest tests/test_demand_forecast.py -v --no-header
+"""
+import os
+import tempfile
+import pytest
+
+# Set up a temp model directory before importing the module
+os.environ["ML_API_KEY"] = "test_key"
+
+
+class TestModelCacheInvalidation:
+    """Tests for _model_cache invalidation after training."""
+
+    def test_predict_demand_returns_float(self, tmp_path):
+        """Basic smoke test: predict_demand returns a non-negative float."""
+        from app.models.demand_forecast import predict_demand
+
+        result = predict_demand([12, 3, 0, 25.0, 0.5, 50, 15])
+        assert isinstance(result, float)
+        assert result >= 0
+
+    def test_reset_model_cache_function_exists(self):
+        """reset_model_cache should be importable and callable."""
+        from app.models.demand_forecast import reset_model_cache
+
+        # Calling reset multiple times should not raise
+        reset_model_cache()
+        reset_model_cache()
+
+    def test_train_resets_cache(self, monkeypatch, tmp_path):
+        """After train_demand_forecast_model, the cache should be invalidated
+        so subsequent predictions use the newly saved model."""
+        import app.models.demand_forecast as df_module
+
+        # Ensure cache is populated first
+        df_module._model_cache = ("fake_model", "fake_scaler")
+
+        # Train in a temp directory
+        monkeypatch.chdir(tmp_path)
+
+        # train_demand_forecast_model should call reset_model_cache internally
+        from app.models.demand_forecast import train_demand_forecast_model
+        train_demand_forecast_model()
+
+        # Cache should be None after training
+        assert df_module._model_cache is None, (
+            "train_demand_forecast_model should reset _model_cache after saving. "
+            "Subsequent predictions would otherwise use the stale cached model."
+        )
+
+    def test_predict_after_train_uses_disk_model(self, monkeypatch, tmp_path):
+        """Verify that predict_demand works correctly after train completes,
+        confirming the cache was reset and the new model was loaded."""
+        import app.models.demand_forecast as df_module
+
+        monkeypatch.chdir(tmp_path)
+
+        # Train the model
+        from app.models.demand_forecast import train_demand_forecast_model, predict_demand
+        train_demand_forecast_model()
+
+        # Cache should be None (was invalidated by train)
+        assert df_module._model_cache is None
+
+        # Predict should load from disk and work
+        result = predict_demand([12, 3, 0, 25.0, 0.5, 50, 15])
+        assert isinstance(result, float)
+        assert result >= 0


### PR DESCRIPTION
Closes #7760.

Summary of What Has Been Done:
Fixed demand_forecast.py to invalidate the module-level _model_cache after train_demand_forecast_model() saves a new model to disk. Previously, subsequent predict_demand calls used the stale in-memory model until the worker restarted. Added reset_model_cache() helper function and called it at the end of train_demand_forecast_model(). Added pytest tests for cache invalidation.

Changes Made:
- backend/ml/app/models/demand_forecast.py: Added reset_model_cache(), called after save_model()
- backend/ml/tests/test_demand_forecast.py: New test file covering cache invalidation

Impact it Made:
- Retraining via /train takes effect immediately without worker restart
- Predictions are always based on the latest trained model

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).