### PR TITLE
[Security] Strip dev identity headers unless impersonation is explicitly opted into

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -143,16 +143,32 @@ export async function authenticate(req, res, next) {
   // independent of NODE_ENV, so a stray NODE_ENV=test deployment cannot
   // silently turn plaintext x-user-id/x-user-role headers into a full
   // impersonation primitive.
-  const testAuthEnabled = process.env.ENABLE_TEST_AUTH === "true";
+  // Never honour the opt-in in production, whatever the environment says.
+  const testAuthEnabled =
+    process.env.ENABLE_TEST_AUTH === "true" &&
+    process.env.NODE_ENV !== "production";
 
-  // ── Production header sanitization (defense in depth) ──────────────
-  // Strip dev-only authentication headers before any logic runs.
-  // This ensures they cannot be used even if BYPASS_AUTH is accidentally
-  // enabled or a proxy misconfiguration exposes them.
-  // This block runs unconditionally in production — the bypass path below
-  // only handles test impersonation via testAuthEnabled; the headers are
-  // always removed so no bypass header can ever survive a production deploy.
-  if (process.env.NODE_ENV === "production") {
+  // ── Dev identity header sanitization (defense in depth) ────────────
+  // Strip the dev-only identity headers before any logic runs, unless this
+  // process has explicitly opted into header impersonation via
+  // ENABLE_TEST_AUTH. Stripping is keyed on the opt-in rather than on
+  // NODE_ENV === "production" so the headers cannot survive in staging,
+  // preview or any environment whose NODE_ENV is something other than
+  // "production" — the only place they are ever legitimate is a process that
+  // asked for them.
+  //
+  // They are removed from req.headers entirely, not merely ignored here, so
+  // no downstream handler or logger can pick a client-supplied identity back
+  // up off the request. The values are captured first because the
+  // DEV_ACCESS_TOKEN flow below still needs them — that path is gated on a
+  // shared secret, so it is authenticated in a way a bare header is not.
+  const devIdentity = {
+    id: req.headers["x-user-id"],
+    role: req.headers["x-user-role"],
+    name: req.headers["x-user-name"],
+  };
+
+  if (!testAuthEnabled) {
     delete req.headers["x-user-id"];
     delete req.headers["x-user-role"];
     delete req.headers["x-user-name"];
@@ -199,9 +215,9 @@ export async function authenticate(req, res, next) {
       process.env.DEV_ACCESS_TOKEN &&
       devToken === process.env.DEV_ACCESS_TOKEN
     ) {
-      const testUserId = req.headers["x-user-id"];
-      const testUserRole = req.headers["x-user-role"] || "customer";
-      const testFullName = req.headers["x-user-name"] || "Test User";
+      const testUserId = devIdentity.id;
+      const testUserRole = devIdentity.role || "customer";
+      const testFullName = devIdentity.name || "Test User";
 
       if (testUserId) {
         req.user = {


### PR DESCRIPTION
Fixes #8496.

`authenticate()` stripped the dev identity headers only when `NODE_ENV === "production"`, leaving them on `req.headers` in every other environment even when header impersonation is off.

### Before

```
$ npx vitest run test/unit/auth.test.js
 FAIL  does not trust x-user-id/x-user-role headers when ENABLE_TEST_AUTH is unset
AssertionError: expected 'victim-uuid' to be undefined
```

### After

```
      Tests  28 passed (28)
```

### Change

- **Strip on the opt-in, not on `NODE_ENV`.** These headers are legitimate only in a process that set `ENABLE_TEST_AUTH`, so they are now deleted whenever that is off — closing the gap in `staging`, `preview` and any environment with `NODE_ENV` unset.
- **`testAuthEnabled` is no longer trusted in production.** It now also requires `NODE_ENV !== "production"`, so the flag cannot be honoured there even if it leaks into the environment. Today the impersonation branch is unreachable in production only because `BYPASS_AUTH` returns 503 first — that is one guard away from mattering.
- **`DEV_ACCESS_TOKEN` flow preserved.** It reads the same headers, so their values are captured into a local before the delete and that path uses the captured copy. It is gated on a shared secret, so it is authenticated in a way a bare header is not. Behaviour unchanged.

### On severity — not overstating this

This is **defence in depth, not a live bypass.** `src/index.js` already refuses to boot with `BYPASS_AUTH=true` outside `development` or `ENABLE_TEST_AUTH=true` outside `test`, and installs its own production-only stripping middleware. An attacker cannot reach the impersonation path on a correctly configured production deploy today.

What is actually wrong: the headers stay readable by any downstream handler, logger or future middleware in non-production environments, and the file's own comment already claims they are *"always removed so no bypass header can ever survive"*. Making that true costs 29 lines and turns a red test green.

29 insertions, 13 deletions. `npx eslint` clean.
