### PR TITLE
fix(api): normalizePhone strips leading trunk zero before country-code check (#8474)

### DIFF
--- a/backend/api/src/utils/phone.js
+++ b/backend/api/src/utils/phone.js
@@ -16,9 +16,13 @@ export function normalizePhone(phone) {
     return null;
   }
 
-  // Strip all non-digit characters except leading +
-  const isInternational = phone.trim().startsWith('+');
+  // Strip all non-digit characters
   let digits = phone.replace(/[^\d]/g, '');
+
+  // Strip a leading trunk prefix 0 (e.g. 0919876543210 -> 919876543210)
+  if (digits.startsWith('0')) {
+    digits = digits.slice(1);
+  }
 
   // Remove country code prefix if present (91 for India)
   if (digits.startsWith('91') && digits.length === 12) {


### PR DESCRIPTION
## Fixes #8474

`normalizePhone()` documented support for `0919876543210` but never stripped the leading trunk `0` before the country-code check. For `0919876543210`, `digits` stayed 13 chars starting with `0`, so the `91` removal branch was skipped and the length check returned `null`.

### Changes
- Strip a leading `0` before the country-code removal so `0919876543210` normalizes to `+919876543210`.
- Remove the unused `isInternational` dead variable while touching the function.

### Verification
Runtime-checked:
```
0919876543210 -> +919876543210
+91 9876543210 -> +919876543210
919876543210  -> +919876543210
9876543210    -> +919876543210
0987654321    -> null (9 digits after trunk strip — correctly rejected)
```
`node --check` passes.

GSSOC
