### PR TITLE
feat(blockchain): add secure multi-sig owner rotation and threshold management

### DIFF
--- a/blockchain/contracts/EnterpriseMultiSig.sol
+++ b/blockchain/contracts/EnterpriseMultiSig.sol
@@ -13,6 +13,9 @@ contract EnterpriseMultiSig {
     event ConfirmTransaction(address indexed owner, uint indexed txIndex);
     event RevokeConfirmation(address indexed owner, uint indexed txIndex);
     event ExecuteTransaction(address indexed owner, uint indexed txIndex);
+    event OwnerAdded(address indexed owner);
+    event OwnerRemoved(address indexed owner);
+    event RequirementChanged(uint numConfirmationsRequired);
 
     address[] public owners;
     mapping(address => bool) public isOwner;
@@ -33,6 +36,11 @@ contract EnterpriseMultiSig {
 
     modifier onlyOwner() {
         require(isOwner[msg.sender], "not owner");
+        _;
+    }
+
+    modifier onlySelf() {
+        require(msg.sender == address(this), "not self");
         _;
     }
 
@@ -150,6 +158,43 @@ contract EnterpriseMultiSig {
 
     function getOwners() public view returns (address[] memory) {
         return owners;
+    }
+
+    function addOwner(address _owner) public onlySelf {
+        require(_owner != address(0), "invalid owner");
+        require(!isOwner[_owner], "owner not unique");
+
+        isOwner[_owner] = true;
+        owners.push(_owner);
+
+        emit OwnerAdded(_owner);
+    }
+
+    function removeOwner(address _owner) public onlySelf {
+        require(isOwner[_owner], "not owner");
+        require(owners.length - 1 >= numConfirmationsRequired, "owners less than required confirmations");
+
+        isOwner[_owner] = false;
+        for (uint i = 0; i < owners.length; i++) {
+            if (owners[i] == _owner) {
+                owners[i] = owners[owners.length - 1];
+                owners.pop();
+                break;
+            }
+        }
+
+        emit OwnerRemoved(_owner);
+    }
+
+    function changeRequirement(uint _numConfirmationsRequired) public onlySelf {
+        require(
+            _numConfirmationsRequired > 0 &&
+                _numConfirmationsRequired <= owners.length,
+            "invalid number of required confirmations"
+        );
+        numConfirmationsRequired = _numConfirmationsRequired;
+
+        emit RequirementChanged(_numConfirmationsRequired);
     }
 
     function getTransactionCount() public view returns (uint) {

--- a/blockchain/test/EnterpriseMultiSig.test.js
+++ b/blockchain/test/EnterpriseMultiSig.test.js
@@ -62,6 +62,38 @@ describe("EnterpriseMultiSig", function () {
     });
   });
 
+  describe("Owner Management and Rotation", function () {
+    it("Should allow adding an owner via multi-sig execution", async function () {
+        const addOwnerData = multiSig.interface.encodeFunctionData("addOwner", [nonOwner.address]);
+        
+        await multiSig.connect(owner1).submitTransaction(multiSig.target || multiSig.address, 0, addOwnerData);
+        await multiSig.connect(owner1).confirmTransaction(0);
+        await multiSig.connect(owner2).confirmTransaction(0);
+
+        await expect(multiSig.connect(owner1).executeTransaction(0))
+            .to.emit(multiSig, "OwnerAdded")
+            .withArgs(nonOwner.address);
+
+        expect(await multiSig.isOwner(nonOwner.address)).to.equal(true);
+        expect((await multiSig.getOwners()).length).to.equal(4);
+    });
+
+    it("Should allow removing an owner and changing requirement via multi-sig execution", async function () {
+        const removeOwnerData = multiSig.interface.encodeFunctionData("removeOwner", [owner3.address]);
+        
+        await multiSig.connect(owner1).submitTransaction(multiSig.target || multiSig.address, 0, removeOwnerData);
+        await multiSig.connect(owner1).confirmTransaction(0);
+        await multiSig.connect(owner2).confirmTransaction(0);
+
+        await expect(multiSig.connect(owner1).executeTransaction(0))
+            .to.emit(multiSig, "OwnerRemoved")
+            .withArgs(owner3.address);
+
+        expect(await multiSig.isOwner(owner3.address)).to.equal(false);
+        expect((await multiSig.getOwners()).length).to.equal(2);
+    });
+  });
+
   describe("Confirm and Execute", function () {
     const value = 1000;
 


### PR DESCRIPTION
## Description
`EnterpriseMultiSig.sol` previously initialized owners and confirmation thresholds immutably in the constructor with no mechanism for key rotation or threshold adjustment, posing permanent risks in the event of a lost or compromised key.
gssoc 26

Changes made:
- Added `addOwner`, `removeOwner`, and `changeRequirement` management functions to `EnterpriseMultiSig.sol`.
- Gated these functions with an `onlySelf` modifier so that owner and threshold changes can only be performed via an approved multi-sig transaction.
- Added corresponding unit tests.

Fixes #8000

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings