### PR TITLE
fix(admin): report total_revenue_today in rupees, not paisa

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -84,7 +84,8 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
       return res.status(500).json({ error: 'Failed to fetch revenue.' });
     }
     
-    const totalRevenue = todayOrders.reduce((sum, order) => sum + (order.total_amount || 0), 0);
+    // total_amount is stored in paisa — divide by 100 for INR display
+    const totalRevenue = todayOrders.reduce((sum, order) => sum + (order.total_amount || 0), 0) / 100;
 
     res.json({
       active_drivers: activeDrivers || 0,


### PR DESCRIPTION
## Summary

The admin dashboard `GET /admin/dashboard` computed `total_revenue_today` by summing `orders.total_amount` directly. `total_amount` is stored in **paisa** (see `paymentRoutes.js` L136-138, `deliveryVerificationService.js` L505, `orderRoutes.js` L356/L424 which divide by 100), so the dashboard reported today's revenue 100x too high.

## Changes

- `adminRoutes.js`: divide the summed `total_amount` by 100 so `total_revenue_today` is reported in rupees (INR), consistent with the rest of the API.

## Verification

- `node --check backend/api/src/routes/adminRoutes.js` passes.
- Follows the existing paisa→INR convention used throughout `orderRoutes`/`paymentRoutes`.

## Closes

Closes #8456

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
