### PR TITLE
fix(api): remove unused CommonJS DomainError.js from ESM package

### DIFF
--- a/backend/api/src/errors/DomainError.js
+++ b/backend/api/src/errors/DomainError.js
@@ -1,9 +1,0 @@
-class DomainError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'DomainError';
-    this.statusCode = 400;
-  }
-}
-
-module.exports = DomainError;


### PR DESCRIPTION
## Summary
`backend/api/src/errors/DomainError.js` used `module.exports` inside an ESM package (`"type": "module"`), which throws `ReferenceError: module is not defined` if imported. The file is unused — every service uses the ESM-compatible `services/order/domainError.js` (`export class DomainError extends Error`).

## Changes
- Deleted the dead `errors/DomainError.js` file. The canonical error class lives in `services/order/domainError.js`.

Closes #8128

GSSOC 2026
