### PR TITLE
[Security] Pin search_path on the two SECURITY DEFINER functions that still lack it

### DIFF
--- a/supabase/migrations/20260809000000_set_search_path_on_remaining_definer_functions.sql
+++ b/supabase/migrations/20260809000000_set_search_path_on_remaining_definer_functions.sql
@@ -1,0 +1,26 @@
+-- Pin search_path on the two SECURITY DEFINER functions that still lack it.
+--
+-- 20260706075009_secure_rpc_search_path.sql hardened every SECURITY DEFINER
+-- function that existed at the time. Two have escaped that guarantee:
+--
+--   * revoke_tracking_tokens_on_terminal_status() — added in
+--     20260716000000_add_public_tracking_tokens.sql, ten days after the
+--     hardening migration.
+--   * register_device_token(...) — added in
+--     20260807000010_register_device_token_tx.sql, the newest migration in the
+--     tree.
+--
+-- A SECURITY DEFINER function runs with the privileges of its owner. Without a
+-- pinned search_path it resolves unqualified names against the *caller's*
+-- search_path, so a caller who can create objects in a schema earlier on that
+-- path can shadow a table or function the body references and have it executed
+-- as the owner.
+--
+-- ALTER FUNCTION is used rather than CREATE OR REPLACE so the bodies are not
+-- duplicated here and cannot drift from their defining migrations.
+
+ALTER FUNCTION public.register_device_token(uuid, text, text, jsonb, uuid)
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.revoke_tracking_tokens_on_terminal_status()
+  SET search_path = public, pg_temp;


### PR DESCRIPTION
Fixes #8554.

Two `SECURITY DEFINER` functions have no pinned `search_path`. Both landed **after** `20260706075009_secure_rpc_search_path.sql`, the migration that hardened every such function existing at the time.

| Function | Introduced in | Relative to hardening |
|---|---|---|
| `revoke_tracking_tokens_on_terminal_status()` | `20260716000000_add_public_tracking_tokens.sql` | 10 days after |
| `register_device_token(uuid, text, text, jsonb, uuid)` | `20260807000010_register_device_token_tx.sql` | newest migration in the tree |

### Why it matters

A `SECURITY DEFINER` function runs with its **owner's** privileges but resolves unqualified names against the **caller's** `search_path`. A caller who can create objects in a schema earlier on that path can shadow a table the body references and have their version executed as the owner.

- `register_device_token` writes `user_devices` and `profiles` on every device registration.
- `revoke_tracking_tokens_on_terminal_status` is the trigger that revokes **public tracking tokens** when an order reaches a terminal status — shadowing `tracking_tokens` would leave public tracking links live after delivery or cancellation.

### Scope — checked, not eyeballed

Of **16** `SECURITY DEFINER` functions, resolving each to its *latest* definition, these two were the only ones left unprotected. Worth noting: `complete_trip_tx` briefly lost its `search_path` in `20260802060000_link_trips_to_orders.sql` and regained it in `20260805120000_secure_complete_trip_tx_auth.sql`, so it is fine today.

### Approach

`ALTER FUNCTION ... SET search_path = public, pg_temp` in a new migration, rather than `CREATE OR REPLACE`:

- editing the original migrations would not re-run on an already-migrated database
- copying the bodies forward here would let them drift from their defining migrations

One new file, 27 lines, no existing migration touched.

### Suggested follow-up

A CI check asserting that no `SECURITY DEFINER` function lacks `SET search_path`, so the next one added after a hardening pass does not slip through the same way. Happy to open that separately if useful.
