### PR TITLE
fix(blockchain): prevent cancellation of executed proposals in DAO

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -237,9 +237,15 @@ contract DAO is Ownable, ReentrancyGuard, Pausable {
         emit ProposalExecuted(proposalId, passed);
     }
 
-    function cancelProposal(uint256 proposalId) external onlyOwner {
+    function cancelProposal(uint256 proposalId) external {
         Proposal storage proposal = proposals[proposalId];
-        require(proposal.state == ProposalState.PENDING || proposal.state == ProposalState.ACTIVE || proposal.state == ProposalState.PASSED, "Cannot cancel");
+        require(msg.sender == owner() || msg.sender == proposal.proposer, "Not authorized");
+        require(!proposal.executed, "Already executed");
+        require(
+            proposal.state == ProposalState.PENDING || proposal.state == ProposalState.ACTIVE,
+            "Cannot cancel"
+        );
+
         proposal.state = ProposalState.CANCELLED;
         emit ProposalCancelled(proposalId, msg.sender);
     }


### PR DESCRIPTION
## Description
`cancelProposal` in `blockchain/contracts/DAO.sol` previously allowed cancelling proposals in the `PASSED` state without checking `proposal.executed`. This allowed executed proposals with paid-out treasury funds to be retroactively flipped to `CANCELLED`, corrupting audit records.
gssoc 26

**Changes made:**
- Added `require(!proposal.executed, "Already executed")` check in `cancelProposal`.
- Restricted cancellable states strictly to `ProposalState.PENDING` and `ProposalState.ACTIVE` (disallowing `PASSED`).
- Updated authorization check to allow either the `owner()` or original `proposal.proposer` to cancel unexecuted proposals.

Fixes #7996

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings