### PR TITLE
fix(api): make CacheKeyBuilder.buildVersioned read live version from Redis

### DIFF
--- a/backend/api/src/cache/CacheKeyBuilder.js
+++ b/backend/api/src/cache/CacheKeyBuilder.js
@@ -22,6 +22,41 @@ import logger from '../middleware/logger.js';
 
 const SEP = ':';
 
+/** Bounded timeout (ms) for the Redis version lookup in buildVersioned. */
+const DEFAULT_VERSION_TIMEOUT_MS = 500;
+
+/** Redis client used for the live version lookup. Wired via CacheManager.init. */
+let redisClient = null;
+
+/**
+ * Register the Redis client used for version lookups.
+ *
+ * @param {object|null} client — ioredis instance (or null to clear)
+ */
+function _setRedisClient(client) {
+  redisClient = client;
+}
+
+/**
+ * Resolve a promise but bound it to a timeout. A late rejection after the
+ * timeout fires is swallowed so it can never surface as an unhandled rejection.
+ *
+ * @param {PromiseLike<*>} promise
+ * @param {number} timeoutMs
+ * @returns {Promise<*>}
+ */
+function _boundedRead(promise, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    Promise.resolve(promise).catch(() => null).then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
 export const CacheKeyBuilder = {
   /**
    * Build a cache key for the given namespace, entity ID and optional sub-key.
@@ -43,20 +78,40 @@ export const CacheKeyBuilder = {
   },
 
   /**
-   * Build a versioned cache key. The version is looked up from Redis
-   * and appended to the key so that bumping the version invalidates
-   * all previous keys.
+   * Build a versioned cache key. The current version is read live from
+   * Redis (see versionKey) and appended to the key, so bumping the version
+   * invalidates all previously built keys. Falls back to `v1` only when the
+   * read fails, times out, or no Redis client is configured.
    *
    * @param {string} namespace
    * @param {string} entityId
    * @param {string} [subKey]
-   * @param {number} [version] — if provided, skips Redis lookup
-   * @returns {string} versioned Redis key
+   * @param {number} [version] — if provided, skips the Redis lookup
+   * @param {object} [opts]
+   * @param {string} [opts.versionKey] — custom version key to read instead
+   * @param {number} [opts.timeoutMs] — bounded timeout for the Redis read
+   * @returns {Promise<string>} versioned Redis key
    */
-  buildVersioned(namespace, entityId, subKey, version) {
+  async buildVersioned(namespace, entityId, subKey, version, opts = {}) {
     const ns = CacheNamespace.get(namespace);
     const prefix = ns?.prefix || namespace;
-    const v = version != null ? version : 1;
+    let v = version;
+    if (v == null) {
+      const client = redisClient;
+      if (client) {
+        try {
+          const versionKey = opts.versionKey || this.versionKey(namespace, entityId, subKey);
+          const raw = await _boundedRead(client.get(versionKey), opts.timeoutMs ?? DEFAULT_VERSION_TIMEOUT_MS);
+          const parsed = raw != null ? parseInt(raw, 10) : 1;
+          v = Number.isNaN(parsed) ? 1 : parsed;
+        } catch (err) {
+          logger.warn({ err }, `[CacheKeyBuilder] Failed to read version for namespace "${namespace}" — falling back to v1.`);
+          v = 1;
+        }
+      } else {
+        v = 1;
+      }
+    }
     const parts = [prefix, `v${v}`, entityId];
     if (subKey) parts.push(subKey);
     return parts.join(SEP);
@@ -123,6 +178,16 @@ export const CacheKeyBuilder = {
         ? (parts.length > 3 ? parts.slice(3).join(SEP) : null)
         : (parts.length > 2 ? parts.slice(2).join(SEP) : null),
     };
+  },
+
+  /**
+   * Register (or clear) the Redis client used for version lookups.
+   * Wired automatically by CacheManager.init.
+   *
+   * @param {object|null} client — ioredis instance
+   */
+  _setRedisClient(client) {
+    _setRedisClient(client);
   },
 };
 

--- a/backend/api/src/cache/CacheManager.js
+++ b/backend/api/src/cache/CacheManager.js
@@ -27,6 +27,7 @@ const stats = {
 export function init(client) {
   if (initialized) return;
   redisClient = client;
+  CacheKeyBuilder._setRedisClient(client);
   if (!client) {
     logger.warn('[CacheManager] No Redis client provided - caching disabled.');
     return;
@@ -159,6 +160,7 @@ export function isInitialized() {
 
 export function shutdown() {
   redisClient = null;
+  CacheKeyBuilder._setRedisClient(null);
   initialized = false;
   logger.info('[CacheManager] Shut down.');
 }

--- a/backend/api/test/unit/cacheKeyBuilder.test.js
+++ b/backend/api/test/unit/cacheKeyBuilder.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CacheKeyBuilder } from '../../src/cache/CacheKeyBuilder.js';
 import { CacheNamespace } from '../../src/cache/CacheNamespace.js';
 
@@ -7,6 +7,10 @@ describe('CacheKeyBuilder', () => {
     CacheNamespace.clear();
     CacheNamespace.register('profile', { defaultTtl: 900 });
     CacheNamespace.register('order', { defaultTtl: 300 });
+  });
+
+  afterEach(() => {
+    CacheKeyBuilder._setRedisClient(null);
   });
 
   describe('build()', () => {
@@ -48,40 +52,110 @@ describe('CacheKeyBuilder', () => {
   });
 
   describe('buildVersioned()', () => {
-    it('includes version v1 by default', () => {
-      const key = CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+    it('includes version v1 by default', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
       expect(key).toBe('profile:v1:sb:abc123');
     });
 
-    it('uses custom version when provided', () => {
-      const key = CacheKeyBuilder.buildVersioned('profile', 'sb:abc123', undefined, 5);
+    it('uses custom version when provided', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123', undefined, 5);
       expect(key).toBe('profile:v5:sb:abc123');
     });
 
-    it('uses custom prefix with version', () => {
+    it('uses custom prefix with version', async () => {
       CacheNamespace.register('custom', { prefix: 'c:v2' });
-      const key = CacheKeyBuilder.buildVersioned('custom', 'entity-1', undefined, 3);
+      const key = await CacheKeyBuilder.buildVersioned('custom', 'entity-1', undefined, 3);
       expect(key).toBe('c:v2:v3:entity-1');
     });
 
-    it('appends subKey after entityId', () => {
-      const key = CacheKeyBuilder.buildVersioned('order', 'order-42', 'items', 2);
+    it('appends subKey after entityId', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('order', 'order-42', 'items', 2);
       expect(key).toBe('order:v2:order-42:items');
     });
 
-    it('defaults to v1 for unknown namespace', () => {
-      const key = CacheKeyBuilder.buildVersioned('unknown', 'id-1');
+    it('defaults to v1 for unknown namespace', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('unknown', 'id-1');
       expect(key).toBe('unknown:v1:id-1');
     });
 
-    it('uses version 0 when explicitly passed', () => {
-      const key = CacheKeyBuilder.buildVersioned('profile', 'id-1', undefined, 0);
+    it('uses version 0 when explicitly passed', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'id-1', undefined, 0);
       expect(key).toBe('profile:v0:id-1');
     });
 
-    it('handles subKey without explicit version', () => {
-      const key = CacheKeyBuilder.buildVersioned('profile', 'sb:abc123', 'driver');
+    it('handles subKey without explicit version', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123', 'driver');
       expect(key).toBe('profile:v1:sb:abc123:driver');
+    });
+
+    it('reads the live version from Redis and appends it to the key', async () => {
+      const mockClient = { get: vi.fn().mockResolvedValue('7') };
+      CacheKeyBuilder._setRedisClient(mockClient);
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(mockClient.get).toHaveBeenCalledWith('profile:version:sb:abc123');
+      expect(key).toBe('profile:v7:sb:abc123');
+    });
+
+    it('produces a different key after a version bump', async () => {
+      let version = 1;
+      const mockClient = {
+        get: vi.fn(() => Promise.resolve(String(version))),
+        incr: vi.fn(() => {
+          version += 1;
+          return Promise.resolve(version);
+        }),
+      };
+      CacheKeyBuilder._setRedisClient(mockClient);
+
+      const keyBefore = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(keyBefore).toBe('profile:v1:sb:abc123');
+
+      await mockClient.incr('profile:version:sb:abc123');
+
+      const keyAfter = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(keyAfter).toBe('profile:v2:sb:abc123');
+    });
+
+    it('respects a custom versionKey', async () => {
+      const mockClient = { get: vi.fn().mockResolvedValue('3') };
+      CacheKeyBuilder._setRedisClient(mockClient);
+      const key = await CacheKeyBuilder.buildVersioned(
+        'profile',
+        'sb:abc123',
+        undefined,
+        undefined,
+        { versionKey: 'cache:version:profile' }
+      );
+      expect(mockClient.get).toHaveBeenCalledWith('cache:version:profile');
+      expect(key).toBe('profile:v3:sb:abc123');
+    });
+
+    it('defaults to v1 when no Redis client is configured', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(key).toBe('profile:v1:sb:abc123');
+    });
+
+    it('falls back to v1 when the version read fails', async () => {
+      const mockClient = { get: vi.fn().mockRejectedValue(new Error('redis down')) };
+      CacheKeyBuilder._setRedisClient(mockClient);
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(key).toBe('profile:v1:sb:abc123');
+    });
+
+    it('falls back to v1 when the version read times out', async () => {
+      const mockClient = {
+        get: vi.fn(() => new Promise(() => {})),
+      };
+      CacheKeyBuilder._setRedisClient(mockClient);
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123', undefined, undefined, { timeoutMs: 20 });
+      expect(key).toBe('profile:v1:sb:abc123');
+    });
+
+    it('treats a non-numeric stored version as v1', async () => {
+      const mockClient = { get: vi.fn().mockResolvedValue('not-a-number') };
+      CacheKeyBuilder._setRedisClient(mockClient);
+      const key = await CacheKeyBuilder.buildVersioned('profile', 'sb:abc123');
+      expect(key).toBe('profile:v1:sb:abc123');
     });
   });
 
@@ -243,8 +317,8 @@ describe('CacheKeyBuilder', () => {
       });
     });
 
-    it('round-trips buildVersioned output correctly', () => {
-      const key = CacheKeyBuilder.buildVersioned('order', 'order-42', 'items', 4);
+    it('round-trips buildVersioned output correctly', async () => {
+      const key = await CacheKeyBuilder.buildVersioned('order', 'order-42', 'items', 4);
       const parsed = CacheKeyBuilder.parse(key);
       expect(parsed).toEqual({
         namespace: 'order',


### PR DESCRIPTION
## Problem

`CacheKeyBuilder.buildVersioned()` documented that it looks up the current version from Redis and appends it to the key, but it never performed the lookup — it always used `v1`. Because of that, every key was built as `...:v1` forever; bumping a namespace version (`CacheInvalidator.bumpVersion` / `CacheManager.bumpVersion`) had no effect on keys produced by this API, so the versioning mechanism was non-functional.

## Fix

- `backend/api/src/cache/CacheKeyBuilder.js`: `buildVersioned` is now async and reads the live version from the namespace's version key (computed via `versionKey(namespace, entityId, subKey)`, or overridable with `opts.versionKey`) using a bounded timeout (`opts.timeoutMs`, default 500ms). It falls back to `v1` **only** when the read fails, times out, returns a non-numeric value, or when no Redis client is configured. An explicit `version` argument still skips the Redis lookup.
- `backend/api/src/cache/CacheManager.js`: `init()` now wires its Redis client into the builder (`CacheKeyBuilder._setRedisClient`), and `shutdown()` clears it — so the builder actually has a client in production and respects the same version keys that `bumpVersion` increments.

## Files changed

- `backend/api/src/cache/CacheKeyBuilder.js`
- `backend/api/src/cache/CacheManager.js`
- `backend/api/test/unit/cacheKeyBuilder.test.js`

## Testing

- `npx vitest run test/unit/cacheKeyBuilder.test.js test/unit/cacheManager.test.js` — 72/72 passing.
- New tests: live version read appends `v7`; a version bump produces a different key (`v1` → `v2`); custom `versionKey` respected; fallback to `v1` when no client, on rejection, on timeout, and for non-numeric stored versions; existing buildVersioned/parse tests converted to async.

Closes #8235
