### PR TITLE
fix(api): remove duplicate rate limiter exports that break module load

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -314,66 +314,6 @@ export const otpVerificationLimiter = rateLimit({
   },
 });
 
-export const verifyDeliveryLimiter = rateLimit({
-  windowMs: Number(process.env.VERIFY_DELIVERY_RATE_LIMIT_WINDOW_MS) || 60 * 60 * 1000,
-  max: Number(process.env.VERIFY_DELIVERY_RATE_LIMIT_MAX_REQUESTS) || 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  validate: { keyGeneratorIpFallback: false },
-  store: createStore("rl:verify-delivery:"),
-  handler: sentryAlertHandler("verifyDeliveryLimiter"),
-  message: { error: "Rate limit exceeded", retryAfter: 3600 },
-});
-
-export const resendOtpLimiter = rateLimit({
-  windowMs: Number(process.env.RESEND_OTP_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000,
-  max: Number(process.env.RESEND_OTP_RATE_LIMIT_MAX_REQUESTS) || 5,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  validate: { keyGeneratorIpFallback: false },
-  store: createStore("rl:resend-otp:"),
-  handler: sentryAlertHandler("resendOtpLimiter"),
-  message: { error: "Too many OTP resend attempts. Please try again later." },
-});
-
-export const changeDropLimiter = rateLimit({
-  windowMs: Number(process.env.CHANGE_DROP_RATE_LIMIT_WINDOW_MS) || 60 * 60 * 1000,
-  max: Number(process.env.CHANGE_DROP_RATE_LIMIT_MAX_REQUESTS) || 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  validate: { keyGeneratorIpFallback: false },
-  store: createStore("rl:change-drop:"),
-  handler: sentryAlertHandler("changeDropLimiter"),
-  message: { error: "Rate limit exceeded", retryAfter: 3600 },
-});
-
-export const predictDemandLimiter = rateLimit({
-  windowMs: Number(process.env.PREDICT_DEMAND_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000,
-  max: Number(process.env.PREDICT_DEMAND_RATE_LIMIT_MAX_REQUESTS) || 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  validate: { keyGeneratorIpFallback: false },
-  store: createStore("rl:predict-demand:"),
-  handler: sentryAlertHandler("predictDemandLimiter"),
-  message: { error: "Rate limit exceeded", retryAfter: 900 },
-});
-
-export const telemetryLimiter = rateLimit({
-  windowMs: Number(process.env.TELEMETRY_RATE_LIMIT_WINDOW_MS) || 60 * 1000,
-  max: Number(process.env.TELEMETRY_RATE_LIMIT_MAX_REQUESTS) || 60,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  validate: { keyGeneratorIpFallback: false },
-  store: createStore("rl:telemetry:"),
-  handler: sentryAlertHandler("telemetryLimiter"),
-  message: { error: "Rate limit exceeded", retryAfter: 60 },
-});
-
 const POD_WINDOW_MS =
   Number(process.env.POD_RATE_LIMIT_WINDOW_MS) || 60 * 60 * 1000;
 const POD_MAX_REQUESTS = Number(process.env.POD_RATE_LIMIT_MAX_REQUESTS) || 10;


### PR DESCRIPTION
## Description
Duplicate named exports for verifyDeliveryLimiter, resendOtpLimiter, changeDropLimiter, predictDemandLimiter, and telemetryLimiter crash module load. Removed the weaker first block and kept the stricter per-user+order limiters.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** node --check backend/api/src/middleware/rateLimiter.js
- **Test Steps / Prerequisites:** n/a
- **Expected Result:** module parses

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7792

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limiting for delivery verification, OTP resend, drop changes, demand predictions, and telemetry requests.
  * Added order-specific controls to help prevent excessive retries and repeated requests.
  * Updated retry guidance to reflect revised request limits and waiting periods.
  * Applied more consistent protections based on account, network, and order activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->