### PR TITLE
fix(driver): always close settlement dialog on contract call failure (#7738)

### DIFF
--- a/apps/driver/lib/screens/wallet_settlement_screen.dart
+++ b/apps/driver/lib/screens/wallet_settlement_screen.dart
@@ -30,11 +30,11 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
     }
   }
 
-  void _signBolAndSettle(SmartContractPayment contract) async {
-    showDialog(
+  Future<void> _signBolAndSettle(SmartContractPayment contract) async {
+    showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (context) => const AlertDialog(
+      builder: (dialogContext) => const AlertDialog(
         content: Row(
           children: [
             CircularProgressIndicator(),
@@ -42,26 +42,44 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
             Expanded(child: Text('Executing Smart Contract on Blockchain...')),
           ],
         ),
-      )
+      ),
     );
 
-    final settledContract = await _paymentService.executeSmartContract(contract);
+    try {
+      final settledContract =
+          await _paymentService.executeSmartContract(contract);
 
-    if (mounted) {
-      Navigator.pop(context); // close dialog
+      if (!mounted) return;
       setState(() {
-        final index = _contracts.indexWhere((c) => c.contractId == contract.contractId);
+        final index =
+            _contracts.indexWhere((c) => c.contractId == contract.contractId);
         if (index != -1) {
           _contracts[index] = settledContract;
         }
       });
-      
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Contract Settled! \$${settledContract.amountUsd} deposited to wallet.'),
+          content: Text(
+              'Contract Settled! \$${settledContract.amountUsd} deposited to wallet.'),
           backgroundColor: Colors.green,
-        )
+        ),
       );
+    } catch (e) {
+      debugPrint('Settlement failed: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Settlement failed: $e. Please tap the button to retry.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      // Always close the non-dismissible dialog, even when the call throws,
+      // so the driver is never stuck on a permanently spinning barrier.
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
     }
   }
 


### PR DESCRIPTION
## Analysis

`_signBolAndSettle` opens a non-dismissible loading dialog and only popped it inside the success branch. If `executeSmartContract` threw (RPC error, timeout, insufficient gas, backend 500), the `Navigator.pop` was never reached, `_contracts` was never updated, and the driver was stuck on a permanently spinning barrier with no way to dismiss or retry.

Closes #7738.

## Changes

- `apps/driver/lib/screens/wallet_settlement_screen.dart`:
  - Wrapped `executeSmartContract` in `try/catch/finally`.
  - `finally` always pops the dialog when the state is still mounted, so the barrier can never be left spinning on a failure.
  - Success path updates `_contracts` and shows the existing green "Contract Settled!" snackbar.
  - `catch` logs the failure and shows a red retryable snackbar; the "SIGN BOL & RELEASE FUNDS" row stays rendered (unchanged `_contracts`), so the driver can retry immediately.
- The idempotency/queryability improvement to `executeSmartContract` noted in the issue is left out of scope — the service is a local mock and the screen-side recovery (dialog always closed, row actionable) fully resolves the lockup.

## Testing

- `flutter analyze` could not be run locally (no Flutter SDK on this machine) — flagged for CI/reviewer verification.
- The mock service never throws, so no widget test was added; the failure path is exercised by the `catch`/`finally` structure itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement error handling with a clear retry notification.
  * Ensured progress indicators close properly after settlement attempts.
  * Prevented contract updates unless settlement completes successfully.
  * Preserved success notifications for completed settlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->