### PR TITLE
fix: prevent storage path collision using randomUUID

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import {
@@ -118,7 +119,7 @@ export async function uploadMaintenancePhotos(req, res) {
       }
 
       const ext = extensionForMime(verifiedMimeType);
-      const storagePath = `${driverId}/${ticketId}/${Date.now()}-${i}.${ext}`;
+      const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
 
       const { error: storageError } = await supabase.storage
         .from('maintenance-photos')


### PR DESCRIPTION
## Description
`uploadMaintenancePhotos` in `backend/api/src/controllers/maintenancePhotoController.js` previously generated storage paths using `${Date.now()}-${i}`, which posed a collision risk during concurrent uploads within the same millisecond.
gssoc 26

Changes made:
- Imported `randomUUID` from `node:crypto`.
- Updated `storagePath` to `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}` to guarantee unique object keys in Supabase storage.

Fixes #7932

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings