### PR TITLE
[Bug] Bound the payout webhook request so one unresponsive provider cannot stall withdrawal settlement

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -11,7 +11,18 @@ import logger from '../../middleware/logger.js';
  *   WITHDRAWAL_PAYOUT_WEBHOOK_URL - HTTP endpoint that executes the payout;
  *                                   it must POST back a JSON body with a
  *                                   `settlement_ref` (or `reference`) string.
+ *   WITHDRAWAL_PAYOUT_TIMEOUT_MS  - abort the payout request after this many
+ *                                   milliseconds (default 15000).
  */
+
+const DEFAULT_PAYOUT_TIMEOUT_MS = 15000;
+
+function payoutTimeoutMs() {
+  const configured = Number(process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_PAYOUT_TIMEOUT_MS;
+}
 
 export function isPayoutProviderConfigured() {
   return Boolean(
@@ -31,17 +42,31 @@ export async function dispatchPayout({ driverId, withdrawal }) {
   }
 
   if (webhookUrl) {
-    const response = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        provider,
-        driver_id: driverId,
-        withdrawal_id: withdrawal.id,
-        amount: withdrawal.amount,
-        reference: `w${withdrawal.id}`,
-      }),
-    });
+    const timeoutMs = payoutTimeoutMs();
+    let response;
+    try {
+      response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          provider,
+          driver_id: driverId,
+          withdrawal_id: withdrawal.id,
+          amount: withdrawal.amount,
+          reference: `w${withdrawal.id}`,
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      // A timeout is indistinguishable from any other transport failure: the
+      // payout may or may not have been accepted. Surface it as a dispatch
+      // failure so the caller keeps its existing fail-safe handling rather
+      // than hanging the settlement worker forever.
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        throw new Error(`Payout webhook did not respond within ${timeoutMs}ms.`);
+      }
+      throw err;
+    }
 
     if (!response.ok) {
       throw new Error(`Payout webhook returned HTTP ${response.status}.`);

--- a/backend/api/test/unit/payoutProvider.test.js
+++ b/backend/api/test/unit/payoutProvider.test.js
@@ -11,10 +11,12 @@ vi.mock('../../src/middleware/logger.js', () => ({
 describe('payoutProvider', () => {
   const originalProvider = process.env.WITHDRAWAL_PAYOUT_PROVIDER
   const originalWebhook = process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL
+  const originalTimeout = process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS
 
   beforeEach(() => {
     delete process.env.WITHDRAWAL_PAYOUT_PROVIDER
     delete process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL
+    delete process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS
   })
 
   afterEach(() => {
@@ -22,6 +24,8 @@ describe('payoutProvider', () => {
     else process.env.WITHDRAWAL_PAYOUT_PROVIDER = originalProvider
     if (originalWebhook === undefined) delete process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL
     else process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL = originalWebhook
+    if (originalTimeout === undefined) delete process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS
+    else process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS = originalTimeout
   })
 
   it('reports not configured when no provider or webhook is set', () => {
@@ -66,6 +70,41 @@ describe('payoutProvider', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
     await expect(dispatchPayout({ driverId: 'd1', withdrawal: { id: 'w1', amount: 1 } }))
       .rejects.toThrow(/HTTP 500/)
+    vi.unstubAllGlobals()
+  })
+
+  it('passes an abort signal so a hung webhook cannot stall the worker', async () => {
+    process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL = 'https://example.com/payout'
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await dispatchPayout({ driverId: 'd1', withdrawal: { id: 'w1', amount: 1 } })
+
+    expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+    vi.unstubAllGlobals()
+  })
+
+  it('surfaces a timeout as a dispatch failure rather than hanging', async () => {
+    process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL = 'https://example.com/payout'
+    process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS = '25'
+    vi.stubGlobal('fetch', vi.fn((url, opts) => new Promise((_resolve, reject) => {
+      opts.signal.addEventListener('abort', () => reject(opts.signal.reason))
+    })))
+
+    await expect(dispatchPayout({ driverId: 'd1', withdrawal: { id: 'w1', amount: 1 } }))
+      .rejects.toThrow(/did not respond within 25ms/)
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores a non-positive configured timeout and falls back to the default', async () => {
+    process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL = 'https://example.com/payout'
+    process.env.WITHDRAWAL_PAYOUT_TIMEOUT_MS = 'not-a-number'
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await expect(dispatchPayout({ driverId: 'd1', withdrawal: { id: 'w1', amount: 1 } }))
+      .resolves.toMatchObject({ success: true })
+    expect(mockFetch.mock.calls[0][1].signal.aborted).toBe(false)
     vi.unstubAllGlobals()
   })
 })


### PR DESCRIPTION
Fixes #8182.

`dispatchPayout()` called `fetch()` with **no timeout**. Node's `fetch` has no default request timeout, so a payout provider that accepts the connection and never responds left the `await` hanging forever.

### Why one stuck request stalls everything

`settlePendingWithdrawals()` walks its batch in a sequential `for` loop:

```js
for (const withdrawal of withdrawals) {
  const result = await dispatchPayout({ driverId: withdrawal.driver_id, withdrawal });
```

So a single unresponsive request meant:

- up to **49 other drivers' withdrawals stayed `pending`** behind the stuck one
- the cycle never completed, so the sweep silently stopped making progress
- `startWithdrawalSettlementWorker` uses `setInterval(..., 60_000)` with no in-flight guard, so **a fresh cycle started every minute on top of the stalled one**, re-reading the same `status = 'pending'` rows

No malice required — a provider outage that drops responses rather than the connection is enough.

### Change

`signal: AbortSignal.timeout(...)`, matching the idiom `ml.js` already uses on all 15 of its calls. Configurable via `WITHDRAWAL_PAYOUT_TIMEOUT_MS` (default 15000; non-numeric and non-positive values fall back to the default). `TimeoutError` / `AbortError` are translated into a clear dispatch error, so the caller's existing fail-safe handling is untouched.

Every other outbound HTTP call in the backend was already bounded — `ml.js`, `osrm.js` (`OSRM_TIMEOUT_MS`), `routingService.js`, `documentController.js`. The payout webhook was the outlier, and the one call that moves money.

### Tests

Three added to the existing suite: the abort signal is passed, a timeout surfaces as a dispatch failure instead of hanging, and a non-numeric configured timeout falls back to the default.

```
$ npx vitest run test/unit/payoutProvider.test.js test/unit/withdrawalSettlementWorker.test.js
 Test Files  2 passed (2)
      Tests  15 passed (15)
```

`npx eslint` clean.

### One thing worth a reviewer's eye

A timed-out request is genuinely ambiguous — the provider may still have accepted the payout — while `settlePendingWithdrawals` treats any `dispatchPayout` throw as "money never left" and calls `fail_withdrawal_tx`. That ambiguity already applies to every other transport failure (a connection reset after the request is sent is indistinguishable), so this PR does not introduce it, and hanging forever is strictly worse. Tightening the classification touches the same fail path as #7868, so it seems better handled there or as a follow-up than folded in here — happy to do it either way.
