### PR TITLE
fix(blockchain): mark nonces used in executeBatch to prevent cross-path signature replay

### DIFF
--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -169,6 +169,8 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             processedTxHashes[txHash] = true;
 
             // Execute
+            require(!usedNonces[from][nonce], "Nonce already used");
+            usedNonces[from][nonce] = true;
             currentState.balances[from] -= value + gasPrice * gasLimit;
             currentState.balances[to] += value;
             currentState.nonces[from] = nonce + 1;


### PR DESCRIPTION
## Description
`zkEVM.sol` allowed transactions processed inside `executeBatch` to be replayed through `executeTransaction` because nonces processed in batches were never recorded in `usedNonces`.
gssoc 26

Changes made:
- Added `require(!usedNonces[from][nonce], "Nonce already used");` and `usedNonces[from][nonce] = true;` inside `executeBatch` for each transaction.

Fixes #7998

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings