### PR TITLE
[Bug] Reconcile the two merged IoT telemetry authorization gates so cold-chain ingestion works

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -59,12 +59,11 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       return res.status(400).json({ error: 'Load does not require refrigeration' });
     }
 
+    // Admins and provisioned IoT devices may always ingest telemetry.
+    // Everyone else must mirror GET authorization: the load owner OR the
+    // assigned driver. The driver is the party physically carrying the load
+    // and the only person able to record cold-chain readings in transit.
     if (req.user.role !== 'admin' && req.user.role !== 'iot_device') {
-      return res.status(403).json({ error: 'Access denied: IoT device authorization required' });
-    // Mirror GET authorization: allow the load owner OR the assigned driver.
-    // The driver is the party physically carrying the load and the only person
-    // able to record cold-chain readings in transit.
-    if (req.user.role !== 'admin') {
       let isAuthorized = load.customer_id === req.user.id;
       if (!isAuthorized && load.order_display_id) {
         const { data: order } = await supabaseAdmin


### PR DESCRIPTION
Fixes #8490.

A merge kept two independently-developed authorization gates for `POST /api/iot/telemetry` and nested one inside the other without closing the first.

### Before

```js
if (req.user.role !== 'admin' && req.user.role !== 'iot_device') {
  return res.status(403).json({ error: 'Access denied: IoT device authorization required' });
// Mirror GET authorization: allow the load owner OR the assigned driver.
if (req.user.role !== 'admin') {          // spliced inside the block above
```

```
$ node --input-type=module -e "await import('./src/routes/iotRoutes.js')"
SyntaxError: Unexpected token 'catch'
```

### Both gates are intentional

```
f18c500d Merge branch 'main' into fix/iot-telemetry-device-auth   <-- kept both
4b8ce17e fix(iot): allow assigned driver cold-chain telemetry during arrived_pickup/arriving
654b2bd4 fix: enforce iot_device role for telemetry ingestion
8ef19be7 fix: allow assigned driver to POST cold-chain telemetry
```

So this merges them into **one** condition rather than picking a side: `admin` and `iot_device` bypass, everyone else must be the load owner or the assigned driver. That is the union of both intents and mirrors the `GET /telemetry/:id` handler exactly.

### Worth flagging

The nesting was not only a parse error. The ownership check sat **after an unconditional `return`** inside the role gate — had it compiled, an `iot_device` could have posted telemetry for **any** load with no ownership check at all.

### Impact of the bug

`iotRoutes.js` never loaded, so both IoT telemetry endpoints were dead and refrigerated loads silently recorded no cold-chain readings.

### Verification

```
$ npx vitest run test/unit/iotRoutes.test.js
      Tests  7 passed (7)
```

4 insertions, 5 deletions. `npx eslint` clean.
