### PR TITLE
Fix invalid // comment in test_ctrnn.py

### DIFF
--- a/backend/ml/models/test_ctrnn.py
+++ b/backend/ml/models/test_ctrnn.py
@@ -7,7 +7,7 @@ class TestCTRNN(unittest.TestCase):
         self.imputer = ContinuousTimeRnnImputer()
 
     def test_continuous_imputation(self):
-        last_coords = (28.6139, 77.2090) // Delhi coords
+        last_coords = (28.6139, 77.2090)  # Delhi coords
         imputed = self.imputer.impute_missing_telemetry(last_coords, dt_seconds=45.0)
         
         self.assertEqual(len(imputed), 2)


### PR DESCRIPTION
## Problem

`backend/ml/models/test_ctrnn.py:10` uses `//` as a comment marker, but `//` is the floor-division operator in Python. The line is a `SyntaxError`, so the module cannot be imported and the CTRNN imputation tests never run.

## Fix

Changed `//` to a proper Python comment:

```python
last_coords = (28.6139, 77.2090)  # Delhi coords
```

## Files changed

- `backend/ml/models/test_ctrnn.py`

## Testing

- `py_compile` on `test_ctrnn.py` passes.

Closes #8696
