### PR TITLE
fix(api): deactivate prior active rows when storing a rotated key

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -104,6 +104,21 @@ class KeyManagementService {
   async storeEncryptedKey(userId, walletAddress, encryptedKeyData, deviceId, version = 1) {
     return measureExecution('KeyManagementService.storeEncryptedKey', async () => {
       try {
+        // Deactivate any previously active row for this user/wallet scope so
+        // exactly one active row exists and retrieveEncryptedKey's
+        // .eq('active', true).single() never 406s on multiple rows.
+        const { error: deactivateError } = await supabase
+          .from('encrypted_wallet_keys')
+          .update({ active: false })
+          .eq('user_id', userId)
+          .eq('wallet_address', walletAddress)
+          .eq('active', true);
+
+        if (deactivateError) {
+          logger.error('[KeyManagementService] Failed to deactivate prior active keys:', deactivateError);
+          throw deactivateError;
+        }
+
         const keyId = crypto.randomUUID();
 
         const { data, error } = await supabase


### PR DESCRIPTION
## Problem

`storeEncryptedKey` in `backend/api/src/services/security/keyManagementService.js` always inserted a row with `active: true` and never deactivated the previous active row when a key was re-stored. The first call created one active row; a second call (rotation, re-registration of the same device, or a retry) inserted a second `active: true` row. Any subsequent `retrieveEncryptedKey` hit `.eq('active', true).single()`, which PostgREST/Supabase rejects with a 406 "JSON object requested, multiple (or no) rows returned" — making the encrypted wallet key permanently unretrievable.

## Fix

`storeEncryptedKey` now first sets `active = false` on all existing rows for the `user_id`/`wallet_address` scope (the same scope `retrieveEncryptedKey` reads), then inserts the new row as active. This guarantees at most one active row exists per user/wallet, so `retrieveEncryptedKey`'s `.single()` always resolves.

## Files changed

- `backend/api/src/services/security/keyManagementService.js` — deactivate prior active rows for the user/wallet scope before inserting the new active row in `storeEncryptedKey`.

## Testing

- `node --check backend/api/src/services/security/keyManagementService.js` passes.
- Logic verified: storing twice for the same user/wallet deactivates the first row before inserting the second, leaving exactly one active row.

Closes #8225
