### PR TITLE
fix(zkevm): enforce per-tx signature/nonce/balance checks in executeBatch (#7735)

### DIFF
--- a/blockchain/contracts/MockZkEVMVerifier.sol
+++ b/blockchain/contracts/MockZkEVMVerifier.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/// @notice Test-only verifier that accepts every proof so the zkEVM execution
+///         paths can be exercised without a real Groth16 proof. Never used in
+///         production deployments.
+contract MockZkEVMVerifier {
+    function verifyProof(
+        uint[2] memory,
+        uint[2][2] memory,
+        uint[2] memory,
+        uint[2] memory
+    ) external pure returns (bool) {
+        return true;
+    }
+}

--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -100,48 +100,7 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
         uint256 gasLimit,
         bytes calldata signature
     ) external whenNotPaused returns (uint256) {
-        // Validate transaction
-        require(to != address(0), "Invalid address");
-        require(value >= 0, "Invalid value");
-        require(!usedNonces[from][nonce], "Nonce already used");
-        require(currentState.balances[from] >= value + gasPrice * gasLimit, "Insufficient balance");
-
-        // Verify signature
-        bytes32 txHash = keccak256(abi.encodePacked(from, to, value, data, nonce, gasPrice, gasLimit));
-        require(_verifySignature(txHash, signature, from), "Invalid signature");
-
-        // Execute transaction
-        uint256 txId = txCounter++;
-        currentState.balances[from] -= value + gasPrice * gasLimit;
-        currentState.balances[to] += value;
-        currentState.nonces[from] = nonce + 1;
-        usedNonces[from][nonce] = true;
-
-        // Store transaction
-        transactions[txId] = Transaction({
-            id: txId,
-            from: from,
-            to: to,
-            value: value,
-            data: data,
-            nonce: nonce,
-            gasPrice: gasPrice,
-            gasLimit: gasLimit,
-            signature: signature,
-            timestamp: block.timestamp
-        });
-
-        // Update state root
-        currentState.root = keccak256(abi.encodePacked(
-            currentState.root,
-            from,
-            to,
-            value,
-            nonce
-        ));
-        globalStateRoot = currentState.root;
-
-        emit TransactionExecuted(txId, from, to, value);
+        (uint256 txId, ) = _applyTx(from, to, value, data, nonce, gasPrice, gasLimit, signature);
         return txId;
     }
 
@@ -161,30 +120,14 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             (address from, address to, uint256 value, bytes memory data, uint256 nonce, uint256 gasPrice, uint256 gasLimit, bytes memory signature) = 
                 abi.decode(transactionsData[i], (address, address, uint256, bytes, uint256, uint256, uint256, bytes));
 
-            uint256 txId = txCounter++;
-            bytes32 txHash = keccak256(transactionsData[i]);
-            txHashes[i] = txHash;
-
+            // Batch-level dedup on the canonical tx digest before applying.
+            bytes32 txHash = _txHash(from, to, value, data, nonce, gasPrice, gasLimit);
             require(!processedTxHashes[txHash], "Duplicate transaction");
             processedTxHashes[txHash] = true;
 
-            // Execute
-            currentState.balances[from] -= value + gasPrice * gasLimit;
-            currentState.balances[to] += value;
-            currentState.nonces[from] = nonce + 1;
-
-            transactions[txId] = Transaction({
-                id: txId,
-                from: from,
-                to: to,
-                value: value,
-                data: data,
-                nonce: nonce,
-                gasPrice: gasPrice,
-                gasLimit: gasLimit,
-                signature: signature,
-                timestamp: block.timestamp
-            });
+            // Same per-tx signature/nonce/balance checks as the single-tx path.
+            _applyTx(from, to, value, data, nonce, gasPrice, gasLimit, signature);
+            txHashes[i] = txHash;
         }
 
         // Submit batch
@@ -292,6 +235,76 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
     }
 
     // ============ Internal Functions ============
