### PR TITLE
fix : added dd missing errorResponse import to deviceController

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,6 +1,7 @@
 import { supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
+import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
Closes #8591.

Summary of What Has Been Done:
Added import of errorResponse from utils/apiResponse.js to deviceController.js. The errorResponse function was being called at line 64 but was not imported, causing a ReferenceError at runtime.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.