### PR TITLE
fix(driver): derive Workmanager isInDebugMode from kDebugMode

### DIFF
--- a/apps/driver/lib/services/background_sync_service.dart
+++ b/apps/driver/lib/services/background_sync_service.dart
@@ -35,7 +35,7 @@ class BackgroundSyncService {
   static void initialize() {
     Workmanager().initialize(
       callbackDispatcher,
-      isInDebugMode: true,
+      isInDebugMode: kDebugMode,
     );
   }
 


### PR DESCRIPTION
## Summary
`background_sync_service.dart` hardcoded `isInDebugMode: true` in the Workmanager registration, so release builds ran with debug scheduling semantics.

## Changes
- Replaced the hardcoded `true` with `kDebugMode` (already imported via `package:flutter/foundation.dart`), so release builds use production scheduling.

Closes #8130

GSSOC 2026
