### PR TITLE
fix: normalize DB event fields, fix snapshot replay, and configure ESM for event-store

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -248,21 +248,32 @@ class EventStore {
             return [];
         }
 
-        this.eventStreams.set(aggregateId, data);
-        return data;
+        const mappedData = (data || []).map(row => ({
+            id: row.event_id || row.id,
+            type: row.event_type || row.type,
+            aggregateId: row.aggregate_id || row.aggregateId,
+            payload: row.payload,
+            version: row.version,
+            timestamp: row.timestamp || row.created_at
+        }));
+
+        this.eventStreams.set(aggregateId, mappedData);
+        return mappedData;
     }
 
     async getAggregateState(aggregateId) {
+        const snapshot = await this.getSnapshot(aggregateId);
+        let state = snapshot ? { ...snapshot.state } : { id: aggregateId, version: 0 };
+        const snapshotVersion = snapshot ? (snapshot.version || snapshot.state?.version || 0) : 0;
+
         const events = await this.getEventStream(aggregateId);
-        if (events.length === 0) {
-            // Check snapshot for last known state when event stream is empty
-            const snapshot = await this.getSnapshot(aggregateId);
-            return snapshot ? snapshot.state : null;
+        const eventsToApply = events.filter(e => e.version > snapshotVersion);
+
+        if (!snapshot && eventsToApply.length === 0) {
+            return null;
         }
 
-        // Apply events to build state
-        let state = { id: aggregateId, version: 0 };
-        for (const event of events) {
+        for (const event of eventsToApply) {
             state = this.applyEvent(state, event);
         }
         return state;

--- a/backend/eventsourcing/package.json
+++ b/backend/eventsourcing/package.json
@@ -3,5 +3,10 @@
   "version": "1.0.0",
   "dependencies": {
     "uuid": "^14.0.1"
+  },
+  "type": "module",
+  "main": "event-store.js",
+  "scripts": {
+    "start": "node event-store.js"
   }
 }


### PR DESCRIPTION
## Description
The event sourcing module had several issues causing state corruption post-restart and inefficient snapshot replay:
1. `getEventStream` returned raw Supabase rows with `event_type` and `aggregate_id`, which caused `applyEvent()` to fail on `event.type` (undefined) during rebuilds.
2. `getAggregateState` replayed the complete event stream regardless of snapshot existence.
3. `package.json` lacked `"type": "module"` and main entrypoint definitions required for ESM module execution.
gssoc 26

### Changes made:
- Mapped database row fields (`event_type` -> `type`, `aggregate_id` -> `aggregateId`, `event_id` -> `id`) in `getEventStream`.
- Updated `getAggregateState` to initialize state from the latest snapshot if available and only replay events with `version > snapshot.version`.
- Added `"type": "module"`, `"main": "event-store.js"`, and start script to `backend/eventsourcing/package.json`.

Fixes #7978

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings