### PR TITLE
fix(tests): rewrite unparseable k6 websocket load scenario

### DIFF
--- a/backend/api/tests/load/websocket.js
+++ b/backend/api/tests/load/websocket.js
@@ -17,7 +17,6 @@ export default function () {
   };
 
   const res = ws.connect(WS_URL, params, function (socket) {
-    socket.on('open', function () {
     socket.on('open', () => {
       socket.send(
         JSON.stringify({
@@ -28,21 +27,12 @@ export default function () {
       );
     });
 
-    socket.setTimeout(function () {
+    socket.setTimeout(() => {
       socket.close();
     }, 10000);
   });
 
   check(res, {
     'websocket connection status is 101': (r) => r && r.status === 101,
-
-      socket.setTimeout(() => {
-        socket.close();
-      }, 10000);
-    });
-  });
-
-  check(res, {
-    'connected successfully': (r) => r && r.status === 101,
   });
 }


### PR DESCRIPTION
## Problem

`backend/api/tests/load/websocket.js` was unparseable: two merged versions of the WebSocket test were concatenated, nesting a `socket.on('open', ...)` callback and a `check(res, ...)` block inside another `socket.on('open', ...)` callback with unbalanced braces. `node --check` failed with a `SyntaxError`, so the load test for WebSocket location-ping ingestion could not run.

## Fix

Rewrote the file as a single clean WebSocket scenario: one `ws.connect(...)` callback containing one `socket.on('open', ...)` handler (sends the `LOCATION_UPDATE` payload), one `socket.setTimeout(...)`/close, and one top-level `check(res, ...)` after the connection.

## Files changed

- `backend/api/tests/load/websocket.js`

## Testing

- `node --check backend/api/tests/load/websocket.js` passes.

Closes #8693
