### PR TITLE
fix(driver-app,backend): parse nested earnings statement so PDF is populated

### DIFF
--- a/apps/driver/lib/models/earnings_statement_model.dart
+++ b/apps/driver/lib/models/earnings_statement_model.dart
@@ -22,6 +22,15 @@ class EarningsStatementModel {
   });
 
   factory EarningsStatementModel.fromJson(Map<String, dynamic> json) {
+    // Backend GET /api/profile/driver/statement returns a nested shape:
+    //   { driver_name, driver_phone, start_date, end_date,
+    //     summary: { total_trips, total_base_freight, total_platform_fees,
+    //                total_toll_estimate, total_net_earnings },
+    //     trips: [{ id, order_display_id, pickup_address, drop_address,
+    //               pickup_date, base_freight, platform_fee, toll_estimate,
+    //               net_earnings, status }] }
+    // Flat keys are still honoured as a fallback.
+    final summary = json['summary'] as Map<String, dynamic>? ?? {};
     final tripsList = (json['trips'] as List? ?? [])
         .map((t) => TripEarningRow.fromJson(t as Map<String, dynamic>))
         .toList();
@@ -31,10 +40,10 @@ class EarningsStatementModel {
       driverPhone: json['driver_phone'] as String?,
       startDate: DateTime.tryParse(json['start_date'] as String? ?? '') ?? DateTime.now(),
       endDate: DateTime.tryParse(json['end_date'] as String? ?? '') ?? DateTime.now(),
-      totalTrips: (json['total_trips'] as num?)?.toInt() ?? tripsList.length,
-      totalEarnings: _parsePaisa(json['total_earnings']),
-      platformFees: _parsePaisa(json['platform_fees']),
-      netEarnings: _parsePaisa(json['net_earnings']),
+      totalTrips: (summary['total_trips'] ?? json['total_trips'] as num?)?.toInt() ?? tripsList.length,
+      totalEarnings: _parsePaisa(summary['total_base_freight'] ?? json['total_earnings']),
+      platformFees: _parsePaisa(summary['total_platform_fees'] ?? json['platform_fees']),
+      netEarnings: _parsePaisa(summary['total_net_earnings'] ?? json['net_earnings']),
       trips: tripsList,
     );
   }
@@ -66,6 +75,8 @@ class TripEarningRow {
   final String? customerName;
   final double earnings;
   final double? platformFee;
+  final double? tollEstimate;
+  final String? status;
 
   TripEarningRow({
     this.tripId,
@@ -75,22 +86,38 @@ class TripEarningRow {
     this.customerName,
     required this.earnings,
     this.platformFee,
+    this.tollEstimate,
+    this.status,
   });
 
   factory TripEarningRow.fromJson(Map<String, dynamic> json) {
+    // Backend trip rows use id/order_display_id/pickup_date/pickup_address/
+    // drop_address/base_freight/platform_fee/toll_estimate/net_earnings/status;
+    // the previous flat keys (trip_id/display_id/trip_date/route/earnings) are
+    // kept as fallbacks.
+    final pickup = json['pickup_address'] as String?;
+    final drop = json['drop_address'] as String?;
+    final route = json['route'] as String? ??
+        (pickup != null && drop != null ? '$pickup → $drop' : json['route_label'] as String?);
+
     return TripEarningRow(
-      tripId: json['trip_id'] as String?,
-      displayId: json['display_id'] as String?,
-      tripDate: json['trip_date'] != null
-          ? DateTime.tryParse(json['trip_date'] as String)
+      tripId: json['trip_id'] as String? ?? json['id'] as String?,
+      displayId: json['display_id'] as String? ?? json['order_display_id'] as String?,
+      tripDate: (json['trip_date'] ?? json['pickup_date']) != null
+          ? DateTime.tryParse((json['trip_date'] ?? json['pickup_date']) as String)
           : null,
-      route: json['route'] as String? ?? json['route_label'] as String?,
+      route: route,
       customerName: json['customer_name'] as String? ??
           json['customer_display_name'] as String?,
-      earnings: EarningsStatementModel._parsePaisa(json['earnings']),
+      earnings: EarningsStatementModel._parsePaisa(
+          json['net_earnings'] ?? json['earnings'] ?? json['base_freight']),
       platformFee: json['platform_fee'] != null
           ? EarningsStatementModel._parsePaisa(json['platform_fee'])
           : null,
+      tollEstimate: json['toll_estimate'] != null
+          ? EarningsStatementModel._parsePaisa(json['toll_estimate'])
+          : null,
+      status: json['status'] as String?,
     );
   }
 
@@ -102,5 +129,7 @@ class TripEarningRow {
         'customer_name': customerName,
         'earnings': (earnings * 100).toInt(),
         'platform_fee': platformFee != null ? (platformFee! * 100).toInt() : null,
+        'toll_estimate': tollEstimate != null ? (tollEstimate! * 100).toInt() : null,
+        'status': status,
       };
 }

--- a/apps/driver/test/earnings_export_service_test.dart
+++ b/apps/driver/test/earnings_export_service_test.dart
@@ -68,6 +68,69 @@ void main() {
       expect(model.trips, isEmpty);
     });
 
