### PR TITLE
fix : added positive-weight guard for weight_tons in loadRoutes

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -319,10 +319,16 @@ router.post('/', authenticate, userLimiter, requireRole(['customer']), async (re
       return res.status(400).json({ error: 'Destination with lat/lng is required' });
     }
 
-    if (weight_tons === undefined || weight_tons === null || Number.isNaN(Number(weight_tons))) {
+    const parsedWeight = Number(weight_tons);
+    if (weight_tons === undefined || weight_tons === null || Number.isNaN(parsedWeight)) {
       return res.status(400).json({ error: 'Valid weight_tons is required' });
     }
-    if (expected_price === undefined || expected_price === null || Number.isNaN(Number(expected_price))) {
+    if (parsedWeight <= 0) {
+      return res.status(400).json({ error: 'weight_tons must be a positive number' });
+    }
+
+    const parsedPrice = Number(expected_price);
+    if (expected_price === undefined || expected_price === null || Number.isNaN(parsedPrice)) {
       return res.status(400).json({ error: 'Valid expected_price is required' });
     }
 


### PR DESCRIPTION
Closes #7775.

Summary of What Has Been Done:
Fixed loadRoutes.js POST /api/loads to reject weight_tons <= 0. Previously, only undefined/null/NaN checks were performed, allowing zero or negative weight loads to be created, corrupting downstream pricing and routing calculations.

Changes Made:
- backend/api/src/routes/loadRoutes.js: Added positive number check for weight_tons returning HTTP 400

Impact it Made:
- Zero/negative weight loads cannot be created
- Pricing engine is protected from division-by-zero
- Data integrity is maintained in load_offers table

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).