### PR TITLE
fix(api): stop fabricating driver performance stats when data is missing

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -756,15 +756,15 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
 
     const trips = orders || [];
     const totalDeliveries = trips.length;
-    const totalDistance = trips.reduce((acc, t) => acc + (Number(t.distance_km) || 12.5), 0);
+    const totalDistance = trips.reduce((acc, t) => acc + (Number(t.distance_km) || 0), 0);
     
     // Calculate average rating
     const ratings = trips.map(t => Number(t.customer_rating)).filter(r => !isNaN(r) && r > 0);
-    const averageRating = ratings.length > 0 ? Number((ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1)) : 4.8;
+    const averageRating = ratings.length > 0 ? Number((ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1)) : 0;
 
     // Calculate on-time percentage
     const onTimeCount = trips.filter(t => t.on_time !== false).length;
-    const onTimePercentage = totalDeliveries > 0 ? Number(((onTimeCount / totalDeliveries) * 100).toFixed(1)) : 100.0;
+    const onTimePercentage = totalDeliveries > 0 ? Number(((onTimeCount / totalDeliveries) * 100).toFixed(1)) : 0;
 
     // Lifetime earnings
     const lifetimeEarnings = trips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0);

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -590,4 +590,72 @@ describe('Profile Routes', () => {
       expect(res.body.trips[0].id).toBe('order-high-earn');
     });
   });
+
+  describe('GET /api/profile/driver/performance-stats', () => {
+    it('computes stats from real order data', async () => {
+      const currentMonth = new Date().toISOString().slice(0, 7);
+      m.store.orders.push(
+        {
+          id: 'order-1',
+          driver_id: 'driver-uuid-456',
+          status: 'delivered',
+          distance_km: 100,
+          customer_rating: 5,
+          on_time: true,
+          base_freight: 1000,
+          created_at: `${currentMonth}-05T00:00:00Z`,
+        },
+        {
+          id: 'order-2',
+          driver_id: 'driver-uuid-456',
+          status: 'payment_released',
+          distance_km: 200,
+          customer_rating: 4,
+          on_time: false,
+          base_freight: 2000,
+          created_at: `${currentMonth}-10T00:00:00Z`,
+        },
+        {
+          id: 'order-other-driver',
+          driver_id: 'other-driver',
+          status: 'delivered',
+          distance_km: 999,
+          customer_rating: 1,
+          on_time: true,
+          base_freight: 9999,
+          created_at: `${currentMonth}-01T00:00:00Z`,
+        }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/profile/driver/performance-stats')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalDeliveries).toBe(2);
+      expect(res.body.totalDistanceKm).toBe(300);
+      expect(res.body.averageRating).toBe(4.5);
+      expect(res.body.onTimePercentage).toBe(50);
+      expect(res.body.lifetimeEarnings).toBe(3000);
+      expect(res.body.monthlyPerformanceSummary).toEqual({
+        month: currentMonth,
+        deliveriesCompleted: 2,
+        earnings: 3000,
+      });
+    });
+
+    it('returns zeros instead of fabricated values when there is no data', async () => {
+      const res = await request(buildApp())
+        .get('/api/profile/driver/performance-stats')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalDeliveries).toBe(0);
+      expect(res.body.totalDistanceKm).toBe(0);
+      expect(res.body.averageRating).toBe(0);
+      expect(res.body.onTimePercentage).toBe(0);
+      expect(res.body.lifetimeEarnings).toBe(0);
+      expect(res.body.achievementBadges).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
`GET /api/profile/driver/performance-stats` (`backend/api/src/routes/profileRoutes.js`) fabricated metrics when real data was missing:
- `totalDistance` added `12.5` km per trip whenever `distance_km` was null/missing.
- `averageRating` defaulted to `4.8` when the driver had no ratings.
- `onTimePercentage` defaulted to `100.0` when the driver had no deliveries.

## Changes
- `totalDistance` now sums only real `distance_km` values (`0` when absent).
- `averageRating` returns `0` when there are no ratings.
- `onTimePercentage` returns `0` when there are no deliveries.
- Added integration tests covering (a) computation from real order rows (distance/rating/on-time/earnings, and the other-driver filter) and (b) the empty case returning honest zeros with no achievement badges.

Closes #8154

GSSOC 2026
