### PR TITLE
fix(api): fail closed in workerHealth when no workers are registered

### DIFF
--- a/backend/api/src/core/health/checks/workerHealth.js
+++ b/backend/api/src/core/health/checks/workerHealth.js
@@ -3,16 +3,19 @@ import { HealthStatus, executeCheck } from '../HealthCheck.js';
 const NAME = 'workers';
 
 function check() {
+  const registeredWorkers = globalThis.__truxify_workers;
   const activeWorkers = [];
-  if (globalThis.__truxify_workers) {
-    for (const [name, running] of Object.entries(globalThis.__truxify_workers)) {
+  if (registeredWorkers && typeof registeredWorkers === 'object') {
+    for (const [name, running] of Object.entries(registeredWorkers)) {
       activeWorkers.push({ name, running });
     }
   }
 
   if (activeWorkers.length === 0) {
+    // No worker states were registered: fail closed instead of reporting a
+    // process with no running background workers as healthy.
     return {
-      status: HealthStatus.HEALTHY,
+      status: HealthStatus.UNHEALTHY,
       message: 'no_registered_workers',
       metadata: { workerCount: 0 },
     };

--- a/backend/api/test/unit/core/healthChecks.test.js
+++ b/backend/api/test/unit/core/healthChecks.test.js
@@ -221,10 +221,11 @@ describe('Individual health checks', () => {
   });
 
   describe('workerHealth', () => {
-    it('returns healthy with no registered workers', async () => {
+    it('returns unhealthy when no workers are registered (fail closed)', async () => {
       const { default: check } = await import('../../../src/core/health/checks/workerHealth.js');
       const result = await check();
-      expect(result.status).toBe(HealthStatus.HEALTHY);
+      expect(result.status).toBe(HealthStatus.UNHEALTHY);
+      expect(result.message).toBe('no_registered_workers');
       expect(result.metadata.workerCount).toBe(0);
     });
 


### PR DESCRIPTION
## Problem

`workerHealth` returned `HEALTHY` with message `no_registered_workers` whenever `globalThis.__truxify_workers` was missing or empty. A process running zero background workers — including one where the workers were never wired up — was reported healthy, failing open and masking worker outages.

## Fix

- Missing, non-object, or empty `globalThis.__truxify_workers` is now `UNHEALTHY` with message `no_registered_workers`.
- `HEALTHY` is only reported when at least one worker is registered and all registered workers are running.
- Partial failures stay `DEGRADED` (some registered workers not running), consistent with existing aggregation behavior.

## Files changed

- `backend/api/src/core/health/checks/workerHealth.js` — fail closed when no workers are registered.
- `backend/api/test/unit/core/healthChecks.test.js` — updated the worker health tests to assert the fail-closed behavior.

## Testing

- `node --check backend/api/src/core/health/checks/workerHealth.js` passes.
- `npx vitest run test/unit/core/healthChecks.test.js -t workerHealth` — 3/3 passing (no registered workers / all running / some not running).

Closes #8230
