### PR TITLE
fix: demandRoutes mark repositioningAreas as mock data

### DIFF
--- a/backend/api/src/routes/demandRoutes.js
+++ b/backend/api/src/routes/demandRoutes.js
@@ -63,8 +63,8 @@ router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'),
     };
 
     const repositioningAreas = [
-      { zone: 'Central Hub / Logistics District', suggestedDrivers: 5, priority: 'HIGH' },
-      { zone: 'Industrial Corridor Sector B', suggestedDrivers: 3, priority: 'MEDIUM' }
+      { zone: 'Central Hub / Logistics District', suggestedDrivers: 5, priority: 'HIGH', isMockData: true },
+      { zone: 'Industrial Corridor Sector B', suggestedDrivers: 3, priority: 'MEDIUM', isMockData: true }
     ];
 
     // 3. Construct GeoJSON


### PR DESCRIPTION
fix(routes/demandRoutes.js): mark repositioningAreas as mock data

Closes #7887

GSSOC-2026

Please assign this PR to the `tmdeveloper007` account.

GSSOC-2026