### PR TITLE
fix(customer): wire booking confirmation success panel to escrow status check (#7737)

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -21,11 +21,24 @@ import '../core/api_client.dart';
 ///   5. POST /api/payments/lock { tx_hash } → backend verifies on-chain
 ///   6. Show "Payment Locked in Escrow 🔒" confirmation
 class BookingConfirmationScreen extends StatefulWidget {
-  const BookingConfirmationScreen(
-      {super.key, required this.draft, required this.truck});
+  const BookingConfirmationScreen({
+    super.key,
+    required this.draft,
+    required this.truck,
+    this.orderService,
+    this.paymentRepository,
+    this.addressRepository,
+    this.apiClient,
+  });
 
   final RouteDraft draft;
   final TruckResultData truck;
+
+  /// Test seam — defaults are constructed in the state when null.
+  final OrderService? orderService;
+  final PaymentRepository? paymentRepository;
+  final AddressRepository? addressRepository;
+  final ApiClient? apiClient;
 
   @override
   State<BookingConfirmationScreen> createState() =>
@@ -34,9 +47,9 @@ class BookingConfirmationScreen extends StatefulWidget {
 
 class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     with SingleTickerProviderStateMixin {
-  final _paymentRepo = PaymentRepository();
-  final _addressRepo = AddressRepository();
-  final _apiClient = ApiClient();
+  late final PaymentRepository _paymentRepo;
+  late final AddressRepository _addressRepo;
+  late final ApiClient _apiClient;
 
   bool _showSuccess = false;
   bool _isLoading = true;
@@ -48,6 +61,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   String? _upiDeepLink;
   String? _amountInr;
   String? _upiIntentError;
+  String? _lockError;
 
   late final AnimationController _controller;
   late final OrderService _orderService;
@@ -60,7 +74,10 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
   @override
   void initState() {
     super.initState();
-    _orderService = OrderService();
+    _orderService = widget.orderService ?? OrderService();
+    _paymentRepo = widget.paymentRepository ?? PaymentRepository();
+    _addressRepo = widget.addressRepository ?? AddressRepository();
+    _apiClient = widget.apiClient ?? ApiClient();
     _controller = AnimationController(
         vsync: this, duration: const Duration(milliseconds: 600));
     _loadCheckoutData();
@@ -236,26 +253,61 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     }
   }
 
-  // ── Step 4: Lock payment after UPI success ────────────────────────────────
-  // POST /api/payments/lock requires the real on-chain tx_hash that the wallet
+  // ── Step 4: Verify payment after UPI success ───────────────────────────────
+  // POST /api/payments/lock requires the real on-chain tx_hash that a wallet
   // SDK returns once `createBooking` is mined; recordDepositTx() verifies it
   // against Polygon. No wallet SDK is integrated in this app, so there is no
-  // real hash to submit. Fabricating one would post a hash the backend can
-  // never verify — the escrow would never lock and the booking would stay
-  // stuck in `funding`. Fail closed instead: never send a fake hash and never
-  // report the payment as locked.
+  // real hash to submit — fabricating one would post a hash the backend can
+  // never verify and the escrow would never lock.
+  //
+  // Instead we poll GET /api/payments/:orderId/status and only show the
+  // success panel when the backend reports escrow_status == 'funded'. Any
+  // other result renders a retryable pending state with a path back to the
+  // bookings list — never a false confirmation, never a dead-end.
   Future<void> _confirmPaymentLocked() async {
-    if (_createdOrderId == null) return;
+    final orderId = _createdOrderId;
+    if (orderId == null || _isSubmitting) return;
 
+    setState(() {
+      _isSubmitting = true;
+      _lockError = null;
+    });
+
+    try {
+      final body = await _apiClient.get('/api/payments/$orderId/status');
+      final escrowStatus =
+          body is Map<String, dynamic> ? body['escrow_status']?.toString() : null;
+
+      if (!mounted) return;
+
+      if (escrowStatus == 'funded') {
+        _showSuccessPanel();
+      } else {
+        setState(() {
+          _lockError = escrowStatus == null
+              ? 'We could not verify your payment right now. Please check again.'
+              : 'Your payment is still being verified (status: $escrowStatus). '
+                  'Please check again in a moment.';
+        });
+      }
+    } catch (e) {
+      debugPrint('Payment verification failed: $e');
+      if (!mounted) return;
+      setState(() {
+        _lockError =
+            'We could not verify your payment right now. Please check again.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  void _exitToBookings() {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-            'On-chain escrow confirmation is unavailable on this device. '
-            'Your booking is created, but the escrow could not be locked. '
-            'Please contact support to complete the payment.'),
-      ),
-    );
+    TruxifyScope.of(context).openOrders(tabIndex: 0);
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   void _showSuccessPanel() {
@@ -266,9 +318,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     });
     _controller.forward(from: 0).then((_) async {
       await Future<void>.delayed(const Duration(milliseconds: 1200));
-      if (!mounted) return;
-      TruxifyScope.of(context).openOrders(tabIndex: 0);
-      Navigator.of(context).popUntil((route) => route.isFirst);
+      _exitToBookings();
     });
   }
 
@@ -495,29 +545,36 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                           orderId: _createdOrderDisplayId ?? _createdOrderId ?? '',
                           amountInr: _amountInr,
                         )
-                      : _upiIntentError != null
-                          ? _UpiIntentErrorSheet(
-                              message: _upiIntentError!,
-                              isRetrying: _isSubmitting,
-                              onRetry: _retryUpiIntent,
+                      : _lockError != null
+                          ? _VerificationPendingSheet(
+                              message: _lockError!,
+                              isChecking: _isSubmitting,
+                              onCheckAgain: _confirmPaymentLocked,
+                              onBackToBookings: _exitToBookings,
                             )
-                          : _isAwaitingUpi
-                              ? _UpiPaymentSheet(
-                                  amountInr: _amountInr ?? widget.truck.price,
-                                  isSubmitting: _isSubmitting,
-                                  onLaunchUpi: _launchUpi,
-                                  onConfirmPaid: _confirmPaymentLocked,
+                          : _upiIntentError != null
+                              ? _UpiIntentErrorSheet(
+                                  message: _upiIntentError!,
+                                  isRetrying: _isSubmitting,
+                                  onRetry: _retryUpiIntent,
                                 )
-                              : PrimaryButton(
-                                  label: _isSubmitting
-                                      ? 'Creating booking...'
-                                      : (_isLoading
-                                          ? 'Loading...'
-                                          : 'Pay & Confirm'),
-                                  onPressed: _isLoading || _isSubmitting
-                                      ? null
-                                      : _createOrderAndInitiatePayment,
-                                ),
+                              : _isAwaitingUpi
+                                  ? _UpiPaymentSheet(
+                                      amountInr: _amountInr ?? widget.truck.price,
+                                      isSubmitting: _isSubmitting,
+                                      onLaunchUpi: _launchUpi,
+                                      onConfirmPaid: _confirmPaymentLocked,
+                                    )
+                                  : PrimaryButton(
+                                      label: _isSubmitting
+                                          ? 'Creating booking...'
+                                          : (_isLoading
+                                              ? 'Loading...'
+                                              : 'Pay & Confirm'),
+                                      onPressed: _isLoading || _isSubmitting
+                                          ? null
+                                          : _createOrderAndInitiatePayment,
+                                    ),
                 ),
               ],
             ),
