### PR TITLE
fix(reputation): release per-row Redis claim after processing

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -67,8 +67,9 @@ export async function reconcileFailedReputationUpdates() {
 
     for (const row of failedReputations ?? []) {
       let claimError;
+      let claimKey;
       if (redisClient) {
-        const claimKey = `reputation:claim:${row.id}`;
+        claimKey = `reputation:claim:${row.id}`;
         const claimed = await redisClient.set(claimKey, instanceId, 'NX', 'EX', 300);
         if (!claimed) {
           logger.info(`[reputation-reconciliation] Row ${row.id} already claimed, skipping.`);
@@ -95,6 +96,16 @@ export async function reconcileFailedReputationUpdates() {
           last_attempt_at: new Date().toISOString(),
         });
         logger.warn(`[reputation-reconciliation] Retry ${newRetryCount}/${MAX_RETRIES} failed for ${row.driver_wallet}: ${err.message}`);
+      } finally {
+        // Release the per-row claim so a re-queued failure can be retried on
+        // the next cycle instead of waiting for the 300s claim TTL to expire.
+        if (claimKey) {
+          try {
+            await redisClient.del(claimKey);
+          } catch (err) {
+            logger.warn(`[reputation-reconciliation] Failed to release claim for ${row.id}:`, err.message);
+          }
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

`reconcileFailedReputationUpdates` set a per-row Redis claim key (`reputation:claim:<id>`) with a 300s TTL and **never released it**. When a row failed and was re-upserted with an incremented `retry_count`, every worker (including other instances) skipped it until the claim TTL expired — delaying each retry by up to 5 minutes and defeating the reconciliation interval (60s default).

## Changes

- `reputationReconciliation.js`: release the per-row claim with `redisClient.del(claimKey)` in a `finally` block after each row is processed, so re-queued failures are retried on the next cycle.

## Verification

- `node --check backend/api/src/services/reputationReconciliation.js` passes.
- Claim keys are now deleted on both success and failure paths.

## Closes

Closes #8459

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
