### PR TITLE
feat: implement lumper fee instant micro-lending (#8199)

### DIFF
--- a/apps/driver/lib/models/lumper_fee_lending_model.dart
+++ b/apps/driver/lib/models/lumper_fee_lending_model.dart
@@ -1,0 +1,29 @@
+class LumperInvoice {
+  final String warehouseName;
+  final double feeAmountUsd;
+  final String loadId;
+  final bool isVerified;
+
+  LumperInvoice({
+    required this.warehouseName,
+    required this.feeAmountUsd,
+    required this.loadId,
+    required this.isVerified,
+  });
+}
+
+class VirtualDebitCard {
+  final String cardNumber;
+  final String expiration;
+  final String cvv;
+  final double authorizedAmountUsd;
+  final String status; // "Active", "Declined", "Charged"
+
+  VirtualDebitCard({
+    required this.cardNumber,
+    required this.expiration,
+    required this.cvv,
+    required this.authorizedAmountUsd,
+    required this.status,
+  });
+}

--- a/apps/driver/lib/screens/lumper_fee_lending_screen.dart
+++ b/apps/driver/lib/screens/lumper_fee_lending_screen.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import '../models/lumper_fee_lending_model.dart';
+import '../services/lumper_fee_lending_service.dart';
+
+class LumperFeeLendingScreen extends StatefulWidget {
+  const LumperFeeLendingScreen({super.key});
+
+  @override
+  State<LumperFeeLendingScreen> createState() => _LumperFeeLendingScreenState();
+}
+
+class _LumperFeeLendingScreenState extends State<LumperFeeLendingScreen> {
+  final LumperFeeLendingService _service = LumperFeeLendingService();
+  LumperInvoice? _invoice;
+  VirtualDebitCard? _card;
+  bool _isProcessing = false;
+  String _statusText = '';
+
+  void _scanReceipt() async {
+    setState(() {
+      _isProcessing = true;
+      _statusText = 'Scanning receipt via OCR...';
+    });
+    
+    final invoice = await _service.scanReceiptOCR();
+    
+    if (mounted) {
+      setState(() {
+        _invoice = invoice;
+        _isProcessing = false;
+      });
+    }
+  }
+
+  void _requestLoan() async {
+    setState(() {
+      _isProcessing = true;
+      _statusText = 'Underwriting micro-loan & issuing virtual card...';
+    });
+
+    final card = await _service.issueMicroLoanCard(_invoice!);
+
+    if (mounted) {
+      setState(() {
+        _card = card;
+        _isProcessing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lumper Fee Micro-Loan'),
+        backgroundColor: Colors.teal[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isProcessing) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 24),
+            Text(_statusText, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+          ],
+        ),
+      );
+    }
+
+    if (_invoice == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.receipt_long, size: 100, color: Colors.teal[200]),
+              const SizedBox(height: 24),
+              const Text('Trapped at the dock?', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              const Text('Scan your lumper receipt to instantly receive a virtual debit card to pay the warehouse. We\'ll deduct it from your load settlement later.', textAlign: TextAlign.center, style: TextStyle(color: Colors.grey)),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                height: 56,
+                child: ElevatedButton.icon(
+                  onPressed: _scanReceipt,
+                  icon: const Icon(Icons.document_scanner),
+                  label: const Text('SCAN LUMPER RECEIPT'),
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.teal[800], foregroundColor: Colors.white),
+                ),
+              )
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _buildInvoiceSummary(),
+        if (_card == null) ...[
+          const SizedBox(height: 32),
+          SizedBox(
+            width: double.infinity,
+            height: 56,
+            child: ElevatedButton.icon(
+              onPressed: _requestLoan,
+              icon: const Icon(Icons.credit_card),
+              label: const Text('REQUEST MICRO-LOAN'),
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.teal[800], foregroundColor: Colors.white),
+            ),
+          )
+        ] else ...[
+          const SizedBox(height: 24),
+          _buildVirtualCard(),
+        ]
+      ],
+    );
+  }
+
+  Widget _buildInvoiceSummary() {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('LUMPER INVOICE', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+                if (_invoice!.isVerified) const Icon(Icons.verified, color: Colors.green),
+              ],
+            ),
+            const Divider(height: 32),
+            Text(_invoice!.warehouseName, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Text('Load ID: ${_invoice!.loadId}', style: const TextStyle(color: Colors.grey)),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('FEE AMOUNT', style: TextStyle(fontWeight: FontWeight.bold)),
+                Text('\$${_invoice!.feeAmountUsd.toStringAsFixed(2)}', style: const TextStyle(fontSize: 28, fontWeight: FontWeight.bold, color: Colors.teal)),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVirtualCard() {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(colors: [Colors.teal[800]!, Colors.teal[600]!], begin: Alignment.topLeft, end: Alignment.bottomRight),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 10, offset: Offset(0, 5))],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('TRUXIFY VIRTUAL DEBIT', style: TextStyle(color: Colors.white70, letterSpacing: 1.5, fontWeight: FontWeight.bold)),
+              Icon(Icons.contactless, color: Colors.white.withOpacity(0.8)),
+            ],
+          ),
+          const SizedBox(height: 32),
+          Text(_card!.cardNumber, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold, letterSpacing: 2)),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('EXP', style: TextStyle(color: Colors.white54, fontSize: 10)),
+                  Text(_card!.expiration, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
+                ],
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('CVV', style: TextStyle(color: Colors.white54, fontSize: 10)),
+                  Text(_card!.cvv, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
+                ],
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                decoration: BoxDecoration(color: Colors.white24, borderRadius: BorderRadius.circular(12)),
+                child: Text('AUTH: \$${_card!.authorizedAmountUsd.toStringAsFixed(2)}', style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/lumper_fee_lending_service.dart
+++ b/apps/driver/lib/services/lumper_fee_lending_service.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+import '../models/lumper_fee_lending_model.dart';
+
+class LumperFeeLendingService {
+  Future<LumperInvoice> scanReceiptOCR() async {
+    // Simulate OCR scanning a crumpled receipt
+    await Future.delayed(const Duration(seconds: 2));
+
+    return LumperInvoice(
+      warehouseName: 'AmeriCold Logistics',
+      feeAmountUsd: 325.50,
+      loadId: 'LD-99120',
+      isVerified: true,
+    );
+  }
+
+  Future<VirtualDebitCard> issueMicroLoanCard(LumperInvoice invoice) async {
+    // Simulate API call to fintech partner to issue a virtual card
+    await Future.delayed(const Duration(seconds: 2));
+
+    return VirtualDebitCard(
+      cardNumber: '4111 2222 3333 4444',
+      expiration: '12/26',
+      cvv: '819',
+      authorizedAmountUsd: invoice.feeAmountUsd,
+      status: 'Active',
+    );
+  }
+}


### PR DESCRIPTION
## Description
Resolves #8199

This PR introduces the frontend UI and mock financial services for the Lumper Fee Instant Micro-Lending system. Grocery warehouses frequently extort arbitrary "lumper fees" from independent drivers to unload their freight. This creates a severe liquidity trap that stalls the supply chain. This feature implements an instant micro-lending facility allowing drivers to scan a warehouse invoice and immediately receive a single-use virtual debit card to pay the fee, with the balance automatically deducted from their final load settlement.

### Changes Made:
- **`lumper_fee_lending_model.dart`**: Created the `LumperInvoice` and `VirtualDebitCard` schemas to structure the transition from an OCR-scanned receipt to an authorized payment instrument.
- **`lumper_fee_lending_service.dart`**: Implemented mock fintech endpoints simulating the OCR extraction of a $325.50 warehouse fee and the subsequent underwriting and provisioning of an active virtual debit card.
- **`lumper_fee_lending_screen.dart`**: Built a premium fintech UI flow. Drivers can easily scan a receipt to verify the amount, then request a micro-loan with a single tap. The app renders a visually striking virtual debit card directly on the screen (complete with CVV and Auth Amount), allowing the driver to pay the warehouse instantly and get back on the road.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
