### PR TITLE
fix : added SQL WHERE filter before LIMIT in getOrders for activeOnly mode

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -56,16 +56,28 @@ class CacheManager {
 
     _database = await openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE IF NOT EXISTS orders (
             id TEXT PRIMARY KEY,
             type TEXT NOT NULL,
+            status TEXT,
             payload TEXT NOT NULL,
             updated_at TEXT NOT NULL
           )
         ''');
+        await db.execute('''
+          CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status)
+        ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute('''ALTER TABLE orders ADD COLUMN status TEXT''');
+          await db.execute('''CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status)''');
+        }
+      },
+    );
         await db.execute('''
           CREATE TABLE IF NOT EXISTS profile (
             key TEXT PRIMARY KEY,
@@ -127,6 +139,7 @@ class CacheManager {
         {
           'id': id,
           'type': item['type'] ?? 'order',
+          'status': item['status']?.toString(),
           'payload': jsonEncode(item),
           'updated_at': updatedAt,
         },
@@ -139,11 +152,34 @@ class CacheManager {
 
   Future<List<Map<String, dynamic>>> getOrders({bool activeOnly = false, int limit = 20}) async {
     final db = await open();
-    final rows = await db.query(
-      'orders',
-      orderBy: 'updated_at DESC',
-      limit: limit,
-    );
+
+    const activeStatuses = {
+      'pending',
+      'active',
+      'truck_assigned',
+      'en_route_pickup',
+      'arrived_pickup',
+      'picked_up',
+      'in_transit',
+      'arriving'
+    };
+
+    List<Map<String, dynamic>> rows;
+    if (activeOnly) {
+      // Filter by status in SQL BEFORE applying LIMIT so active orders are never
+      // excluded by unrelated inactive order updates.
+      final statusList = activeStatuses.map((s) => "'$s'").join(', ');
+      rows = await db.rawQuery(
+        "SELECT * FROM orders WHERE status IN ($statusList) ORDER BY updated_at DESC LIMIT ?",
+        [limit],
+      );
+    } else {
+      rows = await db.query(
+        'orders',
+        orderBy: 'updated_at DESC',
+        limit: limit,
+      );
+    }
 
     final results = <Map<String, dynamic>>[];
 
@@ -161,20 +197,6 @@ class CacheManager {
         ...payload,
         '_cached_at': row['updated_at'],
       });
-    }
-
-    if (activeOnly) {
-      const activeStatuses = {
-        'pending',
-        'active',
-        'truck_assigned',
-        'en_route_pickup',
-        'arrived_pickup',
-        'picked_up',
-        'in_transit',
-        'arriving'
-      };
-      return results.where((item) => activeStatuses.contains(item['status'])).toList();
     }
 
     return results;


### PR DESCRIPTION
Closes #7763.

Summary of What Has Been Done:
Fixed getOrders(activeOnly=true) in apps/customer/lib/core/offline/cache/cache_manager.dart which applied LIMIT before filtering by active status. When recently-updated orders were all inactive, the function returned empty even when active orders existed. Added status column to the orders table with schema migration, store status when caching orders, and filter by status in SQL WHERE clause BEFORE applying LIMIT for activeOnly queries.

Changes Made:
- apps/customer/lib/core/offline/cache/cache_manager.dart: Added status column, migration, store status on cache, filter in SQL before LIMIT

Impact it Made:
- Active shipments view shows correct orders even when inactive orders were updated more recently
- No more false empty-state UI for users with active bookings
- Offline active orders work correctly

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).