### PR TITLE
Fix /wasm/eta returning null or negative ETAs

### DIFF
--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -75,7 +75,7 @@ class EdgeRuntime {
                             return selected;
                         },
                         calculate_eta: (distance, speed, trafficFactor) =>
-                            distance / (speed * (1.0 - (trafficFactor || 0))),
+                            distance / (speed * Math.max(1.0 - (trafficFactor || 0), 0.1)),
                         filter_drivers: (drivers, minRating) =>
                             (drivers || []).filter((d) => d.status !== 'offline' && d.rating >= (minRating || 0)),
                         aggregate_prices: (prices) =>

--- a/wasm/routes.js
+++ b/wasm/routes.js
@@ -83,14 +83,30 @@ router.post('/wasm/optimize', async (req, res) => {
 router.post('/wasm/eta', async (req, res) => {
     try {
         const { distance, speed, trafficFactor } = req.body;
-        if (!distance || !speed) {
+        const numericDistance = Number(distance);
+        const numericSpeed = Number(speed);
+        const numericTrafficFactor = Number(trafficFactor || 0);
+
+        if (!Number.isFinite(numericDistance) || numericDistance <= 0) {
             return res.status(400).json({
                 success: false,
-                error: 'distance and speed required'
+                error: 'distance must be a positive number'
+            });
+        }
+        if (!Number.isFinite(numericSpeed) || numericSpeed <= 0) {
+            return res.status(400).json({
+                success: false,
+                error: 'speed must be a positive number'
+            });
+        }
+        if (!Number.isFinite(numericTrafficFactor) || numericTrafficFactor >= 1) {
+            return res.status(400).json({
+                success: false,
+                error: 'trafficFactor must be a number less than 1'
             });
         }
         
-        const result = await edgeRuntime.calculateETA(distance, speed, trafficFactor || 0);
+        const result = await edgeRuntime.calculateETA(numericDistance, numericSpeed, numericTrafficFactor);
         res.json({
             success: true,
             data: result,


### PR DESCRIPTION
## Problem

`POST /api/wasm/eta` could return `null` or a negative ETA. The formula `distance / (speed * (1.0 - trafficFactor))` divides by a zero/negative denominator when `trafficFactor >= 1` (`Infinity` serializes to `null`), and the route accepted `distance <= 0` / `speed <= 0` and any non-numeric values, producing negative or `NaN` results that consumers treated as valid ETAs.

## Fix

- `wasm/routes.js`: reject invalid inputs with `400` — `distance` must be a positive number, `speed` must be a positive number, and `trafficFactor` must be a number `< 1` (all numeric values coerced and checked with `Number.isFinite`).
- `wasm/edge-runtime.js`: clamp the divisor so it can never be non-positive: `Math.max(1.0 - (trafficFactor || 0), 0.1)`.

## Files changed

- `wasm/routes.js`
- `wasm/edge-runtime.js`

## Testing

- `node --check` passes for both files.
- Formula sanity checks: `tf=1.5` → 25 (clamped, finite), `tf=0.5` → 5, `tf=0` → 2.5.

Closes #8698
