### PR TITLE
fix(voice): add timeouts to Whisper, chat-completion and TTS calls

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -5,6 +5,8 @@ import logger from '../middleware/logger.js';
 
 const MAX_CACHE_SIZE = 100;
 const CACHE_TTL_MS = 10 * 60 * 1000;
+const VOICE_API_TIMEOUT_MS = 10000;
+const WHISPER_TIMEOUT_MS = 15000;
 export const audioCache = new Map();
 
 function trimCache() {
@@ -126,7 +128,8 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
       headers: {
         'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
         'Content-Type': `multipart/form-data; boundary=${boundary}`
-      }
+      },
+      timeout: WHISPER_TIMEOUT_MS
     });
     transcript = whisperResponse.data.text;
   } catch (err) {
@@ -149,7 +152,8 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
       headers: {
         'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
         'Content-Type': 'application/json'
-      }
+      },
+      timeout: VOICE_API_TIMEOUT_MS
     });
     responseText = llmResponse.data.choices[0].message.content;
   } catch (err) {
@@ -173,7 +177,8 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
         'xi-api-key': process.env.ELEVENLABS_API_KEY,
         'accept': 'audio/mpeg'
       },
-      responseType: 'arraybuffer'
+      responseType: 'arraybuffer',
+      timeout: VOICE_API_TIMEOUT_MS
     });
 
     const audioId = crypto.randomUUID();


### PR DESCRIPTION
## Summary

Fixes the indefinite-hang issue described in #8620.

`VoiceAiService` made three axios calls with no `timeout` — Whisper transcription, OpenAI chat completion, and ElevenLabs TTS — so an unresponsive upstream kept the `/api/voice/process` request open forever.

## Changes

- Added `WHISPER_TIMEOUT_MS = 15000` (multipart audio upload gets a larger budget) and `VOICE_API_TIMEOUT_MS = 10000`.
- Applied `timeout` to all three axios calls (Whisper transcription, chat completion, ElevenLabs TTS).

## Verification

- `node --check backend/api/src/services/voiceService.js` passes.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.
