### PR TITLE
fix(customer): carry pickup/drop coordinates through Rebook This Route (#8478)

### DIFF
--- a/apps/customer/lib/models/app_models.dart
+++ b/apps/customer/lib/models/app_models.dart
@@ -235,6 +235,10 @@ class HistoryOrderData {
     this.targetTemperatureMin,
     this.targetTemperatureMax,
     this.escrowStatus,
+    this.pickupLat,
+    this.pickupLng,
+    this.dropLat,
+    this.dropLng,
   });
 
   final String orderId;
@@ -258,6 +262,10 @@ class HistoryOrderData {
   final bool? isFragile;
   final String? specialRequirements;
   final String? escrowStatus;
+  final double? pickupLat;
+  final double? pickupLng;
+  final double? dropLat;
+  final double? dropLng;
 }
 
 class TimelineStepData {

--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -208,6 +208,10 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                     ? orderMap['profiles']['phone']?.toString()
                     : null),
             escrowStatus: orderMap['escrow_status']?.toString(),
+            pickupLat: (orderMap['pickup_lat'] as num?)?.toDouble(),
+            pickupLng: (orderMap['pickup_lng'] as num?)?.toDouble(),
+            dropLat: (orderMap['drop_lat'] as num?)?.toDouble(),
+            dropLng: (orderMap['drop_lng'] as num?)?.toDouble(),
           );
           // Trigger rating flow if status becomes completed and rating dialog hasn't been shown yet
           final orderStatus = orderMap['status']?.toString() ?? '';
@@ -654,6 +658,10 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
                 draft: RouteDraft(
                   pickup: pickup,
                   drop: drop,
+                  pickupLat: _currentOrder.pickupLat,
+                  pickupLng: _currentOrder.pickupLng,
+                  dropLat: _currentOrder.dropLat,
+                  dropLng: _currentOrder.dropLng,
                   dateLabel: _currentOrder.date,
                   goodsType: _currentOrder.goodsType ?? 'General',
                   weightTonnes: _currentOrder.weightTonnes ?? '0',

--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -198,6 +198,10 @@ class _OrdersScreenState extends State<OrdersScreen>
               isStackable: order['is_stackable'] as bool?,
               isFragile: order['is_fragile'] as bool?,
               specialRequirements: order['special_requirements']?.toString(),
+              pickupLat: (order['pickup_lat'] as num?)?.toDouble(),
+              pickupLng: (order['pickup_lng'] as num?)?.toDouble(),
+              dropLat: (order['drop_lat'] as num?)?.toDouble(),
+              dropLng: (order['drop_lng'] as num?)?.toDouble(),
             );
           }).toList();
         });

--- a/apps/customer/lib/screens/shell_screen.dart
+++ b/apps/customer/lib/screens/shell_screen.dart
@@ -164,6 +164,10 @@ class _TruxifyShellScreenState extends State<TruxifyShellScreen> {
       distanceCharge: formatPaise(orderMap['distance_charge']),
       tollCharge: formatPaise(orderMap['toll_charge']),
       platformFee: formatPaise(orderMap['platform_fee']),
+      pickupLat: (orderMap['pickup_lat'] as num?)?.toDouble(),
+      pickupLng: (orderMap['pickup_lng'] as num?)?.toDouble(),
+      dropLat: (orderMap['drop_lat'] as num?)?.toDouble(),
+      dropLng: (orderMap['drop_lng'] as num?)?.toDouble(),
     );
 
     // Switch to Orders tab and push detail screen.


### PR DESCRIPTION
## Fixes #8478

"Rebook This Route" built a `RouteDraft` with only the free-text city names parsed from the order's route string — `pickupLat`/`pickupLng`/`dropLat`/`dropLng` were never set. In `find_trucks_screen.dart` the map pins are only populated from the draft when lat/lng are non-null, and the submit handlers block while either pin is null, so rebooking always forced the user to re-pick both locations.

### Changes
- Add optional `pickupLat`/`pickupLng`/`dropLat`/`dropLng` to `HistoryOrderData`.
- Populate them wherever `HistoryOrderData` is built from API data:
  - `orders_screen.dart` (online + offline cache paths) — `pickup_lat`/`pickup_lng`/`drop_lat`/`drop_lng`
  - `order_detail_screen.dart` (`fetchOrderById` refresh)
  - `shell_screen.dart` (notification-driven order open)
- Pass `_currentOrder`'s coordinates into the rebook `RouteDraft` so `find_trucks_screen.dart` pre-fills the map pins (lines 133-138) and the user can review/confirm without re-picking.

The order-detail API already returns the coordinates: `orderLifecycleService.getOrderDetail` selects `*` on the orders row, which stores `pickup_lat/pickup_lng/drop_lat/drop_lng` (see `orderCreationService.js:139-152`).

GSSOC
