### PR TITLE
[Bug] Replace JS-style // comments that make two ML modules unimportable

### DIFF
--- a/backend/ml/gat/dataset_loader.py
+++ b/backend/ml/gat/dataset_loader.py
@@ -8,7 +8,7 @@ class HighwayGraphDatasetLoader:
         # 5 highway junction nodes with [avg_speed, vehicle_density, toll_wait_time_mins]
         node_features = np.array([
             [60.0, 120.0, 2.0],
-            [25.0, 450.0, 15.0], // Congested Toll Plaza
+            [25.0, 450.0, 15.0],  # Congested Toll Plaza
             [55.0, 150.0, 3.0],
             [40.0, 280.0, 8.0],
             [70.0, 90.0, 1.0],

--- a/backend/ml/imitation/dataset_builder.py
+++ b/backend/ml/imitation/dataset_builder.py
@@ -8,7 +8,8 @@ class TrajectoryDatasetBuilder:
         dataset = []
         for log in raw_gps_logs:
             state = np.array([log.get("speed", 50.0), log.get("slope", 0.0), log.get("congestion", 0.2)])
-            action = int(log.get("reroute_action", 0)) // 0: main highway, 1: bypass detour
+            # reroute_action: 0 = main highway, 1 = bypass detour
+            action = int(log.get("reroute_action", 0))
             dataset.append({"state": state, "action": action})
         return dataset
 


### PR DESCRIPTION
Fixes #8540.

Two `backend/ml` modules use JavaScript-style `//` comments in Python and cannot be imported.

### Before

```
$ flake8 --select=E999 backend/ml
backend/ml/gat/dataset_loader.py:11:35: E999 SyntaxError: invalid syntax
backend/ml/imitation/dataset_builder.py:11:61: E999 SyntaxError: invalid syntax
```

```python
# gat/dataset_loader.py:11
[25.0, 450.0, 15.0], // Congested Toll Plaza

# imitation/dataset_builder.py:11
action = int(log.get("reroute_action", 0)) // 0: main highway, 1: bypass detour
```

### The second one nearly became a runtime bug

`//` is Python's **floor-division operator**, so the parser reads `int(...) // 0` as a real expression and only fails when it reaches the `:`. Had the trailing `: main highway, 1: bypass detour` not been there, this would have parsed cleanly and raised **`ZeroDivisionError`** for every log entry at runtime — a silent landmine instead of an import error. The syntax error is the lucky outcome.

I moved the note onto its own line above the assignment so the operand of `int(...)` is never adjacent to a `//` again.

### Impact

- `HighwayGraphDatasetLoader` — the spatial highway graph behind the GAT congestion model — unimportable
- `TrajectoryDatasetBuilder` — state-action pairs from driver GPS trajectories for the imitation-learning reroute model — unimportable, and it instantiates at module level, so even a bare import fails
- `E999` is a hard error in any lint gate

### Verification

```
$ python -c "import ast; [ast.parse(open(p).read()) for p in (...)]"   # both parse
$ flake8 --select=E999,F backend/ml/gat/dataset_loader.py backend/ml/imitation/dataset_builder.py
$ echo $?
0
```

3 insertions, 2 deletions.
