### PR TITLE
[Bug] Make verifySTARK public so ZKPrivacy compiles

### DIFF
--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -223,10 +223,13 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
 
     // ============ zk-STARKs Transparent ============
 
+    // `public` rather than `external`: processSTARKTransaction calls this
+    // internally, and Solidity cannot resolve an external function by plain
+    // name. The external ABI entry is unchanged.
     function verifySTARK(
         bytes calldata proof,
         bytes calldata publicInputs
-    ) external view returns (bool) {
+    ) public view returns (bool) {
         require(proof.length > 0, "ZKPrivacy: Empty proof");
         require(publicInputs.length > 0, "ZKPrivacy: Empty publicInputs");
         require(verifier != address(0), "ZKPrivacy: Verifier not set");


### PR DESCRIPTION
Fixes #8671.

`processSTARKTransaction` calls `verifySTARK(...)` by plain name, but `verifySTARK` is declared `external` — Solidity only reaches an external function through a message call.

### Before

```
$ cd blockchain && npx hardhat compile

DeclarationError: Undeclared identifier. Did you mean "verifySNARK" or "verifySTARK"?
   --> contracts/ZKPrivacy.sol:254:24:
254 |         bool isValid = verifySTARK(proof, publicInputs);
    |                        ^^^^^^^^^^^
Error HH600: Compilation failed
```

The *"did you mean … verifySTARK"* hint is the tell — the compiler can see the name, it just will not resolve an `external` function internally. Its sibling `verifySNARK` has no internal caller, which is why only this one trips.

### Impact

The entire `blockchain/` workspace fails to compile — nothing can be built, tested, deployed or verified. This is the same total blockage as #8560, from a **second independent cause**, so `ci.yml:187` (`hardhat compile`) and `:191` (`hardhat test`) both fail regardless of which one you fix first.

`processSTARKTransaction` is the zk-STARK payment path — it verifies a transparent proof before processing a transfer.

### Change

`external` → `public`. A `public` function is callable both internally and through the ABI, so **the external interface is unchanged** and no caller needs updating. `public` has accepted `calldata` parameters since Solidity 0.6.9, so the signature stays as-is.

`this.verifySTARK(...)` would also compile, but it turns a free internal jump into a real message call for no benefit.

```
Compiled 5 Solidity files successfully (evm target: cancun).
```

4 insertions, 1 deletion.

> Note: verified with #8561 applied, since without it compilation stops earlier on the OpenZeppelin `mcopy` issue. The two are independent — both are needed for a green build.
