### PR TITLE
fix(api): require WIM_SIGNING_SECRET instead of hardcoded fallback

### DIFF
--- a/backend/api/src/services/wimBypass.js
+++ b/backend/api/src/services/wimBypass.js
@@ -1,7 +1,14 @@
 import crypto from 'crypto';
 
-// Secret key for signing pre-clearance packets
-const PACKET_SIGNING_SECRET = process.env.WIM_SIGNING_SECRET || 'wim-bypass-secret-key';
+// Secret key for signing pre-clearance packets. There is no production
+// fallback: without a configured secret the service fails fast at startup
+// rather than silently signing packets with a public, hardcoded value.
+const IS_TEST = process.env.NODE_ENV === 'test';
+const PACKET_SIGNING_SECRET = process.env.WIM_SIGNING_SECRET || (IS_TEST ? 'wim-bypass-test-secret' : null);
+
+if (!PACKET_SIGNING_SECRET) {
+  throw new Error('WIM_SIGNING_SECRET environment variable is required to sign WIM bypass packets.');
+}
 
 /**
  * Validates truck criteria for weigh station bypass.


### PR DESCRIPTION
## Problem

`backend/api/src/services/wimBypass.js` signed pre-clearance packets with `process.env.WIM_SIGNING_SECRET || 'wim-bypass-secret-key'`. The fallback is a public, hardcoded string: any server deployed without `WIM_SIGNING_SECRET` silently signed packets with a key known to everyone, so anyone could forge a valid bypass packet.

## Fix

- Removed the hardcoded production fallback.
- The signing secret is now `process.env.WIM_SIGNING_SECRET`, and the module throws at startup when it is missing, so a misconfigured deployment fails fast instead of signing packets with a known key.
- A test-only fixture (`'wim-bypass-test-secret'`) is allowed when `NODE_ENV === 'test'`, matching the existing test-mode conventions used elsewhere in the codebase.

## Files changed

- `backend/api/src/services/wimBypass.js` — require `WIM_SIGNING_SECRET`; fail fast when absent in non-test environments.

## Testing

- `node --check backend/api/src/services/wimBypass.js` passes.
- Verified: without `WIM_SIGNING_SECRET` and outside `NODE_ENV=test`, importing the module throws; with the env var set, signing works as before.

Closes #8227
