### PR TITLE
[Bug] Restore the gutted ml.js module and land the #6988 request-context logging properly

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -37,6 +37,10 @@ function parseWeightKg(weight) {
   return match[2] === 'kg' ? value : value * 1000;
 }
 
+/**
+ * Same as parseWeightKg, but never returns NaN: an unparseable value is logged
+ * and treated as 0 so a bad `weight` string cannot poison an ML payload.
+ */
 function parseWeightKgSafe(weight) {
   const result = parseWeightKg(weight);
   if (Number.isNaN(result)) {
@@ -79,16 +83,283 @@ function getHeaders() {
     if (process.env.ML_API_KEY) {
         headers['X-API-Key'] = process.env.ML_API_KEY;
     }
+    return headers;
+}
 
-    if (response.status === 401) {
-      throw new Error(`[MLService] Unauthorized (401) for ${method} ${url}`);
+/**
+ * Read a response body as text without assuming which accessor exists.
+ * Real fetch Responses expose text(); this stays tolerant so a failure to
+ * read the body can never mask the status code we are reporting.
+ */
+async function readBodyText(response) {
+    try {
+        if (typeof response.text === 'function') {
+            return await response.text();
+        }
+        if (typeof response.json === 'function') {
+            return JSON.stringify(await response.json());
+        }
+    } catch {
+        // fall through — the status code is the useful part of the error
+    }
+    return '';
+}
+
+/**
+ * Utility: handle ML engine responses consistently.
+ *
+ * Errors carry the request context (method, URL, status) so a failure can be
+ * traced to the specific ML call that produced it (issue #6988).
+ */
+async function handleResponse(response, url = '', method = 'GET') {
+    const context = `${method} ${url}`.trim() || 'ML request';
+
+    if (response.status === 401 || response.status === 403) {
+        throw new Error(
+            `[ML] Authentication failed (${response.status}) for ${context}: ${await readBodyText(response)}`
+        );
+    }
+    if (!response.ok) {
+        throw new Error(
+            `[ML] Request failed (${response.status}) for ${context}: ${await readBodyText(response)}`
+        );
     }
 
-    if (response.status === 403) {
-      throw new Error(`[MLService] Forbidden (403) for ${method} ${url}`);
+    const text = await readBodyText(response);
+    try {
+        return JSON.parse(text);
+    } catch (err) {
+        throw new Error(
+            `[ML] Invalid JSON response from ML engine for ${context}: ${err.message}`,
+            { cause: err }
+        );
     }
+}
 
-  const result = await handleResponse(response);
+/**
+ * Utility: resolve base URL for ML engine
+ */
+function getBaseUrl() {
+    return (
+        process.env.ML_ENGINE_URL ||
+        process.env.ML_SERVICE_URL ||
+        DEFAULT_ML_ENGINE_URL
+    );
+}
+
+/**
+ * Predicts ride/truck demand
+ * @param {object} features
+ * @returns {Promise<object>}
+ */
+export async function predictDemand(features = {}) {
+  guardMlApiKey();
+  const cacheKey = JSON.stringify(features);
+  const cached = demandCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const url = `${getBaseUrl()}/predict/demand`;
+
+  const response = await fetch(url, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(features),
+      signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const result = await handleResponse(response, url, 'POST');
+  demandCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Predicts freight price.
+ *
+ * Returns the validated ML response with `estimatedPricePaisa` (paisa integer)
+ * and `estimatedPriceInr` (INR float) added. Throws on any validation failure
+ * so callers can transparently fall back to deterministic pricing.
+ *
+ * @param {object} params
+ * @returns {Promise<{estimated_price: number, currency: string, estimatedPricePaisa: number}>}
+ * @throws {Error} on HTTP failure, timeout, or prediction validation failure
+ */
+export async function predictPrice({
+    distanceKm,
+    cargoWeightKg,
+    truckType = 'medium_truck',
+    routeOrigin = '',
+    routeDestination = '',
+    trafficMultiplier = 1.0,
+} = {}) {
+  guardMlApiKey();
+  
+  const cacheKey = JSON.stringify({ distanceKm, cargoWeightKg, truckType, routeOrigin, routeDestination, trafficMultiplier });
+  const cached = priceCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const url = `${getBaseUrl()}/predict/price`;
+
+  const payload = {
+      distance_km: distanceKm,
+      cargo_weight_kg: cargoWeightKg,
+      truck_type: truckType,
+      route_origin: routeOrigin,
+      route_destination: routeDestination,
+      traffic_multiplier: trafficMultiplier,
+  };
+
+  const response = await fetch(url, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const raw = await handleResponse(response, url, 'POST');
+
+  const validated = validatePricePrediction(raw);
+  if (!validated.ok) {
+      logger.warn({
+          reason: validated.reason,
+          detail: validated.detail,
+          response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
+      }, '[ML] Price prediction rejected by validator');
+      throw new Error(`[ML] Invalid prediction: ${validated.reason} — ${validated.detail}`);
+  }
+
+  logger.debug({
+      estimated_price_inr: validated.validated.estimated_price,
+      confidence: validated.validated.confidence,
+  }, '[ML] Price prediction validated successfully');
+
+  const result = {
+      ...validated.validated,
+      estimatedPricePaisa: convertToPaisa(validated.validated.estimated_price * trafficMultiplier),
+      estimatedPriceInr: validated.validated.estimated_price * trafficMultiplier,
+  };
+  priceCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Predicts estimated time of arrival for a route.
+ *
+ * @param {object} params
+ * @param {number} params.routeDistance  - Route distance in km (must be > 0)
+ * @param {number} params.timeOfDay      - Hour of the day (0-23)
+ * @param {number} params.dayOfWeek      - Day of week (0=Sunday, 6=Saturday)
+ * @param {string} params.routeType      - Route type ("highway" or "city")
+ * @param {number} params.historicalSpeed - Historical average speed in km/h (must be > 0)
+ * @returns {Promise<{eta_minutes: number, confidence_interval: {lower: number, upper: number}}>}
+ * @throws {Error} if ML_API_KEY is missing, HTTP fails, or response is invalid
+ */
+export async function predictEta({
+  routeDistance,
+  timeOfDay,
+  dayOfWeek,
+  routeType,
+  historicalSpeed,
+}) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/predict/eta`;
+
+  const payload = {
+    route_distance: routeDistance,
+    time_of_day: timeOfDay,
+    day_of_week: dayOfWeek,
+    route_type: routeType,
+    historical_speed: historicalSpeed,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const result = await handleResponse(response, url, 'POST');
+
+  if (
+    result == null ||
+    typeof result.eta_minutes !== 'number' ||
+    !isFinite(result.eta_minutes)
+  ) {
+    throw new Error('[ML] Invalid ETA prediction: missing or non-finite eta_minutes');
+  }
+
+  return {
+    eta_minutes: result.eta_minutes,
+    confidence_interval: result.confidence_interval ?? { lower: 0, upper: 0 },
+  };
+}
+
+/**
+ * Matches shipments for bilateral load consolidation.
+ *
+ * @param {object} params
+ * @param {Array}  params.loads   - Array of load objects with origin/dest lat/lng, dimensions, deadline
+ * @param {Array}  params.drivers - Array of driver objects with current location, capacity, rating
+ * @returns {Promise<{assignments: Array, unmatched_loads: Array, unmatched_drivers: Array}>}
+ * @throws {Error} if ML_API_KEY is missing or HTTP fails
+ */
+export async function matchBilateral({ loads, drivers }) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/match/bilateral`;
+
+  const payload = { loads, drivers };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
+  });
+
+  return handleResponse(response, url, 'POST');
+}
+
+/**
+ * Predicts driver profit for a given route using ML model.
+ *
+ * @param {object} params
+ * @param {number} params.routeDistanceKm  - Total route distance in km (must be > 0)
+ * @param {number} params.fuelPricePerLitre - Current fuel price in INR/L (must be > 0)
+ * @param {number} params.tollEstimateInr  - Estimated toll cost in INR (must be >= 0)
+ * @param {number} params.truckMileageKmL  - Truck fuel efficiency in km/L (must be > 0)
+ * @param {number} params.cargoWeightKg    - Cargo weight in kg (must be > 0)
+ * @param {number} params.tripDurationHours - Estimated trip duration in hours (must be > 0)
+ * @returns {Promise<{predicted_profit: number, confidence_interval: {lower: number, upper: number}}>}
+ * @throws {Error} if ML_API_KEY is missing, HTTP fails, or response is invalid
+ */
+export async function predictDriverProfit({
+  routeDistanceKm,
+  fuelPricePerLitre,
+  tollEstimateInr,
+  truckMileageKmL,
+  cargoWeightKg,
+  tripDurationHours,
+}) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/predict/driver-profit`;
+
+  const payload = {
+    route_distance: routeDistanceKm,
+    fuel_price: fuelPricePerLitre,
+    toll_estimate: tollEstimateInr,
+    truck_mileage: truckMileageKmL,
+    cargo_weight: cargoWeightKg,
+    trip_duration: tripDurationHours,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const result = await handleResponse(response, url, 'POST');
 
   if (
     result == null ||
@@ -139,7 +410,7 @@ export async function optimisePacking({ packages, truck, deliveryAddresses }) {
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
   });
 
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -171,7 +442,7 @@ export async function recommendLoads({ userId, bookingHistory = [], ratedDrivers
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
 
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -203,7 +474,7 @@ export async function recommendTrucks({ userId, bookingHistory = [], ratedLoads 
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
 
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -237,7 +508,7 @@ export async function scoreTrust({ cancellationRate, onTimePct, avgRating, dispu
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
 
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -264,7 +535,7 @@ export async function matchDeadhead({ driverDestination, truckSpecs, arrivalTime
     }),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
   });
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -282,7 +553,7 @@ export async function optimiseMidTrip(routeData) {
     body: JSON.stringify(routeData),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -300,7 +571,7 @@ export async function trainDemandModel(force = false) {
     body: JSON.stringify({ force }),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
   });
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -318,7 +589,7 @@ export async function trainPriceModel(force = false) {
     body: JSON.stringify({ force }),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
   });
-  return handleResponse(response);
+  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -334,7 +605,7 @@ export async function listModels() {
     headers: getHeaders(),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
-  return handleResponse(response);
+  return handleResponse(response, url, 'GET');
 }
 
 /**
@@ -408,6 +679,7 @@ export async function matchEnRouteLoads({
     } catch (err) {
       logger.warn('[ML] matchEnRouteLoads: falling back to haversine. Reason: ' + err.message);
     }
+  }
 
   // Haversine fallback — score by distance to pickup
   if (!mlUsed || recommendations.length === 0) {
@@ -427,6 +699,60 @@ export async function matchEnRouteLoads({
       .filter(r => r.detour_km <= maxDetourKm)
       .sort((a, b) => b.match_score - a.match_score);
   }
+
+  // Build a lookup map of ML results keyed by load_id
+  const recMap = new Map(recommendations.map(r => [r.load_id, r]));
+
+  // Merge ML/haversine annotations back onto the original offer rows
+  const enriched = offers
+    .map(o => {
+      const rec = recMap.get(o.id);
+      if (!rec) return null; // not recommended by ML — exclude
+      return {
+        ...o,
+        detour_km: rec.detour_km ?? rec.distance_to_pickup_km ?? 0,
+        extra_earnings: rec.estimated_earnings
+          ? Math.round(rec.estimated_earnings * 100) // convert to paisa for consistency
+          : (o.freight_value || 0),
+        match_score: rec.match_score ?? 0,
+        extra_distance_km: rec.detour_km ?? 0,
+        ml_used: mlUsed,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.match_score - a.match_score);
+
+  return enriched;
 }
 
-module.exports = new MLService();
+/**
+ * Haversine great-circle distance in km between two lat/lng points.
+ * @private
+ */
+function _haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export const __testing = {
+  demandCache,
+  priceCache,
+  _haversineKm,
+};
+
+/**
+ * Default export kept for consumers that import the service as an object
+ * (e.g. `import mlService from '../services/ml.js'`) rather than by name.
+ * `handleResponse` is exposed so its request-context error contract can be
+ * tested directly.
+ */
+export default {
+  handleResponse,
+};

--- a/backend/api/test/unit/mlService.test.js
+++ b/backend/api/test/unit/mlService.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import mlService from '../../src/services/ml.js';
 
-describe('mlService handleResponse error context', () => {
+describe('ml handleResponse error context', () => {
   it('should include method, url, and status in non-ok error message', async () => {
     const mockResponse = {
       status: 500,
@@ -11,7 +11,7 @@ describe('mlService handleResponse error context', () => {
 
     await expect(mlService.handleResponse(mockResponse, 'https://api.ml.com/predict', 'POST'))
       .rejects
-      .toThrow(/POST.*https:\/\/api\.ml\.com\/predict.*500/);
+      .toThrow(/500.*POST.*https:\/\/api\.ml\.com\/predict/);
   });
 
   it('should include method, url, and status 401 for unauthorized', async () => {
@@ -23,7 +23,7 @@ describe('mlService handleResponse error context', () => {
 
     await expect(mlService.handleResponse(mockResponse, 'https://api.ml.com/embed', 'GET'))
       .rejects
-      .toThrow(/GET.*https:\/\/api\.ml\.com\/embed.*401/);
+      .toThrow(/401.*GET.*https:\/\/api\.ml\.com\/embed/);
   });
 
   it('should include method, url, and status 403 for forbidden', async () => {
@@ -35,6 +35,6 @@ describe('mlService handleResponse error context', () => {
 
     await expect(mlService.handleResponse(mockResponse, 'https://api.ml.com/train', 'PUT'))
       .rejects
-      .toThrow(/PUT.*https:\/\/api\.ml\.com\/train.*403/);
+      .toThrow(/403.*PUT.*https:\/\/api\.ml\.com\/train/);
   });
 });


### PR DESCRIPTION
Fixes #8486.

`ml.js` was replaced wholesale by a 26-line CommonJS stub and then partially reassembled by two merges. The module does not parse, and the entire ML integration surface is unloadable.

### Before

```
$ node --input-type=module -e "await import('./src/services/ml.js')"
SyntaxError: Unexpected reserved word

$ wc -l src/services/ml.js
432        # was 705
```

### How it happened

```
21cba0ce Merge PR #8022                              432  BAD
1db29c84 Merge PR #7910 (pr-7889)                    432  BAD
0a67b305 fix(api): deadhead pickup timing            705  OK
05ccab0c Merge main into fix/ml-service-...          423  BAD
01b3cb53 fix: add parseWeightKgSafe                  714  OK
87d3237a fix: add request context logging (#6988)     26  <-- gutted here
```

`87d3237a` replaced 705 lines of ESM with a CommonJS `class MLService` and `module.exports`. The later merges pulled most of the file back but kept fragments of the class: the 401/403 checks landed **inside `getHeaders()`**, destroying its `return headers`, and `module.exports = new MLService()` is still at the end of the file.

### Impact

- `predictDriverProfit` no longer exists, while `driverRoutes.js:132` imports it **by name** — an ESM link error, not a runtime `undefined`
- `handleResponse` undefined at all **14** call sites
- `getHeaders()` returned `undefined`, so every ML request would go out with no `Content-Type` and no `X-API-Key`
- 287 lines missing, including `getBaseUrl`, `predictDemand`, `predictPrice`, `predictEta`, `matchBilateral`, `_haversineKm` and `__testing`

### Change

Restored as the union of the last two good revisions — `0a67b305` plus `parseWeightKgSafe` from `01b3cb53`. They differ by four lines and do not overlap, so nothing is dropped.

Then landed **#6988 properly**, since that was the gutting commit's actual goal: `url` and `method` are threaded through all 14 call sites so every `handleResponse` error names the call that failed.

The two suites disagreed on format — `ml.test.js` (established) pins `'[ML] Authentication failed (401)'`, `mlService.test.js` (written for the deleted class) wanted method/url/status. I kept the established prefixes and appended ` for METHOD URL`, then updated `mlService.test.js`'s three regexes. Its assertions were tied to a module shape that never existed here; happy to flip the precedence if you prefer.

### Verification

```
$ npx vitest run test/unit/ml.test.js test/unit/mlService.test.js \
      test/ml.recommendLoads.test.js test/integration/predictProfit.test.js
      Tests  61 passed (61)
```

`predictProfit.test.js` still fails to *collect* — blocked by the unrelated duplicate `verifyDeliveryLimiter` in `rateLimiter.js`, which #7812 already covers. Every test that runs, passes.

`npx eslint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of demand, pricing, ETA, driver-profit, and load-matching predictions.
  * Added stronger validation for prediction results and currency values to prevent invalid recommendations.
  * Improved error reporting with clearer details when ML requests fail.
  * Preserved original offer information when applying route and load-matching recommendations.
  * Reduced repeated prediction delays through response caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->