### PR TITLE
fix : removed unauthenticated sentry-debug endpoint and duplicate import from ML main.py

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -27,7 +27,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from app.models.eta_prediction import eta_predictor
-from fastapi import HTTPException
 
 from app.models.demand_forecast import (
     predict_demand,
@@ -101,11 +100,6 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["X-API-Key", "Content-Type"],
 )
-
-
-@app.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0
 
 
 @app.on_event("startup")


### PR DESCRIPTION
Closes #8582.

Summary of What Has Been Done:
Removed the GET /sentry-debug endpoint from backend/ml/main.py (which was unauthenticated and always raised ZeroDivisionError, burning Sentry quota on every request). Also removed the duplicate 'from fastapi import HTTPException' import that was causing an F811 flake8 error.

Changes Made:
- backend/ml/main.py: removed the /sentry-debug route (trigger_error function)
- backend/ml/main.py: removed duplicate HTTPException import

Impact it Made:
- No more unauthenticated 500-generator endpoint; Sentry quota no longer burned by synthetic requests
- Eliminates F811 duplicate-import flake8 error
- All ML routes now consistently require verify_api_key authentication

Note: This PR is being made as part of GSSOC contribution automation.