### PR TITLE
[Bug] Restore staleOrderWorkerRace suite so its 6 CAS race tests run again

### DIFF
--- a/backend/api/test/unit/staleOrderWorkerRace.test.js
+++ b/backend/api/test/unit/staleOrderWorkerRace.test.js
@@ -5,47 +5,6 @@ const loggerWarnMock = vi.fn();
 const redisSetMock = vi.fn();
 const redisDelMock = vi.fn();
 const redisExpireMock = vi.fn();
-const submitEscrowRefundMock = vi.fn();
-const confirmEscrowRefundMock = vi.fn();
-const ordersUpdateCalls = [];
-let scriptedResponses = [];
-const supabaseAdminBuilder = { from: vi.fn(makeBuilder) };
-const supabaseBuilder = { from: vi.fn(makeBuilder) };
-
-function makeBuilder(table) {
-  const builder = {
-    _mode: 'select',
-    _payload: null,
-    _filters: [],
-    select() { return this; },
-    eq(column, value) {
-      this._filters.push({ op: 'eq', column, value });
-      return this;
-    },
-    lt() { return this; },
-    or(filter) {
-      this._filters.push({ op: 'or', filter });
-      return this;
-    },
-    in() { return this; },
-    maybeSingle() { return this; },
-    update(payload) {
-      this._mode = 'update';
-      this._payload = payload;
-      return this;
-    },
-    then(resolve) {
-      const scripted = scriptedResponses.shift();
-      const result = scripted ?? { data: null, error: null };
-      if (table === 'orders' && this._mode === 'update') {
-        ordersUpdateCalls.push({ payload: this._payload, filters: this._filters, result });
-      }
-      return resolve(result);
-    },
-  };
-
-  return builder;
-}
 
 vi.mock('node-cron', () => ({
   default: {
@@ -94,8 +53,6 @@ vi.mock('../../src/config/db.js', () => ({
     del: redisDelMock,
     expire: redisExpireMock,
   },
-  supabase: supabaseBuilder,
-  supabaseAdmin: supabaseAdminBuilder,
 }));
 
 describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
@@ -125,36 +82,6 @@ describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
       findStalePendingOrders: vi.fn(),
       cancelStaleOrder: vi.fn(),
       updateLoadOffer: vi.fn().mockResolvedValue({ data: null, error: null }),
-    submitEscrowRefundMock.mockReset();
-    confirmEscrowRefundMock.mockReset();
-    supabaseBuilder.from.mockClear();
-    supabaseAdminBuilder.from.mockClear();
-    vi.resetModules();
-    const { startStaleOrderWorker } = await import('../../src/workers/staleOrderWorker.js');
-    startStaleOrderWorker();
-  });
-
-  const staleOrder = { id: 'order-1', customer_id: 'customer-1', order_display_id: 'disp-1' };
-
-  it('routes orders queries through the service-role client, never the anon client', async () => {
-    scriptedResponses = [{ data: [], error: null }];
-
-    await scheduledHandler();
-
-    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('orders');
-    expect(supabaseBuilder.from).not.toHaveBeenCalled();
-  });
-
-  function stillPending(overrides = {}) {
-    return {
-      id: 'order-1',
-      customer_id: 'customer-1',
-      order_display_id: 'disp-1',
-      escrow_status: 'pending',
-      escrow_amount_wei: null,
-      refund_tx_hash: null,
-      escrow_refund_attempts: 0,
-      ...overrides,
     };
     ({ reconcileStaleOrders } = await import('../../src/workers/staleOrderWorker.js'));
   });


### PR DESCRIPTION
Fixes #8168.

`test/unit/staleOrderWorkerRace.test.js` did not parse, so vitest could not collect any of the 6 TOCTOU regression tests it holds (issue #5741).

### Before

```
Cannot parse test/unit/staleOrderWorkerRace.test.js:
Expected `,` or `}` but found `.`
127:       updateLoadOffer: vi.fn().mockResolvedValue({ data: null, error: null }),
128:     submitEscrowRefundMock.mockReset();
                               ^
```

A merge kept both the current repository-based suite and the superseded `supabaseAdmin`-builder one, splicing the old `beforeEach` body into the middle of the new one's `orderRepository` object literal.

### Removed — all from the superseded suite

- `makeBuilder` / `supabaseAdminBuilder` / `supabaseBuilder` / `scriptedResponses` / `ordersUpdateCalls` scaffolding, unused by the live tests
- **Duplicate `supabase` and `supabaseAdmin` keys** in the `config/db.js` mock factory — declared `{}` first, then re-declared as the old builders, which silently won
- The `routes orders queries through the service-role client` test, which calls `scheduledHandler()`, an identifier the file never defines
- The `stillPending()` stub, whose body ended with the tail of the new `beforeEach` stranded after a `return`

Closing the `orderRepository` literal also restores the `await import('../../src/workers/staleOrderWorker.js')` that the current `beforeEach` needs.

### Verification

```
$ npx vitest run test/unit/staleOrderWorkerRace.test.js
      Tests  3 failed | 3 passed (6)      # against main
      Tests  6 passed (6)                 # with #8164 applied
```

The suite now collects. The 3 remaining failures against `main` are the worker bug in #8163 — exactly the regression this coverage exists to catch — and all 6 pass with #8164 applied. `npx eslint` clean.

> **Depends on #8164.** Merging that first turns this suite green.
