### PR TITLE
fix(api): normalizePhone strips leading 0 for national-dialing numbers

### DIFF
--- a/backend/api/src/utils/phone.js
+++ b/backend/api/src/utils/phone.js
@@ -20,6 +20,11 @@ export function normalizePhone(phone) {
   const isInternational = phone.trim().startsWith('+');
   let digits = phone.replace(/[^\d]/g, '');
 
+  // Strip a leading 0 used for national dialing (e.g. 0919876543210)
+  if (digits.startsWith('0')) {
+    digits = digits.slice(1);
+  }
+
   // Remove country code prefix if present (91 for India)
   if (digits.startsWith('91') && digits.length === 12) {
     digits = digits.slice(2);

--- a/backend/api/test/unit/phone.test.js
+++ b/backend/api/test/unit/phone.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizePhone } from '../../src/utils/phone.js';
+
+describe('normalizePhone', () => {
+  it('normalizes a leading-zero national number to E.164', () => {
+    expect(normalizePhone('0919876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes an international format with separators', () => {
+    expect(normalizePhone('+91 9876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes a bare 91-prefixed number', () => {
+    expect(normalizePhone('919876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes a plain 10-digit number', () => {
+    expect(normalizePhone('9876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes an already E.164 number unchanged', () => {
+    expect(normalizePhone('+919876543210')).toBe('+919876543210');
+  });
+
+  it('returns null for a too-short number', () => {
+    expect(normalizePhone('0987654321')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(normalizePhone(null)).toBeNull();
+    expect(normalizePhone(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
`normalizePhone()` (`backend/api/src/utils/phone.js`) documents support for `0919876543210` (leading-zero national dialing), but the implementation only strips the `91` country code when the digit string starts with `91`. A leading-zero number like `0919876543210` produced 13 digits starting with `0`, so the country-code branch was skipped and the length check returned `null` — login/OTP flows rejected numbers entered with a leading `0`.

## Changes
- Strip a single leading `0` before the country-code check (handles `0919876543210` → `+919876543210`).
- Added `test/unit/phone.test.js` covering leading-zero, `+91`-separated, bare `91`-prefixed, plain 10-digit, already-E.164, too-short, and non-string inputs.

Closes #8474

GSSOC 2026
