### PR TITLE
fix(security): send wallet address, not private key, in transferKeyOwnership

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -171,7 +171,7 @@ class KeyRotationService {
         const tx = await signer.sendTransaction({
           to: this.escrowContract.target,
           data: this.escrowContract.interface.encodeFunctionData('transferKeyOwnership', [
-            newPrivateKey,
+            walletAddress,
             Date.now(),
           ]),
         });


### PR DESCRIPTION
## Summary

`transferKeyOwnershipOnChain` in `backend/api/src/services/security/keyRotationService.js` called `transferKeyOwnership(newPrivateKey, Date.now())`, but the ABI signature is `transferKeyOwnership(address newKeyAddress, uint256 nonce)`. The raw **private key string** was encoded into the transaction calldata as the address field and published permanently on-chain — anyone could extract it and take over the escrow wallet. The actual `walletAddress` was passed into the method but never used.

## Changes

- `keyRotationService.js` L174: pass `walletAddress` as the `newKeyAddress` argument instead of `newPrivateKey`. The private key never leaves the server.

## Verification

- `node --check backend/api/src/services/security/keyRotationService.js` passes.
- No secret material is included in `encodeFunctionData` arguments anymore.

## Closes

Closes #8454

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
