### PR TITLE
[Bug] Restore the notif_type allowlist notificationService lost in a bad merge

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -17,6 +17,34 @@ const INVALID_TOKEN_CODES = new Set([
   'messaging/invalid-argument'
 ]);
 
+// Mirrors the notifications_notif_type_check CHECK constraint
+// (supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql).
+// Validating here turns a silent server-side constraint rejection into a
+// named error in the logs — the failure mode reported in #7538.
+const ALLOWED_NOTIF_TYPES = new Set([
+  'order_update',
+  'payment',
+  'load_offer',
+  'trip_update',
+  'document',
+  'system',
+  'bid_accepted',
+  'new_bid',
+  'payment_locked',
+  'payment_released',
+]);
+
+function isAllowedNotifType(notifType) {
+  if (ALLOWED_NOTIF_TYPES.has(notifType)) {
+    return true;
+  }
+  logger.error(
+    { notifType, allowed: [...ALLOWED_NOTIF_TYPES] },
+    '[NotificationService] Refusing to insert notification with a notif_type the database CHECK constraint rejects'
+  );
+  return false;
+}
+
 const MAX_RETRIES = 3;
 const RETRY_DELAYS = [1000, 2000, 4000];
 const RETRY_BASE_DELAY = 500;
@@ -132,6 +160,9 @@ export async function sendPushNotification(userId, title, body, notifType = 'ord
   try {
     if (!supabaseAdmin) {
       logger.error('[NotificationService] Service-role client not configured — cannot persist notification.');
+    } else if (!isAllowedNotifType(notifType)) {
+      // Logged inside isAllowedNotifType; skip the insert rather than let the
+      // database CHECK constraint reject it silently.
     } else {
       const { error } = await supabaseAdmin.from('notifications').insert({
         user_id: userId,

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -1,12 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendPushNotification, sendFcmNotification } from '../../src/services/notificationService.js';
 
+// notificationService reads supabaseAdmin and firebaseAdmin (not supabase),
+// and getUserFcmToken chains .select().eq().maybeSingle() — a mock lacking
+// either export, or with a chain shape that doesn't reach maybeSingle(),
+// makes every scenario collapse into the same early-return branch.
+const { mockFrom, mockInsert, mockSend } = vi.hoisted(() => {
+  const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+  const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  const mockInsert = vi.fn().mockResolvedValue({ data: { id: 'fcm-token-1' }, error: null });
+  const mockFrom = vi.fn(() => ({ select: mockSelect, insert: mockInsert }));
+  const mockSend = vi.fn().mockResolvedValue('mock-message-id');
+  return { mockFrom, mockInsert, mockSend };
+});
+
 vi.mock('../../src/config/db.js', () => ({
-  supabase: {
-    from: vi.fn(() => ({
-      select: vi.fn().mockResolvedValue({ data: [], error: null }),
-      insert: vi.fn().mockResolvedValue({ data: { id: 'fcm-token-1' }, error: null }),
-    })),
+  supabaseAdmin: { from: mockFrom },
+  firebaseAdmin: {
+    messaging: vi.fn(() => ({ send: mockSend })),
   },
 }));
 
@@ -18,7 +30,7 @@ describe('notificationService', () => {
   describe('sendPushNotification', () => {
     it('returns success:false when userId is null', async () => {
       const result = await sendPushNotification(null, 'Test Title', 'Test Body', 'order_update', {});
-      expect(result).toEqual({ success: false, error: 'No userId provided' });
+      expect(result).toEqual({ success: false, error: 'Missing required fields' });
     });
 
     it('returns success:false when fcmToken is missing', async () => {
@@ -53,6 +65,43 @@ describe('notificationService', () => {
       const result = await sendFcmNotification(null, null);
       expect(result.success).toBe(false);
       expect(result.error).toBe('No FCM token');
+    });
+  });
+
+  describe('notif_type allowlist', () => {
+    // Mirrors notifications_notif_type_check
+    // (supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql).
+    const VALID_TYPES = [
+      'order_update',
+      'payment',
+      'load_offer',
+      'trip_update',
+      'document',
+      'system',
+      'bid_accepted',
+      'new_bid',
+      'payment_locked',
+      'payment_released',
+    ];
+
+    it.each(VALID_TYPES)('inserts a notification with notif_type "%s"', async (notifType) => {
+      await sendPushNotification('user-1', 'Title', 'Body', notifType);
+
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(mockInsert.mock.calls[0][0]).toMatchObject({ notif_type: notifType });
+    });
+
+    it('refuses to insert a notif_type the database CHECK would reject', async () => {
+      const result = await sendPushNotification('user-1', 'Title', 'Body', 'invalid_type');
+
+      expect(mockInsert).not.toHaveBeenCalled();
+      expect(result.persisted).toBe(false);
+    });
+
+    it('still resolves (does not throw) when the notif_type is rejected', async () => {
+      await expect(
+        sendPushNotification('user-1', 'Title', 'Body', 'invalid_type')
+      ).resolves.toBeDefined();
     });
   });
 });


### PR DESCRIPTION
Closes #10742

Rebased/reworked: the original module-parse crash this PR targeted (#8494) was already fixed by a different contributor since this was filed — main's \`sendPushNotification\`/\`sendFcmNotification\` load and work fine now.

What's still missing after rebasing onto main: the \`notif_type\` allowlist validation from the same original fix (#7538) was never reapplied. Restored \`ALLOWED_NOTIF_TYPES\`/\`isAllowedNotifType()\`, mirroring the ten values the CHECK constraint (\`20260807000050_widen_notifications_notif_type_check.sql\`) actually allows — an out-of-allowlist type is now logged by name instead of failing as an opaque DB constraint violation, and the insert is skipped without throwing.

Verified no current caller passes anything outside \`order_update\`/\`payment\`/\`document\` — purely additive.

Also fixed the test file while rebasing: the \`config/db.js\` mock omitted \`supabaseAdmin\`/\`firebaseAdmin\` (source destructures both) and didn't match the real \`getUserFcmToken\` chain shape (\`.select().eq().maybeSingle()\`), and one assertion expected a message the source never emits.

18/18 passing in this file; 82/82 across the 12 other suites exercising \`sendPushNotification\`.