### PR TITLE
fix : added emove duplicate neq branch in updateOrderWithFilter

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -155,8 +155,6 @@ export class OrderRepository {
             query = query.not(f.column, f.operator, f.value);
           } else if (f.op === 'in') {
             query = query.in(f.column, f.value);
-          } else if (f.op === 'neq') {
-            query = query.not(f.column, 'neq', f.value);
           }
         }
       }


### PR DESCRIPTION
Closes #8592.

Summary of What Has Been Done:
Removed the unreachable duplicate else if (f.op === 'neq') branch from orderRepository.js updateOrderWithFilter(). The second neq branch incorrectly used .not() with 'neq' as the PostgREST operator.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.