### PR TITLE
fix : skip stale null results in osrm route cache reads

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -57,7 +57,13 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
   if (redisClient) {
     try {
       const cached = await redisClient.get(cacheKey);
-      if (cached) return JSON.parse(cached);
+      // Only return cached result if it is a valid object.
+      // Stale null results (from transient failures) must not be served
+      // from cache — the next call should retry the OSRM API.
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        if (parsed !== null) return parsed;
+      }
     } catch (err) {
       logger.error('[osrm] Redis get error:', err.message);
     }
@@ -161,7 +167,13 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
   if (redisClient) {
     try {
       const cached = await redisClient.get(cacheKey);
-      if (cached) return JSON.parse(cached);
+      // Only return cached result if it is a valid object.
+      // Stale null results (from transient failures) must not be served
+      // from cache — the next call should retry the OSRM API.
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        if (parsed !== null) return parsed;
+      }
     } catch (err) {
       logger.error('[osrm] Redis get error (geometry):', err.message);
     }


### PR DESCRIPTION
Closes #7776.

Summary of What Has Been Done:
Fixed getRouteEstimate and getRouteGeometry in backend/api/src/services/osrm.js to skip cached null values. Previously, if a null result was cached (from a transient OSRM failure), subsequent calls would return the cached null without retrying. Added null guard after JSON.parse to ensure fresh API calls are made for stale null cache entries.

Changes Made:
- backend/api/src/services/osrm.js: Added null guard for both getRouteEstimate and getRouteGeometry cache reads

Impact it Made:
- Transient OSRM failures do not permanently degrade routing for affected routes
- The routing service degrades gracefully instead of silently failing

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).