+    test('fromJson parses nested backend response correctly', () {
+      final json = {
+        'driver_name': 'Ramesh Kumar',
+        'driver_phone': '+919876543210',
+        'start_date': '2026-06-01',
+        'end_date': '2026-06-30',
+        'summary': {
+          'total_trips': 2,
+          'total_base_freight': 800000,
+          'total_platform_fees': 80000,
+          'total_toll_estimate': 12000,
+          'total_net_earnings': 720000,
+        },
+        'trips': [
+          {
+            'id': 'trip-1',
+            'order_display_id': 'TRP-001',
+            'pickup_address': 'Delhi',
+            'drop_address': 'Agra',
+            'pickup_date': '2026-06-05',
+            'base_freight': 500000,
+            'platform_fee': 50000,
+            'toll_estimate': 5000,
+            'net_earnings': 450000,
+            'status': 'delivered',
+          },
+          {
+            'id': 'trip-2',
+            'order_display_id': 'TRP-002',
+            'pickup_address': 'Agra',
+            'drop_address': 'Jaipur',
+            'pickup_date': '2026-06-12',
+            'base_freight': 300000,
+            'platform_fee': 30000,
+            'toll_estimate': 7000,
+            'net_earnings': 270000,
+            'status': 'delivered',
+          },
+        ],
+      };
+
+      final model = EarningsStatementModel.fromJson(json);
+
+      expect(model.driverName, equals('Ramesh Kumar'));
+      expect(model.driverPhone, equals('+919876543210'));
+      expect(model.startDate, equals(DateTime(2026, 6, 1)));
+      expect(model.endDate, equals(DateTime(2026, 6, 30)));
+      expect(model.totalTrips, equals(2));
+      expect(model.totalEarnings, equals(8000.0));
+      expect(model.platformFees, equals(800.0));
+      expect(model.netEarnings, equals(7200.0));
+      expect(model.trips.length, equals(2));
+      expect(model.trips[0].tripId, equals('trip-1'));
+      expect(model.trips[0].displayId, equals('TRP-001'));
+      expect(model.trips[0].tripDate, equals(DateTime(2026, 6, 5)));
+      expect(model.trips[0].route, equals('Delhi → Agra'));
+      expect(model.trips[0].earnings, equals(4500.0));
+      expect(model.trips[0].platformFee, equals(500.0));
+      expect(model.trips[0].tollEstimate, equals(50.0));
+      expect(model.trips[0].status, equals('delivered'));
+      expect(model.trips[1].earnings, equals(2700.0));
+    });
+
     test('fromJson handles null fields gracefully', () {
       final json = {
         'start_date': '2026-06-01',

--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -565,6 +565,18 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
       return res.status(500).json({ error: 'Failed to fetch statement records.', details: error.message });
     }
 
+    // Fetch the driver's name/phone so the statement PDF shows the real driver
+    // instead of the app-side 'Driver' fallback.
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('full_name, phone')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (profileError) {
+      return res.status(500).json({ error: 'Failed to fetch driver profile.', details: profileError.message });
+    }
+
     // Compute totals
     let totalBaseFreight = 0;
     let totalPlatformFees = 0;
@@ -623,6 +635,10 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
     }
 
     res.json({
+      driver_name: profile?.full_name ?? null,
+      driver_phone: profile?.phone ?? null,
+      start_date: start_date ?? null,
+      end_date: end_date ?? null,
       summary: {
         total_trips: tripsList.length,
         total_base_freight: totalBaseFreight,


### PR DESCRIPTION
## Problem

The driver earnings-statement PDF rendered all-zero totals and blank trip rows because `EarningsStatementModel.fromJson` expected flat keys (`driver_name`, `total_earnings`, `platform_fees`, `net_earnings`, and trip rows keyed `trip_id`/`display_id`/`trip_date`/`route`/`earnings`) while `GET /api/profile/driver/statement` returns a nested `summary` + `trips` shape keyed `id`/`order_display_id`/`pickup_address`/`drop_address`/`pickup_date`/`base_freight`/`platform_fee`/`toll_estimate`/`net_earnings`/`status`. The PDF fell back to `'Driver'`, today's date, ₹0 totals, and `- / - / - / ₹0` rows.

## Fix

- **Model** (`apps/driver/lib/models/earnings_statement_model.dart`):
  - Read totals from `json['summary']['total_trips' | 'total_base_freight' | 'total_platform_fees' | 'total_net_earnings']` (flat keys kept as fallbacks).
  - Map trip rows from `json['trips'][*]`: `id`→tripId, `order_display_id`→displayId, `pickup_date`→tripDate, route built from `pickup_address → drop_address`, earnings from `net_earnings`, plus `platform_fee`, `toll_estimate`, and `status`.
- **Backend** (`backend/api/src/routes/profileRoutes.js`): the statement response now also returns `driver_name` (profiles.full_name), `driver_phone` (profiles.phone), and the requested `start_date`/`end_date` so the PDF header and date-range sections show the driver's real name and range.
- Added a regression test for the nested shape in `apps/driver/test/earnings_export_service_test.dart`.

## Files changed

- `apps/driver/lib/models/earnings_statement_model.dart`
- `backend/api/src/routes/profileRoutes.js`
- `apps/driver/test/earnings_export_service_test.dart`

## Testing

`node --check` passes for the backend change. Dart tests could not be executed locally (dart is not installed in this environment); CI should run `flutter test`/`flutter analyze`.

Closes #7846
