### PR TITLE
[Bug] Sign the #7734 commitment in the TruxifyEscrow suite — 80 failures from one signature change

### DIFF
--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -5,6 +5,26 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 
 describe("TruxifyEscrow", function () {
 
+  // createBooking requires an owner-signed EIP-191 commitment binding the
+  // chain, contract, customer wallet, bookingId and the customer's current
+  // nonce (issue #7734). This mirrors what buildDepositTx() produces in
+  // backend/api/src/services/escrow.js.
+  async function signCreateCommitment(escrow, customerAddress, bookingId) {
+    const [owner] = await ethers.getSigners();
+    const { chainId } = await ethers.provider.getNetwork();
+    const commitment = ethers.solidityPackedKeccak256(
+      ["uint256", "address", "address", "uint256", "uint256"],
+      [
+        chainId,
+        await escrow.getAddress(),
+        customerAddress,
+        bookingId,
+        await escrow.commitmentNonces(customerAddress),
+      ],
+    );
+    return owner.signMessage(ethers.getBytes(commitment));
+  }
+
   // ─── Fixture ──────────────────────────────────────────────────────────────
   async function deployEscrowFixture() {
     const [owner, customer, driver, attacker] = await ethers.getSigners();
@@ -20,7 +40,7 @@ describe("TruxifyEscrow", function () {
     const bookingId = 1;
     const amount = ethers.parseEther("1.0");
 
-    await escrow.connect(customer).createBooking(bookingId, driver.address, { value: amount });
+    await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount });
 
     return { escrow, owner, customer, driver, attacker, bookingId, amount };
   }
@@ -35,7 +55,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 1;
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, {
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), {
         value: amount,
       });
 
@@ -52,17 +72,17 @@ describe("TruxifyEscrow", function () {
 
       expect(await escrow.bookingCount()).to.equal(0);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       expect(await escrow.bookingCount()).to.equal(1);
 
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("1") });
       expect(await escrow.bookingCount()).to.equal(2);
     });
 
     it("records createdAt timestamp", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      const tx = await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      const tx = await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       const receipt = await tx.wait();
       const block = await ethers.provider.getBlock(receipt.blockNumber);
 
@@ -77,7 +97,7 @@ describe("TruxifyEscrow", function () {
       const amount = ethers.parseEther("2.5");
 
       await expect(
-        escrow.connect(customer).createBooking(bookingId, driver.address, { value: amount })
+        escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount })
       )
         .to.emit(escrow, "BookingCreated")
         .withArgs(bookingId, customer.address, driver.address, amount);
@@ -87,7 +107,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
       await expect(
-        escrow.connect(customer).createBooking(1, driver.address, { value: 0 })
+        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: 0 })
       ).to.be.revertedWith("TruxifyEscrow: Payment required");
     });
 
@@ -95,17 +115,17 @@ describe("TruxifyEscrow", function () {
       const { escrow, customer } = await loadFixture(deployEscrowFixture);
 
       await expect(
-        escrow.connect(customer).createBooking(1, ethers.ZeroAddress, { value: ethers.parseEther("1") })
+        escrow.connect(customer).createBooking(1, ethers.ZeroAddress, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") })
       ).to.be.revertedWith("TruxifyEscrow: Invalid driver address");
     });
 
     it("reverts if booking already exists", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       await expect(
-        escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") })
+        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") })
       ).to.be.revertedWith("TruxifyEscrow: Booking already exists");
     });
 
