### PR TITLE
fix : added dd defensive err instanceof Error check in circuitBreaker onFailure

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -96,7 +96,8 @@ export class CircuitBreaker {
 
   onFailure(err, args) {
     this.failureCount += 1;
-    logger.error({ err: err.message, failures: this.failureCount }, `[CircuitBreaker:${this.name}] Execution failure`);
+    const errMessage = err instanceof Error ? err.message : String(err);
+    logger.error({ err: errMessage, failures: this.failureCount }, `[CircuitBreaker:${this.name}] Execution failure`);
 
     if (this.state === CircuitState.HALF_OPEN || this.failureCount >= this.failureThreshold) {
       this.state = CircuitState.OPEN;


### PR DESCRIPTION
Closes #8600.

Summary of What Has Been Done:
Added instanceof Error check before accessing err.message in circuitBreaker.js onFailure(). This prevents potential crashes when a non-Error value is thrown.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.