### PR TITLE
fix(api): import errorResponse in deviceController for metadata validation 400s

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,5 +1,6 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
+import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];

--- a/backend/api/test/unit/deviceController.test.js
+++ b/backend/api/test/unit/deviceController.test.js
@@ -65,4 +65,30 @@ describe('registerDeviceToken', () => {
     expect(next).not.toHaveBeenCalled();
     expect(supabaseMock.calls.some((call) => call.table === 'user_devices')).toBe(false);
   });
+
+  it('returns a structured VALIDATION_ERROR 400 when metadata is invalid', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        fcmToken: 'valid_token_12345',
+        metadata: 'not-an-object',
+      },
+    };
+    const res = makeResponse();
+    const next = vi.fn();
+
+    await registerDeviceToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({
+          code: 'VALIDATION_ERROR',
+          message: 'metadata must be an object',
+        }),
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
`backend/api/src/controllers/deviceController.js` called `errorResponse('VALIDATION_ERROR', metadataErr)` but never imported `errorResponse`. When a device registered with invalid metadata, the handler threw `ReferenceError: errorResponse is not defined` (a 500) instead of returning the intended structured 400.

## Changes
- Added the missing import: `import { errorResponse } from '../utils/apiResponse.js';`.
- Added a unit test in `test/unit/deviceController.test.js` asserting invalid metadata returns a 400 with `success: false` and `error.code === 'VALIDATION_ERROR'`.

Closes #8471

GSSOC 2026
