### PR TITLE
[Bug] Restore 6 security middleware suites (24 tests) and add the missing authFailureMonitor production guard

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -6,6 +6,10 @@ const DEFAULT_THRESHOLD = 5;
 const DEFAULT_WINDOW_MS = 60_000;
 
 export default function authFailureMonitor(req, res, next) {
+  if (process.env.NODE_ENV === 'production') {
+    return next();
+  }
+
   res.on('finish', () => {
     if (res.statusCode !== 401 && res.statusCode !== 403) {
       return;

--- a/backend/api/test/authFailureMonitor.test.js
+++ b/backend/api/test/authFailureMonitor.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {
@@ -12,11 +12,16 @@ vi.mock('../src/middleware/logger.js', () => ({
 
 import authFailureMonitor from '../src/middleware/authFailureMonitor.js';
 
-function createApp(statusCode = 401) {
+// The middleware keys its failure counters by IP in a module-level Map that
+// lives for the whole file, so every test needs its own IP to stay isolated.
+function createApp(statusCode = 401, ip = '127.0.0.1') {
   const app = express();
 
   app.use((req, res, next) => {
-    req.ip = '127.0.0.1';
+    // `req.ip` is a getter-only accessor on the Express prototype; a plain
+    // assignment throws in strict mode, which would 500 the request before it
+    // ever reached the monitor.
+    Object.defineProperty(req, 'ip', { value: ip, configurable: true });
     next();
   });
 
@@ -48,7 +53,7 @@ describe('authFailureMonitor', () => {
   });
 
   it('does not warn before the threshold is reached', async () => {
-    const app = createApp(401);
+    const app = createApp(401, '10.0.0.1');
 
     await request(app).get('/test');
     await request(app).get('/test');
@@ -79,7 +84,7 @@ describe('authFailureMonitor', () => {
   });
 
   it('tracks 403 responses as authentication failures', async () => {
-    const app = createApp(403);
+    const app = createApp(403, '10.0.0.3');
 
     await request(app).get('/test');
     await request(app).get('/test');
@@ -89,7 +94,7 @@ describe('authFailureMonitor', () => {
   });
 
   it('ignores successful responses', async () => {
-    const app = createApp(200);
+    const app = createApp(200, '10.0.0.4');
 
     await request(app).get('/test');
 
@@ -99,7 +104,7 @@ describe('authFailureMonitor', () => {
   it('does not run in production', async () => {
     process.env.NODE_ENV = 'production';
 
-    const app = createApp(401);
+    const app = createApp(401, '10.0.0.5');
 
     await request(app).get('/test');
     await request(app).get('/test');

--- a/backend/api/test/cacheControlVerifier.test.js
+++ b/backend/api/test/cacheControlVerifier.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {

--- a/backend/api/test/cookieSecurityValidator.test.js
+++ b/backend/api/test/cookieSecurityValidator.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {

--- a/backend/api/test/headerSizeMonitor.test.js
+++ b/backend/api/test/headerSizeMonitor.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {

--- a/backend/api/test/securityHeaderDuplicates.test.js
+++ b/backend/api/test/securityHeaderDuplicates.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {

--- a/backend/api/test/securityHeadersVerifier.test.js
+++ b/backend/api/test/securityHeadersVerifier.test.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 
-const warnMock = vi.fn();
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
 vi.mock('../src/middleware/logger.js', () => ({
   default: {


### PR DESCRIPTION
Fixes #8175.

Six security-middleware suites failed during collection, so **none of their 24 tests had ever run**.

### Before

```
$ npx vitest run test/securityHeadersVerifier.test.js
Error: [vitest] There was an error when mocking a module. If you are using "vi.mock" factory,
make sure there are no top level variables inside, since this call is hoisted to top of the file.
```

### After

```
 Test Files  6 passed (6)
      Tests  24 passed (24)
```

### 1. The collection failure (all six files)

```js
const warnMock = vi.fn();                        // evaluated in file order
vi.mock('../src/middleware/logger.js', () => ({  // hoisted above it
  default: { warn: warnMock },
}));
```

`vi.mock` is hoisted, so the factory ran before `warnMock` was initialised and hit its temporal dead zone. Each mock moved into `vi.hoisted()`.

### 2. `authFailureMonitor.test.js`, once it collected

- **`req.ip = '127.0.0.1'` throws under Express 5** — `req.ip` is a getter-only accessor on the prototype, so the test's own setup middleware 500'd the request and it never reached the 401/403 the monitor counts. Now set with `Object.defineProperty`.
- **Cross-test state leakage** — the middleware keys its counters in a module-level `Map` that is never cleared, so tests sharing `127.0.0.1` inherited each other's counts. Each test now uses its own IP.

### 3. The real defect this uncovered

With the suite running, `does not run in production` failed legitimately. `authFailureMonitor` was the **only** middleware in this family without the guard its five siblings all open with:

```js
if (process.env.NODE_ENV === 'production') {
  return next();
}
```

`cacheControlVerifier`, `cookieSecurityValidator`, `headerSizeMonitor`, `securityHeaderDuplicates` and `securityHeadersVerifier` each have it. Without it, production kept an unbounded per-IP `Map` and logged on every 401/403 — which is what the convention exists to prevent. Added, matching the siblings' style exactly.

`npx eslint` clean on all seven touched files.
