### PR TITLE
fix(demand): actually apply vehicle_type and cargo_category heatmap filters

### DIFF
--- a/backend/api/src/routes/demandRoutes.js
+++ b/backend/api/src/routes/demandRoutes.js
@@ -15,16 +15,40 @@ const router = express.Router();
 // ============================================================================
 router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'), async (req, res) => {
   try {
+    // Extract optional query filters for vehicle type and cargo category
+    const { vehicle_type, cargo_category } = req.query;
+
+    if (vehicle_type && typeof vehicle_type !== 'string') {
+      return res.status(400).json({ error: 'vehicle_type must be a single string' });
+    }
+    if (cargo_category && typeof cargo_category !== 'string') {
+      return res.status(400).json({ error: 'cargo_category must be a single string' });
+    }
+
     // 1. Fetch recent load offers (historical/current volume)
     const { data: loads, error } = await supabase
       .from('load_offers')
-      .select('pickup_address, drop_address, status, pickup_lat, pickup_lng')
+      .select('pickup_address, drop_address, status, pickup_lat, pickup_lng, goods_type')
       .in('status', ['available', 'claimed'])
       .limit(100);
 
     if (error) {
       logger.error('Failed to fetch historical volume for heatmap:', error);
       return res.status(500).json({ error: 'Failed to fetch heatmap data.' });
+    }
+
+    // Apply the filters in JS: load_offers has no vehicle_type / cargo_category
+    // columns (same convention as the marketplace board in loadRoutes.js, where
+    // vehicle_type is a synthetic 'Truck' value). cargo_category maps onto the
+    // real goods_type column.
+    let filteredLoads = loads || [];
+    if (vehicle_type && vehicle_type.toLowerCase() !== 'truck') {
+      filteredLoads = [];
+    }
+    if (cargo_category) {
+      filteredLoads = filteredLoads.filter(
+        (l) => String(l.goods_type || '').toLowerCase() === cargo_category.toLowerCase()
+      );
     }
 
     // 2. Fetch ML prediction aggregation for high-demand zones & route insights
@@ -35,22 +59,19 @@ router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'),
         day_of_week: new Date().getDay(),
         temperature: 25.0,
         precipitation: 0,
-        historical_volume: loads?.length || 0,
+        historical_volume: filteredLoads?.length || 0,
         nearby_drivers: 0,
       });
     } catch (mlErr) {
       logger.warn('[DemandHeatmap] ML engine prediction failed, falling back to basic data:', mlErr.message);
     }
 
-    // Extract optional query filters for vehicle type and cargo category
-    const { vehicle_type, cargo_category } = req.query;
-
     // Generate intelligent route recommendations and earnings potential based on ML predictions
     const baseEarningRate = demandConfig.baseEarningRate; // per km estimate
     const multiplier = mlPrediction.predicted_demand || 0.5;
     const estimatedEarningPotential = Number((baseEarningRate * (1 + multiplier)).toFixed(2));
 
-    const routeSuggestions = (loads || []).slice(0, 3).map((l, idx) => ({
+    const routeSuggestions = (filteredLoads || []).slice(0, 3).map((l, idx) => ({
       id: idx + 1,
       recommendedRoute: `${l.pickup_address || 'Current Location'} -> ${l.drop_address || 'High Demand Zone'}`,
       estimatedEarnings: estimatedEarningPotential * (demandConfig.routeMultiplierBase + idx * demandConfig.routeMultiplierStep),
@@ -69,7 +90,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'),
     ];
 
     // 3. Construct GeoJSON
-    const features = (loads || []).map((load) => {
+    const features = (filteredLoads || []).map((load) => {
       const lat = load.pickup_lat;
       const lng = load.pickup_lng;
 


### PR DESCRIPTION
## Summary

`GET /api/demand-heatmap` accepted `vehicle_type` and `cargo_category` query filters and even echoed them in `filtersApplied`, but never applied them — every request returned the same unfiltered heatmap.

`load_offers` has no `vehicle_type`/`cargo_category` columns (the marketplace board in `loadRoutes.js` filters `vehicle_type` in JS because it is a synthetic `'Truck'` value), so a `.eq()` database filter would error. The fix filters in JS, consistent with the existing convention.

## Changes

- `demandRoutes.js`:
  - Validate `vehicle_type`/`cargo_category` are single strings (400 on repeated filters, matching `loadRoutes`).
  - Fetch `goods_type` and filter in JS: `vehicle_type` matches only the synthetic `'Truck'` value; `cargo_category` maps onto the real `goods_type` column.
  - `routeSuggestions`, `features`, and the ML `historical_volume` now use the filtered set.

## Verification

- `node --check backend/api/src/routes/demandRoutes.js` passes.
- Filter behavior mirrors `loadRoutes.js` L177-191.

## Closes

Closes #8457

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
