### PR TITLE
[CI] Shard the whole backend test tree so the 23 never-run suites execute

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   unit-tests:
-    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
+    name: Backend Tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -40,9 +40,14 @@ jobs:
         working-directory: backend/api
         run: npm install --workspaces=false --legacy-peer-deps --ignore-scripts
 
-      - name: Run unit tests (shard ${{ matrix.shard }}/4)
+      # Shard the whole test/ tree, not just test/unit. vitest.config.js
+      # collects test/**/*.test.js, so limiting this to test/unit left the 19
+      # suites at the top level of test/ and the 4 in test/contracts/ with no
+      # CI coverage at all. test/integration is excluded here because it runs
+      # in the job below, which provisions Postgres and Redis.
+      - name: Run tests (shard ${{ matrix.shard }}/4)
         working-directory: backend/api
-        run: npx vitest run test/unit --shard=${{ matrix.shard }}/4
+        run: npx vitest run --exclude "test/integration/**" --shard=${{ matrix.shard }}/4
 
   integration-tests:
     name: Backend Integration Tests


### PR DESCRIPTION
Fixes #8549.

`vitest.config.js` collects `test/**/*.test.js` — **216** suites. Backend CI runs only `test/unit` (162) and `test/integration` (31). The other **23** have never run.

### What was uncovered

| Location | Count | Includes |
|---|---|---|
| `test/*.test.js` | 19 | `tracker.wsSecurity`, `rpcSecurity.releaseGate`, `sharding`, `securityHeadersVerifier`, `securityHeaderDuplicates`, `cookieSecurityValidator`, `authFailureMonitor`, `headerSizeMonitor`, `cacheControlVerifier`, `orderLifecycle.verifyDelivery`, `changeDrop.escrowRebalance`, `deliveryVerification.*`, `orcale`, … |
| `test/contracts/*.test.js` | 4 | `orders`, `bids`, `delivery`, `timeline` — every API contract test |

The WebSocket security suite, the RPC release-gate suite, the security-header suites and all four contract tests.

### Change

```diff
-        run: npx vitest run test/unit --shard=${{ matrix.shard }}/4
+        run: npx vitest run --exclude "test/integration/**" --shard=${{ matrix.shard }}/4
```

`vitest run` with no path argument uses the config's `include`, so this picks up the whole tree. `test/integration` stays excluded because it has its own job with the Postgres and Redis services.

8 insertions, 3 deletions — one command and a comment.

### Why it matters

```
$ npx vitest run test/contracts
 Test Files  4 failed (4)

$ npx vitest run test/*.test.js
 Test Files  15 failed | 4 passed (19)
```

19 of 23 are red, several having drifted a full refactor behind the source they cover. A suite nothing runs is a suite nothing maintains.

It also explains how eleven unparseable source files reached `main`: the suites that import them are largely in the unrun set, so the import failure never surfaced as a CI failure on the PRs that introduced it.

### ⚠️ Merge ordering — please read

**This will be red on arrival.** Most of the 19 fail at *import* on `rateLimiter.js`, `orderRoutes.js`, `OracleService.js`, `deliveryVerificationService.js`, `orderLifecycleService.js`, `escrow.js`, `notificationService.js`, `ml.js` and `dlqService.js`.

Those are tracked in #7792, #7794, #7795, #8120, #8122, #8150, #8486, #8490, #8494 and PRs #7812 / #7813 / #7816 / #7880. **This PR should land after them.** I would rather say that plainly than quietly scope the job down to only the suites that already pass — the point is to close the gap, and a green-but-hollow job would recreate it.

Verified locally that the command collects correctly:

```
$ npx vitest run --exclude "test/integration/**" --shard=1/4
 Test Files  10 failed | 37 passed (47)      # shard 1 of 4 — 47 suites collected, vs test/unit only before
```
