### PR TITLE
fix(ml): replace asyncio.get_event_loop() at import with get_running_loop()

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -49,7 +49,6 @@ class TrafficPipeline:
         Base.metadata.create_all(self.engine)
         self.Session = sessionmaker(bind=self.engine)
         self.redis = redis.Redis.from_url(redis_url)
-        self._loop = asyncio.get_event_loop()
         self.model = self._load_or_create_model()
         self.gmaps_api_key = os.getenv('GOOGLE_MAPS_API_KEY', '')
         self.osrm_url = os.getenv('OSRM_URL', 'http://localhost:5000')
@@ -150,7 +149,7 @@ class TrafficPipeline:
                 session.close()
             
             # Cache in Redis
-            await self._loop.run_in_executor(
+            await asyncio.get_running_loop().run_in_executor(
                 None, partial(self.redis.setex,
                     f"traffic:{route_id}",
                     300,
@@ -217,7 +216,7 @@ class TrafficPipeline:
     
     async def get_real_time_traffic(self, route_id: str):
         """Get real-time traffic data for a route"""
-        cached = await self._loop.run_in_executor(None, partial(self.redis.get, f"traffic:{route_id}"))
+        cached = await asyncio.get_running_loop().run_in_executor(None, partial(self.redis.get, f"traffic:{route_id}"))
         if cached:
             return json.loads(cached)
         return None
@@ -327,7 +326,7 @@ class TrafficPipeline:
                     eta_string = str(timedelta(seconds=int(eta_seconds)))
                     
                     # Update Redis
-                    await self._loop.run_in_executor(
+                    await asyncio.get_running_loop().run_in_executor(
                         None, partial(self.redis.setex,
                             f"eta:order:{order_id}",
                             300,


### PR DESCRIPTION
## Problem

`backend/ml/services/traffic_pipeline.py:52` calls `asyncio.get_event_loop()` inside `TrafficPipeline.__init__`, and the pipeline is constructed at module import time (in `backend/ml/routes/eta_routes.py:21`) when no event loop is running. On Python 3.12+ this raises `RuntimeError: There is no current event loop in thread 'MainThread'`, failing the ML service at boot.

## Fix

Removed the `self._loop = asyncio.get_event_loop()` capture from the constructor. The three `run_in_executor` call sites (all inside async methods) now look up the running loop at call time with `asyncio.get_running_loop()`.

## Files changed

- `backend/ml/services/traffic_pipeline.py`

## Testing

- `python -m py_compile backend/ml/services/traffic_pipeline.py` passes.
- No `asyncio.get_event_loop()` remains anywhere under `backend/ml`.
- Module can be imported at startup without a running loop.

Closes #8688