+
+    /**
+     * @dev Apply a single transaction with the full signature/nonce/balance
+     *      validation. Shared by executeTransaction and executeBatch so the two
+     *      paths cannot diverge again (issue #7735).
+     */
+    function _applyTx(
+        address from,
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce,
+        uint256 gasPrice,
+        uint256 gasLimit,
+        bytes memory signature
+    ) internal returns (uint256 txId, bytes32 txHash) {
+        // CHECKS
+        require(to != address(0), "Invalid address");
+        require(!usedNonces[from][nonce], "Nonce already used");
+        require(currentState.balances[from] >= value + gasPrice * gasLimit, "Insufficient balance");
+
+        // Verify the sender's signature over the canonical tx digest.
+        txHash = _txHash(from, to, value, data, nonce, gasPrice, gasLimit);
+        require(_verifySignature(txHash, signature, from), "Invalid signature");
+
+        // EFFECTS
+        txId = txCounter++;
+        currentState.balances[from] -= value + gasPrice * gasLimit;
+        currentState.balances[to] += value;
+        currentState.nonces[from] = nonce + 1;
+        usedNonces[from][nonce] = true;
+
+        // STORE
+        transactions[txId] = Transaction({
+            id: txId,
+            from: from,
+            to: to,
+            value: value,
+            data: data,
+            nonce: nonce,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            signature: signature,
+            timestamp: block.timestamp
+        });
+
+        // UPDATE STATE ROOT
+        currentState.root = keccak256(abi.encodePacked(
+            currentState.root,
+            from,
+            to,
+            value,
+            nonce
+        ));
+        globalStateRoot = currentState.root;
+
+        emit TransactionExecuted(txId, from, to, value);
+    }
+
+    function _txHash(
+        address from,
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce,
+        uint256 gasPrice,
+        uint256 gasLimit
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(from, to, value, data, nonce, gasPrice, gasLimit));
+    }
 
     function _verifyProof(bytes calldata proof) internal view returns (bool) {
         require(proof.length > 0, "Empty proof");

--- a/blockchain/contracts/zkEVM.test.js
+++ b/blockchain/contracts/zkEVM.test.js
@@ -1,0 +1,173 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const ZERO_DATA = "0x";
+const GAS_PRICE = 10n;
+const GAS_LIMIT = 1000n;
+const FEE = GAS_PRICE * GAS_LIMIT;
+
+async function deployZkEVM() {
+  const [owner, alice, bob, attacker] = await ethers.getSigners();
+  const MockVerifier = await ethers.getContractFactory("MockZkEVMVerifier");
+  const verifier = await MockVerifier.deploy();
+  const zk = await ethers.getContractFactory("zkEVM");
+  const contract = await zk.deploy(await verifier.getAddress());
+  return { contract, owner, alice, bob, attacker };
+}
+
+function validProof() {
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ["uint256[2]", "uint256[2][2]", "uint256[2]", "uint256[2]"],
+    [[1n, 2n], [[3n, 4n], [5n, 6n]], [7n, 8n], [9n, 10n]]
+  );
+}
+
+async function signTx(signer, tx) {
+  const { from, to, value, data, nonce, gasPrice, gasLimit } = tx;
+  const digest = ethers.solidityPackedKeccak256(
+    ["address", "address", "uint256", "bytes", "uint256", "uint256", "uint256"],
+    [from, to, value, data, nonce, gasPrice, gasLimit]
+  );
+  return signer.signMessage(ethers.getBytes(digest));
+}
+
+function encodeBatchTx(tx) {
+  const { from, to, value, data, nonce, gasPrice, gasLimit, signature } = tx;
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ["address", "address", "uint256", "bytes", "uint256", "uint256", "uint256", "bytes"],
+    [from, to, value, data, nonce, gasPrice, gasLimit, signature]
+  );
+}
+
+describe("zkEVM", function () {
+  describe("executeTransaction (single-tx path)", function () {
+    it("executes a signed transaction", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("2") });
+
+      const tx = {
+        from: alice.address,
+        to: bob.address,
+        value: ethers.parseEther("1"),
+        data: ZERO_DATA,
+        nonce: 0n,
+        gasPrice: GAS_PRICE,
+        gasLimit: GAS_LIMIT,
+      };
+      const signature = await signTx(alice, tx);
+
+      await expect(contract.executeTransaction(
+        tx.from, tx.to, tx.value, tx.data, tx.nonce, tx.gasPrice, tx.gasLimit, signature
+      )).to.emit(contract, "TransactionExecuted");
+
+      expect(await contract.getBalance(alice.address)).to.equal(ethers.parseEther("2") - ethers.parseEther("1") - FEE);
+      expect(await contract.getBalance(bob.address)).to.equal(ethers.parseEther("1"));
+      expect(await contract.getNonce(alice.address)).to.equal(1n);
+    });
+  });
+
+  describe("executeBatch — per-tx signature/nonce/balance checks (issue #7735)", function () {
+    it("executes a batch of validly signed transactions", async function () {
+      const { contract, owner, alice, bob, attacker } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("3") });
+      await contract.connect(bob).depositToL2({ value: ethers.parseEther("2") });
+
+      const txs = [
+        { from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT },
+        { from: bob.address, to: attacker.address, value: ethers.parseEther("0.5"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT },
+      ];
+      for (const t of txs) t.signature = await signTx(t.from === alice.address ? alice : bob, t);
+
+      await expect(contract.connect(owner).executeBatch(
+        txs.map(encodeBatchTx), validProof()
+      )).to.emit(contract, "BatchSubmitted");
+
+      expect(await contract.getBalance(alice.address)).to.equal(ethers.parseEther("3") - ethers.parseEther("1") - FEE);
+      expect(await contract.getBalance(bob.address)).to.equal(ethers.parseEther("2") + ethers.parseEther("1") - ethers.parseEther("0.5") - FEE);
+      expect(await contract.getBalance(attacker.address)).to.equal(ethers.parseEther("0.5"));
+    });
+
+    it("reverts the whole batch when a tx has a forged signature", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("2") });
+
+      const tx = {
+        from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA,
+        nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT,
+        signature: (await signTx(bob, {
+          from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA,
+          nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT,
+        })), // signed by the wrong party
+      };
+
+      await expect(
+        contract.connect(owner).executeBatch([encodeBatchTx(tx)], validProof())
+      ).to.be.revertedWith("Invalid signature");
+      expect(await contract.getBalance(alice.address)).to.equal(ethers.parseEther("2"));
+    });
+
+    it("reverts the whole batch when a tx reuses a nonce", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("3") });
+
+      const first = { from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT };
+      first.signature = await signTx(alice, first);
+      await contract.connect(owner).executeBatch([encodeBatchTx(first)], validProof());
+
+      // Same nonce again with different content (different tx digest), even
+      // with a fresh signature — the usedNonces gate rejects it.
+      const second = { from: alice.address, to: bob.address, value: ethers.parseEther("0.5"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT };
+      second.signature = await signTx(alice, second);
+
+      await expect(
+        contract.connect(owner).executeBatch([encodeBatchTx(second)], validProof())
+      ).to.be.revertedWith("Nonce already used");
+    });
+
+    it("reverts the whole batch when from lacks balance (no negative balances)", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("0.1") });
+
+      const tx = { from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT };
+      tx.signature = await signTx(alice, tx);
+
+      await expect(
+        contract.connect(owner).executeBatch([encodeBatchTx(tx)], validProof())
+      ).to.be.revertedWith("Insufficient balance");
+      expect(await contract.getBalance(alice.address)).to.equal(ethers.parseEther("0.1"));
+    });
+
+    it("rejects duplicate transactions within a batch", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("3") });
+
+      const tx = { from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT };
+      tx.signature = await signTx(alice, tx);
+      const encoded = encodeBatchTx(tx);
+
+      await expect(
+        contract.connect(owner).executeBatch([encoded, encoded], validProof())
+      ).to.be.revertedWith("Duplicate transaction");
+    });
+
+    it("is only callable by the owner", async function () {
+      const { contract, attacker } = await deployZkEVM();
+      await expect(
+        contract.connect(attacker).executeBatch([], validProof())
+      ).to.be.revertedWithCustomError(contract, "OwnableUnauthorizedAccount");
+    });
+
+    it("rejects an empty proof", async function () {
+      const { contract, owner, alice, bob } = await deployZkEVM();
+      await contract.connect(alice).depositToL2({ value: ethers.parseEther("2") });
+
+      const tx = { from: alice.address, to: bob.address, value: ethers.parseEther("1"), data: ZERO_DATA, nonce: 0n, gasPrice: GAS_PRICE, gasLimit: GAS_LIMIT };
+      tx.signature = await signTx(alice, tx);
+
+      await expect(
+        contract.connect(owner).executeBatch([encodeBatchTx(tx)], "0x")
+      ).to.be.revertedWith("Empty proof");
+      expect(await contract.getBalance(alice.address)).to.equal(ethers.parseEther("2"));
+    });
+  });
+});


