### PR TITLE
fix: guard null coordinate result before .error access

### DIFF
--- a/backend/api/src/middleware/shardMiddleware.js
+++ b/backend/api/src/middleware/shardMiddleware.js
@@ -29,9 +29,9 @@ export const shardMiddleware = async (req, res, next) => {
       const parsedLat = parseCoordinate(rawLat);
       const parsedLng = parseCoordinate(rawLng);
 
-      if (rawLat === undefined || rawLng === undefined || parsedLat.error || parsedLng.error) {
+      if (rawLat === undefined || rawLng === undefined || parsedLat === null || parsedLng === null || parsedLat.error || parsedLng.error) {
         return res.status(400).json({
-          error: parsedLat.error || parsedLng.error || 'lat and lng are both required when routing by location'
+          error: parsedLat?.error || parsedLng?.error || 'lat and lng are both required when routing by location'
         });
       }
 


### PR DESCRIPTION
## Description
`shardMiddleware.js` threw an unhandled `TypeError: Cannot read properties of null (reading 'error')` when a client sent only one of `lat`/`lng`. `parseCoordinate()` returns `null` (not `{ error }`) when a value is `undefined`, but the validation check accessed `parsedLat.error`/`parsedLng.error` directly without first guarding against `null`. The error was silently swallowed by the outer `try/catch`, which then routed the request to the default `north` shard and returned `200 OK` instead of the intended `400`.

Added explicit `null` checks (`parsedLat === null || parsedLng === null`) before the `.error` access, and used optional chaining (`?.`) when building the error message so it can't throw even if one side is `null` while the other has `.error`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `npx vitest run test/unit/shardMiddleware.test.js`
- **Test Steps / Prerequisites:** Ran `node --check` to confirm valid syntax, ran the existing unit test suite (no regressions), and manually simulated the exact bug scenario from the issue (only `lat` provided, `lng` missing) in an isolated script to confirm it now correctly triggers the 400 rejection path instead of throwing/falling through to the `north` shard.
- **Expected Result:** Requests missing either coordinate now return `400 { error: 'lat and lng are both required when routing by location' }` instead of silently succeeding on the `north` shard.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #8313

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.