### PR TITLE
fix: refund on-chain deposits for orders cancelled during escrow funding

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -52,6 +52,26 @@ async function finalizeOrRevert(order, orderRepository) {
       }
     }
 
+    if (bookingFunded && !mismatchReason && order.status === 'cancelled') {
+      logger.info(`[escrow-funding] Order ${order.order_display_id} is cancelled but deposit landed on-chain. Triggering refund.`);
+      try {
+        await submitEscrowRefund(order.order_display_id);
+        await orderRepository.updateOrder(order.id, {
+          escrow_status: 'refunded',
+          escrow_refund_error: null,
+          updated_at: new Date().toISOString(),
+        });
+      } catch (err) {
+        logger.error(`[escrow-funding] Failed to refund cancelled order ${order.order_display_id}: ${err.message}`);
+        await orderRepository.updateOrder(order.id, {
+          escrow_status: 'refund_failed',
+          escrow_refund_error: err.message,
+          updated_at: new Date().toISOString(),
+        });
+      }
+      return;
+    }
+
     if (bookingFunded && !mismatchReason) {
       // The deposit DID land on-chain with the correct amount. Heal the
       // acceptance by running accept_bid_tx as the backend (service_role).

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -679,7 +679,7 @@ export class OrderLifecycleService {
           throw new DomainError(409, { error: 'Cannot cancel: the shipment has already been picked up and is in transit.' });
         }
 
-        const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(currentOrder.escrow_status);
+        const requiresRefund = ['funding', 'funded', 'refund_pending', 'refund_failed'].includes(currentOrder.escrow_status);
         const penaltyBps = currentOrder.status === 'truck_assigned'
           ? 1000
           : ['arrived_pickup', 'picked_up', 'in_transit', 'delivered'].includes(currentOrder.status)


### PR DESCRIPTION
## Description
Cancelling an order while `escrow_status === 'funding'` previously skipped on-chain refund logic because `'funding'` was missing from the `requiresRefund` check in `orderLifecycleService.js`. If an in-flight deposit landed on-chain post-cancellation, the stale-funding reconciler attempted to run `accept_bid_tx`, which failed on already cancelled orders and left funds stranded in escrow.
gssoc 26

### Changes made:
- Updated `requiresRefund` in `orderLifecycleService.js` to include `'funding'`.
- Added explicit cancelled-order handling in `escrowFundingReconciliation.js` to issue `submitEscrowRefund` and update `escrow_status` to `'refunded'` when a deposit lands on a cancelled order.

Fixes #7991

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings