### PR TITLE
fix(blockchain): verify implementation approval during proposal execution

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -384,6 +384,7 @@ function disputeEscrow(uint256 escrowId) external onlyRole(DEFAULT_ADMIN_ROLE) n
         proposal.executed = true;
 
         if (passed) {
+            require(approvedImplementations[proposal.newImplementation], "Implementation not approved");
             // Set the DAO approval flag before calling upgradeToAndCall. The _authorizeUpgrade
             // hook will find this flag, consume it, and allow the upgrade to proceed.
             daoApprovedUpgrades[proposal.newImplementation] = true;


### PR DESCRIPTION
## Description
`TruxifyUpgradeable.sol` checked `approvedImplementations[newImplementation]` when creating a proposal, but failed to re-check this status at execution time in `executeProposal`. If an implementation's approval was revoked during the voting or timelock period, the contract would still execute the upgrade.
gssoc 26

**Changes made:**
- Added `require(approvedImplementations[proposal.newImplementation], "Implementation not approved")` inside `executeProposal` before performing `upgradeToAndCall`.

Fixes #7994

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings