### PR TITLE
security(supabase): revoke update privileges on escrow_disabled column from anon and authenticated roles

### DIFF
--- a/supabase/migrations/20260802040000_restrict_financial_column_writes.sql
+++ b/supabase/migrations/20260802040000_restrict_financial_column_writes.sql
@@ -52,6 +52,7 @@ BEGIN
   FOREACH v_col IN ARRAY ARRAY[
     'status',
     'escrow_status',
+    'escrow_disabled',
     'escrow_booking_id',
     'escrow_driver_wallet',
     'pending_bid_acceptance',

--- a/supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql
+++ b/supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql
@@ -153,3 +153,5 @@ BEGIN
     trip_count = earnings_daily.trip_count + 1;
 END;
 $$;
+
+REVOKE UPDATE (escrow_disabled) ON orders FROM anon, authenticated;


### PR DESCRIPTION
## Description
The `escrow_disabled` column added on `orders` in migration `20260802130000_complete_trip_tx_require_funded_escrow.sql` was not included in the column-level privilege revocation list. Authenticated customers could send direct PostgREST `PATCH` requests setting `escrow_disabled = true` on their own orders and bypass the fail-closed escrow gate during trip completion.
gssoc 26

Changes made:
- Added `'escrow_disabled'` to the list of restricted financial columns in `supabase/migrations/20260802040000_restrict_financial_column_writes.sql`.
- Added explicit `REVOKE UPDATE (escrow_disabled) ON orders FROM anon, authenticated;` in `supabase/migrations/20260802130000_complete_trip_tx_require_funded_escrow.sql`.

Fixes #8002

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings