### PR TITLE
fix(api): remove stray brace and module.exports breaking notificationService.js load

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -280,6 +280,3 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     // Push notification logic placeholder / dispatch
     return { success: true };
   }
-}
-
-module.exports = new NotificationService();


### PR DESCRIPTION
## Summary
`notificationService.js` had a stray closing brace and a trailing `module.exports = new NotificationService()` in a pure ES module (`"type": "module"`). This produced a `SyntaxError: Unexpected token '}'` at import time, so every file importing it — `orderRoutes.js`, `paymentRoutes.js`, `orderLifecycleService.js`, `orderMilestoneService.js`, `documentExpiryService.js`, `escrowFundingReconciliation.js`, `staleOrderWorker.js`, `OracleService.js` — failed to load, and the API server plus workers could not boot.

## Changes
- Removed the extra `}` at the end of `sendDeliveryOtpNotification`.
- Removed the dead `module.exports = new NotificationService()` line (`NotificationService` was never defined; the module exports named functions).
- Verified the module parses with `node --check` (exit 0).

Closes #8143

GSSOC 2026
