### PR TITLE
fix(tokenization): sign sellFraction with caller signer instead of server wallet (#8668)

### DIFF
--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -105,9 +105,10 @@ class TokenizationService {
         }
     }
 
-    async sellFraction(assetId, amount, userAddress) {
+    async sellFraction(assetId, amount, userAddress, signer) {
         try {
-            const tx = await this.token.sellFraction(
+            const userContract = new ethers.Contract(this.tokenAddress, this.tokenABI, signer);
+            const tx = await userContract.sellFraction(
                 assetId,
                 ethers.parseEther(amount.toString()),
                 { gasLimit: 150000 }


### PR DESCRIPTION
## Fixes #8668

`sellFraction()` signed with `this.token` — a contract instance bound to the server's `PRIVATE_KEY` wallet — so every sell transaction originated from the server address and reverted on-chain (the server wallet doesn't own the user's tokens). `userAddress` was only used for DB logging.

### Changes
- Added a `signer` parameter to `sellFraction(assetId, amount, userAddress, signer)`, mirroring the existing `purchaseFraction` pattern.
- Build a user-specific contract instance (`new ethers.Contract(this.tokenAddress, this.tokenABI, signer)`) and submit the sell through it, so the transaction is signed by the caller's wallet.
- Rest of the method (storeTransaction, logging, return shape) unchanged.

The caller is responsible for passing the user's `signer` (same contract as `purchaseFraction`, which already follows this pattern).

GSSOC
