### PR TITLE
fix(notifications): forward order/trip/bid ids for deep-linking

### DIFF
--- a/apps/customer/lib/screens/notifications_screen.dart
+++ b/apps/customer/lib/screens/notifications_screen.dart
@@ -23,6 +23,10 @@ class NotificationsScreen extends StatelessWidget {
           type: item.notifType,
           title: item.title,
           body: item.body,
+          orderId: item.orderId,
+          tripId: item.tripId,
+          bidId: item.bidId,
+          supportTicketId: item.supportTicketId,
         );
         final route = shared.NotificationRouter.resolve(payload);
         shared.NotificationRouter.executeNavigation(context, route);

--- a/packages/truxify_shared/lib/src/models/notification_item.dart
+++ b/packages/truxify_shared/lib/src/models/notification_item.dart
@@ -28,6 +28,9 @@ class NotificationItem {
   /// Bid ID extracted from [metadata], if present.
   String? get bidId => metadata?['bid_id']?.toString();
 
+  /// Support ticket ID extracted from [metadata], if present.
+  String? get supportTicketId => metadata?['support_ticket_id']?.toString();
+
   factory NotificationItem.fromMap(Map<String, dynamic> map) {
     final metadata = map['metadata'];
 


### PR DESCRIPTION
## Problem

The customer notifications screen built the navigation `NotificationPayload` with only `type`/`title`/`body`, dropping the identifiers `NotificationItem` already carries (`orderId`, `tripId`, `bidId`). `NotificationRouter` only navigates to the order detail / live-tracking / load-detail screens when `orderId`/`bidId` are set, so every tap fell back to the plain notifications list — order and bid notifications could never deep-link.

## Fix

Forwarded the identifiers into the payload:

- `orderId`, `tripId`, `bidId` from the item's existing metadata getters.
- Added a `supportTicketId` getter to `NotificationItem` (reading `metadata['support_ticket_id']`) and forwarded it so support-ticket notifications can also deep-link, matching the router's `support_ticket` case.

## Files changed

- `apps/customer/lib/screens/notifications_screen.dart`
- `packages/truxify_shared/lib/src/models/notification_item.dart`

## Testing

Confirmed the payload now carries `orderId`/`tripId`/`bidId`/`supportTicketId`, so `NotificationRouter` resolves `order_update` to order detail, `order_delivered` to live tracking, and `bid_received` to load detail instead of the notifications list.

Closes #8417
