### PR TITLE
fix(eventsourcing): ensure safe rebuilds and optimistic concurrency

### DIFF
--- a/backend/eventsourcing/errors.js
+++ b/backend/eventsourcing/errors.js
@@ -1,0 +1,125 @@
+/**
+ * Typed, domain-specific errors for the event-sourcing package.
+ *
+ * Every error that escapes the event store is one of these classes so that
+ * callers (HTTP routes, workers, tests) can branch on `error.code` instead of
+ * sniffing SQL/Supabase internals. No raw database exception is ever meant to
+ * cross this boundary — adapters must translate persistence failures into
+ * these classes before propagating.
+ */
+
+const HTTP_STATUS = {
+  CONFLICT: 409,
+  NOT_FOUND: 404,
+  BAD_REQUEST: 400,
+  INTERNAL: 500,
+};
+
+export class EventStoreError extends Error {
+  constructor(message, { code = 'EVENT_STORE_ERROR', status = HTTP_STATUS.INTERNAL, cause } = {}) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.status = status;
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+
+  get httpStatus() {
+    return this.status;
+  }
+
+  toPublic() {
+    return {
+      code: this.code,
+      error: this.message,
+    };
+  }
+}
+
+/**
+ * Raised when a command cannot be applied because the aggregate's version
+ * moved since the command read it (or because a concurrent command already
+ * claimed the target version). Maps to HTTP 409 Conflict.
+ */
+export class EventStoreVersionConflictError extends EventStoreError {
+  constructor({ aggregateId, expectedVersion, currentVersion, reason } = {}) {
+    const expected = expectedVersion === undefined || expectedVersion === null ? 'unknown' : expectedVersion;
+    const current = currentVersion === undefined || currentVersion === null ? 'unknown' : currentVersion;
+    const detail = reason || `aggregate=${aggregateId} expected version ${expected}, found ${current}`;
+    super(`Version conflict: ${detail}`, {
+      code: 'EVENT_VERSION_CONFLICT',
+      status: HTTP_STATUS.CONFLICT,
+    });
+    this.aggregateId = aggregateId;
+    this.expectedVersion = expectedVersion;
+    this.currentVersion = currentVersion;
+  }
+}
+
+export class EventStoreMissingAggregateError extends EventStoreError {
+  constructor(aggregateId) {
+    super(`Aggregate not found: ${aggregateId}`, {
+      code: 'EVENT_AGGREGATE_NOT_FOUND',
+      status: HTTP_STATUS.NOT_FOUND,
+    });
+    this.aggregateId = aggregateId;
+  }
+}
+
+export class EventStoreInvalidAggregateError extends EventStoreError {
+  constructor(aggregateId, reason) {
+    super(`Aggregate ${aggregateId} is invalid: ${reason}`, {
+      code: 'EVENT_AGGREGATE_INVALID',
+      status: HTTP_STATUS.BAD_REQUEST,
+    });
+    this.aggregateId = aggregateId;
+  }
+}
+
+export class EventStoreSnapshotError extends EventStoreError {
+  constructor(message, { aggregateId, code = 'EVENT_SNAPSHOT_ERROR', cause } = {}) {
+    super(message, { code, status: HTTP_STATUS.INTERNAL, cause });
+    this.aggregateId = aggregateId;
+  }
+}
+
+export class EventStorePersistenceError extends EventStoreError {
+  constructor(message, { cause } = {}) {
+    super(message, { code: 'EVENT_PERSISTENCE_ERROR', cause });
+  }
+}
+
+export class EventStoreValidationError extends EventStoreError {
+  constructor(message) {
+    super(message, { code: 'EVENT_VALIDATION_ERROR', status: HTTP_STATUS.BAD_REQUEST });
+  }
+}
+
+/**
+ * Best-effort translation of a persistence error into a typed domain error.
+ * Adapters call this instead of rethrowing Supabase/PostgreSQL objects.
+ */
+export function toEventStoreError(error, { context } = {}) {
+  if (error instanceof EventStoreError) {
+    return error;
+  }
+
+  const message = (error && error.message) || 'Unknown event-store failure';
+  const isUniqueViolation =
+    (error && error.code === '23505') || // PostgreSQL unique_violation
+    /duplicate key value violates unique constraint/i.test(message) ||
+    /unique constraint/i.test(message) ||
+    /ON CONFLICT/i.test(message);
+
+  if (isUniqueViolation) {
+    const aggregateId = context && context.aggregateId;
+    return new EventStoreVersionConflictError({
+      aggregateId,
+      reason: 'database rejected a duplicate (aggregate_id, version)',
+    });
+  }
+
+  return new EventStorePersistenceError('Event store persistence failure', { cause: error });
+}

--- a/backend/eventsourcing/event-sourcing-core.js
+++ b/backend/eventsourcing/event-sourcing-core.js
@@ -1,0 +1,464 @@
+/**
+ * Event-sourcing core: normalization, replay, optimistic concurrency and
+ * snapshotting, expressed against an injected persistence interface.
+ *
+ * This module has ZERO external dependencies so it can be imported, executed
+ * and tested on its own (see `npm test` in this package). The adapter in
+ * event-store.js wires it to Supabase, Kafka and telemetry.
+ *
+ * Persistence contract (`db`):
+ *   - fetchEventStream(aggregateId)      -> Promise<raw rows ordered by version>
+ *   - fetchLatestVersion(aggregateId)    -> Promise<{ version } | null>
+ *   - insertEvent(row)                   -> Promise<{ data: rows, error }>
+ *   - fetchSnapshot(aggregateId)         -> Promise<row | null>
+ *   - upsertSnapshot(row)                -> Promise<{ error }>
+ *
+ * insertEvent MUST run against a uniqueness guarantee on
+ * (aggregate_id, version) — the database constraint is the final safety
+ * mechanism against duplicate versions. When the target version already
+ * exists the adapter returns `{ data: [] }` (e.g. INSERT ... ON CONFLICT
+ * DO NOTHING) so the core can raise a typed concurrency conflict.
+ *
+ * Row format (database boundary):
+ *   { event_id, event_type, aggregate_id, payload, version, timestamp }
+ *
+ * Domain event format (replay boundary):
+ *   { id, type, aggregateId, payload, version, timestamp }
+ */
+import {
+  EventStoreError,
+  EventStoreVersionConflictError,
+  EventStoreSnapshotError,
+  EventStoreValidationError,
+  toEventStoreError,
+} from './errors.js';
+
+import { randomUUID } from 'node:crypto';
+
+export const SNAPSHOT_SCHEMA_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// 1. THE SINGLE NORMALIZATION BOUNDARY
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a persisted database row into a domain event. This is the only
+ * place in the codebase where `event_id` -> `id`, `event_type` -> `type` and
+ * `aggregate_id` -> `aggregateId` are translated. Historical rows keep their
+ * original column layout forever; nothing below ever needs to know about it.
+ *
+ * Rows that are already in domain shape are passed through untouched, which
+ * keeps in-memory events and database-loaded events interchangeable.
+ */
+export function normalizeEventRow(row) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  // Already a domain event (e.g. produced by storeEvent in this process).
+  if (row.type && !row.event_type && row.aggregateId !== undefined) {
+    return { ...row };
+  }
+
+  return {
+    id: row.event_id ?? row.id,
+    type: row.event_type ?? row.type,
+    aggregateId: row.aggregate_id ?? row.aggregateId,
+    payload: row.payload ?? {},
+    version: Number(row.version),
+    timestamp: row.timestamp ?? row.created_at,
+  };
+}
+
+/**
+ * Inverse of normalizeEventRow — domain event to database row. Only used when
+ * persisting new events; historical rows are never rewritten.
+ */
+export function toEventRow(event) {
+  return {
+    event_id: event.id,
+    event_type: event.type,
+    aggregate_id: event.aggregateId,
+    payload: event.payload ?? {},
+    version: event.version,
+    timestamp: event.timestamp,
+    created_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2. AGGREGATE REDUCER
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure reducer: (state, domainEvent) -> nextState. Kept side-effect free so
+ * replay is deterministic regardless of cache temperature or process history.
+ */
+export function applyEvent(state, event) {
+  switch (event.type) {
+    case 'ORDER_CREATED':
+      return {
+        ...state,
+        ...event.payload,
+        status: 'CREATED',
+        version: event.version,
+      };
+    case 'ORDER_UPDATED':
+      return {
+        ...state,
+        ...event.payload,
+        version: event.version,
+      };
+    case 'ORDER_CANCELLED':
+      return {
+        ...state,
+        status: 'CANCELLED',
+        cancelledAt: event.payload.cancelledAt,
+        reason: event.payload.reason,
+        version: event.version,
+      };
+    case 'DRIVER_ASSIGNED':
+      return {
+        ...state,
+        driverId: event.payload.driverId,
+        status: 'ASSIGNED',
+        version: event.version,
+      };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. CORE
+// ---------------------------------------------------------------------------
+
+export class EventStoreCore {
+  constructor({
+    db,
+    logger = console,
+    snapshotThreshold = 50,
+    snapshotSchemaVersion = SNAPSHOT_SCHEMA_VERSION,
+    now = () => new Date().toISOString(),
+    uuid = () => randomUUID(),
+  }) {
+    if (!db) {
+      throw new EventStoreError('EventStoreCore requires a persistence adapter (`db`).');
+    }
+    this.db = db;
+    this.logger = logger;
+    this.snapshotThreshold = Number(snapshotThreshold) || 50;
+    this.snapshotSchemaVersion = snapshotSchemaVersion;
+    this._now = now;
+    this._uuid = uuid;
+
+    this.eventStreams = new Map(); // aggregateId -> domain events (in-memory cache)
+    this.snapshots = new Map(); // aggregateId -> validated snapshot
+  }
+
+  // ---- Cache --------------------------------------------------------------
+
+  /**
+   * Clears in-memory state. Used by cold-start tests and by long-running
+   * workers that want to force a fresh read from the database.
+   */
+  clearCache(aggregateId) {
+    if (aggregateId === undefined || aggregateId === null) {
+      this.eventStreams.clear();
+      this.snapshots.clear();
+      return;
+    }
+    this.eventStreams.delete(aggregateId);
+    this.snapshots.delete(aggregateId);
+  }
+
+  // ---- Event stream -------------------------------------------------------
+
+  async getEventStream(aggregateId) {
+    if (this.eventStreams.has(aggregateId)) {
+      return this.eventStreams.get(aggregateId);
+    }
+
+    const rawRows = await this.db.fetchEventStream(aggregateId);
+    const events = (rawRows || [])
+      .map(normalizeEventRow)
+      .filter(Boolean)
+      .sort((a, b) => Number(a.version) - Number(b.version));
+
+    this.eventStreams.set(aggregateId, events);
+    return events;
+  }
+
+  /**
+   * Latest committed version from the database — deliberately bypasses the
+   * in-memory cache so the value is authoritative across processes/instances.
+   */
+  async getLatestVersion(aggregateId) {
+    const row = await this.db.fetchLatestVersion(aggregateId);
+    const version = row && row.version !== null && row.version !== undefined ? Number(row.version) : null;
+    return version === null || Number.isNaN(version) ? null : version;
+  }
+
+  // ---- Aggregate reconstruction ------------------------------------------
+
+  /**
+   * Reconstructs aggregate state from the latest valid snapshot plus only the
+   * events newer than it. Warm cache, cold cache and database rows all flow
+   * through the same reducer, so the result is identical in every case.
+   *
+   * Returns null when the aggregate has never been created.
+   */
+  async getAggregateState(aggregateId) {
+    const snapshot = await this.getSnapshot(aggregateId);
+    const snapshotVersion = snapshot ? Number(snapshot.version) : 0;
+    let state = snapshot ? { ...snapshot.state } : { id: aggregateId, version: 0 };
+
+    const events = await this.getEventStream(aggregateId);
+    const eventsToApply = events
+      .filter((event) => Number(event.version) > snapshotVersion)
+      .sort((a, b) => Number(a.version) - Number(b.version));
+
+    if (!snapshot && eventsToApply.length === 0) {
+      return null;
+    }
+
+    for (const event of eventsToApply) {
+      state = applyEvent(state, event);
+    }
+    return state;
+  }
+
+  /**
+   * Rebuilds an aggregate purely from pre-fetched database rows (used by the
+   * rebuild endpoint so it does not re-query per aggregate). Still consults
+   * the latest valid snapshot so the rows older than the snapshot are skipped.
+   */
+  async rebuildFromRows(aggregateId, rawRows) {
+    const snapshot = await this.getSnapshot(aggregateId);
+    const snapshotVersion = snapshot ? Number(snapshot.version) : 0;
+    let state = snapshot ? { ...snapshot.state } : { id: aggregateId, version: 0 };
+
+    const events = (rawRows || [])
+      .map(normalizeEventRow)
+      .filter(Boolean)
+      .filter((event) => Number(event.version) > snapshotVersion)
+      .sort((a, b) => Number(a.version) - Number(b.version));
+
+    if (!snapshot && events.length === 0) {
+      return null;
+    }
+
+    for (const event of events) {
+      state = applyEvent(state, event);
+    }
+    return state;
+  }
+
+  // ---- Optimistic concurrency --------------------------------------------
+
+  /**
+   * Appends one event under optimistic concurrency control.
+   *
+   *   current === expectedVersion  ->  event stored at expectedVersion + 1
+   *   current !== expectedVersion  ->  EventStoreVersionConflictError
+   *
+   * The read-then-write check is advisory; the real safety net is the
+   * database uniqueness on (aggregate_id, version). If a concurrent writer
+   * commits the same version between our read and our insert, the insert is a
+   * no-op (`data: []`) and we raise a typed conflict.
+   */
+  async appendEvent(aggregateId, event, expectedVersion) {
+    if (!aggregateId) {
+      throw new EventStoreValidationError('appendEvent requires an aggregateId');
+    }
+    if (!event || typeof event.type !== 'string' || event.type.length === 0) {
+      throw new EventStoreValidationError('appendEvent requires an event with a non-empty `type`');
+    }
+
+    const currentVersion = await this.getLatestVersion(aggregateId);
+    const hasExpected = expectedVersion !== undefined && expectedVersion !== null;
+
+    if (hasExpected) {
+      const current = currentVersion === null ? 0 : currentVersion;
+      if (current !== expectedVersion) {
+        throw new EventStoreVersionConflictError({
+          aggregateId,
+          expectedVersion,
+          currentVersion: current,
+          reason: 'aggregate version advanced since the command was evaluated',
+        });
+      }
+    }
+
+    const nextVersion = hasExpected
+      ? expectedVersion + 1
+      : (currentVersion === null ? 0 : currentVersion) + 1;
+
+    const domainEvent = {
+      id: event.id || this._uuid(),
+      type: event.type,
+      aggregateId,
+      payload: event.payload ?? {},
+      version: nextVersion,
+      timestamp: event.timestamp || this._now(),
+    };
+
+    const { data, error } = await this.db.insertEvent(toEventRow(domainEvent));
+
+    if (error) {
+      const typed = toEventStoreError(error, { aggregateId });
+      this.logger.error?.('Event append failed:', typed);
+      throw typed;
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      // Unique (aggregate_id, version) rejected our insert: a concurrent
+      // request already claimed nextVersion. Never expose the raw conflict.
+      throw new EventStoreVersionConflictError({
+        aggregateId,
+        expectedVersion,
+        currentVersion: nextVersion,
+        reason: 'a concurrent command already committed this version',
+      });
+    }
+
+    // Persisted first, cache second — never cache a phantom event.
+    this._cacheEvent(aggregateId, domainEvent);
+    return domainEvent;
+  }
+
+  _cacheEvent(aggregateId, event) {
+    if (!this.eventStreams.has(aggregateId)) {
+      this.eventStreams.set(aggregateId, []);
+    }
+    const stream = this.eventStreams.get(aggregateId);
+    if (!stream.some((e) => e.version === event.version)) {
+      stream.push(event);
+      stream.sort((a, b) => Number(a.version) - Number(b.version));
+    }
+  }
+
+  // ---- Snapshots ----------------------------------------------------------
+
+  /**
+   * Loads the latest snapshot for an aggregate and validates it. An invalid
+   * or incompatible snapshot is treated as absent so callers fall back to a
+   * full replay instead of trusting corrupted state.
+   */
+  async getSnapshot(aggregateId) {
+    if (this.snapshots.has(aggregateId)) {
+      return this.snapshots.get(aggregateId);
+    }
+
+    let row = null;
+    try {
+      row = await this.db.fetchSnapshot(aggregateId);
+    } catch (error) {
+      this.logger.error?.(`Snapshot read failed for ${aggregateId}:`, error);
+      return null;
+    }
+
+    if (!row) {
+      this.snapshots.set(aggregateId, null);
+      return null;
+    }
+
+    const snapshot = this._validateSnapshot(row);
+    this.snapshots.set(aggregateId, snapshot);
+    return snapshot;
+  }
+
+  _validateSnapshot(row) {
+    if (!row || typeof row !== 'object') {
+      return null;
+    }
+    const version = Number(row.version);
+    if (!Number.isInteger(version) || version < 0) {
+      return null;
+    }
+    if (!row.state || typeof row.state !== 'object' || Array.isArray(row.state)) {
+      return null;
+    }
+    if (row.snapshot_version !== undefined && row.snapshot_version !== null) {
+      const schemaVersion = Number(row.snapshot_version);
+      if (Number.isNaN(schemaVersion) || schemaVersion > this.snapshotSchemaVersion) {
+        return null;
+      }
+    }
+    return {
+      aggregateId: row.aggregate_id ?? row.aggregateId,
+      version,
+      state: row.state,
+      snapshotVersion: Number(row.snapshot_version) || this.snapshotSchemaVersion,
+      createdAt: row.created_at ?? row.timestamp,
+    };
+  }
+
+  async takeSnapshot(aggregateId, state, version) {
+    const snapshotVersion = version !== undefined && version !== null ? Number(version) : Number(state?.version);
+    if (!Number.isInteger(snapshotVersion) || snapshotVersion < 0) {
+      throw new EventStoreSnapshotError(`Cannot snapshot ${aggregateId}: invalid version ${snapshotVersion}`, {
+        aggregateId,
+      });
+    }
+    if (!state || typeof state !== 'object') {
+      throw new EventStoreSnapshotError(`Cannot snapshot ${aggregateId}: state is not an object`, {
+        aggregateId,
+      });
+    }
+
+    const snapshot = {
+      aggregateId,
+      version: snapshotVersion,
+      state,
+      snapshotVersion: this.snapshotSchemaVersion,
+      timestamp: this._now(),
+    };
+
+    const { error } = await this.db.upsertSnapshot({
+      aggregate_id: aggregateId,
+      version: snapshotVersion,
+      state,
+      snapshot_version: this.snapshotSchemaVersion,
+      timestamp: snapshot.timestamp,
+    });
+
+    if (error) {
+      throw toEventStoreError(error, { aggregateId });
+    }
+
+    this.snapshots.set(aggregateId, {
+      aggregateId,
+      version: snapshotVersion,
+      state,
+      snapshotVersion: this.snapshotSchemaVersion,
+      createdAt: snapshot.timestamp,
+    });
+    return snapshot;
+  }
+
+  /**
+   * Snapshot policy: snapshot when the aggregate has grown by
+   * `snapshotThreshold` events since its last snapshot. Never snapshot every
+   * event, and never delete the underlying event history.
+   */
+  async checkSnapshot(aggregateId) {
+    const events = await this.getEventStream(aggregateId);
+    if (!events || events.length === 0) {
+      return;
+    }
+    const latestVersion = Math.max(...events.map((e) => Number(e.version) || 0));
+    const snapshot = await this.getSnapshot(aggregateId);
+    const snapshotVersion = snapshot ? Number(snapshot.version) : 0;
+
+    if (latestVersion - snapshotVersion >= this.snapshotThreshold) {
+      const state = await this.getAggregateState(aggregateId);
+      await this.takeSnapshot(aggregateId, state, latestVersion);
+      this.logger.info?.(`Snapshot taken for ${aggregateId} at version ${latestVersion}`);
+      return true;
+    }
+    return false;
+  }
+}
+
+export default EventStoreCore;

--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -1,5 +1,3 @@
-import kafka from '../kafka/config/kafka.config.js';
-import { TOPICS } from '../kafka/config/kafka.config.js';
 import { v4 as uuidv4 } from 'uuid';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
@@ -8,26 +6,150 @@ import { ContextPropagator } from '../api/src/core/telemetry/ContextPropagator.j
 import spanFactory from '../api/src/core/telemetry/SpanFactory.js';
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
 
+import { EventStoreCore, normalizeEventRow } from './event-sourcing-core.js';
+import {
+  EventStoreValidationError,
+  EventStoreVersionConflictError,
+  EventStorePersistenceError,
+  toEventStoreError,
+} from './errors.js';
+
+// Topic names mirror the values in backend/kafka/config/kafka.config.js.
+// They are duplicated here (instead of importing TOPICS) so this package does
+// not statically depend on kafkajs, which is not part of the repo's install.
+const EVENT_TOPIC_MAP = {
+  ORDER_CREATED: 'order.created',
+  ORDER_UPDATED: 'order.updated',
+  ORDER_CANCELLED: 'order.cancelled',
+  DRIVER_ASSIGNED: 'driver.assigned',
+};
+
+const SNAPSHOT_THRESHOLD_ENV = Number(process.env.EVENT_STORE_SNAPSHOT_THRESHOLD) || 50;
+
+/**
+ * Persistence adapter translating the core's `db` contract to Supabase.
+ * All insert/lookup logic (expected-version checks, uniqueness enforcement,
+ * snapshot validation) lives in EventStoreCore; this adapter only moves rows.
+ */
+function createSupabaseDb(supabaseClient, loggerAdapter) {
+  return {
+    async fetchEventStream(aggregateId) {
+      const { data, error } = await supabaseClient
+        .from('event_store')
+        .select('*')
+        .eq('aggregate_id', aggregateId)
+        .order('version', { ascending: true });
+      if (error) {
+        loggerAdapter.error(`Failed to fetch event stream for ${aggregateId}:`, error);
+        throw toEventStoreError(error, { aggregateId });
+      }
+      return data || [];
+    },
+
+    async fetchLatestVersion(aggregateId) {
+      const { data, error } = await supabaseClient
+        .from('event_store')
+        .select('version')
+        .eq('aggregate_id', aggregateId)
+        .order('version', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) {
+        throw toEventStoreError(error, { aggregateId });
+      }
+      return data;
+    },
+
+    async insertEvent(row) {
+      // Single atomic statement: INSERT ... ON CONFLICT (aggregate_id, version)
+      // DO NOTHING. The unique index is the final safety mechanism — when the
+      // version already exists this resolves to `{ data: [] }` and the core
+      // raises a typed EventStoreVersionConflictError.
+      return supabaseClient
+        .from('event_store')
+        .upsert([row], {
+          onConflict: 'aggregate_id,version',
+          ignoreDuplicates: true,
+        });
+    },
+
+    async fetchSnapshot(aggregateId) {
+      const { data, error } = await supabaseClient
+        .from('snapshots')
+        .select('*')
+        .eq('aggregate_id', aggregateId)
+        .single();
+      if (error) {
+        if (error.code === 'PGRST116') {
+          return null; // no rows for this aggregate
+        }
+        loggerAdapter.error(`Failed to fetch snapshot for ${aggregateId}:`, error);
+        throw toEventStoreError(error, { aggregateId });
+      }
+      return data;
+    },
+
+    async upsertSnapshot(row) {
+      return supabaseClient
+        .from('snapshots')
+        .upsert([row], { onConflict: 'aggregate_id' });
+    },
+  };
+}
+
 class EventStore {
-    constructor({ eventBus: externalEventBus } = {}) {
-        this.eventStore = new Map(); // In-memory cache
-        this.eventStreams = new Map();
-        this.snapshots = new Map();
-        this.snapshotThreshold = 50; // Take snapshot every 50 events
+    constructor({ eventBus: externalEventBus = null, db = null, logger: loggerAdapter = logger, snapshotThreshold = SNAPSHOT_THRESHOLD_ENV, client = null } = {}) {
+        this.logger = loggerAdapter;
+        this.snapshotThreshold = snapshotThreshold;
+        this.eventStore = new Map(); // kept for backwards compatibility with getEventStoreStats callers
         this.kafkaProducer = null;
         this.isInitialized = false;
         this._eventBus = externalEventBus || null;
+        this._db = db; // injectable for tests; defaults to supabase-backed adapter
+        this._client = client || supabase; // injectable for tests; defaults to the supabase client
+        this._core = null;
+        this._kafka = undefined; // lazy kafka module (null when unavailable)
     }
 
     setEventBus(eventBus) {
         this._eventBus = eventBus;
     }
 
+    _getCore() {
+        if (!this._core) {
+            this._core = new EventStoreCore({
+                db: this._db || createSupabaseDb(this._client, this.logger),
+                logger: this.logger,
+                snapshotThreshold: this.snapshotThreshold,
+            });
+        }
+        return this._core;
+    }
+
+    async _loadKafka() {
+        if (this._kafka === undefined) {
+            try {
+                this._kafka = await import('../kafka/config/kafka.config.js');
+            } catch (error) {
+                this.logger.warn('kafkajs is not installed — Kafka publishing disabled:', error?.message);
+                this._kafka = null;
+            }
+        }
+        return this._kafka;
+    }
+
     async initialize() {
         if (this.isInitialized) return;
-        this.kafkaProducer = await kafka.getProducer();
+        const kafkaModule = await this._loadKafka();
+        if (kafkaModule) {
+            try {
+                this.kafkaProducer = await kafkaModule.default.getProducer();
+            } catch (error) {
+                this.logger.warn('Kafka producer initialization failed:', error?.message);
+            }
+        }
         this.isInitialized = true;
-        logger.info('✅ EventStore initialized');
+        this.logger.info('✅ EventStore initialized');
     }
 
     // ============ Command Handling ============
@@ -42,39 +164,48 @@ class EventStore {
 
         try {
             await this.initialize();
-            
+
             const commandId = uuidv4();
             const timestamp = new Date().toISOString();
-            
-            logger.info(`📝 Handling command: ${command.type}`, { commandId, aggregateId: command.aggregateId });
+
+            this.logger.info(`📝 Handling command: ${command.type}`, { commandId, aggregateId: command.aggregateId });
 
             const result = await context.with(trace.setSpan(context.active(), span), async () => {
                 // Validate command
                 const validation = await this.validateCommand(command);
                 if (!validation.valid) {
-                    throw new Error(`Command validation failed: ${validation.error}`);
+                    throw new EventStoreValidationError(`Command validation failed: ${validation.error}`);
                 }
 
                 // Execute command and generate events
                 const events = await this.executeCommand(command);
 
-                // Store events
+                // Store events under optimistic concurrency. When a command
+                // emits multiple events, each one chains off the previous.
+                const storedEvents = [];
+                let lastVersion = null;
                 for (const event of events) {
-                    await this.storeEvent(event);
+                    const expectedVersion =
+                        event.expectedVersion !== undefined && event.expectedVersion !== null
+                            ? event.expectedVersion
+                            : lastVersion;
+                    const stored = await this.storeEvent(event, expectedVersion);
+                    lastVersion = stored.version;
+                    storedEvents.push(stored);
                 }
 
-                // Publish events to Kafka
-                await this.publishEvents(events);
+                // Publish events to Kafka / event bus
+                await this.publishEvents(storedEvents);
 
                 // Update read models
-                await this.updateReadModels(events);
+                await this.updateReadModels(storedEvents);
 
                 // Check if snapshot needed
                 await this.checkSnapshot(command.aggregateId);
 
                 return {
                     commandId,
-                    events,
+                    events: storedEvents,
                     timestamp,
                     success: true
                 };
@@ -86,8 +217,8 @@ class EventStore {
         } catch (error) {
             spanFactory.recordError(span, error);
             span.end();
-            logger.error('Command handling failed:', error);
-            throw error;
+            this.logger.error('Command handling failed:', error);
+            throw toEventStoreError(error, { aggregateId: command.aggregateId });
         }
     }
 
@@ -144,12 +275,14 @@ class EventStore {
                     aggregateId: command.aggregateId || `order_${Date.now()}`,
                     payload: command.payload,
                     timestamp,
-                    version: 1
+                    version: 1,
+                    expectedVersion: 0 // a new aggregate must start from version 0
                 });
                 break;
 
-            case 'UPDATE_ORDER':
+            case 'UPDATE_ORDER': {
                 const currentState = await this.getAggregateState(command.aggregateId);
+                const currentVersion = currentState?.version ?? 0;
                 events.push({
                     id: uuidv4(),
                     type: 'ORDER_UPDATED',
@@ -159,11 +292,15 @@ class EventStore {
                         previousState: currentState
                     },
                     timestamp,
-                    version: (currentState?.version || 0) + 1
+                    version: currentVersion + 1,
+                    expectedVersion: currentVersion
                 });
                 break;
+            }
 
-            case 'CANCEL_ORDER':
+            case 'CANCEL_ORDER': {
+                const currentState = await this.getAggregateState(command.aggregateId);
+                const currentVersion = currentState?.version ?? 0;
                 events.push({
                     id: uuidv4(),
                     type: 'ORDER_CANCELLED',
@@ -174,11 +311,15 @@ class EventStore {
                         cancelledAt: timestamp
                     },
                     timestamp,
-                    version: ((await this.getAggregateState(command.aggregateId))?.version || 0) + 1
+                    version: currentVersion + 1,
+                    expectedVersion: currentVersion
                 });
                 break;
+            }
 
-            case 'ASSIGN_DRIVER':
+            case 'ASSIGN_DRIVER': {
+                const currentState = await this.getAggregateState(command.aggregateId);
+                const currentVersion = currentState?.version ?? 0;
                 events.push({
                     id: uuidv4(),
                     type: 'DRIVER_ASSIGNED',
@@ -189,12 +330,14 @@ class EventStore {
                         assignedAt: timestamp
                     },
                     timestamp,
-                    version: ((await this.getAggregateState(command.aggregateId))?.version || 0) + 1
+                    version: currentVersion + 1,
+                    expectedVersion: currentVersion
                 });
                 break;
+            }
 
             default:
-                throw new Error(`Unknown command type: ${command.type}`);
+                throw new EventStoreValidationError(`Unknown command type: ${command.type}`);
         }
 
         return events;
@@ -202,175 +345,40 @@ class EventStore {
 
     // ============ Event Storage ============
 
-    async storeEvent(event) {
-        // Store in memory
-        if (!this.eventStreams.has(event.aggregateId)) {
-            this.eventStreams.set(event.aggregateId, []);
-        }
-        this.eventStreams.get(event.aggregateId).push(event);
-
-        // Store in database
-        const { error } = await supabase
-            .from('event_store')
-            .insert([{
-                event_id: event.id,
-                event_type: event.type,
-                aggregate_id: event.aggregateId,
-                payload: event.payload,
-                version: event.version,
-                timestamp: event.timestamp,
-                created_at: new Date().toISOString()
-            }]);
-
-        if (error) {
-            logger.error('Failed to store event:', error);
-            throw error;
-        }
-
-        logger.info(`✅ Event stored: ${event.type}`, { eventId: event.id, aggregateId: event.aggregateId });
+    /**
+     * Persists an event under optimistic concurrency control. On success the
+     * core also refreshes the in-memory stream cache — a phantom event is
+     * never cached, because the database insert happens first.
+     */
+    async storeEvent(event, expectedVersion) {
+        return this._getCore().appendEvent(event.aggregateId, event, expectedVersion);
     }
 
     async getEventStream(aggregateId) {
-        // Check cache
-        if (this.eventStreams.has(aggregateId)) {
-            return this.eventStreams.get(aggregateId);
-        }
-
-        // Fetch from database
-        const { data, error } = await supabase
-            .from('event_store')
-            .select('*')
-            .eq('aggregate_id', aggregateId)
-            .order('version', { ascending: true });
-
-        if (error) {
-            logger.error('Failed to fetch event stream:', error);
-            return [];
-        }
-
-        const mappedData = (data || []).map(row => ({
-            id: row.event_id || row.id,
-            type: row.event_type || row.type,
-            aggregateId: row.aggregate_id || row.aggregateId,
-            payload: row.payload,
-            version: row.version,
-            timestamp: row.timestamp || row.created_at
-        }));
-
-        this.eventStreams.set(aggregateId, mappedData);
-        return mappedData;
+        return this._getCore().getEventStream(aggregateId);
     }
 
     async getAggregateState(aggregateId) {
-        const snapshot = await this.getSnapshot(aggregateId);
-        let state = snapshot ? { ...snapshot.state } : { id: aggregateId, version: 0 };
-        const snapshotVersion = snapshot ? (snapshot.version || snapshot.state?.version || 0) : 0;
-
-        const events = await this.getEventStream(aggregateId);
-        const eventsToApply = events.filter(e => e.version > snapshotVersion);
-
-        if (!snapshot && eventsToApply.length === 0) {
-            return null;
-        }
-
-        for (const event of eventsToApply) {
-            state = this.applyEvent(state, event);
-        }
-        return state;
+        return this._getCore().getAggregateState(aggregateId);
     }
 
-    applyEvent(state, event) {
-        switch (event.type) {
-            case 'ORDER_CREATED':
-                return {
-                    ...state,
-                    ...event.payload,
-                    status: 'CREATED',
-                    version: event.version
-                };
-            case 'ORDER_UPDATED':
-                return {
-                    ...state,
-                    ...event.payload,
-                    version: event.version
-                };
-            case 'ORDER_CANCELLED':
-                return {
-                    ...state,
-                    status: 'CANCELLED',
-                    cancelledAt: event.payload.cancelledAt,
-                    reason: event.payload.reason,
-                    version: event.version
-                };
-            case 'DRIVER_ASSIGNED':
-                return {
-                    ...state,
-                    driverId: event.payload.driverId,
-                    status: 'ASSIGNED',
-                    version: event.version
-                };
-            default:
-                return state;
-        }
+    /** Clears in-memory caches (all aggregates, or one). Used on cold start. */
+    clearCache(aggregateId) {
+        return this._getCore().clearCache(aggregateId);
     }
 
     // ============ Snapshotting ============
 
     async checkSnapshot(aggregateId) {
-        const events = await this.getEventStream(aggregateId);
-        if (events.length >= this.snapshotThreshold) {
-            const state = await this.getAggregateState(aggregateId);
-            await this.takeSnapshot(aggregateId, state);
-        }
+        return this._getCore().checkSnapshot(aggregateId);
     }
 
-    async takeSnapshot(aggregateId, state) {
-        this.snapshots.set(aggregateId, {
-            state,
-            timestamp: new Date().toISOString(),
-            version: state.version
-        });
-
-        // Store in database
-        const { error } = await supabase
-            .from('snapshots')
-            .upsert([{
-                aggregate_id: aggregateId,
-                state: state,
-                version: state.version,
-                timestamp: new Date().toISOString()
-            }], {
-                onConflict: 'aggregate_id'
-            });
-
-        if (error) {
-            logger.error('Failed to store snapshot:', error);
-        } else {
-            logger.info(`✅ Snapshot taken for ${aggregateId}`);
-            // Clear events up to snapshot
-            this.eventStreams.set(aggregateId, []);
-        }
+    async takeSnapshot(aggregateId, state, version) {
+        return this._getCore().takeSnapshot(aggregateId, state, version);
     }
 
     async getSnapshot(aggregateId) {
-        // Check cache
-        if (this.snapshots.has(aggregateId)) {
-            return this.snapshots.get(aggregateId);
-        }
-
-        // Fetch from database
-        const { data, error } = await supabase
-            .from('snapshots')
-            .select('*')
-            .eq('aggregate_id', aggregateId)
-            .single();
-
-        if (error) {
-            return null;
-        }
-
-        this.snapshots.set(aggregateId, data);
-        return data;
+        return this._getCore().getSnapshot(aggregateId);
     }
 
     // ============ Projections ============
@@ -399,26 +407,41 @@ class EventStore {
         }
     }
 
-    async updateOrderReadModel(event) {
-        const { data, error } = await supabase
+    /**
+     * Persists the aggregate's full reconstructed state as the read model.
+     * Both the live projection path and the rebuild endpoint converge on the
+     * same payload shape (the aggregate state), so `payload->>status` and
+     * `payload->>customerId` filters behave identically after warm writes and
+     * after a rebuild.
+     */
+    async _upsertOrderReadModel(orderId, state, eventType, version) {
+        const { error } = await this._client
             .from('orders_read_model')
             .upsert([{
-                order_id: event.aggregateId,
-                payload: event.payload,
-                event_type: event.type,
-                version: event.version,
+                order_id: orderId,
+                payload: state,
+                event_type: eventType,
+                version: version ?? state?.version,
                 updated_at: new Date().toISOString()
             }], {
                 onConflict: 'order_id'
             });
 
         if (error) {
-            logger.error('Failed to update order read model:', error);
+            this.logger.error('Failed to update order read model:', error);
         }
     }
 
+    async updateOrderReadModel(event) {
+        const state = await this.getAggregateState(event.aggregateId);
+        if (!state) {
+            return;
+        }
+        await this._upsertOrderReadModel(event.aggregateId, state, event.type, event.version);
+    }
+
     async updateDriverReadModel(event) {
-        const { data, error } = await supabase
+        const { error } = await this._client
             .from('drivers_read_model')
             .upsert([{
                 driver_id: event.payload.driverId,
@@ -430,8 +453,52 @@ class EventStore {
             });
 
         if (error) {
-            logger.error('Failed to update driver read model:', error);
+            this.logger.error('Failed to update driver read model:', error);
         }
+    }
+
+    /**
+     * Rebuilds every read model from persisted event rows (used by
+     * POST /eventsourcing/rebuild). Each aggregate is reconstructed from its
+     * latest valid snapshot plus only the newer events, so the rebuild and a
+     * live aggregate have identical state.
+     */
+    async rebuildProjections(rawRows) {
+        const rows = rawRows || [];
+        const aggregates = [...new Set(rows.map((r) => r.aggregate_id ?? r.aggregateId))];
+
+        let orderCount = 0;
+        for (const aggregateId of aggregates) {
+            const aggRows = rows.filter((r) => (r.aggregate_id ?? r.aggregateId) === aggregateId);
+            const sorted = aggRows
+                .map(normalizeEventRow)
+                .filter(Boolean)
+                .sort((a, b) => Number(a.version) - Number(b.version));
+            const lastEventType = sorted.length ? sorted[sorted.length - 1].type : 'REBUILT';
+
+            const state = await this._getCore().rebuildFromRows(aggregateId, aggRows);
+            if (state) {
+                await this._upsertOrderReadModel(aggregateId, state, lastEventType, state.version);
+                orderCount += 1;
+            }
+        }
+
+        const driverEvents = rows
+            .map(normalizeEventRow)
+            .filter((event) => event && event.type === 'DRIVER_ASSIGNED');
+
+        let driverCount = 0;
+        for (const event of driverEvents) {
+            await this.updateDriverReadModel(event);
+            driverCount += 1;
+        }
+
+        return {
+            aggregates: aggregates.length,
+            orderCount,
+            driverCount,
+            eventCount: rows.length,
+        };
     }
 
     // ============ Event Publishing ============
@@ -454,29 +521,28 @@ class EventStore {
                 category: EVENT_CATEGORIES.DOMAIN,
             });
             this._eventBus.publish(baseEvent, { deduplicate: false });
-            logger.info(`📤 Event published via EventBus: ${event.type}`);
+            this.logger.info(`📤 Event published via EventBus: ${event.type}`);
         } else {
             const topic = this.getEventTopic(event.type);
             const enriched = ContextPropagator.injectIntoEventPayload(event);
-            await kafka.publishEvent(topic, enriched, event.aggregateId);
-            logger.info(`📤 Event published to Kafka: ${event.type}`);
+            const kafkaModule = await this._loadKafka();
+            if (!kafkaModule) {
+                this.logger.warn(`Kafka unavailable — skipping publish of ${event.type}`);
+                return;
+            }
+            await kafkaModule.default.publishEvent(topic, enriched, event.aggregateId);
+            this.logger.info(`📤 Event published to Kafka: ${event.type}`);
         }
     }
 
     getEventTopic(eventType) {
-        const topicMap = {
-            'ORDER_CREATED': TOPICS.ORDER_CREATED,
-            'ORDER_UPDATED': TOPICS.ORDER_UPDATED,
-            'ORDER_CANCELLED': TOPICS.ORDER_CANCELLED,
-            'DRIVER_ASSIGNED': TOPICS.DRIVER_ASSIGNED
-        };
-        return topicMap[eventType] || eventType;
+        return EVENT_TOPIC_MAP[eventType] || eventType;
     }
 
     // ============ Query ============
 
     async getOrderReadModel(orderId) {
-        const { data, error } = await supabase
+        const { data, error } = await this._client
             .from('orders_read_model')
             .select('*')
             .eq('order_id', orderId)
@@ -499,7 +565,7 @@ class EventStore {
     }
 
     async getOrderList(filters = {}) {
-        let query = supabase
+        let query = this._client
             .from('orders_read_model')
             .select('*');
 
@@ -515,7 +581,7 @@ class EventStore {
 
         const { data, error } = await query;
         if (error) {
-            logger.error('Failed to get order list:', error);
+            this.logger.error('Failed to get order list:', error);
             return [];
         }
         return data;
@@ -524,13 +590,17 @@ class EventStore {
     // ============ Stats ============
 
     async getEventStoreStats() {
-        const { data: events, count: totalEvents } = await supabase
+        const { data: events, count: totalEvents, error: eventsError } = await this._client
             .from('event_store')
             .select('event_type', { count: 'exact' });
 
-        const { count: totalSnapshots } = await supabase
+        const { count: totalSnapshots, error: snapshotsError } = await this._client
             .from('snapshots')
             .select('*', { count: 'exact', head: true });
+
+        if (eventsError || snapshotsError) {
+            this.logger.error('Failed to read event-store stats:', eventsError || snapshotsError);
+        }
 
         return {
             totalEvents: totalEvents || 0,
@@ -542,6 +612,18 @@ class EventStore {
             timestamp: new Date().toISOString()
         };
     }
+
+    // ============ Optimistic concurrency (adapter level) ============
+
+    /**
+     * Appends an event requiring the current version to match `expectedVersion`.
+     * Exposed for external consumers that want the same guarantee without going
+     * through a full command. Returns the stored domain event.
+     */
+    async appendEvent(aggregateId, event, expectedVersion) {
+        return this._getCore().appendEvent(aggregateId, event, expectedVersion);
+    }
 }
 
 export default new EventStore();
+export { EventStore, EventStoreVersionConflictError, EventStorePersistenceError };

--- a/backend/eventsourcing/package.json
+++ b/backend/eventsourcing/package.json
@@ -1,12 +1,24 @@
 {
   "name": "truxify-eventsourcing",
   "version": "1.0.0",
-  "dependencies": {
-    "uuid": "^14.0.1"
-  },
+  "description": "Truxify event-sourcing store: optimistic concurrency, snapshot-based replay and read-model rebuilds",
   "type": "module",
   "main": "event-store.js",
+  "exports": {
+    ".": "./event-store.js",
+    "./core": "./event-sourcing-core.js",
+    "./errors": "./errors.js"
+  },
+  "engines": {
+    "node": ">=18.13.0"
+  },
   "scripts": {
-    "start": "node event-store.js"
+    "start": "node event-store.js",
+    "dev": "node --watch event-store.js",
+    "test": "node --test test/",
+    "test:watch": "node --test --watch test/"
+  },
+  "dependencies": {
+    "uuid": "^14.0.1"
   }
 }

--- a/backend/eventsourcing/routes.js
+++ b/backend/eventsourcing/routes.js
@@ -2,8 +2,30 @@ import express from 'express';
 import eventStore from './event-store.js';
 import { supabase } from '../api/src/config/db.js';
 import logger from '../api/src/middleware/logger.js';
+import { EventStoreError } from './errors.js';
 
 const router = express.Router();
+
+/**
+ * Controlled error response: typed event-store errors are translated to their
+ * HTTP status with a public message; everything else collapses to a generic
+ * 500 so SQL errors, Supabase internals and stack traces never reach clients.
+ */
+function sendEventStoreError(res, error, fallbackMessage) {
+    logger.error(fallbackMessage, error);
+    if (error instanceof EventStoreError) {
+        return res.status(error.httpStatus).json({
+            success: false,
+            error: error.message,
+            code: error.code,
+        });
+    }
+    return res.status(500).json({
+        success: false,
+        error: fallbackMessage,
+        code: 'EVENT_STORE_INTERNAL_ERROR',
+    });
+}
 
 // Handle command
 router.post('/eventsourcing/command', async (req, res) => {
@@ -25,8 +47,7 @@ router.post('/eventsourcing/command', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Command error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Command processing failed');
     }
 });
 
@@ -41,8 +62,7 @@ router.get('/eventsourcing/order/:orderId', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Get order error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Get order error');
     }
 });
 
@@ -62,8 +82,7 @@ router.get('/eventsourcing/orders', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Get orders error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Get orders error');
     }
 });
 
@@ -79,8 +98,7 @@ router.get('/eventsourcing/stream/:aggregateId', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Get event stream error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Get event stream error');
     }
 });
 
@@ -95,8 +113,7 @@ router.get('/eventsourcing/state/:aggregateId', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Get state error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Get state error');
     }
 });
 
@@ -110,33 +127,40 @@ router.get('/eventsourcing/stats', async (req, res) => {
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Get stats error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Get stats error');
     }
 });
 
 // Rebuild projections
+// Loads every persisted event, groups by aggregate, and reconstructs each
+// aggregate from its latest valid snapshot plus only the newer events (see
+// EventStoreCore.rebuildFromRows). Read models therefore match live aggregates.
 router.post('/eventsourcing/rebuild', async (req, res) => {
     try {
-        // Rebuild all projections from events
-        const { data: events } = await supabase
+        const { data, error } = await supabase
             .from('event_store')
             .select('*')
             .order('timestamp', { ascending: true });
 
-        for (const event of events) {
-            await eventStore.updateReadModel(event);
+        if (error) {
+            logger.error('Rebuild error:', error);
+            return res.status(500).json({
+                success: false,
+                error: 'Projection rebuild failed',
+                code: 'EVENT_STORE_INTERNAL_ERROR',
+            });
         }
+
+        const result = await eventStore.rebuildProjections(data || []);
 
         res.json({
             success: true,
             message: 'Projections rebuilt',
-            count: events.length,
+            ...result,
             timestamp: new Date().toISOString()
         });
     } catch (error) {
-        logger.error('Rebuild error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        sendEventStoreError(res, error, 'Projection rebuild failed');
     }
 });
 

--- a/backend/eventsourcing/test/event-sourcing-core.test.js
+++ b/backend/eventsourcing/test/event-sourcing-core.test.js
@@ -1,0 +1,462 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EventStoreCore, normalizeEventRow, applyEvent } from '../event-sourcing-core.js';
+import { EventStoreVersionConflictError, EventStoreError } from '../errors.js';
+import { InMemoryDb, dbRow } from './in-memory-db.js';
+
+const silentLogger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function createCore({ db, threshold = 50 } = {}) {
+  return new EventStoreCore({
+    db: db || new InMemoryDb(),
+    logger: silentLogger,
+    snapshotThreshold: threshold,
+    uuid: () => `evt_${Math.random().toString(36).slice(2)}`,
+    now: () => new Date('2026-08-08T00:00:00Z').toISOString(),
+  });
+}
+
+/**
+ * Appends a chain of events to an aggregate using optimistic concurrency.
+ * By default the chain continues from the aggregate's current latest version.
+ */
+async function appendChain(core, aggregateId, typesAndPayloads, startVersion) {
+  const stored = [];
+  let expected = startVersion ?? (await core.getLatestVersion(aggregateId)) ?? 0;
+  for (const { type, payload } of typesAndPayloads) {
+    stored.push(await core.appendEvent(aggregateId, { type, payload }, expected));
+    expected += 1;
+  }
+  return stored;
+}
+
+describe('EventStoreCore — event replay', () => {
+  test('CASE 1: normal event replay produces correct state and version', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_1';
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'cust_1', amount: 100, pickup: 'A', dropoff: 'B' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 120 } },
+      { type: 'DRIVER_ASSIGNED', payload: { orderId, driverId: 'drv_1', assignedAt: 't1' } },
+    ]);
+
+    const state = await core.getAggregateState(orderId);
+    assert.equal(state.status, 'ASSIGNED');
+    assert.equal(state.customerId, 'cust_1');
+    assert.equal(state.amount, 120);
+    assert.equal(state.driverId, 'drv_1');
+    assert.equal(state.version, 3);
+  });
+
+  test('CASE 2: cold start (cleared cache) reconstructs identical state to warm cache', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_cold';
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'cust_x', amount: 10, pickup: 'P', dropoff: 'D' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 15 } },
+      { type: 'DRIVER_ASSIGNED', payload: { orderId, driverId: 'drv_9' } },
+      { type: 'ORDER_CANCELLED', payload: { orderId, reason: 'late' } },
+    ]);
+
+    const warmState = await core.getAggregateState(orderId);
+
+    // Simulate application restart: in-memory caches are empty.
+    core.clearCache();
+
+    const coldState = await core.getAggregateState(orderId);
+    assert.deepEqual(coldState, warmState);
+    assert.equal(coldState.status, 'CANCELLED');
+    assert.equal(coldState.reason, 'late');
+    assert.equal(coldState.version, 4);
+  });
+
+  test('CASE 3: event normalization maps event_type->type and aggregate_id->aggregateId', async () => {
+    const row = dbRow({
+      id: 'evt_abc',
+      type: 'ORDER_CREATED',
+      aggregateId: 'order_norm',
+      payload: { customerId: 'c', amount: 1, pickup: 'a', dropoff: 'b' },
+      version: 1,
+      timestamp: '2026-01-01T00:00:00Z',
+    });
+    const db = new InMemoryDb({ initialEvents: [row] });
+    const core = createCore({ db });
+
+    const events = await core.getEventStream('order_norm');
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, 'ORDER_CREATED');
+    assert.equal(events[0].aggregateId, 'order_norm');
+    assert.equal(events[0].id, 'evt_abc');
+    assert.equal(events[0].version, 1);
+    assert.equal(events[0].payload.amount, 1);
+    assert.equal(events[0].timestamp, '2026-01-01T00:00:00Z');
+
+    // normalizeEventRow must also pass through already-domain-shaped events.
+    const domain = normalizeEventRow({ id: 'x', type: 'ORDER_UPDATED', aggregateId: 'a', payload: {}, version: 2 });
+    assert.deepEqual(domain, { id: 'x', type: 'ORDER_UPDATED', aggregateId: 'a', payload: {}, version: 2 });
+  });
+
+  test('CASE 10: historical DB-format events remain replayable', async () => {
+    // Old rows use event_id/event_type/aggregate_id and may lack created_at.
+    const db = new InMemoryDb({
+      initialEvents: [
+        dbRow({ id: 'e1', type: 'ORDER_CREATED', aggregateId: 'order_hist', payload: { customerId: 'c', amount: 5, pickup: 'p', dropoff: 'd' }, version: 1 }),
+        dbRow({ id: 'e2', type: 'DRIVER_ASSIGNED', aggregateId: 'order_hist', payload: { orderId: 'order_hist', driverId: 'drv_h' }, version: 2 }),
+      ],
+    });
+    const core = createCore({ db });
+
+    const state = await core.getAggregateState('order_hist');
+    assert.equal(state.version, 2);
+    assert.equal(state.status, 'ASSIGNED');
+    assert.equal(state.driverId, 'drv_h');
+    assert.equal(state.customerId, 'c');
+  });
+});
+
+describe('EventStoreCore — snapshots', () => {
+  test('CASE 4: snapshot is loaded first and only newer events are replayed', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_snap';
+
+    // Events 1..10 all write `earlyFlag = true`. The snapshot at version 10
+    // is authoritative and says `earlyFlag = false`. If replay incorrectly
+    // starts from event 1 the flag would become true again.
+    const early = Array.from({ length: 9 }, (_, i) => ({
+      type: 'ORDER_UPDATED',
+      payload: { earlyFlag: true, seq: i + 1 },
+    }));
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' } },
+      ...early,
+    ]);
+
+    const stateAt10 = await core.getAggregateState(orderId);
+    assert.equal(stateAt10.version, 10);
+
+    // Overwrite the snapshot with an authoritative state that differs from a
+    // naive replay of events 1..10.
+    const snapshotState = { ...stateAt10, earlyFlag: false };
+    await core.takeSnapshot(orderId, snapshotState, 10);
+
+    // Events 11..15 — only these may be replayed on top of the snapshot.
+    await appendChain(core, orderId, [
+      { type: 'ORDER_UPDATED', payload: { note: 'post-snapshot' } },
+      { type: 'ORDER_UPDATED', payload: { note: 'post-snapshot-2' } },
+      { type: 'ORDER_UPDATED', payload: { note: 'post-snapshot-3' } },
+      { type: 'ORDER_UPDATED', payload: { note: 'post-snapshot-4' } },
+      { type: 'ORDER_UPDATED', payload: { note: 'post-snapshot-5' } },
+    ]);
+
+    core.clearCache(orderId);
+    const state = await core.getAggregateState(orderId);
+
+    // Snapshot state is the base (its earlyFlag survives) and only 11..15
+    // were applied on top.
+    assert.equal(state.earlyFlag, false);
+    assert.equal(state.note, 'post-snapshot-5');
+    assert.equal(state.version, 15);
+
+    const snapshot = await core.getSnapshot(orderId);
+    assert.equal(snapshot.version, 10);
+  });
+
+  test('CASE 5: invalid snapshot falls back to full event replay', async () => {
+    const orderId = 'order_invalid';
+    const baseEvents = [
+      dbRow({ id: 'e1', type: 'ORDER_CREATED', aggregateId: orderId, payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'e2', type: 'ORDER_UPDATED', aggregateId: orderId, payload: { amount: 99 }, version: 2 }),
+    ];
+
+    for (const corrupt of [
+      { version: 2, state: 'not-an-object' },
+      { version: 'corrupt', state: { amount: 0 } },
+      { version: 2, state: { amount: 0 }, snapshot_version: 999 },
+      { version: 2, state: { amount: 0 }, snapshot_version: 'abc' },
+    ]) {
+      const db = new InMemoryDb({
+        initialEvents: baseEvents,
+        initialSnapshots: [{ aggregate_id: orderId, ...corrupt }],
+      });
+      const core = createCore({ db });
+
+      const state = await core.getAggregateState(orderId);
+      // Full replay — the corrupt snapshot is ignored, state is intact.
+      assert.equal(state.amount, 99);
+      assert.equal(state.version, 2);
+      assert.equal(state.status, 'CREATED');
+    }
+  });
+
+  test('CASE 12: snapshot + newer events reconstruct correctly after restart', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_restart';
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 10, pickup: 'p', dropoff: 'd' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 20 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 30 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 40 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 50 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 60 } },
+    ]);
+    const stateAt6 = await core.getAggregateState(orderId);
+    await core.takeSnapshot(orderId, stateAt6, 6);
+
+    // More events arrive after the snapshot.
+    await appendChain(core, orderId, [
+      { type: 'ORDER_UPDATED', payload: { amount: 70 } },
+      { type: 'DRIVER_ASSIGNED', payload: { orderId, driverId: 'drv_r' } },
+    ]);
+
+    // Shutdown: wipe all in-memory state.
+    core.clearCache();
+
+    const restarted = await core.getAggregateState(orderId);
+    assert.equal(restarted.amount, 70);
+    assert.equal(restarted.driverId, 'drv_r');
+    assert.equal(restarted.status, 'ASSIGNED');
+    assert.equal(restarted.version, 8);
+  });
+
+  test('snapshot threshold policy only snapshots after N new events', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db, threshold: 5 });
+    const orderId = 'order_thresh';
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 2 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 3 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 4 } },
+    ]);
+    // 4 events, threshold 5 -> no snapshot yet.
+    await core.checkSnapshot(orderId);
+    assert.equal(await core.getSnapshot(orderId), null);
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_UPDATED', payload: { amount: 5 } },
+    ]);
+    await core.checkSnapshot(orderId);
+    const snap = await core.getSnapshot(orderId);
+    assert.equal(snap.version, 5);
+  });
+});
+
+describe('EventStoreCore — optimistic concurrency', () => {
+  test('CASE 6: two concurrent commands never produce duplicate versions', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_race';
+
+    await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 2 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 3 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 4 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 5 } },
+    ]);
+    assert.equal((await core.getLatestVersion(orderId)), 5);
+
+    // Simulate the production race: BOTH requests read version 5 before either
+    // one inserts. The database uniqueness (mirrored by InMemoryDb) lets only
+    // one of them commit version 6.
+    const originalFetch = db.fetchLatestVersion.bind(db);
+    let reads = 0;
+    let releaseGate;
+    const gate = new Promise((resolve) => { releaseGate = resolve; });
+    db.fetchLatestVersion = async (aggregateId) => {
+      const captured = await originalFetch(aggregateId); // both capture 5
+      reads += 1;
+      if (reads >= 2) releaseGate();
+      await gate;
+      return captured;
+    };
+
+    const results = await Promise.allSettled([
+      core.appendEvent(orderId, { type: 'UPDATE_ORDER_EVENT', payload: { note: 'A' } }, 5),
+      core.appendEvent(orderId, { type: 'UPDATE_ORDER_EVENT', payload: { note: 'B' } }, 5),
+    ]);
+
+    const successes = results.filter((r) => r.status === 'fulfilled');
+    const conflicts = results.filter((r) => r.status === 'rejected');
+    assert.equal(successes.length, 1);
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].reason instanceof EventStoreVersionConflictError);
+    assert.equal(conflicts[0].reason.code, 'EVENT_VERSION_CONFLICT');
+
+    // Exactly one version 6 event exists.
+    assert.equal(db.hasVersion(orderId, 6), true);
+    assert.equal(db.rawRows(orderId).filter((r) => r.version === 6).length, 1);
+    assert.equal(db.rawRows(orderId).length, 6);
+  });
+
+  test('CASE 7: duplicate version is rejected as a typed domain error', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_dup';
+
+    const first = await core.appendEvent(orderId, { type: 'ORDER_CREATED', payload: { a: 1 } }, 0);
+    assert.equal(first.version, 1);
+
+    // Second write that claims version 1 again must be a typed conflict.
+    await assert.rejects(
+      () => core.appendEvent(orderId, { type: 'ORDER_CREATED', payload: { a: 2 } }, 0),
+      (err) => {
+        assert.ok(err instanceof EventStoreVersionConflictError);
+        assert.equal(err.code, 'EVENT_VERSION_CONFLICT');
+        return true;
+      }
+    );
+
+    // A mismatched expected version (stale read) is also a typed conflict.
+    await assert.rejects(
+      () => core.appendEvent(orderId, { type: 'ORDER_UPDATED', payload: { a: 3 } }, 5),
+      (err) => {
+        assert.ok(err instanceof EventStoreVersionConflictError);
+        assert.equal(err.expectedVersion, 5);
+        assert.equal(err.currentVersion, 1);
+        return true;
+      }
+    );
+
+    assert.equal(db.rawRows(orderId).length, 1);
+  });
+
+  test('CASE 8: different aggregates may use the same version', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+
+    await core.appendEvent('order_A', { type: 'ORDER_CREATED', payload: { customerId: 'a', amount: 1, pickup: 'p', dropoff: 'd' } }, 0);
+    await core.appendEvent('order_B', { type: 'ORDER_CREATED', payload: { customerId: 'b', amount: 2, pickup: 'p', dropoff: 'd' } }, 0);
+
+    assert.equal(db.rawRows('order_A').length, 1);
+    assert.equal(db.rawRows('order_B').length, 1);
+    assert.equal(db.hasVersion('order_A', 1), true);
+    assert.equal(db.hasVersion('order_B', 1), true);
+
+    const stateA = await core.getAggregateState('order_A');
+    const stateB = await core.getAggregateState('order_B');
+    assert.equal(stateA.version, 1);
+    assert.equal(stateB.version, 1);
+  });
+
+  test('expected version chaining stores consecutive versions', async () => {
+    const db = new InMemoryDb();
+    const core = createCore({ db });
+    const orderId = 'order_chain';
+
+    const events = await appendChain(core, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 2 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 3 } },
+    ]);
+    assert.deepEqual(events.map((e) => e.version), [1, 2, 3]);
+    assert.deepEqual(db.rawRows(orderId).map((r) => r.version), [1, 2, 3]);
+  });
+});
+
+describe('EventStoreCore — rebuild from persisted rows', () => {
+  test('CASE 9: rebuild reconstructs correct read-model state per aggregate', async () => {
+    const rows = [
+      dbRow({ id: 'a1', type: 'ORDER_CREATED', aggregateId: 'order_rb_a', payload: { customerId: 'ca', amount: 10, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'a2', type: 'ORDER_UPDATED', aggregateId: 'order_rb_a', payload: { amount: 15 }, version: 2 }),
+      dbRow({ id: 'b1', type: 'ORDER_CREATED', aggregateId: 'order_rb_b', payload: { customerId: 'cb', amount: 20, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'b2', type: 'DRIVER_ASSIGNED', aggregateId: 'order_rb_b', payload: { orderId: 'order_rb_b', driverId: 'drv_b' }, version: 2 }),
+    ];
+    const db = new InMemoryDb({ initialEvents: rows });
+    const core = createCore({ db });
+
+    const stateA = await core.rebuildFromRows('order_rb_a', rows.filter((r) => r.aggregate_id === 'order_rb_a'));
+    const stateB = await core.rebuildFromRows('order_rb_b', rows.filter((r) => r.aggregate_id === 'order_rb_b'));
+
+    assert.equal(stateA.version, 2);
+    assert.equal(stateA.amount, 15);
+    assert.equal(stateB.version, 2);
+    assert.equal(stateB.status, 'ASSIGNED');
+    assert.equal(stateB.driverId, 'drv_b');
+  });
+
+  test('rebuild skips events already covered by a valid snapshot', async () => {
+    const orderId = 'order_rb_snap';
+    const rows = [
+      dbRow({ id: 'e1', type: 'ORDER_CREATED', aggregateId: orderId, payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'e2', type: 'ORDER_UPDATED', aggregateId: orderId, payload: { amount: 2 }, version: 2 }),
+      dbRow({ id: 'e3', type: 'ORDER_UPDATED', aggregateId: orderId, payload: { amount: 3 }, version: 3 }),
+    ];
+    const db = new InMemoryDb({
+      initialEvents: rows,
+      initialSnapshots: [{
+        aggregate_id: orderId,
+        version: 2,
+        state: { id: orderId, version: 2, customerId: 'c', amount: 999 },
+        snapshot_version: 1,
+      }],
+    });
+    const core = createCore({ db });
+
+    const state = await core.rebuildFromRows(orderId, rows);
+    // Event 3 only is applied on top of the snapshot state.
+    assert.equal(state.amount, 3);
+    assert.equal(state.version, 3);
+  });
+});
+
+describe('EventStoreCore — errors', () => {
+  test('persistence errors are translated to typed errors', async () => {
+    const db = new InMemoryDb();
+    db.insertEvent = async () => ({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "uq_event_store_aggregate_version"' } });
+    const core = createCore({ db });
+
+    await assert.rejects(
+      () => core.appendEvent('order_err', { type: 'ORDER_CREATED', payload: {} }, 0),
+      (err) => {
+        assert.ok(err instanceof EventStoreVersionConflictError);
+        assert.equal(err.code, 'EVENT_VERSION_CONFLICT');
+        return true;
+      }
+    );
+  });
+
+  test('missing aggregate returns null (not an error)', async () => {
+    const core = createCore();
+    assert.equal(await core.getAggregateState('does_not_exist'), null);
+    assert.equal(await core.getLatestVersion('does_not_exist'), null);
+  });
+
+  test('appendEvent validates inputs with typed errors', async () => {
+    const core = createCore();
+    await assert.rejects(() => core.appendEvent(null, { type: 'ORDER_CREATED' }, 0), EventStoreError);
+    await assert.rejects(() => core.appendEvent('a', {}, 0), EventStoreError);
+    await assert.rejects(() => core.appendEvent('a', { type: '' }, 0), EventStoreError);
+  });
+});
+
+describe('applyEvent — pure reducer', () => {
+  test('ORDER_CREATED / ORDER_UPDATED / ORDER_CANCELLED / DRIVER_ASSIGNED', () => {
+    let s = { id: 'x', version: 0 };
+    s = applyEvent(s, { type: 'ORDER_CREATED', payload: { customerId: 'c' }, version: 1 });
+    assert.equal(s.status, 'CREATED');
+    assert.equal(s.customerId, 'c');
+    s = applyEvent(s, { type: 'ORDER_UPDATED', payload: { amount: 5 }, version: 2 });
+    assert.equal(s.amount, 5);
+    s = applyEvent(s, { type: 'DRIVER_ASSIGNED', payload: { driverId: 'd' }, version: 3 });
+    assert.equal(s.status, 'ASSIGNED');
+    assert.equal(s.driverId, 'd');
+    s = applyEvent(s, { type: 'ORDER_CANCELLED', payload: { reason: 'r', cancelledAt: 't' }, version: 4 });
+    assert.equal(s.status, 'CANCELLED');
+    assert.equal(s.reason, 'r');
+    assert.equal(s.version, 4);
+  });
+});

--- a/backend/eventsourcing/test/event-store-adapter.test.js
+++ b/backend/eventsourcing/test/event-store-adapter.test.js
@@ -1,0 +1,124 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EventStore, EventStoreVersionConflictError, EventStorePersistenceError } from '../event-store.js';
+import { InMemoryDb, dbRow } from './in-memory-db.js';
+
+const silentLogger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/** Minimal chainable supabase-like client for the adapter's read models. */
+function createMockClient() {
+  const orders = new Map();
+  const drivers = new Map();
+  const client = {
+    orders,
+    drivers,
+    from(name) {
+      if (name === 'orders_read_model') {
+        return {
+          upsert: async (items) => {
+            for (const item of items) orders.set(item.order_id, item);
+            return { data: items, error: null };
+          },
+        };
+      }
+      if (name === 'drivers_read_model') {
+        return {
+          upsert: async (items) => {
+            for (const item of items) drivers.set(item.driver_id, item);
+            return { data: items, error: null };
+          },
+        };
+      }
+      return { upsert: async () => ({ data: [], error: null }) };
+    },
+  };
+  return client;
+}
+
+describe('EventStore adapter', () => {
+  test('CASE 11: package exposes ESM exports', async () => {
+    assert.equal(typeof EventStore, 'function');
+    assert.equal(typeof EventStoreVersionConflictError, 'function');
+    assert.equal(typeof EventStorePersistenceError, 'function');
+  });
+
+  test('CASE 9: rebuildProjections reconstructs read models from persisted rows', async () => {
+    const rows = [
+      dbRow({ id: 'a1', type: 'ORDER_CREATED', aggregateId: 'order_rb_a', payload: { customerId: 'ca', amount: 10, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'a2', type: 'ORDER_UPDATED', aggregateId: 'order_rb_a', payload: { amount: 15 }, version: 2 }),
+      dbRow({ id: 'b1', type: 'ORDER_CREATED', aggregateId: 'order_rb_b', payload: { customerId: 'cb', amount: 20, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'b2', type: 'DRIVER_ASSIGNED', aggregateId: 'order_rb_b', payload: { orderId: 'order_rb_b', driverId: 'drv_b', assignedAt: 't' }, version: 2 }),
+    ];
+
+    const db = new InMemoryDb({ initialEvents: rows });
+    const client = createMockClient();
+    const store = new EventStore({ db, client, logger: silentLogger });
+
+    const result = await store.rebuildProjections(rows);
+
+    assert.equal(result.aggregates, 2);
+    assert.equal(result.orderCount, 2);
+    assert.equal(result.driverCount, 1);
+    assert.equal(result.eventCount, 4);
+
+    // Read model payload equals the aggregate state, not a single event payload.
+    const rmA = client.orders.get('order_rb_a');
+    assert.equal(rmA.version, 2);
+    assert.equal(rmA.payload.amount, 15);
+    assert.equal(rmA.payload.status, 'CREATED');
+
+    const rmB = client.orders.get('order_rb_b');
+    assert.equal(rmB.payload.status, 'ASSIGNED');
+    assert.equal(rmB.payload.driverId, 'drv_b');
+
+    assert.equal(client.drivers.get('drv_b').order_id, 'order_rb_b');
+  });
+
+  test('rebuild honors a valid snapshot and skips covered events', async () => {
+    const orderId = 'order_rb_snap_adapter';
+    const rows = [
+      dbRow({ id: 'e1', type: 'ORDER_CREATED', aggregateId: orderId, payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' }, version: 1 }),
+      dbRow({ id: 'e2', type: 'ORDER_UPDATED', aggregateId: orderId, payload: { amount: 2 }, version: 2 }),
+      dbRow({ id: 'e3', type: 'ORDER_UPDATED', aggregateId: orderId, payload: { amount: 3 }, version: 3 }),
+    ];
+    const db = new InMemoryDb({
+      initialEvents: rows,
+      initialSnapshots: [{
+        aggregate_id: orderId,
+        version: 2,
+        state: { id: orderId, version: 2, customerId: 'c', amount: 999, status: 'CREATED' },
+        snapshot_version: 1,
+      }],
+    });
+    const client = createMockClient();
+    const store = new EventStore({ db, client, logger: silentLogger });
+
+    await store.rebuildProjections(rows);
+
+    const rm = client.orders.get(orderId);
+    assert.equal(rm.payload.amount, 3);
+    assert.equal(rm.version, 3);
+  });
+
+  test('adapter appendEvent converts duplicate version into a typed conflict', async () => {
+    const db = new InMemoryDb();
+    const client = createMockClient();
+    const store = new EventStore({ db, client, logger: silentLogger });
+
+    await store.appendEvent('order_dup', { type: 'ORDER_CREATED', payload: { a: 1 } }, 0);
+    await assert.rejects(
+      () => store.appendEvent('order_dup', { type: 'ORDER_CREATED', payload: { a: 2 } }, 0),
+      (err) => {
+        assert.ok(err instanceof EventStoreVersionConflictError);
+        assert.equal(err.code, 'EVENT_VERSION_CONFLICT');
+        return true;
+      }
+    );
+    assert.equal(db.rawRows('order_dup').length, 1);
+  });
+});

--- a/backend/eventsourcing/test/in-memory-db.js
+++ b/backend/eventsourcing/test/in-memory-db.js
@@ -1,0 +1,110 @@
+/**
+ * In-memory implementation of the EventStoreCore persistence contract.
+ *
+ * It mirrors the PostgreSQL migration for event_store:
+ *   - unique (aggregate_id, version): insertEvent returns `{ data: [] }` when
+ *     the target version already exists, exactly like
+ *     INSERT ... ON CONFLICT (aggregate_id, version) DO NOTHING.
+ *   - one snapshot per aggregate, upserted on aggregate_id.
+ *
+ * Seeded rows are stored in the same column layout as the `event_store` table
+ * (event_id / event_type / aggregate_id / payload / version / timestamp) so
+ * tests exercise the real normalization boundary.
+ */
+export class InMemoryDb {
+  constructor({ initialEvents = [], initialSnapshots = [] } = {}) {
+    this.rows = [];
+    this.snapshots = [];
+    this.byKey = new Map(); // `${aggregate_id}\0${version}` -> row
+    this.insertAttempts = 0;
+
+    for (const row of initialEvents) {
+      this._storeRow(row);
+    }
+    for (const snap of initialSnapshots) {
+      this._storeSnapshot(snap);
+    }
+  }
+
+  static key(aggregateId, version) {
+    return `${aggregateId}\u0000${version}`;
+  }
+
+  _storeRow(row) {
+    const key = InMemoryDb.key(row.aggregate_id, row.version);
+    if (!this.byKey.has(key)) {
+      this.byKey.set(key, row);
+      this.rows.push(row);
+    }
+    return this.byKey.get(key);
+  }
+
+  _storeSnapshot(snap) {
+    const existing = this.snapshots.find((s) => s.aggregate_id === snap.aggregate_id);
+    if (existing) {
+      Object.assign(existing, snap);
+    } else {
+      this.snapshots.push({ ...snap });
+    }
+  }
+
+  async fetchEventStream(aggregateId) {
+    return this.rows
+      .filter((r) => r.aggregate_id === aggregateId)
+      .sort((a, b) => a.version - b.version);
+  }
+
+  async fetchLatestVersion(aggregateId) {
+    const versions = this.rows
+      .filter((r) => r.aggregate_id === aggregateId)
+      .map((r) => r.version);
+    if (versions.length === 0) {
+      return null;
+    }
+    return { version: Math.max(...versions) };
+  }
+
+  async insertEvent(row) {
+    this.insertAttempts += 1;
+    const key = InMemoryDb.key(row.aggregate_id, row.version);
+    if (this.byKey.has(key)) {
+      // Simulates the database rejecting a duplicate (aggregate_id, version).
+      return { data: [], error: null };
+    }
+    this._storeRow(row);
+    return { data: [row], error: null };
+  }
+
+  async fetchSnapshot(aggregateId) {
+    const matches = this.snapshots
+      .filter((s) => s.aggregate_id === aggregateId)
+      .sort((a, b) => b.version - a.version);
+    return matches[0] || null;
+  }
+
+  async upsertSnapshot(row) {
+    this._storeSnapshot(row);
+    return { error: null };
+  }
+
+  rawRows(aggregateId) {
+    return this.rows.filter((r) => r.aggregate_id === aggregateId);
+  }
+
+  hasVersion(aggregateId, version) {
+    return this.byKey.has(InMemoryDb.key(aggregateId, version));
+  }
+}
+
+/** Builds a database-format event row for seeding. */
+export function dbRow({ id, type, aggregateId, payload, version, timestamp }) {
+  return {
+    event_id: id,
+    event_type: type,
+    aggregate_id: aggregateId,
+    payload: payload ?? {},
+    version,
+    timestamp: timestamp ?? new Date().toISOString(),
+    created_at: new Date().toISOString(),
+  };
+}

--- a/supabase/migrations/20260808000000_event_store_concurrency_and_snapshots.sql
+++ b/supabase/migrations/20260808000000_event_store_concurrency_and_snapshots.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- EVENT SOURCING — Optimistic concurrency + functional snapshots
+-- ============================================================================
+-- Fixes three correctness issues in the eventsourcing module
+-- (backend/eventsourcing/event-store.js):
+--
+--   1. No uniqueness on (aggregate_id, version). Concurrent commands read the
+--      current version and both try to insert the same next version, so
+--      duplicate versions are possible. This migration adds a UNIQUE index on
+--      (aggregate_id, version); the app now inserts with
+--      INSERT ... ON CONFLICT DO NOTHING so the constraint is the final
+--      safety mechanism for optimistic concurrency.
+--
+--   2. The `snapshots` table the module writes to (takeSnapshot) was never
+--      created by any migration, so snapshot writes always failed and reads
+--      always returned null. This migration creates it.
+--
+--   3. `version` was nullable. A NULL version cannot satisfy the
+--      "one event per (aggregate_id, version)" invariant, so the column is
+--      made NOT NULL after the null rows are detected below.
+--
+-- DUPLICATE / NULL DATA REMEDIATION
+-- --------------------------------
+-- This migration NEVER deletes or rewrites event history. Instead it fails
+-- safely when the data cannot support the invariant, with these steps for an
+-- operator to follow:
+--
+--   a) Duplicate (aggregate_id, version) pairs:
+--        SELECT aggregate_id, version, count(*)
+--        FROM event_store
+--        WHERE version IS NOT NULL
+--        GROUP BY aggregate_id, version
+--        HAVING count(*) > 1;
+--      Review each group. If both rows are genuine duplicates of the same
+--      event, keep the authoritative row (same payload) and delete the other
+--      copy. If the payloads differ, one is a write that lost a race and must
+--      be retired manually. Then re-run this migration.
+--
+--   b) NULL versions:
+--        SELECT * FROM event_store WHERE version IS NULL;
+--      Such rows are malformed (the app always persists a version). Decide per
+--      row whether it is authoritative and, if so, assign it the next
+--      available version for its aggregate; otherwise remove it. Then re-run
+--      this migration.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. SAFETY CHECKS — fail instead of silently destroying data
+-- ────────────────────────────────────────────────────────────────────────────
+do $$
+declare
+  n_dups bigint;
+  n_nulls bigint;
+begin
+  select count(*) into n_dups
+  from (
+    select aggregate_id, version, count(*)
+    from event_store
+    where version is not null
+    group by aggregate_id, version
+    having count(*) > 1
+  ) duplicates;
+
+  if n_dups > 0 then
+    raise exception
+      'event_store contains % duplicate (aggregate_id, version) pairs; '
+      'manual remediation required before the unique constraint can be enforced '
+      '(see migration header comments).',
+      n_dups;
+  end if;
+
+  select count(*) into n_nulls
+  from event_store
+  where version is null;
+
+  if n_nulls > 0 then
+    raise exception
+      'event_store contains % row(s) with a NULL version; '
+      'NULL versions cannot satisfy the (aggregate_id, version) uniqueness '
+      'invariant and must be reviewed manually before this migration.',
+      n_nulls;
+  end if;
+end $$;
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. UNIQUE VERSION INVARIANT
+-- ────────────────────────────────────────────────────────────────────────────
+alter table event_store
+  alter column version set not null;
+
+-- One event per (aggregate_id, version). A UNIQUE index is used (rather than
+-- a UNIQUE constraint) so PostgREST `on_conflict=aggregate_id,version` and
+-- `INSERT ... ON CONFLICT ... DO NOTHING` can target it.
+create unique index if not exists uq_event_store_aggregate_version
+  on event_store (aggregate_id, version);
+
+-- The old non-unique index on the same columns is now redundant.
+drop index if exists idx_event_store_aggregate_version;
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. SNAPSHOTS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+-- One snapshot per aggregate (upserted on `aggregate_id`). `version` is the
+-- aggregate version the snapshot represents; `snapshot_version` is the
+-- snapshot schema version so consumers can detect incompatible snapshots and
+-- fall back to a full replay instead of trusting corrupted state.
+create table if not exists snapshots (
+  aggregate_id     text primary key,
+  version          integer not null check (version >= 0),
+  state            jsonb not null,
+  snapshot_version integer not null default 1 check (snapshot_version >= 1),
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+create index if not exists idx_snapshots_version
+  on snapshots (version);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. ROW LEVEL SECURITY (mirrors event_store: service_role only)
+-- ────────────────────────────────────────────────────────────────────────────
+alter table snapshots enable row level security;
+
+drop policy if exists "Service role full access on snapshots"
+  on snapshots;
+create policy "Service role full access on snapshots"
+  on snapshots
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table snapshots from anon, authenticated;


### PR DESCRIPTION
## Summary

This PR fixes several correctness issues in the event-sourcing module related to aggregate reconstruction, optimistic concurrency, snapshot recovery, and independent ESM execution.

The main issues addressed are:

- Database event fields not matching the internal event representation.
- Incorrect cold-start aggregate reconstruction after application restart.
- Concurrent commands being able to calculate the same event version.
- Missing database-level uniqueness for aggregate versions.
- Snapshots not being effectively used during rebuild.
- Event-sourcing package runtime configuration not fully supporting the existing ESM implementation.

## Problem

The event store persists fields such as:

- event_id
- event_type
- aggregate_id
- payload
- version
- timestamp

while the replay logic expects an internal representation containing fields such as:

- type
- aggregateId
- payload
- version

When the in-memory event cache is empty after a restart, raw database rows can be passed directly into the replay logic.

This can cause event types to be unresolved and aggregate state to be reconstructed incorrectly.

The event append flow also uses a read-then-write version calculation.

Two concurrent requests can therefore calculate the same next version:

```text
Request A → version 5 → calculates version 6
Request B → version 5 → calculates version 6

Request A → version 6
Request B → version 6
```

This creates ambiguous event ordering and can corrupt aggregate reconstruction.

Snapshots were also not being effectively used as the starting point for event replay.

## Changes Made

### Event Normalization

Added a clear normalization boundary between database event rows and internal domain events.

Database fields such as:

```text
event_type
aggregate_id
```

are correctly mapped to the internal representation:

```text
type
aggregateId
```

This allows existing persisted events to remain readable without requiring a destructive migration of historical data.

### Cold-Start Reconstruction

Fixed aggregate rebuilding so that database-loaded events are reconstructed using the same internal event representation as in-memory events.

Cold-start reconstruction now produces the same aggregate state and version as warm-cache reconstruction.

### Optimistic Concurrency

Added expected-version validation to event appending.

Concurrent commands operating on the same aggregate can no longer silently create the same event version.

A conflicting request receives a controlled concurrency error instead.

### Database-Level Version Uniqueness

Added a database migration enforcing uniqueness for:

```text
aggregate_id + version
```

This provides a database-level invariant preventing multiple events from occupying the same version for the same aggregate.

The constraint is scoped to the aggregate, so different aggregates can still use the same version numbers.

### Snapshot-Based Rebuild

Updated aggregate reconstruction to use the latest valid snapshot as the starting point.

The rebuild flow is now:

```text
Latest Snapshot
      ↓
Snapshot Version N
      ↓
Load Events > N
      ↓
Replay Remaining Events
      ↓
Current Aggregate State
```

This avoids unnecessarily replaying the entire event history when a valid snapshot is available.

### Snapshot Failure Handling

Invalid or incompatible snapshots do not silently produce corrupted state.

The implementation can safely fall back to event-history reconstruction when appropriate.

### Rebuild Endpoint

Updated the event-sourcing rebuild flow to correctly:

- Normalize database events.
- Load snapshots.
- Replay events newer than the snapshot.
- Produce the correct aggregate/read-model state.
- Handle failures using controlled errors.

### ESM Runtime Configuration

Updated the event-sourcing package configuration so the existing ESM implementation can be independently executed and tested using the repository's supported Node.js/package-manager conventions.

## Concurrency Behavior

The new behavior is:

```text
Request A
    ↓
Expected Version N
    ↓
Version N+1
    ↓
SUCCESS

Request B
    ↓
Expected Version N
    ↓
Version N+1
    ↓
CONFLICT
```

The implementation does not rely on in-memory locks because those would not provide safe concurrency control across multiple API instances.

The database uniqueness constraint remains the final protection against duplicate aggregate versions.

## Testing

Added/updated tests covering:

- Normal event replay
- Cold-start aggregate reconstruction
- Event field normalization
- Snapshot-based reconstruction
- Invalid snapshot fallback
- Concurrent event appends
- Optimistic concurrency conflicts
- Duplicate aggregate/version insertion
- Different aggregates using the same version
- Rebuild endpoint behavior
- Historical event compatibility
- Snapshot reconstruction after restart
- ESM runtime configuration

## Performance Validation

Snapshot-based rebuilding was compared against full event replay where practical.

The implementation verifies that valid snapshots reduce the number of historical events that need to be loaded and replayed.

Actual measurements are based on the tests/benchmarks executed for this PR.

## Backward Compatibility

Existing persisted events remain readable.

Historical events do not need to be rewritten simply because their database field names differ from the internal domain-event representation.

Normalization occurs at the database/repository boundary.

Existing event types and aggregate behavior remain compatible.

## Type of Change

- [x] Bug Fix
- [x] Data Integrity Improvement
- [x] Event-Sourcing Reliability Improvement
- [x] Concurrency Control
- [x] Performance Improvement
- [x] Test Coverage
- [ ] Breaking Change

## Breaking Changes

None expected.

Existing event history remains readable and existing event-sourcing behavior is preserved.

## Related Issue

Closes #7978 

##GSSoC
#ECSoC26

This PR is submitted as part of GirlScript Summer of Code (GSSoC) 2026.

## Expected Outcome

Event-sourced aggregates now rebuild correctly after application restarts.

Concurrent commands cannot create duplicate event versions for the same aggregate.

Snapshots are actually used to reduce unnecessary event replay.

The event-sourcing package can also be independently executed and tested without ESM configuration errors.

Most importantly, aggregate reconstruction now has deterministic behavior across both warm-cache and cold-start scenarios.