### PR TITLE
fix(k8s): remove /graphql route to nonexistent graphql-service

### DIFF
--- a/k8s/istio/gateway.yaml
+++ b/k8s/istio/gateway.yaml
@@ -54,14 +54,6 @@ spec:
           number: 5000
   - match:
     - uri:
-        prefix: /graphql
-    route:
-    - destination:
-        host: graphql-service
-        port:
-          number: 4000
-  - match:
-    - uri:
         prefix: /docs
     route:
     - destination:


### PR DESCRIPTION
## Problem

The Istio `VirtualService` in `k8s/istio/gateway.yaml` routed `/graphql` to host `graphql-service` (port 4000), but a repo-wide search shows that is the only reference to that host — there is no `Service`, `Deployment`, or endpoints named `graphql-service` anywhere under `k8s/`. Every GraphQL request through the gateway hit a black hole (404/503).

## Fix

Removed the `/graphql` route block from the VirtualService. `backend/graphql` has no Dockerfile or Deployment in the repo, so adding a Service would have created another dead route with no endpoints; removing the route keeps the manifest set internally consistent.

## Files changed

- `k8s/istio/gateway.yaml`

## Testing

Review that no other mesh config references `graphql-service`. Manifest apply should be re-run in CI.

Closes #7844
