### PR TITLE
[Bug] Repair Raft nextIndex independently of matchIndex so it cannot stick below matchIndex+1

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -413,7 +413,15 @@ func (rn *RaftNode) sendHeartbeats() {
 			newMatch := res.request.PrevLogIndex + uint64(len(res.request.Entries))
 			if newMatch > rn.matchIndex[res.url] {
 				rn.matchIndex[res.url] = newMatch
-				rn.nextIndex[res.url] = newMatch + 1
+			}
+			// nextIndex must never lag matchIndex+1. Repairing it separately
+			// matters when a stale failure response has already decremented
+			// nextIndex below what the follower is known to hold: newMatch
+			// would then not exceed matchIndex, and nesting this update inside
+			// that check would leave nextIndex stuck low forever, re-sending
+			// entries the follower already has on every heartbeat.
+			if next := rn.matchIndex[res.url] + 1; next > rn.nextIndex[res.url] {
+				rn.nextIndex[res.url] = next
 			}
 		} else if rn.nextIndex[res.url] > 1 && res.request.PrevLogIndex+1 == rn.nextIndex[res.url] {
 			// Log inconsistency: back off and retry from an earlier prefix if probe matches current nextIndex.


### PR DESCRIPTION
Fixes #8669.

The Raft leader advanced `nextIndex` only inside the branch that advances `matchIndex`, so a `nextIndex` pushed too low by a stale failure response could never recover.

### Before

```
$ cd services/consensus-raft-go && go test ./...
--- FAIL: TestOutofOrderAppendResponseDoesNotRegressMatchIndex
    main_test.go:350: expected nextIndex to remain at 3, got 1
```

```go
if newMatch > rn.matchIndex[res.url] {
    rn.matchIndex[res.url] = newMatch
    rn.nextIndex[res.url] = newMatch + 1     // only reached when matchIndex grows
}
```

### The trap

| step | matchIndex | nextIndex |
|---|---|---|
| steady state | 2 | 3 |
| stale failure response decrements | 2 | **1** |
| heartbeat sends `PrevLogIndex=0`, `Entries=[1,2]`; follower succeeds | | |
| `newMatch = 2`, and `2 > 2` is false → neither updates | 2 | **1** |

Every later heartbeat recomputes `newMatch = 2`, which never exceeds `matchIndex`. **The condition that repairs `nextIndex` is gated on the one thing that can no longer happen.**

### Impact — liveness, not safety

`matchIndex` stays monotonic, so `advanceCommitIndexLocked()` still commits correctly and no entry is lost or double-applied. What breaks is that the leader permanently re-ships the follower's entire log suffix every heartbeat — every order-lifecycle `LogEntry` from index 1, to a follower that already has them all. It degrades with log length and only clears on a leader election, when `nextIndex` is reinitialised.

### Change

```go
if newMatch > rn.matchIndex[res.url] {
    rn.matchIndex[res.url] = newMatch
}
if next := rn.matchIndex[res.url] + 1; next > rn.nextIndex[res.url] {
    rn.nextIndex[res.url] = next
}
```

Both stay monotonic; a `nextIndex` a stale response pushed too low is restored on the next successful append.

```
$ go test ./...
ok  	truxify.com/consensus-raft-go	0.634s
$ go vet ./...     # clean
$ gofmt -l main.go # clean
```

9 insertions, 1 deletion. (`gofmt -l` also flags `main_test.go`, but that is pre-existing on `main` and untouched here.)
