### PR TITLE
fix(api): pick up stale pending orders with NULL escrow_status for cancellation

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -573,7 +573,7 @@ export class OrderRepository {
       .select('id')
       .eq('status', 'pending')
       .lt('created_at', cutoff)
-      .neq('escrow_status', 'funding')
+      .or('escrow_status.is.null,escrow_status.neq.funding')
       .limit(limit), 'findStalePendingOrders');
   }
 

--- a/backend/api/test/unit/repositories/orderRepositoryStaleCancel.test.js
+++ b/backend/api/test/unit/repositories/orderRepositoryStaleCancel.test.js
@@ -12,7 +12,7 @@ describe('OrderRepository stale-order cancellation', () => {
     orderRepository = new OrderRepository(supabaseMock.supabase);
   });
 
-  it('findStalePendingOrders selects only pending, older-than-cutoff, non-funding orders in a bounded batch', async () => {
+  it('findStalePendingOrders selects only pending, older-than-cutoff, non-funding or null-escrow orders in a bounded batch', async () => {
     supabaseMock.programData([]);
 
     const cutoff = '2024-01-01T00:00:00.000Z';
@@ -24,7 +24,7 @@ describe('OrderRepository stale-order cancellation', () => {
     expect(call.filters).toEqual(expect.arrayContaining([
       { col: 'status', op: 'eq', val: 'pending' },
       { col: 'created_at', op: 'lt', val: cutoff },
-      { col: 'escrow_status', op: 'neq', val: 'funding' },
+      { col: null, op: 'or', val: 'escrow_status.is.null,escrow_status.neq.funding' },
     ]));
     expect(call.limit).toBe(100);
   });


### PR DESCRIPTION
## Summary
`findStalePendingOrders()` (`backend/api/src/repositories/orderRepository.js:570-577`) filtered with `.neq('escrow_status', 'funding')`. PostgREST's `column.neq(value)` does not match `NULL`, so orders with `escrow_status IS NULL` (orders created before escrow support, or never escrow-funded) were never returned by the stale-cancellation query — the `staleOrderWorker` could never cancel plain non-escrow stale orders, leaving them `pending` forever.

## Changes
- Replaced `.neq('escrow_status', 'funding')` with `.or('escrow_status.is.null,escrow_status.neq.funding')` so both NULL and non-funding rows are selected.
- Updated `test/unit/repositories/orderRepositoryStaleCancel.test.js` to assert the new `or` filter.

Closes #8470

GSSOC 2026
