### PR TITLE
fix(customer): show savings stat in rupees instead of raw paisa (#8476)

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -118,6 +118,11 @@ class _HomeScreenState extends State<HomeScreen> {
     return 'Good evening';
   }
 
+  String _formatSavingsValue() {
+    final totalSaved = (_customerStats?['totalSaved'] as num?)?.toDouble() ?? 0;
+    return '₹${(totalSaved / 100).toStringAsFixed(totalSaved % 100 == 0 ? 0 : 2)}';
+  }
+
   void _showComingSoon(BuildContext context, String title) {
     ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context)!.comingSoon(title))));
@@ -443,8 +448,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                       StatCard(
                                         title: AppLocalizations.of(context)!
                                             .savings,
-                                        value:
-                                            '${_customerStats?['totalSaved'] ?? 0}',
+                                        value: _formatSavingsValue(),
                                         icon: Icons.savings_rounded,
                                       ),
                                     ],
@@ -477,8 +481,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                           title:
                                               AppLocalizations.of(context)!
                                                   .savings,
-                                          value:
-                                              '${_customerStats?['totalSaved'] ?? 0}',
+                                          value: _formatSavingsValue(),
                                           icon: Icons.savings_rounded,
                                         ),
                                       ),


### PR DESCRIPTION
## Fixes #8476

The home screen Savings stat card rendered `_customerStats['totalSaved']` raw. The backend returns `totalSaved` in paisa (`backend/api/src/models/ProfileModel.js:33`), so ₹125 displayed as "12500".

### Changes
- Add `_formatSavingsValue()` which converts paisa to rupees (e.g. `12500` → `₹125`, `12550` → `₹125.50`), matching the existing formatting on the profile screen (`profile_screen.dart:589`).
- Use it in both the XL `GridView` and standard `Row` savings `StatCard`s.

GSSOC
