### PR TITLE
fix(ml): tolerate missing dlib model so VisionMonitor import cannot crash service

### DIFF
--- a/backend/ml/multimodal/vision_monitor.py
+++ b/backend/ml/multimodal/vision_monitor.py
@@ -32,9 +32,16 @@ class VisionMonitor:
             min_tracking_confidence=0.5
         )
         
-        # Initialize dlib for facial landmarks
+        # Initialize dlib for facial landmarks. The 68-landmark shape
+        # predictor requires a ~100 MB .dat model that is not shipped in the
+        # repo, so tolerate its absence here — constructing VisionMonitor()
+        # at module import must never crash the ML service.
         self.detector = dlib.get_frontal_face_detector()
-        self.predictor = dlib.shape_predictor('models/shape_predictor_68_face_landmarks.dat')
+        self.predictor = None
+        try:
+            self.predictor = dlib.shape_predictor('models/shape_predictor_68_face_landmarks.dat')
+        except (RuntimeError, OSError) as e:
+            logger.warning("dlib shape predictor model unavailable (%s); landmark extraction disabled", e)
         
         # Load models
         self.drowsiness_model = self._load_drowsiness_model()


### PR DESCRIPTION
## Problem

`backend/ml/multimodal/vision_monitor.py:37` loads `models/shape_predictor_68_face_landmarks.dat`, which does not exist anywhere in the repository. `backend/ml/routes/safety_routes.py:76` constructs `VisionMonitor()` at module scope, so importing the safety routes (done at ML app startup) raises `RuntimeError: Unable to open models/shape_predictor_68_face_landmarks.dat` and breaks the whole ML service.

## Fix

Made the dlib shape-predictor load resilient: it is now wrapped in a try/except, so a missing `.dat` model logs a warning and sets `self.predictor = None` instead of crashing construction. `VisionMonitor()` (and thus the ML app import) no longer fails when the model file is absent.

## Files changed

- `backend/ml/multimodal/vision_monitor.py`

## Testing

- `python -m py_compile backend/ml/multimodal/vision_monitor.py` passes.
- `VisionMonitor()` now constructs successfully without the `.dat` file; `self.predictor` is `None` and a warning is logged when the model is missing.

Closes #8690
