### PR TITLE
fix(orders): include NULL escrow_status in stale pending order scan (#8470)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -573,7 +573,7 @@ export class OrderRepository {
       .select('id')
       .eq('status', 'pending')
       .lt('created_at', cutoff)
-      .neq('escrow_status', 'funding')
+      .or('escrow_status.is.null,escrow_status.neq.funding')
       .limit(limit), 'findStalePendingOrders');
   }
 

--- a/backend/api/test/unit/repositories/orderRepositoryStaleCancel.test.js
+++ b/backend/api/test/unit/repositories/orderRepositoryStaleCancel.test.js
@@ -12,7 +12,7 @@ describe('OrderRepository stale-order cancellation', () => {
     orderRepository = new OrderRepository(supabaseMock.supabase);
   });
 
-  it('findStalePendingOrders selects only pending, older-than-cutoff, non-funding orders in a bounded batch', async () => {
+  it('findStalePendingOrders selects pending, older-than-cutoff orders with null or non-funding escrow in a bounded batch', async () => {
     supabaseMock.programData([]);
 
     const cutoff = '2024-01-01T00:00:00.000Z';
@@ -24,7 +24,7 @@ describe('OrderRepository stale-order cancellation', () => {
     expect(call.filters).toEqual(expect.arrayContaining([
       { col: 'status', op: 'eq', val: 'pending' },
       { col: 'created_at', op: 'lt', val: cutoff },
-      { col: 'escrow_status', op: 'neq', val: 'funding' },
+      { col: null, op: 'or', val: 'escrow_status.is.null,escrow_status.neq.funding' },
     ]));
     expect(call.limit).toBe(100);
   });


### PR DESCRIPTION
## Fixes #8470

`findStalePendingOrders()` filtered with `.neq('escrow_status', 'funding')`. In PostgREST, `column.neq(value)` excludes rows where the column is `NULL`, so orders that predate escrow support (or never set `escrow_status`) were never picked up for stale cancellation — the `staleOrderWorker` could not auto-cancel plain non-escrow stale orders.

### Changes
- Replace `.neq('escrow_status', 'funding')` with `.or('escrow_status.is.null,escrow_status.neq.funding')` so both `NULL` and non-`funding` escrow states are matched.
- Update `orderRepositoryStaleCancel.test.js` to assert the new `or` filter (the mock already parses/evaluates `or` specs).

### Verification
- `node --check` passes on both files.
- The `cancel_stale_order_tx` RPC already handles `escrow_status IS NULL` as a plain cancellation (see `20260807000000_cancel_stale_order_tx.sql`), so cancelling these orders is supported.

GSSOC
