### PR TITLE
fix(ml): correct GAT node_features shape to (1, num_nodes, 1, features)

### DIFF
--- a/backend/ml/routes/gat_routes.py
+++ b/backend/ml/routes/gat_routes.py
@@ -88,7 +88,9 @@ async def predict_traffic(request: GraphRequest):
         data = builder.get_pytorch_data()
         
         # Generate synthetic node features for time steps
-        node_features = data.x.unsqueeze(0).unsqueeze(0)  # (1, 1, nodes, features)
+        # Model expects (batch_size, num_nodes, time_steps, features); build
+        # (1, num_nodes, 1, features) so batch_size == 1 and time_steps == 1.
+        node_features = data.x.unsqueeze(0).unsqueeze(2).contiguous()
         
         # Predict
         predictions = trainer.model.predict_traffic(node_features, data.edge_index)


### PR DESCRIPTION
## Problem

In `backend/ml/routes/gat_routes.py`, `node_features = data.x.unsqueeze(0).unsqueeze(0)` produced a tensor of shape `(1, 1, nodes, features)`. The model's `forward` (`backend/ml/gat/model.py:107`) unpacks its input as `(batch_size, num_nodes, time_steps, features)`, so the endpoint's tensor was interpreted as `batch=1, num_nodes=1, time_steps=nodes, features=features` — a shape mismatch that made every `POST /api/gat/traffic-predict` request fail.

## Fix

Build the feature tensor in the layout the model actually expects — `(1, num_nodes, 1, features)` with `batch_size == 1`, `num_nodes == data.num_nodes`, `time_steps == 1`:

```python
node_features = data.x.unsqueeze(0).unsqueeze(2).contiguous()
```

`data.edge_index` is already forwarded to `forward`'s `edge_index` parameter (via `predict_traffic` at `gat/model.py:149`), so no change was needed there.

## Files changed

- `backend/ml/routes/gat_routes.py`

## Testing

- `python -m py_compile backend/ml/routes/gat_routes.py` passes.
- Verified the unpack at `gat/model.py:107`: `batch_size == 1`, `time_steps == 1`, `num_nodes == data.num_nodes`.

Closes #8689
