### PR TITLE
fix(escort-wallet): import AppError from correct path (#8666)

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -1,7 +1,7 @@
 import didService from '../../../did/did.service.js';
 import logger from '../middleware/logger.js';
 import { validationResult } from 'express-validator';
-import { AppError } from '../errors/AppError.js';
+import { AppError } from '../utils/errors.js';
 
 export const loadCredential = async (req, res, next) => {
     try {


### PR DESCRIPTION
## Summary

Fixes #8666

`backend/api/src/controllers/escortWalletController.js` line 4 imported `AppError` from `'../errors/AppError.js'`, but the `errors/` directory no longer exists under `backend/api/src/`. `AppError` is exported from `backend/api/src/utils/errors.js` instead.

This caused `MODULE_NOT_FOUND` at import time, crashing the entire escort wallet feature (any route using `escortWalletController` would fail to mount).

## Fix
Changed the import path:
```diff
- import { AppError } from '../errors/AppError.js';
+ import { AppError } from '../utils/errors.js';
```

## Verification
- `node --check` passes
- `AppError` confirmed exported from `utils/errors.js:1`