### PR TITLE
fix: webhookRoutes include orderId in error response

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -82,6 +82,7 @@ router.post('/escrow', verifyWebhookSignature, async (req, res) => {
     return res.status(202).json({
       received: true,
       status: 'queued_for_retry',
+      error: `Webhook processing failed for order ${orderId}: ${error?.message || 'Unknown error'}`,
     });
   }
 });


### PR DESCRIPTION
fix(routes/webhookRoutes.js): include orderId in webhook error response

Closes #7890

GSSOC-2026

Please assign this PR to the `tmdeveloper007` account.

GSSOC-2026