### PR TITLE
fix(driver): relabel payout button to TRIGGER PAYOUT and drop unused isReady (#8667)

### DIFF
--- a/apps/driver/lib/screens/settlement_wallet_screen.dart
+++ b/apps/driver/lib/screens/settlement_wallet_screen.dart
@@ -113,7 +113,6 @@ class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
                   itemCount: _contracts.length,
                   itemBuilder: (context, index) {
                     final contract = _contracts[index];
-                    final isReady = contract.isGeofenceConfirmed && !contract.isPodUploaded; // Simplified logic for mock UI
                     final isReleased = contract.status == 'RELEASED';
 
                     return Card(
@@ -151,7 +150,7 @@ class _SettlementWalletScreenState extends State<SettlementWalletScreen> {
                                   backgroundColor: isReleased ? Colors.grey[300] : Colors.blueAccent,
                                   foregroundColor: isReleased ? Colors.grey[600] : Colors.white,
                                 ),
-                                child: Text(isReleased ? 'FUNDS RELEASED' : 'UPLOAD POD & TRIGGER PAYOUT'),
+                                child: Text(isReleased ? 'FUNDS RELEASED' : 'TRIGGER PAYOUT'),
                               ),
                             )
                           ],


### PR DESCRIPTION
## Fixes #8667

The settlement wallet card button was labeled "UPLOAD POD & TRIGGER PAYOUT" but pressing it only called `_processPayout`, which refuses to proceed unless `isPodUploaded` is already true — it never uploaded a PoD. The label over-promised behavior the handler does not perform.

### Changes
- Renamed the button label to "TRIGGER PAYOUT" so it accurately reflects what the button does (the PoD upload requirement is already surfaced by the "PoD Uploaded" status row and the snackbar error).
- Removed the unused `final isReady = ...` local (declared but never referenced).

GSSOC
