### PR TITLE
[Bug] Target the cancun EVM so the contracts compile again

### DIFF
--- a/blockchain/hardhat.config.cjs
+++ b/blockchain/hardhat.config.cjs
@@ -41,6 +41,11 @@ module.exports = {
         runs: 200,
       },
       viaIR: true,
+      // solc 0.8.24 defaults to the shanghai EVM, which has no MCOPY.
+      // OpenZeppelin Contracts 5.x (Bytes.sol) emits mcopy in assembly, so the
+      // whole tree fails to compile without this. Polygon PoS has supported
+      // the cancun opcodes since the Napoli upgrade.
+      evmVersion: "cancun",
     },
   },
   networks: {


### PR DESCRIPTION
Fixes #8560.

`npx hardhat compile` fails on a clean checkout — the entire `blockchain/` workspace is unbuildable.

### Before

```
$ cd blockchain && npx hardhat compile

DeclarationError: Function "mcopy" not found.
   --> @openzeppelin/contracts/utils/Bytes.sol:168:13:
168 |             mcopy(add(add(buffer, 0x20), pos), ...)
Error HH600: Compilation failed
```

### After

```
Compiled 70 Solidity files successfully (evm target: cancun).
```

### Root cause

`hardhat.config.cjs` pins solc `0.8.24` with **no `evmVersion`**, so it targets `shanghai` — which has no `MCOPY`. OpenZeppelin Contracts 5.x emits `mcopy` in `Bytes.sol` assembly.

**This is not a local-environment issue.** `package.json` declares `"@openzeppelin/contracts": "^5.6.1"` and `package-lock.json` pins `5.6.1`, so a clean `npm ci` installs the version that uses `mcopy`. The two are incompatible as configured.

### Impact

- All 70 contracts uncompilable — `TruxifyEscrow`, `Reputation`, `DocumentRegistry`, the DAO, the multi-sig
- **CI is red**: `ci.yml:187` runs `npx hardhat compile`, `:191` runs `npx hardhat test`
- Nothing can be tested, deployed or verified, and `scripts/check-escrow-abi.sh` has no ABI to check against

### Change

```diff
       viaIR: true,
+      // solc 0.8.24 defaults to the shanghai EVM, which has no MCOPY.
+      // OpenZeppelin Contracts 5.x (Bytes.sol) emits mcopy in assembly, so the
+      // whole tree fails to compile without this. Polygon PoS has supported
+      // the cancun opcodes since the Napoli upgrade.
+      evmVersion: "cancun",
```

Polygon PoS has supported the Cancun opcodes since the Napoli upgrade, so this matches the deployment target. One setting, five lines with the comment.
