### PR TITLE
fix(driver-app): fetch completed trips for fuel analytics

### DIFF
--- a/apps/driver/lib/services/fuel_analytics_service.dart
+++ b/apps/driver/lib/services/fuel_analytics_service.dart
@@ -6,7 +6,7 @@ class FuelAnalyticsService {
   Future<Map<String, dynamic>> calculateAnalytics(double averageMpg) async {
     try {
       // Fetch all completed trips for this driver
-      final trips = await _tripService.fetchTrips(status: 'delivered');
+      final trips = await _tripService.fetchTrips(status: 'completed');
       
       double totalDistanceKm = 0;
       double totalPayout = 0;


### PR DESCRIPTION
## Problem

`FuelAnalyticsService.calculateAnalytics` fetched trips with `status: 'delivered'`, but the `trips` table only allows `active`, `completed`, and `cancelled` (the backend route filters `query.eq('status', status)`). The query always returned an empty list, so the fuel-analytics screen showed zero trips, zero payout, and no chart points.

## Fix

Fetch `status: 'completed'` so completed trips are actually loaded into the analytics.

## Files changed

- `apps/driver/lib/services/fuel_analytics_service.dart`

## Testing

Single-line change; behavior verified against the backend trip status constraint. Flutter analyze could not run locally (dart is not installed in this environment); CI should run `flutter analyze`/tests.

Closes #7845
