### PR TITLE
fix(driver): remove undefined FcmService.initialize/registerTokenForUser calls in main.dart

### DIFF
--- a/apps/driver/lib/main.dart
+++ b/apps/driver/lib/main.dart
@@ -22,10 +22,6 @@ Future<void> main() async {
   BackgroundSyncService.initialize();
   BackgroundSyncService.registerSyncTask();
   BackgroundSyncService.listenForConnectivity();
-  FcmService.initialize();
-  Firebase.initializeApp();
-  FcmService.registerTokenForUser(userId);
-
   // ── Validate all required environment variables before app starts ────────
   Env.validate();  // Throws an error if SUPABASE_URL or SUPABASE_ANON_KEY are missing
   // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`apps/driver/lib/main.dart` called `FcmService.initialize()`, `Firebase.initializeApp()` and `FcmService.registerTokenForUser(userId)` — none of which exist on `FcmService` (it only exposes `initializeAndRegister()`, `unregisterToken()`, `clearToken()`), and `userId` is not declared anywhere in `main.dart`. This is a compile error.

## Changes
- Removed the three bogus calls from `main.dart`.
- `FcmService.initializeAndRegister()` is already invoked from `shell_screen.dart:117` where a user context exists, so FCM registration is preserved.
- `Firebase.initializeApp()` remains in the existing guarded try/catch block.

Closes #8131

GSSOC 2026
