### PR TITLE
fix(earnings): keep decimal points when parsing trip distance

### DIFF
--- a/backend/api/src/services/driver/earningsReportService.js
+++ b/backend/api/src/services/driver/earningsReportService.js
@@ -109,11 +109,11 @@ export function parseDistanceKm(value) {
   if (value === null || value === undefined) {
     return 0;
   }
-  const digits = String(value).replace(/[^0-9]/g, '');
-  if (digits.length === 0) {
+  const decimal = String(value).replace(/[^0-9.]/g, '');
+  if (decimal.length === 0) {
     return 0;
   }
-  const parsed = parseInt(digits, 10);
+  const parsed = parseFloat(decimal);
   return Number.isFinite(parsed) ? parsed : 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes the distance-parsing bug described in #8621.

`parseDistanceKm` in `earningsReportService.js` stripped every non-digit character before parsing, which also removed the decimal separator: a `"24.5 km"` trip parsed as **245 km**. This inflated `sumDistanceKm`, the per-trip `distance` values, and the derived `avg_earning_per_km` in the driver earnings report.

## Changes

- `parseDistanceKm` now keeps the decimal point (`/[^0-9.]/`) and parses with `parseFloat` instead of `parseInt` over stripped digits.
- Unparseable inputs still return `0`.

## Verification

- `node --check` passes.
- Spot-checked: `"24.5 km" → 24.5`, `"10km" → 10`, `"5.75 KM" → 5.75`, `"km" → 0`, `"0.5" → 0.5`.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.
