### PR TITLE
fix(profile): page the /driver/statement fetch instead of truncating at 1000 rows

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -546,24 +546,41 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
   const { start_date, end_date, sort_by, format } = req.query;
 
   try {
-    let query = supabase
-      .from('orders')
-      .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, base_freight, toll_estimate, platform_fee, created_at')
-      .eq('driver_id', userId)
-      .in('status', ['delivered', 'payment_released']);
+    // PostgREST caps a single response at 1000 rows, so page through the
+    // whole history instead of silently truncating the statement.
+    const pageSize = 1000;
+    const trips = [];
 
-    if (start_date) {
-      query = query.gte('pickup_date', start_date);
-    }
-    if (end_date) {
-      query = query.lte('pickup_date', end_date);
+    while (true) {
+      let pageQuery = supabase
+        .from('orders')
+        .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, base_freight, toll_estimate, platform_fee, created_at')
+        .eq('driver_id', userId)
+        .in('status', ['delivered', 'payment_released'])
+        .order('pickup_date', { ascending: true })
+        .range(trips.length, trips.length + pageSize - 1);
+
+      if (start_date) {
+        pageQuery = pageQuery.gte('pickup_date', start_date);
+      }
+      if (end_date) {
+        pageQuery = pageQuery.lte('pickup_date', end_date);
+      }
+
+      const { data: pageRows, error } = await pageQuery;
+
+      if (error) {
+        return res.status(500).json({ error: 'Failed to fetch statement records.', details: error.message });
+      }
+
+      trips.push(...(pageRows || []));
+      if (!pageRows || pageRows.length < pageSize) {
+        break;
+      }
     }
 
-    const { data: trips, error } = await query.order('pickup_date', { ascending: false });
-
-    if (error) {
-      return res.status(500).json({ error: 'Failed to fetch statement records.', details: error.message });
-    }
+    // Pages were fetched oldest-first; restore newest-first ordering.
+    trips.reverse();
 
     // Fetch the driver's name/phone so the statement PDF shows the real driver
     // instead of the app-side 'Driver' fallback.


### PR DESCRIPTION
## Summary

Fixes the silently-truncated statement described in #8623.

`GET /driver/statement` in `profileRoutes.js` applied no `.range()` pagination, so PostgREST returned at most the first **1000** delivered orders. Drivers with longer history got a truncated statement — wrong `summary` totals and a CSV missing trips beyond the 1000-row cap.

## Changes

- Replaced the single un-paged query with a `while` loop using offset-based `.range(trips.length, trips.length + pageSize - 1)` pages until the full history is fetched.
- Pages are fetched oldest-first, then `trips.reverse()` restores the previous newest-first ordering.
- Same pattern already used by the `driverRoutes.js` statement fix.

## Verification

- `node --check backend/api/src/routes/profileRoutes.js` passes.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.
