### PR TITLE
fix(blockchain): allow cancelWithPenalty for started bookings in TruxifyEscrow

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -304,7 +304,6 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
-        require(!booking.started, "TruxifyEscrow: Trip already started");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
 
         // ── EFFECTS ───────────────────────────────────────────────────────

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -511,13 +511,21 @@ describe("TruxifyEscrow", function () {
         .to.be.revertedWith("TruxifyEscrow: Penalty exceeds escrow");
     });
 
-    it("reverts once the trip has started", async function () {
-      const { escrow, owner, bookingId } = await loadFixture(deployWithBookingFixture);
+    it("allows cancellation with penalty even after the trip has started", async function () {
+      const { escrow, owner, customer, driver, bookingId, amount } = await loadFixture(deployWithBookingFixture);
+      const driverFee = ethers.parseEther("0.2");
 
       await escrow.connect(owner).markBookingStarted(bookingId);
 
-      await expect(escrow.connect(owner).cancelWithPenalty(bookingId, ethers.parseEther("0.1")))
-        .to.be.revertedWith("TruxifyEscrow: Trip already started");
+      await expect(escrow.connect(owner).cancelWithPenalty(bookingId, driverFee))
+        .to.emit(escrow, "CancellationPenaltyApplied")
+        .withArgs(bookingId, driver.address, driverFee, customer.address, amount - driverFee);
+
+      const booking = await escrow.getBooking(bookingId);
+      expect(booking.status).to.equal(2); // Cancelled
+      expect(booking.paid).to.be.true;
+      expect(await escrow.pendingWithdrawals(driver.address)).to.equal(driverFee);
+      expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount - driverFee);
     });
   });
 


### PR DESCRIPTION
## Description
Removed the `!booking.started` constraint inside `cancelWithPenalty` within `TruxifyEscrow.sol`. Previously, both `cancelBooking` and `cancelWithPenalty` enforced `require(!booking.started, "TruxifyEscrow: Trip already started");`, making the penalty compensation flow unreachable once a trip had started.
gssoc 26

**Changes made:**
- Removed `!booking.started` check from `cancelWithPenalty` in `blockchain/contracts/TruxifyEscrow.sol`.
- Updated contract unit tests in `blockchain/test/TruxifyEscrow.test.js` to assert that `cancelWithPenalty` executes successfully after `markBookingStarted`.

Fixes #7997

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking owners can now cancel and receive a refund even after pickup has begun.
  * Penalty-based cancellation is supported after a trip starts, with cancellation status and pending withdrawals updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->