### PR TITLE
[Bug] Import errorResponse in deviceController and restore its dead test suite

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,6 +1,7 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
+import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -435,6 +435,18 @@ export function createSupabaseMock(initialStore = {}) {
     supabase,
     store,
     calls,
+    /**
+     * Return the mock to its initial state. Needed by suites that build the
+     * mock once at module scope — the usual shape when it has to be visible
+     * to a hoisted vi.mock factory — and clear it between tests instead of
+     * constructing a fresh one.
+     */
+    reset() {
+      for (const table of Object.keys(store)) delete store[table];
+      Object.assign(store, initialStore);
+      calls.length = 0;
+      for (const key of Object.keys(programmed)) delete programmed[key];
+    },
     programError(msg = 'mock error')    { programmed.nextError    = { message: msg }; },
     programErrorFor(table, mode, msg = 'mock error') {
       programmed.matchingErrors ??= [];

--- a/backend/api/test/unit/deviceController.test.js
+++ b/backend/api/test/unit/deviceController.test.js
@@ -44,7 +44,16 @@ describe('registerDeviceToken', () => {
 
     expect(res.status).not.toHaveBeenCalledWith(400);
     expect(next).not.toHaveBeenCalled();
-    expect(supabaseMock.calls.some((call) => call.table === 'user_devices' && call.mode === 'upsert')).toBe(true);
+    // Registration goes through the transactional register_device_token RPC,
+    // not a direct upsert, so the device row, the previous owner's profile and
+    // the current user's profile all commit or roll back together.
+    const rpcCall = supabaseMock.calls.find((call) => call.rpc === 'register_device_token');
+    expect(rpcCall).toBeDefined();
+    expect(rpcCall.args).toMatchObject({
+      p_user_id: 'user-1',
+      p_fcm_token: 'valid_token_12345',
+      p_platform: 'android',
+    });
     expect(res.json).toHaveBeenCalledWith({
       success: true,
       message: 'Device token registered',


### PR DESCRIPTION
Fixes #8534.

### 1. The bug — `errorResponse` is never imported

```
$ npx eslint src/controllers/deviceController.js
  64:9  error  'errorResponse' is not defined  no-undef
```

```js
if (metadataErr) {
  return res.status(400).json(
    errorResponse('VALIDATION_ERROR', metadataErr)    // ReferenceError
  );
}
```

A client posting invalid `metadata` hits a `ReferenceError`. It is thrown inside the surrounding `try`, so it lands in the generic catch and comes back as an **opaque 500** instead of the intended **400** with a `VALIDATION_ERROR` code — a caller cannot tell a malformed request from a server fault.

The function is exported from `utils/apiResponse.js`; this file just never imported it. `deviceController` is the only consumer of `errorResponse` in the codebase, so nothing else covered the gap.

### 2. Why no test caught it

```
$ npx vitest run test/unit/deviceController.test.js
 Tests  2 failed (2)
TypeError: supabaseMock.reset is not a function
```

The suite builds the mock at module scope — the usual shape when it must be visible to a hoisted `vi.mock` factory — and calls `supabaseMock.reset()` in `beforeEach`. `createSupabaseMock` returned no `reset`, so **every test died in setup**. Added one that clears `store`, `calls` and the programmed responses.

### 3. A stale assertion underneath that

```js
expect(supabaseMock.calls.some((c) => c.table === 'user_devices' && c.mode === 'upsert')).toBe(true);
```

Registration no longer upserts `user_devices` directly — it goes through the transactional `register_device_token` RPC so the device row, the previous owner's profile and the current user's profile commit or roll back together. Re-pointed the assertion at the RPC and its arguments.

### Verification

```
$ npx vitest run test/unit/deviceController.test.js
      Tests  2 passed (2)
```

23 insertions, 1 deletion across three files. `npx eslint` clean.
