### PR TITLE
[Bug] Persist the settlement tx hash on escrow refund and withdrawal webhooks

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -21,7 +21,7 @@ async function findOrderByIdOrDisplayId(orderId) {
     throw new Error('Missing orderId in escrow webhook payload');
   }
 
-  const columns = 'id, order_display_id, driver_id, escrow_status, release_tx_hash';
+  const columns = 'id, order_display_id, driver_id, escrow_status, release_tx_hash, refund_tx_hash';
 
   if (UUID_REGEX.test(orderId)) {
     const { data, error } = await db
@@ -128,6 +128,7 @@ async function handleBookingCancelled(payload) {
     .from('orders')
     .update({
       escrow_status: 'refunded',
+      refund_tx_hash: payload.txHash || order.refund_tx_hash || null,
       updated_at: now,
     })
     .eq('id', order.id)
@@ -161,12 +162,22 @@ async function handleWithdrawalSettled(payload) {
     return;
   }
 
+  // Persist the settlement hash under the column that matches the outcome, so
+  // the on-chain evidence survives on the order either way. Falls back to any
+  // hash already on file when the webhook payload omits one.
+  const settlement = isRefund
+    ? { escrow_status: 'refunded', refund_tx_hash: txHash || order.refund_tx_hash || null }
+    : {
+        escrow_status: 'released',
+        release_tx_hash: txHash || order.release_tx_hash || null,
+        escrow_released_at: now,
+        escrow_release_error: null,
+      };
+
   const { error } = await requireDb()
     .from('orders')
     .update({
-      escrow_status: isRefund ? 'refunded' : 'released',
-      escrow_released_at: isRefund ? undefined : now,
-      escrow_release_error: isRefund ? undefined : null,
+      ...settlement,
       updated_at: now,
     })
     .eq('id', order.id)


### PR DESCRIPTION
Fixes #8171.

`handleBookingCancelled` and `handleWithdrawalSettled` recorded the settlement **status** but never wrote the on-chain **transaction hash**, so orders finished `refunded` / `released` with `refund_tx_hash` and `release_tx_hash` still `NULL`. The hash only ever reached the log line on the next statement.

### Before

```
$ npx vitest run test/unit/escrowWebhookProcessor.test.js
 Tests  3 failed | 9 passed

- ObjectContaining { escrow_status: 'refunded', refund_tx_hash: '0xdef' }
+ { escrow_status: 'refunded', updated_at: '...' }
```

### After

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

### Change

`handlePaymentReleased` already did this correctly. Both other handlers now use the same `payload.txHash || order.<column> || null` fallback, writing `refund_tx_hash` or `release_tx_hash` according to the outcome. `refund_tx_hash` was added to the selected columns — without it the "keep the hash already on file" fallback could not work on the refund path.

### Why it matters beyond the audit trail

`escrowReleaseReconciliation` reads `release_tx_hash` to decide whether a release already landed on-chain, and the refund reconcilers read `refund_tx_hash` to avoid resubmitting a refund that is already in flight. A settlement arriving through the withdrawal webhook left both `NULL`, so those workers saw no evidence on file and could resubmit against a booking that was already settled.

`npx eslint` clean.
