### PR TITLE
fix(api): mark multicall3 cache hits as cached:true

### DIFF
--- a/backend/api/src/services/blockchain/multicall3Service.js
+++ b/backend/api/src/services/blockchain/multicall3Service.js
@@ -112,10 +112,11 @@ class Multicall3Service {
       const cacheKey = this.generateCacheKey(call);
 
       if (this.isInCache(cacheKey)) {
+        const entry = this.callCache.get(cacheKey);
         cachedResults.push({
           index: i,
-          result: this.getFromCache(cacheKey),
-          cached: true,
+          result: entry.value,
+          cachedAt: entry.timestamp,
         });
       } else {
         callIndexMap[uncachedCalls.length] = i;
@@ -140,8 +141,8 @@ class Multicall3Service {
       });
     }
 
-    cachedResults.forEach(({ index, result }) => {
-      results[index] = result;
+    cachedResults.forEach(({ index, result, cachedAt }) => {
+      results[index] = { ...result, cached: true, cachedAt };
     });
 
     return results;

--- a/backend/api/test/unit/multicall3Service.test.js
+++ b/backend/api/test/unit/multicall3Service.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Multicall3Service from '../../src/services/blockchain/multicall3Service.js';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+const CALL_A = { target: '0x1111111111111111111111111111111111111111', callData: '0xabcdef' };
+const CALL_B = { target: '0x2222222222222222222222222222222222222222', callData: '0x123456' };
+
+describe('Multicall3Service.batchCallsWithCache', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new Multicall3Service({});
+    service.batchCalls = vi.fn();
+  });
+
+  it('marks fresh reads as cached:false', async () => {
+    service.batchCalls.mockResolvedValue([
+      { success: true, returnData: '0x01', callIndex: 0, blockNumber: 10 },
+    ]);
+
+    const results = await service.batchCallsWithCache([CALL_A]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].cached).toBe(false);
+    expect(service.batchCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks cache hits as cached:true with a cachedAt timestamp', async () => {
+    service.batchCalls.mockResolvedValue([
+      { success: true, returnData: '0x01', callIndex: 0, blockNumber: 10 },
+    ]);
+
+    const first = await service.batchCallsWithCache([CALL_A]);
+    expect(first[0].cached).toBe(false);
+
+    const second = await service.batchCallsWithCache([CALL_A]);
+
+    expect(second).toHaveLength(1);
+    expect(second[0].cached).toBe(true);
+    expect(second[0].cachedAt).toBeTypeOf('number');
+    expect(second[0].returnData).toBe('0x01');
+    expect(service.batchCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it('mixes fresh and cached results in the correct order', async () => {
+    service.batchCalls.mockResolvedValue([
+      { success: true, returnData: '0xaa', callIndex: 0, blockNumber: 10 },
+      { success: true, returnData: '0xbb', callIndex: 1, blockNumber: 10 },
+    ]);
+
+    await service.batchCallsWithCache([CALL_A, CALL_B]);
+
+    const results = await service.batchCallsWithCache([CALL_A, CALL_B]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].cached).toBe(true);
+    expect(results[1].cached).toBe(true);
+    expect(service.batchCalls).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

`batchCallsWithCache` in `backend/api/src/services/blockchain/multicall3Service.js` marked fresh reads with `cached: false`, but for cache hits it wrote the raw cached value straight into the results array — dropping the `cached` flag entirely. Callers could not distinguish cached results from live reads, and any logic branching on `cached` (e.g. freshness handling) treated cache hits as live data.

## Fix

- Cache hits now resolve to `{ ...value, cached: true, cachedAt }`, where `cachedAt` is the epoch-ms timestamp of the cache entry.
- Fresh reads keep `cached: false` unchanged.
- The cache-hit path now reads the full cache entry (value + timestamp) in a single lookup.

## Files changed

- `backend/api/src/services/blockchain/multicall3Service.js` — return `cached: true` with entry timestamp for cache hits.
- `backend/api/test/unit/multicall3Service.test.js` — new tests covering fresh reads, cache hits, and mixed batches.

## Testing

- `node --check backend/api/src/services/blockchain/multicall3Service.js` passes.
- `npx vitest run test/unit/multicall3Service.test.js` — 3/3 passing (fresh read `cached:false`, cache hit `cached:true` + `cachedAt`, mixed batch ordering).

Closes #8232
