### PR TITLE
test : added dded unit tests for validate.js formatValidationIssues

### DIFF
--- a/backend/api/test/unit/validate.test.js
+++ b/backend/api/test/unit/validate.test.js
@@ -93,6 +93,33 @@ describe('validateBody middleware', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(res.status).not.toHaveBeenCalled();
   });
+
+describe('formatValidationIssues', () => {
+  it('formats a single field error', () => {
+    const error = { issues: [{ path: ['email'], message: 'Invalid email' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'email', message: 'Invalid email' }]);
+  });
+
+  it('formats a nested field error path', () => {
+    const error = { issues: [{ path: ['address', 'city'], message: 'Required' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'address.city', message: 'Required' }]);
+  });
+
+  it('formats an empty path as "body"', () => {
+    const error = { issues: [{ path: [], message: 'Body is required' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'body', message: 'Body is required' }]);
+  });
+
+  it('returns empty array for empty issues', () => {
+    const error = { issues: [] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([]);
+  });
+});
+
 });
 
 describe('validateParams middleware', () => {
@@ -183,4 +210,31 @@ describe('validateQuery middleware', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(res.status).not.toHaveBeenCalled();
   });
+
+describe('formatValidationIssues', () => {
+  it('formats a single field error', () => {
+    const error = { issues: [{ path: ['email'], message: 'Invalid email' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'email', message: 'Invalid email' }]);
+  });
+
+  it('formats a nested field error path', () => {
+    const error = { issues: [{ path: ['address', 'city'], message: 'Required' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'address.city', message: 'Required' }]);
+  });
+
+  it('formats an empty path as "body"', () => {
+    const error = { issues: [{ path: [], message: 'Body is required' }] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([{ field: 'body', message: 'Body is required' }]);
+  });
+
+  it('returns empty array for empty issues', () => {
+    const error = { issues: [] };
+    const result = formatValidationIssues(error);
+    expect(result).toEqual([]);
+  });
+});
+
 });


### PR DESCRIPTION
Closes #8603.

Summary of What Has Been Done:
Added unit tests for formatValidationIssues covering single-field errors, nested paths, empty paths, and empty issues.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.