### PR TITLE
fix : added dd null/undefined input guard to escapeLike function

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -1,4 +1,5 @@
 export function escapeLike(value) {
+  if (value == null) return value;
   if (typeof value !== 'string') return value;
   return value
     .replace(/\\/g, '\\\\')


### PR DESCRIPTION
Closes #8597.

Summary of What Has Been Done:
Added an early null/undefined guard at the start of escapeLike() in backend/api/src/lib/escapeLike.js. Passing null or undefined now safely returns the original value instead of throwing a TypeError.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.