### PR TITLE
[Security] Remove the unauthenticated /sentry-debug endpoint from the ML service

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -27,7 +27,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from app.models.eta_prediction import eta_predictor
-from fastapi import HTTPException
 
 from app.models.demand_forecast import (
     predict_demand,
@@ -89,11 +88,6 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["X-API-Key", "Content-Type"],
 )
-
-
-@app.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0
 
 
 @app.on_event("startup")


### PR DESCRIPTION
Fixes #8543.

### The endpoint

```python
@app.get("/sentry-debug")
async def trigger_error():
    division_by_zero = 1 / 0
```

This is the snippet from Sentry's FastAPI onboarding guide — used once to confirm the SDK is wired up, then committed and never removed.

### It is the only unauthenticated route on the service

```python
@app.get("/")                        async def root(_auth=Depends(verify_api_key)):
@app.post("/predict/demand")         ... _auth=Depends(verify_api_key)
@app.post("/predict/price")          ... _auth=Depends(verify_api_key)
@app.post("/predict/driver-profit")  ... _auth=Depends(verify_api_key)
```

Every endpoint has the dependency, including the root route. `/sentry-debug` is the single exception.

### Impact

- **Unauthenticated 500 generator** — anyone who can reach the ML service can hit it in a loop. One unhandled `ZeroDivisionError` per request means one Sentry event per request: quota burn, alert noise, and real incidents buried under synthetic ones.
- **Traceback disclosure** — an unhandled FastAPI exception returns a stack trace with file paths and internals, to a caller with no key.
- It is a route that exists only to break, on the service that also serves pricing and driver-profit predictions.

### Also removed

```
backend/ml/main.py:30:1: F811 redefinition of unused 'HTTPException' from line 25
```

A bare `from fastapi import HTTPException` five lines below the import that already includes it.

### Verification

`F811` and the `F841` for the unused `division_by_zero` binding are both clear; the file still parses. The remaining `F401` unused imports in this file are pre-existing and deliberately left alone to keep the diff to the point.

6 deletions, 0 insertions.
