### PR TITLE
fix(api): wire createLoadSchema into POST /api/loads

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -55,8 +55,8 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
-import { loadFilterQuerySchema } from '../validation/loadSchemas.js';
-import { validateParams, validateQuery } from '../middleware/validate.js';
+import { loadFilterQuerySchema, createLoadSchema } from '../validation/loadSchemas.js';
+import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
 import { paramIdSchema, uuidParamSchema } from '../validation/requestSchemas.js';
 import { escapeLike } from '../lib/escapeLike.js';
 
@@ -310,29 +310,9 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), a
 // 1.5 CREATE NEW LOAD OFFER (CUSTOMER)
 // POST /api/loads
 // ============================================================================
-router.post('/', authenticate, userLimiter, requireRole(['customer']), async (req, res) => {
+router.post('/', authenticate, userLimiter, requireRole(['customer']), validateBody(createLoadSchema), async (req, res) => {
   try {
     const { origin, destination, weight_tons, expected_price, material_type } = req.body;
-
-    if (!origin || !origin.lat || !origin.lng) {
-      return res.status(400).json({ error: 'Origin with lat/lng is required' });
-    }
-    if (!destination || !destination.lat || !destination.lng) {
-      return res.status(400).json({ error: 'Destination with lat/lng is required' });
-    }
-
-    const parsedWeight = Number(weight_tons);
-    if (weight_tons === undefined || weight_tons === null || Number.isNaN(parsedWeight)) {
-      return res.status(400).json({ error: 'Valid weight_tons is required' });
-    }
-    if (parsedWeight <= 0) {
-      return res.status(400).json({ error: 'weight_tons must be a positive number' });
-    }
-
-    const parsedPrice = Number(expected_price);
-    if (expected_price === undefined || expected_price === null || Number.isNaN(parsedPrice)) {
-      return res.status(400).json({ error: 'Valid expected_price is required' });
-    }
 
     const pickupAddress = origin.address || 'Unknown Origin';
     const dropAddress = destination.address || 'Unknown Destination';

--- a/backend/api/src/validation/loadSchemas.js
+++ b/backend/api/src/validation/loadSchemas.js
@@ -35,8 +35,17 @@ export const loadFilterQuerySchema = z.object({
 });
 
 export const createLoadSchema = z.object({
-  pickup_location: z.string().min(5).max(255),
-  drop_location: z.string().min(5).max(255),
-  weight_tons: z.number().positive().max(50),
-  goods_type: z.string().min(2).max(100)
+  origin: z.object({
+    lat: z.coerce.number(),
+    lng: z.coerce.number(),
+    address: z.string().optional(),
+  }),
+  destination: z.object({
+    lat: z.coerce.number(),
+    lng: z.coerce.number(),
+    address: z.string().optional(),
+  }),
+  weight_tons: z.coerce.number().positive().max(50),
+  expected_price: z.coerce.number().positive(),
+  material_type: z.string().min(2).max(100).optional(),
 });


### PR DESCRIPTION
## Summary
`POST /api/loads` manually validated `origin`, `destination`, `weight_tons` and `expected_price` with ad-hoc `if` checks, while `createLoadSchema` in `validation/loadSchemas.js` was exported but never imported. This left two divergent sources of truth for the same payload.

## Changes
- Updated `createLoadSchema` to encode the real request contract (`origin`/`destination` objects with `lat`/`lng`/`address`, `weight_tons`, `expected_price`, `material_type`), with `z.coerce.number()` matching the route's previous `Number()` coercion.
- Wired it into the route via `validateBody(createLoadSchema)`.
- Removed the duplicated manual `if` blocks, which also missed `material_type` validation.

Closes #8126

GSSOC 2026
