### PR TITLE
feat: implement anti-hijacking remote trailer disconnect (#8512)

### DIFF
--- a/apps/driver/lib/models/anti_hijack_model.dart
+++ b/apps/driver/lib/models/anti_hijack_model.dart
@@ -1,0 +1,29 @@
+class SecurityTelemetry {
+  final bool engineStarted;
+  final bool geofenceBreached;
+  final bool isDriverAuthorized; // e.g. biometric check passed
+  final String trailerBrakeStatus; // "Pressurized (Free)", "Air Dumped (Locked)"
+  final String kingpinStatus; // "Unlocked", "Deadbolt Engaged"
+
+  SecurityTelemetry({
+    required this.engineStarted,
+    required this.geofenceBreached,
+    required this.isDriverAuthorized,
+    required this.trailerBrakeStatus,
+    required this.kingpinStatus,
+  });
+}
+
+class AntiHijackSession {
+  final String loadId;
+  final String cargoType;
+  final String status; // "Secured in Geofence", "Unauthorized Engine Start Detected", "Trailer Immobilized"
+  final SecurityTelemetry telemetry;
+
+  AntiHijackSession({
+    required this.loadId,
+    required this.cargoType,
+    required this.status,
+    required this.telemetry,
+  });
+}

--- a/apps/driver/lib/screens/anti_hijack_screen.dart
+++ b/apps/driver/lib/screens/anti_hijack_screen.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import '../models/anti_hijack_model.dart';
+import '../services/anti_hijack_service.dart';
+
+class AntiHijackScreen extends StatefulWidget {
+  const AntiHijackScreen({super.key});
+
+  @override
+  State<AntiHijackScreen> createState() => _AntiHijackScreenState();
+}
+
+class _AntiHijackScreenState extends State<AntiHijackScreen> {
+  final AntiHijackService _service = AntiHijackService();
+  AntiHijackSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.securityStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateHijackAttempt();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Anti-Hijacking Security'),
+        backgroundColor: Colors.black,
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+    
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildLoadCard(s),
+              const SizedBox(height: 24),
+              const Text('PHYSICAL SECURITY TELEMETRY', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              _buildTelemetryList(s.telemetry),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(AntiHijackSession s) {
+    Color headerColor = Colors.green[800]!;
+    IconData icon = Icons.security;
+    
+    if (s.status.contains('Unauthorized')) {
+      headerColor = Colors.orange[800]!;
+      icon = Icons.warning_amber_rounded;
+    } else if (s.status.contains('IMMOBILIZED')) {
+      headerColor = Colors.red[900]!;
+      icon = Icons.lock;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('DEFENDER PROTOCOL', style: TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold, letterSpacing: 2)),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 22, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadCard(AntiHijackSession s) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            const Text('PROTECTED ASSET', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            const SizedBox(height: 12),
+            Text(s.cargoType, style: const TextStyle(color: Colors.black87, fontSize: 24, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            Text('Load ID: ${s.loadId}', style: const TextStyle(color: Colors.grey, fontSize: 14)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTelemetryList(SecurityTelemetry t) {
+    return Column(
+      children: [
+        _buildSensorRow(
+          'Engine Ignition',
+          t.engineStarted ? 'STARTED' : 'OFF',
+          t.engineStarted ? Icons.power_settings_new : Icons.power_off,
+          t.engineStarted && !t.isDriverAuthorized ? Colors.red : Colors.grey[700]!,
+        ),
+        _buildSensorRow(
+          'Driver Authorization',
+          t.isDriverAuthorized ? 'VERIFIED' : 'FAILED / UNAVAILABLE',
+          t.isDriverAuthorized ? Icons.fingerprint : Icons.no_accounts,
+          !t.isDriverAuthorized && t.engineStarted ? Colors.red : Colors.grey[700]!,
+        ),
+        _buildSensorRow(
+          'Geofence Boundary',
+          t.geofenceBreached ? 'BREACHED' : 'SECURE',
+          t.geofenceBreached ? Icons.gps_off : Icons.gps_fixed,
+          t.geofenceBreached ? Colors.red : Colors.green[700]!,
+        ),
+        const SizedBox(height: 12),
+        const Divider(),
+        const SizedBox(height: 12),
+        _buildSensorRow(
+          'Trailer Air Brakes',
+          t.trailerBrakeStatus,
+          Icons.air,
+          t.trailerBrakeStatus.contains('Locked') ? Colors.red[900]! : Colors.orange[700]!,
+        ),
+        _buildSensorRow(
+          '5th Wheel Kingpin',
+          t.kingpinStatus,
+          t.kingpinStatus.contains('Deadbolt') ? Icons.lock : Icons.lock_open,
+          t.kingpinStatus.contains('Deadbolt') ? Colors.red[900]! : Colors.grey[700]!,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSensorRow(String label, String value, IconData icon, Color statusColor) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8), side: BorderSide(color: Colors.grey[300]!)),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Icon(icon, color: statusColor),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(label, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(color: statusColor.withOpacity(0.1), borderRadius: BorderRadius.circular(8)),
+              child: Text(value, style: TextStyle(color: statusColor, fontWeight: FontWeight.bold, fontSize: 12)),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/anti_hijack_service.dart
+++ b/apps/driver/lib/services/anti_hijack_service.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import '../models/anti_hijack_model.dart';
+
+class AntiHijackService {
+  final _sessionController = StreamController<AntiHijackSession>.broadcast();
+
+  Stream<AntiHijackSession> get securityStream => _sessionController.stream;
+
+  void simulateHijackAttempt() async {
+    // 1. Driver asleep at truck stop
+    _sessionController.add(AntiHijackSession(
+      loadId: 'HIGH-VALUE-PHARMA-991',
+      cargoType: 'Schedule II Pharmaceuticals',
+      status: 'Secured at Truck Stop Geofence',
+      telemetry: SecurityTelemetry(
+        engineStarted: false,
+        geofenceBreached: false,
+        isDriverAuthorized: false,
+        trailerBrakeStatus: 'Air Dumped (Locked)', // Normally locked when parked
+        kingpinStatus: 'Unlocked',
+      ),
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 2. Thief hotwires truck / unauthorized start
+    _sessionController.add(AntiHijackSession(
+      loadId: 'HIGH-VALUE-PHARMA-991',
+      cargoType: 'Schedule II Pharmaceuticals',
+      status: 'Unauthorized Engine Start Detected',
+      telemetry: SecurityTelemetry(
+        engineStarted: true,
+        geofenceBreached: false, // hasn't moved yet
+        isDriverAuthorized: false, // Biometrics failed/bypassed
+        trailerBrakeStatus: 'Pressurizing...', // Thief trying to air up brakes
+        kingpinStatus: 'Unlocked',
+      ),
+    ));
+    
+    await Future.delayed(const Duration(seconds: 3));
+
+    // 3. Thief tries to drive away, geofence breaches, physical immobilizers activate
+    _sessionController.add(AntiHijackSession(
+      loadId: 'HIGH-VALUE-PHARMA-991',
+      cargoType: 'Schedule II Pharmaceuticals',
+      status: 'HIJACKING DETECTED - TRAILER IMMOBILIZED',
+      telemetry: SecurityTelemetry(
+        engineStarted: true,
+        geofenceBreached: true,
+        isDriverAuthorized: false,
+        trailerBrakeStatus: 'Air Dumped (Locked) - OVERRIDE', // App dumps the air
+        kingpinStatus: 'Deadbolt Engaged', // Physically locks trailer to truck or ground
+      ),
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #8512

This PR introduces the frontend UI and mock telemetry services for the Anti-Hijacking Remote Trailer Disconnect system (Defender Protocol). Cargo theft of high-value loads (pharmaceuticals, electronics) frequently occurs while drivers are asleep at truck stops. Traditional GPS only tracks where the stolen cargo goes after the fact. This feature implements extreme physical security by integrating the app directly with the trailer's air lines and the fifth-wheel kingpin. If a hijacking is detected, it physically locks the trailer to the ground, preventing the theft entirely.

### Changes Made:
- **`anti_hijack_model.dart`**: Established the `AntiHijackSession` and `SecurityTelemetry` schemas to map ignition states, geofence boundaries, biometric driver authorization, and the physical statuses of the trailer air brakes and kingpin deadbolt.
- **`anti_hijack_service.dart`**: Implemented a mock `Stream` simulating an active hijacking attempt on a load of Schedule II Pharmaceuticals. The service progresses from a secure parked state to an unauthorized engine start, culminating in the "Defender Protocol" activating—simulating the dumping of the trailer air brakes and engaging the kingpin deadbolt to immobilize the truck.
- **`anti_hijack_screen.dart`**: Built a high-stakes security dashboard. The UI focuses on immediate state awareness, transitioning from a secure green header to a bright red "DEFENDER PROTOCOL" lock-down header. It features a detailed telemetry list that visually highlights failing security sensors (Unauthorized Driver) and explicitly confirms the physical lock-down mechanisms (Air Brakes Dumped, Kingpin Locked).

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
