### PR TITLE
fix(booking): pass selected pickup date when creating order

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -168,6 +168,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
         dropLat: finalDropLat,
         dropLng: finalDropLng,
         pickupTime: widget.draft.dateLabel,
+        pickupDate: widget.draft.pickupDate,
         goodsType: widget.draft.goodsType + (_isPassengerMode ? ' + Passenger' : ''),
         weightTonnes: double.tryParse(widget.draft.weightTonnes) ?? 0,
         paymentMethodId: _selectedPayment?.id,


### PR DESCRIPTION
## Problem

The booking confirmation screen never passed `pickupDate` when creating an order, so `createOrder` fell back to `DateTime.now()` for `pickup_date`. Whenever a user booked for a future date, the created order recorded today's date as the pickup day, and the mismatch propagated to scheduling/reminders that rely on `pickup_date`.

## Fix

Forwarded the selected date from the draft model to `createOrder` (`pickupDate: widget.draft.pickupDate`), so the created order's `pickup_date` reflects the date the user chose instead of `now()`.

## Files changed

- `apps/customer/lib/screens/booking_confirmation_screen.dart`

## Testing

Confirmed `createOrder` is now called with the draft's `pickupDate`, so `order_service.dart` sends the user-selected date in `pickup_date` rather than the `DateTime.now()` fallback.

Closes #8418
