### PR TITLE
fix(supabase): serialize withdraw_funds_tx cap check with the row lock

### DIFF
--- a/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
@@ -55,7 +55,16 @@ BEGIN
     RAISE EXCEPTION 'Withdrawal amount must be a positive whole number of paisa';
   END IF;
 
-  -- Enforce the per-driver per-day withdrawal cap.
+  -- Lock the wallet row first so the daily cap decision and the balance
+  -- movement are serialized: two concurrent withdrawals from the same driver
+  -- cannot both read the same v_day_total and both pass the cap check.
+  SELECT wallet_confirmed, wallet_pending
+    INTO v_confirmed, v_pending
+    FROM driver_details
+   WHERE user_id = p_driver_id
+     FOR UPDATE;
+
+  -- Enforce the per-driver per-day withdrawal cap under the row lock.
   SELECT COALESCE(SUM(amount), 0)
     INTO v_day_total
     FROM wallet_transactions
@@ -67,13 +76,6 @@ BEGIN
     RAISE EXCEPTION 'Daily withdrawal cap exceeded: % of % used',
       v_day_total + p_amount, v_daily_cap;
   END IF;
-
-  -- Lock the wallet row to prevent concurrent withdrawals.
-  SELECT wallet_confirmed, wallet_pending
-    INTO v_confirmed, v_pending
-    FROM driver_details
-   WHERE user_id = p_driver_id
-     FOR UPDATE;
 
   IF v_confirmed IS NULL OR v_confirmed < p_amount THEN
     RAISE EXCEPTION 'Insufficient balance: available %, requested %',


### PR DESCRIPTION
## Problem

`withdraw_funds_tx` computed the per-driver daily cap `SUM` **before** locking the `driver_details` row. Two concurrent calls from the same driver both read the same `v_day_total` and both passed the cap check before either inserted its `wallet_transactions` row, letting the driver exceed the daily cap.

## Fix

Reorder the function so the row lock, the day-total computation, and the cap check all happen inside the same transaction:

1. Lock the wallet row first: `SELECT wallet_confirmed, wallet_pending ... FOR UPDATE`.
2. Compute `v_day_total` from `wallet_transactions` under that lock.
3. Enforce the cap (`v_day_total + p_amount > v_daily_cap`), then the balance check and the confirmed → pending movement.

Concurrent withdrawals from the same driver now serialize on the row lock before deciding the cap.

## Files changed

- `supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql` (`withdraw_funds_tx`)

## Testing

Reviewed the PL/pgSQL control flow (lock → SUM → cap check → balance check → update). SQL is not executed in this environment; migration behavior should be verified against a Postgres instance in CI.

Closes #7840
