### PR TITLE
fix(customer-app): humanize order status before in-transit comparison

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -160,6 +160,31 @@ class _HomeScreenState extends State<HomeScreen> {
     return parts.first.trim();
   }
 
+  String _formatStatus(String status) {
+    switch (status) {
+      case 'driver_assigned':
+      case 'accepted':
+        return 'Accepted';
+      case 'in_transit':
+        return 'In Transit';
+      case 'payment_released':
+      case 'completed':
+      case 'delivered':
+        return 'Delivered';
+      case 'cancelled':
+        return 'Cancelled';
+      case 'pending':
+        return 'Pending';
+      default:
+        return status
+            .split('_')
+            .map((word) => word.isEmpty
+                ? word
+                : '${word[0].toUpperCase()}${word.substring(1)}')
+            .join(' ');
+    }
+  }
+
   ShipmentCardData? _buildShipmentFromOrder(Map<String, dynamic> order) {
     final route = '${order['pickup_city'] ?? '?'} \u2192 ${order['drop_city'] ?? '?'}';
     final rawDriverName = order['driver_name']?.toString() ?? '';
@@ -167,7 +192,9 @@ class _HomeScreenState extends State<HomeScreen> {
     final driverName = hasDriver ? rawDriverName : '';
     final truckNum = order['truck_number']?.toString() ?? '';
     final driver = driverName.isNotEmpty ? '$driverName | $truckNum' : (truckNum.isNotEmpty ? truckNum : 'Assigning driver');
-    final status = order['status']?.toString() ?? 'Active';
+    // The API returns snake_case statuses; humanize before comparing so the
+    // in-transit styling/live badge actually triggers.
+    final status = _formatStatus(order['status']?.toString() ?? 'pending');
     final eta = order['estimated_arrival']?.toString() ?? 'Pending';
 
     return ShipmentCardData(


### PR DESCRIPTION
## Problem

`_buildShipmentFromOrder` in `home_screen.dart` compared the raw snake_case API status (e.g. `in_transit`) against the Title-Cased label `'In Transit'`, which is never true. As a result the in-transit teal color and the live indicator were dead, and the card showed the raw `in_transit` string as the visible status label.

## Fix

Humanize the status before comparing and displaying, using the same mapping as `orders_screen.dart`:

```dart
final status = _formatStatus(order['status']?.toString() ?? 'pending');
...
statusColor: status == 'In Transit' ? const Color(0xFF00897B) : const Color(0xFFFFB300),
isLive: status == 'In Transit',
```

Added a private `_formatStatus` helper (mirroring `orders_screen.dart:74-97`) that maps `in_transit` → `In Transit`, plus `Accepted`/`Delivered`/`Cancelled`/`Pending` and a snake_case-to-title fallback.

## Files changed

- `apps/customer/lib/screens/home_screen.dart`

## Testing

Reviewed the mapping and the comparison/display paths. Flutter analyze could not run locally (dart not installed); CI should run `flutter analyze`.

Closes #7848
