### PR TITLE
fix : added dd rate-limit retry with Retry-After header support in reverseGeocode

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -31,12 +31,26 @@ export async function reverseGeocode(lat, lon) {
     // 2. Fetch from OpenStreetMap Nominatim
     // Note: Nominatim requires a valid User-Agent to avoid being blocked
     const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${roundedLat}&lon=${roundedLon}&zoom=14`;
-    const response = await fetch(url, {
+    let response = await fetch(url, {
       headers: {
         'User-Agent': 'Truxify-Node-Backend/1.0',
         'Accept-Language': 'en-US,en;q=0.9',
       },
     });
+
+    // Handle rate-limiting with Retry-After support
+    if (response.status === 429) {
+      const retryAfter = response.headers.get('Retry-After');
+      const waitMs = retryAfter ? Math.min(parseInt(retryAfter, 10) * 1000, 60000) : 60000;
+      logger.warn({ waitMs, lat: roundedLat, lon: roundedLon }, '[ReverseGeocode] Rate-limited, retrying after Retry-After delay');
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      response = await fetch(url, {
+        headers: {
+          'User-Agent': 'Truxify-Node-Backend/1.0',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+      });
+    }
 
     if (!response.ok) {
       logger.error({ status: response.status }, '[ReverseGeocode] Nominatim API error');


### PR DESCRIPTION
Closes #8611.

Summary of What Has Been Done:
Added retry logic to reverseGeocode() for 429 Too Many Requests. The function now respects the Retry-After header, waiting before retrying once.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.