### PR TITLE
fix : added dd caught error variable to bare catch block in cors.js

### DIFF
--- a/backend/api/src/middleware/cors.js
+++ b/backend/api/src/middleware/cors.js
@@ -8,7 +8,7 @@ const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
     try {
       const parsed = new URL(origin);
       return parsed.protocol === "http:" || parsed.protocol === "https:";
-    } catch {
+    } catch (_) {
       return false;
     }
   });


### PR DESCRIPTION
Closes #8599.

Summary of What Has Been Done:
Changed bare catch {} to catch (_) { in backend/api/src/middleware/cors.js to make the intentionally-unused error variable explicit.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.