### PR TITLE
fix(driver): page statement fetch instead of capping at 1000 rows

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1197,26 +1197,42 @@ async function handleDriverEarningsAndStatement(req, res, filename, errorLabel) 
   const { start_date, end_date, sort_by, format } = req.query;
 
   try {
-    let query = supabase
-      .from('orders')
-      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, base_freight, toll_estimate, platform_fee')
-      .eq('driver_id', userId)
-      .in('status', ['delivered', 'payment_released'])
-      .limit(1000);
+    // PostgREST caps a single response at 1000 rows, so page through the
+    // whole history instead of silently truncating the statement.
+    const pageSize = 1000;
+    const trips = [];
 
-    if (start_date) {
-      query = query.gte('pickup_date', start_date);
-    }
-    if (end_date) {
-      query = query.lte('pickup_date', end_date);
+    while (true) {
+      let pageQuery = supabase
+        .from('orders')
+        .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, base_freight, toll_estimate, platform_fee')
+        .eq('driver_id', userId)
+        .in('status', ['delivered', 'payment_released'])
+        .order('pickup_date', { ascending: true })
+        .range(trips.length, trips.length + pageSize - 1);
+
+      if (start_date) {
+        pageQuery = pageQuery.gte('pickup_date', start_date);
+      }
+      if (end_date) {
+        pageQuery = pageQuery.lte('pickup_date', end_date);
+      }
+
+      const { data: pageRows, error } = await pageQuery;
+
+      if (error) {
+        logger.error({ err: error }, errorLabel);
+        return res.status(500).json({ error: 'Failed to fetch statement records.' });
+      }
+
+      trips.push(...(pageRows || []));
+      if (!pageRows || pageRows.length < pageSize) {
+        break;
+      }
     }
 
-    const { data: trips, error } = await query.order('pickup_date', { ascending: false });
-
-    if (error) {
-      logger.error({ err: error }, errorLabel);
-      return res.status(500).json({ error: 'Failed to fetch statement records.' });
-    }
+    // Pages were fetched oldest-first; restore newest-first ordering.
+    trips.reverse();
 
     // Compute totals
     let totalBaseFreight = 0;


### PR DESCRIPTION
## Summary

The driver statement/earnings handler (`GET /api/driver/statement`) applied `.limit(1000)` to the `orders` query. PostgREST caps a single response at 1000 rows, so any driver with more than 1000 delivered orders got a **silently truncated** statement with incorrect totals (`total_trips`, sums of base freight / platform fee / toll estimate / net earnings).

## Changes

- `driverRoutes.js`: replace the single `.limit(1000)` query with an offset-based `.range()` pagination loop that fetches the full history in 1000-row pages, then restores newest-first ordering.

## Verification

- `node --check backend/api/src/routes/driverRoutes.js` passes.
- Statement totals now cover the driver's entire delivered-order history, not just the first 1000.

## Closes

Closes #8458

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
