### PR TITLE
fix(zkp-verifier-rust): replace forgeable weight proof with signed claims

### DIFF
--- a/services/zkp-verifier-rust/src/lib.rs
+++ b/services/zkp-verifier-rust/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod verifier;
+pub mod weight_proof;

--- a/services/zkp-verifier-rust/src/verifier.rs
+++ b/services/zkp-verifier-rust/src/verifier.rs
@@ -1,18 +1,57 @@
-use crate::weight_proof::{WeightProofOutput};
+use crate::weight_proof::{canonical_payload, WeightProofOutput};
+use ed25519_dalek::{Signature, VerifyingKey};
+
+/// Maximum allowed skew (seconds) between the device timestamp and the
+/// verifier clock. Proofs stamped further in the future (or further in the
+/// past) are rejected to keep the weight claim fresh.
+const MAX_TIMESTAMP_SKEW_SECS: u64 = 300;
 
 pub struct ZkWeightVerifier;
 
 impl ZkWeightVerifier {
-    pub fn verify_proof(proof: &WeightProofOutput, max_allowed_limit: u64) -> bool {
-        if !proof.is_valid {
+    /// Independently enforces the weight limit and verifies the Ed25519
+    /// signature over the canonical payload (weight + device limit + nonce +
+    /// timestamp), which only the weighing device's secret key can produce.
+    ///
+    /// The prover's self-declared validity is never trusted: the claimed axle
+    /// weight is re-checked against the verifier's own `max_allowed_limit`.
+    pub fn verify_proof(
+        proof: &WeightProofOutput,
+        max_allowed_limit: u64,
+        verifying_key: &VerifyingKey,
+        now: u64,
+    ) -> bool {
+        // 1. Independent weight enforcement against the caller's limit.
+        if proof.axle_weight_kg > max_allowed_limit {
             return false;
         }
 
-        // Verify succinct PLONK proof hash prefix
-        if !proof.proof_hash.starts_with("0xzkPLONK_") {
+        // 2. Timestamp freshness: reject future-stamped proofs (beyond clock
+        //    skew) and stale proofs (older than the skew window).
+        if proof.timestamp > now.saturating_add(MAX_TIMESTAMP_SKEW_SECS) {
+            return false;
+        }
+        if proof.timestamp < now.saturating_sub(MAX_TIMESTAMP_SKEW_SECS) {
             return false;
         }
 
-        true
+        // 3. Signature check over the exact canonical payload that was signed.
+        //    A tampered weight, limit, nonce, or timestamp breaks the binding.
+        let payload = canonical_payload(
+            proof.axle_weight_kg,
+            proof.max_legal_limit_kg,
+            &proof.nonce,
+            proof.timestamp,
+        );
+
+        match hex::decode(&proof.signature_hex) {
+            Ok(bytes) => match <[u8; 64]>::try_from(bytes.as_slice()) {
+                Ok(sig_bytes) => verifying_key
+                    .verify_strict(&payload, &Signature::from_bytes(&sig_bytes))
+                    .is_ok(),
+                Err(_) => false,
+            },
+            Err(_) => false,
+        }
     }
 }

--- a/services/zkp-verifier-rust/src/weight_proof.rs
+++ b/services/zkp-verifier-rust/src/weight_proof.rs
@@ -1,4 +1,6 @@
+use ed25519_dalek::{Signer, SigningKey};
 use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WeightProofInput {
@@ -7,28 +9,74 @@ pub struct WeightProofInput {
     pub nonce: String,
 }
 
+/// A weight claim signed by the weighing device. There is intentionally NO
+/// `is_valid` flag and no self-declared "proof hash": validity is decided by
+/// the verifier, which independently compares the claimed axle weight against
+/// its own `max_allowed_limit` and cryptographically verifies the signature.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WeightProofOutput {
-    pub is_valid: bool,
-    pub proof_hash: String,
+    pub axle_weight_kg: u64,
+    pub max_legal_limit_kg: u64,
+    pub nonce: String,
     pub timestamp: u64,
+    pub signature_hex: String,
+}
+
+/// Canonically encodes the claim (weight, device limit, nonce, timestamp) so
+/// the signed commitment is unambiguous and the verifier can re-derive exactly
+/// the bytes that were signed. Length-prefixing the nonce prevents collisions
+/// between different field combinations.
+pub fn canonical_payload(
+    axle_weight_kg: u64,
+    max_legal_limit_kg: u64,
+    nonce: &str,
+    timestamp: u64,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"truxify.zkp.weight.v1");
+    out.extend_from_slice(&axle_weight_kg.to_be_bytes());
+    out.extend_from_slice(&max_legal_limit_kg.to_be_bytes());
+    out.extend_from_slice(&timestamp.to_be_bytes());
+    out.extend_from_slice(&(nonce.len() as u64).to_be_bytes());
+    out.extend_from_slice(nonce.as_bytes());
+    out
+}
+
+/// Current Unix time in seconds. The timestamp is real and monotonic (not the
+/// previous hardcoded constant) so the verifier can enforce freshness.
+pub fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 pub struct WeightProofGenerator;
 
 impl WeightProofGenerator {
-    pub fn generate_proof(input: &WeightProofInput) -> WeightProofOutput {
-        // PLONK ZK constraint check: axle_weight_kg <= max_legal_limit_kg
-        let is_valid = input.axle_weight_kg <= input.max_legal_limit_kg;
-        let proof_payload = format!("{}:{}:{}", input.axle_weight_kg, input.max_legal_limit_kg, input.nonce);
-        
-        // Simulating PLONK ZK proof hash derivation
-        let proof_hash = format!("0xzkPLONK_{}", hex::encode(proof_payload.as_bytes()));
+    /// Signs the weight claim with the device-held Ed25519 secret key. Only the
+    /// weighing device possesses the key, so a client that reads the (public)
+    /// verifier binary cannot fabricate a claim. The timestamp is captured at
+    /// generation time and is part of the signed payload.
+    pub fn generate_proof(
+        input: &WeightProofInput,
+        signing_key: &SigningKey,
+    ) -> WeightProofOutput {
+        let timestamp = now_seconds();
+        let payload = canonical_payload(
+            input.axle_weight_kg,
+            input.max_legal_limit_kg,
+            &input.nonce,
+            timestamp,
+        );
+        let signature = signing_key.sign(&payload);
 
         WeightProofOutput {
-            is_valid,
-            proof_hash,
-            timestamp: 1775462400,
+            axle_weight_kg: input.axle_weight_kg,
+            max_legal_limit_kg: input.max_legal_limit_kg,
+            nonce: input.nonce.clone(),
+            timestamp,
+            signature_hex: hex::encode(signature.to_bytes()),
         }
     }
 }

--- a/services/zkp-verifier-rust/tests/proof_test.rs
+++ b/services/zkp-verifier-rust/tests/proof_test.rs
@@ -1,30 +1,103 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use truxify_zkp_verifier::verifier::ZkWeightVerifier;
+use truxify_zkp_verifier::weight_proof::{now_seconds, WeightProofGenerator, WeightProofInput};
 
-    #[test]
-    fn test_valid_weight_proof() {
-        let input = weight_proof::WeightProofInput {
-            axle_weight_kg: 14000,
-            max_legal_limit_kg: 16200,
-            nonce: "nonce_test_123".to_string(),
-        };
+/// Test-only signing key whose public half is used by the verifier in these
+/// tests. In production the secret key lives only with the weighing device.
+const TEST_SIGNING_SEED: [u8; 32] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+];
 
-        let proof = weight_proof::WeightProofGenerator::generate_proof(&input);
-        assert!(proof.is_valid);
-        assert!(verifier::ZkWeightVerifier::verify_proof(&proof, 16200));
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&TEST_SIGNING_SEED)
+}
+
+fn verifying_key() -> VerifyingKey {
+    signing_key().verifying_key()
+}
+
+fn input(axle_weight_kg: u64, max_legal_limit_kg: u64, nonce: &str) -> WeightProofInput {
+    WeightProofInput {
+        axle_weight_kg,
+        max_legal_limit_kg,
+        nonce: nonce.to_string(),
     }
+}
 
-    #[test]
-    fn test_overweight_proof_rejection() {
-        let input = weight_proof::WeightProofInput {
-            axle_weight_kg: 18500, // Overweight
-            max_legal_limit_kg: 16200,
-            nonce: "nonce_test_456".to_string(),
-        };
+#[test]
+fn test_valid_weight_proof() {
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_test_123"),
+        &signing_key(),
+    );
 
-        let proof = weight_proof::WeightProofGenerator::generate_proof(&input);
-        assert!(!proof.is_valid);
-        assert!(!verifier::ZkWeightVerifier::verify_proof(&proof, 16200));
-    }
+    assert!(ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+}
+
+#[test]
+fn test_overweight_proof_rejection() {
+    // A correctly signed claim that is overweight relative to the VERIFIER's
+    // limit must still be rejected: validity is decided by the verifier, not
+    // by the device's own is_valid flag.
+    let proof = WeightProofGenerator::generate_proof(
+        &input(18500, 16200, "nonce_test_456"),
+        &signing_key(),
+    );
+
+    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+}
+
+#[test]
+fn test_forged_proof_rejected() {
+    // A signature produced with a different secret key must not verify.
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_test_789"),
+        &signing_key(),
+    );
+    let attacker_key = SigningKey::from_bytes(&[0xaa; 32]);
+
+    assert!(!ZkWeightVerifier::verify_proof(
+        &proof,
+        16200,
+        &attacker_key.verifying_key(),
+        now_seconds(),
+    ));
+}
+
+#[test]
+fn test_tampered_weight_rejected() {
+    // The signature binds the axle weight: tampering with it after signing
+    // must invalidate the proof even though the forged weight is within limit.
+    let mut proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_test_135"),
+        &signing_key(),
+    );
+    proof.axle_weight_kg = 14001;
+
+    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+}
+
+#[test]
+fn test_future_timestamp_rejected() {
+    // Proofs stamped beyond the allowed clock skew must be rejected so a
+    // captured signature cannot be replayed forever.
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_test_246"),
+        &signing_key(),
+    );
+    let now = now_seconds();
+
+    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now + 1_000_000));
+}
+
+#[test]
+fn test_stale_timestamp_rejected() {
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_test_358"),
+        &signing_key(),
+    );
+    let now = now_seconds();
+
+    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now - 1_000_000));
 }


