### PR TITLE
fix(profile): keep localized profile load error message

### DIFF
--- a/apps/customer/lib/screens/edit_profile_screen.dart
+++ b/apps/customer/lib/screens/edit_profile_screen.dart
@@ -55,7 +55,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         setState(() {
           _isLoading = false;
           _loadError = AppLocalizations.of(context)!.failedToLoadProfile;
-          _loadError = 'Profile not found';
         });
       }
     } catch (e) {


### PR DESCRIPTION
## Problem

In the customer edit-profile screen, `_loadError` was assigned the localized `AppLocalizations.of(context)!.failedToLoadProfile` value and then immediately overwritten by the hardcoded string `'Profile not found'`. The second assignment made the first unreachable, so users always saw the literal English text in every locale and the l10n entry was never used.

## Fix

Removed the overwriting hardcoded assignment, keeping the localized `failedToLoadProfile` message.

## Files changed

- `apps/customer/lib/screens/edit_profile_screen.dart`

## Testing

Confirmed `_loadError` now retains the localized `failedToLoadProfile` value when the profile is missing, so the UI shows the localized message for the current app locale instead of the hardcoded English text.

Closes #8420
