### PR TITLE
fix(profile): report performance-stats earnings in rupees, not paisa

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -766,13 +766,13 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
     const onTimeCount = trips.filter(t => t.on_time !== false).length;
     const onTimePercentage = totalDeliveries > 0 ? Number(((onTimeCount / totalDeliveries) * 100).toFixed(1)) : 0;
 
-    // Lifetime earnings
-    const lifetimeEarnings = trips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0);
+    // Lifetime earnings (base_freight is stored in paisa; report in rupees)
+    const lifetimeEarnings = trips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0) / 100;
 
     // Monthly summary (current month)
     const currentMonth = new Date().toISOString().slice(0, 7);
     const monthlyTrips = trips.filter(t => t.created_at && t.created_at.startsWith(currentMonth));
-    const monthlyEarnings = monthlyTrips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0);
+    const monthlyEarnings = monthlyTrips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0) / 100;
 
     const monthlyPerformanceSummary = {
       month: currentMonth,

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -636,11 +636,11 @@ describe('Profile Routes', () => {
       expect(res.body.totalDistanceKm).toBe(300);
       expect(res.body.averageRating).toBe(4.5);
       expect(res.body.onTimePercentage).toBe(50);
-      expect(res.body.lifetimeEarnings).toBe(3000);
+      expect(res.body.lifetimeEarnings).toBe(30);
       expect(res.body.monthlyPerformanceSummary).toEqual({
         month: currentMonth,
         deliveriesCompleted: 2,
-        earnings: 3000,
+        earnings: 30,
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes the unit mismatch described in #8622.

`base_freight` is stored in **paisa** across the codebase — `loadRoutes`, `orderRoutes` and `paymentRoutes` all divide by 100 before returning rupee amounts. The `/driver/performance-stats` handler summed `base_freight` directly, so `lifetimeEarnings` and the `monthlyPerformanceSummary.earnings` were returned 100× too large.

## Changes

- `lifetimeEarnings` and `monthlyEarnings` now divide the paisa sums by 100, so the endpoint returns rupees consistently with the rest of the API.

## Verification

- `node --check backend/api/src/routes/profileRoutes.js` passes.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Driver performance statistics now display lifetime and current-month earnings in rupees instead of paisa.
  * Earnings values are correctly rounded after conversion for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->