### PR TITLE
fix(api): extract hardcoded demand earnings rates and peak hours into config

### DIFF
--- a/backend/api/src/config/demand.js
+++ b/backend/api/src/config/demand.js
@@ -1,0 +1,19 @@
+const parseNumber = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const parseNumberList = (value, fallback) => {
+  if (!value) return fallback;
+  const parsed = value.split(',').map((entry) => entry.trim()).filter(Boolean);
+  return parsed.length > 0 ? parsed : fallback;
+};
+
+export const demandConfig = {
+  baseEarningRate: parseNumber(process.env.DEMAND_BASE_EARNING_RATE, 18.50),
+  routeMultiplierBase: parseNumber(process.env.DEMAND_ROUTE_MULTIPLIER_BASE, 1.2),
+  routeMultiplierStep: parseNumber(process.env.DEMAND_ROUTE_MULTIPLIER_STEP, 0.1),
+  next24HoursFactor: parseNumber(process.env.DEMAND_NEXT_24H_FACTOR, 1.1),
+  next48HoursFactor: parseNumber(process.env.DEMAND_NEXT_48H_FACTOR, 0.95),
+  peakHours: parseNumberList(process.env.DEMAND_PEAK_HOURS, ['08:00 - 10:00', '17:00 - 19:00']),
+};

--- a/backend/api/src/routes/demandRoutes.js
+++ b/backend/api/src/routes/demandRoutes.js
@@ -5,6 +5,7 @@ import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 import { predictDemand } from '../services/ml.js';
+import { demandConfig } from '../config/demand.js';
 
 const router = express.Router();
 
@@ -45,21 +46,21 @@ router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'),
     const { vehicle_type, cargo_category } = req.query;
 
     // Generate intelligent route recommendations and earnings potential based on ML predictions
-    const baseEarningRate = 18.50; // per km estimate
+    const baseEarningRate = demandConfig.baseEarningRate; // per km estimate
     const multiplier = mlPrediction.predicted_demand || 0.5;
     const estimatedEarningPotential = Number((baseEarningRate * (1 + multiplier)).toFixed(2));
 
     const routeSuggestions = (loads || []).slice(0, 3).map((l, idx) => ({
       id: idx + 1,
       recommendedRoute: `${l.pickup_address || 'Current Location'} -> ${l.drop_address || 'High Demand Zone'}`,
-      estimatedEarnings: estimatedEarningPotential * (1.2 + idx * 0.1),
+      estimatedEarnings: estimatedEarningPotential * (demandConfig.routeMultiplierBase + idx * demandConfig.routeMultiplierStep),
       confidenceScore: Number((multiplier * 100).toFixed(1))
     }));
 
     const predictedDemandNext48Hours = {
-      next24Hours: Number((multiplier * 1.1).toFixed(2)),
-      next48Hours: Number((multiplier * 0.95).toFixed(2)),
-      peakHours: ['08:00 - 10:00', '17:00 - 19:00']
+      next24Hours: Number((multiplier * demandConfig.next24HoursFactor).toFixed(2)),
+      next48Hours: Number((multiplier * demandConfig.next48HoursFactor).toFixed(2)),
+      peakHours: demandConfig.peakHours
     };
 
     const repositioningAreas = [


### PR DESCRIPTION
## Summary
`GET /api/demand-heatmap` embedded business-critical constants directly in the route handler: `baseEarningRate = 18.50`, the `1.2 + idx * 0.1` multiplier, the `* 1.1` / `* 0.95` next-24/48h factors, and the `peakHours` array. Changing them required editing source and redeploying.

## Changes
- Added `config/demand.js` exposing these figures via env vars with the existing values as defaults (`DEMAND_BASE_EARNING_RATE`, `DEMAND_ROUTE_MULTIPLIER_BASE`, `DEMAND_ROUTE_MULTIPLIER_STEP`, `DEMAND_NEXT_24H_FACTOR`, `DEMAND_NEXT_48H_FACTOR`, `DEMAND_PEAK_HOURS`).
- Updated the route handler to reference `demandConfig`. Defaults preserve the current behavior exactly.

Closes #8124

GSSOC 2026