@@ -826,6 +883,115 @@ class _SuccessPanel extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+// ── Payment Verification Pending Sheet ───────────────────────────────────────
+
+class _VerificationPendingSheet extends StatelessWidget {
+  const _VerificationPendingSheet({
+    required this.message,
+    required this.isChecking,
+    required this.onCheckAgain,
+    required this.onBackToBookings,
+  });
+
+  final String message;
+  final bool isChecking;
+  final VoidCallback onCheckAgain;
+  final VoidCallback onBackToBookings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: TruxifyColors.warning.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+            color: TruxifyColors.warning.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: TruxifyColors.warning.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(Icons.hourglass_top_rounded,
+                    color: TruxifyColors.warning, size: 22),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Verifying your payment',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleSmall
+                            ?.copyWith(fontWeight: FontWeight.w800)),
+                    Text('Your booking is created.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: TruxifyColors.adaptiveSecondaryText(
+                                context))),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(message,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: TruxifyColors.warning)),
+          const SizedBox(height: 14),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              id: 'btn_check_payment_status',
+              onPressed: isChecking ? null : onCheckAgain,
+              icon: isChecking
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Icon(Icons.refresh_rounded, size: 18),
+              label: Text(isChecking ? 'Checking...' : 'Check payment status'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: TruxifyColors.accentDark,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              id: 'btn_back_to_bookings',
+              onPressed: isChecking ? null : onBackToBookings,
+              icon: const Icon(Icons.arrow_back_rounded, size: 18),
+              label: const Text('Back to bookings'),
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+                side: BorderSide(
+                    color: TruxifyColors.accent.withValues(alpha: 0.5)),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/customer/test/screen/booking_confirmation_screen_test.dart
+++ b/apps/customer/test/screen/booking_confirmation_screen_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:truxify/controllers/app_controller.dart';
+import 'package:truxify/core/api_client.dart';
+import 'package:truxify/l10n/app_localizations.dart';
+import 'package:truxify/models/app_models.dart';
+import 'package:truxify/models/payment_method.dart';
+import 'package:truxify/models/saved_address.dart';
+import 'package:truxify/repositories/address_repository.dart';
+import 'package:truxify/repositories/payment_repository.dart';
+import 'package:truxify/screens/booking_confirmation_screen.dart';
+import 'package:truxify/services/order_service.dart';
+
+class MockOrderService extends Mock implements OrderService {}
+class MockApiClient extends Mock implements ApiClient {}
+class MockPaymentRepository extends Mock implements PaymentRepository {}
+class MockAddressRepository extends Mock implements AddressRepository {}
+
+const _draft = RouteDraft(
+  pickup: 'Surat, Gujarat',
+  drop: 'Mumbai, Maharashtra',
+  dateLabel: 'Today, 10:00 AM',
+  goodsType: 'General',
+  weightTonnes: '10',
+  dimensions: '10 x 5 x 5 ft',
+  stacked: false,
+  fragile: false,
+  requirements: [],
+  pickupLat: 21.17,
+  pickupLng: 72.83,
+  dropLat: 19.07,
+  dropLng: 72.87,
+);
+
+const _truck = TruckResultData(
+  driver: 'Suresh Kumar',
+  rating: 4.5,
+  truck: 'Eicher 14FT',
+  capacity: '10 Ton',
+  price: '₹12000',
+  eta: '3 hrs',
+  baseFreight: '₹11000',
+  tollEstimate: '₹500',
+  platformFee: '₹500',
+  truckNumber: 'GJ-05-XX-1234',
+);
+
+const _paymentMethod = PaymentMethod(
+  id: 'pm-1',
+  userId: 'u-1',
+  methodType: 'UPI',
+  displayLabel: 'GPay',
+  isDefault: true,
+);
+
+const _savedAddress = SavedAddress(
+  id: 'addr-1',
+  userId: 'u-1',
+  label: 'Home',
+  addressLine: '1 MG Road',
+  city: 'Surat',
+  state: 'Gujarat',
+  pincode: '395001',
+  latitude: 21.17,
+  longitude: 72.83,
+  isDefault: true,
+);
+
+void main() {
+  late MockOrderService mockOrderService;
+  late MockApiClient mockApiClient;
+  late MockPaymentRepository mockPaymentRepository;
+  late MockAddressRepository mockAddressRepository;
+
+  setUp(() {
+    mockOrderService = MockOrderService();
+    mockApiClient = MockApiClient();
+    mockPaymentRepository = MockPaymentRepository();
+    mockAddressRepository = MockAddressRepository();
+
+    when(() => mockPaymentRepository.fetchAll())
+        .thenAnswer((_) async => [_paymentMethod]);
+    when(() => mockAddressRepository.fetchAll())
+        .thenAnswer((_) async => [_savedAddress]);
+    when(() => mockOrderService.createOrder(
+      pickupAddress: any(named: 'pickupAddress'),
+      dropAddress: any(named: 'dropAddress'),
+      pickupLat: any(named: 'pickupLat'),
+      pickupLng: any(named: 'pickupLng'),
+      dropLat: any(named: 'dropLat'),
+      dropLng: any(named: 'dropLng'),
+      pickupTime: any(named: 'pickupTime'),
+      goodsType: any(named: 'goodsType'),
+      weightTonnes: any(named: 'weightTonnes'),
+      paymentMethodId: any(named: 'paymentMethodId'),
+      upiId: any(named: 'upiId'),
+      pickupDate: any(named: 'pickupDate'),
+      requiresRefrigeration: any(named: 'requiresRefrigeration'),
+      targetTemperatureMin: any(named: 'targetTemperatureMin'),
+      targetTemperatureMax: any(named: 'targetTemperatureMax'),
+    )).thenAnswer((_) async => 'order-123');
+    when(() => mockApiClient.post(
+      any(),
+      body: any(named: 'body'),
+    )).thenAnswer((_) async => {
+      'deep_link': 'upi://pay?pa=truxify@upi&am=120.00&cu=INR&tr=TX-123',
+      'amount_inr': '120.00',
+      'order_ref': 'TX-123',
+    });
+  });
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    Map<String, dynamic>? statusResponse,
+    bool statusError = false,
+  }) async {
+    tester.view.physicalSize = const Size(800, 2600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    if (statusError) {
+      when(() => mockApiClient.get(any()))
+          .thenThrow(Exception('network down'));
+    } else {
+      when(() => mockApiClient.get(any())).thenAnswer(
+        (_) async => statusResponse ?? {'escrow_status': 'funded'},
+      );
+    }
+
+    await tester.pumpWidget(
+      TruxifyScope(
+        controller: TruxifyController(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: BookingConfirmationScreen(
+            draft: _draft,
+            truck: _truck,
+            orderService: mockOrderService,
+            paymentRepository: mockPaymentRepository,
+            addressRepository: mockAddressRepository,
+            apiClient: mockApiClient,
+          ),
+        ),
+      ),
+    );
+    await tester.pump(); // checkout data load
+    await tester.pump(); // rebuild with loaded data
+  }
+
+  Future<void> reachUpiSheet(WidgetTester tester) async {
+    await tester.tap(find.text('Pay & Confirm'));
+    await tester.pump(); // create order
+    await tester.pump(); // upi intent resolves -> UPI sheet
+    expect(find.text('Booking created!'), findsOneWidget);
+  }
+
+  group('BookingConfirmationScreen payment flow', () {
+    testWidgets('shows the success panel when escrow status is funded',
+        (tester) async {
+      await pumpScreen(tester);
+
+      await reachUpiSheet(tester);
+
+      await tester.tap(find.textContaining("I've Paid"));
+      await tester.pump(); // confirm starts
+      await tester.pump(); // status poll resolves -> success state
+
+      expect(find.textContaining('Booking Confirmed'), findsOneWidget);
+
+      // Flush the auto-navigation timer so no timers leak after teardown.
+      await tester.pump(const Duration(milliseconds: 1900));
+      await tester.pump();
+    });
+
+    testWidgets('shows a retryable pending state while escrow is still funding',
+        (tester) async {
+      await pumpScreen(
+        tester,
+        statusResponse: {'escrow_status': 'funding'},
+      );
+
+      await reachUpiSheet(tester);
+
+      await tester.tap(find.textContaining("I've Paid"));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Verifying your payment'), findsOneWidget);
+      expect(find.text('Check payment status'), findsOneWidget);
+      expect(find.text('Back to bookings'), findsOneWidget);
+    });
+
+    testWidgets('shows the pending state with retry when verification errors',
+        (tester) async {
+      await pumpScreen(tester, statusError: true);
+
+      await reachUpiSheet(tester);
+
+      await tester.tap(find.textContaining("I've Paid"));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Verifying your payment'), findsOneWidget);
+      expect(find.textContaining('could not verify'), findsOneWidget);
+      expect(find.text('Check payment status'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Analysis

`_showSuccessPanel()` was dead code — the only way to reach it was `_confirmPaymentLocked`, which was a placeholder that only showed a "contact support" snackbar. After a successful UPI payment the customer was stuck on a static screen, the booking stayed in its pre-payment state, and the flow dead-ended.

The one nuance is that the placeholder was itself a deliberate hardening (see #6133/#6160): `POST /api/payments/lock` only accepts a real on-chain `tx_hash` that a wallet SDK returns after `createBooking` is mined, and this app has no wallet SDK — fabricating a hash would post something the backend can never verify. So the fix must make the success panel reachable through a *real* verification path, not by resuming the fabricated-hash behavior.

Closes #7737.

## Changes

- `apps/customer/lib/screens/booking_confirmation_screen.dart`:
  - `_confirmPaymentLocked` now polls `GET /api/payments/:orderId/status` and calls `_showSuccessPanel()` only when the backend reports `escrow_status == 'funded'` — the escrow is genuinely locked.
  - Any other result (still `funding`, or a verification error) renders a new `_VerificationPendingSheet` with the real status shown, a "Check payment status" retry, and a "Back to bookings" escape — no more false confirmation, no more dead-end snackbar.
  - Added a small `_exitToBookings()` helper used by both the success panel and the pending sheet.
  - Added optional `orderService` / `paymentRepository` / `addressRepository` / `apiClient` constructor params as a test seam (defaults unchanged).
- Added `apps/customer/test/screen/booking_confirmation_screen_test.dart`:
  - Success panel is shown when the status poll returns `funded`.
  - Retryable pending state is shown while status is still `funding`.
  - Pending state with retry is shown when verification throws.

## Testing

- `flutter analyze` / `flutter test test/screen/booking_confirmation_screen_test.dart` could not be run locally (no Flutter SDK on this machine) — flagged for CI/reviewer verification.
- The changed Dart follows the exact widget/pattern conventions of the existing `_UpiPaymentSheet` / `_UpiIntentErrorSheet` in the same file.
