### PR TITLE
fix(customer-app): carry reefer requirement and temperature range into RouteDraft

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -335,6 +335,9 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
       minCapacity: _filterMinCapacity > 0 ? _filterMinCapacity : null,
       maxCapacity: _filterMaxCapacity < 25 ? _filterMaxCapacity : null,
       materialType: _filterMaterialType != 'Any' ? _filterMaterialType : null,
+      requiresRefrigeration: _requirements.contains('Temperature control'),
+      targetTemperatureMin: double.tryParse(_tempMinController.text),
+      targetTemperatureMax: double.tryParse(_tempMaxController.text),
     );
   }
 


### PR DESCRIPTION
## Problem

`find_trucks_screen.dart` collected the temperature-control (reefer) inputs but `_buildDraft()` never copied `requiresRefrigeration`, `targetTemperatureMin`, or `targetTemperatureMax` onto the `RouteDraft`. Downstream, `booking_confirmation_screen.dart` reads `widget.draft.requiresRefrigeration ?? false` and the `null` temps, so `createOrder` never sent `requires_refrigeration`/`target_temperature_min`/`target_temperature_max` — the customer's cold-chain requirement was reduced to a loose string and silently lost.

## Fix

Populate the fields in `_buildDraft()`:

```dart
requiresRefrigeration: _requirements.contains('Temperature control'),
targetTemperatureMin: double.tryParse(_tempMinController.text),
targetTemperatureMax: double.tryParse(_tempMaxController.text),
```

The restore path (lines 158-162) already re-populates `_requirements` and the temperature controllers from a pending draft, so round-tripping stays consistent.

## Files changed

- `apps/customer/lib/screens/find_trucks_screen.dart`

## Testing

Verified the downstream consumer (`booking_confirmation_screen.dart:157-159`) reads exactly these fields and that the draft restore path remains consistent. Flutter analyze could not run locally (dart not installed); CI should run `flutter analyze`.

Closes #7847
