### PR TITLE
[Bug] Remove duplicate markEscrowBookingStarted so the escrow module loads again

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -607,44 +607,6 @@ export async function escrowRelease (orderDisplayId, expectedAmountWei = null) {
 }
 
 /**
- * Marks the on-chain booking as started, which is required for the escrow
- * release/withdraw logic to proceed.
- *
- * @param {string} orderDisplayId — display ID of the order, e.g. "#FF20260521"
- * @returns {Promise<{txHash: string | null, bookingId: string, error?: string}>}
- */
-export async function markEscrowBookingStarted(orderDisplayId) {
-  return measureExecution('EscrowService.markEscrowBookingStarted', async () => {
-    const bookingId = getEscrowBookingId(orderDisplayId)
-
-    if (!escrowContract) {
-      logger.warn('[escrow] Contract not initialised — skipping markBookingStarted.')
-      return { txHash: null, bookingId }
-    }
-
-    try {
-      const tx = await escrowContract.markBookingStarted(bookingId)
-      logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
-      return {
-        txHash: tx.hash,
-        bookingId,
-        waitForConfirmation: async () => {
-          const receipt = await tx.wait(1)
-          if (!receipt || receipt.status === 0) {
-            throw new Error('Escrow markBookingStarted transaction reverted or was not found.')
-          }
-          logger.info(`[escrow] markBookingStarted confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
-          return receipt
-        },
-      }
-    } catch (err) {
-      logger.error(`[escrow] markBookingStarted failed for booking ${orderDisplayId}: ${err.message}`)
-      return { txHash: null, bookingId, error: err.message }
-    }
-  })
-}
-
-/**
  * Submit an escrow refund and return its hash before confirmation.
  */
 export async function submitEscrowRefund (orderDisplayId) {


### PR DESCRIPTION
Fixes #8120.

`backend/api/src/services/escrow.js` declared `export async function markEscrowBookingStarted` twice (lines 517 and 616) — a duplicate top-level export binding, which is a hard `SyntaxError` in an ES module.

### Before

```
SyntaxError: Identifier 'markEscrowBookingStarted' has already been declared
```

Every consumer of `escrow.js` went down with it: `orderLifecycleService`, `deliveryVerificationService`, the escrow funding/refund/release reconciliation workers, the escrow webhook processor and `orderRoutes`. The API could not boot, and `test/unit/escrow.test.js`, `test/unit/escrowSenderVerification.test.js` and `test/integration/escrow.test.js` failed at import time.

### Change

Removed the second copy and its duplicated JSDoc. It was a merge artifact — byte-for-byte equivalent to the first declaration apart from indentation — so there is no behaviour change beyond the module now parsing.

### Verification

- `escrow.js` now parses as an ES module (checked with `vm.SourceTextModule`).
- `npx eslint src/services/escrow.js` — clean.

Scope is one file, one deletion, no logic touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate escrow booking logic to improve service reliability and prevent conflicting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->