### PR TITLE
fix: remove leaked catch block in dlqService.js logBacklogIfNeeded

### DIFF
--- a/backend/api/src/services/webhook/dlqService.js
+++ b/backend/api/src/services/webhook/dlqService.js
@@ -339,38 +339,6 @@ export const dlqService = {
       const backlog = await this.getBacklogCount();
       if (backlog !== null) {
         logger.info(`[DLQ] Backlog of pending webhook failures: ${backlog}`);
-        } catch (procErr) {
-          logger.error(`[DLQ] Retry failed for event ${event.id}: ${procErr.message}`);
-
-          const newRetryCount = (event.retry_count ?? 0) + 1;
-          const nextBackoffMin = RETRY_BACKOFF[newRetryCount] || -1;
-
-          if (nextBackoffMin === -1) {
-            // Failed permanently
-            await dlqDb()
-              .from('webhook_failures')
-              .update({ 
-                status: 'failed_permanently', 
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString()
-              })
-              .eq('id', event.id);
-            logger.warn(`[DLQ] Event ${event.id} marked as failed_permanently`);
-          } else {
-            // Schedule next retry by resetting status to pending so the event can be re-claimed.
-            const nextRetryAt = new Date(Date.now() + nextBackoffMin * 60000).toISOString();
-            await dlqDb()
-              .from('webhook_failures')
-              .update({
-                status: 'pending',
-                retry_count: newRetryCount,
-                next_retry_at: nextRetryAt,
-                error_message: String(procErr.message || procErr).slice(0, 1000),
-                updated_at: new Date().toISOString(),
-              })
-              .eq('id', event.id);
-          }
-        }
       }
     } catch (err) {
       logger.warn(`[DLQ] Backlog metrics unavailable: ${err.message}`);


### PR DESCRIPTION
## Description
`dlqService.js`'s `logBacklogIfNeeded()` had a leaked copy of the retry/permanent-failure `catch (procErr) { ... }` block from `processQueue()`'s event-processing logic, accidentally pasted into the middle of the backlog-logging method. This referenced `event` and `procErr` which don't exist in that scope, causing a `SyntaxError: Unexpected token 'catch'` that broke the entire module (and anything importing it, including the DLQ worker).

Removed the stray leaked block so `logBacklogIfNeeded()` keeps only its original single `try/catch`, logging the backlog count via `logger.info` and falling back to `logger.warn` on failure — matching its documented "best-effort, no-op on failure" behavior.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `npx vitest run test/unit/dlqService.test.js`
- **Test Steps / Prerequisites:** Synced local `main` with `upstream/main` to get the affected file version, applied the fix, ran `node --check` to confirm valid syntax, then ran the full existing unit test suite for this file.
- **Expected Result:** File parses without a SyntaxError, and all existing dlqService tests pass unaffected.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #8312

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook failure handling by centralizing retry scheduling and permanent-failure processing.
  * Removed redundant failure persistence logic from the queue-processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->