### PR TITLE
fix(ml): account for metric direction and non-zero diffs when prod_value is zero

### DIFF
--- a/backend/ml/services/ab_testing.py
+++ b/backend/ml/services/ab_testing.py
@@ -100,12 +100,18 @@ class ABTestModel:
                 metric_df = df[df['metric_name'] == metric]
                 avg_metrics = metric_df.groupby('model_version')['metric_value'].mean()
                 
+                prod_val = avg_metrics.get('production', None)
+                shadow_val = avg_metrics.get('shadow', None)
+                lower_is_better_keywords = {'rmse', 'mae', 'mse', 'loss', 'error_rate', 'latency', 'error'}
+                higher_is_better = not any(k in metric.lower() for k in lower_is_better_keywords)
+
                 results[metric] = {
-                    'production': avg_metrics.get('production', None),
-                    'shadow': avg_metrics.get('shadow', None),
+                    'production': prod_val,
+                    'shadow': shadow_val,
                     'improvement': self.calculate_improvement(
-                        avg_metrics.get('production', 0),
-                        avg_metrics.get('shadow', 0)
+                        prod_val if prod_val is not None else 0.0,
+                        shadow_val if shadow_val is not None else 0.0,
+                        higher_is_better=higher_is_better
                     )
                 }
             
@@ -122,34 +128,50 @@ class ABTestModel:
         finally:
             session.close()
     
-    def calculate_improvement(self, prod_value: float, shadow_value: float) -> float:
-        """Calculate percentage improvement"""
+    def calculate_improvement(
+        self, prod_value: float, shadow_value: float, higher_is_better: bool = True
+    ) -> float:
+        """Calculate percentage improvement taking metric direction into account and handling zero prod_value."""
         if prod_value == 0:
-            return 0
-        return ((shadow_value - prod_value) / prod_value) * 100
+            if shadow_value == 0:
+                return 0.0
+            diff = shadow_value - prod_value
+            pct = diff * 100.0
+            return pct if higher_is_better else -pct
+
+        diff = shadow_value - prod_value
+        pct = (diff / abs(prod_value)) * 100.0
+        return pct if higher_is_better else -pct
+
+    
     
     def is_shadow_better(self, results: Dict) -> bool:
-        """Determine if shadow model outperforms production"""
-        # For regression: lower RMSE is better
-        # For classification: higher accuracy is better
-        
+        """Determine if shadow model outperforms production based on metric direction and threshold."""
         better_count = 0
         total_metrics = 0
-        
+
+        lower_is_better_keywords = {'rmse', 'mae', 'mse', 'loss', 'error_rate', 'latency', 'error'}
+
         for metric, values in results.items():
-            if values['production'] is None or values['shadow'] is None:
+            prod = values.get('production')
+            shadow = values.get('shadow')
+            if prod is None or shadow is None:
                 continue
-                
+
             total_metrics += 1
-            if metric in ['rmse', 'mae', 'mse']:
-                if values['shadow'] < values['production'] * self.threshold:
+            metric_lower = metric.lower()
+            is_lower_better = any(k in metric_lower for k in lower_is_better_keywords)
+
+            if is_lower_better:
+                if shadow < prod * self.threshold:
                     better_count += 1
-            else:  # Higher is better (accuracy, f1, precision, recall)
-                if values['shadow'] > values['production'] * self.threshold:
+            else:
+                if shadow > prod * self.threshold:
                     better_count += 1
-        
-        # Require majority of metrics to be better
+
         return better_count > (total_metrics / 2) if total_metrics > 0 else False
+
+    
     
     def get_active_test(self) -> Optional[Dict]:
         """Get currently active A/B test from database"""


### PR DESCRIPTION
## Description
`ab_testing.py` previously treated all non-regression metrics as "higher is better", causing models with lower performance on inverse metrics (such as loss, error rates, or latency) to be misclassified. Additionally, when `prod_value == 0`, `calculate_improvement` defaulted to `0%`, concealing valid performance differences between models.
gssoc 26

**Changes made:**
- Extended lower-is-better metric identification across `is_shadow_better` and `calculate_improvement` for keywords like `loss`, `latency`, `error_rate`, `rmse`, `mae`, `mse`, and `error`.
- Refactored `calculate_improvement` to factor in metric direction (`higher_is_better`) and calculate percentage deltas accurately when `prod_value == 0`.
- Updated threshold comparison logic in `is_shadow_better` to handle both lower-is-better and higher-is-better criteria.

Fixes #7993

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings