### PR TITLE
fix(api): log transactional order error with structured logger

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1053,7 +1053,7 @@ async function createOrderTransactional({ idempotencyKey, orderData, timelineDat
 
     return data;
   } catch (err) {
-    console.error(`[TRANSACTIONAL_ORDER_ERROR] Key ${idempotencyKey}:`, err.message);
+    logger.error({ err: err.message, key: idempotencyKey }, 'TRANSACTIONAL_ORDER_ERROR');
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
`createOrderTransactional` logged the transactional error with bare `console.error`, bypassing the pino/structured logger used everywhere else in the file (imported at line 22).

## Changes
- Replaced `console.error(...)` with the structured `logger.error({ err: err.message, key: idempotencyKey }, 'TRANSACTIONAL_ORDER_ERROR')`.

Closes #8125

GSSOC 2026
