### PR TITLE
fix(snyk): store sanitized path in code scan records

### DIFF
--- a/snyk/snyk.service.js
+++ b/snyk/snyk.service.js
@@ -135,7 +135,7 @@ class SnykService {
             const results = JSON.parse(stdout);
             this.scanResults.push({
                 type: 'code',
-                path,
+                path: safePath,
                 timestamp: new Date().toISOString(),
                 results
             });


### PR DESCRIPTION
## Problem

`SnykService.scanCode` computed `safePath` (via `_sanitizePath`) to build the snyk command, but the pushed scan record used the bare `path` identifier — the imported `node:path` module — instead of the sanitized project path. `GET /api/snyk/stats` scan records for code scans therefore contained the Node `path` module object rather than the directory that was scanned.

## Fix

Use `safePath` when pushing the code scan record, matching how the other scan methods store their input.

## Files changed

- `snyk/snyk.service.js`

## Testing

Confirmed the code scan record now stores the sanitized project path (`safePath`) instead of the imported `path` module, so `getStats()`/scan records show which directory was scanned.

Closes #8413
