### PR TITLE
[Bug] Drop superseded merge fragments so the escrow release reconciliation worker loads

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -66,20 +66,6 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
       }
       throw err;
     }
-  } else {
-    // Redis not configured — single-instance mode, use in-process guard only
-    if (reconciliationRunning) return;
-  }
-
-  try {
-    if (!lockAcquired) reconciliationRunning = true;
-    const instanceId = process.env.HOSTNAME || os.hostname();
-    const { data: failedOrders, error } = await supabaseAdmin
-      .from('orders')
-      .select('id, order_display_id, escrow_amount_wei, escrow_release_attempts, release_tx_hash')
-      .eq('escrow_status', 'release_failed')
-      .lt('escrow_release_attempts', MAX_RETRIES)
-      .limit(50);
 
     if (!globalLockValue) {
       logger.info('[escrow-release-reconciliation] Global lock held by another instance, skipping batch.');
@@ -104,85 +90,6 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
 
       try {
         await finalizeReleasedOrder(order, orderRepository);
-        const { data: claimed, error: claimError } = await supabaseAdmin
-          .rpc('claim_release_reconciliation', {
-            p_order_id: order.id,
-            p_instance_id: instanceId,
-          });
-
-        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0)) && !claimError) {
-          logger.info(`[escrow-release-reconciliation] Order ${order.order_display_id} already claimed by another instance, skipping.`);
-          continue;
-        }
-
-        if (claimError) {
-          const { data: existing } = await supabaseAdmin
-            .from('orders')
-            .select('escrow_status, reconciled_by')
-            .eq('id', order.id)
-            .maybeSingle();
-          if (existing && (existing.escrow_status !== 'release_failed' || existing.reconciled_by)) {
-            logger.info(`[escrow-release-reconciliation] Order ${order.order_display_id} already processed, skipping.`);
-            continue;
-          }
-        }
-
-        const releaseAttemptedAt = new Date().toISOString();
-        const releaseAttempts = (order.escrow_release_attempts || 0) + 1;
-
-        // The expected amount is passed so escrowRelease verifies the on-chain
-        // booking amount before submitting the release (defense-in-depth).
-        const result = await escrowRelease(order.order_display_id, order.escrow_amount_wei ?? null);
-        const { txHash, alreadyReleased } = result;
-        if (!txHash && !alreadyReleased) {
-          if (result.code === 'DEPOSIT_AMOUNT_MISMATCH') {
-            // The on-chain amount will not change by retrying — record the
-            // reason and escalate to manual review instead of looping.
-            const releaseAttemptedAt = new Date().toISOString();
-            const releaseAttempts = (order.escrow_release_attempts || 0) + 1;
-            await supabaseAdmin
-              .from('orders')
-              .update({
-                escrow_release_attempts: releaseAttempts,
-                escrow_release_last_attempt_at: releaseAttemptedAt,
-                escrow_release_error: String(result.error).slice(0, 1000),
-                reconciled_by: null,
-                updated_at: releaseAttemptedAt,
-              })
-              .eq('id', order.id);
-            logger.error(
-              `[escrow-release-reconciliation] Order ${order.order_display_id} on-chain amount mismatch (${result.error}). Escalating to manual review.`
-            );
-            continue;
-          }
-          throw new Error('Escrow release did not return a transaction hash');
-        }
-
-        const releasedAt = new Date().toISOString();
-        const { error: updateError } = await supabaseAdmin
-          .from('orders')
-          .update({
-            escrow_status: 'released',
-            release_tx_hash: txHash || order.release_tx_hash,
-            escrow_release_error: null,
-            escrow_released_at: releasedAt,
-            escrow_release_attempts: releaseAttempts,
-            escrow_release_last_attempt_at: releaseAttemptedAt,
-            reconciled_by: null,
-            updated_at: releasedAt,
-          })
-          .eq('id', order.id)
-          .in('escrow_status', ['release_failed', 'funded'])
-          .eq('reconciled_by', instanceId);
-
-        if (updateError) {
-          logger.error(
-            `[escrow-release-reconciliation] Failed to finalize release for ${order.order_display_id}:`,
-            updateError.message
-          );
-        } else {
-          logger.info(`[escrow-release-reconciliation] Release succeeded for ${order.order_display_id}`);
-        }
       } catch (err) {
         logger.error(
           `[escrow-release-reconciliation] Finalization failed for order ${order.order_display_id}:`,

--- a/backend/api/test/unit/escrowReleaseReconciliation.test.js
+++ b/backend/api/test/unit/escrowReleaseReconciliation.test.js
@@ -56,10 +56,6 @@ vi.mock('../../src/lib/redisLock.js', () => ({
   releaseLock: mockReleaseLock,
   renewLock: mockRenewLock,
   LockAcquisitionError: class LockAcquisitionError extends Error {},
-vi.mock('../../src/config/db.js', () => ({
-  supabase: mockSupabase,
-  supabaseAdmin: mockSupabase,
-  redisClient: mockRedisClient,
 }));
 
 vi.mock('../../src/services/escrow.js', () => ({


### PR DESCRIPTION
Fixes #8122.

`escrowReleaseReconciliation.js` was left holding **both sides of a rewrite**. Three fragments of the superseded direct-`supabaseAdmin` implementation had been spliced into the current repository-backed one, leaving the module unparseable.

### Before

```
$ node --input-type=module -e "await import('./src/services/escrowReleaseReconciliation.js')"
SyntaxError: Missing catch or finally after try
```

### What was removed

| Fragment | Why it is dead code |
|---|---|
| `} else { ... }` arm at line 69 | Attached to no `if` — this is the actual parse error |
| Second `try {` + stale `release_failed` query (74-83) | Redeclares `error` alongside the real `findPendingEscrowReleases()` destructure |
| ~79-line `claim_release_reconciliation` block (107+) | Superseded by `finalizeReleasedOrder` + per-order `escrow_lock` |

All three reference `os.hostname()`, `redisClient` and `lockAcquired` — `os` and `redisClient` are not imported by this module and `lockAcquired` is never declared. The code could not have run even if it had parsed, which is what confirms it is the stale side of the merge rather than a live change.

The result is byte-identical to the coherent implementation the file's own header comment describes.

### Impact of the bug

The release reconciliation worker is the safety net for the release→finalize window: an on-chain release that succeeded while `complete_trip_tx` did not. With the module failing to load, those orders sat at `escrow_status = funded`/`release_failed` indefinitely with the driver uncredited — the deadlock #5704 fixed.

### Test file

`test/unit/escrowReleaseReconciliation.test.js` carried the identical artifact: a stale `vi.mock('../../src/config/db.js', ...)` block spliced inside the `vi.mock('../../src/lib/redisLock.js', ...)` factory, referencing `mockSupabase` / `mockRedisClient` which the file never defines. Closed the factory and dropped the stale block.

### Verification

```
$ npx vitest run test/unit/escrowReleaseReconciliation.test.js
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

`npx eslint` clean on both files.
