### PR TITLE
[Bug] Drop pre-RPC re-fetch that made every stale-order cancellation throw

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -20,8 +20,6 @@ const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_STALE_ORDER_AGE_MS = 24 * 60 * 60 * 1000;
 const CONCURRENCY_LIMIT = 5;
 
-let staleOrderClient = null;
-
 export const startStaleOrderWorker = (orderRepository) => {
   if (staleOrderWorkerTask) {
     logger.info('[StaleOrderWorker] Stale order cleanup cron job already scheduled.');
@@ -29,12 +27,7 @@ export const startStaleOrderWorker = (orderRepository) => {
   }
 
   const repository = orderRepository || new OrderRepository(supabaseAdmin || supabase);
-  if (orderRepository) {
-    staleOrderClient = orderRepository.supabase;
-  } else if (supabaseAdmin) {
-    staleOrderClient = supabaseAdmin;
-  } else {
-    staleOrderClient = supabase;
+  if (!orderRepository && !supabaseAdmin) {
     logger.warn(
       '[StaleOrderWorker] Service-role client not configured - falling back to the anon-key client. RLS will block stale-order reads/writes.'
     );
@@ -177,20 +170,6 @@ async function cancelStaleOrder(staleOrder, staleSince, repository, metrics) {
       return;
     }
 
-    // Re-fetch the order inside the loop with a status filter to close the
-    // window between the batch SELECT and the per-order UPDATE.
-    const { data: current, error: refetchErr } = await staleOrderClient
-      .from('orders')
-      .select('id, customer_id, order_display_id, escrow_status, refund_tx_hash, escrow_refund_attempts')
-      .eq('id', staleOrder.id)
-      .eq('status', 'pending')
-      .maybeSingle();
-
-    if (refetchErr) {
-      logger.error(`[StaleOrderWorker] Failed to re-fetch order ${staleOrder.id}: ${refetchErr.message}`);
-      return;
-    }
-
     const won = Array.isArray(cancelled) ? cancelled.length > 0 : Boolean(cancelled);
     if (!won) {
       metrics.skipped += 1;
@@ -209,10 +188,6 @@ async function cancelStaleOrder(staleOrder, staleSince, repository, metrics) {
     await repository.updateLoadOffer(orderDisplayId, { status: 'cancelled' }).catch((offerErr) => {
       logger.warn(`[StaleOrderWorker] Failed to cancel load offer for order ${orderDisplayId}: ${offerErr.message}`);
     });
-    await staleOrderClient
-      .from('load_offers')
-      .update({ status: 'cancelled' })
-      .eq('order_display_id', current.order_display_id);
 
     // Send a notification to the customer
     try {
@@ -232,131 +207,6 @@ async function cancelStaleOrder(staleOrder, staleSince, repository, metrics) {
   } catch (err) {
     metrics.errors += 1;
     logger.error(`[StaleOrderWorker] Error processing stale order ${staleOrder.id}: ${err.message}`);
-  }
-}
-
-/**
- * Cancel an order that has no escrow involvement (escrow_status NULL or
- * 'pending'). The UPDATE is guarded on status='pending' AND escrow_status
- * NULL/'pending', so a concurrently accepted order is never overwritten.
- *
- * @returns {Promise<boolean>} true when the order was actually cancelled
- */
-async function cancelPlain(current) {
-  const { data: cancelled, error: updateErr } = await staleOrderClient
-    .from('orders')
-    .update({
-      status: 'cancelled',
-      cancellation_reason: STALE_ORDER_CANCELLATION_REASON,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', current.id)
-    .eq('status', 'pending')
-    .or('escrow_status.is.null,escrow_status.eq.pending')
-    .select('id');
-
-  if (updateErr) {
-    logger.error(`[StaleOrderWorker] Failed to cancel order ${current.id}: ${updateErr.message}`);
-    return false;
-  }
-
-  return Boolean(cancelled && cancelled.length > 0);
-}
-
-/**
- * Cancel an order whose escrow is (or was) funded, routing the refund through
- * the same pipeline used by orderLifecycleService.cancelOrder: first place the
- * order into 'refund_pending' with a guarded update, then submit/confirm the
- * refund, then finalise to 'refunded'. Any failure lands the order in
- * 'refund_pending'/'refund_failed' so the escrow-refund reconciliation worker
- * retries it.
- *
- * @returns {Promise<boolean>} true when the order was actually cancelled
- */
-async function cancelWithRefund(current, escrowStatus) {
-  const attemptAt = new Date().toISOString();
-
-  // Guarded transition: only an order that is STILL pending AND in the exact
-  // escrow state we observed may enter refund reconciliation. This is the
-  // serialisation point that prevents two workers from double-refunding.
-  const { data: pendingOrder, error: pendingErr } = await staleOrderClient
-    .from('orders')
-    .update({
-      status: 'cancelled',
-      cancellation_reason: STALE_ORDER_CANCELLATION_REASON,
-      escrow_status: 'refund_pending',
-      escrow_refund_error: null,
-      escrow_refund_attempts: (current.escrow_refund_attempts ?? 0) + 1,
-      escrow_refund_last_attempt_at: attemptAt,
-      updated_at: attemptAt,
-    })
-    .eq('id', current.id)
-    .eq('status', 'pending')
-    .eq('escrow_status', escrowStatus)
-    .select('id');
-
-  if (pendingErr) {
-    logger.error(`[StaleOrderWorker] Failed to place order ${current.order_display_id} into refund reconciliation: ${pendingErr.message}`);
-    return false;
-  }
-
-  if (!pendingOrder || pendingOrder.length === 0) {
-    return false;
-  }
-
-  let refundTxHash = current.refund_tx_hash ?? null;
-  try {
-    if (refundTxHash) {
-      await confirmEscrowRefund(refundTxHash);
-    } else {
-      const submitted = await submitEscrowRefund(current.order_display_id);
-      if (submitted.waitForConfirmation) {
-        const receipt = await submitted.waitForConfirmation();
-        refundTxHash = receipt.hash ?? submitted.txHash;
-      } else {
-        // Escrow contract may not be initialised — record the tx hash and let
-        // the escrow-refund reconciliation worker finalise confirmation.
-        refundTxHash = submitted.txHash;
-      }
-    }
-
-    const refundedAt = new Date().toISOString();
-    const { error: finalErr } = await staleOrderClient
-      .from('orders')
-      .update({
-        status: 'cancelled',
-        escrow_status: 'refunded',
-        refund_tx_hash: refundTxHash,
-        escrow_refunded_at: refundedAt,
-        escrow_refund_error: null,
-        updated_at: refundedAt,
-      })
-      .eq('id', current.id)
-      .in('escrow_status', ['refund_pending', 'refund_failed'])
-      .select('id');
-
-    if (finalErr) {
-      logger.error(`[StaleOrderWorker] Refund confirmed for ${current.order_display_id} but final order update failed: ${finalErr.message}`);
-    }
-
-    return true;
-  } catch (refundErr) {
-    const failedAt = new Date().toISOString();
-    const nextEscrowStatus = refundTxHash ? 'refund_pending' : 'refund_failed';
-    await staleOrderClient
-      .from('orders')
-      .update({
-        status: 'cancelled',
-        escrow_status: nextEscrowStatus,
-        refund_tx_hash: refundTxHash,
-        escrow_refund_error: String(refundErr.message || refundErr).slice(0, 1000),
-        escrow_refund_last_attempt_at: failedAt,
-        updated_at: failedAt,
-      })
-      .eq('id', current.id)
-      .in('escrow_status', ['refund_pending', 'refund_failed']);
-    logger.error(`[StaleOrderWorker] Refund failed for order ${current.order_display_id}: ${refundErr.message}`);
-    return true;
   }
 }
 


### PR DESCRIPTION
Fixes #8163.

`cancelStaleOrder()` still ran the re-fetch belonging to the implementation that `cancel_stale_order_tx` replaced. It executed on **every** successful cancellation and threw.

### Before

```
$ npx vitest run test/unit/staleOrderWorkerConcurrency.test.js test/unit/staleOrderWorkerNotifications.test.js
 Tests  4 failed | 6 passed

- { 'stale_orders.cancelled': 1, 'stale_orders.skipped': 1, 'stale_orders.errors': 0 }
+ { 'stale_orders.cancelled': 0, 'stale_orders.skipped': 0, 'stale_orders.errors': 2 }
```

### After

```
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

### Two independent faults in the removed block

1. `staleOrderClient` is only assigned inside `startStaleOrderWorker()`. Any caller driving `reconcileStaleOrders()` directly — the tests, and any sweep not going through the cron bootstrap — hit `null.from(...)`.
2. Even with the client set, the re-fetch filters on `.eq('status', 'pending')` while the RPC has just set `status = 'cancelled'`. It returns `null` with `refetchErr === null`, so the guard below does not fire and the next line dereferences `current`.

Both paths exit through the outer `catch` **before** `sendPushNotification`. The customer was never told their order was cancelled, the load offer kept its stale status, and a cancellation that had already committed to the database was counted in `metrics.errors` — corrupting both the `stale_orders.*` span attributes and the completion log.

The RPC's returned row already carries `customer_id`, `order_display_id` and `escrow_status`, so the re-fetch was redundant as well as broken. The direct `load_offers` update below it duplicated the `repository.updateLoadOffer(...)` call immediately above, so it went too.

### Dead code removed in the same pass

`cancelPlain()` and `cancelWithRefund()` (~120 lines) are the old non-RPC cancellation paths. Nothing calls them, and they reference `submitEscrowRefund` / `confirmEscrowRefund`, which this module never imports:

```
$ npx eslint src/workers/staleOrderWorker.js     # before
  310:13  error  'confirmEscrowRefund' is not defined  no-undef
  312:31  error  'submitEscrowRefund' is not defined   no-undef
```

They would throw `ReferenceError` if reached, so they are unreachable leftovers, not a live path. With them gone `staleOrderClient` had no readers and was removed; the anon-key RLS warning it guarded is preserved.

ESLint on the file is now clean.

> Note: `test/unit/staleOrderWorkerRace.test.js` also covers this worker and currently fails to parse for an unrelated reason. Tracked and fixed separately so this PR stays a single concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cancellation of stale orders by using the latest cancellation result.
  * Prevented duplicate order lookups during stale-order processing.
  * Improved handling of related load offers and notifications after cancellation.
  * Added clearer warnings when the required service configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->