### PR TITLE
fix(driver): keep avg_earning_per_km in the same unit as the rest of the report

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1628,7 +1628,7 @@ router.get('/:id/earnings', authenticate, userLimiter, requirePolicy('driver:vie
       })),
       cumulative_stats: {
         total_km: totalKm,
-        avg_earning_per_km: totalKm > 0 ? (totalNetEarnings / 100.0) / totalKm : 0,
+        avg_earning_per_km: totalKm > 0 ? totalNetEarnings / totalKm : 0,
         lifetime_trips: lifetimeTrips || 0
       },
       deadhead_trips_saved: deadheadTripsSaved


### PR DESCRIPTION
## Summary

Fixes the unit mismatch described in #8624.

The `/:id/earnings` report is paisa-denominated end to end — `weekly_chart` buckets, `gross_earnings`, `net_earnings` and every per-trip `gross_earnings`/`net_earnings` come straight from `trips` where `total_earnings`/`net_earnings` are stored in **paisa**. Only `avg_earning_per_km` applied a `/ 100.0`, so the headline average was reported in rupees — 100× lower than the figures it summarises.

## Changes

- `avg_earning_per_km` now stays in paisa/km, consistent with the rest of the response:
  ```js
  avg_earning_per_km: totalKm > 0 ? totalNetEarnings / totalKm : 0,
  ```

## Verification

- `node --check backend/api/src/routes/driverRoutes.js` passes.

---
Part of GSSOC 2026. This PR is a GSSOC contribution addressing the issue above.
