### PR TITLE
fix(driver): guard chartPoints cast in my_truck_screen against null/malformed API data

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -944,7 +944,7 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
     final totalPayout = (_data!['totalPayout'] as num?)?.toDouble() ?? 0.0;
     final estFuel = (_data!['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
     final margin = (_data!['profitMargin'] as num?)?.toDouble() ?? 0.0;
-    final chartPoints = _data!['chartPoints'] as List<Map<String, dynamic>>;
+    final chartPoints = (_data!['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
 
     return RefreshIndicator(
       onRefresh: _load,
@@ -985,7 +985,12 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
               child: Text('No recent trips to display'),
             ))
           else
-            ...chartPoints.map((p) => _buildChartBar(context, p['label'], p['payout'], p['fuelCost'])),
+            ...chartPoints.map((p) => _buildChartBar(
+              context,
+              (p['label'] as String?) ?? 'Unknown trip',
+              (p['payout'] as num?)?.toDouble() ?? 0.0,
+              (p['fuelCost'] as num?)?.toDouble() ?? 0.0,
+            )),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
`my_truck_screen.dart` cast `chartPoints` with an unguarded `as List<Map<String, dynamic>>` in `build()`. If the API omits `chartPoints`, returns `null`, or returns a different shape, this throws a `_TypeError` that is not caught by `_error` handling and takes down the entire truck screen. The sibling fields above it already use safe `as num?` / `??` patterns.

## Changes
- Replaced the unguarded cast with a nullable-safe cast: `(_data!['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const []`.
- Hardened per-point extraction so a malformed point (missing/null `label`, `payout`, or `fuelCost`) degrades to a safe fallback instead of throwing.

Closes #8132

GSSOC 2026
