### PR TITLE
fix: truckRoutes extract hardcoded truck types to constant

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -93,6 +93,8 @@ import { getLiveTrafficMultiplier } from '../services/trafficService.js';
 import { escapeLike } from '../lib/escapeLike.js';
 import logger from '../middleware/logger.js';
 
+const DEFAULT_TRUCK_TYPES = ['Open Body', 'Closed Body', 'Container', 'Refrigerated'];
+
 function sanitizeNumberPlate(plate) {
   if (!plate || typeof plate !== 'string') return '';
   return plate.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
@@ -133,7 +135,7 @@ const router = express.Router();
  */
 router.get('/types', authenticate, userLimiter, (req, res) => {
   return res.json({
-    types: ['Open Body', 'Closed Body', 'Container', 'Refrigerated']
+    types: DEFAULT_TRUCK_TYPES
   });
 });
 function parseCapacityFilter(value, field) {


### PR DESCRIPTION
fix(routes/truckRoutes.js): extract hardcoded truck types to constant

Closes #7888

GSSOC-2026

Please assign this PR to the `tmdeveloper007` account.

GSSOC-2026