### PR TITLE
fix(api): make /api/wim routes reachable - mount wimBypassRouter before 404/error middleware

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -579,6 +579,7 @@ app.use('/api', wasiRoutes)
 app.use('/api', wasmRoutes)
 app.use('/api', snykRoutes)
 app.use('/api', liquibaseRoutes)
+app.use('/api/wim', wimBypassRouter)
 
 // 🆕 WebRTC Health Check Endpoint
 app.get('/api/webrtc/status', (req, res) => {
@@ -853,5 +854,3 @@ app.use((err, req, res, next) => {
 
   next(err);
 });
-
-app.use('/api/wim', wimBypassRouter);


### PR DESCRIPTION
## Problem

The WIM bypass router is mounted **after** the 404 handler and the error-handling middleware in `backend/api/src/index.js`. Since `notFound` responds `404 { error: 'Endpoint resource not found.' }` and never calls `next()`, every `/api/wim/*` request returns 404 and the route is permanently unreachable.

## Fix

Moved the `app.use('/api/wim', wimBypassRouter)` mount into the main API route registration block (with the other subsystem routes), so it is registered before the 404/error middleware. Removed the dead mount at the very end of the file.

## Files changed

- `backend/api/src/index.js`

## Testing

- `node --check backend/api/src/index.js` passes.
- `POST /api/wim/request-bypass` now reaches the router instead of returning `Endpoint resource not found.`

Closes #8684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blockchain monitoring request handling.
  * Added the WIM bypass API route at its expected endpoint.
  * Removed duplicate webhook route registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->