### PR TITLE
fix(driver): use FreightSmartContract instead of undefined SmartContract type

### DIFF
--- a/apps/driver/lib/models/smart_contract_model.dart
+++ b/apps/driver/lib/models/smart_contract_model.dart
@@ -3,8 +3,10 @@ class FreightSmartContract {
   final String loadId;
   final String brokerName;
   final double payoutAmount;
-  final String status; // 'ESCROW_FUNDED', 'POD_UPLOADED', 'GEOFENCE_BREACHED', 'SETTLED'
+  final String status; // 'ESCROW_FUNDED', 'POD_UPLOADED', 'GEOFENCE_BREACHED', 'RELEASED', 'SETTLED'
   final String walletAddress;
+  final bool isGeofenceConfirmed;
+  final bool isPodUploaded;
   final DateTime createdAt;
   final DateTime? settledAt;
 
@@ -15,6 +17,8 @@ class FreightSmartContract {
     required this.payoutAmount,
     required this.status,
     required this.walletAddress,
+    this.isGeofenceConfirmed = false,
+    this.isPodUploaded = false,
     required this.createdAt,
     this.settledAt,
   });

--- a/apps/driver/lib/screens/settlement_wallet_screen.dart
+++ b/apps/driver/lib/screens/settlement_wallet_screen.dart
@@ -11,7 +11,7 @@ class SettlementWalletScreen extends StatefulWidget {
 
 class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
   final SmartContractService _contractService = SmartContractService();
-  List<SmartContract> _contracts = [];
+  List<FreightSmartContract> _contracts = [];
   bool _isLoading = true;
   double _walletBalance = 4250.00; // Mock current balance
 
@@ -31,30 +31,34 @@ class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
     }
   }
 
-  Future<void> _processPayout(SmartContract contract) async {
+  Future<void> _processPayout(FreightSmartContract contract) async {
     if (contract.status == 'RELEASED') return;
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Verifying conditions and executing smart contract...')),
     );
 
-    final success = await _contractService.triggerPayout(contract.contractAddress);
+    final success = await _contractService.triggerPayout(contract.contractId);
     if (success && mounted) {
       setState(() {
-        _walletBalance += contract.escrowAmount;
+        _walletBalance += contract.payoutAmount;
         // Update local state to reflect released contract
         final index = _contracts.indexOf(contract);
-        _contracts[index] = SmartContract(
-          contractAddress: contract.contractAddress,
+        _contracts[index] = FreightSmartContract(
+          contractId: contract.contractId,
           loadId: contract.loadId,
-          escrowAmount: contract.escrowAmount,
+          brokerName: contract.brokerName,
+          payoutAmount: contract.payoutAmount,
           isGeofenceConfirmed: true,
           isPodUploaded: true,
           status: 'RELEASED',
+          walletAddress: contract.walletAddress,
+          createdAt: contract.createdAt,
+          settledAt: DateTime.now(),
         );
       });
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('\$${contract.escrowAmount} released to wallet instantly!')),
+        SnackBar(content: Text('\$${contract.payoutAmount} released to wallet instantly!')),
       );
     }
   }
@@ -117,7 +121,7 @@ class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
                                 Text('Load: ${contract.loadId}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-                                Text('\$${contract.escrowAmount.toStringAsFixed(2)}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: Colors.green)),
+                                Text('\$${contract.payoutAmount.toStringAsFixed(2)}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: Colors.green)),
                               ],
                             ),
                             const SizedBox(height: 12),

--- a/apps/driver/lib/services/smart_contract_service.dart
+++ b/apps/driver/lib/services/smart_contract_service.dart
@@ -3,31 +3,38 @@ import '../models/smart_contract_model.dart';
 
 class SmartContractService {
   /// Simulates fetching the active smart contracts for a driver's digital wallet
-  Future<List<SmartContract>> fetchActiveContracts() async {
+  Future<List<FreightSmartContract>> fetchActiveContracts() async {
     await Future.delayed(const Duration(seconds: 1));
+    final now = DateTime.now();
     return [
-      SmartContract(
-        contractAddress: '0xabc123...',
+      FreightSmartContract(
+        contractId: '0xabc123...',
         loadId: 'L-5920-A',
-        escrowAmount: 1850.00,
+        brokerName: 'ACME Freight',
+        payoutAmount: 1850.00,
         isGeofenceConfirmed: true,
         isPodUploaded: false,
         status: 'ESCROW_FUNDED',
+        walletAddress: '0xabc123...',
+        createdAt: now.subtract(const Duration(days: 2)),
       ),
-      SmartContract(
-        contractAddress: '0xdef456...',
+      FreightSmartContract(
+        contractId: '0xdef456...',
         loadId: 'L-5921-B',
-        escrowAmount: 2400.00,
+        brokerName: 'ACME Freight',
+        payoutAmount: 2400.00,
         isGeofenceConfirmed: true,
         isPodUploaded: true,
         status: 'RELEASED',
+        walletAddress: '0xdef456...',
+        createdAt: now.subtract(const Duration(days: 1)),
       ),
     ];
   }
 
   /// Simulates executing a blockchain transaction to release funds
   /// when both GPS arrival and PoD upload conditions are met.
-  Future<bool> triggerPayout(String contractAddress) async {
+  Future<bool> triggerPayout(String contractId) async {
     // Simulate network delay for block mining/verification
     await Future.delayed(const Duration(seconds: 3));
     return true; // transaction successful


### PR DESCRIPTION
## Problem

The driver app references a `SmartContract` type that does not exist anywhere in the codebase — only `FreightSmartContract` is defined — so `dart analyze` / `flutter build` fails with "Undefined class 'SmartContract'" and the whole driver package cannot compile.

- `apps/driver/lib/services/smart_contract_service.dart` used `SmartContract(...)` (lines 6, 9, 17).
- `apps/driver/lib/screens/settlement_wallet_screen.dart` used `List<SmartContract>` (line 14), `_processPayout(SmartContract contract)` (line 34), and `_contracts[index] = SmartContract(...)` (line 47).

A rename alone is not enough: the field sets differ (`contractId`/`brokerName`/`payoutAmount` vs `contractAddress`/`loadId`/`escrowAmount`).

## Fix

Switched both files to the existing `FreightSmartContract` type and mapped the fields the screen uses:

- `contractAddress` → `contractId`
- `escrowAmount` → `payoutAmount`
- `isGeofenceConfirmed` / `isPodUploaded` → added to the model (with defaults, so existing constructors in `blockchain_settlement_service.dart` keep working)
- Added the model's required `brokerName`, `walletAddress`, and `createdAt` to the mock contracts.
- Renamed `triggerPayout(String contractAddress)` → `triggerPayout(String contractId)` to match the model.

## Files changed

- `apps/driver/lib/models/smart_contract_model.dart` — added `isGeofenceConfirmed` / `isPodUploaded` fields; documented `RELEASED` status.
- `apps/driver/lib/services/smart_contract_service.dart` — uses `FreightSmartContract` with mapped fields.
- `apps/driver/lib/screens/settlement_wallet_screen.dart` — typed against `FreightSmartContract`, all usages mapped.

## Testing

- Manual review: no remaining references to the undefined `SmartContract` type in the touched files; the `FreightSmartContract` constructors in `blockchain_settlement_service.dart` / `freight_settlement_dashboard.dart` still compile (new model fields are optional).
- The other `SmartContract*` classes (`SmartContractService`, `SmartContractPayment`, `SmartContractPaymentService`) are separately defined and untouched.

Closes #8422
