### PR TITLE
[Bug] Import the logger auditRoutes calls, so failures are logged instead of crashing the catch

### DIFF
--- a/backend/api/src/routes/auditRoutes.js
+++ b/backend/api/src/routes/auditRoutes.js
@@ -6,6 +6,7 @@ import { supabaseAdmin } from '../config/db.js';
 import { auditLog } from '../middleware/auditLog.js';
 import { auditLogService } from '../services/auditLogService.js';
 import { validateQuery } from '../middleware/validate.js';
+import logger from '../middleware/logger.js';
 import { z } from 'zod';
 
 const router = express.Router();


### PR DESCRIPTION
Fixes #8536.

The `catch` block for `GET /api/v1/admin/audit-logs` calls `logger.error()`, but the module never imports `logger`.

### Before

```
$ npx eslint src/routes/auditRoutes.js
  202:5  error  'logger' is not defined  no-undef
```

```js
} catch (err) {
  logger.error({ requestId: req.requestId }, "[AuditRoutes] Error:", err?.message || err);   // ReferenceError
  res.status(500).json({ error: "Failed to fetch audit logs.", details: ... });
}
```

### Why this is worse than a missing log line

The `ReferenceError` is thrown on the **first statement** of the `catch`, so:

1. `res.status(500).json(...)` never runs — the client gets no structured error
2. the original `err` is **discarded** — whatever actually broke the query is replaced by `ReferenceError: logger is not defined` before it reaches the logs or Sentry
3. it only fires on the error path, so the endpoint looks healthy until the first genuine failure, at which point it is undiagnosable

This is the admin audit-log endpoint — the one you reach for when investigating an incident, and the worst place to lose the underlying error.

This is the file's only `logger` reference (the other `catch`, at line 256, logs nothing), so nothing else made the missing import visible.

### Change

One line — the same import every other module in `src/routes/` already uses.

`npx eslint src/routes/auditRoutes.js` — clean.
