### PR TITLE
fix : remove duplicate DELIVERY_IN_PROGRESS_STATUSES declaration in OracleService

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -3,17 +3,6 @@ import logger from '../middleware/logger.js';
 import { verifyDeliveryOtpHash } from '../services/notificationService.js';
 import { DeliveryVerificationService } from '../services/order/deliveryVerificationService.js';
 
-// Statuses that indicate a delivery is currently in progress and therefore
-// eligible for verification. Terminal states ('delivered', 'payment_released')
-// must NOT be used here: confirmDelivery runs BEFORE the order is marked
-// delivered, so a status check against those states could never confirm and
-// the 2-of-3 provider consensus would be unreachable.
-const DELIVERY_IN_PROGRESS_STATUSES = new Set([
-  'picked_up',
-  'in_transit',
-  'arriving',
-]);
-
 const DELIVERY_IN_PROGRESS_STATUSES = new Set([
   'picked_up',
   'in_transit',


### PR DESCRIPTION
Closes #8263.

Summary of What Has Been Done:
OracleService.js had two top-level const DELIVERY_IN_PROGRESS_STATUSES declarations. A duplicate top-level const binding is a hard SyntaxError in an ES module, preventing the oracle module from loading at all. This fix removes the first duplicate declaration.

Changes Made:
- backend/api/src/oracle/OracleService.js: removed the first DELIVERY_IN_PROGRESS_STATUSES declaration block (including JSDoc comment). Kept the second declaration which is semantically identical.

Impact it Made:
- The oracle module now loads without SyntaxError
- OracleService delivery confirmation and 2-of-3 provider consensus logic work end-to-end

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the tmdeveloper007 account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal explanatory comments without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->