### PR TITLE
fix(api): repair broken escrow release reconciliation module and tests

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -66,20 +66,6 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
       }
       throw err;
     }
-  } else {
-    // Redis not configured — single-instance mode, use in-process guard only
-    if (reconciliationRunning) return;
-  }
-
-  try {
-    if (!lockAcquired) reconciliationRunning = true;
-    const instanceId = process.env.HOSTNAME || os.hostname();
-    const { data: failedOrders, error } = await supabaseAdmin
-      .from('orders')
-      .select('id, order_display_id, escrow_amount_wei, escrow_release_attempts, release_tx_hash')
-      .eq('escrow_status', 'release_failed')
-      .lt('escrow_release_attempts', MAX_RETRIES)
-      .limit(50);
 
     if (!globalLockValue) {
       logger.info('[escrow-release-reconciliation] Global lock held by another instance, skipping batch.');
@@ -104,85 +90,6 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
 
       try {
         await finalizeReleasedOrder(order, orderRepository);
-        const { data: claimed, error: claimError } = await supabaseAdmin
-          .rpc('claim_release_reconciliation', {
-            p_order_id: order.id,
-            p_instance_id: instanceId,
-          });
-
-        if ((!claimed || (Array.isArray(claimed) && claimed.length === 0)) && !claimError) {
-          logger.info(`[escrow-release-reconciliation] Order ${order.order_display_id} already claimed by another instance, skipping.`);
-          continue;
-        }
-
-        if (claimError) {
-          const { data: existing } = await supabaseAdmin
-            .from('orders')
-            .select('escrow_status, reconciled_by')
-            .eq('id', order.id)
-            .maybeSingle();
-          if (existing && (existing.escrow_status !== 'release_failed' || existing.reconciled_by)) {
-            logger.info(`[escrow-release-reconciliation] Order ${order.order_display_id} already processed, skipping.`);
-            continue;
-          }
-        }
-
-        const releaseAttemptedAt = new Date().toISOString();
-        const releaseAttempts = (order.escrow_release_attempts || 0) + 1;
-
-        // The expected amount is passed so escrowRelease verifies the on-chain
-        // booking amount before submitting the release (defense-in-depth).
-        const result = await escrowRelease(order.order_display_id, order.escrow_amount_wei ?? null);
-        const { txHash, alreadyReleased } = result;
-        if (!txHash && !alreadyReleased) {
-          if (result.code === 'DEPOSIT_AMOUNT_MISMATCH') {
-            // The on-chain amount will not change by retrying — record the
-            // reason and escalate to manual review instead of looping.
-            const releaseAttemptedAt = new Date().toISOString();
-            const releaseAttempts = (order.escrow_release_attempts || 0) + 1;
-            await supabaseAdmin
-              .from('orders')
-              .update({
-                escrow_release_attempts: releaseAttempts,
-                escrow_release_last_attempt_at: releaseAttemptedAt,
-                escrow_release_error: String(result.error).slice(0, 1000),
-                reconciled_by: null,
-                updated_at: releaseAttemptedAt,
-              })
-              .eq('id', order.id);
-            logger.error(
-              `[escrow-release-reconciliation] Order ${order.order_display_id} on-chain amount mismatch (${result.error}). Escalating to manual review.`
-            );
-            continue;
-          }
-          throw new Error('Escrow release did not return a transaction hash');
-        }
-
-        const releasedAt = new Date().toISOString();
-        const { error: updateError } = await supabaseAdmin
-          .from('orders')
-          .update({
-            escrow_status: 'released',
-            release_tx_hash: txHash || order.release_tx_hash,
-            escrow_release_error: null,
-            escrow_released_at: releasedAt,
-            escrow_release_attempts: releaseAttempts,
-            escrow_release_last_attempt_at: releaseAttemptedAt,
-            reconciled_by: null,
-            updated_at: releasedAt,
-          })
-          .eq('id', order.id)
-          .in('escrow_status', ['release_failed', 'funded'])
-          .eq('reconciled_by', instanceId);
-
-        if (updateError) {
-          logger.error(
-            `[escrow-release-reconciliation] Failed to finalize release for ${order.order_display_id}:`,
-            updateError.message
-          );
-        } else {
-          logger.info(`[escrow-release-reconciliation] Release succeeded for ${order.order_display_id}`);
-        }
       } catch (err) {
         logger.error(
           `[escrow-release-reconciliation] Finalization failed for order ${order.order_display_id}:`,

--- a/backend/api/test/unit/escrowReleaseReconciliation.test.js
+++ b/backend/api/test/unit/escrowReleaseReconciliation.test.js
@@ -56,10 +56,6 @@ vi.mock('../../src/lib/redisLock.js', () => ({
   releaseLock: mockReleaseLock,
   renewLock: mockRenewLock,
   LockAcquisitionError: class LockAcquisitionError extends Error {},
-vi.mock('../../src/config/db.js', () => ({
-  supabase: mockSupabase,
-  supabaseAdmin: mockSupabase,
-  redisClient: mockRedisClient,
 }));
 
 vi.mock('../../src/services/escrow.js', () => ({


### PR DESCRIPTION
## Problem

`backend/api/test/unit/escrowReleaseReconciliation.test.js` failed to parse (`SyntaxError: Unexpected token '.'`). A bad merge left the `vi.mock('../../src/lib/redisLock.js', ...)` factory unclosed, swallowing a second (nested, dead) `vi.mock('../../src/config/db.js', ...)` that referenced undefined `mockSupabase`/`mockRedisClient`.

Fixing the test alone exposed that the service it imports, `backend/api/src/services/escrowReleaseReconciliation.js`, is equally broken on `main`:
- An orphaned `} else {` attached to a `try` — `Missing catch or finally clause`.
- An undefined `lockAcquired` reference and an `os.hostname()` call without `os` imported (would throw on every cycle).
- Dead `claim_release_reconciliation` RPC / `failedOrders` sweep leftovers that called `supabaseAdmin.rpc`/`supabaseAdmin.from` and would throw against the configured client.

## Fix

- **Test file**: closed the `redisLock` mock factory properly and removed the bogus nested `config/db.js` mock.
- **Service**: reconstructed `reconcilePendingEscrowReleases` to its documented architecture — acquire the global lock (`LockAcquisitionError` → skip cycle), bail when the lock is held elsewhere, sweep via `orderRepository.findPendingEscrowReleases`, and finalize each order under the per-order lock (`finalizeReleasedOrder` → persist evidence + `complete_trip_tx` service_role, no OTP). All writes go through the service-role repository; the mangled direct-`supabaseAdmin` and claim-RPC blocks are gone. Global and per-order locks are always released via `finally`.

## Files changed

- `backend/api/test/unit/escrowReleaseReconciliation.test.js` — fix the malformed `vi.mock` block.
- `backend/api/src/services/escrowReleaseReconciliation.js` — fix the unparseable function and remove the dead/throw-at-runtime merge leftovers.

## Testing

- `node --check` passes for both files.
- `npx vitest run test/unit/escrowReleaseReconciliation.test.js` — 13/13 passing (skip when no repo/admin, Redis-unavailable skip, global-lock-held skip, no-pending early return, on-chain finalize, release_failed retry, funded no-auto-release, complete_trip_tx failure handling, idempotent skip, lock cleanup, timer lifecycle).

Closes #8233
