### PR TITLE
[Security] Make Dockerfile.api buildable, non-root, and stop baking .env into the image

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,13 +1,36 @@
+# Root-context image build for the API, referenced by k8s/README.md and
+# snyk/snyk-github-actions.yaml:
+#
+#   docker build -t truxify/api:latest -f Dockerfile.api .
+#
+# Mirrors backend/api/Dockerfile, which docker-compose builds with
+# ./backend/api as its context.
 FROM node:20-alpine
 
 WORKDIR /app
 
-COPY backend/api/package*.json ./
-RUN npm ci --only=production
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -S appuser -u 1001 -G appgroup
 
-COPY backend/api/src ./src
-COPY backend/api/.env ./
+COPY backend/api/package.json ./
+
+# `npm install`, not `npm ci`: backend/api is an npm workspace with no
+# package-lock.json of its own, and no lockfile is committed at the
+# repository root either, so `npm ci` has nothing to install from.
+# --legacy-peer-deps matches backend/api/Dockerfile and the CI workflows.
+RUN npm install --omit=dev --legacy-peer-deps
+
+COPY --chown=appuser:appgroup backend/api/src ./src
+
+# No .env is copied. Configuration is supplied at runtime through the
+# container environment (k8s Secret / ConfigMap, or `docker run --env-file`),
+# so credentials never become part of an image layer.
+
+USER appuser
 
 EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD ["node", "-e", "fetch('http://localhost:5000/api/health/live').then(r=>{if(!r.ok)throw 1}).catch(()=>process.exit(1))"]
 
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
Fixes #8682.

`Dockerfile.api` is the build documented in `k8s/README.md` and run by `snyk/snyk-github-actions.yaml`. It cannot succeed from a clean clone — and if it did, it would ship credentials.

### Two independent build failures

```dockerfile
COPY backend/api/package*.json ./
RUN npm ci --only=production        # (1) no lockfile exists
...
COPY backend/api/.env ./            # (2) gitignored — absent from a clean context
```

1. `npm ci` has **no lockfile**. `backend/api` is a workspace with no `package-lock.json`, and none is committed at the root either — `git ls-files | grep package-lock.json` returns only `blockchain/package-lock.json`.
2. `.env` is gitignored (`.gitignore:52`), so `COPY` fails on a fresh checkout.

### The `.env` line is the serious one

On a machine that *does* have a local `.env` — a CI runner, and `snyk-github-actions.yaml:79` runs this build — that file becomes a **permanent image layer**. For this service that is the Supabase **service-role** key, Firebase credentials and `RELAYER_WALLET_PRIVATE_KEY`, readable by anyone who can pull the image. Deleting it in a later step would not help; the layer is already in the history.

### Two smaller problems

- **No `USER`** — runs as root. `backend/api/Dockerfile`, which `docker-compose` uses, creates `appuser` and drops to it. The two builds of the same service disagree, and the hardened one is *not* the one k8s is told to use.
- **`--only=production`** deprecated since npm 7; `--omit=dev` is current.

### Change

Mirrors `backend/api/Dockerfile`: `appuser`, `npm install --omit=dev --legacy-peer-deps`, no `.env`, same `HEALTHCHECK`. Config arrives at runtime via a k8s Secret/ConfigMap or `--env-file`.

### Verification — please read

**I could not run `docker build`** — no daemon in this environment. This is verified by inspection against `backend/api/Dockerfile` and by confirming every `COPY` source exists in the repo. I would rather say that than imply a build I did not run. Worth a build check before merge.

> Separately: no root `package-lock.json` is committed at all, so no Node build here is reproducible. Bigger than this file — happy to raise it on its own if useful.
