### PR TITLE
fix(api): make profileCacheKey emit legacy user:profile:sb key format

### DIFF
--- a/backend/api/src/cache/CacheNamespace.js
+++ b/backend/api/src/cache/CacheNamespace.js
@@ -81,6 +81,7 @@ export const CacheNamespace = {
 
 // ── Built-in namespaces ─────────────────────────────────────────────
 CacheNamespace.register('profile', {
+  prefix: 'user:profile',
   defaultTtl: parseInt(process.env.REDIS_CACHE_TTL || '900', 10),
 });
 CacheNamespace.register('order', { defaultTtl: 300 });

--- a/backend/api/test/unit/cacheManager.test.js
+++ b/backend/api/test/unit/cacheManager.test.js
@@ -74,7 +74,7 @@ describe('CacheManager', () => {
 
       const result = await CacheManager.get('profile', 'user-123');
       expect(result).toEqual(mockData);
-      expect(mockClient.get).toHaveBeenCalledWith('profile:user-123');
+      expect(mockClient.get).toHaveBeenCalledWith('user:profile:user-123');
     });
 
     it('returns null on cache miss', async () => {
@@ -102,7 +102,7 @@ describe('CacheManager', () => {
       CacheManager.init(mockClient);
 
       await CacheManager.get('profile', 'user-123', 'stats');
-      expect(mockClient.get).toHaveBeenCalledWith('profile:user-123:stats');
+      expect(mockClient.get).toHaveBeenCalledWith('user:profile:user-123:stats');
     });
   });
 
@@ -141,7 +141,7 @@ describe('CacheManager', () => {
       const result = await CacheManager.set('profile', 'user-123', data);
       expect(result).toBe(true);
       expect(mockClient.set).toHaveBeenCalledWith(
-        'profile:user-123',
+        'user:profile:user-123',
         JSON.stringify(data),
         'EX',
         expect.any(Number)
@@ -155,7 +155,7 @@ describe('CacheManager', () => {
 
       await CacheManager.set('profile', 'user-123', { data: 1 });
       expect(mockClient.set).toHaveBeenCalledWith(
-        'profile:user-123',
+        'user:profile:user-123',
         expect.any(String),
         'EX',
         profileNs.defaultTtl
@@ -168,7 +168,7 @@ describe('CacheManager', () => {
 
       await CacheManager.set('profile', 'user-123', { data: 1 }, { ttl: 60 });
       expect(mockClient.set).toHaveBeenCalledWith(
-        'profile:user-123',
+        'user:profile:user-123',
         expect.any(String),
         'EX',
         60
@@ -181,7 +181,7 @@ describe('CacheManager', () => {
 
       await CacheManager.set('profile', 'user-123', { data: 1 }, { ttl: 0 });
       expect(mockClient.set).toHaveBeenCalledWith(
-        'profile:user-123',
+        'user:profile:user-123',
         expect.any(String)
       );
     });
@@ -206,7 +206,7 @@ describe('CacheManager', () => {
       await CacheManager.invalidate('profile', 'user-123');
       expect(invalidateKey).toHaveBeenCalledWith(
         'profile',
-        'profile:user-123',
+        'user:profile:user-123',
         { localOnly: undefined }
       );
     });
@@ -219,7 +219,7 @@ describe('CacheManager', () => {
       await CacheManager.invalidate('profile', 'user-123', { localOnly: true });
       expect(invalidateKey).toHaveBeenCalledWith(
         'profile',
-        'profile:user-123',
+        'user:profile:user-123',
         { localOnly: true }
       );
     });

--- a/backend/api/test/unit/profileCacheKeys.test.js
+++ b/backend/api/test/unit/profileCacheKeys.test.js
@@ -47,15 +47,26 @@ describe('profileCacheKeys - CacheKeyBuilder integration', () => {
     expect(mod.PROFILE_SUB_KEYS).toEqual({ STATS: 'stats', DRIVER: 'driver' });
   });
 
-  it('profileCacheKey produces CacheKeyBuilder-compatible key', async () => {
+  it('profileCacheKey produces backward-compatible key', async () => {
     const mod = await import('../../src/cache/profileCacheKeys.js');
     const key = mod.profileCacheKey('user-789');
-    expect(key).toBe('profile:sb:user-789');
+    expect(key).toBe('user:profile:sb:user-789');
   });
 
   it('profileCacheKey with subKey produces correct key', async () => {
     const mod = await import('../../src/cache/profileCacheKeys.js');
     const key = mod.profileCacheKey('user-789', 'stats');
-    expect(key).toBe('profile:sb:user-789:stats');
+    expect(key).toBe('user:profile:sb:user-789:stats');
+  });
+
+  it('profileCacheKey matches the legacy Supabase profile key (writer == invalidator)', async () => {
+    const mod = await import('../../src/cache/profileCacheKeys.js');
+    expect(mod.profileCacheKey('user-789')).toBe(mod.supabaseProfileKey('user-789'));
+  });
+
+  it('profileCacheKey with subKey matches the legacy sub-key helpers', async () => {
+    const mod = await import('../../src/cache/profileCacheKeys.js');
+    expect(mod.profileCacheKey('user-789', 'stats')).toBe(mod.customerStatsKey('user-789'));
+    expect(mod.profileCacheKey('user-789', 'driver')).toBe(mod.driverDetailsKey('user-789'));
   });
 });


### PR DESCRIPTION
## Problem

`profileCacheKey()` in `backend/api/src/cache/profileCacheKeys.js` built `profile:sb:{id}` via `CacheKeyBuilder.build('profile', 'sb:{id}')`, while the legacy helpers (`supabaseProfileKey`, `customerStatsKey`, `driverDetailsKey`) and every writer/invalidator in `profileCache.js` use `user:profile:sb:{id}`. The formats differed by the `user:` prefix, so a key built by the new builder could never be reached by the legacy invalidation paths (and vice versa) — stale cached profiles would keep being served after a role/status change.

Root cause: the built-in `profile` cache namespace was registered without the `user:profile` prefix it should have had to match the legacy keyspace.

## Fix

- `backend/api/src/cache/CacheNamespace.js`: register the `profile` namespace with `prefix: 'user:profile'`.
- This makes `profileCacheKey()` emit `user:profile:sb:{id}` (and `user:profile:sb:{id}:stats` / `:driver` with a sub-key) — identical to the legacy helpers.
- It also aligns namespace-level invalidation: `CacheKeyBuilder.pattern('profile')` now emits `user:profile:*`, which matches the keys readers actually use.
- No change needed to `profileCacheKeys.js` — its existing "backward compatible" contract is now actually true.

## Files changed

- `backend/api/src/cache/CacheNamespace.js` — add `prefix: 'user:profile'` to the `profile` namespace registration.
- `backend/api/test/unit/profileCacheKeys.test.js` — update expectations to the legacy format and add tests asserting writer and invalidator (builder) produce identical keys.
- `backend/api/test/unit/cacheManager.test.js` — update key-string expectations to the corrected `user:profile` prefix.

## Testing

- `npx vitest run test/unit/profileCacheKeys.test.js test/unit/cacheManager.test.js test/unit/cacheNamespace.test.js test/unit/cacheKeyBuilder.test.js test/unit/profileCache.test.js` — 148/148 passing.
- New assertions: `profileCacheKey('user-789') === supabaseProfileKey('user-789')`, and `profileCacheKey('user-789', 'stats'|'driver')` equals the matching legacy sub-key helpers.

Closes #8234
