### PR TITLE
fix(contracts): make StateChannel.openChannel channel IDs collision-free

### DIFF
--- a/blockchain/contracts/StateChannel.sol
+++ b/blockchain/contracts/StateChannel.sol
@@ -25,6 +25,7 @@ contract StateChannel is ReentrancyGuard {
     }
 
     mapping(bytes32 => Channel) public channels;
+    uint256 public channelCounter;
     uint256 public constant CHALLENGE_PERIOD = 1 days;
 
     event ChannelOpened(bytes32 indexed channelId, address indexed userA, address indexed userB, uint256 deposit);
@@ -35,7 +36,9 @@ contract StateChannel is ReentrancyGuard {
         require(msg.value > 0, "Deposit required");
         require(userB != address(0), "Invalid user B");
 
-        channelId = keccak256(abi.encodePacked(msg.sender, userB, block.timestamp));
+        channelCounter++;
+        channelId = keccak256(abi.encodePacked(msg.sender, userB, block.timestamp, channelCounter));
+        require(channels[channelId].userA == address(0), "Channel exists");
         channels[channelId] = Channel({
             userA: msg.sender,
             userB: userB,


### PR DESCRIPTION
## Problem

`StateChannel.openChannel` derived the channel ID from `(msg.sender, userB, block.timestamp)` only, so two opens in the same block produced the same ID and silently overwrote the first party's deposited funds. A user who opened a channel twice in one block would lose the first deposit.

## Fix

- Added `uint256 public channelCounter;` and mixed it into the channel ID:
  `channelId = keccak256(abi.encodePacked(msg.sender, userB, block.timestamp, channelCounter))`.
- Added `require(channels[channelId].userA == address(0), "Channel exists")` so a (now impossible) ID collision reverts instead of overwriting a live deposit.

## Files changed

- `blockchain/contracts/StateChannel.sol`

## Testing

Reviewed ID derivation and the existence guard. Compile/test re-run deferred to CI because the workspace-root `node_modules` has a broken hardhat install that shadows the repo's own.

Closes #7837
