### PR TITLE
fix(orders): remove no-op Delivery Date sort option

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -58,7 +58,7 @@ class _OrdersScreenState extends State<OrdersScreen>
   DateTime? _startDate;
   DateTime? _endDate;
   String _selectedSort = 'Newest';
-  final List<String> _sortOptions = ['Newest', 'Oldest', 'Delivery Date'];
+  final List<String> _sortOptions = ['Newest', 'Oldest'];
 
   void _resetFilters() {
     setState(() {
@@ -432,12 +432,9 @@ class _OrdersScreenState extends State<OrdersScreen>
       final dateB = DateTime.tryParse(b.date) ?? DateTime(1970);
       if (_selectedSort == 'Oldest') {
         return dateA.compareTo(dateB);
-      } else if (_selectedSort == 'Delivery Date') {
-        return dateB.compareTo(dateA); // Or delivery date equivalent fallback
-      } else {
-        // Default 'Newest'
-        return dateB.compareTo(dateA);
       }
+      // Default 'Newest'
+      return dateB.compareTo(dateA);
     });
 
     return filtered;


### PR DESCRIPTION
## Problem

The "Delivery Date" sort option in the customer orders screen was byte-for-byte identical to the default "Newest" comparator (both `dateB.compareTo(dateA)`), and even the ordering key is the pickup date (`order.date` is mapped from `order['pickup_date']`). Selecting "Delivery Date" was a no-op. The order data model has no delivery/ETA date field, so a distinct delivery-date ordering could not be implemented.

## Fix

Removed the non-functional "Delivery Date" option from `_sortOptions` (the data model exposes no delivery date) and removed the dead `'Delivery Date'` branch from the sort comparator, leaving the two working options: "Newest" and "Oldest".

## Files changed

- `apps/customer/lib/screens/orders_screen.dart`

## Testing

Confirmed the sort options now contain only `['Newest', 'Oldest']`, and the sort comparator only handles `'Oldest'` (ascending) versus the default "Newest" (descending), so there is no longer a duplicated no-op branch.

Closes #8419
