### PR TITLE
Fix escrow amount reconciliation script module imports

### DIFF
--- a/scripts/reconcileEscrowAmounts.js
+++ b/scripts/reconcileEscrowAmounts.js
@@ -1,25 +1,40 @@
-const { db } = require('../backend/api/src/db');
-const { escrowContract } = require('../backend/api/src/services/escrow');
-const { paisaToMaticWei } = require('../backend/api/src/utils/currency');
-
 async function reconcileEscrowAmounts() {
   console.log('Running Escrow Amount Reconciliation Audit...');
-  
-  const orders = await db('orders')
-    .select('id', 'display_id', 'accepted_bid_amount', 'escrow_status')
-    .whereIn('escrow_status', ['funded', 'released', 'payment_released']);
+
+  const { supabase } = await import('../backend/api/src/config/db.js');
+  const { getEscrowBooking, getEscrowBookingId, paisaToMaticWei } = await import('../backend/api/src/services/escrow.js');
+
+  const { data: orders, error } = await supabase
+    .from('orders')
+    .select('id, order_display_id, escrow_status, pending_bid_acceptance')
+    .in('escrow_status', ['funded', 'released', 'payment_released']);
+
+  if (error) {
+    console.error(`Failed to query orders: ${error.message}`);
+    process.exit(1);
+  }
 
   let mismatches = 0;
 
   for (const order of orders) {
     try {
-      const expectedWei = BigInt(paisaToMaticWei(order.accepted_bid_amount));
-      const booking = await escrowContract.bookings(order.display_id);
+      const bidAmountPaisa = order.pending_bid_acceptance?.bid_amount;
+      if (bidAmountPaisa == null) {
+        console.warn(`[SKIPPED] Order: ${order.id} | No accepted bid amount recorded`);
+        continue;
+      }
+
+      const expectedWei = BigInt(paisaToMaticWei(bidAmountPaisa));
+      const booking = await getEscrowBooking(getEscrowBookingId(order.order_display_id));
+      if (booking == null) {
+        console.warn(`[SKIPPED] Order: ${order.id} | No on-chain booking found`);
+        continue;
+      }
       const onChainWei = BigInt(booking.amount.toString());
 
       if (onChainWei < expectedWei) {
         mismatches++;
-        console.warn(`[MISMATCH DETECTED] Order: ${order.id} | Display ID: ${order.display_id}`);
+        console.warn(`[MISMATCH DETECTED] Order: ${order.id} | Display ID: ${order.order_display_id}`);
         console.warn(`  Expected: ${expectedWei.toString()} Wei | On-Chain: ${onChainWei.toString()} Wei`);
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

`scripts/reconcileEscrowAmounts.js` aborts on the very first line because it `require()`s modules that do not exist:

- `../backend/api/src/db` — the DB module lives at `backend/api/src/config/db.js` and exports a Supabase client, not a knex-style `db` factory.
- `../backend/api/src/utils/currency` — no such module; `paisaToMaticWei` is defined and exported from `backend/api/src/services/escrow.js`.
- `../backend/api/src/services/escrow` — exists, but exports no `escrowContract`; the correct helpers are `getEscrowBooking` / `getEscrowBookingId`.

The query also referenced columns that do not exist on the orders table (`display_id`, `accepted_bid_amount`).

## Fix

- Load the real modules with dynamic `import()` (the ESM modules use top-level await, so `require()` can never load them from this CJS script): `backend/api/src/config/db.js` for the DB client and `backend/api/src/services/escrow.js` for `getEscrowBooking`, `getEscrowBookingId`, and `paisaToMaticWei`.
- Query orders via the Supabase client using real columns (`id`, `order_display_id`, `escrow_status`, `pending_bid_acceptance`), filtering on the same escrow statuses.
- Derive the expected amount from the accepted bid in paisa (`pending_bid_acceptance.bid_amount`) with `paisaToMaticWei`, and read the on-chain booking via `getEscrowBooking(getEscrowBookingId(order.order_display_id))` — the same pattern used by `escrowFundingReconciliation.js`.
- Skip (with a warning) orders that have no recorded bid amount or no on-chain booking, instead of reporting spurious errors.

## Files changed

- `scripts/reconcileEscrowAmounts.js`

## Testing

- `node --check scripts/reconcileEscrowAmounts.js` passes.
- Verified the required module paths/exports and column names against the codebase.

Closes #8694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow reconciliation reliability by using current booking and order data sources.
  * Orders with missing accepted bids or on-chain bookings are now skipped safely.
  * Reconciliation stops when order data cannot be retrieved, preventing incomplete checks.
  * Underfunded escrow bookings continue to be identified by comparing expected and on-chain amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->