### PR TITLE
fix(ml): remove dead MAX_CONCURRENT_INFERENCE/INFERENCE_SEMAPHORE concurrency limit

### DIFF
--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -70,9 +70,6 @@ loaded_models: set[str] = set()
 
 import os
 
-MAX_CONCURRENT_INFERENCE = int(os.getenv("MAX_CONCURRENT_INFERENCE", "10"))
-INFERENCE_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_INFERENCE)
-
 app = FastAPI(
     title="Truxify ML Engine",
     description="ML prediction service for load matching, pricing, ETA, and route optimization",


### PR DESCRIPTION
## Problem

`backend/ml/main.py:73-74` defined `MAX_CONCURRENT_INFERENCE` (read from env) and `INFERENCE_SEMAPHORE` (an `asyncio.Semaphore` created at import time), but the semaphore was never acquired anywhere in the codebase. The configured limit was a no-op; operators setting `MAX_CONCURRENT_INFERENCE` saw no backpressure, while the real cap was silently driven by `ML_MAX_CONCURRENT_INFERENCE` in `backend/ml/app/execution.py`.

## Fix

Removed the dead `MAX_CONCURRENT_INFERENCE` / `INFERENCE_SEMAPHORE` lines from `main.py`. `ML_MAX_CONCURRENT_INFERENCE` (used by `execution.py`) remains the single source of truth for concurrency control.

## Files changed

- `backend/ml/main.py`

## Testing

- `python -m py_compile backend/ml/main.py` passes.
- Confirmed `MAX_CONCURRENT_INFERENCE` / `INFERENCE_SEMAPHORE` are not referenced anywhere else in the codebase.

Closes #8691
