### PR TITLE
fix(ml): remove dead duplicate weather block in price_prediction.py so module parses

### DIFF
--- a/backend/ml/app/models/price_prediction.py
+++ b/backend/ml/app/models/price_prediction.py
@@ -406,16 +406,6 @@ async def _get_weather_multiplier_async(client: httpx.AsyncClient, city: str) ->
         multiplier = _parse_weather_multiplier(response)
         _cache_weather_multiplier(city, multiplier)
         return multiplier
-        url = f"https://api.openweathermap.org/data/2.5/weather?q={city}&appid={api_key}"
-        with httpx.Client(timeout=5.0) as client:
-        response = client.get(url, timeout=2.0)
-        response = httpx.get(url, timeout=2.0)
-        if response.status_code == 200:
-            weather_main = response.json().get("weather", [{}])[0].get("main", "").lower()
-            if weather_main in ["rain", "snow", "thunderstorm", "extreme", "squall", "tornado"]:
-                return 1.2
-            elif weather_main in ["drizzle", "mist", "fog", "haze", "dust", "sand", "ash"]:
-                return 1.1
     except Exception as e:
         logger.warning("Weather API failed for %s: %s", city, e)
         _cache_weather_multiplier(city, 1.0)


### PR DESCRIPTION
## Problem

`backend/ml/app/models/price_prediction.py` lines 409-418 are a botched merge block left behind after `return multiplier` (line 408). The block is mis-indented (`response = client.get(url, ...)` at the same level as the `with` statement) and makes the module unparseable with `IndentationError: expected an indented block after 'with' statement`. Since `backend/ml/main.py` imports `predict_price` unconditionally, the whole ML service fails to boot.

## Fix

Deleted the duplicate/dead lines 409-418 after `return multiplier`, keeping only the original working weather lookup code.

## Files changed

- `backend/ml/app/models/price_prediction.py`

## Testing

- `python -m py_compile backend/ml/app/models/price_prediction.py` passes.

Closes #8685
