### PR TITLE
fix(escrow): gate createBooking behind owner-signed commitment and free slots on cancel (#7734)

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -9,7 +9,10 @@
  * relayer wallet (RELAYER_WALLET_PRIVATE_KEY) calls releasePayment
  * and cancelBooking. createBooking() is sent by the **customer's wallet**
  * directly — the contract requires msg.sender == customer to
- * prevent the relayer from bearing the escrow cost.
+ * prevent the relayer from bearing the escrow cost — but the call is only
+ * valid with an owner-signed EIP-191 commitment binding the customer wallet,
+ * bookingId, and a per-customer nonce, so a third party cannot front-run a
+ * pending bookingId (issue #7734). buildDepositTx() mints that commitment.
  *
  * The buildDepositTx() function below builds the deposit transaction
  * and returns it as an unsigned populated transaction so the
@@ -33,8 +36,9 @@ import logger from '../middleware/logger.js'
 import { measureExecution } from '../core/performanceMetrics.js'
 
 const ESCROW_ABI = [
-  'function createBooking(uint256 bookingId, address payable driver) external payable',
+  'function createBooking(uint256 bookingId, address payable driver, bytes signature) external payable',
   'function lockPayment(uint256 bookingId, address payable customer, address payable driver) external payable',
+  'function commitmentNonces(address customer) external view returns (uint256)',
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
   'function cancelWithPenalty(uint256 bookingId, uint256 driverFee) external',
@@ -61,12 +65,14 @@ const MAX_ESCROW_MATIC = parseEnvFloat(process.env.MAX_ESCROW_MATIC, '100', 'MAX
 
 /** @type {ethers.Contract | null} */
 let escrowContract = null
+/** @type {ethers.Wallet | null} */
+let relayerWallet = null
 
 if (rpcUrl && contractAddress && relayerPrivateKey) {
   try {
     const provider = new ethers.JsonRpcProvider(rpcUrl);
-    const relayer  = new ethers.Wallet(relayerPrivateKey, provider);
-    escrowContract = new ethers.Contract(contractAddress, ESCROW_ABI, relayer);
+    relayerWallet = new ethers.Wallet(relayerPrivateKey, provider);
+    escrowContract = new ethers.Contract(contractAddress, ESCROW_ABI, relayerWallet);
     logger.info('✅ Polygon Escrow contract client initialised.');
     logger.info(`📊 Escrow rate: ${ESCROW_MATIC_PER_PAISA} MATIC/paisa → max deposit: ${MAX_ESCROW_MATIC} MATIC`);
   } catch (err) {
@@ -343,18 +349,19 @@ export async function getEscrowBooking(escrowBookingId) {
  * backend can confirm the on-chain deposit.
  *
  * @param {string} orderDisplayId
+ * @param {string} customerWalletAddress — 0x-prefixed Polygon address of the customer (the signer of the deposit tx)
  * @param {string} driverWalletAddress   — 0x-prefixed Polygon address of the driver
  * @param {string} amountWei             — amount in wei (string or bigint)
  * @returns {Promise<{txData: object|null, bookingId: string}>}
  */
-export async function buildDepositTx (orderDisplayId, driverWalletAddress, amountWei) {
+export async function buildDepositTx (orderDisplayId, customerWalletAddress, driverWalletAddress, amountWei) {
   return measureExecution('EscrowService.buildDepositTx', async () => {
   const bookingId = getEscrowBookingId(orderDisplayId)
   if (!escrowContract) {
     return { txData: null, bookingId }
   }
 
-  if (!ethers.isAddress(driverWalletAddress)) {
+  if (!ethers.isAddress(driverWalletAddress) || !ethers.isAddress(customerWalletAddress)) {
     return { txData: null, bookingId }
   }
   if (!amountWei || BigInt(amountWei) <= 0n) {
@@ -363,9 +370,22 @@ export async function buildDepositTx (orderDisplayId, driverWalletAddress, amoun
 
   let txData
   try {
+    // Owner-signed EIP-191 commitment binding chain, contract, customer,
+    // bookingId and the customer's next nonce. Without it the contract
+    // rejects createBooking, so a third party cannot front-run the slot
+    // (issue #7734).
+    const network = await escrowContract.runner.provider.getNetwork()
+    const nonce = await escrowContract.commitmentNonces(customerWalletAddress)
+    const commitment = ethers.solidityPackedKeccak256(
+      ['uint256', 'address', 'address', 'uint256', 'uint256'],
+      [network.chainId, contractAddress, customerWalletAddress, bookingId, nonce]
+    )
+    const signature = await relayerWallet.signMessage(ethers.getBytes(commitment))
+
     txData = await escrowContract.createBooking.populateTransaction(
       bookingId,
       driverWalletAddress,
+      signature,
       {
         value: amountWei
       }
@@ -399,10 +419,11 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
   }
 
   // Idempotency: check if this booking already has a funded escrow on-chain.
-  // createBooking is callable by anyone, so an already-existing booking must be
-  // verified to have been created by the registered customer — and, when the
-  // expected values are persisted on the order, for the assigned driver and
-  // for at least the expected escrow amount — before it is accepted as funded.
+  // createBooking now requires an owner-signed commitment (issue #7734), but an
+  // already-existing booking is still verified to have been created by the
+  // registered customer — and, when the expected values are persisted on the
+  // order, for the assigned driver and for at least the expected escrow amount
+  // — before it is accepted as funded.
   try {
     const booking = await escrowContract.bookings(bookingId)
     if (booking && booking.amount > 0n) {

--- a/backend/api/src/services/order/bidAcceptanceService.js
+++ b/backend/api/src/services/order/bidAcceptanceService.js
@@ -155,7 +155,7 @@ export class BidAcceptanceService {
             recovery: 'Configure ESCROW_MATIC_PER_PAISA / MAX_ESCROW_MATIC or contact support for a larger escrow limit.',
           });
         }
-        const depositTx = await this.buildDepositTxFn(order.order_display_id, freshDriverWallet, amountWei);
+        const depositTx = await this.buildDepositTxFn(order.order_display_id, freshCustomerWallet, freshDriverWallet, amountWei);
         const bookingId = depositTx?.bookingId || getEscrowBookingId(order.order_display_id);
 
         // Guard against silent escrow disable: if buildDepositTx returned

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -49,6 +49,12 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     uint256 public bookingCount;
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;
+
+    // Backend-issued commitment nonce per customer wallet. A valid createBooking
+    // requires an owner-signed EIP-191 commitment over (chain, this, customer,
+    // bookingId, nonce). The nonce is burned on success so a commitment cannot
+    // be replayed by anyone who observes a submitted deposit transaction.
+    mapping(address => uint256) public commitmentNonces;
     uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
     uint256 public constant DISPUTE_TIMEOUT = 7 days;
 
@@ -131,16 +137,72 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         _;
     }
 
+    /**
+     * @dev Verify the owner's EIP-191 signature over the create commitment:
+     *      keccak256(chainId, this, customer, bookingId, commitmentNonces[customer]).
+     *      Only the contract owner (the backend relayer) can authorise a slot,
+     *      so an external party cannot claim a pending bookingId for 1 wei.
+     */
+    function _verifyCreateCommitment(
+        address customer,
+        uint256 bookingId,
+        bytes calldata signature
+    ) private view returns (bool) {
+        require(signature.length == 65, "TruxifyEscrow: Invalid signature length");
+
+        bytes32 commitment = keccak256(
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                customer,
+                bookingId,
+                commitmentNonces[customer]
+            )
+        );
+        bytes32 signedHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", commitment)
+        );
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+
+        return ecrecover(signedHash, v, r, s) == owner();
+    }
+
+    /**
+     * @dev Release a booking id slot after its escrow is fully settled so the
+     *      bookingId can be re-created for a retried/regenerated order
+     *      (issue #7734). Only invoked from the Cancelled terminal paths —
+     *      Delivered/Resolved ids must never be reused.
+     */
+    function _releaseBookingSlot(uint256 bookingId) private {
+        bookings[bookingId].customer = payable(address(0));
+        bookings[bookingId].driver = payable(address(0));
+    }
+
     // ─── External Functions ──────────────────────────────────────────────────
 
     /**
      * @dev Create a booking and lock payment in escrow.
+     *      The customer's wallet pays the deposit, but the call is only valid
+     *      with an owner-signed EIP-191 commitment that binds the customer
+     *      wallet, bookingId, and a per-customer nonce. This prevents a third
+     *      party from front-running a pending bookingId and permanently
+     *      bricking the real customer's booking (issue #7734).
      * @param bookingId Unique booking ID from the Node.js backend
      * @param driver    Truck driver's wallet address
+     * @param signature Owner's EIP-191 signature over the create commitment
      */
     function createBooking(
         uint256 bookingId,
-        address payable driver
+        address payable driver,
+        bytes calldata signature
     ) external payable {
         require(msg.value > 0, "TruxifyEscrow: Payment required");
         require(driver != address(0), "TruxifyEscrow: Invalid driver address");
@@ -148,6 +210,13 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             bookings[bookingId].customer == address(0),
             "TruxifyEscrow: Booking already exists"
         );
+        require(
+            _verifyCreateCommitment(msg.sender, bookingId, signature),
+            "TruxifyEscrow: Invalid commitment signature"
+        );
+
+        // Burn the nonce so the same commitment can never be replayed.
+        commitmentNonces[msg.sender]++;
 
         bookings[bookingId] = Booking({
             customer:  payable(msg.sender),
@@ -323,6 +392,9 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
         emit WithdrawalReady(bookingId, customer, refundAmount);
         emit BookingCancelled(bookingId, customer, refundAmount);
+
+        // Release the slot so a retried/regenerated order can re-use the id.
+        _releaseBookingSlot(bookingId);
     }
 
     /**
@@ -373,6 +445,9 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         }
 
         emit CancellationPenaltyApplied(bookingId, driver, driverFee, customer, customerRefund);
+
+        // Release the slot so a retried/regenerated order can re-use the id.
+        _releaseBookingSlot(bookingId);
     }
 
     /**
@@ -495,6 +570,9 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
         emit WithdrawalReady(bookingId, customer, refundAmount);
         emit BookingCancelled(bookingId, customer, refundAmount);
+
+        // Release the slot so a retried/regenerated order can re-use the id.
+        _releaseBookingSlot(bookingId);
     }
 
     /**

--- a/blockchain/contracts/TruxifyEscrow.test.js
+++ b/blockchain/contracts/TruxifyEscrow.test.js
@@ -1,12 +1,173 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("TruxifyEscrow - re-entrancy guard", function () {
-  it("should not allow re-entrant releasePayment calls", async function () {
-    const [owner, driver, customer] = await ethers.getSigners();
+const AMOUNT = ethers.parseEther("1");
+const DISPUTE_TIMEOUT_SECS = 7 * 24 * 3600;
+
+// BookingStatus: Active=0, Delivered=1, Cancelled=2, Disputed=3, Resolved=4
+const STATUS = { Active: 0, Delivered: 1, Cancelled: 2, Disputed: 3, Resolved: 4 };
+
+/**
+ * Mint the same EIP-191 commitment the contract verifies:
+ *   keccak256(chainId, this, customer, bookingId, commitmentNonces[customer])
+ */
+async function signCommitment(signer, escrow, customer, bookingId) {
+  const { chainId } = await ethers.provider.getNetwork();
+  const nonce = await escrow.commitmentNonces(customer);
+  const commitment = ethers.solidityPackedKeccak256(
+    ["uint256", "address", "address", "uint256", "uint256"],
+    [chainId, escrow.target, customer, bookingId, nonce]
+  );
+  return signer.signMessage(ethers.getBytes(commitment));
+}
+
+describe("TruxifyEscrow", function () {
+  let escrow;
+  let owner, customer, driver, attacker, otherCustomer;
+
+  beforeEach(async function () {
+    [owner, customer, driver, attacker, otherCustomer] = await ethers.getSigners();
     const Escrow = await ethers.getContractFactory("TruxifyEscrow");
-    const escrow = await Escrow.deploy();
-    // ... setup booking, attempt re-entrant attack, expect revert
-    // Full test omitted for brevity but structure is here
+    escrow = await Escrow.deploy();
+  });
+
+  describe("createBooking — owner-signed commitment (issue #7734)", function () {
+    it("creates a booking with a valid owner-signed commitment", async function () {
+      const bookingId = 1;
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
+      )
+        .to.emit(escrow, "BookingCreated")
+        .withArgs(bookingId, customer.address, driver.address, AMOUNT);
+
+      const booking = await escrow.bookings(bookingId);
+      expect(booking.customer).to.equal(customer.address);
+      expect(booking.driver).to.equal(driver.address);
+      expect(booking.amount).to.equal(AMOUNT);
+      expect(booking.status).to.equal(STATUS.Active);
+      expect(booking.paid).to.equal(false);
+    });
+
+    it("reverts when the commitment is forged by a non-owner (front-running blocked)", async function () {
+      const bookingId = 1;
+      const forged = await signCommitment(attacker, escrow, customer.address, bookingId);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, driver.address, forged, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
+
+      expect((await escrow.bookings(bookingId)).customer).to.equal(ethers.ZeroAddress);
+    });
+
+    it("reverts for a malformed signature", async function () {
+      await expect(
+        escrow.connect(customer).createBooking(1, driver.address, "0x1234", { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid signature length");
+    });
+
+    it("reverts when the commitment covers a different bookingId", async function () {
+      const bookingId = 1;
+      const sig = await signCommitment(owner, escrow, customer.address, 99);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
+    });
+
+    it("reverts when the commitment covers a different customer wallet", async function () {
+      const bookingId = 1;
+      const sig = await signCommitment(owner, escrow, otherCustomer.address, bookingId);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
+    });
+
+    it("burns the nonce — a replayed commitment reverts", async function () {
+      const bookingId = 1;
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+      await escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
+
+      await expect(
+        escrow.connect(customer).createBooking(2, driver.address, sig, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
+    });
+
+    it("records msg.sender as the customer so the wallet funds the escrow", async function () {
+      const bookingId = 1;
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+      await escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
+
+      const booking = await escrow.bookings(bookingId);
+      expect(booking.customer).to.equal(customer.address);
+      expect(booking.customer).not.to.equal(owner.address);
+    });
+  });
+
+  describe("slot reuse after settlement (issue #7734)", function () {
+    async function createBooking(bookingId, who = customer) {
+      const sig = await signCommitment(owner, escrow, who.address, bookingId);
+      await escrow.connect(who).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
+    }
+
+    it("cannot re-create the slot while the original booking is active", async function () {
+      await createBooking(1);
+      const sig = await signCommitment(owner, escrow, customer.address, 1);
+
+      await expect(
+        escrow.connect(customer).createBooking(1, driver.address, sig, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Booking already exists");
+    });
+
+    it("re-creates the booking after cancelBooking and the refund is withdrawable", async function () {
+      await createBooking(1);
+      await escrow.connect(owner).cancelBooking(1);
+      expect((await escrow.bookings(1)).status).to.equal(STATUS.Cancelled);
+
+      await escrow.connect(customer).withdraw();
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(0n);
+
+      // Same bookingId can now be re-created (fresh commitment, nonce bumped).
+      await createBooking(1);
+      const booking = await escrow.bookings(1);
+      expect(booking.customer).to.equal(customer.address);
+      expect(booking.status).to.equal(STATUS.Active);
+      expect(booking.amount).to.equal(AMOUNT);
+    });
+
+    it("re-creates the booking after cancelWithPenalty", async function () {
+      await createBooking(1);
+      await escrow.connect(owner).cancelWithPenalty(1, ethers.parseEther("0.2"));
+
+      await createBooking(1);
+      expect((await escrow.bookings(1)).customer).to.equal(customer.address);
+      expect((await escrow.bookings(1)).status).to.equal(STATUS.Active);
+    });
+
+    it("re-creates the booking after resolveDisputeTimeout", async function () {
+      await createBooking(1);
+      await escrow.connect(owner).raiseDispute(1);
+      await ethers.provider.send("evm_increaseTime", [DISPUTE_TIMEOUT_SECS + 1]);
+      await ethers.provider.send("evm_mine", []);
+      await escrow.connect(owner).resolveDisputeTimeout(1);
+      expect((await escrow.bookings(1)).status).to.equal(STATUS.Cancelled);
+
+      await createBooking(1);
+      expect((await escrow.bookings(1)).customer).to.equal(customer.address);
+      expect((await escrow.bookings(1)).status).to.equal(STATUS.Active);
+    });
+
+    it("does NOT free the slot after releasePayment (Delivered is terminal)", async function () {
+      await createBooking(1);
+      await escrow.connect(owner).releasePayment(1);
+      expect((await escrow.bookings(1)).status).to.equal(STATUS.Delivered);
+
+      const sig = await signCommitment(owner, escrow, customer.address, 1);
+      await expect(
+        escrow.connect(customer).createBooking(1, driver.address, sig, { value: AMOUNT })
+      ).to.be.revertedWith("TruxifyEscrow: Booking already exists");
+    });
   });
 });


### PR DESCRIPTION
## Analysis

`blockchain/contracts/TruxifyEscrow.sol` exposes `createBooking(bookingId, driver)` to **anyone** with no authentication (lines 141-166). Because `bookingId` is a predictable backend-derived value, an attacker who learns a pending id can call `createBooking` with 1 wei **before** the real customer's deposit lands, permanently bricking the victim's booking with "Booking already exists" — an on-chain DoS for negligible cost.

Separately, `cancelBooking` (and `cancelWithPenalty` / `resolveDisputeTimeout`) set `status = Cancelled` but never reset `bookings[bookingId].customer`, so the `customer == address(0)` guard never passes again and the bookingId slot is permanently locked — retried/regenerated orders that reuse the id fail forever, even through the backend's `onlyOwner` path.

The contract relies on the **customer's wallet** funding the escrow (`msg.sender == customer`, per `backend/api/src/services/escrow.js` `buildDepositTx` → customer signs the populated tx), so a plain `onlyOwner` gate would break the funding model. Instead, creation is gated on an **owner-signed EIP-191 commitment** that binds chain, contract, customer wallet, bookingId, and a per-customer nonce — only the backend relayer (owner) can authorise a slot, while the customer still pays.

## Changes

- `blockchain/contracts/TruxifyEscrow.sol`
  - Added `mapping(address => uint256) commitmentNonces` and a `_verifyCreateCommitment` helper that `ecrecover`s the owner's EIP-191 signature over `keccak256(chainId, this, customer, bookingId, nonce)`.
  - `createBooking` now takes `bytes calldata signature`; it reverts with `Invalid commitment signature` unless signed by `owner()`, and burns the nonce on success so observed commitments cannot be replayed.
  - Added `_releaseBookingSlot` which zeroes `customer`/`driver` after settlement; invoked from `cancelBooking`, `cancelWithPenalty`, and `resolveDisputeTimeout` (all terminal **Cancelled** paths) so the bookingId can be re-created. Delivered/Resolved ids are intentionally never freed.
- `backend/api/src/services/escrow.js`
  - Updated `ESCROW_ABI` for the new `createBooking(..., bytes)` signature and added `commitmentNonces(address)`.
  - `buildDepositTx` now accepts the customer wallet address, reads the customer's next nonce, mints the commitment (`ethers.solidityPackedKeccak256`), signs it with the relayer wallet, and embeds the signature in the populated `createBooking` tx.
  - `recordDepositTx` verification (sender/driver/amount, fail-closed) is unchanged; comments updated.
- `backend/api/src/services/order/bidAcceptanceService.js` — passes the freshly re-validated customer wallet into `buildDepositTx` (it was already fetched for the TOCTOU check).
- `blockchain/contracts/TruxifyEscrow.test.js` — replaced the empty re-entrancy stub with 12 regression tests.

## Testing

- 12 hardhat tests pass in an isolated workspace (`blockchain/_tmp_escrow`, `npx hardhat test`), covering: valid owner-signed create, forged/malformed/wrong-target commitment reverts, nonce replay rejection, `msg.sender == customer` (wallet funds escrow), and slot reuse after `cancelBooking` / `cancelWithPenalty` / `resolveDisputeTimeout` — plus confirmation that Delivered slots are never reused.
- Backend: `vitest run test/unit/escrow.test.js test/unit/escrowSenderVerification.test.js test/integration/escrow.test.js` → 69 passed.

Closes #7734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customer-signed authorization for escrow booking creation.
  - Prevented unauthorized booking claims and replayed authorizations.
  - Booking identifiers can now be reused after eligible cancellations or dispute resolutions.
  - Preserved completed bookings while improving refund and penalty handling.

- **Bug Fixes**
  - Strengthened validation of customer, driver, booking, and payment details during escrow deposits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->