### PR TITLE
fix(escrow): use ESM export instead of module.exports

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -880,7 +880,7 @@ export const lockPayment = escrowLockPayment;
 
 
 
-async function verifyOnChainEscrowBalance(bookingId, expectedWei) {
+export async function verifyOnChainEscrowBalance(bookingId, expectedWei) {
   const bookingOnChain = await escrowContract.bookings(bookingId);
   const onChainAmountBN = BigInt(bookingOnChain.amount.toString());
   const expectedWeiBN = BigInt(expectedWei);
@@ -890,5 +890,3 @@ async function verifyOnChainEscrowBalance(bookingId, expectedWei) {
     expectedAmount: expectedWeiBN.toString()
   };
 }
-
-module.exports.verifyOnChainEscrowBalance = verifyOnChainEscrowBalance;


### PR DESCRIPTION
## Summary

`backend/api/src/services/escrow.js` runs under `"type": "module"` (ESM), but the trailing line used `module.exports.verifyOnChainEscrowBalance = verifyOnChainEscrowBalance;`. The global `module` is undefined in ESM, so importing `escrow.js` threw a `ReferenceError: module is not defined` — which includes server startup via `src/index.js` (L33 imports from `./services/escrow.js`).

## Changes

- `escrow.js`: convert `verifyOnChainEscrowBalance` to a named `export` declaration and remove the `module.exports` line.

## Verification

- `node --check backend/api/src/services/escrow.js` passes.
- No `module.exports` / `require` references remain in the file (all other exports are already ESM `export` statements).

## Closes

Closes #8462

---

This PR is part of the GSSOC (GirlScript Summer of Code) batch.
