### PR TITLE
fix(driver): replace null Colors.grey[850] with grey[900] in bridge strike prevention screen (#8655)

### DIFF
--- a/apps/driver/lib/screens/bridge_strike_prevention_screen.dart
+++ b/apps/driver/lib/screens/bridge_strike_prevention_screen.dart
@@ -85,7 +85,7 @@ class _BridgeStrikePreventionScreenState extends State<BridgeStrikePreventionScr
     return Container(
       height: 300,
       width: double.infinity,
-      color: Colors.grey[850],
+      color: Colors.grey[900],
       child: Stack(
         alignment: Alignment.center,
         children: [
@@ -198,7 +198,7 @@ class _BridgeStrikePreventionScreenState extends State<BridgeStrikePreventionScr
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(color: Colors.grey[850], borderRadius: BorderRadius.circular(16)),
+      decoration: BoxDecoration(color: Colors.grey[900], borderRadius: BorderRadius.circular(16)),
       child: Column(
         children: [
           Icon(Icons.check_circle_outline, color: safeColor, size: 48),


### PR DESCRIPTION
## Fixes #8655

`Colors.grey` only defines swatch keys 50-900 in steps of 100, so `Colors.grey[850]` resolves to `null`. Both usages in `bridge_strike_prevention_screen.dart` rendered transparent backgrounds:
- line 88: map placeholder container color
- line 201: "clearance safe" card background

### Changes
- Replaced both `Colors.grey[850]` with `Colors.grey[900]` so the map placeholder and safe-clearance card get a visible dark grey background.

GSSOC
