### PR TITLE
fix : added emove unauthenticated /sentry-debug endpoint from ML main.py

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -103,11 +103,6 @@ app.add_middleware(
 )
 
 
-@app.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0
-
-
 @app.on_event("startup")
 async def startup_event():
     from app.models.base import preload_all_models


### PR DESCRIPTION
Closes #8594.

Summary of What Has Been Done:
Removed the unauthenticated /sentry-debug GET endpoint from backend/ml/main.py that always raised ZeroDivisionError.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.