### PR TITLE
[Bug] Fix out-of-scope 'result' in checkEscrow that crashed every health probe

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -122,17 +122,12 @@ function checkFirebase() {
 
 async function checkEscrow() {
   try {
-  try {
-  const result = await checkEscrowHealth();
+    const result = await checkEscrowHealth();
+    return result?.status ?? 'unavailable';
   } catch (err) {
     logger.error('[Health] checkEscrow failed:', err?.message || err);
-    return { status: 'failed', detail: err?.message || 'Unknown error' };
+    return 'failed';
   }
-  } catch (err) {
-    logger.error('[Health] checkEscrow failed:', err?.message || err);
-    return { status: 'failed', detail: err?.message || 'Unknown error' };
-  }
-  return result.status;
 }
 
 function checkPolygon() {


### PR DESCRIPTION
Fixes #8530.

`checkEscrow()` had **two nested copies** of the same `try`/`catch`, with `const result` declared inside the inner `try` and read after both blocks closed.

### Before

```js
async function checkEscrow() {
  try {
  try {
  const result = await checkEscrowHealth();      // block-scoped to the inner try
  } catch (err) { ... return { status: 'failed', detail: ... }; }
  } catch (err) { ... return { status: 'failed', detail: ... }; }   // identical duplicate
  return result.status;                           // ReferenceError
}
```

```
$ npx eslint src/routes/healthRoutes.js
  135:10  error  'result' is not defined  no-undef
```

The `ReferenceError` is thrown **after** both `catch` blocks, so nothing catches it. It propagates out of the `Promise.all` at line 169 and rejects the whole health handler — the readiness/liveness probe fails on **every** request, which reads to an orchestrator as a permanently unhealthy service.

### Two bugs, not one

Also fixed the return type. Both `catch` blocks returned an **object** `{ status, detail }`, but the caller uses the value as a plain status **string**:

```js
escrow: escrowStatus,                       // line 176
CRITICAL_UNHEALTHY.has(escrowStatus)        // a Set of strings
```

An object could never match, so the error path reported the wrong thing even when reached. Now returns `'failed'` on error and `result?.status ?? 'unavailable'` on success.

### Relationship to #8100 — worth a look before merging

PR #8100 fixes this same function, but against the pre-merge two-line body (`const result = await checkEscrowHealth(); return result.status;`). The state on `main` looks like a **botched merge of that very change** — the new `try`/`catch` applied twice with the original body left in between — so #8100 will not apply cleanly as things stand. Happy to close this in favour of a rebased #8100 if you prefer; flagging so the two are not fixed in conflict.

### Verification

`npx eslint src/routes/healthRoutes.js` — clean.

The health suites cannot run locally: they stop at collection on the unrelated duplicate `verifyDeliveryLimiter` in `rateLimiter.js` (#7812). I could not execute them, so I am not claiming test coverage here — the change is 3 insertions, 8 deletions and purely a scope/return-type correction.
