### PR TITLE
[Bug] Assert the requesting user is forwarded to the WebRTC offline peer APIs

### DIFF
--- a/backend/api/test/integration/webrtcOfflineRoutes.test.js
+++ b/backend/api/test/integration/webrtcOfflineRoutes.test.js
@@ -58,6 +58,13 @@ describe('WebRTC offline routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual([{ peerId: 'peer-1' }]);
-    expect(signalingMock.getOfflineGPSData).toHaveBeenCalledWith('peer-1', undefined);
+    // The requesting user is forwarded so the service can re-check access:
+    // getOfflineGPSData returns [] for a peer the caller cannot reach, which is
+    // the last line of defence behind the route's own 403.
+    expect(signalingMock.getOfflineGPSData).toHaveBeenCalledWith(
+      'peer-1',
+      undefined,
+      expect.objectContaining({ id: 'user-1' }),
+    );
   });
 });

--- a/backend/api/test/integration/webrtcOfflineSync.test.js
+++ b/backend/api/test/integration/webrtcOfflineSync.test.js
@@ -58,6 +58,12 @@ describe('WebRTC offline sync route', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(signalingMock.syncOfflineData).toHaveBeenCalledWith('peer-1');
+    // The requesting user is forwarded so the service can re-check access:
+    // syncOfflineData is a no-op for a peer the caller cannot reach, which is
+    // the last line of defence behind the route's own 403.
+    expect(signalingMock.syncOfflineData).toHaveBeenCalledWith(
+      'peer-1',
+      expect.objectContaining({ id: 'user-1' }),
+    );
   });
 });


### PR DESCRIPTION
Fixes #8509.

`getOfflineGPSData` and `syncOfflineData` gained a `requestingUser` parameter and an in-service authorization check; the two route tests still assert the old argument lists.

### Before

```
$ npx vitest run test/integration/webrtcOfflineRoutes.test.js test/integration/webrtcOfflineSync.test.js
 Tests  2 failed | 2 passed (4)

AssertionError: expected "vi.fn()" to be called with arguments: [ 'peer-1', undefined ]
Received:
  [ "peer-1", undefined, + { "id": "user-1", "role": "driver" } ]
```

### The source is the correct side

```js
async getOfflineGPSData(peerId, since, requestingUser) {
  if (!requestingUser || !this.canUserAccessPeer(peerId, requestingUser)) {
    logger.warn(`[WebRTC] Unauthorized offline GPS data access attempt for peer ${peerId}`);
    return [];
  }
```

The route already returns 403 via `canUserAccessPeer`; the service repeats the check so a future caller reaching it directly cannot skip authorization. Driver location history warrants two checks. **No source change in this PR.**

### What the stale assertions stopped covering

As written they would still pass if someone dropped `req.user` from the route call. `requestingUser` would be `undefined`, the `!requestingUser` guard would trip, and both endpoints would become **silent no-ops** — `getOfflineGPSData` returning `[]`, `syncOfflineData` returning without syncing. An accessible peer's GPS history would come back empty with a `200`: a quiet failure rather than a loud one.

Updated both to include the user via `expect.objectContaining({ id: 'user-1' })`, which stays robust if `req.user` grows.

```
      Tests  4 passed (4)
```

`npx eslint` clean.
