### PR TITLE
[Bug] Put glued '---' separators on their own line so 4 lost Istio resources apply

### DIFF
--- a/k8s/istio/circuit-breaker.yaml
+++ b/k8s/istio/circuit-breaker.yaml
@@ -21,7 +21,8 @@ spec:
       baseEjectionTime: 30s
       maxEjectionPercent: 50
 
-      minHealthPercent: 50---
+      minHealthPercent: 50
+---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:

--- a/k8s/istio/destination-rule.yaml
+++ b/k8s/istio/destination-rule.yaml
@@ -31,7 +31,8 @@ spec:
       version: v2
     trafficPolicy:
       loadBalancer:
-        simple: RANDOM---
+        simple: RANDOM
+---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -50,7 +51,8 @@ spec:
       consecutive5xxErrors: 3
       interval: 20s
       baseEjectionTime: 20s
-      maxEjectionPercent: 30---
+      maxEjectionPercent: 30
+---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:

--- a/k8s/istio/telemetry.yaml
+++ b/k8s/istio/telemetry.yaml
@@ -14,7 +14,8 @@ spec:
 
   accessLogging:
   - providers:
-    - name: envoy---
+    - name: envoy
+---
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:


### PR DESCRIPTION
Fixes #8675.

Four YAML document separators in `k8s/istio/` are glued to the preceding value, so YAML reads them as part of the scalar rather than as separators.

### Before

```
$ sed -n '25p' k8s/istio/circuit-breaker.yaml | od -c
    m  i  n  H  e  a  l  t  h  P  e  r  c  e  n  t  :     5  0  -  -  -  \n

$ node .github/scripts/check-istio-manifests.js
Duplicate top-level mapping key "apiVersion" in document 1 of k8s/istio/circuit-breaker.yaml
...16 errors across three files...
exit 1
```

### What was lost

| File | Should define | Parsed as |
|---|---|---|
| `circuit-breaker.yaml` | `api-circuit-breaker`, `ml-circuit-breaker` | 1 malformed doc |
| `destination-rule.yaml` | `truxify-`, `ml-`, `redis-destination-rule` | 1 malformed doc |
| `telemetry.yaml` | `truxify-telemetry`, `mesh-default` | 1 malformed doc |

`kubectl apply` either rejects the file or applies only the first resource. In practice **the ML service and Redis had no `DestinationRule` at all** — no outlier detection, no connection-pool limits, no circuit breaking — while the API service did. A mesh that looks configured but, for half its services, is not.

### After

```
$ node .github/scripts/check-istio-manifests.js
All k8s/istio manifests look clean: no BOM, no duplicate top-level mapping keys.
exit 0

circuit-breaker.yaml  -> docs: 2  errors: 0
destination-rule.yaml -> docs: 3  errors: 0
telemetry.yaml        -> docs: 2  errors: 0
```

Four one-character insertions. No resource semantics changed.

### Why CI did not stop it

`.github/workflows/k8s-istio-manifests.yml` is path-filtered to `k8s/istio/**`, so it only runs when those files change. The check is correct and fails on `main` today — nothing re-ran it after the breakage landed.

### One observation for a follow-up

`check-istio-manifests.js` splits on `/^---\s*$/m`, so glued separators defeat the split and the whole file becomes "document 1". It still failed, but reported *duplicate keys* rather than the real cause, which sent me looking in the wrong place first. Detecting `[^\s]---$` directly would name the actual problem. Happy to add that separately if you want it.
