### PR TITLE
fix(api): apply per-check timeoutMs in HealthAggregator.aggregate

### DIFF
--- a/backend/api/src/core/health/HealthAggregator.js
+++ b/backend/api/src/core/health/HealthAggregator.js
@@ -1,5 +1,5 @@
 import logger from "../../middleware/logger.js";
-import { HealthStatus } from "./HealthCheck.js";
+import { HealthStatus, withTimeout } from "./HealthCheck.js";
 
 /**
  * @typedef {object} ServiceHealthResult
@@ -55,19 +55,43 @@ export class HealthAggregator {
     const start = Date.now();
 
     const results = await Promise.all(
-      this._checks.map(async ({ name, checkFn }) => {
+      this._checks.map(async ({ name, checkFn, critical, timeoutMs }) => {
+        const startTime = Date.now();
+
+        const run = async () => {
+          try {
+            return await checkFn();
+          } catch (err) {
+            logger.error(
+              `[health] Aggregator check "${name}" threw: ${err.message}`,
+            );
+            return {
+              name,
+              status: HealthStatus.UNHEALTHY,
+              message: err.message,
+              responseTime: Date.now() - startTime,
+              critical: Boolean(critical),
+              timestamp: new Date().toISOString(),
+            };
+          }
+        };
+
+        // Apply the registered per-check timeoutMs when set. A timed-out
+        // check resolves as UNHEALTHY so aggregation always completes.
+        const executed = timeoutMs ? withTimeout(run(), timeoutMs) : run();
+
         try {
-          return await checkFn();
+          return await executed;
         } catch (err) {
           logger.error(
-            `[health] Aggregator check "${name}" threw: ${err.message}`,
+            `[health] Aggregator check "${name}" timed out: ${err.message}`,
           );
           return {
             name,
             status: HealthStatus.UNHEALTHY,
             message: err.message,
-            responseTime: 0,
-            critical: false,
+            responseTime: Date.now() - startTime,
+            critical: Boolean(critical),
             timestamp: new Date().toISOString(),
           };
         }

--- a/backend/api/test/unit/core/healthAggregator.test.js
+++ b/backend/api/test/unit/core/healthAggregator.test.js
@@ -220,6 +220,43 @@ describe('HealthAggregator', () => {
       expect(result.status).toBe('degraded');
     });
 
+    it('applies registered timeoutMs and marks timed-out checks unhealthy', async () => {
+      aggregator.register('slow', () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(makeHealthyResult('slow')), 200)
+        ),
+        { timeoutMs: 30 }
+      );
+
+      const result = await aggregator.aggregate();
+      expect(result.services.slow.status).toBe(HealthStatus.UNHEALTHY);
+      expect(result.services.slow.message).toMatch(/timeout/);
+    });
+
+    it('does not time out checks without a registered timeoutMs', async () => {
+      aggregator.register('slow', () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(makeHealthyResult('slow')), 50)
+        )
+      );
+
+      const result = await aggregator.aggregate();
+      expect(result.services.slow.status).toBe(HealthStatus.HEALTHY);
+    });
+
+    it('treats a timed-out critical check as critical in overall status', async () => {
+      aggregator.register('db', () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(makeHealthyResult('db')), 200)
+        ),
+        { timeoutMs: 30, critical: true }
+      );
+
+      const result = await aggregator.aggregate();
+      expect(result.services.db.status).toBe(HealthStatus.UNHEALTHY);
+      expect(result.status).toBe('unhealthy');
+    });
+
     it('marks individual response times per service', async () => {
       aggregator.register('svc', () => makeHealthyResult('svc'));
 


### PR DESCRIPTION
## Problem

`HealthAggregator.register()` stored a per-check `timeoutMs`, but `aggregate()` never used it — it just `await checkFn()`. A check that hangs without its own internal timeout (e.g. a custom check that is not backed by `executeCheck`) would stall the whole health endpoint indefinitely, since `aggregate()` awaited it with no deadline. Additionally, when a check threw, the error result hardcoded `critical: false`, so a critical check that failed could never push overall status to `unhealthy`.

## Fix

- `aggregate()` now wraps each registered check in `withTimeout(checkFn(), timeoutMs)` when a `timeoutMs` was registered. A timed-out check resolves as `UNHEALTHY` with the timeout message, and aggregation always completes.
- Checks registered without `timeoutMs` behave exactly as before (the check itself governs its own timeout).
- Error and timeout results now preserve the registered `critical` flag instead of hardcoding `false`, so a throwing or timing-out critical check correctly makes overall health `unhealthy`.

## Files changed

- `backend/api/src/core/health/HealthAggregator.js` — apply registered `timeoutMs` via `withTimeout`; preserve `critical` on error/timeout results.
- `backend/api/test/unit/core/healthAggregator.test.js` — added tests for timed-out checks, no-timeout checks, and critical timeouts.

## Testing

- `node --check backend/api/src/core/health/HealthAggregator.js` passes.
- `npx vitest run test/unit/core/healthAggregator.test.js` — 20/20 passing, including the new timeout cases.

Closes #8231
