### PR TITLE
fix(shards): register /shards/all/orders before :shardName route

### DIFF
--- a/backend/api/src/routes/shardRoutes.js
+++ b/backend/api/src/routes/shardRoutes.js
@@ -88,6 +88,29 @@ router.get('/shards/location', authenticate, userLimiter, requirePolicy('shard:v
   }
 });
 
+// Cross-shard query (registered before /shards/:shardName/orders so "all" is not captured as a shard name)
+router.get('/shards/all/orders', authenticate, userLimiter, requirePolicy('shard:query-orders'), crossShardQuery, async (req, res) => {
+  try {
+    const results = await req.executeCrossShard(
+      'SELECT COUNT(*) as total FROM orders'
+    );
+    const total = results.reduce((sum, r) => sum + parseInt(r.data[0]?.total || 0), 0);
+    res.json({
+      success: true,
+      data: {
+        total,
+        shards: results
+      }
+    });
+  } catch (error) {
+    logger.error({ requestId: req.requestId }, '[ShardRoutes] Error:', error?.message || error);
+    res.status(500).json({
+      success: false,
+      error: 'Internal Server Error'
+    });
+  }
+});
+
 // Get orders from specific shard
 router.get('/shards/:shardName/orders', authenticate, userLimiter, requirePolicy('shard:query-orders'), shardMiddleware, async (req, res) => {
   try {
@@ -101,29 +124,6 @@ router.get('/shards/:shardName/orders', authenticate, userLimiter, requirePolicy
       success: true,
       data: rows,
       shard: shardName
-    });
-  } catch (error) {
-    logger.error({ requestId: req.requestId }, '[ShardRoutes] Error:', error?.message || error);
-    res.status(500).json({
-      success: false,
-      error: 'Internal Server Error'
-    });
-  }
-});
-
-// Cross-shard query
-router.get('/shards/all/orders', authenticate, userLimiter, requirePolicy('shard:query-orders'), crossShardQuery, async (req, res) => {
-  try {
-    const results = await req.executeCrossShard(
-      'SELECT COUNT(*) as total FROM orders'
-    );
-    const total = results.reduce((sum, r) => sum + parseInt(r.data[0]?.total || 0), 0);
-    res.json({
-      success: true,
-      data: {
-        total,
-        shards: results
-      }
     });
   } catch (error) {
     logger.error({ requestId: req.requestId }, '[ShardRoutes] Error:', error?.message || error);


### PR DESCRIPTION
## Summary

In `backend/api/src/routes/shardRoutes.js`, the route `GET /shards/:shardName/orders` was registered **before** `GET /shards/all/orders`. Since Express matches in registration order, requests to `/shards/all/orders` were captured by the `:shardName` route (`shardName = "all"`) and the cross-shard query was never reachable — the endpoint was fully shadowed and dead.

## Changes

- Moved the `GET /shards/all/orders` cross-shard handler above the `GET /shards/:shardName/orders` handler so the static path wins.

## Verification

- `node --check backend/api/src/routes/shardRoutes.js` passes.
- Route ordering verified: static `/shards/all/orders` now registered before the dynamic param route.

## Closes

Closes #8455

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
