### PR TITLE
fix(tests): repair unparseable k6 scenarios.js check block

### DIFF
--- a/backend/api/tests/load/scenarios.js
+++ b/backend/api/tests/load/scenarios.js
@@ -27,14 +27,6 @@ export default function () {
   const resLoads = http.get(`${BASE_URL}/api/loads/available`, params);
   check(resLoads, {
     'available loads status is 200': (r) => r.status === 200,
-  const healthRes = http.get(`${BASE_URL}/health`, params);
-  check(healthRes, {
-    'status is 200': (r) => r.status === 200,
-  });
-
-  const availableLoadsRes = http.get(`${BASE_URL}/api/loads/available`, params);
-  check(availableLoadsRes, {
-    'status is 200': (r) => r.status === 200,
   });
 
   sleep(1);


### PR DESCRIPTION
## Problem

`backend/api/tests/load/scenarios.js` was unparseable: a duplicate "health + available-loads" block was pasted inside the `check(resLoads, {...})` object literal, leaving statements where an object property was expected. `node --check backend/api/tests/load/scenarios.js` failed with a `SyntaxError` at line 30, so the k6 scenario could not run.

## Fix

Restored the correct structure: closed the `check(resLoads, {...})` block after the `'available loads status is 200'` entry and removed the duplicated `healthRes` / `availableLoadsRes` block. The scenario now runs one health check and one available-loads check.

## Files changed

- `backend/api/tests/load/scenarios.js`

## Testing

- `node --check backend/api/tests/load/scenarios.js` passes.

Closes #8692