### PR DESCRIPTION
## Analysis

`zkEVM.executeBatch` skipped the per-transaction validation that the single-tx path (`executeTransaction`) enforces:

- **No signature check** — `transactionsData[i]` was decoded but its signature never verified, so anyone could submit a batch executing arbitrary transactions.
- **No balance check** — the batch only relied on arithmetic underflow reverting, which is weaker and inconsistent with the explicit `Insufficient balance` gate on the single-tx path.
- **Weak dedup digest** — the batch-level duplicate check used `keccak256(transactionsData[i])` (the raw calldata bytes) instead of the canonical transaction digest used everywhere else, so identical logical transactions encoded differently could bypass dedup.

Closes #7735.

## Changes

- Extracted the full check → effects → store → state-root update sequence from `executeTransaction` into a shared `_applyTx` helper, now used by both `executeTransaction` and `executeBatch` so the two paths cannot diverge again.
- `_applyTx` enforces, per transaction: `to != address(0)`, `usedNonces[from][nonce]` (`Nonce already used`), balance `>= value + gasPrice * gasLimit` (`Insufficient balance`), and `_verifySignature` over the canonical digest (`Invalid signature`).
- Batch dedup now runs *before* applying, on the canonical digest via a shared `_txHash` helper (same digest the signature covers), and is keyed off the same digest as `executeTransaction`.
- Added `blockchain/contracts/zkEVM.test.js` (chai) and `blockchain/contracts/MockZkEVMVerifier.sol` (test-only always-true proof verifier) covering: valid batch execution, forged signature reverts the whole batch, nonce reuse (fresh signature, same nonce), insufficient balance (no negative balances), in-batch duplicates, owner-only gating, and empty-proof rejection.

## Testing

- `blockchain/_tmp_zk`: `npx hardhat test test/zkEVM.test.js` — 8/8 passing.
