### PR TITLE
fix(api): probe the Polygon RPC endpoint in polygonHealth

### DIFF
--- a/backend/api/src/core/health/checks/polygonHealth.js
+++ b/backend/api/src/core/health/checks/polygonHealth.js
@@ -1,19 +1,60 @@
 import { HealthStatus, executeCheck } from '../HealthCheck.js';
 
 const NAME = 'polygon';
+const PROBE_TIMEOUT_MS = 4000;
+
+async function probeRpc(rpcUrl) {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }),
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RPC HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(`RPC error: ${payload.error.message || payload.error.code}`);
+  }
+  if (payload.result === undefined || payload.result === null) {
+    throw new Error('RPC returned no block number');
+  }
+
+  return payload.result;
+}
+
+function redactUrl(rpcUrl) {
+  return rpcUrl.replace(/\/\/.*@/, '//***@');
+}
 
 function check() {
-  if (!process.env.POLYGON_RPC_URL) {
+  const rpcUrl = process.env.POLYGON_RPC_URL;
+
+  if (!rpcUrl) {
     return { status: HealthStatus.UNHEALTHY, message: 'not_configured' };
   }
-  return {
-    status: HealthStatus.HEALTHY,
-    metadata: {
-      rpcUrl: process.env.POLYGON_RPC_URL.replace(/\/\/.*@/, '//***@'),
-    },
-  };
+
+  return probeRpc(rpcUrl)
+    .then((blockNumber) => ({
+      status: HealthStatus.HEALTHY,
+      message: 'reachable',
+      metadata: {
+        rpcUrl: redactUrl(rpcUrl),
+        blockNumber,
+      },
+    }))
+    .catch((err) => ({
+      status: HealthStatus.UNHEALTHY,
+      message: `configured_but_unreachable: ${err.message}`,
+      metadata: {
+        rpcUrl: redactUrl(rpcUrl),
+      },
+    }));
 }
 
 export default function polygonHealth(opts) {
-  return executeCheck(NAME, check, { critical: false, ...opts });
+  return executeCheck(NAME, check, { critical: false, timeoutMs: PROBE_TIMEOUT_MS + 1000, ...opts });
 }

--- a/backend/api/test/integration/healthAggregation.test.js
+++ b/backend/api/test/integration/healthAggregation.test.js
@@ -53,6 +53,14 @@ describe('GET /api/health/full (Centralized Health Aggregation)', () => {
     delete process.env.ML_ENGINE_URL;
     delete globalThis.__truxify_workers;
     delete globalThis.__truxify_wsState;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ jsonrpc: '2.0', id: 1, result: '0x100' }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('returns 200 with aggregated status when all critical services are healthy', async () => {

--- a/backend/api/test/unit/core/healthChecks.test.js
+++ b/backend/api/test/unit/core/healthChecks.test.js
@@ -175,6 +175,10 @@ describe('Individual health checks', () => {
   });
 
   describe('polygonHealth', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('returns unhealthy when not configured', async () => {
       delete process.env.POLYGON_RPC_URL;
       const { default: check } = await import('../../../src/core/health/checks/polygonHealth.js');
@@ -184,12 +188,29 @@ describe('Individual health checks', () => {
       expect(result.critical).toBe(false);
     });
 
-    it('returns healthy when RPC URL is set', async () => {
+    it('returns healthy when the RPC endpoint answers a probe', async () => {
       process.env.POLYGON_RPC_URL = 'https://polygon-rpc.com';
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ jsonrpc: '2.0', id: 1, result: '0x19a3b7' }),
+      }));
+
       const { default: check } = await import('../../../src/core/health/checks/polygonHealth.js');
       const result = await check();
       expect(result.status).toBe(HealthStatus.HEALTHY);
       expect(result.metadata.rpcUrl).toBe('https://polygon-rpc.com');
+      expect(result.metadata.blockNumber).toBe('0x19a3b7');
+    });
+
+    it('returns unhealthy when RPC URL is set but unreachable', async () => {
+      process.env.POLYGON_RPC_URL = 'https://polygon-rpc.com';
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+      const { default: check } = await import('../../../src/core/health/checks/polygonHealth.js');
+      const result = await check();
+      expect(result.status).toBe(HealthStatus.UNHEALTHY);
+      expect(result.message).toMatch(/^configured_but_unreachable/);
+      expect(result.critical).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Problem

`polygonHealth` reported `HEALTHY` whenever `POLYGON_RPC_URL` was set, without ever contacting the node. A dead or unreachable RPC endpoint still made the Polygon service look healthy, so the health check could not detect RPC outages.

## Fix

- The check now issues a real `eth_blockNumber` JSON-RPC probe to `POLYGON_RPC_URL` with a bounded timeout (`AbortSignal.timeout`, 4s) and reports `HEALTHY` (`reachable`) only when the node answers with a block number.
- A configured-but-unreachable node now reports `UNHEALTHY` with a distinct `configured_but_unreachable: <reason>` message instead of `not_configured`.
- `metadata.blockNumber` is included on success; the RPC URL stays redacted in both cases.
- Per-check `timeoutMs` for `executeCheck` is raised past the probe budget so the probe's own timeout governs.

## Files changed

- `backend/api/src/core/health/checks/polygonHealth.js` — real RPC probe with distinct `configured_but_unreachable` failure.
- `backend/api/test/unit/core/healthChecks.test.js` — polygon tests now stub `fetch` (healthy probe and unreachable-probe cases) instead of asserting healthy from env presence alone.
- `backend/api/test/integration/healthAggregation.test.js` — stub `fetch` in `beforeEach` so the aggregation suite stays hermetic when `POLYGON_RPC_URL` is set.

## Testing

- `node --check backend/api/src/core/health/checks/polygonHealth.js` passes.
- `npx vitest run test/unit/core/healthChecks.test.js -t polygonHealth` — 3/3 passing (not configured / reachable / configured-but-unreachable).

Closes #8228
