### PR TITLE
fix(service): remove CJS module.exports that crashed orderLifecycleService load

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1034,7 +1034,7 @@ async function createOrderTransactional({ idempotencyKey, orderData, timelineDat
   }
 
   try {
-    const { data, error } = await db.rpc('create_order_tx', {
+    const { data, error } = await supabaseAdmin.rpc('create_order_tx', {
       p_idempotency_key: idempotencyKey,
       p_order_data: orderData,
       p_timeline_data: timelineData || { status: 'created', details: { note: 'Order initialized' } },
@@ -1056,5 +1056,3 @@ async function createOrderTransactional({ idempotencyKey, orderData, timelineDat
     throw err;
   }
 }
-
-module.exports.createOrderTransactional = createOrderTransactional;


### PR DESCRIPTION
## Summary

Fixes the API boot crash described in #8617.

`backend/api/src/services/order/orderLifecycleService.js` is an ES module (`"type": "module"` in `backend/api/package.json`) but its final line was:

```js
module.exports.createOrderTransactional = createOrderTransactional;
```

`module` is not defined in ES module scope, so Node threw `ReferenceError: module is not defined in ES module scope` at module evaluation. Since `src/core/container.js` imports this module at boot, the whole API process failed to start.

Additionally, the RPC call used `db.rpc('create_order_tx', …)` where `db` is never imported (only `supabaseAdmin` is), which would throw `ReferenceError: db is not defined` if the function were ever invoked.

## Changes

- Removed the trailing `module.exports.createOrderTransactional = createOrderTransactional;` line (the function is not imported by any other module).
- Changed `db.rpc('create_order_tx', …)` to `supabaseAdmin.rpc('create_order_tx', …)`.

## Verification

- `node --check backend/api/src/services/order/orderLifecycleService.js` passes.
- No remaining `module.exports` / `db.` references in the file.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order creation reliability by routing transactional order creation through the administrative database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->