### PR TITLE
fix(api): propagate critical flag in HealthAggregator so outages report unhealthy

### DIFF
--- a/backend/api/src/core/health/HealthAggregator.js
+++ b/backend/api/src/core/health/HealthAggregator.js
@@ -55,9 +55,14 @@ export class HealthAggregator {
     const start = Date.now();
 
     const results = await Promise.all(
-      this._checks.map(async ({ name, checkFn }) => {
+      this._checks.map(async ({ name, checkFn, critical }) => {
         try {
-          return await checkFn();
+          const result = await checkFn();
+          return {
+            ...result,
+            name,
+            critical: !!critical,
+          };
         } catch (err) {
           logger.error(
             `[health] Aggregator check "${name}" threw: ${err.message}`,
@@ -67,7 +72,7 @@ export class HealthAggregator {
             status: HealthStatus.UNHEALTHY,
             message: err.message,
             responseTime: 0,
-            critical: false,
+            critical: !!critical,
             timestamp: new Date().toISOString(),
           };
         }

--- a/backend/api/test/unit/healthAggregator.test.js
+++ b/backend/api/test/unit/healthAggregator.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const { HealthAggregator } = await import('../../src/core/health/HealthAggregator.js');
+
+describe('HealthAggregator critical flag propagation', () => {
+  it('reports UNHEALTHY overall status when a critical check throws', async () => {
+    const aggregator = new HealthAggregator();
+    aggregator.register('postgres', async () => {
+      throw new Error('connection refused');
+    }, { critical: true });
+
+    const result = await aggregator.aggregate();
+
+    expect(result.services.postgres.critical).toBe(true);
+    expect(result.services.postgres.status).toBe('unhealthy');
+    expect(result.status).toBe('unhealthy');
+  });
+
+  it('reports DEGRADED overall status when only a non-critical check fails', async () => {
+    const aggregator = new HealthAggregator();
+    aggregator.register('redis', async () => {
+      throw new Error('timeout');
+    }, { critical: false });
+
+    const result = await aggregator.aggregate();
+
+    expect(result.services.redis.critical).toBe(false);
+    expect(result.status).toBe('degraded');
+  });
+
+  it('propagates the registered critical flag on successful checks', async () => {
+    const aggregator = new HealthAggregator();
+    aggregator.register('supabase', async () => ({
+      status: 'unhealthy',
+      message: 'query failed',
+    }), { critical: true });
+
+    const result = await aggregator.aggregate();
+
+    expect(result.services.supabase.critical).toBe(true);
+    expect(result.status).toBe('unhealthy');
+  });
+});


### PR DESCRIPTION
## Summary
`HealthAggregator.aggregate()` never propagated the `critical` flag registered per check:
- The map callback destructured only `{ name, checkFn }`, discarding `critical` on the success path, and
- the catch block hardcoded `critical: false`.

Since `_determineOverallStatus()` only escalates to `unhealthy` when `r.critical && r.status === UNHEALTHY`, a critical service (supabase, postgres, mongodb are registered `critical: true` in `core/health/index.js`) that threw or reported unhealthy was reported as `degraded` instead of `unhealthy`.

## Changes
- Forward the registered `critical` flag into both the success and catch paths of `aggregate()`, making the aggregator registration the source of truth.
- Added `test/unit/healthAggregator.test.js` covering: critical check throw → `unhealthy`, non-critical throw → `degraded`, and registered-critical propagation on a successful (but unhealthy) check.

Closes #8472

GSSOC 2026
