### PR TITLE
fix(ml): remove duplicate asyncio.to_thread calls so inference runs once per request

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -448,7 +448,6 @@ async def predict_demand_endpoint(input: DemandForecastInput, _auth=Depends(veri
         # auto-train on first use); run it off the event loop so it cannot
         # stall unrelated requests or /health.
         demand = await run_inference(predict_demand, features)
-        demand = await asyncio.to_thread(predict_demand, features)
         if demand is None:
             raise HTTPException(status_code=503, detail="Model not available")
         return DemandForecastOutput(predicted_demand=demand)
@@ -566,7 +565,6 @@ async def packing_endpoint(input: PackingInput, _auth=Depends(verify_api_key)):
         # 3-D bin packing and nearest-neighbour sequencing are CPU-bound; run
         # off the event loop so large packing jobs cannot stall the service.
         result = await run_inference(optimise_packing, packages, truck, addresses)
-        result = await asyncio.to_thread(optimise_packing, packages, truck, addresses)
         return PackingOutput(**result)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
@@ -662,7 +660,6 @@ async def deadhead_endpoint(input: DeadheadInput, _auth=Depends(verify_api_key))
         result = await run_inference(
             find_return_loads, driver_dest, truck_specs, input.arrival_time, loads
         )
-        result = await asyncio.to_thread(find_return_loads, driver_dest, truck_specs, input.arrival_time, loads)
         return DeadheadOutput(**result)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
@@ -688,7 +685,6 @@ async def mid_trip_endpoint(input: MidTripInput, _auth=Depends(verify_api_key)):
         result = await run_inference(
             find_mid_trip_loads, current_loc, route, capacity, loads
         )
-        result = await asyncio.to_thread(find_mid_trip_loads, current_loc, route, capacity, loads)
         return MidTripOutput(**result)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))


### PR DESCRIPTION
## Problem

Several inference endpoints in `backend/ml/main.py` call the same CPU-bound model **twice per request** — once via `await run_inference(...)` and immediately again via `await asyncio.to_thread(...)` on the same function and arguments. The second call overwrites the first, doubling CPU usage, response latency, and (under backpressure) concurrency-slot consumption.

## Fix

Deleted the four duplicate `asyncio.to_thread(...)` lines (demand-forecast, packing-optimisation, return-loads and mid-trip-loads endpoints). `await run_inference(...)` is now the single execution path, which already offloads work to a thread pool via `backend/ml/app/execution.py`.

## Files changed

- `backend/ml/main.py`

## Testing

- `python -m py_compile backend/ml/main.py` passes.
- Confirmed each affected endpoint now runs `run_inference` exactly once.

Closes #8686
