### PR TITLE
fix(documents): prevent storage path collision using randomUUID (#7922)

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import {
@@ -72,7 +73,10 @@ export async function uploadDriverDocument(req, res) {
     const extension = verifiedMimeType === 'application/pdf' ? 'pdf'
       : verifiedMimeType === 'image/png' ? 'png'
       : 'jpg';
-    const storagePath = `${driverId}/${documentType}-${Date.now()}.${extension}`;
+    
+    // Use crypto.randomUUID() alongside Date.now() to guarantee path uniqueness and prevent collisions
+    const uniqueId = crypto.randomUUID();
+    const storagePath = `${driverId}/${documentType}-${Date.now()}-${uniqueId}.${extension}`;
 
     const { error: storageError } = await supabase.storage
       .from('driver-documents')


### PR DESCRIPTION
## Description
Replaced timestamp-only storage path generation (`${driverId}/${documentType}-${Date.now()}.${extension}`) with a collision-proof path strategy utilizing `crypto.randomUUID()`. This eliminates path collisions and accidental overwrites during rapid concurrent document upload requests.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `npm test`
- **Test Steps / Prerequisites:**
  1. Simulated concurrent POST upload requests for the same `driverId` and `documentType` within the same millisecond.
  2. Verified that each uploaded file received a unique storage path and uploaded successfully without overwriting existing files.
- **Expected Result:**
  - Every uploaded document receives a unique UUID-tagged storage path.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7922

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.