### PR TITLE
fix(api): make CacheKeyBuilder.pattern match unversioned build() keys

### DIFF
--- a/backend/api/src/cache/CacheKeyBuilder.js
+++ b/backend/api/src/cache/CacheKeyBuilder.js
@@ -81,17 +81,20 @@ export const CacheKeyBuilder = {
 
   /**
    * Build a SCAN-compatible glob pattern for invalidating all keys
-   * under a namespace + entity prefix.
+   * under a namespace + entity prefix. Matches the unversioned keys
+   * produced by build()/buildWithPrefix() (and their sub-keys), e.g.
+   * `prefix:entity*` matches `prefix:entity`, `prefix:entity:123`,
+   * and `prefix:entity:123:stats`.
    *
    * @param {string} namespace
    * @param {string} [entityId] — if omitted, matches the entire namespace
-   * @returns {string} glob pattern e.g. 'profile:*' or 'profile:*:sb:abc123'
+   * @returns {string} glob pattern e.g. 'profile:*' or 'profile:sb:abc123*'
    */
   pattern(namespace, entityId) {
     const ns = CacheNamespace.get(namespace);
     const prefix = ns?.prefix || namespace;
     if (entityId) {
-      return `${prefix}:*:${entityId}*`;
+      return `${prefix}:${entityId}*`;
     }
     return `${prefix}:*`;
   },

--- a/backend/api/test/unit/cacheKeyBuilder.test.js
+++ b/backend/api/test/unit/cacheKeyBuilder.test.js
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { CacheKeyBuilder } from '../../src/cache/CacheKeyBuilder.js';
 import { CacheNamespace } from '../../src/cache/CacheNamespace.js';
 
+function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
 describe('CacheKeyBuilder', () => {
   beforeEach(() => {
     CacheNamespace.clear();
@@ -109,9 +114,17 @@ describe('CacheKeyBuilder', () => {
   });
 
   describe('pattern()', () => {
-    it('creates SCAN glob matching all versions for an entity', () => {
+    it('creates SCAN glob matching the unversioned keys build() writes', () => {
       const pat = CacheKeyBuilder.pattern('profile', 'sb:abc123');
-      expect(pat).toBe('profile:*:sb:abc123*');
+      expect(pat).toBe('profile:sb:abc123*');
+    });
+
+    it('pattern() matches the key produced by build() (round-trip)', () => {
+      const key = CacheKeyBuilder.build('profile', 'sb:abc123', 'stats');
+      const pat = CacheKeyBuilder.pattern('profile', 'sb:abc123');
+      const regex = globToRegExp(pat);
+      expect(regex.test(key)).toBe(true);
+      expect(regex.test(CacheKeyBuilder.build('profile', 'sb:abc123'))).toBe(true);
     });
 
     it('matches entire namespace when entityId is omitted', () => {
@@ -132,12 +145,12 @@ describe('CacheKeyBuilder', () => {
     it('uses custom prefix in pattern', () => {
       CacheNamespace.register('custom', { prefix: 'c:v2' });
       const pat = CacheKeyBuilder.pattern('custom', 'entity-1');
-      expect(pat).toBe('c:v2:*:entity-1*');
+      expect(pat).toBe('c:v2:entity-1*');
     });
 
     it('falls back for unknown namespace', () => {
       const pat = CacheKeyBuilder.pattern('unknown', 'id-1');
-      expect(pat).toBe('unknown:*:id-1*');
+      expect(pat).toBe('unknown:id-1*');
     });
 
     it('falls back for unknown namespace without entityId', () => {


### PR DESCRIPTION
## Problem

`CacheKeyBuilder.pattern()` emitted a versioned-shaped glob — `prefix:*:entity*` — which only matches `prefix:<version>:entity:...` keys. But `build()` (and the legacy writers) produce **unversioned** keys like `prefix:entity:123`, so every delete-by-pattern invalidation missed all of its targets. No keys were deleted, no error was raised, and stale cached values survived invalidation.

## Fix

- `backend/api/src/cache/CacheKeyBuilder.js`: `pattern(namespace, entityId)` now emits `prefix:entityId*` (e.g. `profile:sb:abc123*`), matching the unversioned keys that `build()` produces, including their sub-keys (`profile:sb:abc123`, `profile:sb:abc123:stats`, ...). The no-entityId case still emits `prefix:*`.
- `backend/api/test/unit/cacheKeyBuilder.test.js`: updated the pattern expectations and added a round-trip test that writes a key with `build()` and asserts the glob emitted by `pattern()` matches it.

## Files changed

- `backend/api/src/cache/CacheKeyBuilder.js`
- `backend/api/test/unit/cacheKeyBuilder.test.js`

## Testing

- `npx vitest run test/unit/cacheKeyBuilder.test.js test/unit/cacheManager.test.js test/unit/cacheNamespace.test.js test/unit/profileCacheKeys.test.js` — 108/108 passing.
- New round-trip test: `CacheKeyBuilder.pattern('profile', 'sb:abc123')` matches both `CacheKeyBuilder.build('profile', 'sb:abc123')` and `CacheKeyBuilder.build('profile', 'sb:abc123', 'stats')`.

Closes #8236
