### PR TITLE
Fix unparseable export_prometheus_format signature in ebpf_exporter.py

### DIFF
--- a/backend/otel/ebpf_exporter.py
+++ b/backend/otel/ebpf_exporter.py
@@ -13,7 +13,7 @@ class EbpfMetricsExporter:
             "timestamp": time.time()
         }
 
-    def export_prometheus_format((self) -> str:
+    def export_prometheus_format(self) -> str:
         metrics = self.collect_ebpf_metrics()
         lines = [
             f"# HELP ebpf_telemetry_drops_total Total telemetry drops by eBPF",


### PR DESCRIPTION
## Problem

`backend/otel/ebpf_exporter.py:16` has a double parenthesis in the method signature, which is a Python syntax error (`SyntaxError: function parameters cannot be parenthesized`). The module fails to parse, so `EbpfMetricsExporter` is unavailable to the OpenTelemetry collector agent.

## Fix

Removed the extra parenthesis so the signature reads:

```python
def export_prometheus_format(self) -> str:
```

## Files changed

- `backend/otel/ebpf_exporter.py`

## Testing

- `py_compile` passes.
- Imported the module and invoked `EbpfMetricsExporter().export_prometheus_format()` — returns valid Prometheus text.

Closes #8695