@@ -115,8 +135,8 @@ describe("TruxifyEscrow", function () {
       const addr1 = "0x0000000000000000000000000000000000000001";
       const addr2 = "0x0000000000000000000000000000000000000002";
 
-      await escrow.connect(customer).createBooking(100, driver.address, { value: ethers.parseEther("1") });
-      await escrow.connect(customer).createBooking(200, addr2, { value: ethers.parseEther("2") });
+      await escrow.connect(customer).createBooking(100, driver.address, await signCreateCommitment(escrow, customer.address, 100), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(200, addr2, await signCreateCommitment(escrow, customer.address, 200), { value: ethers.parseEther("2") });
 
       const booking1 = await escrow.getBooking(100);
       const booking2 = await escrow.getBooking(200);
@@ -138,7 +158,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 1;
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, {
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), {
         value: amount,
       });
 
@@ -163,7 +183,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("3.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       expect(await escrow.pendingWithdrawals(driver.address)).to.equal(amount);
@@ -172,7 +192,7 @@ describe("TruxifyEscrow", function () {
     it("sets releaseTimestamps for driver", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       const tx = await escrow.connect(owner).releasePayment(1);
       const receipt = await tx.wait();
@@ -187,7 +207,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 7;
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount });
 
       const tx = escrow.connect(owner).releasePayment(bookingId);
 
@@ -202,7 +222,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
 
@@ -214,7 +234,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by customer", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
 
@@ -226,7 +246,7 @@ describe("TruxifyEscrow", function () {
     it("reverts on double payment attempt", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
 
@@ -240,7 +260,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is cancelled", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).cancelBooking(1);
@@ -253,7 +273,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is disputed", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).raiseDispute(1);
@@ -276,7 +296,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).pause();
@@ -289,8 +309,8 @@ describe("TruxifyEscrow", function () {
     it("handles multiple bookings independently", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("2") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2") });
 
       await escrow.connect(owner).releasePayment(1);
 
@@ -316,7 +336,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 99;
       const amount = ethers.parseEther("5.0");
 
-      await escrow.connect(customer).createBooking(bookingId, await malicious.getAddress(), {
+      await escrow.connect(customer).createBooking(bookingId, await malicious.getAddress(), await signCreateCommitment(escrow, customer.address, bookingId), {
         value: amount,
       });
 
@@ -347,7 +367,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
 
       const balanceBefore = await ethers.provider.getBalance(customer.address);
       await escrow.connect(owner).cancelBooking(1);
@@ -367,7 +387,7 @@ describe("TruxifyEscrow", function () {
     it("allows owner to cancel booking", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).cancelBooking(1);
 
       const booking = await escrow.getBooking(1);
@@ -378,7 +398,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).cancelBooking(1);
 
       expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount);
@@ -387,7 +407,7 @@ describe("TruxifyEscrow", function () {
     it("sets releaseTimestamps for customer", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       const tx = await escrow.connect(owner).cancelBooking(1);
       const receipt = await tx.wait();
@@ -401,7 +421,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(5, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(5, driver.address, await signCreateCommitment(escrow, customer.address, 5), { value: amount });
 
       const tx = escrow.connect(owner).cancelBooking(5);
 
@@ -416,7 +436,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if not customer or owner", async function () {
       const { escrow, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
 
@@ -429,7 +449,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if driver tries to cancel", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
 
@@ -442,7 +462,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is already paid", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).releasePayment(1);
@@ -463,7 +483,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).pause();
@@ -476,7 +496,7 @@ describe("TruxifyEscrow", function () {
     it("reverts once the trip has started", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, {
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
         value: ethers.parseEther("1.0"),
       });
       await escrow.connect(owner).markBookingStarted(1);
@@ -586,7 +606,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(customer).markBookingStarted(1)
@@ -612,7 +632,7 @@ describe("TruxifyEscrow", function () {
     it("allows owner to raise dispute", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).raiseDispute(1);
 
       const booking = await escrow.getBooking(1);
@@ -622,7 +642,7 @@ describe("TruxifyEscrow", function () {
     it("emits BookingDisputed event with correct args", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       // Owner raises dispute on booking 1
       await expect(escrow.connect(owner).raiseDispute(1))
@@ -633,7 +653,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if customer tries to raise dispute", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(customer).raiseDispute(1)
@@ -644,7 +664,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if driver tries to raise dispute", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(driver).raiseDispute(1)
@@ -655,7 +675,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is not active", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -666,7 +686,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is already cancelled", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).cancelBooking(1);
 
       await expect(
@@ -691,7 +711,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -710,7 +730,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -725,7 +745,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).cancelBooking(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -743,7 +763,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -756,7 +776,7 @@ describe("TruxifyEscrow", function () {
     it("clears releaseTimestamps after withdrawal", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       expect(await escrow.releaseTimestamps(driver.address)).to.be.gt(0);
@@ -779,7 +799,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).pause();
 
@@ -793,8 +813,8 @@ describe("TruxifyEscrow", function () {
       const amount1 = ethers.parseEther("1");
       const amount2 = ethers.parseEther("2");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount1 });
-      await escrow.connect(customer).createBooking(2, driver.address, { value: amount2 });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount1 });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: amount2 });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).releasePayment(2);
 
@@ -821,7 +841,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Fast-forward past withdrawal timeout (30 days)
@@ -839,7 +859,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("0.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -852,7 +872,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, owner, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -865,7 +885,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if recipient is zero address", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -878,7 +898,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if withdrawal period is still active", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       // Don't fast-forward — timeout hasn't passed
@@ -890,7 +910,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if amount exceeds pending withdrawals", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -912,7 +932,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -966,7 +986,7 @@ describe("TruxifyEscrow", function () {
       await escrow.connect(owner).pause();
 
       // createBooking has no whenNotPaused modifier, so this succeeds
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       const booking = await escrow.getBooking(1);
       expect(booking.amount).to.equal(ethers.parseEther("1"));
     });
@@ -977,7 +997,7 @@ describe("TruxifyEscrow", function () {
       await escrow.connect(owner).pause();
       await escrow.connect(owner).unpause();
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       const booking = await escrow.getBooking(1);
       expect(booking.amount).to.equal(ethers.parseEther("1"));
     });
@@ -985,7 +1005,7 @@ describe("TruxifyEscrow", function () {
     it("prevents withdrawal when paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).pause();
 
@@ -997,7 +1017,7 @@ describe("TruxifyEscrow", function () {
     it("prevents cancellation when paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
       await escrow.connect(owner).pause();
 
       await expect(
@@ -1080,7 +1100,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses so the timestamp is cleared
@@ -1097,7 +1117,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       const WITHDRAWAL_TIMEOUT = await escrow.WITHDRAWAL_TIMEOUT();
@@ -1111,7 +1131,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -1126,7 +1146,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking for driver — sets deadline D1
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
       const deadline1 = await escrow.releaseTimestamps(driver.address);
 
@@ -1134,7 +1154,7 @@ describe("TruxifyEscrow", function () {
       await time.increase(3600); // 1 hour
 
       // Second booking for same driver — must extend deadline
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
       const deadline2 = await escrow.releaseTimestamps(driver.address);
 
@@ -1145,7 +1165,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking for customer — sets deadline D1
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).cancelBooking(1);
       const deadline1 = await escrow.releaseTimestamps(customer.address);
 
@@ -1153,7 +1173,7 @@ describe("TruxifyEscrow", function () {
       await time.increase(3600);
 
       // Second booking for same customer — must extend deadline
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).cancelBooking(2);
       const deadline2 = await escrow.releaseTimestamps(customer.address);
 
@@ -1164,7 +1184,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking — release, withdraw (clears timestamp)
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
       // Withdraw after the withdrawal timelock elapses
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -1174,7 +1194,7 @@ describe("TruxifyEscrow", function () {
       expect(await escrow.releaseTimestamps(driver.address)).to.equal(0n);
 
       // Second booking — must set a fresh timestamp
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
       const newDeadline = await escrow.releaseTimestamps(driver.address);
       expect(newDeadline).to.be.gt(0n);
@@ -1183,10 +1203,10 @@ describe("TruxifyEscrow", function () {
     it("allows withdraw after each booking independently", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
 
-      await escrow.connect(customer).createBooking(2, driver.address, { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
 
       // Both funds should be withdrawable
@@ -1208,7 +1228,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(2, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: amount });
 
       // Raise dispute (owner-only)
       await escrow.connect(owner).raiseDispute(2);
@@ -1233,7 +1253,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(3, driver.address, { value: amount });
+      await escrow.connect(customer).createBooking(3, driver.address, await signCreateCommitment(escrow, customer.address, 3), { value: amount });
 
       // Raise dispute (owner-only)
       await escrow.connect(owner).raiseDispute(3);
@@ -1247,7 +1267,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by a non-owner before timeout expires", async function () {
       const { escrow, owner, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(4, driver.address, { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(4, driver.address, await signCreateCommitment(escrow, customer.address, 4), { value: ethers.parseEther("1") });
       await escrow.connect(owner).raiseDispute(4);
 
       await hre.network.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);


### PR DESCRIPTION
Fixes #8564.

`TruxifyEscrow.createBooking` gained a `bytes calldata signature` parameter with the #7734 front-running fix. The suite was never updated, so all **75** call sites still pass the overrides object where the signature belongs.

### Before

```
$ npx hardhat test test/TruxifyEscrow.test.js
TypeError: invalid BytesLike value (argument="value", value={ "value": 1000000000000000000 })
```

ethers binds `{ value: ... }` to the `signature` parameter and only then looks for overrides — which is why the error names the deposit amount as an invalid byte string. That one mismatch caused **80 of the suite's 94 failures**.

### After

```
  83 passing (943ms)
  14 failing
```

Up from the whole file erroring out.

### Change

A `signCreateCommitment()` helper reproducing exactly what `buildDepositTx()` in `backend/api/src/services/escrow.js` already sends:

```js
solidityPackedKeccak256(
  ["uint256", "address", "address", "uint256", "uint256"],
  [chainId, await escrow.getAddress(), customerAddress, bookingId,
   await escrow.commitmentNonces(customerAddress)],
)
```

signed by `owner` with `signMessage`, so the EIP-191 prefix matches what `_verifyCreateCommitment` reconstructs before checking `ecrecover(...) == owner()`. Threaded through all 75 call sites.

**The production path was never broken** — only the tests. That is why it went unnoticed: the suite has not been runnable at all (#8560, #8562).

95 insertions, 75 deletions, confined to `test/TruxifyEscrow.test.js`.

### The 14 that remain

A **different** pre-existing cluster around `markBookingStarted` and the withdrawal flow — `'Trip already started'`, `'No pending withdrawal'`, `'Withdrawal period active'`, zero `releaseTimestamps`. Those are expectation drift against contract behaviour changes and need a call on which side is correct, so I have left them rather than guess. Happy to take them on once you say which way they should go.

### Verification note

Requires #8561 (compilation) and #8563 (ESM loading) to run; the 83-passing figure above is with both applied.
