### PR TITLE
fix : added try-catch for i18n JSON.parse to prevent server crash on malformed locale files

### DIFF
--- a/backend/api/src/middleware/i18n.js
+++ b/backend/api/src/middleware/i18n.js
@@ -7,8 +7,23 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const enDict = JSON.parse(fs.readFileSync(path.join(__dirname, '../locales/en.json')));
-const esDict = JSON.parse(fs.readFileSync(path.join(__dirname, '../locales/es.json')));
+const enDict = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '../locales/en.json')));
+  } catch (err) {
+    console.warn('[i18n] Failed to load en.json locale, falling back to empty object:', err.message);
+    return {};
+  }
+})();
+
+const esDict = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '../locales/es.json')));
+  } catch (err) {
+    console.warn('[i18n] Failed to load es.json locale, falling back to empty object:', err.message);
+    return {};
+  }
+})();
 
 i18next
   .use(middleware.LanguageDetector)


### PR DESCRIPTION
Closes #8050.

Summary of What Has Been Done:
Added try-catch blocks around the synchronous JSON.parse calls for loading locale files (en.json and es.json) in the i18n middleware. When a locale file is missing, empty, or malformed, the server previously crashed at startup. Now it logs a warning and falls back to an empty translation object, allowing the server to start and serve requests.

Changes Made:
- backend/api/src/middleware/i18n.js: Wrapped JSON.parse(fs.readFileSync(...)) calls in IIFE try-catch blocks
- On parse failure, logs a warning and returns an empty object {} so i18next can still initialize

Impact it Made:
- Server no longer crashes at startup for corrupted or missing locale files
- Graceful degradation means the server can start and serve requests even when locale files have issues
- Operations teams can fix locale files without redeploying

Note: Please assign this PR to the `tmdeveloper007` account. This PR was created as part of GSSOC (GirlScript Summer of Code).