### PR TITLE
[Security] Pin the fail-closed contract for unset VALID_API_KEYS instead of asserting an open door

### DIFF
--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -2,7 +2,7 @@
  * Unit tests for backend/api/src/middleware/apiKey.js
  *
  * Coverage:
- *   - Skips verification when VALID_API_KEYS is not set (calls next immediately)
+ *   - Fails closed with 503 when VALID_API_KEYS is unset, empty or only separators
  *   - Returns 401 when x-api-key header is missing
  *   - Returns 401 when x-api-key header is invalid
  *   - Returns 401 when api_key query param is invalid

--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -68,14 +68,26 @@ describe('requireApiKey', () => {
     vi.clearAllMocks();
   });
 
-  it('skips verification when VALID_API_KEYS is not set', () => {
+  // Fails closed: an unconfigured VALID_API_KEYS must not turn into an open
+  // door on the backend-to-backend routes this middleware guards.
+  it('returns 503 and does not call next() when VALID_API_KEYS is not set', () => {
     vi.stubEnv('VALID_API_KEYS', '');
     const { req, res, next } = createMocks();
 
     requireApiKey(req, res, next);
 
-    expect(next).toHaveBeenCalled();
-    expect(res.status).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when VALID_API_KEYS is only separators or whitespace', () => {
+    vi.stubEnv('VALID_API_KEYS', ' , ,  ');
+    const { req, res, next } = createMocks();
+
+    requireApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('returns 401 when x-api-key header is missing', () => {


### PR DESCRIPTION
Fixes #8501.

`test/unit/apiKey.test.js` asserted that `requireApiKey` **skips verification** when `VALID_API_KEYS` is unset. The middleware deliberately fails closed with 503, so the test has been red on `main` — while asserting the *less* safe behaviour.

### Before

```
$ npx vitest run test/unit/apiKey.test.js
 FAIL  requireApiKey > skips verification when VALID_API_KEYS is not set
AssertionError: expected "vi.fn()" to be called at least once
```

### The middleware is the correct side here

```js
if (validKeys.length === 0) {
  logger.error(..., 'API key auth unavailable: VALID_API_KEYS is not configured');
  return res.status(503).json({ error: 'Service Unavailable: ...' });
}
```

`requireApiKey` guards backend-to-backend routes. An unset or empty `VALID_API_KEYS` is an easy deployment mistake and must not silently make those routes public. **No source change in this PR** — only the test.

### Why this one is worth fixing rather than muting

The risk is the direction of the obvious fix. A contributor triaging a red test named *"skips verification when VALID_API_KEYS is not set"* would most naturally delete the 503 guard to make it pass — converting a misconfigured deployment into an unauthenticated one. The test as written is an active invitation to reintroduce the hole.

### Change

Pinned the fail-closed contract (503, `next()` not called), plus a case for `VALID_API_KEYS` containing only separators or whitespace — `split(',').map(trim).filter(Boolean)` collapses that to an empty list too, the same open-door input in a form that is easier to get wrong.

```
      Tests  9 passed (9)
```

15 insertions, 3 deletions. `npx eslint` clean.
