### PR TITLE
[Bug] Close TestSweepDrivers so the telemetry-ingestion package compiles

### DIFF
--- a/services/telemetry-ingestion/main_test.go
+++ b/services/telemetry-ingestion/main_test.go
@@ -37,6 +37,15 @@ func TestSweepDrivers(t *testing.T) {
 	if _, ok := pingRateLimit.Load("driver-stale"); ok {
 		t.Errorf("expected driver-stale to be evicted from pingRateLimit")
 	}
+
+	// activeDrivers and pingRateLimit are package-level sync.Maps shared by
+	// every test in this file, so clean up what this one stored.
+	activeDrivers.Delete("driver-fresh")
+	activeDrivers.Delete("driver-stale")
+	pingRateLimit.Delete("driver-fresh")
+	pingRateLimit.Delete("driver-stale")
+}
+
 func TestSweepDriversEvictsStaleRetainsFresh(t *testing.T) {
 	now := time.Now()
 	staleAge := driverTTL + time.Minute


### PR DESCRIPTION
Fixes #8664.

`services/telemetry-ingestion/main_test.go` does not compile — `TestSweepDrivers` is never closed, so the next declaration begins inside its body.

### Before

```
$ gofmt -e services/telemetry-ingestion/main_test.go
main_test.go:40:6: expected '(', found TestSweepDriversEvictsStaleRetainsFresh
main_test.go:69:3: expected '}', found 'EOF'
```

```go
	if _, ok := pingRateLimit.Load("driver-stale"); ok {
		t.Errorf("expected driver-stale to be evicted from pingRateLimit")
	}
func TestSweepDriversEvictsStaleRetainsFresh(t *testing.T) {     // no closing brace above
```

Two tests for `sweepDrivers()` were written independently — one keyed on `driver-fresh`/`driver-stale`, the other on `stale-driver`/`fresh-driver` — and merged without closing the first. Go does not allow a nested function declaration, hence the cascade to EOF.

### After

```
$ go vet ./...          # clean
$ go test ./...
ok  	truxify/telemetry-ingestion	0.572s
```

### Why it matters

The telemetry-ingestion service had **no working tests**. `sweepDrivers()` is the eviction pass that clears stale entries from the package-level `activeDrivers` and `pingRateLimit` `sync.Map`s — what keeps a long-running ingestion process from growing without bound as driver IDs accumulate. Both tests exist to prove eviction happens; neither had ever run.

### Also included

`TestSweepDrivers` now gets the same `Delete` cleanup the second test already performs. Both write to package-level maps; the keys are disjoint today so nothing was breaking, but the first was leaking state into whatever ran after it.

9 insertions, 0 deletions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to prevent temporary telemetry driver and rate-limit data from affecting other tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->