### PR TITLE
fix: scope WorkerEventAdapter message delivery to originating worker 

### DIFF
--- a/backend/api/src/core/events/adapters/WorkerEventAdapter.js
+++ b/backend/api/src/core/events/adapters/WorkerEventAdapter.js
@@ -51,7 +51,7 @@ export class WorkerEventAdapter extends EventPublisher {
             },
             payload: message.payload || message,
           };
-          this._emitWorkerEvent(event);
+          this._emitWorkerEvent(name, event);
         }
       });
     }
@@ -98,8 +98,8 @@ export class WorkerEventAdapter extends EventPublisher {
     this._messageHandlers.get(workerName).push(handler);
   }
 
-  _emitWorkerEvent(event) {
-    for (const [, handlers] of this._messageHandlers) {
+  _emitWorkerEvent(workerName, event) {
+    const handlers = this._messageHandlers.get(workerName) || [];
       for (const handler of handlers) {
         try {
           const result = handler(event);
@@ -110,6 +110,5 @@ export class WorkerEventAdapter extends EventPublisher {
           logger.error('[WorkerEventAdapter] Handler error:', err.message);
         }
       }
-    }
   }
 }


### PR DESCRIPTION
## Description
`WorkerEventAdapter._emitWorkerEvent()` iterated over every registered worker's handler array and delivered the message to all of them, discarding which worker actually emitted it. `onWorkerMessage(workerName, handler)` is explicitly keyed per-worker, but that key was never used when dispatching — with two or more workers, a message from worker A was also delivered to worker B's handlers, causing double-processing and cross-pipeline side effects on foreign data.

Threaded the worker name through: `registerWorker()`'s message listener now calls `this._emitWorkerEvent(name, event)` instead of `this._emitWorkerEvent(event)`, and `_emitWorkerEvent(workerName, event)` now looks up only `this._messageHandlers.get(workerName)` instead of iterating the entire `_messageHandlers` map.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `node --check`, `npx vitest run test/unit/core/workerEventAdapter.test.js`, plus a standalone reproduction script
- **Test Steps / Prerequisites:** Ran the existing unit test suite (7/7 pass, no regressions — though as the issue notes, that suite only registers a single worker so it wouldn't have caught this bug on its own). Wrote an isolated script registering two workers (A and B) and emitting a message tagged as coming from worker A, confirming worker B's handler is not invoked.
- **Expected Result:** A message from worker A only reaches worker A's registered handlers; worker B's handler count stays at 0.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #8317

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.