### PR TITLE
fix : keyManagementService storeEncryptedKey deactivates prior active rows before inserting new

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -122,6 +122,18 @@ class KeyManagementService {
 
         const keyId = crypto.randomUUID();
 
+        // Deactivate any previously active key for this user+wallet
+        await supabase
+          .from('encrypted_wallet_keys')
+          .update({
+            active: false,
+            archived_at: new Date().toISOString(),
+            archive_reason: 'rotated',
+          })
+          .eq('user_id', userId)
+          .eq('wallet_address', walletAddress)
+          .eq('active', true);
+
         const { data, error } = await supabase
           .from('encrypted_wallet_keys')
           .insert([{


### PR DESCRIPTION
Closes #8256.

Summary of What Has Been Done:
storeEncryptedKey always inserted a new row with active: true without deactivating prior active rows for the same (userId, walletAddress). retrieveEncryptedKey then called .eq('active', true).single() which 406'd when multiple active rows existed. This fix deactivates prior active rows before inserting the new one.

Changes Made:
- backend/api/src/services/security/keyManagementService.js: added update call to deactivate existing active rows before the insert.

Impact it Made:
- Exactly one active key row per (userId, walletAddress) at all times
- retrieveEncryptedKey never hits a 406 duplicate-row error

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the tmdeveloper007 account.