### PR TITLE
fix(blockchain): add deposit flow and validate commitment amounts in ZKPrivacy

### DIFF
--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -42,6 +42,8 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
 
     mapping(bytes32 => bool) public nullifiers;
     mapping(bytes32 => bool) public commitments;
+    mapping(bytes32 => uint256) public commitmentAmounts;
+    mapping(bytes32 => bool) public spentCommitments;
     mapping(bytes32 => PrivateTransaction) public transactions;
 
     MerkleTree public merkleTree;
@@ -53,6 +55,7 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
     // Events
     event CommitmentAdded(bytes32 indexed commitment, uint256 index);
     event TransactionProcessed(bytes32 indexed nullifier, address indexed recipient, uint256 amount);
+    event Deposit(bytes32 indexed commitment, uint256 amount, uint256 index);
     event ProofVerified(bytes32 indexed transactionId, bool isValid);
 
     // ============ Constructor ============
@@ -124,6 +127,20 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         return isValid;
     }
 
+    // ============ Deposit ============
+
+    function deposit(bytes32 commitment) external payable whenNotPaused nonReentrant {
+        require(msg.value > 0, "Deposit amount must be > 0");
+        require(commitment != bytes32(0), "Invalid commitment");
+        require(!commitments[commitment], "Commitment already exists");
+
+        commitments[commitment] = true;
+        commitmentAmounts[commitment] = msg.value;
+
+        uint256 index = _insertCommitment(commitment);
+        emit Deposit(commitment, msg.value, index);
+    }
+
     function processPrivateTransaction(
         bytes32 nullifier,
         bytes32 commitment,
@@ -132,7 +149,9 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         Proof memory proof
     ) external nonReentrant whenNotPaused {
         require(!nullifiers[nullifier], "Nullifier already used");
-        require(!commitments[commitment], "Commitment already used");
+        require(commitments[commitment], "Commitment does not exist");
+        require(!spentCommitments[commitment], "Commitment already spent");
+        require(commitmentAmounts[commitment] >= amount, "Insufficient deposit amount");
         require(recipient != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be > 0");
 
@@ -165,10 +184,7 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         });
 
         nullifiers[nullifier] = true;
-        commitments[commitment] = true;
-
-        // Insert into Merkle tree
-        _insertCommitment(commitment);
+        spentCommitments[commitment] = true;
 
         emit TransactionProcessed(nullifier, recipient, amount);
     }


### PR DESCRIPTION
## Description
`ZKPrivacy.sol` lacked a deposit mechanism and allowed `processPrivateTransaction` to spend the contract's entire raw balance without verifying that the commitment had been funded.
gssoc 26

**Changes made:**
- Added a payable `deposit(bytes32 commitment)` function to record commitment deposits and insert them into the Merkle tree.
- Updated `processPrivateTransaction` to verify that `commitments[commitment]` exists, `!spentCommitments[commitment]`, and `commitmentAmounts[commitment] >= amount`.
- Added `spentCommitments[commitment]` tracking alongside `nullifiers[nullifier]` to prevent reuse of commitment deposits.

Fixes #7995

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings