### PR TITLE
feat(driver): implement on-device image compression for POD #8659

### DIFF
--- a/apps/driver/lib/screens/pod_capture_screen.dart
+++ b/apps/driver/lib/screens/pod_capture_screen.dart
@@ -7,6 +7,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import '../services/pod_storage_service.dart';
 import '../services/background_sync_service.dart';
 import '../services/sync_service.dart';
+import '../services/image_compression_service.dart';
 
 class PodCaptureScreen extends StatefulWidget {
   final String orderId;
@@ -32,8 +33,10 @@ class _PodCaptureScreenState extends State<PodCaptureScreen> {
   Future<void> _takePhoto() async {
     final XFile? photo = await _picker.pickImage(source: ImageSource.camera);
     if (photo != null) {
+      final File rawImage = File(photo.path);
+      final File compressedImage = await ImageCompressionService.compressImage(rawImage) ?? rawImage;
       setState(() {
-        _photoPath = photo.path;
+        _photoPath = compressedImage.path;
       });
     }
   }
@@ -205,8 +208,15 @@ class _PodCaptureScreenState extends State<PodCaptureScreen> {
                     style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 8),
-                  if (_photoPath != null)
+                  if (_photoPath != null) ...[
                     Image.file(File(_photoPath!), height: 200, fit: BoxFit.cover),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Uploading ${ImageCompressionService.getFileSize(File(_photoPath!))}...',
+                      style: const TextStyle(color: Colors.grey, fontSize: 12),
+                    ),
+                    const SizedBox(height: 8),
+                  ],
                   ElevatedButton.icon(
                     onPressed: _takePhoto,
                     icon: const Icon(Icons.camera_alt),

--- a/apps/driver/lib/screens/pod_screen.dart
+++ b/apps/driver/lib/screens/pod_screen.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:truxify_shared/truxify_shared.dart';
 import '../services/sync_service.dart';
+import '../services/image_compression_service.dart';
 import '../theme/app_theme.dart';
 
 class ProofOfDeliveryScreen extends StatefulWidget {
@@ -69,8 +70,10 @@ class _ProofOfDeliveryScreenState extends State<ProofOfDeliveryScreen> {
     if (_cameraController == null || !_cameraController!.value.isInitialized) return;
     try {
       final photo = await _cameraController!.takePicture();
+      final File rawImage = File(photo.path);
+      final File compressedImage = await ImageCompressionService.compressImage(rawImage) ?? rawImage;
       setState(() {
-        _capturedPhoto = photo;
+        _capturedPhoto = XFile(compressedImage.path);
       });
     } catch (e) {
       debugPrint('Error taking photo: $e');
@@ -197,11 +200,19 @@ class _ProofOfDeliveryScreenState extends State<ProofOfDeliveryScreen> {
                             )
                           : const Center(child: Text('Camera initializing...')),
                     )
-                  else
+                  else ...[
                     ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: Image.file(File(_capturedPhoto!.path), height: 250, width: double.infinity, fit: BoxFit.cover),
                     ),
+                    const SizedBox(height: 4),
+                    Center(
+                      child: Text(
+                        'Uploading ${ImageCompressionService.getFileSize(File(_capturedPhoto!.path))}...',
+                        style: const TextStyle(color: Colors.grey, fontSize: 12),
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 10),
                   Center(
                     child: ElevatedButton.icon(

--- a/apps/driver/lib/services/image_compression_service.dart
+++ b/apps/driver/lib/services/image_compression_service.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path_provider/path_provider.dart';
+
+class ImageCompressionService {
+  static Future<File?> compressImage(File file) async {
+    try {
+      final dir = await getTemporaryDirectory();
+      final targetPath = '${dir.absolute.path}/temp_${DateTime.now().millisecondsSinceEpoch}.jpg';
+      
+      final XFile? compressedFile = await FlutterImageCompress.compressAndGetFile(
+        file.absolute.path,
+        targetPath,
+        quality: 80,
+        minWidth: 1920,
+        minHeight: 1920,
+      );
+      
+      if (compressedFile != null) {
+        return File(compressedFile.path);
+      }
+    } catch (e) {
+      print('Compression error: $e');
+    }
+    return file; // Fallback to original if compression fails
+  }
+
+  static String getFileSize(File file) {
+    final bytes = file.lengthSync();
+    if (bytes <= 0) return "0 B";
+    final kb = bytes / 1024;
+    if (kb > 1024) {
+      return '${(kb / 1024).toStringAsFixed(2)} MB';
+    }
+    return '${kb.toStringAsFixed(0)} KB';
+  }
+}

--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   camera: ^0.11.0
   signature: ^6.3.0
   image_picker: ^1.1.2
+  flutter_image_compress: ^2.3.0
   battery_plus: ^6.2.1
   flutter_dotenv: ^5.2.0
   sentry_flutter: ^8.14.1


### PR DESCRIPTION
## Description
Implemented on-device image compression for Proof of Delivery (POD) uploads in the `apps/driver` application. 
- Added `flutter_image_compress` dependency to `apps/driver/pubspec.yaml`.
- Built `ImageCompressionService` ([image_compression_service.dart](file:///c:/Users/admin/Desktop/GSSoC%202026/Truxify/apps/driver/lib/services/image_compression_service.dart)) to compress captured images down to max 1920x1920 with 80% quality before storage/upload, with fallback to raw file on error. Included human-readable file size calculation.
- Integrated compression step into POD upload screens ([pod_capture_screen.dart](file:///c:/Users/admin/Desktop/GSSoC%202026/Truxify/apps/driver/lib/screens/pod_capture_screen.dart) and [pod_screen.dart](file:///c:/Users/admin/Desktop/GSSoC%202026/Truxify/apps/driver/lib/screens/pod_screen.dart)) immediately after image capture/picking and before network sync.
- Added UI text indicator showing the compressed upload file size below image previews.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:**
  `flutter test` (in `apps/driver`)
- **Test Steps / Prerequisites:**
  1. Open `apps/driver` and navigate to the Proof of Delivery capture screen.
  2. Capture or select a high-resolution photo of goods/delivery receipt.
  3. Verify that the image is compressed on-device and the UI text indicator displays the file size (e.g. `Uploading 345 KB...`).
  4. Complete the delivery and verify that compressed image file path is handed over to the sync pipeline.
- **Expected Result:**
  Images are automatically compressed before upload without loss of visual clarity, reducing upload bandwidth usage and payload size.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #8659

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
