### PR TITLE
fix(driver): add missing break statements to _onNavigate switch

### DIFF
--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -175,13 +175,16 @@ class _ShellScreenState extends State<ShellScreen> {
       case NavigateToOrderDetail():
       case NavigateToLiveTracking():
         _openTab(1); // Active Trip
+        break;
 
       case NavigateToLoadDetail():
         _openTab(2); // Available Loads
+        break;
 
       case NavigateToEarnings():
       case NavigateToWallet():
         _openTab(0); // Home (earnings summary is on the home card)
+        break;
 
       case NavigateToSupportTicket():
       case NavigateToNotificationsList():
@@ -189,6 +192,7 @@ class _ShellScreenState extends State<ShellScreen> {
           Navigator.of(context)
               .push(truxifyPageRoute((_) => const NotificationsScreen()));
         });
+        break;
     }
   }
 


### PR DESCRIPTION
## Summary
In `apps/driver/lib/screens/shell_screen.dart`, the `_onNavigate` switch statement was missing `break` statements after every non-empty case body. This caused every matched notification route to fall through into the next case, so e.g. an order-detail notification landed on the "Available Loads" tab instead of "Active Trip", and a notifications-list push was also executed after the earnings/home branch. (Non-empty cases that complete normally are also a Dart compile error.)

## Changes
- Added `break` after each case body in `_onNavigate`, preserving the intended tab mapping for order/live-tracking → tab 1, load detail → tab 2, earnings/wallet → tab 0, support/notifications → notifications screen in the home tab.

Closes #8146

GSSOC 2026
