### PR TITLE
fix(fraud): aggregate getFraudStats over the whole table, not 1000 rows

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -714,13 +714,31 @@ class FraudDetectionService {
 
   async getFraudStats() {
     if (!supabaseAdmin) return { total: 0, highRisk: 0, mediumRisk: 0, lowRisk: 0, avgScore: 0 };
-    const { data: scores } = await supabaseAdmin
-      .from('fraud_risk_scores')
-      .select('risk_score, created_at')
-      .order('created_at', { ascending: false })
-      .limit(1000);
 
-    const safe = scores || [];
+    // PostgREST caps a single response at 1000 rows, so page through the whole
+    // table instead of letting the stats silently reflect only the latest slice.
+    const pageSize = 1000;
+    const scores = [];
+    while (true) {
+      const from = scores.length;
+      const { data: page, error } = await supabaseAdmin
+        .from('fraud_risk_scores')
+        .select('risk_score, created_at')
+        .order('created_at', { ascending: false })
+        .range(from, from + pageSize - 1);
+
+      if (error) {
+        logger.error('Failed to load fraud stats:', error);
+        return { total: 0, highRisk: 0, mediumRisk: 0, lowRisk: 0, avgScore: 0 };
+      }
+
+      scores.push(...(page || []));
+      if (!page || page.length < pageSize) {
+        break;
+      }
+    }
+
+    const safe = scores;
 
     const highRisk = safe.filter(s => s.risk_score > 0.7).length;
     const mediumRisk = safe.filter(s => s.risk_score > 0.4 && s.risk_score <= 0.7).length;


### PR DESCRIPTION
## Summary

Fixes the silent undercounting described in #8618.

`FraudDetectionService.getFraudStats()` fetched only the most recent 1000 `fraud_risk_scores` rows (`.limit(1000)`) and computed every metric from that slice. PostgREST caps a single response at 1000 rows, so once the table grows past that, `total` plateaus at 1000 and `highRisk`/`mediumRisk`/`lowRisk`/`avgScore` are all computed from an incomplete window.

## Changes

- Replaced the single capped query with an offset-based `.range()` pagination loop that aggregates the full table, preserving the existing bucket logic.

## Verification

- `node --check backend/api/src/services/fraud/FraudDetectionService.js` passes.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.
