### PR TITLE
fix(api): validate coordinate query params on GET /trips/:id/events

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -498,10 +498,29 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
       eventsQuery = eventsQuery.eq('event_type', type);
     }
 
-    if (min_lat !== undefined) eventsQuery = eventsQuery.gte('latitude', Number(min_lat));
-    if (max_lat !== undefined) eventsQuery = eventsQuery.lte('latitude', Number(max_lat));
-    if (min_lng !== undefined) eventsQuery = eventsQuery.gte('longitude', Number(min_lng));
-    if (max_lng !== undefined) eventsQuery = eventsQuery.lte('longitude', Number(max_lng));
+    const coordParams = [
+      { raw: min_lat, min: -90, max: 90, label: 'min_lat' },
+      { raw: max_lat, min: -90, max: 90, label: 'max_lat' },
+      { raw: min_lng, min: -180, max: 180, label: 'min_lng' },
+      { raw: max_lng, min: -180, max: 180, label: 'max_lng' },
+    ];
+    const parsedCoords = {};
+    for (const { raw, min, max, label } of coordParams) {
+      if (raw === undefined) continue;
+      if (typeof raw !== 'string' || raw.trim() === '') {
+        return res.status(400).json({ error: `Query parameter ${label} must be a number.` });
+      }
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+        return res.status(400).json({ error: `Query parameter ${label} must be a number within [${min}, ${max}].` });
+      }
+      parsedCoords[label] = parsed;
+    }
+
+    if (parsedCoords.min_lat !== undefined) eventsQuery = eventsQuery.gte('latitude', parsedCoords.min_lat);
+    if (parsedCoords.max_lat !== undefined) eventsQuery = eventsQuery.lte('latitude', parsedCoords.max_lat);
+    if (parsedCoords.min_lng !== undefined) eventsQuery = eventsQuery.gte('longitude', parsedCoords.min_lng);
+    if (parsedCoords.max_lng !== undefined) eventsQuery = eventsQuery.lte('longitude', parsedCoords.max_lng);
 
     const { data: events, error: eventsErr, count } = await eventsQuery
       .order('event_timestamp', { ascending: isAscending })

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -536,4 +536,30 @@ describe('GET /api/trips/:id/events', () => {
     expect(res.body.events).toHaveLength(1);
     expect(res.body.events[0].event_id).toBe('ev-in');
   });
+
+  it('returns 400 for a non-numeric coordinate query param', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: '11111111-1111-4111-a111-111111111111', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/11111111-1111-4111-a111-111111111111/events?min_lat=abc')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('min_lat must be a number');
+  });
+
+  it('returns 400 for an out-of-range coordinate query param', async () => {
+    m.store.trip_events.push(
+      { event_id: 'ev-1', user_id: 'driver-1', trip_id: '11111111-1111-4111-a111-111111111111', event_type: 'gpsUpdate', event_timestamp: '2026-06-01T10:00:00Z', latitude: 19.0, longitude: 72.8, metadata: {}, created_at: '2026-06-01T10:00:00Z' },
+    );
+
+    const res = await request(buildEventsApp())
+      .get('/api/trips/11111111-1111-4111-a111-111111111111/events?max_lng=200')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('max_lng must be a number within [-180, 180]');
+  });
 });


### PR DESCRIPTION
## Summary
`GET /api/trips/:id/events` (`backend/api/src/routes/tripRoutes.js`) applied the `min_lat` / `max_lat` / `min_lng` / `max_lng` query params with `Number(value)` and no validation. A non-numeric value (e.g. `?min_lat=abc`) became `NaN` and was passed into the Supabase query, and values outside real-world bounds (lat outside [-90, 90], lng outside [-180, 180]) were accepted as filters.

## Changes
- Validate all four coordinate query params before building the query:
  - non-numeric / blank values → `400 Query parameter <name> must be a number.`
  - out-of-range values → `400 Query parameter <name> must be a number within [<min>, <max>].`
- Valid numeric params are applied to the query exactly as before (existing bounding-box filter test still passes).
- Added regression tests for the non-numeric and out-of-range cases.

Closes #8156

GSSOC 2026
