### PR TITLE
fix : escrow.js removes duplicate markEscrowBookingStarted declaration

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -527,44 +527,6 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
   });
 }
 
-/**
- * Mark an escrow booking as started on-chain once the trip has begun, so
- * cancelBooking / cancelWithPenalty revert and a full refund is blocked
- * (issue #5768).
- *
- * @param {string} orderDisplayId
- * @returns {Promise<{txHash: string|null, bookingId: string, waitForConfirmation?: Function, error?: string}>}
- */
-export async function markEscrowBookingStarted (orderDisplayId) {
-  return measureExecution('EscrowService.markEscrowBookingStarted', async () => {
-  const bookingId = getEscrowBookingId(orderDisplayId)
-
-  if (!escrowContract) {
-    logger.warn('[escrow] Contract not initialised — skipping markBookingStarted.')
-    return { txHash: null, bookingId }
-  }
-
-  try {
-    const tx = await escrowContract.markBookingStarted(bookingId)
-    logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
-    return {
-      txHash: tx.hash,
-      bookingId,
-      waitForConfirmation: async () => {
-        const receipt = await tx.wait(1)
-        if (!receipt || receipt.status === 0) {
-          throw new Error('Escrow markBookingStarted transaction reverted or was not found.')
-        }
-        logger.info(`[escrow] markBookingStarted confirmed for booking ${orderDisplayId} in block ${receipt.blockNumber}`)
-        return receipt
-      },
-    }
-  } catch (err) {
-    logger.error(`[escrow] markBookingStarted failed for booking ${orderDisplayId}: ${err.message}`)
-    return { txHash: null, bookingId, error: err.message }
-  }
-  });
-}
 
 /**
  * Release escrowed funds to the driver after successful delivery verification.


### PR DESCRIPTION
Closes #8258.

Summary of What Has Been Done:
escrow.js had two top-level export async function markEscrowBookingStarted declarations causing a SyntaxError that prevented the entire escrow module from loading. The first declaration (with wrong indentation and missing await) was removed, keeping the second correct implementation.

Changes Made:
- backend/api/src/services/escrow.js: removed the first markEscrowBookingStarted function block (JSDoc + function implementation).

Impact it Made:
- The escrow module loads without SyntaxError
- All escrow operations (mark booking started, release, refund) work without module-load failures

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the tmdeveloper007 account.