### PR TITLE
[CI] Fail the build when a SECURITY DEFINER function has no pinned search_path

### DIFF
--- a/.github/workflows/supabase-ci.yml
+++ b/.github/workflows/supabase-ci.yml
@@ -27,6 +27,9 @@ jobs:
           fi
           echo "No duplicate CREATE TABLE definitions."
 
+      - name: Check SECURITY DEFINER functions pin search_path
+        run: python3 scripts/check-definer-search-path.py
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:

--- a/scripts/check-definer-search-path.py
+++ b/scripts/check-definer-search-path.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Fail if any SECURITY DEFINER function in supabase/migrations/ is left without a
+pinned search_path.
+
+A SECURITY DEFINER function runs with its owner's privileges but resolves
+unqualified names against the *caller's* search_path, so a caller who can create
+objects in a schema earlier on that path can shadow a table the body references
+and have it executed as the owner.
+
+Migrations are replayed in filename order, so a function is judged by its LAST
+definition; a later `ALTER FUNCTION ... SET search_path` also counts as pinned.
+"""
+import glob
+import os
+import re
+import sys
+
+FUNC_RE = re.compile(r"create\s+or\s+replace\s+function\s+(?:[a-z0-9_]+\.)?([a-z0-9_]+)\s*\(", re.I)
+ALTER_RE = re.compile(
+    r"alter\s+function\s+(?:[a-z0-9_]+\.)?([a-z0-9_]+)\s*\([^)]*\)\s*set\s+search_path", re.I
+)
+BODY_RE = re.compile(r"\bas\s*\$", re.I)
+
+
+def main() -> int:
+    latest: dict[str, tuple[str, bool, bool]] = {}
+    altered: set[str] = set()
+
+    for path in sorted(glob.glob("supabase/migrations/*.sql")):
+        sql = open(path, encoding="utf-8", errors="replace").read()
+
+        for match in FUNC_RE.finditer(sql):
+            # The header is everything before the `AS $$` body marker.
+            header = BODY_RE.split(sql[match.start() : match.start() + 4000])[0]
+            latest[match.group(1)] = (
+                os.path.basename(path),
+                bool(re.search(r"security\s+definer", header, re.I)),
+                bool(re.search(r"set\s+search_path", header, re.I)),
+            )
+
+        altered.update(m.group(1) for m in ALTER_RE.finditer(sql))
+
+    unpinned = sorted(
+        (name, src)
+        for name, (src, is_definer, has_path) in latest.items()
+        if is_definer and not has_path and name not in altered
+    )
+
+    if unpinned:
+        print("SECURITY DEFINER functions without a pinned search_path:\n")
+        for name, src in unpinned:
+            print(f"  {name}  (last defined in {src})")
+        print(
+            "\nAdd `SET search_path = public, pg_temp` to the definition, or "
+            "`ALTER FUNCTION <name>(<args>) SET search_path = public, pg_temp` "
+            "in a new migration."
+        )
+        return 1
+
+    definers = sum(1 for _, is_definer, _ in latest.values() if is_definer)
+    print(f"All {definers} SECURITY DEFINER functions pin search_path.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #8556. Follow-up to #8555, as promised there.

Nothing currently prevents a `SECURITY DEFINER` function from landing without a pinned `search_path`. `20260706075009_secure_rpc_search_path.sql` was a one-time sweep.

### The case that makes this worth automating

`complete_trip_tx` — the function that **credits the driver's wallet** — lost its `search_path` in `20260802060000_link_trips_to_orders.sql` and only regained it three days later in `20260805120000_secure_complete_trip_tx_auth.sql`.

`CREATE OR REPLACE FUNCTION` does not inherit `SET` clauses from the previous definition. Dropping one is invisible in review unless a reviewer happens to check, and the function keeps working — it is only the hardening that quietly disappears.

### Change

`scripts/check-definer-search-path.py`, wired into `supabase-ci.yml` next to the existing duplicate-`CREATE TABLE` guard, which is the same kind of check.

It models how migrations actually apply, which a naive grep would not:

- migrations replay in filename order, so a function is judged by its **last** definition, not any earlier one
- a later `ALTER FUNCTION ... SET search_path` counts as pinned — that is the correct way to fix an already-applied migration without editing history
- only the function **header** (before the `AS $$` marker) is inspected, so a `search_path` string inside a body cannot cause a false pass

### Verified both directions

```
$ python3 scripts/check-definer-search-path.py          # on main today
SECURITY DEFINER functions without a pinned search_path:
  register_device_token  (last defined in 20260807000010_register_device_token_tx.sql)
  revoke_tracking_tokens_on_terminal_status  (last defined in 20260716000000_add_public_tracking_tokens.sql)
exit=1

$ # with #8555's migration applied
All 17 SECURITY DEFINER functions pin search_path.
exit=0
```

### ⚠️ Ordering

**This fails until #8555 merges** — because it is correctly reporting the two real findings from #8554. Merge #8555 first and this goes green.