### PR DESCRIPTION
## Problem

`ZkWeightVerifier::verify_proof` ignored the `max_allowed_limit` parameter and trusted the prover's self-declared `is_valid` flag plus a `0xzkPLONK_` string prefix. `generate_proof` derived both from the prover's own plaintext inputs with no secret, signature, or commitment — so any client could fabricate `is_valid: true` and a matching hash to pass off an overweight axle as verified. `timestamp` was also hardcoded.

## Fix

Replaced the forgeable scheme with a real Ed25519 proof scheme, consistent with the crate's existing `main.rs` verifier:

- `weight_proof.rs`: `generate_proof(input, signing_key)` signs a canonical, length-prefixed payload `(axle_weight_kg, max_legal_limit_kg, nonce, timestamp)` with the device-held secret key. The timestamp is now the current Unix time (`now_seconds()`). `WeightProofOutput` carries the plaintext weight fields, timestamp, and `signature_hex` — no `is_valid` flag.
- `verifier.rs`: `verify_proof(proof, max_allowed_limit, verifying_key, now)` independently rejects `axle_weight_kg > max_allowed_limit`, enforces timestamp freshness (±5 min skew), and verifies the Ed25519 signature over the canonical payload.
- Added `src/lib.rs` (`pub mod verifier; pub mod weight_proof;`) so the crate's integration tests actually compile.
- Regenerated `tests/proof_test.rs` with valid/overweight/forged/tampered/stale/future coverage.

## Files changed

- `services/zkp-verifier-rust/src/weight_proof.rs`
- `services/zkp-verifier-rust/src/verifier.rs`
- `services/zkp-verifier-rust/src/lib.rs`
- `services/zkp-verifier-rust/tests/proof_test.rs`

## Testing

Cargo is not installed in this environment, so `cargo test` could not be run. The implementation mirrors the exact `ed25519-dalek` v2 API already used and tested in `main.rs` (`SigningKey::sign`, `VerifyingKey::verify_strict`, `[u8; 64]` signatures). Tests should be run via `cargo test` in CI.

Closes #7841
