### PR TITLE
fix: return delivery success from WS send and prevent location throttle corruption on offline pings

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -257,9 +257,14 @@ class LocationService {
             'charging_status': batteryInfo.isCharging ? 'charging' : 'discharging',
           }
         };
-        _resilientWs!.send(payload);
-        debugPrint('[LocationService] Location ping sent: lat=${position.latitude}, lng=${position.longitude}');
-        return true;
+        final success = _resilientWs!.send(payload);
+        if (success) {
+          debugPrint('[LocationService] Location ping sent: lat=${position.latitude}, lng=${position.longitude}');
+          return true;
+        } else {
+          debugPrint('[LocationService] Failed to send location ping — WebSocket unavailable');
+          return false;
+        }
       }
       return false;
     } catch (e) {

--- a/packages/truxify_shared/lib/src/services/resilient_websocket.dart
+++ b/packages/truxify_shared/lib/src/services/resilient_websocket.dart
@@ -103,18 +103,26 @@ class ResilientWebSocket {
     }
   }
 
+  /// Whether the WebSocket connection is currently active and ready.
+  bool get isConnected => _channel != null && !_closed && !_reconnecting;
+
   /// Sends a message over the WebSocket.
   ///
   /// Strings are sent as-is. All other values are JSON-encoded.
-  /// If the connection is not currently open the message is silently dropped.
-  void send(dynamic message) {
+  /// Returns true if sent successfully, false if the connection is unavailable.
+  bool send(dynamic message) {
     final channel = _channel;
-    if (channel == null) {
-      return;
+    if (channel == null || _closed) {
+      return false;
     }
 
-    final payload = message is String ? message : jsonEncode(message);
-    channel.sink.add(payload);
+    try {
+      final payload = message is String ? message : jsonEncode(message);
+      channel.sink.add(payload);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<void> _scheduleReconnect() async {


### PR DESCRIPTION
## Description
When network connectivity dropped, `ResilientWebSocket.send()` silently dropped location pings while returning void. `LocationService._sendLocationPing()` assumed success and updated `_lastSentPosition` and `_lastSentTime`, corrupting the 15m/30s throttle calculation and causing gaps in live telemetry.
gssoc 26

### Changes made:
- Refactored `ResilientWebSocket.send()` to return `bool` indicating whether the message was enqueued to the socket sink.
- Added `isConnected` getter to `ResilientWebSocket`.
- Updated `LocationService._sendLocationPing()` to check the return status of `send()` and return `false` on failure, preventing `_lastSentPosition` / `_lastSentTime` from advancing when offline.

Fixes #7977

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings