### PR TITLE
feat(driver): implement global non-blocking offline banner #8660

### DIFF
--- a/apps/driver/lib/app.dart
+++ b/apps/driver/lib/app.dart
@@ -15,6 +15,7 @@ import 'screens/past_trips_screen.dart';
 import 'models/app_models.dart';
 import 'theme/app_theme.dart';
 import 'widgets/app_page_route.dart';
+import 'widgets/offline_banner_overlay.dart';
 
 class TruxifyApp extends StatefulWidget {
   const TruxifyApp({super.key});
@@ -53,6 +54,9 @@ class _TruxifyAppState extends State<TruxifyApp> {
       controller: _controller,
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
+        builder: (context, child) {
+          return OfflineBannerOverlay(child: child!);
+        },
         onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
         theme: TruxifyTheme.light(),
         darkTheme: TruxifyTheme.dark(),

--- a/apps/driver/lib/main.dart
+++ b/apps/driver/lib/main.dart
@@ -10,6 +10,9 @@ import 'core/firebase_config.dart';
 import 'package:truxify_driver/config/env.dart';
 import 'services/background_sync_service.dart';
 
+import 'package:provider/provider.dart';
+import 'providers/network_provider.dart';
+
 Future<void> main() async {
   // Ensure Flutter engine is initialized.
   WidgetsFlutterBinding.ensureInitialized();
@@ -69,7 +72,14 @@ Future<void> main() async {
 
   // Wrap runApp in a guarded zone to capture uncaught async errors.
   runZonedGuarded(() {
-    runApp(const TruxifyApp());
+    runApp(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => NetworkProvider()),
+        ],
+        child: const TruxifyApp(),
+      ),
+    );
   }, (error, stackTrace) {
     CrashReportingService.captureException(
       error,

--- a/apps/driver/lib/providers/network_provider.dart
+++ b/apps/driver/lib/providers/network_provider.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+
+class NetworkProvider extends ChangeNotifier {
+  bool _isOffline = false;
+  late StreamSubscription<List<ConnectivityResult>> _subscription;
+
+  bool get isOffline => _isOffline;
+
+  NetworkProvider() {
+    _initConnectivity();
+    _subscription = Connectivity().onConnectivityChanged.listen(_updateConnectionStatus);
+  }
+
+  Future<void> _initConnectivity() async {
+    try {
+      final results = await Connectivity().checkConnectivity();
+      _updateConnectionStatus(results);
+    } catch (e) {
+      debugPrint('Could not check connectivity status: $e');
+    }
+  }
+
+  void _updateConnectionStatus(List<ConnectivityResult> results) {
+    final offline = results.isNotEmpty && results.every((result) => result == ConnectivityResult.none);
+    if (_isOffline != offline) {
+      _isOffline = offline;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}

--- a/apps/driver/lib/widgets/offline_banner_overlay.dart
+++ b/apps/driver/lib/widgets/offline_banner_overlay.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/network_provider.dart';
+
+class OfflineBannerOverlay extends StatelessWidget {
+  final Widget child;
+
+  const OfflineBannerOverlay({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isOffline = context.watch<NetworkProvider>().isOffline;
+
+    return Stack(
+      children: [
+        child,
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+          top: isOffline ? 0 : -100,
+          left: 0,
+          right: 0,
+          child: IgnorePointer(
+            child: SafeArea(
+              bottom: false,
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                color: Colors.red,
+                child: const Text(
+                  'No Internet Connection - Showing cached data',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    decoration: TextDecoration.none,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   google_fonts: ^8.1.0
   fl_chart: ^0.66.0
   flutter_riverpod: ^2.5.1
+  provider: ^6.1.2
   flutter_map: ^8.1.1
   latlong2: ^0.10.1
   http: ^1.6.0


### PR DESCRIPTION
## Description
Implemented a global, non-blocking "No Internet Connection" top banner overlay for the `apps/driver` application. The banner listens to real-time network status changes via `connectivity_plus`, smoothly sliding down from the top edge when offline and sliding up out of view when reconnected, without blocking driver touch interactions on underlying UI elements.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `flutter test`
- **Test Steps / Prerequisites:**
  1. Launch the `apps/driver` application.
  2. Turn off Wi-Fi/Cellular data or enable Airplane mode on the test device/emulator.
  3. Observe that the red top banner smoothly slides down with the text `"No Internet Connection - Showing cached data"`.
  4. Tap interactive elements underneath the banner to verify that gestures pass through seamlessly via `IgnorePointer`.
  5. Re-enable internet connection and observe the banner slide back up out of view.
- **Expected Result:** The offline banner dynamically slides in when connection is lost, permits full touch interaction with the underlying UI, and hides smoothly when connectivity is restored.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #8660

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
