### PR TITLE
fix: profileCache snapshot counters atomically in getCacheStats

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -40,13 +40,17 @@ let cacheMisses = 0;
 let cacheSets = 0;
 
 export function getCacheStats() {
-  const total = cacheHits + cacheMisses;
+  // Snapshot all counters in one read to avoid inconsistent intermediate sums
+  const hits = cacheHits;
+  const misses = cacheMisses;
+  const sets = cacheSets;
+  const total = hits + misses;
   return {
-    hits: cacheHits,
-    misses: cacheMisses,
-    sets: cacheSets,
+    hits,
+    misses,
+    sets,
     total,
-    hitRate: total > 0 ? ((cacheHits / total) * 100).toFixed(1) + "%" : "0%",
+    hitRate: total > 0 ? ((hits / total) * 100).toFixed(1) + '%' : '0%',
   };
 }
 


### PR DESCRIPTION
fix(lib/profileCache.js): snapshot counters atomically in getCacheStats

Closes #7891

GSSOC-2026

Please assign this PR to the `tmdeveloper007` account.

GSSOC-2026