### PR TITLE
fix(api): remove duplicate DELIVERY_IN_PROGRESS_STATUSES declaration in OracleService

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -14,12 +14,6 @@ const DELIVERY_IN_PROGRESS_STATUSES = new Set([
   'arriving',
 ]);
 
-const DELIVERY_IN_PROGRESS_STATUSES = new Set([
-  'picked_up',
-  'in_transit',
-  'arriving',
-]);
-
 class OracleService {
   constructor(deps = {}) {
     this.orderRepository = deps.orderRepository || null;


### PR DESCRIPTION
## Summary
`backend/api/src/oracle/OracleService.js` declared `DELIVERY_IN_PROGRESS_STATUSES` twice (lines 11-15 and 17-21). Duplicate `const` declarations in the same scope throw `SyntaxError: Identifier 'DELIVERY_IN_PROGRESS_STATUSES' has already been declared` at module load, which breaks the whole API boot since `OracleService` is imported by `core/container.js` and `services/order/deliveryVerificationService.js`.

## Changes
- Removed the duplicate block, keeping the single declaration.

Closes #8467

GSSOC 2026
