### PR TITLE
fix(ml): restore ml.js corrupted by merge #7910

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -79,14 +79,251 @@ function getHeaders() {
     if (process.env.ML_API_KEY) {
         headers['X-API-Key'] = process.env.ML_API_KEY;
     }
+    return headers;
+}
 
-    if (response.status === 401) {
-      throw new Error(`[MLService] Unauthorized (401) for ${method} ${url}`);
+/**
+ * Utility: handle ML engine responses consistently
+ */
+async function handleResponse(response) {
+    const text = await response.text();
+
+    if (response.status === 401 || response.status === 403) {
+        throw new Error(`[ML] Authentication failed (${response.status}): ${text}`);
+    }
+    if (!response.ok) {
+        throw new Error(`[ML] Request failed (${response.status}): ${text}`);
     }
 
-    if (response.status === 403) {
-      throw new Error(`[MLService] Forbidden (403) for ${method} ${url}`);
+    try {
+        return JSON.parse(text);
+    } catch (err) {
+        throw new Error(`[ML] Invalid JSON response from ML engine: ${err.message}`, { cause: err });
     }
+}
+
+/**
+ * Utility: resolve base URL for ML engine
+ */
+function getBaseUrl() {
+    return (
+        process.env.ML_ENGINE_URL ||
+        process.env.ML_SERVICE_URL ||
+        DEFAULT_ML_ENGINE_URL
+    );
+}
+
+/**
+ * Predicts ride/truck demand
+ * @param {object} features
+ * @returns {Promise<object>}
+ */
+export async function predictDemand(features = {}) {
+  guardMlApiKey();
+  const cacheKey = JSON.stringify(features);
+  const cached = demandCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const url = `${getBaseUrl()}/predict/demand`;
+
+  const response = await fetch(url, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(features),
+      signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const result = await handleResponse(response);
+  demandCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Predicts freight price.
+ *
+ * Returns the validated ML response with `estimatedPricePaisa` (paisa integer)
+ * and `estimatedPriceInr` (INR float) added. Throws on any validation failure
+ * so callers can transparently fall back to deterministic pricing.
+ *
+ * @param {object} params
+ * @returns {Promise<{estimated_price: number, currency: string, estimatedPricePaisa: number}>}
+ * @throws {Error} on HTTP failure, timeout, or prediction validation failure
+ */
+export async function predictPrice({
+    distanceKm,
+    cargoWeightKg,
+    truckType = 'medium_truck',
+    routeOrigin = '',
+    routeDestination = '',
+    trafficMultiplier = 1.0,
+} = {}) {
+  guardMlApiKey();
+  
+  const cacheKey = JSON.stringify({ distanceKm, cargoWeightKg, truckType, routeOrigin, routeDestination, trafficMultiplier });
+  const cached = priceCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const url = `${getBaseUrl()}/predict/price`;
+
+  const payload = {
+      distance_km: distanceKm,
+      cargo_weight_kg: cargoWeightKg,
+      truck_type: truckType,
+      route_origin: routeOrigin,
+      route_destination: routeDestination,
+      traffic_multiplier: trafficMultiplier,
+  };
+
+  const response = await fetch(url, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const raw = await handleResponse(response);
+
+  const validated = validatePricePrediction(raw);
+  if (!validated.ok) {
+      logger.warn({
+          reason: validated.reason,
+          detail: validated.detail,
+          response_keys: raw && typeof raw === 'object' ? Object.keys(raw) : typeof raw,
+      }, '[ML] Price prediction rejected by validator');
+      throw new Error(`[ML] Invalid prediction: ${validated.reason} — ${validated.detail}`);
+  }
+
+  logger.debug({
+      estimated_price_inr: validated.validated.estimated_price,
+      confidence: validated.validated.confidence,
+  }, '[ML] Price prediction validated successfully');
+
+  const result = {
+      ...validated.validated,
+      estimatedPricePaisa: convertToPaisa(validated.validated.estimated_price * trafficMultiplier),
+      estimatedPriceInr: validated.validated.estimated_price * trafficMultiplier,
+  };
+  priceCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Predicts estimated time of arrival for a route.
+ *
+ * @param {object} params
+ * @param {number} params.routeDistance  - Route distance in km (must be > 0)
+ * @param {number} params.timeOfDay      - Hour of the day (0-23)
+ * @param {number} params.dayOfWeek      - Day of week (0=Sunday, 6=Saturday)
+ * @param {string} params.routeType      - Route type ("highway" or "city")
+ * @param {number} params.historicalSpeed - Historical average speed in km/h (must be > 0)
+ * @returns {Promise<{eta_minutes: number, confidence_interval: {lower: number, upper: number}}>}
+ * @throws {Error} if ML_API_KEY is missing, HTTP fails, or response is invalid
+ */
+export async function predictEta({
+  routeDistance,
+  timeOfDay,
+  dayOfWeek,
+  routeType,
+  historicalSpeed,
+}) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/predict/eta`;
+
+  const payload = {
+    route_distance: routeDistance,
+    time_of_day: timeOfDay,
+    day_of_week: dayOfWeek,
+    route_type: routeType,
+    historical_speed: historicalSpeed,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
+
+  const result = await handleResponse(response);
+
+  if (
+    result == null ||
+    typeof result.eta_minutes !== 'number' ||
+    !isFinite(result.eta_minutes)
+  ) {
+    throw new Error('[ML] Invalid ETA prediction: missing or non-finite eta_minutes');
+  }
+
+  return {
+    eta_minutes: result.eta_minutes,
+    confidence_interval: result.confidence_interval ?? { lower: 0, upper: 0 },
+  };
+}
+
+/**
+ * Matches shipments for bilateral load consolidation.
+ *
+ * @param {object} params
+ * @param {Array}  params.loads   - Array of load objects with origin/dest lat/lng, dimensions, deadline
+ * @param {Array}  params.drivers - Array of driver objects with current location, capacity, rating
+ * @returns {Promise<{assignments: Array, unmatched_loads: Array, unmatched_drivers: Array}>}
+ * @throws {Error} if ML_API_KEY is missing or HTTP fails
+ */
+export async function matchBilateral({ loads, drivers }) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/match/bilateral`;
+
+  const payload = { loads, drivers };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
+  });
+
+  return handleResponse(response);
+}
+
+/**
+ * Predicts driver profit for a given route using ML model.
+ *
+ * @param {object} params
+ * @param {number} params.routeDistanceKm  - Total route distance in km (must be > 0)
+ * @param {number} params.fuelPricePerLitre - Current fuel price in INR/L (must be > 0)
+ * @param {number} params.tollEstimateInr  - Estimated toll cost in INR (must be >= 0)
+ * @param {number} params.truckMileageKmL  - Truck fuel efficiency in km/L (must be > 0)
+ * @param {number} params.cargoWeightKg    - Cargo weight in kg (must be > 0)
+ * @param {number} params.tripDurationHours - Estimated trip duration in hours (must be > 0)
+ * @returns {Promise<{predicted_profit: number, confidence_interval: {lower: number, upper: number}}>}
+ * @throws {Error} if ML_API_KEY is missing, HTTP fails, or response is invalid
+ */
+export async function predictDriverProfit({
+  routeDistanceKm,
+  fuelPricePerLitre,
+  tollEstimateInr,
+  truckMileageKmL,
+  cargoWeightKg,
+  tripDurationHours,
+}) {
+  guardMlApiKey();
+  const url = `${getBaseUrl()}/predict/driver-profit`;
+
+  const payload = {
+    route_distance: routeDistanceKm,
+    fuel_price: fuelPricePerLitre,
+    toll_estimate: tollEstimateInr,
+    truck_mileage: truckMileageKmL,
+    cargo_weight: cargoWeightKg,
+    trip_duration: tripDurationHours,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
+  });
 
   const result = await handleResponse(response);
 
@@ -408,6 +645,7 @@ export async function matchEnRouteLoads({
     } catch (err) {
       logger.warn('[ML] matchEnRouteLoads: falling back to haversine. Reason: ' + err.message);
     }
+  }
 
   // Haversine fallback — score by distance to pickup
   if (!mlUsed || recommendations.length === 0) {
@@ -427,6 +665,50 @@ export async function matchEnRouteLoads({
       .filter(r => r.detour_km <= maxDetourKm)
       .sort((a, b) => b.match_score - a.match_score);
   }
+
+  // Build a lookup map of ML results keyed by load_id
+  const recMap = new Map(recommendations.map(r => [r.load_id, r]));
+
+  // Merge ML/haversine annotations back onto the original offer rows
+  const enriched = offers
+    .map(o => {
+      const rec = recMap.get(o.id);
+      if (!rec) return null; // not recommended by ML — exclude
+      return {
+        ...o,
+        detour_km: rec.detour_km ?? rec.distance_to_pickup_km ?? 0,
+        extra_earnings: rec.estimated_earnings
+          ? Math.round(rec.estimated_earnings * 100) // convert to paisa for consistency
+          : (o.freight_value || 0),
+        match_score: rec.match_score ?? 0,
+        extra_distance_km: rec.detour_km ?? 0,
+        ml_used: mlUsed,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.match_score - a.match_score);
+
+  return enriched;
 }
 
-module.exports = new MLService();
+/**
+ * Haversine great-circle distance in km between two lat/lng points.
+ * @private
+ */
+function _haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export const __testing = {
+  demandCache,
+  priceCache,
+  _haversineKm,
+};


### PR DESCRIPTION
## Summary

`backend/api/src/services/ml.js` on `main` was corrupted by bad merge PR #7910 (`1db29c84`): the file was resolved to the broken side of the conflict and lost 8 functions that the routes import at startup — `predictDemand`, `predictPrice`, `predictEta`, `matchBilateral`, `predictDriverProfit`, and the internal helpers `handleResponse`, `getBaseUrl`, `_haversineKm`. Because routes import the missing exports (`demandRoutes.js:7`, `driverRoutes.js:132`, `truckRoutes.js:91`, `orderRoutes.js:173`), the API failed to boot (`ReferenceError: ... is not a function`).

This PR rebuilds the file from the last-good commit `01b3cb53` and re-applies the three legitimate post-merge changes from PR #8022 (pickup-deadline fallback, `arrivalTime` = now, empty-recommendations fallback).

## Changes

- Restored the 8 missing functions and the full 15-export surface of `MLService`.
- Re-applied the 3 post-good changes from PR #8022 that were present in HEAD.

## Verification

- `node --check backend/api/src/services/ml.js` passes (exit 0).
- All exports verified present via grep: `predictDemand`, `predictPrice`, `predictEta`, `matchBilateral`, `predictDriverProfit`, etc.
- Diff vs `01b3cb53` is limited to the 3 intended PR #8022 lines.

## Closes

Closes #8452

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-learning support for demand forecasting, price prediction, ETA estimation, bilateral matching, and driver-profit prediction.
  * Added intelligent offer matching with fallback recommendations and improved result sorting.
  * Added response caching to improve performance for demand and price predictions.

* **Bug Fixes**
  * Improved validation, timeout handling, API-key protection, and error reporting for ML requests.
  * Ensured en-route matching results consistently include enriched recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->