### PR TITLE
fix: parallelize maintenance photo validation, scanning, and uploads

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import {
@@ -69,88 +70,87 @@ export async function uploadMaintenancePhotos(req, res) {
       });
     }
 
-    // Validate and upload each file
-    for (let i = 0; i < uploadedFiles.length; i += 1) {
-      const file = uploadedFiles[i];
-
-      let verifiedMimeType;
-      try {
-        verifiedMimeType = validateDocumentBuffer(file.buffer, file.mimetype);
-      } catch (validationError) {
-        // Clean up any files already uploaded in this request
-        await cleanupStorage(uploadedPaths);
-        if (validationError instanceof DocumentValidationError) {
-          const allowed = ALLOWED_PHOTO_MIME_TYPES.join(', ');
-          return res.status(422).json({
-            error: `Photo ${i + 1}: ${validationError.message}. Only ${allowed} images are accepted.`,
-          });
+    // Validate, scan, and upload files in parallel
+    const uploadResults = await Promise.all(
+      uploadedFiles.map(async (file, i) => {
+        let verifiedMimeType;
+        try {
+          verifiedMimeType = validateDocumentBuffer(file.buffer, file.mimetype);
+        } catch (validationError) {
+          if (validationError instanceof DocumentValidationError) {
+            const allowed = ALLOWED_PHOTO_MIME_TYPES.join(', ');
+            const errObj = new Error(`Photo ${i + 1}: ${validationError.message}. Only ${allowed} images are accepted.`);
+            errObj.statusCode = 422;
+            throw errObj;
+          }
+          throw validationError;
         }
-        throw validationError;
-      }
 
-      if (!ALLOWED_PHOTO_MIME_TYPES.includes(verifiedMimeType)) {
-        await cleanupStorage(uploadedPaths);
-        return res.status(422).json({
-          error: `Photo ${i + 1}: Unsupported image type (${verifiedMimeType}). Only JPEG and PNG are accepted.`,
-        });
-      }
-
-      try {
-        const scanResult = await scanDocument(file.buffer);
-        if (!scanResult.clean) {
-          await cleanupStorage(uploadedPaths);
-          return res.status(422).json({
-            error: `Photo ${i + 1}: Uploaded file failed malware scanning.`,
-          });
+        if (!ALLOWED_PHOTO_MIME_TYPES.includes(verifiedMimeType)) {
+          const errObj = new Error(`Photo ${i + 1}: Unsupported image type (${verifiedMimeType}). Only JPEG and PNG are accepted.`);
+          errObj.statusCode = 422;
+          throw errObj;
         }
-      } catch (scanError) {
-        await cleanupStorage(uploadedPaths);
-        if (scanError instanceof MalwareScanError) {
-          logger.warn(
-            { driverId, ticketId, photoIndex: i, reason: scanError.message },
-            '[MaintenancePhotoController] Upload rejected by malware scanner',
-          );
-          return res.status(422).json({
-            error: `Photo ${i + 1}: ${scanError.message}`,
-          });
+
+        try {
+          const scanResult = await scanDocument(file.buffer);
+          if (!scanResult.clean) {
+            const errObj = new Error(`Photo ${i + 1}: Uploaded file failed malware scanning.`);
+            errObj.statusCode = 422;
+            throw errObj;
+          }
+        } catch (scanError) {
+          if (scanError instanceof MalwareScanError) {
+            logger.warn(
+              { driverId, ticketId, photoIndex: i, reason: scanError.message },
+              '[MaintenancePhotoController] Upload rejected by malware scanner',
+            );
+            const errObj = new Error(`Photo ${i + 1}: ${scanError.message}`);
+            errObj.statusCode = 422;
+            throw errObj;
+          }
+          throw scanError;
         }
-        throw scanError;
-      }
 
-      const ext = extensionForMime(verifiedMimeType);
-      const storagePath = `${driverId}/${ticketId}/${Date.now()}-${i}.${ext}`;
+        const ext = extensionForMime(verifiedMimeType);
+        const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
 
-      const { error: storageError } = await supabase.storage
-        .from('maintenance-photos')
-        .upload(storagePath, file.buffer, {
-          contentType: verifiedMimeType,
-          upsert: false,
-        });
+        const { error: storageError } = await supabase.storage
+          .from('maintenance-photos')
+          .upload(storagePath, file.buffer, {
+            contentType: verifiedMimeType,
+            upsert: false,
+          });
 
-      if (storageError) {
-        logger.error('[MaintenancePhotoController] Storage upload failed:', storageError.message);
-        await cleanupStorage(uploadedPaths);
-        return res.status(500).json({ error: 'Failed to store photo' });
-      }
+        if (storageError) {
+          logger.error('[MaintenancePhotoController] Storage upload failed:', storageError.message);
+          const errObj = new Error('Failed to store photo');
+          errObj.statusCode = 500;
+          throw errObj;
+        }
 
-      uploadedPaths.push(storagePath);
-    }
+        uploadedPaths.push(storagePath);
+        return storagePath;
+      })
+    );
 
-    // Generate signed URLs for the uploaded files
-    const photoUrls = [];
-    for (const path of uploadedPaths) {
-      const { data: urlData, error: urlError } = await supabase.storage
-        .from('maintenance-photos')
-        .createSignedUrl(path, 60 * 60 * 24 * 7); // 7-day expiry
+    // Generate signed URLs for the uploaded files in parallel
+    const photoUrls = await Promise.all(
+      uploadResults.map(async (path) => {
+        const { data: urlData, error: urlError } = await supabase.storage
+          .from('maintenance-photos')
+          .createSignedUrl(path, 60 * 60 * 24 * 7); // 7-day expiry
 
-      if (urlError) {
-        logger.error('[MaintenancePhotoController] Failed to create signed URL:', urlError.message);
-        await cleanupStorage(uploadedPaths);
-        return res.status(500).json({ error: 'Failed to generate photo URL' });
-      }
+        if (urlError) {
+          logger.error('[MaintenancePhotoController] Failed to create signed URL:', urlError.message);
+          const errObj = new Error('Failed to generate photo URL');
+          errObj.statusCode = 500;
+          throw errObj;
+        }
 
-      photoUrls.push(urlData.signedUrl);
-    }
+        return urlData.signedUrl;
+      })
+    );
 
     // Update the ticket with the new photo PATHS (not ephemeral URLs)
     const allPaths = [...existingUrls, ...uploadedPaths];
@@ -171,8 +171,13 @@ export async function uploadMaintenancePhotos(req, res) {
       uploaded_count: photoUrls.length,
     });
   } catch (err) {
+    if (uploadedPaths.length > 0) {
+      await cleanupStorage(uploadedPaths);
+    }
+    if (err.statusCode) {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
     logger.error('[MaintenancePhotoController] Unexpected error:', err.message);
-    await cleanupStorage(uploadedPaths);
     return res.status(500).json({ error: 'An unexpected error occurred' });
   }
 }


### PR DESCRIPTION
## Description
`uploadMaintenancePhotos` in `backend/api/src/controllers/maintenancePhotoController.js` previously processed files sequentially inside a `for` loop. For multi-file uploads (up to 3 photos), executing validation, malware scanning, storage upload, and signed URL generation serially multiplied request latency threefold.
gssoc 26

Changes made:
- Wrapped file validation, malware scanning, and storage upload tasks inside `Promise.all()` to process incoming files concurrently.
- Concurrently generated signed URLs for all uploaded storage paths using `Promise.all()`.
- Ensured proper error handling and storage cleanup (`cleanupStorage`) if any concurrent upload or validation fails.

Fixes #7934

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings