### PR TITLE
fix(api): remove duplicate DELIVERY_IN_PROGRESS_STATUSES in OracleService

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -14,12 +14,6 @@ const DELIVERY_IN_PROGRESS_STATUSES = new Set([
   'arriving',
 ]);
 
-const DELIVERY_IN_PROGRESS_STATUSES = new Set([
-  'picked_up',
-  'in_transit',
-  'arriving',
-]);
-
 class OracleService {
   constructor(deps = {}) {
     this.orderRepository = deps.orderRepository || null;


### PR DESCRIPTION
## Problem

`DELIVERY_IN_PROGRESS_STATUSES` is declared twice in `backend/api/src/oracle/OracleService.js`. `node --check` fails on this file with `SyntaxError: Identifier 'DELIVERY_IN_PROGRESS_STATUSES' has already been declared`. Because `OracleService` is imported as `new OracleService()` when the oracle module boots, any deployment path that requires this module crashes at load time.

## Fix

Removed the second, duplicate `const DELIVERY_IN_PROGRESS_STATUSES = new Set(...)` declaration and kept the single canonical definition. The file now passes `node --check` and the oracle module loads without a SyntaxError.

## Files changed

- `backend/api/src/oracle/OracleService.js` — removed the duplicate `DELIVERY_IN_PROGRESS_STATUSES` declaration.

## Testing

- Ran `node --check backend/api/src/oracle/OracleService.js` — passes (SYNTAX OK).
- The constant is now declared exactly once at module scope.

Closes #8223
