### PR TITLE
fix(maintenance): enforce atomic MAX_PHOTOS validation to prevent race condition (#7931)

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -152,22 +152,29 @@ export async function uploadMaintenancePhotos(req, res) {
       photoUrls.push(urlData.signedUrl);
     }
 
-    // Update the ticket with the new photo PATHS (not ephemeral URLs)
-    const allPaths = [...existingUrls, ...uploadedPaths];
-    const { error: updateError } = await supabase
-      .from('truck_maintenance_tickets')
-      .update({ photo_urls: allPaths })
-      .eq('id', ticketId);
+    // Atomically append new paths via PostgreSQL RPC to enforce MAX_PHOTOS and prevent race conditions
+    const { error: updateError } = await supabase.rpc('append_maintenance_photos', {
+      p_ticket_id: ticketId,
+      p_new_paths: uploadedPaths,
+      p_max_photos: MAX_PHOTOS,
+    });
 
     if (updateError) {
-      logger.error('[MaintenancePhotoController] Failed to update ticket:', updateError.message);
+      logger.error('[MaintenancePhotoController] Failed to update ticket photos atomically:', updateError.message);
       await cleanupStorage(uploadedPaths);
+
+      if (updateError.message.includes('MAX_PHOTOS_EXCEEDED')) {
+        return res.status(400).json({
+          error: `Cannot add ${uploadedPaths.length} photo(s). Maximum ${MAX_PHOTOS} photos allowed per ticket.`,
+        });
+      }
+
       return res.status(500).json({ error: 'Failed to save photo references' });
     }
 
     return res.status(200).json({
       success: true,
-      photo_urls: [...existingUrls, ...photoUrls], // Return signed URLs to the client for immediate rendering
+      photo_urls: [...existingUrls, ...photoUrls],
       uploaded_count: photoUrls.length,
     });
   } catch (err) {


### PR DESCRIPTION
## Description
Replaced the non-atomic update logic in `uploadMaintenancePhotos` with a call to an atomic PostgreSQL function (`append_maintenance_photos`) utilizing `FOR UPDATE` row-level locking. This prevents concurrent photo upload requests from bypassing the `MAX_PHOTOS` limit (3) and writing excess photo paths to `truck_maintenance_tickets.photo_urls`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `npm test`
- **Test Steps / Prerequisites:**
  1. Executed database migration for `append_maintenance_photos`.
  2. Fired concurrent POST upload requests sending 2 photos each to a ticket with 0 existing photos.
  3. Checked the `photo_urls` column in `truck_maintenance_tickets`.
- **Expected Result:**
  - One request succeeds and appends 2 photos.
  - The second concurrent request fails atomically with HTTP 400 (`MAX_PHOTOS_EXCEEDED`) and cleans up uploaded storage files without exceeding the limit of 3.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7931

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.