### PR TITLE
[CI] Report a glued '---' separator instead of phantom duplicate keys

### DIFF
--- a/.github/scripts/check-istio-manifests.js
+++ b/.github/scripts/check-istio-manifests.js
@@ -15,6 +15,21 @@ for (const file of files) {
     failed = true;
   }
 
+  // A separator glued to the previous value (`minHealthPercent: 50---`) is not
+  // a separator at all: YAML reads the dashes as part of the scalar and the
+  // whole file collapses into one document, silently dropping every resource
+  // after the first. Report it directly — the duplicate-key check below would
+  // otherwise fire instead and point at the wrong cause.
+  content.split(/\r?\n/).forEach((line, idx) => {
+    if (/[^\s]---\s*$/.test(line)) {
+      console.error(
+        `Document separator "---" is not on its own line at ${full}:${idx + 1} — ` +
+          `"${line.trim()}". Every resource after this point is lost.`
+      );
+      failed = true;
+    }
+  });
+
   const documents = content.split(/^---\s*$/m).filter((doc) => doc.trim().length > 0);
 
   documents.forEach((doc, i) => {


### PR DESCRIPTION
Fixes #8679. Follow-up to #8677, as offered there.

`check-istio-manifests.js` splits on `/^---\s*$/m`, so a separator glued to the previous value never matches — and the script blames the wrong thing.

### The misleading output (on `main` today)

```
Duplicate top-level mapping key "apiVersion" in document 1 of k8s/istio/circuit-breaker.yaml
Duplicate top-level mapping key "kind" in document 1 of k8s/istio/circuit-breaker.yaml
```

**There is no duplicate `apiVersion` in that file.** It contains two well-formed `DestinationRule` documents; they only look duplicated because the separator between them was not recognised, so both folded into "document 1".

A reader following that message hunts for a copy-pasted key and finds none. The four dashes at the end of line 24 — the actual fault — appear nowhere in the output and carry no line number. I went looking in the wrong place first myself.

### After

```
Document separator "---" is not on its own line at k8s/istio/circuit-breaker.yaml:24 — "minHealthPercent: 50---". Every resource after this point is lost.
```

### Why separate from #8677

Fixing the manifests makes the script pass again but leaves the *next* occurrence just as misleading — and this is exactly the failure mode the script exists to catch. It is also the most likely to recur: a missing newline before `---` is invisible in review and survives most editors' formatting.

The duplicate-key check is unchanged — still correct for genuine duplicates, and running both means either fault is reported accurately.

### Verified both ways

- on `main` (broken manifests): leads with the separator error, exit 1
- with #8677 applied: `All k8s/istio manifests look clean`, exit 0
