### PR TITLE
fix(wallet): gate payout on geofence and PoD upload preconditions

### DIFF
--- a/apps/driver/lib/screens/settlement_wallet_screen.dart
+++ b/apps/driver/lib/screens/settlement_wallet_screen.dart
@@ -33,6 +33,12 @@ class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
 
   Future<void> _processPayout(SmartContract contract) async {
     if (contract.status == 'RELEASED') return;
+    if (!contract.isGeofenceConfirmed || !contract.isPodUploaded) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('PoD upload and GPS arrival required before payout.')),
+      );
+      return;
+    }
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Verifying conditions and executing smart contract...')),


### PR DESCRIPTION
## Problem

`SettlementWalletScreen._processPayout` released escrow without enforcing the GPS-arrival / PoD-upload conditions documented on `SmartContractService.triggerPayout`. It only skipped contracts whose status was already `'RELEASED'`, so a contract with `isPodUploaded: false` (no proof of delivery) was eligible for immediate payout. The `isGeofenceConfirmed` / `isPodUploaded` preconditions were dead code.

## Fix

Gated the payout on the documented conditions in `_processPayout` before executing the transaction:

```dart
if (contract.status == 'RELEASED') return;
if (!contract.isGeofenceConfirmed || !contract.isPodUploaded) {
  ScaffoldMessenger.of(context).showSnackBar(
    const SnackBar(content: Text('PoD upload and GPS arrival required before payout.')),
  );
  return;
}
```

Funds are now only released when the driver arrived (geofence confirmed) **and** uploaded the PoD.

## Files changed

- `apps/driver/lib/screens/settlement_wallet_screen.dart` — added the precondition guard in `_processPayout`.

## Testing

- Manual review: the payout path is unreachable when either `isGeofenceConfirmed` or `isPodUploaded` is false; a snackbar explains why instead of releasing funds.
- Note: the guard reads `isGeofenceConfirmed` / `isPodUploaded`, which were missing from the `FreightSmartContract` model on `main`; those fields are added by PR #8422. Both PRs must merge for the driver app to compile.

Closes #8423
