### PR TITLE
fix(geocode): add timeout to Nominatim reverse-geocode fetch

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -2,6 +2,12 @@ import { redisClient } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
 const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const NOMINATIM_TIMEOUT_MS = 5000;
+
+function getTimeoutMs() {
+  const configured = Number(process.env.NOMINATIM_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : NOMINATIM_TIMEOUT_MS;
+}
 
 /**
  * Reverse geocodes a latitude and longitude to a human-readable address
@@ -36,6 +42,7 @@ export async function reverseGeocode(lat, lon) {
         'User-Agent': 'Truxify-Node-Backend/1.0',
         'Accept-Language': 'en-US,en;q=0.9',
       },
+      signal: AbortSignal.timeout(getTimeoutMs()),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

`reverseGeocode` in `backend/api/src/lib/reverseGeocode.js` fetched `nominatim.openstreetmap.org` with no timeout. A slow or unresponsive Nominatim blocked the calling route indefinitely (the aggressive Redis cache only helps on cache hits).

## Changes

- `reverseGeocode.js`:
  - Added `AbortSignal.timeout()` to the Nominatim fetch with a 5s default, overridable via `NOMINATIM_TIMEOUT_MS` (same env-config pattern as `osrm.js`).
  - The existing `catch` already degrades gracefully to `null`.

## Verification

- `node --check backend/api/src/lib/reverseGeocode.js` passes.

## Closes

Closes #8461

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
