### PR TITLE
[Security] Add a root .dockerignore and harden Dockerfile.ml (context, root user, deps)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Docker resolves .dockerignore from the build-context root. Dockerfile.api and
+# Dockerfile.ml both build with the repository root as context, so
+# backend/ml/.dockerignore never applies to them and this file is what governs
+# those builds.
+**/__pycache__/
+**/*.py[cod]
+**/venv/
+**/node_modules/
+**/.env
+**/.env.*
+!**/.env.example
+**/*.db
+.git/
+.github/
+**/coverage/
+**/.pytest_cache/
+**/.dart_tool/
+**/build/

--- a/Dockerfile.ml
+++ b/Dockerfile.ml
@@ -1,12 +1,38 @@
+# Root-context image build for the ML service, referenced by k8s/README.md:
+#
+#   docker build -t truxify/ml:latest -f Dockerfile.ml .
+#
+# Mirrors backend/ml/Dockerfile, which docker-compose builds with
+# ./backend/ml as its context.
 FROM python:3.11-slim
+
+# tensorflow, torch and scipy need a toolchain and the OpenGL/glib runtime
+# libraries; backend/ml/Dockerfile installs these and this build needs them
+# for the same requirements.txt.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        libgl1-mesa-glx \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1001 appgroup && \
+    useradd -u 1001 -g appgroup -s /bin/sh -d /app appuser
 
 WORKDIR /app
 
 COPY backend/ml/requirements.txt ./
+
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY backend/ml/ ./
+COPY --chown=appuser:appgroup backend/ml/ ./
+
+USER appuser
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Fixes #8699.

### The core issue: `.dockerignore` is in a place that cannot take effect

`backend/ml/.dockerignore` excludes exactly the right things:

```
__pycache__/
*.pyc
venv/
.env
```

But Docker resolves `.dockerignore` from the **build context root**, and `k8s/README.md` documents:

```
docker build -t truxify/ml:latest -f Dockerfile.ml .
```

Context is `.` — the repository root, which has **no** `.dockerignore`. So that file governs only the `docker-compose` build (context `./backend/ml`) and is silently inert for the image k8s is told to build. `COPY backend/ml/ ./` then ships `__pycache__/`, `ab_testing.db`, and `backend/ml/.env` if one exists.

Added a `.dockerignore` at the repository root — the only location that affects these builds.

### Three more gaps against `backend/ml/Dockerfile`

| | `backend/ml/Dockerfile` | `Dockerfile.ml` (before) |
|---|---|---|
| `USER` | `appuser` | **root** |
| apt deps | `build-essential`, `cmake`, `libgl1-mesa-glx`, `libglib2.0-0` | none |
| `HEALTHCHECK` | `/health` | none |

The apt layer is not cosmetic: `requirements.txt` pins `tensorflow==2.13.0`, `torch==2.13.0`, `scipy==1.11.3`, `numpy==1.23.5`, which is exactly why the other Dockerfile installs a toolchain before `pip install`.

The `USER` split is the same one as #8682 for the API image — the hardened build is not the one k8s uses.

### Verification — please read

**I could not run `docker build`** — no daemon in this environment. Verified by inspection against `backend/ml/Dockerfile`, and by confirming the new ignore patterns match the files that currently leak in (`backend/ml/__pycache__`, `backend/ml/ab_testing.db`). Worth a build check before merge.
