### PR TITLE
fix(contracts): bind KYCVerifier proof public inputs to the verified user

### DIFF
--- a/blockchain/contracts/KYCVerifier.sol
+++ b/blockchain/contracts/KYCVerifier.sol
@@ -45,6 +45,11 @@ contract KYCVerifier is Verifier {
         require(a[0] != 0 || a[1] != 0, "Zero proof rejected");
         require(input[0] != 0 || input[1] != 0, "Empty public input");
 
+        // Bind the proof to the user: the circuit's first public input must
+        // commit to the address being verified so one proof cannot be replayed
+        // to mark arbitrary accounts as KYC-verified.
+        require(uint256(input[0]) == uint256(uint160(user)), "Proof not bound to user");
+
         // Verify the proof
         bool isValid = verifyProof(a, b, c, input);
         


### PR DESCRIPTION
## Problem

`KYCVerifier.verifyKYC` never bound the Groth16 proof's public input to the `user` address being verified, so a single valid proof could be replayed to mark arbitrary accounts as KYC-verified.

## Fix

Added a binding check in `verifyKYC` before setting `verifiedUsers[user] = true`:

```solidity
require(uint256(input[0]) == uint256(uint160(user)), "Proof not bound to user");
```

The circuit's first public input must commit to the target address, so one proof cannot be reused across addresses. The existing zero/empty proof rejection runs first, so the all-zero proof test still passes.

## Files changed

- `blockchain/contracts/KYCVerifier.sol`

## Testing

Reviewed guard ordering against `blockchain/test/zkVerifier.test.js` (the zero-proof rejection is hit before the new binding require). Compile/test re-run deferred to CI because the workspace-root `node_modules` has a broken hardhat install that shadows the repo's own.

Closes #7836
