### PR TITLE
fix(ml): preserve 404 HTTPException in threshold endpoints

### DIFF
--- a/backend/ml/routes/anomaly_routes.py
+++ b/backend/ml/routes/anomaly_routes.py
@@ -181,6 +181,8 @@ async def set_threshold(data_type: str, threshold: float):
             }
         else:
             raise HTTPException(status_code=404, detail=f"Data type {data_type} not found")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Threshold setting failed: {e}")
         logger.error(f"Internal error: {e}")
@@ -203,6 +205,8 @@ async def get_threshold(data_type: str):
             }
         else:
             raise HTTPException(status_code=404, detail=f"Data type {data_type} not found")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Threshold fetch failed: {e}")
         logger.error(f"Internal error: {e}")


### PR DESCRIPTION
## Problem

`set_threshold` and `get_threshold` in `anomaly_routes.py` raise `HTTPException(status_code=404, ...)` for unknown data types inside the `try` block, but the broad `except Exception` catches and re-wraps it as a 500 "Internal server error". Clients asking for an unknown data type get a misleading 500 instead of a 404.

## Fix

Added `except HTTPException: raise` before the broad `except Exception` in both handlers, so the intended 404 passes through untouched while genuine errors still surface as 500.

- `set_threshold` (POST `/anomaly/threshold/set`)
- `get_threshold` (GET `/anomaly/threshold/{data_type}`)

## Files changed

- `backend/ml/routes/anomaly_routes.py`

## Testing

- Python `ast.parse` passes.
- With an unknown `data_type`, `HTTPException(404)` now propagates to FastAPI's handler instead of being converted to a 500.

Closes #8425
