### PR TITLE
fix(blockchain): prevent credential ID collisions in DIDRegistry using per-issuer nonces

### DIFF
--- a/blockchain/contracts/DIDRegistry.sol
+++ b/blockchain/contracts/DIDRegistry.sol
@@ -50,6 +50,7 @@ contract DIDRegistry is Ownable, Pausable {
     mapping(string => ServiceEndpoint[]) public didServiceEndpoints;
     mapping(string => VerificationMethod[]) public didVerificationMethods;
     mapping(bytes32 => Credential) public credentials;
+    mapping(address => uint256) public issuerNonces;
     mapping(address => string[]) public addressToDIDs;
     mapping(bytes32 => bool) public credentialRevoked;
 
@@ -200,14 +201,18 @@ contract DIDRegistry is Ownable, Pausable {
             "Issuer not authorized for credential type"
         );
 
+        uint256 nonce = issuerNonces[msg.sender]++;
         bytes32 credentialId = keccak256(
             abi.encodePacked(
                 block.timestamp,
                 msg.sender,
                 subject,
-                credentialType
+                credentialType,
+                nonce
             )
         );
+
+        require(credentials[credentialId].issuer == address(0), "Credential already exists");
 
         credentials[credentialId] = Credential({
             id: credentialId,


### PR DESCRIPTION
## Description
`DIDRegistry.sol` derived `credentialId` using `block.timestamp`, `msg.sender`, `subject`, and `credentialType` without any nonce or counter. Multiple credentials issued within the same block by the same issuer for the same subject and type collided and silently overwrote prior credentials.
gssoc 26

Changes made:
- Added a per-issuer nonce tracker (`issuerNonces`) and included it in the `keccak256` credential ID hash.
- Added an explicit `require(credentials[credentialId].issuer == address(0), "Credential already exists");` collision guard.

Fixes #7999

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings