### PR TITLE
fix(driver): reliably queue and replay offline location updates

### DIFF
--- a/apps/driver/lib/services/local_db_service.dart
+++ b/apps/driver/lib/services/local_db_service.dart
@@ -23,7 +23,7 @@ class LocalDbService {
 
     return await openDatabase(
       path,
-      version: 2,
+      version: 3,
       onCreate: _createDB,
       onUpgrade: _upgradeDB,
     );
@@ -47,11 +47,39 @@ CREATE TABLE pending_pods (
   sync_status $intType
 )
 ''');
+    await _createLocationQueueTable(db);
+  }
+
+  /// Durable offline queue for driver location pings and geofence milestones.
+  ///
+  /// Every row is one undelivered item that must survive application restarts.
+  /// Milestones use a stable `idempotency_key` (`milestone:{orderId}:{milestone}`)
+  /// which is UNIQUE so re-enqueueing the same logical milestone is a no-op.
+  /// Location rows use a `null` key (SQLite UNIQUE permits multiple NULLs) —
+  /// their dedup/coalescing is handled at the app layer.
+  Future<void> _createLocationQueueTable(Database db) async {
+    await db.execute('''
+CREATE TABLE IF NOT EXISTS location_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind TEXT NOT NULL,
+  driver_id TEXT,
+  order_id TEXT,
+  order_display_id TEXT,
+  milestone TEXT,
+  idempotency_key TEXT UNIQUE,
+  payload TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0
+)
+''');
   }
 
   Future<void> _upgradeDB(Database db, int oldVersion, int newVersion) async {
     if (oldVersion < 2) {
       await db.execute('ALTER TABLE pending_pods ADD COLUMN order_id TEXT');
+    }
+    if (oldVersion < 3) {
+      await _createLocationQueueTable(db);
     }
   }
 

--- a/apps/driver/lib/services/location_replay_service.dart
+++ b/apps/driver/lib/services/location_replay_service.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+
+import 'offline_location_queue.dart';
+
+/// Current state of the replay worker.
+enum LocationReplayState {
+  /// No replay pass is running.
+  idle,
+
+  /// A replay pass is in flight. `kick()` calls made during this window are
+  /// no-ops.
+  replaying,
+}
+
+/// Single source of truth for delivering items from the offline
+/// [OfflineLocationQueue] once the backend becomes reachable.
+///
+/// Guarantees
+/// ----------
+/// * **Single worker** — `kick()` is a no-op while another replay is running,
+///   so background sync, foreground connect and reconnect can never spawn two
+///   competing replay loops.
+/// * **At-least-once, exactly-once-removal** — an item is removed only after
+///   the backend accepts it. A failed item stays queued for the next reconnect.
+/// * **Stops on disconnect** — the loop checks connection health before every
+///   item and aborts as soon as the transport drops, leaving the remainder
+///   queued.
+/// * **Rate-limit aware** — the backend WebSocket limiter allows
+///   `MAX_MSG_PER_SECOND` (10) messages per socket per second. [replayDelay]
+///   spaces replays far below that budget so the normal 5s live ping cadence
+///   is never starved and replayed batches are not silently dropped.
+/// * **Idempotent** — milestone items carry a stable `orderId + milestone`
+///   identity; replaying the same logical milestone uses the same identity.
+class LocationReplayService {
+  LocationReplayService._();
+
+  /// Production singleton.
+  static final LocationReplayService instance = LocationReplayService._();
+
+  /// Test hook: substitute the queue backing the replay worker.
+  @visibleForTesting
+  OfflineLocationQueue? queueOverride;
+
+  OfflineLocationQueue get _queue => queueOverride ?? OfflineLocationQueue.instance;
+
+  bool _replaying = false;
+  bool _stopRequested = false;
+
+  /// Whether a replay pass is currently running.
+  LocationReplayState get state =>
+      _replaying ? LocationReplayState.replaying : LocationReplayState.idle;
+
+  /// Transport hooks — installed by [LocationService] when tracking starts.
+  ///
+  /// * [sendLocation] — hands a `location_ping` data map to the tracking
+  ///   WebSocket; returns [WsSendResult.delivered] only when the socket
+  ///   accepted it.
+  /// * [sendMilestone] — delivers a geofence milestone over HTTP; returns
+  ///   `true` when the backend accepted it (2xx or 409 "already completed").
+  /// * [tokenProvider] — current auth token for milestone HTTP calls.
+  /// * [driverIdProvider] — current authenticated driver id.
+  /// * [isConnected] — whether the tracking WebSocket is currently usable.
+  WsSendResult Function(Map<String, dynamic> payload)? sendLocation;
+  Future<bool> Function({
+    required String orderId,
+    required String milestone,
+    required String token,
+  })?
+      sendMilestone;
+  String? Function()? tokenProvider;
+  String? Function()? driverIdProvider;
+  bool Function()? isConnected;
+
+  /// Spacing between replayed messages (≈4 msg/s, well under the backend's
+  /// 10 msg/s per-socket budget). Mutable so tests can shorten it.
+  @visibleForTesting
+  static Duration replayDelay = const Duration(milliseconds: 250);
+
+  /// The largest batch replayed in one pass — bounds a single reconnect burst
+  /// so hundreds of stale points are never flushed at once. A follow-up
+  /// reconnect (or the next live ping path) replays the rest.
+  @visibleForTesting
+  static const int maxBatchPerRun = 100;
+
+  /// Kicks a replay pass. Safe to call from any trigger (reconnect, app start,
+  /// manual retry): concurrent callers simply no-op.
+  Future<void> kick() async {
+    if (_replaying) return;
+    _replaying = true;
+    _stopRequested = false;
+    try {
+      final sendLoc = sendLocation;
+      if (sendLoc == null) return;
+
+      final currentDriverId = driverIdProvider?.call();
+      final pending = await _queue.pending();
+
+      var sentInBatch = 0;
+      for (final item in pending) {
+        if (_stopRequested) break;
+        if (isConnected?.call() == false) break;
+        if (sentInBatch >= maxBatchPerRun) break;
+
+        switch (item.kind) {
+          case QueueItemKind.location:
+            final payload = Map<String, dynamic>.from(item.payload);
+            final data = payload['data'] is Map<String, dynamic>
+                ? (payload['data'] as Map<String, dynamic>)
+                : payload;
+            if (currentDriverId != null &&
+                data['driver_id']?.toString() != currentDriverId) {
+              // Belongs to a different driver session — never deliver it, but
+              // leave it queued (it may become valid again after re-login).
+              continue;
+            }
+            // Freshen the timestamp so the backend's clock-skew gate
+            // (±5 min) accepts replayed fixes from an offline stretch.
+            final nowIso = DateTime.now().toIso8601String();
+            data['device_timestamp'] = nowIso;
+            data['timestamp'] = nowIso;
+            if (sendLoc(payload) != WsSendResult.delivered) {
+              // Transport dropped mid-replay — stop now, keep the rest queued.
+              debugPrint('[Replay] Location ${item.id} failed — stopping replay');
+              return;
+            }
+            await _queue.remove(item.id);
+            sentInBatch++;
+            debugPrint('[Replay] Location ${item.id} delivered');
+            break;
+
+          case QueueItemKind.milestone:
+            final orderId = item.orderId;
+            final milestone = item.milestone;
+            final token = tokenProvider?.call();
+            final sendMs = sendMilestone;
+            if (orderId == null || milestone == null || token == null || sendMs == null) {
+              continue;
+            }
+            final delivered =
+                await sendMs(orderId: orderId, milestone: milestone, token: token);
+            if (!delivered) {
+              // Backend unreachable/unhappy — stop and retry on next reconnect.
+              debugPrint('[Replay] Milestone ${item.id} failed — stopping replay');
+              return;
+            }
+            await _queue.remove(item.id);
+            sentInBatch++;
+            debugPrint('[Replay] Milestone ${item.id} delivered ($orderId / $milestone)');
+            break;
+        }
+
+        await Future<void>.delayed(replayDelay);
+      }
+    } finally {
+      _replaying = false;
+    }
+  }
+
+  /// Asks an in-flight replay to stop before the next item.
+  ///
+  /// Called when tracking stops so a background replay never outlives the
+  /// activity that triggered it.
+  void requestStop() {
+    _stopRequested = true;
+  }
+}

--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -9,7 +9,25 @@ import 'package:http/http.dart' as http;
 import 'package:truxify_shared/truxify_shared.dart';
 
 import 'battery_service.dart';
+import 'location_replay_service.dart';
+import 'offline_location_queue.dart';
 import 'secure_storage.dart';
+
+/// Outcome of a location ping attempt.
+///
+/// A ping is `delivered` only when the WebSocket transport accepted it, and
+/// `queued` only when it was durably persisted into the offline queue. A ping
+/// that is neither must never advance the "last sent" throttle state.
+enum LocationDelivery {
+  /// Accepted by the WebSocket transport.
+  delivered,
+
+  /// Not accepted by the transport, but durably queued for later replay.
+  queued,
+
+  /// Neither delivered nor persisted — safe to retry on the next fix.
+  failed,
+}
 
 class LocationService {
   LocationService._privateConstructor();
@@ -39,9 +57,25 @@ class LocationService {
   String? _activeOrderDisplayId;
   int? _lastCloseCode;
   String? _authToken;
+
+  /// Whether the current WebSocket completed the first-frame `auth` handshake
+  /// (issue #5739). Location pings are only delivered over a socket once this
+  /// is true — the backend otherwise rejects the connection with code 4001.
+  bool _wsAuthenticated = false;
+
+  /// Throttle state: the last location *accepted into the delivery pipeline*
+  /// (either delivered over the WebSocket or durably queued for replay).
+  ///
+  /// It intentionally does NOT advance for a ping that was neither delivered
+  /// nor persisted — a dropped message must never suppress future GPS updates
+  /// by making the app believe the backend saw an earlier fix.
   Position? _lastSentPosition;
   DateTime? _lastSentTime;
   String? _lastTriggeredMilestone;
+
+  // Durable offline queue + single replay worker for it.
+  final OfflineLocationQueue _offlineQueue = OfflineLocationQueue.instance;
+  final LocationReplayService _replayService = LocationReplayService.instance;
 
   // Throttling configuration: send ping if moved 10m+ OR 5 seconds passed
   // (Issue: Driver app must emit GPS updates every 5 seconds during active trip)
@@ -88,7 +122,7 @@ class LocationService {
     if (permission.isPermanentlyDenied) {
       debugPrint('[LocationService] Location permission permanently denied');
       openAppSettings();
-      throw Exception('Location permissions are permanently denied. Please enable in app settings.');
+      throw Exception('Location permissions are permanently denied. Please open app settings.');
     }
 
     // Pre-seed active order display ID if the caller already knows it.
@@ -100,19 +134,61 @@ class LocationService {
     _isTracking = true;
     _emitStatus(WsConnectionStatus.connecting);
     debugPrint('[LocationService] Starting driver location tracking...');
+
+    // Install the replay transport hooks so the single replay worker can
+    // deliver queued pings/milestones through this service's own transport.
+    _installReplayHooks();
+
     _startPositionSubscription();
+  }
+
+  void _installReplayHooks() {
+    _replayService.sendLocation = (payload) {
+      final ws = _resilientWs;
+      if (ws == null || !ws.isConnected || !_wsAuthenticated) {
+        return WsSendResult.failed;
+      }
+      return ws.sendResult(payload);
+    };
+    _replayService.sendMilestone =
+        ({required orderId, required milestone, required token}) async {
+      try {
+        final url = Uri.parse('$defaultApiBaseUrl/api/orders/$orderId/milestones');
+        final response = await http.put(
+          url,
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer $token',
+          },
+          body: jsonEncode({'milestone': milestone}),
+        );
+        // 409 = milestone already completed server-side: idempotent success.
+        return response.statusCode >= 200 && response.statusCode < 300 ||
+            response.statusCode == 409;
+      } catch (_) {
+        return false;
+      }
+    };
+    _replayService.tokenProvider =
+        () => Supabase.instance.client.auth.currentSession?.accessToken;
+    _replayService.driverIdProvider =
+        () => Supabase.instance.client.auth.currentUser?.id;
+    _replayService.isConnected = () => _wsAuthenticated;
   }
 
   void stopTracking() {
     if (!_isTracking) return;
     _isTracking = false;
     debugPrint('[LocationService] Stopping driver location tracking...');
+    // Abort any in-flight replay so it never outlives this tracking session.
+    _replayService.requestStop();
     _positionSubscription?.cancel();
     _positionSubscription = null;
     _maxIntervalTimer?.cancel();
     _maxIntervalTimer = null;
     _lastSentPosition = null;
     _lastTriggeredMilestone = null;
+    _wsAuthenticated = false;
     _activeOrderId = null;
     _activeOrderDisplayId = null;
     _closeWebSocket();
@@ -149,8 +225,9 @@ class LocationService {
     // Implement displacement-based throttling
     if (_lastSentPosition == null) {
       // First position, always send
-      final sent = await _sendLocationPing(position);
-      if (sent) {
+      final result = await _sendLocationPing(position);
+      if (result == LocationDelivery.delivered ||
+          result == LocationDelivery.queued) {
         _lastSentPosition = position;
         _lastSentTime = DateTime.now();
       }
@@ -171,8 +248,9 @@ class LocationService {
     // Send if: moved 15m+ OR max interval (30s) has elapsed
     if (distanceMoved >= _minDistanceMeters ||
         timeSinceLastSend.compareTo(_maxInterval) >= 0) {
-      final sent = await _sendLocationPing(position);
-      if (sent) {
+      final result = await _sendLocationPing(position);
+      if (result == LocationDelivery.delivered ||
+          result == LocationDelivery.queued) {
         _lastSentPosition = position;
         _lastSentTime = now;
       }
@@ -184,26 +262,43 @@ class LocationService {
     }
   }
 
-  Future<bool> _sendLocationPing(Position position) async {
+  /// Sends a location ping, or durably queues it when the transport is
+  /// unavailable. Returns [LocationDelivery]:
+  ///
+  /// * `delivered` — the WebSocket accepted it; throttle state may advance.
+  /// * `queued` — persisted to the offline queue; throttle state may advance
+  ///   (the fix is guaranteed to be replayed later).
+  /// * `failed` — neither delivered nor persisted; throttle state MUST NOT
+  ///   advance so the next fix retries.
+  Future<LocationDelivery> _sendLocationPing(Position position) async {
     try {
       final driverId = Supabase.instance.client.auth.currentUser?.id;
-      if (driverId == null || driverId.isEmpty) return false;
+      if (driverId == null || driverId.isEmpty) return LocationDelivery.failed;
 
       if (_activeOrderId != null) {
-        final cachedOrder = await Supabase.instance.client
-            .from('orders')
-            .select('id, status, pickup_lat, pickup_lng, drop_lat, drop_lng')
-            .eq('id', _activeOrderId!)
-            .eq('driver_id', driverId)
-            .inFilter('status', _activeOrderStatuses)
-            .maybeSingle();
+        try {
+          final cachedOrder = await Supabase.instance.client
+              .from('orders')
+              .select('id, status, pickup_lat, pickup_lng, drop_lat, drop_lng')
+              .eq('id', _activeOrderId!)
+              .eq('driver_id', driverId)
+              .inFilter('status', _activeOrderStatuses)
+              .maybeSingle();
 
-        if (cachedOrder == null) {
-          _activeOrderId = null;
-          _activeOrderDisplayId = null;
-          _lastTriggeredMilestone = null;
-        } else {
-          unawaited(_checkGeofence(cachedOrder, position));
+          if (cachedOrder == null) {
+            _activeOrderId = null;
+            _activeOrderDisplayId = null;
+            _lastTriggeredMilestone = null;
+          } else {
+            unawaited(_checkGeofence(cachedOrder, position));
+          }
+        } catch (_) {
+          // Server unreachable (fully offline). Keep the cached order context
+          // so the ping can still be persisted for offline replay instead of
+          // being dropped by a Supabase lookup failure.
+          debugPrint(
+            '[LocationService] Order re-validation failed — keeping cached order context',
+          );
         }
       }
 
@@ -227,7 +322,7 @@ class LocationService {
       final orderDisplayId = _activeOrderDisplayId;
       if (orderId == null || orderDisplayId == null) {
         debugPrint('[LocationService] No active order found; skipping order telemetry ping');
-        return false;
+        return LocationDelivery.failed;
       }
 
       // 2. Ensure WebSocket is connected (ResilientWebSocket handles
@@ -236,41 +331,75 @@ class LocationService {
         await _connectWebSocket();
       }
 
-      if (_resilientWs != null) {
-        final batteryInfo = BatteryService.instance.currentInfo;
-        final payload = {
-          'event': 'location_ping',
-          'data': {
-            'driver_id': driverId,
-            'driverId': driverId,
-            'order_display_id': orderDisplayId,
-            'orderId': orderId,
-            'latitude': position.latitude,
-            'longitude': position.longitude,
-            'lat': position.latitude,
-            'lng': position.longitude,
-            'speed': position.speed,
-            'bearing': position.heading,
-            'device_timestamp': DateTime.now().toIso8601String(),
-            'timestamp': DateTime.now().toIso8601String(),
-            'battery_level': batteryInfo.level,
-            'charging_status': batteryInfo.isCharging ? 'charging' : 'discharging',
-          }
-        };
-        final success = _resilientWs!.send(payload);
-        if (success) {
+      final payload = _buildLocationPayload(
+        position,
+        driverId: driverId,
+        orderId: orderId,
+        orderDisplayId: orderDisplayId,
+      );
+
+      // 3. Try the live transport first. Delivery is gated on a completed
+      //    `auth` handshake — the backend otherwise closes the socket with
+      //    code 4001.
+      final ws = _resilientWs;
+      if (ws != null && ws.isConnected && _wsAuthenticated) {
+        final result = ws.sendResult(payload);
+        if (result == WsSendResult.delivered) {
           debugPrint('[LocationService] Location ping sent: lat=${position.latitude}, lng=${position.longitude}');
-          return true;
-        } else {
-          debugPrint('[LocationService] Failed to send location ping — WebSocket unavailable');
-          return false;
+          return LocationDelivery.delivered;
         }
+        debugPrint('[LocationService] Location ping not accepted by WebSocket');
+      } else {
+        debugPrint('[LocationService] WebSocket unavailable — persisting ping for offline replay');
       }
-      return false;
+
+      // 4. Transport unavailable: persist durably. Successfully persisted
+      //    items are guaranteed to be replayed after reconnect.
+      final queued = await _offlineQueue.enqueueLocation(payload);
+      if (queued) {
+        debugPrint('[LocationService] Location ping queued for offline delivery');
+        return LocationDelivery.queued;
+      }
+      debugPrint('[LocationService] Failed to queue location ping for delivery');
+      return LocationDelivery.failed;
     } catch (e) {
       debugPrint('[LocationService] Error sending location ping: $e');
-      return false;
+      return LocationDelivery.failed;
     }
+  }
+
+  /// Builds the exact `location_ping` message the backend tracking WebSocket
+  /// contract expects (kept in sync with `tracker.js`): a `{event, data}`
+  /// envelope whose `data` carries the telemetry fields the server validates.
+  ///
+  /// This is the format used both for live delivery and for offline replay, so
+  /// replayed pings are byte-identical to live ones.
+  Map<String, dynamic> _buildLocationPayload(
+    Position position, {
+    required String driverId,
+    required String orderId,
+    required String orderDisplayId,
+  }) {
+    final batteryInfo = BatteryService.instance.currentInfo;
+    return {
+      'event': 'location_ping',
+      'data': {
+        'driver_id': driverId,
+        'driverId': driverId,
+        'order_display_id': orderDisplayId,
+        'orderId': orderId,
+        'latitude': position.latitude,
+        'longitude': position.longitude,
+        'lat': position.latitude,
+        'lng': position.longitude,
+        'speed': position.speed,
+        'bearing': position.heading,
+        'device_timestamp': DateTime.now().toIso8601String(),
+        'timestamp': DateTime.now().toIso8601String(),
+        'battery_level': batteryInfo.level,
+        'charging_status': batteryInfo.isCharging ? 'charging' : 'discharging',
+      },
+    };
   }
 
   Future<void> _checkGeofence(Map<String, dynamic> order, Position position) async {
@@ -303,12 +432,35 @@ class LocationService {
     }
   }
 
+  /// Delivers a geofence milestone, persisting it for idempotent retry when
+  /// the backend is unreachable.
+  ///
+  /// Reliability contract:
+  /// 1. A pending entry for the same logical milestone (order + type) blocks
+  ///    duplicate delivery — the milestone is already in the pipeline.
+  /// 2. Success (2xx) or "already completed" (409) marks it delivered.
+  /// 3. Any other failure persists it to the offline queue with a stable
+  ///    idempotency key (`milestone:{orderId}:{milestone}`) so retries reuse
+  ///    the same identity and never create duplicate order-state transitions.
   Future<void> _updateOrderMilestone(String orderId, String milestone) async {
+    final driverId = Supabase.instance.client.auth.currentUser?.id;
+    if (driverId == null || driverId.isEmpty) return;
+
+    // Already guaranteed delivery by a queued entry — do not re-trigger.
+    if (await _offlineQueue.containsPendingMilestone(
+      orderId: orderId,
+      milestone: milestone,
+    )) {
+      return;
+    }
+
+    final token = Supabase.instance.client.auth.currentSession?.accessToken;
+    if (token == null) {
+      await _queueMilestone(orderId, milestone, driverId);
+      return;
+    }
+
     try {
-      final session = Supabase.instance.client.auth.currentSession;
-      final token = session?.accessToken;
-      if (token == null) return;
-      
       final url = Uri.parse('$defaultApiBaseUrl/api/orders/$orderId/milestones');
       final response = await http.put(
         url,
@@ -318,15 +470,37 @@ class LocationService {
         },
         body: jsonEncode({'milestone': milestone}),
       );
-      
+
       if (response.statusCode >= 200 && response.statusCode < 300) {
         _lastTriggeredMilestone = milestone;
         debugPrint('[LocationService] Successfully auto-triggered milestone: $milestone');
-      } else {
-        debugPrint('[LocationService] Failed to auto-trigger milestone $milestone. Status: ${response.statusCode}');
+        return;
       }
+      if (response.statusCode == 409) {
+        // Already completed server-side — idempotent, stop re-triggering.
+        _lastTriggeredMilestone = milestone;
+        debugPrint('[LocationService] Milestone $milestone already completed server-side');
+        return;
+      }
+      debugPrint('[LocationService] Failed to auto-trigger milestone $milestone. Status: ${response.statusCode}');
     } catch (e) {
       debugPrint('[LocationService] Exception triggering milestone $milestone: $e');
+    }
+
+    await _queueMilestone(orderId, milestone, driverId);
+  }
+
+  Future<void> _queueMilestone(String orderId, String milestone, String driverId) async {
+    final queued = await _offlineQueue.enqueueMilestone(
+      orderId: orderId,
+      milestone: milestone,
+      driverId: driverId,
+    );
+    if (queued) {
+      // The milestone is now durably in the pipeline — advancing this guard
+      // prevents re-triggering and creating duplicate queue entries.
+      _lastTriggeredMilestone = milestone;
+      debugPrint('[LocationService] Milestone $milestone queued for offline delivery');
     }
   }
 
@@ -365,14 +539,30 @@ class LocationService {
   /// Uses [ResilientWebSocket] which handles reconnection, exponential
   /// backoff and heartbeat pings automatically. A fresh instance is created
   /// on demand so reconnects always re-run [_buildWsUri] for a current URL.
+  ///
+  /// The backend authenticates via a first-frame `auth` event (issue #5739):
+  /// as soon as the socket connects we present the bearer token as a message
+  /// — never in the URL query string, where it would leak through proxies,
+  /// logs and web analytics. Only after the server confirms with
+  /// `{status: 'authenticated'}` are location pings delivered.
   Future<void> _connectWebSocket() async {
     _socketSubscription?.cancel();
     _socketSubscription = null;
     _lastCloseCode = null;
+    _wsAuthenticated = false;
 
     final ws = ResilientWebSocket(
       _buildWsUri().toString(),
-      onConnect: () => _emitStatus(WsConnectionStatus.connected),
+      onConnect: () async {
+        _emitStatus(WsConnectionStatus.connected);
+        // The auth handshake runs on every (re)connect — the server requires
+        // the token as a first frame on each new TCP/TLS session.
+        _wsAuthenticated = false;
+        final token = await _resolveAuthToken();
+        if (token != null && token.isNotEmpty) {
+          ws.send({'event': 'auth', 'data': {'token': token}});
+        }
+      },
       urlFactory: () => _buildWsUri().toString(),
     );
     _resilientWs = ws;
@@ -383,16 +573,25 @@ class LocationService {
         debugPrint('[LocationService] Received WebSocket message: $message');
         try {
           final parsed = jsonDecode(message.toString());
-          if (parsed is Map && parsed['code'] != null) {
-            _lastCloseCode = parsed['code'] as int;
-            if (_lastCloseCode == 4001 || _lastCloseCode == 4003) {
-              debugPrint(
-                '[LocationService] Auth rejected (code $_lastCloseCode) — stopping tracking',
-              );
-              ws.close();
-              _resilientWs = null;
-              stopTracking();
+          if (parsed is Map) {
+            if (parsed['status'] == 'authenticated') {
+              // Auth handshake complete — safe to deliver pings and to flush
+              // anything queued while offline.
+              _wsAuthenticated = true;
+              unawaited(_replayService.kick());
               return;
+            }
+            if (parsed['code'] != null) {
+              _lastCloseCode = parsed['code'] as int;
+              if (_lastCloseCode == 4001 || _lastCloseCode == 4003) {
+                debugPrint(
+                  '[LocationService] Auth rejected (code $_lastCloseCode) — stopping tracking',
+                );
+                ws.close();
+                _resilientWs = null;
+                stopTracking();
+                return;
+              }
             }
           }
         } catch (_) {}

--- a/apps/driver/lib/services/offline_location_queue.dart
+++ b/apps/driver/lib/services/offline_location_queue.dart
@@ -1,0 +1,517 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:sqflite/sqflite.dart';
+
+import 'local_db_service.dart';
+
+/// What a queued item is.
+enum QueueItemKind {
+  /// A driver location ping (`location_ping` over the tracking WebSocket).
+  location,
+
+  /// A geofence milestone (`PUT /api/orders/:id/milestones`).
+  milestone,
+}
+
+/// A single entry in the durable offline delivery queue.
+class QueueItem {
+  const QueueItem({
+    required this.id,
+    required this.kind,
+    this.driverId,
+    this.orderId,
+    this.orderDisplayId,
+    this.milestone,
+    this.idempotencyKey,
+    required this.payload,
+    required this.createdAt,
+    this.attempts = 0,
+  });
+
+  final int id;
+  final QueueItemKind kind;
+  final String? driverId;
+  final String? orderId;
+  final String? orderDisplayId;
+  final String? milestone;
+  final String? idempotencyKey;
+
+  /// Full JSON payload of the item. For locations this is the complete
+  /// `location_ping` data map. For milestones it is
+  /// `{'orderId': ..., 'milestone': ...}`.
+  final Map<String, dynamic> payload;
+
+  /// When the item was first accepted into the pipeline.
+  final DateTime createdAt;
+
+  /// Number of delivery attempts made so far (informational).
+  final int attempts;
+
+  static String kindTo(QueueItemKind kind) =>
+      kind == QueueItemKind.milestone ? 'milestone' : 'location';
+
+  static QueueItemKind kindFrom(String? value) =>
+      value == 'milestone' ? QueueItemKind.milestone : QueueItemKind.location;
+
+  /// Decodes a database row. Throws [FormatException] for corrupted rows so
+  /// callers can quarantine them instead of crashing.
+  factory QueueItem.fromRow(Map<String, dynamic> row) {
+    final id = row['id'];
+    if (id is! int) {
+      throw const FormatException('Queue record missing numeric id');
+    }
+    final createdMs = row['created_at'];
+    if (createdMs is! int) {
+      throw const FormatException('Queue record missing numeric created_at');
+    }
+    final rawPayload = row['payload'];
+    if (rawPayload is! String || rawPayload.isEmpty) {
+      throw const FormatException('Queue record missing payload');
+    }
+    final decoded = jsonDecode(rawPayload);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Queue payload is not a JSON object');
+    }
+    return QueueItem(
+      id: id,
+      kind: kindFrom(row['kind'] as String?),
+      driverId: row['driver_id'] as String?,
+      orderId: row['order_id'] as String?,
+      orderDisplayId: row['order_display_id'] as String?,
+      milestone: row['milestone'] as String?,
+      idempotencyKey: row['idempotency_key'] as String?,
+      payload: decoded,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdMs),
+      attempts: row['attempts'] as int? ?? 0,
+    );
+  }
+}
+
+/// Persistence surface for the offline queue.
+///
+/// Abstracted so the queue policy (dedup, coalescing, capacity) is
+/// unit-testable without the sqflite platform plugin. The production
+/// implementation reads/writes the shared driver local database
+/// (`truxify_driver.db`, see [LocalDbService]).
+abstract class LocationQueueStore {
+  /// Inserts a row. Returns 1 when inserted, 0 when a duplicate
+  /// `idempotency_key` was ignored.
+  Future<int> insert(Map<String, dynamic> row);
+
+  /// Returns all rows ordered oldest first (stable tiebreak by id).
+  Future<List<Map<String, dynamic>>> query();
+
+  Future<int> deleteWhereId(int id);
+
+  Future<int> count();
+
+  /// Replaces the stored payload/created_at of a row (used by coalescing).
+  Future<int> updatePayload(
+    int id, {
+    required String payload,
+    required int createdAtMs,
+  });
+
+  /// Deletes the [count] oldest location rows, never [keepNewestId].
+  Future<int> deleteOldestLocations({
+    required int count,
+    required int keepNewestId,
+  });
+
+  /// Deletes the [count] oldest rows of any kind (last-resort trim).
+  Future<int> deleteOldestRows(int count);
+
+  /// Looks up a row by its unique idempotency key (or null).
+  Future<Map<String, dynamic>?> findByIdempotencyKey(String key);
+}
+
+/// sqflite-backed implementation over the driver's shared local DB.
+class SqfliteLocationQueueStore implements LocationQueueStore {
+  static const String table = 'location_queue';
+
+  Future<Database> get _db => LocalDbService.instance.database;
+
+  @override
+  Future<int> insert(Map<String, dynamic> row) async {
+    final db = await _db;
+    return db.insert(
+      table,
+      row,
+      conflictAlgorithm: ConflictAlgorithm.ignore,
+    );
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> query() async {
+    final db = await _db;
+    return db.query(table, orderBy: 'created_at ASC, id ASC');
+  }
+
+  @override
+  Future<int> deleteWhereId(int id) async {
+    final db = await _db;
+    return db.delete(table, where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<int> count() async {
+    final db = await _db;
+    final result = await db.rawQuery('SELECT COUNT(*) AS c FROM $table');
+    return Sqflite.firstIntValue(result) ?? 0;
+  }
+
+  @override
+  Future<int> updatePayload(
+    int id, {
+    required String payload,
+    required int createdAtMs,
+  }) async {
+    final db = await _db;
+    return db.update(
+      table,
+      {'payload': payload, 'created_at': createdAtMs, 'attempts': 0},
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  @override
+  Future<int> deleteOldestLocations({
+    required int count,
+    required int keepNewestId,
+  }) async {
+    final db = await _db;
+    final rows = await db.rawQuery(
+      'SELECT id FROM $table '
+      'WHERE kind = "location" AND id != ? '
+      'ORDER BY created_at ASC, id ASC LIMIT ?',
+      [keepNewestId, count],
+    );
+    if (rows.isEmpty) return 0;
+    final ids = rows.map((r) => r['id']).toList();
+    return db.delete(
+      table,
+      where: 'id IN (${List.filled(ids.length, '?').join(',')})',
+      whereArgs: ids,
+    );
+  }
+
+  @override
+  Future<int> deleteOldestRows(int count) async {
+    final db = await _db;
+    final rows = await db.rawQuery(
+      'SELECT id FROM $table ORDER BY created_at ASC, id ASC LIMIT ?',
+      [count],
+    );
+    if (rows.isEmpty) return 0;
+    final ids = rows.map((r) => r['id']).toList();
+    return db.delete(
+      table,
+      where: 'id IN (${List.filled(ids.length, '?').join(',')})',
+      whereArgs: ids,
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByIdempotencyKey(String key) async {
+    final db = await _db;
+    final rows = await db.query(
+      table,
+      where: 'idempotency_key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    return rows.isEmpty ? null : rows.first;
+  }
+}
+
+/// Bounded, durable queue for driver location pings and geofence milestones.
+///
+/// Delivery semantics
+/// ------------------
+/// An item is only ever removed from the queue after the backend accepts it.
+/// `enqueueLocation`/`enqueueMilestone` return `true` when the item is now
+/// guaranteed to be delivered eventually (either it was inserted or an
+/// equivalent item is already queued). Callers must treat `true` as "in the
+/// pipeline" and `false` as "not persisted — retry later".
+///
+/// Capacity policy (deterministic)
+/// -------------------------------
+/// * The queue never grows past [maxEntries] rows.
+/// * Consecutive fixes within [coalesceWindow]/[coalesceDistanceMeters] are
+///   coalesced into a single row (the newest fix wins) so long offline
+///   stretches collapse into representative points.
+/// * When capacity is exceeded, the OLDEST location rows are dropped while the
+///   newest location fix (the truck's actual position) is always retained.
+/// * Milestone rows are never dropped by the capacity policy — a geofence
+///   event outranks ordinary telemetry.
+///
+/// Corruption safety
+/// -----------------
+/// Rows that fail to decode are quarantined (deleted) on read so a corrupted
+/// record can never crash the application or block delivery of healthy rows.
+class OfflineLocationQueue {
+  /// Production singleton backed by the shared driver local DB.
+  static final OfflineLocationQueue instance = OfflineLocationQueue();
+
+  /// Test hook: inject a fake store without touching sqflite.
+  @visibleForTesting
+  static OfflineLocationQueue Function()? testInstanceBuilder;
+
+  /// Creates a queue. Tests pass a fake [LocationQueueStore].
+  OfflineLocationQueue({
+    LocationQueueStore? store,
+    this.maxEntries = 500,
+    this.coalesceWindow = const Duration(seconds: 60),
+    this.coalesceDistanceMeters = 500.0,
+    this.duplicateWindow = const Duration(seconds: 120),
+    this.duplicateDistanceMeters = 15.0,
+  }) : _store = store ?? SqfliteLocationQueueStore();
+
+  final LocationQueueStore _store;
+
+  /// Hard cap on stored rows. Bounds storage even during very long offline
+  /// stretches.
+  final int maxEntries;
+
+  /// Locations within this time+space window of the newest queued fix are
+  /// treated as one cluster and coalesced into a single representative row.
+  final Duration coalesceWindow;
+  final double coalesceDistanceMeters;
+
+  /// A location identical (within distance) to the newest queued fix and
+  /// queued within this window is considered already in the pipeline and is
+  /// not written again. Guards the 5-second heartbeat ping from duplicating
+  /// rows while offline.
+  final Duration duplicateWindow;
+  final double duplicateDistanceMeters;
+
+  static const String _msKey = 'milestone';
+
+  String _milestoneKey(String orderId, String milestone) =>
+      '$_msKey:$orderId:$milestone';
+
+  /// Queues a location ping payload. Returns `true` when the fix is now
+  /// guaranteed to be delivered (inserted or already represented in the queue).
+  Future<bool> enqueueLocation(Map<String, dynamic> payload) async {
+    final data = _dataOf(payload);
+    final now = DateTime.now();
+    final createdAtMs = now.millisecondsSinceEpoch;
+    final driverId = data['driver_id']?.toString();
+    final orderId = data['orderId']?.toString() ?? data['order_id']?.toString();
+    final orderDisplayId = data['order_display_id']?.toString();
+
+    final newest = await _newestLocation();
+    if (newest != null) {
+      // Already in the pipeline: an identical fix was queued moments ago
+      // (e.g. the 5s heartbeat ping) — skip the write entirely.
+      if (_isDuplicate(newest.payload, payload, now.difference(newest.createdAt))) {
+        return true;
+      }
+      // Same cluster: replace the representative row with this newer fix so
+      // offline stretches collapse instead of unboundedly growing.
+      if (_inCluster(newest.payload, payload, now.difference(newest.createdAt))) {
+        await _store.updatePayload(
+          newest.id,
+          payload: jsonEncode(payload),
+          createdAtMs: createdAtMs,
+        );
+        return true;
+      }
+    }
+
+    await _store.insert({
+      'kind': QueueItemKind.kindTo(QueueItemKind.location),
+      'driver_id': driverId,
+      'order_id': orderId,
+      'order_display_id': orderDisplayId,
+      'milestone': null,
+      'idempotency_key': null,
+      'payload': jsonEncode(payload),
+      'created_at': createdAtMs,
+      'attempts': 0,
+    });
+
+    await _trimToCapacity();
+    return true;
+  }
+
+  /// Queues a geofence milestone. Idempotent: re-enqueueing the same logical
+  /// milestone (same order + milestone) is a no-op. Returns `true` when the
+  /// milestone is guaranteed to be delivered.
+  Future<bool> enqueueMilestone({
+    required String orderId,
+    required String milestone,
+    required String driverId,
+  }) async {
+    final key = _milestoneKey(orderId, milestone);
+    if (await _store.findByIdempotencyKey(key) != null) {
+      return true;
+    }
+    final now = DateTime.now();
+    await _store.insert({
+      'kind': QueueItemKind.kindTo(QueueItemKind.milestone),
+      'driver_id': driverId,
+      'order_id': orderId,
+      'order_display_id': null,
+      'milestone': milestone,
+      'idempotency_key': key,
+      'payload': jsonEncode({'orderId': orderId, 'milestone': milestone}),
+      'created_at': now.millisecondsSinceEpoch,
+      'attempts': 0,
+    });
+    return true;
+  }
+
+  /// Whether a pending milestone for this order+type already exists.
+  Future<bool> containsPendingMilestone({
+    required String orderId,
+    required String milestone,
+  }) async {
+    return await _store.findByIdempotencyKey(
+          _milestoneKey(orderId, milestone),
+        ) !=
+        null;
+  }
+
+  /// All pending items, oldest first. Corrupted rows are quarantined and
+  /// skipped; healthy rows are returned in stable order.
+  Future<List<QueueItem>> pending() async {
+    final rows = await _store.query();
+    final items = <QueueItem>[];
+    for (final row in rows) {
+      try {
+        items.add(QueueItem.fromRow(row));
+      } on FormatException {
+        await _quarantineCorruptRow(row);
+      }
+    }
+    return items;
+  }
+
+  /// Permanently removes a successfully-delivered item.
+  Future<void> remove(int id) async {
+    await _store.deleteWhereId(id);
+  }
+
+  /// Number of queued items (including milestones).
+  Future<int> count() => _store.count();
+
+  Future<QueueItem?> _newestLocation() async {
+    final rows = await _store.query();
+    for (final row in rows.reversed) {
+      try {
+        final item = QueueItem.fromRow(row);
+        if (item.kind == QueueItemKind.location) return item;
+      } on FormatException {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  bool _isDuplicate(
+    Map<String, dynamic> a,
+    Map<String, dynamic> b,
+    Duration age,
+  ) {
+    if (age > duplicateWindow) return false;
+    final dataA = _dataOf(a);
+    final dataB = _dataOf(b);
+    if (dataA['orderId']?.toString() != dataB['orderId']?.toString()) return false;
+    if (dataA['driver_id']?.toString() != dataB['driver_id']?.toString()) {
+      return false;
+    }
+    return _distanceBetween(a, b) <= duplicateDistanceMeters;
+  }
+
+  bool _inCluster(
+    Map<String, dynamic> a,
+    Map<String, dynamic> b,
+    Duration age,
+  ) {
+    if (age > coalesceWindow) return false;
+    final dataA = _dataOf(a);
+    final dataB = _dataOf(b);
+    if (dataA['orderId']?.toString() != dataB['orderId']?.toString()) return false;
+    return _distanceBetween(a, b) <= coalesceDistanceMeters;
+  }
+
+  double _distanceBetween(Map<String, dynamic> a, Map<String, dynamic> b) {
+    final latA = _latOf(a);
+    final lngA = _lngOf(a);
+    final latB = _latOf(b);
+    final lngB = _lngOf(b);
+    if (latA == null || lngA == null || latB == null || lngB == null) {
+      return double.infinity;
+    }
+    return _haversineMeters(latA, lngA, latB, lngB);
+  }
+
+  /// Telemetry lives under the `data` key of the `{event, data}` envelope the
+  /// backend tracking contract expects. Falls back to the whole map for
+  /// robustness (e.g. items queued by older formats).
+  Map<String, dynamic> _dataOf(Map<String, dynamic> payload) {
+    final data = payload['data'];
+    return data is Map<String, dynamic> ? data : payload;
+  }
+
+  double? _latOf(Map<String, dynamic> p) {
+    final data = _dataOf(p);
+    final v = data['latitude'] ?? data['lat'];
+    return v is num ? v.toDouble() : null;
+  }
+
+  double? _lngOf(Map<String, dynamic> p) {
+    final data = _dataOf(p);
+    final v = data['longitude'] ?? data['lng'];
+    return v is num ? v.toDouble() : null;
+  }
+
+  double _haversineMeters(double lat1, double lng1, double lat2, double lng2) {
+    const earthRadiusM = 6371000.0;
+    final dLat = _rad(lat2 - lat1);
+    final dLng = _rad(lng2 - lng1);
+    final a = math.pow(math.sin(dLat / 2), 2) +
+        math.cos(_rad(lat1)) *
+            math.cos(_rad(lat2)) *
+            math.pow(math.sin(dLng / 2), 2);
+    return 2 * earthRadiusM * math.asin(math.sqrt(a));
+  }
+
+  double _rad(double deg) => deg * math.pi / 180.0;
+
+  /// Drops the oldest location rows until the queue is within capacity.
+  /// The newest location fix and all milestone rows survive.
+  Future<void> _trimToCapacity() async {
+    var guard = 0;
+    while (guard++ < 10) {
+      final total = await _store.count();
+      if (total <= maxEntries) return;
+      final newest = await _newestLocation();
+      final before = total;
+      if (newest != null) {
+        await _store.deleteOldestLocations(
+          count: total - maxEntries,
+          keepNewestId: newest.id,
+        );
+      } else {
+        await _store.deleteOldestRows(total - maxEntries);
+      }
+      final after = await _store.count();
+      if (after >= before) return; // nothing deleted — stop to avoid a loop
+    }
+  }
+
+  Future<void> _quarantineCorruptRow(Map<String, dynamic> row) async {
+    final id = row['id'];
+    if (id is! int) return;
+    try {
+      await _store.deleteWhereId(id);
+    } catch (_) {
+      // Never let a corrupt row block the queue.
+    }
+  }
+}

--- a/apps/driver/test/location_replay_service_test.dart
+++ b/apps/driver/test/location_replay_service_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+import 'package:truxify_driver/services/location_replay_service.dart';
+import 'package:truxify_driver/services/offline_location_queue.dart';
+
+import 'offline_location_queue_test.dart'
+    show FakeLocationQueueStore, dataOf, loc;
+
+void main() {
+  late FakeLocationQueueStore store;
+  late OfflineLocationQueue queue;
+  late LocationReplayService replay;
+  late List<Map<String, dynamic>> sent;
+  WsSendResult Function(Map<String, dynamic>)? locationSender;
+  bool Function()? connected;
+
+  setUp(() {
+    store = FakeLocationQueueStore();
+    queue = OfflineLocationQueue(store: store);
+    sent = [];
+    locationSender = null;
+    connected = null;
+    replay = LocationReplayService(
+      queue: queue,
+      sendLocation: (m) {
+        sent.add(m);
+        return locationSender?.call(m) ?? WsSendResult.delivered;
+      },
+      sendMilestone:
+          ({required orderId, required milestone, required token}) async {
+        sent.add({
+          'event': 'milestone',
+          'data': {'orderId': orderId, 'milestone': milestone},
+        });
+        return true;
+      },
+      tokenProvider: () => 'test-token',
+      driverIdProvider: () => 'driver-1',
+      isConnected: () => connected?.call() ?? true,
+    );
+    LocationReplayService.replayDelay = Duration.zero;
+  });
+
+  tearDown(() {
+    LocationReplayService.replayDelay = const Duration(milliseconds: 250);
+  });
+
+  group('LocationReplayService happy path', () {
+    test('replays queued locations and removes them after delivery', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+
+      await replay.kick();
+
+      expect(sent, hasLength(2));
+      expect(sent[0]['data']['lat'], 21.0);
+      expect(sent[1]['data']['lat'], 21.01);
+      expect(await queue.count(), 0, reason: 'delivered items are removed');
+      expect(replay.state, LocationReplayState.idle);
+    });
+
+    test('replays milestones via sendMilestone', () async {
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arrived at Pickup',
+        driverId: 'driver-1',
+      );
+
+      await replay.kick();
+
+      expect(sent, hasLength(1));
+      expect(sent.first['data']['milestone'], 'Arrived at Pickup');
+      expect(await queue.count(), 0);
+    });
+
+    test('a fresh replay service drains what a previous one left behind', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+
+      final restarted = LocationReplayService(
+        queue: queue,
+        sendLocation: (m) {
+          sent.add(m);
+          return WsSendResult.delivered;
+        },
+        sendMilestone:
+            ({required orderId, required milestone, required token}) async {
+          return true;
+        },
+        driverIdProvider: () => 'driver-1',
+      );
+      await restarted.kick();
+
+      expect(sent, hasLength(1));
+      expect(await queue.count(), 0);
+    });
+  });
+
+  group('LocationReplayService failure handling', () {
+    test('failed delivery is left in the queue and replay stops', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+      locationSender = (_) => WsSendResult.failed;
+
+      await replay.kick();
+
+      expect(await queue.count(), 2, reason: 'nothing may be dropped on failure');
+      expect(replay.state, LocationReplayState.idle);
+    });
+
+    test('connection dropped mid-replay stops and keeps the remainder', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+      await queue.enqueueLocation(loc(lat: 21.02, lng: 72.02));
+      var call = 0;
+      locationSender = (_) {
+        call += 1;
+        // First delivery succeeds, then the socket drops.
+        return call == 1 ? WsSendResult.delivered : WsSendResult.failed;
+      };
+
+      await replay.kick();
+
+      expect(call, 2);
+      expect(await queue.count(), 2, reason: 'undelivered items survive');
+      expect(replay.state, LocationReplayState.idle);
+    });
+
+    test('replay aborts when the transport drops before delivery', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      connected = () => false;
+
+      await replay.kick();
+
+      expect(sent, isEmpty);
+      expect(await queue.count(), 1, reason: 'items stay queued while offline');
+    });
+
+    test('driver-mismatched entry is skipped without being dropped', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0, driverId: 'driver-1'));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01, driverId: 'other'));
+
+      await replay.kick();
+
+      // The foreign entry is neither delivered nor deleted.
+      expect(sent, hasLength(1));
+      expect(await queue.count(), 1);
+      final remaining = await queue.pending();
+      expect(dataOf(remaining.single.payload)['driver_id'], 'other');
+    });
+  });
+
+  group('LocationReplayService exactly-once removal', () {
+    test('only a delivered result removes the item; anything else keeps it', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      locationSender = (_) => WsSendResult.failed;
+
+      await replay.kick();
+
+      expect(await queue.count(), 1, reason: 'only delivered is removed');
+      expect(replay.state, LocationReplayState.idle);
+    });
+  });
+
+  group('LocationReplayService single-worker guarantee', () {
+    test('concurrent kicks do not run parallel replays', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+      await queue.enqueueLocation(loc(lat: 21.02, lng: 72.02));
+
+      final first = replay.kick();
+      final second = replay.kick(); // must no-op while first is running
+      await Future.wait([first, second]);
+
+      expect(sent, hasLength(3), reason: 'each item is sent exactly once');
+      expect(await queue.count(), 0);
+    });
+  });
+}

--- a/apps/driver/test/offline_location_queue_test.dart
+++ b/apps/driver/test/offline_location_queue_test.dart
@@ -1,0 +1,345 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/services/offline_location_queue.dart';
+
+/// In-memory [LocationQueueStore] mirroring the sqflite row semantics so the
+/// queue policy is testable without the sqflite platform plugin.
+class FakeLocationQueueStore implements LocationQueueStore {
+  FakeLocationQueueStore({this.maxId = 0});
+
+  int maxId;
+  final List<Map<String, dynamic>> rows = [];
+
+  @override
+  Future<int> insert(Map<String, dynamic> row) async {
+    final key = row['idempotency_key'];
+    if (key != null && rows.any((r) => r['idempotency_key'] == key)) {
+      return 0; // UNIQUE conflict ignored.
+    }
+    maxId += 1;
+    rows.add({...row, 'id': maxId});
+    return 1;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> query() async {
+    final sorted = [...rows]
+      ..sort((a, b) {
+        final byTime = (a['created_at'] as int).compareTo(b['created_at'] as int);
+        if (byTime != 0) return byTime;
+        return (a['id'] as int).compareTo(b['id'] as int);
+      });
+    return sorted;
+  }
+
+  @override
+  Future<int> deleteWhereId(int id) async {
+    final before = rows.length;
+    rows.removeWhere((r) => r['id'] == id);
+    return before - rows.length;
+  }
+
+  @override
+  Future<int> count() async => rows.length;
+
+  @override
+  Future<int> updatePayload(
+    int id, {
+    required String payload,
+    required int createdAtMs,
+  }) async {
+    for (final row in rows) {
+      if (row['id'] == id) {
+        row['payload'] = payload;
+        row['created_at'] = createdAtMs;
+        row['attempts'] = 0;
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  @override
+  Future<int> deleteOldestLocations({
+    required int count,
+    required int keepNewestId,
+  }) async {
+    final candidates = rows
+        .where((r) => r['kind'] == 'location' && r['id'] != keepNewestId)
+        .toList()
+      ..sort((a, b) {
+        final byTime = (a['created_at'] as int).compareTo(b['created_at'] as int);
+        if (byTime != 0) return byTime;
+        return (a['id'] as int).compareTo(b['id'] as int);
+      });
+    final doomed = candidates.take(count).map((r) => r['id']).toSet();
+    final before = rows.length;
+    rows.removeWhere((r) => doomed.contains(r['id']));
+    return before - rows.length;
+  }
+
+  @override
+  Future<int> deleteOldestRows(int count) async {
+    final sorted = [...rows]
+      ..sort((a, b) {
+        final byTime = (a['created_at'] as int).compareTo(b['created_at'] as int);
+        if (byTime != 0) return byTime;
+        return (a['id'] as int).compareTo(b['id'] as int);
+      });
+    final doomed = sorted.take(count).map((r) => r['id']).toSet();
+    final before = rows.length;
+    rows.removeWhere((r) => doomed.contains(r['id']));
+    return before - rows.length;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByIdempotencyKey(String key) async {
+    for (final row in rows) {
+      if (row['idempotency_key'] == key) return row;
+    }
+    return null;
+  }
+}
+
+Map<String, dynamic> loc({
+  double lat = 20.0,
+  double lng = 70.0,
+  String driverId = 'driver-1',
+  String orderId = 'order-1',
+}) {
+  return {
+    'event': 'location_ping',
+    'data': {
+      'driver_id': driverId,
+      'driverId': driverId,
+      'orderId': orderId,
+      'order_display_id': 'OD-1',
+      'lat': lat,
+      'lng': lng,
+      'latitude': lat,
+      'longitude': lng,
+      'speed': 0,
+      'bearing': 0,
+      'device_timestamp': DateTime.now().toIso8601String(),
+      'timestamp': DateTime.now().toIso8601String(),
+    },
+  };
+}
+
+Map<String, dynamic> dataOf(Map<String, dynamic> payload) =>
+    payload['data'] is Map<String, dynamic>
+        ? payload['data'] as Map<String, dynamic>
+        : payload;
+
+void main() {
+  late FakeLocationQueueStore store;
+  late OfflineLocationQueue queue;
+
+  setUp(() {
+    store = FakeLocationQueueStore();
+    queue = OfflineLocationQueue(
+      store: store,
+      maxEntries: 10,
+      duplicateWindow: const Duration(seconds: 120),
+      duplicateDistanceMeters: 15.0,
+      coalesceWindow: const Duration(seconds: 60),
+      coalesceDistanceMeters: 500.0,
+    );
+  });
+
+  group('OfflineLocationQueue persistence', () {
+    test('enqueued location survives a "restart" (new queue over same store)', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+
+      // Simulate app restart: a brand-new queue instance over the same store.
+      final restarted = OfflineLocationQueue(store: store);
+      final pending = await restarted.pending();
+
+      expect(pending, hasLength(1));
+      expect(dataOf(pending.first.payload)['lat'], 21.0);
+      expect(dataOf(pending.first.payload)['lng'], 72.0);
+      expect(pending.first.kind, QueueItemKind.location);
+    });
+
+    test('pending() returns items oldest first', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+      await queue.enqueueLocation(loc(lat: 21.02, lng: 72.02));
+
+      final pending = await queue.pending();
+      expect(pending, hasLength(3));
+      expect(pending[0].payload['data']['lat'], 21.0);
+      expect(pending[1].payload['data']['lat'], 21.01);
+      expect(pending[2].payload['data']['lat'], 21.02);
+    });
+
+    test('remove() deletes only the target row', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      await queue.enqueueLocation(loc(lat: 21.01, lng: 72.01));
+      final pending = await queue.pending();
+      await queue.remove(pending.first.id);
+
+      final remaining = await queue.pending();
+      expect(remaining, hasLength(1));
+      expect(remaining.first.payload['data']['lat'], 21.01);
+    });
+  });
+
+  group('OfflineLocationQueue dedup & coalescing', () {
+    test('identical position within window is not written again', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      final ok = await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      expect(ok, isTrue, reason: 'an equivalent fix is already in the pipeline');
+      expect(await queue.count(), 1);
+    });
+
+    test('near-identical position within duplicate distance is deduped', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      // ~7m north — inside the 15m duplicate window.
+      await queue.enqueueLocation(loc(lat: 21.0001, lng: 72.0));
+      expect(await queue.count(), 1);
+    });
+
+    test('movement beyond duplicate window creates a new entry', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      // ~2.2 km away — new entry.
+      await queue.enqueueLocation(loc(lat: 21.02, lng: 72.0));
+      expect(await queue.count(), 2);
+    });
+
+    test('cluster coalescing replaces the representative with the newest fix', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      // ~220m away — same cluster, coalesced.
+      await queue.enqueueLocation(loc(lat: 21.002, lng: 72.0));
+      expect(await queue.count(), 1);
+      final pending = await queue.pending();
+      expect(pending.single.payload['data']['lat'], 21.002,
+          reason: 'the newest fix in the cluster must win');
+    });
+  });
+
+  group('OfflineLocationQueue capacity policy', () {
+    test('queue is bounded and retains the newest location + all milestones', () async {
+      // Fill past capacity: 15 distinct locations.
+      for (var i = 0; i < 15; i++) {
+        await queue.enqueueLocation(loc(lat: 21.0 + i * 0.01, lng: 72.0));
+      }
+      // Add two milestones (priority: never dropped).
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arrived at Pickup',
+        driverId: 'driver-1',
+      );
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arriving',
+        driverId: 'driver-1',
+      );
+
+      final total = await queue.count();
+      expect(total, lessThanOrEqualTo(10 + 2),
+          reason: 'milestones are never dropped by the capacity policy');
+
+      final pending = await queue.pending();
+      final locations =
+          pending.where((i) => i.kind == QueueItemKind.location).toList();
+      final milestones =
+          pending.where((i) => i.kind == QueueItemKind.milestone).toList();
+
+      expect(milestones, hasLength(2));
+      expect(locations, hasLength(10));
+      // The newest location fix is always retained.
+      expect(locations.last.payload['data']['lat'], 21.0 + 14 * 0.01);
+      // Oldest location was dropped first.
+      expect(locations.first.payload['data']['lat'], isNot(21.0));
+    });
+  });
+
+  group('OfflineLocationQueue milestones', () {
+    test('same logical milestone is only queued once (stable idempotency key)', () async {
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arrived at Pickup',
+        driverId: 'driver-1',
+      );
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arrived at Pickup',
+        driverId: 'driver-1',
+      );
+      await queue.enqueueMilestone(
+        orderId: 'order-1',
+        milestone: 'Arriving',
+        driverId: 'driver-1',
+      );
+
+      expect(await queue.count(), 2);
+      expect(
+        await queue.containsPendingMilestone(
+          orderId: 'order-1',
+          milestone: 'Arrived at Pickup',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('OfflineLocationQueue corruption safety', () {
+    test('corrupted row is quarantined and healthy rows remain usable', () async {
+      await queue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      store.rows.add({
+        'id': store.maxId + 1,
+        'kind': 'location',
+        'driver_id': 'driver-1',
+        'order_id': 'order-1',
+        'order_display_id': null,
+        'milestone': null,
+        'idempotency_key': null,
+        'payload': '{not valid json',
+        'created_at': DateTime.now().millisecondsSinceEpoch,
+        'attempts': 0,
+      });
+      store.rows.add({
+        'id': store.maxId + 2,
+        'kind': 'milestone',
+        'driver_id': 'driver-1',
+        'order_id': 'order-1',
+        'order_display_id': null,
+        'milestone': 'Arriving',
+        'idempotency_key': 'milestone:order-1:Arriving',
+        'payload': jsonEncode({'orderId': 'order-1', 'milestone': 'Arriving'}),
+        'created_at': DateTime.now().millisecondsSinceEpoch,
+        'attempts': 0,
+      });
+
+      final pending = await queue.pending();
+      // Corrupt row was dropped; the two healthy rows are intact.
+      expect(pending, hasLength(2));
+      expect(
+        pending.every((i) {
+          final data = i.payload['data'];
+          return (data is Map && data['lat'] != null) || i.milestone != null;
+        }),
+        isTrue,
+      );
+      expect(store.rows, hasLength(2), reason: 'corrupt row was quarantined');
+    });
+
+    test('pending() with all-corrupt rows does not throw', () async {
+      store.rows.add({
+        'id': 1,
+        'kind': 'location',
+        'driver_id': null,
+        'order_id': null,
+        'order_display_id': null,
+        'milestone': null,
+        'idempotency_key': null,
+        'payload': '###',
+        'created_at': 1,
+        'attempts': 0,
+      });
+      expect(await queue.pending(), isEmpty);
+    });
+  });
+}

--- a/packages/truxify_shared/lib/src/services/resilient_websocket.dart
+++ b/packages/truxify_shared/lib/src/services/resilient_websocket.dart
@@ -3,6 +3,43 @@ import 'dart:convert';
 
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+/// Connection state of a [ResilientWebSocket].
+///
+/// The wrapper tracks the real transport lifecycle so callers can react to
+/// reconnects and so [send] never pretends a dead socket is writable.
+enum WsConnectionState {
+  /// No channel exists yet and no connect has been requested.
+  disconnected,
+
+  /// A connect has been requested but the TCP/TLS handshake has not completed.
+  connecting,
+
+  /// The channel is established, authenticated transport is ready.
+  connected,
+
+  /// The remote end closed/errored and a reconnect is scheduled (backoff).
+  reconnecting,
+
+  /// The wrapper gave up after exhausting [maxAttempts] and will not
+  /// reconnect unless [connect] is called again.
+  failed,
+}
+
+/// Outcome of a single [ResilientWebSocket.sendResult] call.
+///
+/// This describes transport acceptance only — a message is `delivered` once it
+/// was handed to an actually-connected socket. It says nothing about whether
+/// the remote processed it. Callers that need stronger guarantees must buffer
+/// the message themselves until the remote acknowledges it.
+enum WsSendResult {
+  /// The message was handed to a live, connected socket.
+  delivered,
+
+  /// The message was NOT handed to the socket (disconnected, reconnecting,
+  /// connecting, permanently failed, or the channel threw).
+  failed,
+}
+
 /// A WebSocket wrapper that automatically reconnects with exponential
 /// backoff, sends periodic heartbeat pings, and exposes a broadcast stream.
 ///
@@ -51,8 +88,27 @@ class ResilientWebSocket {
   final StreamController<dynamic> _controller =
       StreamController<dynamic>.broadcast();
 
+  final StreamController<WsConnectionState> _stateController =
+      StreamController<WsConnectionState>.broadcast();
+  WsConnectionState _connectionState = WsConnectionState.disconnected;
+
   /// A broadcast stream of incoming messages from the WebSocket.
   Stream<dynamic> get stream => _controller.stream;
+
+  /// A broadcast stream of connection state transitions. Emits every time
+  /// the wrapper enters a new [WsConnectionState].
+  Stream<WsConnectionState> get connectionState => _stateController.stream;
+
+  /// The current connection state of the wrapper.
+  WsConnectionState get connectionStateValue => _connectionState;
+
+  void _setConnectionState(WsConnectionState state) {
+    if (_connectionState == state) return;
+    _connectionState = state;
+    if (!_stateController.isClosed) {
+      _stateController.add(state);
+    }
+  }
 
   /// Opens (or re-opens) the WebSocket connection.
   ///
@@ -65,6 +121,7 @@ class ResilientWebSocket {
     _reconnecting = false;
     _heartbeatTimer?.cancel();
     _reconnectTimer?.cancel();
+    _setConnectionState(WsConnectionState.connecting);
     await _cleanupChannel();
     await _connectOnce();
   }
@@ -94,6 +151,7 @@ class ResilientWebSocket {
       );
       _attempt = 0;
       _startHeartbeat();
+      _setConnectionState(WsConnectionState.connected);
       onConnect?.call();
     } catch (_) {
       if (!_reconnecting) {
@@ -104,26 +162,44 @@ class ResilientWebSocket {
   }
 
   /// Whether the WebSocket connection is currently active and ready.
-  bool get isConnected => _channel != null && !_closed && !_reconnecting;
+  bool get isConnected => _connectionState == WsConnectionState.connected;
 
   /// Sends a message over the WebSocket.
   ///
   /// Strings are sent as-is. All other values are JSON-encoded.
-  /// Returns true if sent successfully, false if the connection is unavailable.
-  bool send(dynamic message) {
+  ///
+  /// Returns a [WsSendResult]. A message is only reported `delivered` when the
+  /// socket is in the `connected` state — messages sent while connecting,
+  /// reconnecting, disconnected, or permanently failed are reported `failed`
+  /// so callers can buffer them for later replay instead of silently losing
+  /// them.
+  ///
+  /// See also [send], the backwards-compatible boolean wrapper.
+  WsSendResult sendResult(dynamic message) {
+    if (_connectionState != WsConnectionState.connected) {
+      return WsSendResult.failed;
+    }
     final channel = _channel;
-    if (channel == null || _closed) {
-      return false;
+    if (channel == null) {
+      return WsSendResult.failed;
     }
 
     try {
       final payload = message is String ? message : jsonEncode(message);
       channel.sink.add(payload);
-      return true;
+      return WsSendResult.delivered;
     } catch (_) {
-      return false;
+      return WsSendResult.failed;
     }
   }
+
+  /// Backwards-compatible boolean form of [sendResult].
+  ///
+  /// Returns `true` only when the message was actually handed to a live
+  /// socket; `false` when the connection is unavailable (disconnected,
+  /// connecting, reconnecting, or permanently failed).
+  bool send(dynamic message) =>
+      sendResult(message) == WsSendResult.delivered;
 
   Future<void> _scheduleReconnect() async {
     if (_closed) {
@@ -134,6 +210,7 @@ class ResilientWebSocket {
 
     if (_attempt >= maxAttempts) {
       _closed = true;
+      _setConnectionState(WsConnectionState.failed);
       await _cleanupChannel();
       _controller.addError(
         Exception('Max reconnect attempts reached ($maxAttempts)'),
@@ -148,9 +225,11 @@ class ResilientWebSocket {
           delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs,
     );
     _attempt += 1;
+    _setConnectionState(WsConnectionState.reconnecting);
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(capped, () async {
       _reconnecting = false;
+      _setConnectionState(WsConnectionState.connecting);
       await _cleanupChannel();
       if (_closed) {
         return;
@@ -185,8 +264,15 @@ class ResilientWebSocket {
     _closed = true;
     _heartbeatTimer?.cancel();
     _reconnectTimer?.cancel();
+    _connectionState = WsConnectionState.disconnected;
+    // Always emit — even a never-connected instance must surface the final
+    // state to listeners.
+    if (!_stateController.isClosed) {
+      _stateController.add(WsConnectionState.disconnected);
+    }
     await _cleanupChannel();
     await _controller.close();
+    await _stateController.close();
   }
 
   Future<void> _cleanupChannel() async {

--- a/packages/truxify_shared/pubspec.yaml
+++ b/packages/truxify_shared/pubspec.yaml
@@ -23,3 +23,8 @@ dependencies:
   device_info_plus: ^11.3.0
   web_socket_channel: ^3.0.0
   uuid: ^4.5.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+

--- a/packages/truxify_shared/test/resilient_websocket_test.dart
+++ b/packages/truxify_shared/test/resilient_websocket_test.dart
@@ -34,6 +34,57 @@ void main() {
       expect(() => ws.send('plain string'), returnsNormally);
     });
 
+    test('send reports false when not connected (no silent pretend-success)', () {
+      final ws = ResilientWebSocket('ws://localhost:8080/ws');
+      // A disconnected socket must NOT claim the message was handed off.
+      expect(ws.send({'test': 'data'}), isFalse);
+      expect(ws.send('plain string'), isFalse);
+    });
+
+    test('sendResult reports failed when not connected', () {
+      final ws = ResilientWebSocket('ws://localhost:8080/ws');
+      expect(ws.sendResult({'test': 'data'}), WsSendResult.failed);
+      expect(ws.sendResult('plain string'), WsSendResult.failed);
+    });
+
+    test('sendResult reports failed while connecting', () async {
+      // No server is listening; after connect() the wrapper is in the
+      // connecting/reconnecting states, never `connected`.
+      final ws = ResilientWebSocket('ws://localhost:1/nonexistent');
+      await ws.connect();
+      expect(
+        ws.sendResult({'test': 'data'}),
+        WsSendResult.failed,
+        reason: 'Messages must never be accepted while the socket is not '
+            'confirmed connected.',
+      );
+      await ws.close();
+    });
+
+    test('sendResult reports failed after close', () async {
+      final ws = ResilientWebSocket('ws://localhost:8080/ws');
+      await ws.close();
+      expect(ws.sendResult('anything'), WsSendResult.failed);
+    });
+
+    test('connection state starts disconnected', () {
+      final ws = ResilientWebSocket('ws://localhost:8080/ws');
+      expect(ws.connectionStateValue, WsConnectionState.disconnected);
+      expect(ws.isConnected, isFalse);
+    });
+
+    test('connection state transitions to disconnected after close', () async {
+      final ws = ResilientWebSocket('ws://localhost:8080/ws');
+      final states = <WsConnectionState>[];
+      final sub = ws.connectionState.listen(states.add);
+      await ws.close();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await sub.cancel();
+      expect(states, isNotEmpty);
+      expect(states.last, WsConnectionState.disconnected);
+      expect(ws.isConnected, isFalse);
+    });
+
     test('close is safe when not connected', () async {
       final ws = ResilientWebSocket('ws://localhost:8080/ws');
       // close() should not throw when called on an unconnected instance.


### PR DESCRIPTION
## Summary

This PR improves the Driver application's offline location reliability by preventing GPS updates and geofence milestones from being silently lost when the WebSocket connection is unavailable.

Previously, a disconnected WebSocket could cause `send()` to return without delivering the message while the location service still treated the operation as successful.

This could incorrectly update `_lastSentPosition` and `_lastSentTime`, causing future location updates to be throttled even though the backend never received the previous update.

## Problem

The previous flow could behave like:

Driver generates GPS location
        ↓
WebSocket unavailable
        ↓
Message silently dropped
        ↓
Application treats send as successful
        ↓
_lastSentPosition updated
_lastSentTime updated
        ↓
Future location updates suppressed
        ↓
Telemetry gap

Geofence milestone requests were also vulnerable to silent delivery failures because failed network operations were not reliably persisted for later retry.

## Changes Made

### Reliable Delivery State

The location delivery flow now distinguishes between:

- Delivered
- Queued
- Failed

A location is no longer considered successfully sent merely because the send operation was invoked.

### Persistent Offline Queue

Added/reused persistent local storage for offline location updates.

The queue:

- Survives application restarts.
- Has a bounded capacity.
- Preserves useful ordering.
- Removes successfully delivered entries.
- Retains failed entries for retry.
- Handles invalid queue records safely.

### Reconnect Replay

When WebSocket connectivity is restored, queued location updates are replayed safely.

Replay:

- Runs only once at a time.
- Stops safely if connectivity is lost again.
- Removes entries only after successful delivery.
- Retains failed entries for future retry.
- Respects backend location rate limits.

### Throttle State Correction

The location service no longer advances its sent-state bookkeeping when a location was silently dropped.

This prevents:

- `_lastSentPosition`
- `_lastSentTime`

from incorrectly indicating that the backend received a location that was never delivered.

### Location Coalescing

Offline location history is handled using a bounded/coalescing strategy so that extended connectivity loss does not result in an unbounded backlog or a burst of requests after reconnection.

### Geofence Milestone Reliability

Geofence milestone updates are now handled through the reliable delivery mechanism.

Offline milestones are persisted and retried after reconnect.

Stable idempotency keys are used to prevent the same logical milestone from causing duplicate order-state transitions.

### Application Restart Recovery

Queued location and milestone data survives application restarts and can be replayed once connectivity returns.

### Background Sync Compatibility

The implementation was integrated with the existing Driver synchronization/background services without introducing competing replay mechanisms.

## Delivery Flow

### Offline

```text
GPS Location
     ↓
Connectivity Check
     ↓
Persistent Local Queue
     ↓
No False "Sent" State
```

### Reconnected

```text
Persistent Queue
     ↓
Rate-Limit-Aware Replay
     ↓
Backend
     ↓
Successful Delivery
     ↓
Remove Queue Entry
```

### Milestone

```text
Geofence Milestone
     ↓
Persistent Queue
     ↓
Reconnect
     ↓
Idempotent Delivery
     ↓
Exactly One Logical State Transition
```

## Testing

Added/updated coverage for:

- Connected location delivery
- Offline location queueing
- WebSocket disconnect/reconnect
- Queue persistence
- Application restart recovery
- Queue capacity limits
- Location replay
- Replay failure recovery
- Rate-limit-aware replay
- Location coalescing
- Throttle bookkeeping
- Offline geofence milestones
- Milestone retry
- Milestone idempotency
- Concurrent replay protection
- Corrupted queue records
- Shared WebSocket regression behavior

## Acceptance Criteria

- [x] Location messages are not silently discarded.
- [x] Offline location pings are persisted.
- [x] The queue is bounded.
- [x] Queued locations survive application restart.
- [x] Queued locations are replayed after reconnect.
- [x] Replay respects backend rate limits.
- [x] Failed entries remain queued.
- [x] Successfully delivered entries are removed safely.
- [x] Throttle state does not falsely indicate successful delivery.
- [x] Offline milestones are persisted.
- [x] Milestones are retried after reconnect.
- [x] Milestones are protected against duplicate processing.
- [x] Existing WebSocket reconnect behavior remains functional.
- [x] Existing shared WebSocket consumers remain compatible.

## Type of Change

- [x] Bug Fix
- [x] Reliability Improvement
- [x] Offline-First Improvement
- [x] Driver Application Improvement
- [x] Test Coverage
- [ ] Breaking Change

## Breaking Changes

None expected.

The existing location and WebSocket behavior remains compatible while adding reliable offline delivery.

## Related Issue

Closes #7977 

##GSSoC
#ECSoC26

This PR is submitted as part of GirlScript Summer of Code (GSSoC) 2026.

## Expected Outcome

Temporary connectivity loss should no longer cause critical driver location telemetry or geofence milestones to disappear.

The Driver application can now persist updates while offline and safely replay them after reconnecting without falsely advancing throttle state, exceeding backend rate limits, or creating duplicate milestone transitions.