### PR TITLE
[Bug] Remove unreachable duplicate 'neq' branch in updateOrderWithFilter

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -155,8 +155,6 @@ export class OrderRepository {
             query = query.not(f.column, f.operator, f.value);
           } else if (f.op === 'in') {
             query = query.in(f.column, f.value);
-          } else if (f.op === 'neq') {
-            query = query.not(f.column, 'neq', f.value);
           }
         }
       }


### PR DESCRIPTION
Fixes #8538.

`updateOrderWithFilter` tested `f.op === 'neq'` **twice** in the same `if/else-if` chain.

### Before

```
$ npx eslint src/repositories/orderRepository.js
  158:22  error  This branch can never execute. Its condition is a duplicate or
                 covered by previous conditions in the if-else-if chain  no-dupe-else-if
```

```js
} else if (f.op === 'neq') {
  query = query.neq(f.column, f.value);          // reachable, correct
} else if (f.op === 'not') {
  query = query.not(f.column, f.operator, f.value);
} else if (f.op === 'in') {
  query = query.in(f.column, f.value);
} else if (f.op === 'neq') {                     // unreachable
  query = query.not(f.column, 'neq', f.value);   // and not the same query
}
```

The two branches disagree: the live one uses PostgREST's `.neq(column, value)`; the dead one uses `.not(column, 'neq', value)`, passing the operator positionally in the shape the `'not'` branch above expects `f.operator` for.

### Severity — low, and worth saying so

`op: 'neq'` has exactly one caller today — `paymentRoutes.js:308`, `escrow_status neq 'funded'` — and the first branch already serves it correctly. **No query is currently wrong.**

What it costs:

- `npm run lint` is `eslint . --max-warnings=0`, so this is a hard error in the lint gate.
- It leaves a trap: reordering the chain, or inserting a condition above the live `neq`, would silently switch to a differently-built query on the filter that enforces *"only update this order if its escrow is not yet funded"*.

### Change

Two-line deletion, no behaviour change. `npx eslint src/repositories/orderRepository.js` — clean.
