### PR TITLE
fix(ebpf): import node:path to resolve path.join ReferenceError

### DIFF
--- a/ebpf/routes.js
+++ b/ebpf/routes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import path from 'node:path';
 import rateLimit from 'express-rate-limit';
 import logger from '../backend/api/src/middleware/logger.js';
 import { authenticate } from '../backend/api/src/middleware/auth.js';


### PR DESCRIPTION
## Problem

`ebpf/routes.js` uses `path.join(...)` in the program-load handler (line 209/210) but never imports the `node:path` module. When `EBPF_PROGRAMS_PATH` is not set, the handler throws `ReferenceError: path is not defined` at runtime.

## Fix

Added the missing import at the top of `ebpf/routes.js`:

```js
import path from 'node:path';
```

## Files changed

- `ebpf/routes.js`

## Testing

- `node --check ebpf/routes.js` passes.
- `path.join` is now resolved when `EBPF_PROGRAMS_PATH` is unset.

Closes #8687
