### PR TITLE
[Bug] Fix tracker tests asserting pre-refactor contracts and an un-awaited async toArray()

### DIFF
--- a/backend/api/test/tracker.test.js
+++ b/backend/api/test/tracker.test.js
@@ -138,20 +138,26 @@ describe('tracker', () => {
     it('rejects invalid coordinates', async () => {
       const ws = makeWs();
       await handleLocationPing(ws, { lat: 'abc', lng: 72.8 });
-      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ error: 'Missing mandatory tracking parameters (lat, lng).' }));
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({
+        error: 'Invalid telemetry payload.',
+        details: ['lat must be a valid number'],
+      }));
     });
 
     it('rejects out-of-range coordinates', async () => {
       const ws = makeWs();
       await handleLocationPing(ws, { lat: 100, lng: 72.8 });
-      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ error: 'Coordinates out of valid range' }));
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({
+        error: 'Invalid telemetry payload.',
+        details: ['lat must be <= 90'],
+      }));
     });
 
     it('buffers valid location ping', async () => {
       const ws = makeWs();
       await handleLocationPing(ws, { lat: 19.076, lng: 72.877 });
-      const rawBuf = __testing.getTelemetryWriteBuffer();
-      const buffer = rawBuf.toArray ? rawBuf.toArray() : rawBuf;
+      // telemetryWriteBuffer is a TelemetryRingBuffer whose toArray() is async.
+      const buffer = await __testing.getTelemetryWriteBuffer().toArray();
       expect(buffer.length).toBe(1);
       expect(buffer[0].lat).toBe(19.076);
       expect(buffer[0].lng).toBe(72.877);
@@ -198,10 +204,11 @@ describe('tracker', () => {
       expect(subs).toBeInstanceOf(Map);
     });
 
-    it('getTelemetryWriteBuffer returns an array', () => {
+    it('getTelemetryWriteBuffer exposes the ring buffer, whose toArray() resolves to an array', async () => {
       const rawBuf = __testing.getTelemetryWriteBuffer();
-      const buf = rawBuf.toArray ? rawBuf.toArray() : rawBuf;
-      expect(Array.isArray(buf)).toBe(true);
+      expect(typeof rawBuf.toArray).toBe('function');
+      expect(typeof rawBuf.push).toBe('function');
+      expect(Array.isArray(await rawBuf.toArray())).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Fixes #8519.

Four tests assert contracts the tracker no longer has. **No source change** — the source is the better side in both cases.

### Before

```
$ npx vitest run test/tracker.test.js
 Tests  4 failed | 14 passed (18)
```

### 1 & 2 — validation errors are structured now

```
- "{\"error\":\"Missing mandatory tracking parameters (lat, lng).\"}"
+ "{\"error\":\"Invalid telemetry payload.\",\"details\":[\"lat must be a valid number\"]}"

- "{\"error\":\"Coordinates out of valid range\"}"
+ "{\"error\":\"Invalid telemetry payload.\",\"details\":[\"lat must be <= 90\"]}"
```

`details` names the offending field and bound rather than leaving the client to guess which coordinate was wrong. Assertions updated to the structured shape.

### 3 & 4 — `toArray()` is async

```js
const rawBuf = __testing.getTelemetryWriteBuffer();
const buffer = rawBuf.toArray ? rawBuf.toArray() : rawBuf;   // a Promise
expect(buffer.length).toBe(1);                               // undefined
```

`telemetryWriteBuffer` is a `TelemetryRingBuffer` (`tracker.js:257`) whose `toArray()` is `async` (`:205`). That ternary is a shim from when the buffer was a plain array — it now picks the `toArray` branch and hands back a Promise. Awaited it and **dropped the shim**, so the buffer type cannot silently change again.

### What had rotted

`buffers valid location ping` was no longer verifying that a valid ping is buffered **at all**. It fails loudly today — but loosening the assertion to make it pass would have removed the only check that driver telemetry is captured before the flush. Worth fixing in the right direction.

```
      Tests  18 passed (18)
```

14 insertions, 7 deletions. `npx eslint` clean.
