### PR TITLE
fix(auth): clear all OTP lockout state on successful verification (#8656)

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -241,15 +241,9 @@ async function clearAuthOtpFailures(phone) {
   if (redisClient) {
     try {
       await redisClient.del(`auth_otp_failed_count:${phoneKey}`);
-      return;
     } catch (err) {
       logger.error("[auth/verify-otp] Redis error in clearAuthOtpFailures, falling back to memory:", err.message);
     }
-  }
-  const record = authOtpFailedAttempts.get(phoneKey);
-  if (record) {
-    record.count = 0;
-    if (record.lockedUntil) return;
   }
   authOtpFailedAttempts.delete(phoneKey);
 }


### PR DESCRIPTION
## Summary

Fixes #8656

`clearAuthOtpFailures()` in `backend/api/src/routes/authRoutes.js` had two early-return bugs that left users permanently locked out after successfully verifying an OTP:

### Bug 1 — Redis path early return
When `redisClient` existed and `del` succeeded, the function returned immediately without cleaning the in-memory `authOtpFailedAttempts` map. If the process later fell back to the in-memory path, stale lockout records remained.

### Bug 2 — In-memory path early return
When `record.lockedUntil` was set, the function returned early without clearing `lockedUntil` or deleting the record. After a successful OTP, the lockout state persisted — the user stayed locked out forever.

## Fix
Removed both early returns so `authOtpFailedAttempts.delete(phoneKey)` always executes, fully clearing `count` and `lockedUntil`:

```diff
 async function clearAuthOtpFailures(phone) {
   const phoneKey = hashPhoneForLockout(phone);
   if (redisClient) {
     try {
       await redisClient.del(`auth_otp_failed_count:${phoneKey}`);
-      return;
     } catch (err) {
       logger.error("...", err.message);
     }
   }
-  const record = authOtpFailedAttempts.get(phoneKey);
-  if (record) {
-    record.count = 0;
-    if (record.lockedUntil) return;
-  }
   authOtpFailedAttempts.delete(phoneKey);
 }
```

## Verification
- `node --check` passes
- The in-memory map is now always cleaned regardless of Redis path