### PR TITLE
[Bug] Give the auditLog response double a res.on('finish') so its 11 dead tests run

### DIFF
--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -43,10 +43,22 @@ describe('auditLog middleware', () => {
     };
   }
 
+  // The middleware subscribes with res.on('finish', ...), the way Express
+  // exposes the real response. This stands in for that: on() records the
+  // handlers and finish() fires them, so the tests can drive completion
+  // synchronously.
   function mockRes(overrides = {}) {
+    const handlers = { finish: [] };
     const res = {
       statusCode: 200,
-      finish: vi.fn(function () { return this; }),
+      on: vi.fn(function (event, handler) {
+        (handlers[event] ??= []).push(handler);
+        return this;
+      }),
+      finish: vi.fn(function () {
+        for (const handler of handlers.finish) handler();
+        return this;
+      }),
       ...overrides,
     };
     return res;


### PR DESCRIPTION
Fixes #8498.

The suite modelled the Express response as an object with a `finish()` **method**, but `auditLog` subscribes with `res.on('finish', ...)`.

### Before

```
$ npx vitest run test/unit/auditLog.test.js
 Tests  11 failed | 4 passed (15)

TypeError: res.on is not a function
```

`res.on` was undefined, so the middleware threw the moment it tried to subscribe — **before `next()`** — and none of those paths ran. The four passing tests were the early-return cases that never reach the subscription.

### After

```
      Tests  15 passed (15)
```

### Change

`mockRes` now records handlers in `on(event, handler)` and fires the `finish` ones from `finish()`. All eleven existing `res.finish()` call sites work unchanged, so the fix is confined to that one helper — 13 insertions, 1 deletion.

### Coverage restored

- the audit entry written on response finish
- `before_state` / `after_state` capture, including after-state only on 2xx
- the status code being visible to the caller
- `getMetadata` capture
- resource-ID resolution from `req.params.id`, `req.params.orderId`, `req.params.userId`
- `resourceType` override
- `getBeforeState` / `getMetadata` throwing without crashing the request

`auditLogService` is what records who changed what on admin and financial routes, so this is the suite that should catch a regression there.

`npx eslint` clean.
