### PR TITLE
fix(api): set driver_id when creating a truck via PUT /api/driver/truck

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1721,6 +1721,7 @@ router.put('/truck', authenticate, userLimiter, async (req, res) => {
       const { data, error } = await supabase
         .from('trucks')
         .insert({
+          driver_id: req.user.id,
           truck_type: type,
           capacity_weight_tonnes: capacityWeight || 0,
           capacity_volume_m3: capacityVolume || 0,

--- a/backend/api/test/integration/driverProfile.test.js
+++ b/backend/api/test/integration/driverProfile.test.js
@@ -246,7 +246,9 @@ describe('Driver Profile & Availability Endpoints', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(mockInsertTruck).toHaveBeenCalled();
+      expect(mockInsertTruck).toHaveBeenCalledWith(
+        expect.objectContaining({ driver_id: 'driver-123' })
+      );
       expect(mockUpdateDetails).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
When `PUT /api/driver/truck` created a new truck (`backend/api/src/routes/driverRoutes.js`), the inserted `trucks` row was missing `driver_id`. The only link between driver and truck was `driver_details.truck_id`. The `trucks` table has a `driver_id` ownership column that other routes rely on (e.g. `truckRoutes.js` `canViewTruckNumber` checks `truck.driver_id === user.id`), so freshly created trucks were unowned — visible to nobody, and unreassignable/ungovernable through the ownership checks.

## Changes
- Set `driver_id: req.user.id` on the `trucks` insert so every truck created through this endpoint is immediately owned by the authenticated driver.
- Extended the existing integration test to assert the insert payload carries `driver_id: 'driver-123'`.

Closes #8151

GSSOC 2026
