### PR TITLE
fix(ml): serialize torch.Size shapes as JSON-compatible lists

### DIFF
--- a/backend/ml/routes/diffusion_routes.py
+++ b/backend/ml/routes/diffusion_routes.py
@@ -54,7 +54,7 @@ async def generate_routes(request: GenerateRequest):
             'success': True,
             'data': {
                 'routes': routes.cpu().numpy().tolist(),
-                'shape': routes.shape,
+                'shape': list(routes.shape),
                 'num_routes': request.batch_size
             },
             'timestamp': datetime.now().isoformat()

--- a/backend/ml/routes/gat_routes.py
+++ b/backend/ml/routes/gat_routes.py
@@ -65,7 +65,7 @@ async def build_graph(request: GraphRequest):
             'data': {
                 'nodes': len(graph.nodes),
                 'edges': len(graph.edges),
-                'features': data.x.shape,
+                'features': list(data.x.shape),
                 'is_connected': nx.is_connected(graph)
             },
             'timestamp': datetime.now().isoformat()

--- a/backend/ml/routes/pinns_routes.py
+++ b/backend/ml/routes/pinns_routes.py
@@ -78,7 +78,7 @@ async def predict_pinns(x: List[List[float]]):
             'success': True,
             'data': {
                 'predictions': predictions.tolist(),
-                'shape': predictions.shape
+                'shape': list(predictions.shape)
             },
             'timestamp': datetime.now().isoformat()
         }


### PR DESCRIPTION
## Problem

Three ML routes return `torch.Size` objects (which are not JSON serializable) inside FastAPI responses, causing a 500 error:

- `backend/ml/routes/diffusion_routes.py:57` — `'shape': routes.shape`
- `backend/ml/routes/gat_routes.py:68` — `'features': data.x.shape`
- `backend/ml/routes/pinns_routes.py:81` — `'shape': predictions.shape`

## Fix

Wrapped each `torch.Size` in `list(...)` so it serializes as a plain JSON array of integers (e.g. `[4, 10, 2]`):

- `list(routes.shape)`
- `list(data.x.shape)`
- `list(predictions.shape)`

## Files changed

- `backend/ml/routes/diffusion_routes.py`
- `backend/ml/routes/gat_routes.py`
- `backend/ml/routes/pinns_routes.py`

## Testing

- Python `ast.parse` passes on all three files.
- `list(torch.Size(...))` yields a standard Python list of ints, which FastAPI/pydantic serializes without error.

Closes #8424
