### PR TITLE
fix(tracker): add Redis Pub/Sub for multi-replica WebSocket location broadcasting

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -68,6 +68,57 @@ const RECOVERY_FILE_PATH = process.env.RECOVERY_FILE_PATH || path.join(os.tmpdir
 // In-memory mapping of active client subscriptions
 const trackingSubscriptions = new Map();
 
+// Dedicated Redis subscriber instance for multi-replica WebSocket broadcasting
+let redisSubClient = null;
+const TRACKER_CHANNELS = {
+  LOCATION: 'tracker:location_updates',
+  MILESTONE: 'tracker:milestone_updates',
+};
+
+function deliverToLocalSubscribers(targetId, payload) {
+  if (!targetId || !trackingSubscriptions.has(targetId)) return;
+  const clients = trackingSubscriptions.get(targetId);
+  clients.forEach((client) => {
+    if (client.readyState === 1) {
+      client.send(payload);
+    }
+  });
+}
+
+function initRedisTrackerPubSub() {
+  if (!redisClient || redisSubClient) return;
+
+  try {
+    redisSubClient = redisClient.duplicate();
+    redisSubClient.subscribe(TRACKER_CHANNELS.LOCATION, TRACKER_CHANNELS.MILESTONE, (err) => {
+      if (err) {
+        logger.error({ err }, '[Tracker] Failed to subscribe to Redis tracker channels');
+      } else {
+        logger.info('[Tracker] Subscribed to Redis Pub/Sub tracker channels for multi-replica broadcasting');
+      }
+    });
+
+    redisSubClient.on('message', (channel, message) => {
+      try {
+        const parsed = JSON.parse(message);
+        if (channel === TRACKER_CHANNELS.LOCATION) {
+          const { orderDisplayId, driver_id, payload } = parsed;
+          if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, payload);
+          if (driver_id) deliverToLocalSubscribers(driver_id, payload);
+        } else if (channel === TRACKER_CHANNELS.MILESTONE) {
+          const { orderDisplayId, payload } = parsed;
+          if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, payload);
+        }
+      } catch (err) {
+        logger.error({ err }, '[Tracker] Error handling Pub/Sub message');
+      }
+    });
+  } catch (err) {
+    logger.error({ err }, '[Tracker] Redis Pub/Sub initialization error');
+  }
+}
+
+
 // Cached Supabase Realtime channels keyed by orderUUID to avoid creating a new
 // channel per location ping. Reused across pings and cleaned up on disconnect.
 const locationChannels = new Map();
@@ -977,22 +1028,22 @@ export async function handleLocationPing(ws, data, req) {
     }
   });
 
-  if (orderDisplayId && trackingSubscriptions.has(orderDisplayId)) {
-    const clients = trackingSubscriptions.get(orderDisplayId);
-    clients.forEach((client) => {
-      if (client.readyState === 1) { 
-        client.send(broadcastPayload);
-      }
-    });
-  }
+  initRedisTrackerPubSub();
 
-  if (trackingSubscriptions.has(driver_id)) {
-    const clients = trackingSubscriptions.get(driver_id);
-    clients.forEach((client) => {
-      if (client.readyState === 1) {
-        client.send(broadcastPayload);
-      }
+  if (redisClient) {
+    const pubSubMessage = JSON.stringify({
+      orderDisplayId,
+      driver_id,
+      payload: broadcastPayload,
     });
+    redisClient.publish(TRACKER_CHANNELS.LOCATION, pubSubMessage).catch((err) => {
+      logger.error({ err }, '[Tracker] Redis publish error for location update');
+      if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, broadcastPayload);
+      if (driver_id) deliverToLocalSubscribers(driver_id, broadcastPayload);
+    });
+  } else {
+    if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, broadcastPayload);
+    if (driver_id) deliverToLocalSubscribers(driver_id, broadcastPayload);
   }
 
   // Publish to Supabase Realtime channel driver-location:{orderId}
@@ -1256,9 +1307,7 @@ export async function closeWebSocketServer() {
 }
 
 export function broadcastOrderMilestone(orderDisplayId, milestone, status) {
-  if (!orderDisplayId || !trackingSubscriptions.has(orderDisplayId)) {
-    return;
-  }
+  if (!orderDisplayId) return;
 
   const payload = JSON.stringify({
     event: 'milestone_update',
@@ -1270,12 +1319,17 @@ export function broadcastOrderMilestone(orderDisplayId, milestone, status) {
     },
   });
 
-  const clients = trackingSubscriptions.get(orderDisplayId);
-  clients.forEach((client) => {
-    if (client.readyState === 1) {
-      client.send(payload);
-    }
-  });
+  initRedisTrackerPubSub();
+
+  if (redisClient) {
+    const pubSubMessage = JSON.stringify({ orderDisplayId, payload });
+    redisClient.publish(TRACKER_CHANNELS.MILESTONE, pubSubMessage).catch((err) => {
+      logger.error({ err }, '[Tracker] Redis publish error for milestone');
+      deliverToLocalSubscribers(orderDisplayId, payload);
+    });
+  } else {
+    deliverToLocalSubscribers(orderDisplayId, payload);
+  }
 }
 
 export async function handleSubscribe(ws, data) {


### PR DESCRIPTION
## Description
The WebSocket tracker server previously used a process-local in-memory `Map` (`trackingSubscriptions`) to deliver location updates and milestone events. In multi-replica deployments (e.g., Kubernetes HPA), when a driver connected to Replica A sent location pings, customers connected to Replica B never received updates.
gssoc 26

### Changes made:
- Added a dedicated Redis subscriber instance (`redisSubClient`) listening on `tracker:location_updates` and `tracker:milestone_updates`.
- Refactored `broadcastOrderMilestone` and location update processing to publish messages through Redis Pub/Sub.
- Ensured all connected replicas receive the published updates and deliver them to their local connected WebSocket subscribers.
- Added graceful fallback to local delivery if Redis client is unavailable.

Fixes #7976

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings