### PR TITLE
fix: bind ZKP verify/status endpoints to authenticated caller 

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -60,6 +60,9 @@ router.post('/verify', authenticate, zkpVerifyLimiter, async (req, res) => {
     if (!userId) {
       return res.status(400).json({ success: false, error: 'userId is required' });
     }
+    if (userId !== req.user.id) {
+      return res.status(403).json({ success: false, error: 'Forbidden' });
+    }
 
     const result = await zkpService.verifyDriver({
       userId,
@@ -102,6 +105,9 @@ router.post('/verify', authenticate, zkpVerifyLimiter, async (req, res) => {
 router.get('/status/:userId', authenticate, async (req, res) => {
   try {
     const { userId } = req.params;
+    if (userId !== req.user.id) {
+      return res.status(403).json({ success: false, error: 'Forbidden' });
+    }
     const verified = await zkpService.isVerified(userId);
     return res.status(200).json({ success: true, verified });
   } catch (error) {


### PR DESCRIPTION
## Description
`POST /zkp/verify` and `GET /zkp/status/:userId` operated on an attacker-chosen `userId` with no ownership check against the authenticated user — a cross-user authorization (IDOR) vulnerability, not just a missing feature. `authenticate` middleware only confirmed the caller was logged in; it never bound the request to the target `userId`.

**Impact fixed:**
- Any authenticated user could previously mark any other user as KYC-verified (privilege/status tampering) and insert `zk_proofs` rows for them.
- Any authenticated user could previously probe whether a given victim was KYC-verified (info disclosure), including victims' wallet addresses used in the on-chain calls.

Added an explicit ownership check to both endpoints: `if (userId !== req.user.id) return res.status(403).json({ success: false, error: 'Forbidden' })`, placed immediately after parameter extraction and before any service/blockchain calls.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `node --check`, plus a standalone script simulating both handlers with mock `req`/`res` objects
- **Test Steps / Prerequisites:** No existing test file covers `zkp.routes.js`. Simulated 4 scenarios: (1) user verifying themselves, (2) user attempting to verify a different `userId`, (3) user checking their own status, (4) user attempting to check another user's status.
- **Expected Result:** Self-access returns 200 and proceeds normally; cross-user access on both endpoints returns 403 Forbidden before reaching `zkpService`.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.) — no existing test file for this route

## Related Issues
Closes #8319

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.