### PR TITLE
[Bug] Cover securityHeaders middleware and remove the two zero-byte test files

### DIFF
--- a/backend/api/test/unit/securityHeaders.test.js
+++ b/backend/api/test/unit/securityHeaders.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import securityHeaders from '../../src/middleware/securityHeaders.js';
+
+function createApp(preset = {}) {
+  const app = express();
+
+  app.use((req, res, next) => {
+    for (const [name, value] of Object.entries(preset)) {
+      res.setHeader(name, value);
+    }
+    next();
+  });
+
+  app.use(securityHeaders);
+
+  app.get('/test', (req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  return app;
+}
+
+describe('securityHeaders', () => {
+  it('sets the baseline security headers on a plain request', async () => {
+    const res = await request(createApp()).get('/test');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['x-frame-options']).toBe('DENY');
+    expect(res.headers['x-xss-protection']).toBe('1; mode=block');
+    expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    expect(res.headers['permissions-policy']).toBe(
+      'geolocation=(self), camera=(self), microphone=(self)'
+    );
+    expect(res.headers['cross-origin-resource-policy']).toBe('same-origin');
+    expect(res.headers['x-content-security-policy']).toBe("default-src 'self'");
+  });
+
+  it('does not send HSTS over plain HTTP', async () => {
+    const res = await request(createApp()).get('/test');
+
+    expect(res.headers['strict-transport-security']).toBeUndefined();
+  });
+
+  it('sends HSTS when the request arrived over HTTPS at the proxy', async () => {
+    const res = await request(createApp())
+      .get('/test')
+      .set('x-forwarded-proto', 'https');
+
+    expect(res.headers['strict-transport-security']).toBe(
+      'max-age=31536000; includeSubDomains'
+    );
+  });
+
+  it('preserves headers an earlier layer already set', async () => {
+    const res = await request(
+      createApp({
+        'X-Frame-Options': 'SAMEORIGIN',
+        'Referrer-Policy': 'no-referrer',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      })
+    ).get('/test');
+
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+    expect(res.headers['cross-origin-resource-policy']).toBe('cross-origin');
+    // The headers nobody set are still filled in.
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('never overrides an existing Content-Security-Policy', async () => {
+    const csp = "default-src 'none'; script-src 'self'";
+    const res = await request(createApp({ 'Content-Security-Policy': csp })).get('/test');
+
+    expect(res.headers['content-security-policy']).toBe(csp);
+  });
+
+  it('does not set a Content-Security-Policy of its own', async () => {
+    const res = await request(createApp()).get('/test');
+
+    expect(res.headers['content-security-policy']).toBeUndefined();
+  });
+
+  it('calls next() so the request reaches the route', async () => {
+    const res = await request(createApp()).get('/test');
+
+    expect(res.body).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Fixes #8177.

`test/middleware.test.js` and `test/unit/securityHeaders.test.js` were both **zero bytes**. Vitest treats an empty test file as a hard failure, so every run carried two failures unrelated to the code under test.

### Before

```
$ npx vitest run
 FAIL  test/middleware.test.js [ test/middleware.test.js ]
Error: No test suite found in file .../test/middleware.test.js

 FAIL  test/unit/securityHeaders.test.js [ test/unit/securityHeaders.test.js ]
Error: No test suite found in file .../test/unit/securityHeaders.test.js
```

Neither file has ever held content — `git show` on the commits that introduced them returns 0 bytes. They were placeholders that were never filled in.

### `securityHeaders` — coverage gap closed

`src/middleware/securityHeaders.js` had **no tests at all**, despite owning `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, HSTS, `Referrer-Policy`, `Permissions-Policy` and `Cross-Origin-Resource-Policy`. The new suite covers its actual contract:

- the baseline headers it always sets
- HSTS **only** when the request is secure or arrived as `x-forwarded-proto: https`
- headers an earlier layer already set are preserved, while the ones nobody set are still filled in
- an existing `Content-Security-Policy` is never overridden, and the middleware sets none of its own
- `next()` is called so the request reaches the route

```
$ npx vitest run test/unit/securityHeaders.test.js
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### `middleware.test.js` — deleted

`src/middleware/` is already covered by dedicated per-middleware suites (`apiKey`, `auditLog`, `idempotency`, `rateLimiter`, `cors`, `securityHeaders` and others), so an empty catch-all file adds nothing. Happy to write a suite for it instead if you would rather keep the filename.

`npx eslint` clean.
