### PR TITLE
fix : added ix out-of-scope result reference in checkEscrow nested try-catch

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -122,17 +122,12 @@ function checkFirebase() {
 
 async function checkEscrow() {
   try {
-  try {
-  const result = await checkEscrowHealth();
+    const result = await checkEscrowHealth();
+    return result.status;
   } catch (err) {
     logger.error('[Health] checkEscrow failed:', err?.message || err);
     return { status: 'failed', detail: err?.message || 'Unknown error' };
   }
-  } catch (err) {
-    logger.error('[Health] checkEscrow failed:', err?.message || err);
-    return { status: 'failed', detail: err?.message || 'Unknown error' };
-  }
-  return result.status;
 }
 
 function checkPolygon() {


### PR DESCRIPTION
Closes #8593.

Summary of What Has Been Done:
Restructured the checkEscrow() function in healthRoutes.js to use a single try-catch instead of nested try-catch blocks. The outer catch was referencing 'result' which was out of scope.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.