### PR TITLE
fix(api): key keyManagementService cache on full SHA-256 of masterSecret

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -16,7 +16,8 @@ class KeyManagementService {
 
   async deriveDeviceEncryptionKey(deviceId, masterSecret) {
     return measureExecution('KeyManagementService.deriveDeviceEncryptionKey', async () => {
-      const cacheKey = `${deviceId}:${masterSecret.slice(0, 8)}`;
+      const secretHash = crypto.createHash('sha256').update(masterSecret).digest('hex');
+      const cacheKey = `${deviceId}:${secretHash}`;
 
       if (this.encryptionKeyCache.has(cacheKey)) {
         return this.encryptionKeyCache.get(cacheKey);

--- a/backend/api/test/unit/keyManagementService.test.js
+++ b/backend/api/test/unit/keyManagementService.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: null,
+  supabaseAdmin: null,
+}));
+
+vi.mock('../../src/core/performanceMetrics.js', () => ({
+  measureExecution: vi.fn(async (_name, fn) => fn()),
+}));
+
+describe('KeyManagementService', () => {
+  let KeyManagementService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ default: KeyManagementService } = await import('../../src/services/security/keyManagementService.js'));
+  });
+
+  it('derives distinct keys for secrets sharing the same first 8 hex chars', async () => {
+    const svc = new KeyManagementService();
+    const secretA = `${'aaaa0000'}${'f'.repeat(56)}`;
+    const secretB = `${'aaaa0000'}${'e'.repeat(56)}`;
+
+    const keyA = await svc.deriveDeviceEncryptionKey('dev-1', secretA);
+    const keyB = await svc.deriveDeviceEncryptionKey('dev-1', secretB);
+
+    expect(keyA.equals(keyB)).toBe(false);
+  });
+
+  it('still caches derivations for the same device + secret', async () => {
+    const svc = new KeyManagementService();
+    const secret = 'c'.repeat(64);
+
+    const first = await svc.deriveDeviceEncryptionKey('dev-1', secret);
+    const second = await svc.deriveDeviceEncryptionKey('dev-1', secret);
+
+    expect(first).toBe(second);
+  });
+
+  it('does not share a cached key across different secrets with an 8-char prefix', async () => {
+    const svc = new KeyManagementService();
+    const secretA = `${'beef0000'}${'a'.repeat(56)}`;
+    const secretB = `${'beef0000'}${'b'.repeat(56)}`;
+
+    const keyA = await svc.deriveDeviceEncryptionKey('dev-1', secretA);
+    const keyB = await svc.deriveDeviceEncryptionKey('dev-1', secretB);
+
+    expect(keyA.equals(keyB)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`deriveDeviceEncryptionKey` in `backend/api/src/services/security/keyManagementService.js` built its cache/lookup key from only the **first 8 hex characters** of `masterSecret` (`.slice(0, 8)`) — a 32-bit digest. Any two `masterSecret`s sharing those 8 hex characters collided in the in-memory cache, so the second account's derivation returned the first account's derived key (wrong ciphertext → decryption failure) or silently reused the wrong key. The truncation provided no security benefit.

## Fix

- `backend/api/src/services/security/keyManagementService.js`: the cache key is now `${deviceId}:${sha256(masterSecret)}` — a full SHA-256 digest of the secret instead of the 8-char slice, making collisions negligible.
- Added `backend/api/test/unit/keyManagementService.test.js` covering:
  - distinct derived keys for two secrets sharing the same first 8 hex chars,
  - cache reuse for the identical device + secret,
  - no cross-secret cache sharing for an 8-char-common prefix.

## Files changed

- `backend/api/src/services/security/keyManagementService.js`
- `backend/api/test/unit/keyManagementService.test.js`

## Testing

- `npx vitest run test/unit/keyManagementService.test.js` — 3/3 passing.
- Without the fix, the shared-prefix test fails (the second derivation returns the first secret's cached key).

Closes #8237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device encryption-key isolation by ensuring different master secrets always produce distinct keys, even when they share the same beginning characters.
  * Preserved reliable key reuse for identical device and secret combinations, improving consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->