### PR TITLE
[Bug] Remove orphaned retry block so the DLQ worker loads again

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -339,38 +339,6 @@ export const dlqService = {
       const backlog = await this.getBacklogCount();
       if (backlog !== null) {
         logger.info(`[DLQ] Backlog of pending webhook failures: ${backlog}`);
-        } catch (procErr) {
-          logger.error(`[DLQ] Retry failed for event ${event.id}: ${procErr.message}`);
-
-          const newRetryCount = (event.retry_count ?? 0) + 1;
-          const nextBackoffMin = RETRY_BACKOFF[newRetryCount] || -1;
-
-          if (nextBackoffMin === -1) {
-            // Failed permanently
-            await dlqDb()
-              .from('webhook_failures')
-              .update({ 
-                status: 'failed_permanently', 
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString()
-              })
-              .eq('id', event.id);
-            logger.warn(`[DLQ] Event ${event.id} marked as failed_permanently`);
-          } else {
-            // Schedule next retry by resetting status to pending so the event can be re-claimed.
-            const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
-            await dlqDb()
-              .from('webhook_failures')
-              .update({
-                status: 'pending',
-                retry_count: newRetryCount,
-                next_retry_at: nextRetryAt,
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString(),
-              })
-              .eq('id', event.id);
-          }
-        }
       }
     } catch (err) {
       logger.warn(`[DLQ] Backlog metrics unavailable: ${err.message}`);


### PR DESCRIPTION
Fixes #8150.

A 32-line fragment of the old inline retry handling was spliced into the middle of `logBacklogIfNeeded()`, opening a `catch (procErr)` with no matching `try`.

### Before

```
$ node --input-type=module -e "await import('./src/services/webhook/dlqService.js')"
SyntaxError: Unexpected token 'catch'
```

### Why the removed block is dead code

- It references `event` and `procErr`, neither of which is in scope inside `logBacklogIfNeeded()` — both belong to the per-event loop.
- Its logic is already implemented by `recordFailure()` directly above, which does the same `RETRY_BACKOFF` lookup but routes the writes through the ownership-fenced `failClaim()` / `requeueClaim()` helpers. The spliced copy is the un-fenced predecessor.

So this is a deletion only; `logBacklogIfNeeded()` is restored to the five-line best-effort helper its doc comment describes.

### Impact of the bug

`dlqWorker` could not start, so the dead-letter queue was never drained — every escrow webhook that failed its first delivery stayed in `webhook_failures` at `status = pending` indefinitely. `webhookRoutes.js` and `dlqWorker.js` failed to load with it.

### Verification

```
$ npx vitest run test/unit/dlqService.test.js
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

`npx eslint src/services/webhook/dlqService.js` — clean.
