### PR TITLE
fix(customer): read pickup/drop city from pickup_address/drop_address on home card

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -186,7 +186,9 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   ShipmentCardData? _buildShipmentFromOrder(Map<String, dynamic> order) {
-    final route = '${order['pickup_city'] ?? '?'} \u2192 ${order['drop_city'] ?? '?'}';
+    final pickupCity = _shortenAddress(order['pickup_address']?.toString() ?? '');
+    final dropCity = _shortenAddress(order['drop_address']?.toString() ?? '');
+    final route = '${pickupCity.isNotEmpty ? pickupCity : '?'} \u2192 ${dropCity.isNotEmpty ? dropCity : '?'}';
     final rawDriverName = order['driver_name']?.toString() ?? '';
     final hasDriver = DriverUtils.isValidDriverName(rawDriverName);
     final driverName = hasDriver ? rawDriverName : '';


### PR DESCRIPTION
## Summary
In `apps/customer/lib/screens/home_screen.dart`, `_buildShipmentFromOrder` read the route from `order['pickup_city']` and `order['drop_city']`, but the API order payload only contains `pickup_address` / `drop_address` (see `order_service.dart`, which sends exactly those keys). As a result the active-shipment card always displayed the placeholder `? → ?` even when the order had valid addresses.

## Changes
- Build the route string from `pickup_address` / `drop_address` instead.
- Reuse the existing `_shortenAddress` helper (same display logic as the "usual routes" cards) so only the city portion is shown, keeping the card compact.
- Fall back to `?` only when the address is empty/missing.

Closes #8147

GSSOC 2026
