### PR TITLE
fix(customer): move orphaned cache table DDL into openDatabase callbacks

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -58,69 +58,71 @@ class CacheManager {
       path,
       version: 2,
       onCreate: (db, version) async {
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS orders (
-            id TEXT PRIMARY KEY,
-            type TEXT NOT NULL,
-            status TEXT,
-            payload TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
-        await db.execute('''
-          CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status)
-        ''');
+        await _createTables(db);
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
           await db.execute('''ALTER TABLE orders ADD COLUMN status TEXT''');
-          await db.execute('''CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status)''');
+          await _createTables(db);
         }
-      },
-    );
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS profile (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS documents (
-            id TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            payload TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS settings (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS last_location (
-            id TEXT PRIMARY KEY,
-            latitude REAL NOT NULL,
-            longitude REAL NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
-        await db.execute('''
-          CREATE TABLE IF NOT EXISTS milestones (
-            id TEXT PRIMARY KEY,
-            order_id TEXT NOT NULL,
-            title TEXT NOT NULL,
-            completed INTEGER NOT NULL,
-            updated_at TEXT NOT NULL
-          )
-        ''');
       },
     );
 
     return _database!;
+  }
+
+  Future<void> _createTables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS orders (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        status TEXT,
+        payload TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status)
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS profile (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS documents (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS last_location (
+        id TEXT PRIMARY KEY,
+        latitude REAL NOT NULL,
+        longitude REAL NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS milestones (
+        id TEXT PRIMARY KEY,
+        order_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    ''');
   }
 
   Future<void> cacheOrders(List<Map<String, dynamic>> orders) async {


### PR DESCRIPTION
## Summary
In `apps/customer/lib/core/offline/cache/cache_manager.dart`, the `CREATE TABLE` statements for `profile`, `documents`, `settings`, `last_location`, and `milestones` were placed **outside** the `openDatabase()` callbacks (after the `);` that closed the call), referencing `db` out of scope plus stray `},` and `);` tokens. On a fresh install `onCreate` only created the `orders` table, so every other cache operation (`cacheProfile`, `cacheDocuments`, `cacheSettings`, `cacheLastLocation`, `cacheMilestones`) failed at runtime with `no such table`.

## Changes
- Extracted all table DDL into a shared `_createTables(Database db)` helper using `CREATE TABLE IF NOT EXISTS` (idempotent).
- `onCreate` now calls `_createTables(db)` so all six tables are created on fresh installs.
- `onUpgrade` (v1 → v2) now also calls `_createTables(db)` so existing v1 installs get the missing tables too, alongside the existing `ALTER TABLE orders ADD COLUMN status` migration.

Closes #8145

GSSOC 2026
