### PR TITLE
fix(api): drop duplicate newAmountWei declaration in changeDrop

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -580,7 +580,6 @@ export class OrderLifecycleService {
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
         const newAmountWei = paisaToMaticWei(pricing.totalAmount);
-        const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {
           drop_address,


### PR DESCRIPTION
## Description
changeDrop redeclared `const newAmountWei`, which throws SyntaxError on module load. Kept the paisaToMaticWei assignment and removed the redundant BigInt wrap.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** node --check backend/api/src/services/order/orderLifecycleService.js
- **Test Steps / Prerequisites:** n/a
- **Expected Result:** module parses

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7793

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)