### PR TITLE
fix(api): remove orphaned retry block from dlqService.logBacklogIfNeeded

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -339,38 +339,6 @@ export const dlqService = {
       const backlog = await this.getBacklogCount();
       if (backlog !== null) {
         logger.info(`[DLQ] Backlog of pending webhook failures: ${backlog}`);
-        } catch (procErr) {
-          logger.error(`[DLQ] Retry failed for event ${event.id}: ${procErr.message}`);
-
-          const newRetryCount = (event.retry_count ?? 0) + 1;
-          const nextBackoffMin = RETRY_BACKOFF[newRetryCount] || -1;
-
-          if (nextBackoffMin === -1) {
-            // Failed permanently
-            await dlqDb()
-              .from('webhook_failures')
-              .update({ 
-                status: 'failed_permanently', 
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString()
-              })
-              .eq('id', event.id);
-            logger.warn(`[DLQ] Event ${event.id} marked as failed_permanently`);
-          } else {
-            // Schedule next retry by resetting status to pending so the event can be re-claimed.
-            const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
-            await dlqDb()
-              .from('webhook_failures')
-              .update({
-                status: 'pending',
-                retry_count: newRetryCount,
-                next_retry_at: nextRetryAt,
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString(),
-              })
-              .eq('id', event.id);
-          }
-        }
       }
     } catch (err) {
       logger.warn(`[DLQ] Backlog metrics unavailable: ${err.message}`);


### PR DESCRIPTION
## Summary
`backend/api/src/services/webhook/dlqService.js` had an orphaned retry block accidentally pasted inside `logBacklogIfNeeded()`. The block referenced `event` / `procErr`, which are out of scope there, and left a trailing `catch (err)` with no matching `try` — a `SyntaxError: Unexpected token 'catch'`. Because `dlqWorker.js` imports this module at top level (and the API `index.js` imports `dlqWorker`), the syntax error prevented the API server and the DLQ worker from booting at all.

## Changes
- Removed the orphaned retry block from `logBacklogIfNeeded()`, restoring the intended simple try/catch that logs the pending backlog.
- The retry logic the orphaned block duplicated is already fully implemented in `dlqService.recordFailure()` (fenced `requeueClaim` / `failClaim` with backoff), so no behavior is lost.
- Verified the module parses with `node --check` (exit 0).

Closes #8150

GSSOC 2026
