### PR TITLE
fix(driver): remove stray paren and duplicate OfflineBanner/LowBatteryBanner in home screen (#8654)

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1116,13 +1116,6 @@ class _HomeScreenState extends State<HomeScreen> {
                             ],
                           ),
                         ),
-                      if (_isOffline) const OfflineBanner(),
-                      if (!_isCharging && _batteryLevel <= 20)
-                        LowBatteryBanner(
-                          batteryLevel: _batteryLevel,
-                          isCritical: _batteryLevel <= 10,
-                        ),
-                      ),
                     if (_isOffline) const OfflineBanner(),
                     if (!_isCharging && _batteryLevel <= 20)
                       LowBatteryBanner(


### PR DESCRIPTION
## Fixes #8654

`apps/driver/lib/screens/home_screen.dart` contained an unresolved merge conflict artifact: a first copy of `OfflineBanner`/`LowBatteryBanner` ending in a stray `)` with no matching `(`, followed by a second duplicate copy. The stray paren broke Dart compilation, and both copies would have rendered the banners twice.

### Changes
- Removed the first (broken) copy at lines 1119-1125, including the stray `),`.
- Kept the single clean copy.

Verified paren balance in the file (1138 open / 1138 close).

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved home screen overlay layout across device sizes.
  * Centered and constrained overlay content on extra-large screens.
  * Preserved consistent spacing on smaller screens.
  * Kept the map and full-width banners unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->