### PR TITLE
fix(api): persist non-telemetry events in batch sync instead of dropping them

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -306,14 +306,6 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
     }
 
     const recordsToInsert = events.map(event => {
-      const lat = event.payload?.lat !== undefined ? Number(event.payload.lat) : null;
-      const lng = event.payload?.lng !== undefined ? Number(event.payload.lng) : null;
-
-      if (lat === null || lng === null || !Number.isFinite(lat) || !Number.isFinite(lng)) {
-        logger.warn('[SyncEngine] Skipping event with invalid coordinates:', { eventId: event.id, lat, lng });
-        return null;
-      }
-
       const safeMetadata = deepSanitize(event.payload, SENSITIVE_FIELDS);
 
       return {
@@ -322,23 +314,19 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
         trip_id: event.trip_id || null,
         event_type: event.type,
         event_timestamp: event.occurred_at,
-        latitude: lat,
-        longitude: lng,
+        latitude: event.payload?.lat !== undefined ? Number(event.payload.lat) : null,
+        longitude: event.payload?.lng !== undefined ? Number(event.payload.lng) : null,
         metadata: safeMetadata,
         created_at: new Date().toISOString()
       };
     });
 
     // 3. Bulk Insert / Upsert into the trip_events table
-    // Filter out null records (events with invalid coordinates)
-    const validRecords = recordsToInsert.filter(Boolean);
-
-    // 4. Bulk Insert / Upsert into the trip_events table
     // Upsert ensures that if a specific event ID already exists, it just updates it
     // rather than failing the whole batch.
     const { error: insertError } = await supabase
       .from('trip_events')
-      .upsert(validRecords, { onConflict: 'event_id' });
+      .upsert(recordsToInsert, { onConflict: 'event_id' });
 
     if (insertError) {
       logger.error('[SyncEngine] Bulk Insert Failed:', insertError.message);

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -379,6 +379,60 @@ describe('Trip Routes', () => {
         expect(upsertCall.payload[0].metadata).not.toHaveProperty('password');
         expect(upsertCall.payload[0].metadata.lat).toBe(19.076);
     });
+
+    it('POST /events/batch inserts non-telemetry events (otpDelivery) with NULL coordinates', async () => {
+        const originalFrom = m.supabase.from.bind(m.supabase);
+        m.supabase.from = table => {
+            const builder = originalFrom(table);
+            if (table === 'trip_events') {
+                builder.upsert = vi.fn(async payload => {
+                    m.calls.push({
+                        table: 'trip_events',
+                        mode: 'upsert',
+                        payload,
+                    });
+                    m.store.trip_events.push(...payload);
+                    return { data: payload, error: null };
+                });
+            }
+            return builder;
+        };
+
+        const res = await request(buildApp())
+            .post('/api/v1/trips/events/batch')
+            .set(DRIVER_HEADERS)
+            .send({
+                idempotencyKey: 'batch-otp-delivery',
+                events: [
+                    {
+                        id: 'event-otp',
+                        trip_id: 'trip-1',
+                        type: 'otpDelivery',
+                        occurred_at: new Date().toISOString(),
+                        payload: {
+                            stopId: 'stop-1',
+                        },
+                    },
+                ],
+            });
+
+        m.supabase.from = originalFrom;
+
+        expect(res.status).toBe(202);
+        const upsertCall = m.calls.find(
+            c => c.table === 'trip_events' && c.mode === 'upsert' && c.payload[0].event_id === 'event-otp'
+        );
+        expect(upsertCall).toBeTruthy();
+        expect(upsertCall.payload[0]).toEqual(
+            expect.objectContaining({
+                event_id: 'event-otp',
+                event_type: 'otpDelivery',
+                latitude: null,
+                longitude: null,
+                metadata: { stopId: 'stop-1' },
+            })
+        );
+    });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
In the offline-sync batch endpoint (`backend/api/src/routes/tripRoutes.js`), `POST /api/v1/trips/events/batch` only inserted events that had numeric `lat`/`lng` in their payload. Every other event — including `otpDelivery`, milestones, status updates etc. — was silently dropped (`return null` + `.filter(Boolean)`), so OTP deliveries queued offline were never recorded server-side.

Coordinate data is already strictly validated for telemetry frames earlier in the handler (out-of-range or missing pairs reject the whole batch with `400`), and the `trip_events` table has nullable `latitude`/`longitude`. Non-telemetry events simply carry no coordinates.

## Changes
- Build insert records for **all** validated events; store `latitude`/`longitude` as the numeric payload values when present and `null` when the event has no coordinates.
- Removed the null-record filter.
- Added a regression test asserting an `otpDelivery` event (valid `stopId`, no `otp`) is persisted with `latitude: null`, `longitude: null` and its metadata intact.

Closes #8148

GSSOC 2026
