### PR TITLE
fix(api): require driver role on PUT /api/driver/truck

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1677,7 +1677,7 @@ router.patch('/availability', authenticate, userLimiter, async (req, res) => {
   }
 });
 
-router.put('/truck', authenticate, userLimiter, async (req, res) => {
+router.put('/truck', authenticate, userLimiter, requireDriverRole, async (req, res) => {
   try {
     const { type, capacityWeight, capacityVolume, registrationNumber } = req.body;
 

--- a/backend/api/test/integration/driverProfile.test.js
+++ b/backend/api/test/integration/driverProfile.test.js
@@ -130,7 +130,8 @@ describe('Driver Profile & Availability Endpoints', () => {
       id: 'driver-123',
       full_name: 'John Driver',
       phone: '+919999999999',
-      email: 'john.driver@truxify.com'
+      email: 'john.driver@truxify.com',
+      role: 'driver'
     };
     mockDriverDetails = {
       rating: 4.7,
@@ -248,6 +249,24 @@ describe('Driver Profile & Availability Endpoints', () => {
       expect(res.body.success).toBe(true);
       expect(mockInsertTruck).toHaveBeenCalled();
       expect(mockUpdateDetails).toHaveBeenCalled();
+    });
+
+    it('returns 403 for a customer role', async () => {
+      mockProfile = { ...mockProfile, role: 'customer' };
+      const res = await request(app)
+        .put('/api/driver/truck')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          type: 'Heavy Duty Truck',
+          capacityWeight: 16.0,
+          capacityVolume: 50.0,
+          registrationNumber: 'MH12AB9999'
+        });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('Forbidden: Driver role required');
+      expect(mockUpdateTruck).not.toHaveBeenCalled();
+      expect(mockInsertTruck).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
`PUT /api/driver/truck` (`backend/api/src/routes/driverRoutes.js`) was protected only by `authenticate` + `userLimiter`, with no role check. Any authenticated user — including customers — could create or update a truck record. Every other driver-scoped route in the same file uses the file-local `requireDriverRole` guard.

## Changes
- Added `requireDriverRole` to the `PUT /api/driver/truck` middleware chain, so only `driver` (or `admin`) roles can mutate truck records.
- Updated the existing integration test profile mock to carry `role: 'driver'`.
- Added a regression test asserting a `customer` role gets `403 Forbidden: Driver role required` and no truck insert/update is attempted.

Closes #8149

GSSOC 2026
