### PR TITLE
fix(api): run cookie security validation in production

### DIFF
--- a/backend/api/src/middleware/cookieSecurityValidator.js
+++ b/backend/api/src/middleware/cookieSecurityValidator.js
@@ -3,10 +3,6 @@ import logger from './logger.js';
 const RECOMMENDED_ATTRIBUTES = ['HttpOnly', 'SameSite', 'Path'];
 
 export default function cookieSecurityValidator(req, res, next) {
-  if (process.env.NODE_ENV === 'production') {
-    return next();
-  }
-
   const originalSetHeader = res.setHeader.bind(res);
 
   res.setHeader = (name, value) => {

--- a/backend/api/test/cookieSecurityValidator.test.js
+++ b/backend/api/test/cookieSecurityValidator.test.js
@@ -80,13 +80,16 @@ describe('cookieSecurityValidator', () => {
     );
   });
 
-  it('does not log warnings in production', async () => {
+  it('logs warnings in production too', async () => {
     process.env.NODE_ENV = 'production';
 
     const app = createApp('session=abc123');
 
     await request(app).get('/test');
 
-    expect(warnMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][1]).toBe(
+      'Cookie missing recommended security attributes'
+    );
   });
 });


### PR DESCRIPTION
## Summary
`cookieSecurityValidator` had an inverted guard: in production it returned early and never validated cookie security attributes, while in dev/test it validated on every response. Production — precisely where insecure cookies must be caught — went silently unreported.

## Changes
- Removed the `NODE_ENV === 'production'` early-return so the check runs in production too (and everywhere else).
- Updated the unit test that asserted the buggy production-skip behavior to assert production logging instead.

Closes #8123

GSSOC 2026
