### PR TITLE
feat: implement driver fatigue ocular tracking integration (#8516)

### DIFF
--- a/apps/driver/lib/models/driver_fatigue_model.dart
+++ b/apps/driver/lib/models/driver_fatigue_model.dart
@@ -1,17 +1,29 @@
-class FatigueMetrics {
-  final double eyeClosurePercentage; // 0.0 to 1.0
+class OcularTelemetry {
   final double blinkRatePerMinute;
-  final int headNodsDetected;
-  final bool isMicroSleepDetected;
-  final String fatigueLevel; // 'Awake', 'Drowsy', 'Critical'
-  final DateTime timestamp;
+  final double averageEyeClosureDurationMs; // Normal is ~100-150ms. Microsleep is >500ms.
+  final double headNodAngleDegrees;
+  final bool microsleepDetected;
 
-  FatigueMetrics({
-    required this.eyeClosurePercentage,
+  OcularTelemetry({
     required this.blinkRatePerMinute,
-    required this.headNodsDetected,
-    required this.isMicroSleepDetected,
-    required this.fatigueLevel,
-    required this.timestamp,
+    required this.averageEyeClosureDurationMs,
+    required this.headNodAngleDegrees,
+    required this.microsleepDetected,
+  });
+}
+
+class FatigueSession {
+  final String driverId;
+  final String status; // "Alert & Active", "Drowsiness Detected", "CRITICAL - MICROSLEEP ALARM"
+  final double fatigueScore; // 0-100
+  final String recommendedAction;
+  final OcularTelemetry ocularData;
+
+  FatigueSession({
+    required this.driverId,
+    required this.status,
+    required this.fatigueScore,
+    required this.recommendedAction,
+    required this.ocularData,
   });
 }

--- a/apps/driver/lib/screens/driver_fatigue_screen.dart
+++ b/apps/driver/lib/screens/driver_fatigue_screen.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import '../models/driver_fatigue_model.dart';
+import '../services/driver_fatigue_service.dart';
+
+class DriverFatigueScreen extends StatefulWidget {
+  const DriverFatigueScreen({super.key});
+
+  @override
+  State<DriverFatigueScreen> createState() => _DriverFatigueScreenState();
+}
+
+class _DriverFatigueScreenState extends State<DriverFatigueScreen> {
+  final DriverFatigueService _service = DriverFatigueService();
+  FatigueSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.fatigueStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateFatigueTracking();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ocular Fatigue Tracking'),
+        backgroundColor: Colors.black,
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+    bool isCritical = s.status.contains('CRITICAL');
+    bool isWarning = s.status.contains('Warning');
+
+    return Column(
+      children: [
+        _buildStatusHeader(s, isWarning, isCritical),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildActionCard(s, isCritical),
+              const SizedBox(height: 24),
+              const Text('INFRARED OCULAR TELEMETRY', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              _buildTelemetryGrid(s.ocularData, isCritical),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(FatigueSession s, bool isWarning, bool isCritical) {
+    Color headerColor = Colors.green[800]!;
+    IconData icon = Icons.visibility;
+    
+    if (isWarning) {
+      headerColor = Colors.orange[800]!;
+      icon = Icons.visibility_off;
+    } else if (isCritical) {
+      headerColor = Colors.red[900]!;
+      icon = Icons.airline_seat_flat;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('IR DRIVER CAMERA', style: TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold, letterSpacing: 2)),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 22, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 16),
+          LinearProgressIndicator(
+            value: s.fatigueScore / 100,
+            backgroundColor: Colors.white24,
+            color: Colors.white,
+            minHeight: 8,
+          ),
+          const SizedBox(height: 8),
+          Text('Fatigue Score: ${s.fatigueScore.toInt()}/100', style: const TextStyle(color: Colors.white70, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionCard(FatigueSession s, bool isCritical) {
+    return Card(
+      elevation: isCritical ? 8 : 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: isCritical ? Colors.redAccent : Colors.transparent, width: 2),
+      ),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: isCritical ? Colors.red[50] : Colors.white,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          children: [
+            Text('SYSTEM DIRECTIVE', style: TextStyle(color: isCritical ? Colors.red[900] : Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (isCritical) ...[
+                  const Icon(Icons.notifications_active, color: Colors.red, size: 32),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Text(s.recommendedAction, textAlign: TextAlign.center, style: TextStyle(color: isCritical ? Colors.red[900] : Colors.black87, fontSize: 18, fontWeight: FontWeight.bold)),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTelemetryGrid(OcularTelemetry t, bool isCritical) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(child: _buildMetricCard('Blink Rate', '${t.blinkRatePerMinute.toInt()} /min', Icons.remove_red_eye, t.blinkRatePerMinute < 10 || t.blinkRatePerMinute > 25)),
+            const SizedBox(width: 12),
+            Expanded(child: _buildMetricCard('Eye Closure', '${t.averageEyeClosureDurationMs.toInt()} ms', Icons.timer, t.averageEyeClosureDurationMs > 300)),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(child: _buildMetricCard('Head Drop', '${t.headNodAngleDegrees.toStringAsFixed(1)}°', Icons.face, t.headNodAngleDegrees > 15)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Card(
+                color: isCritical ? Colors.red[900] : Colors.grey[100],
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    children: [
+                      Icon(isCritical ? Icons.warning : Icons.check_circle, color: isCritical ? Colors.white : Colors.green),
+                      const SizedBox(height: 8),
+                      Text(isCritical ? 'MICROSLEEP' : 'AWAKE', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: isCritical ? Colors.white : Colors.black87)),
+                      Text('Biological State', style: TextStyle(color: isCritical ? Colors.white70 : Colors.grey, fontSize: 12)),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMetricCard(String label, String value, IconData icon, bool isAnomalous) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: isAnomalous ? Colors.orangeAccent : Colors.grey[200]!),
+      ),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: isAnomalous ? Colors.orange[50] : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          children: [
+            Icon(icon, color: isAnomalous ? Colors.orange[900] : Colors.blueGrey[400]),
+            const SizedBox(height: 8),
+            Text(value, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22, color: isAnomalous ? Colors.orange[900] : Colors.black87)),
+            Text(label, style: const TextStyle(color: Colors.grey, fontSize: 12)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/driver_fatigue_service.dart
+++ b/apps/driver/lib/services/driver_fatigue_service.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import '../models/driver_fatigue_model.dart';
+
+class DriverFatigueService {
+  final _sessionController = StreamController<FatigueSession>.broadcast();
+
+  Stream<FatigueSession> get fatigueStream => _sessionController.stream;
+
+  void simulateFatigueTracking() async {
+    // 1. Driver is alert
+    _sessionController.add(FatigueSession(
+      driverId: 'TRX-DRV-9941',
+      status: 'Alert & Active',
+      fatigueScore: 12.0,
+      recommendedAction: 'Continue Driving Safely',
+      ocularData: OcularTelemetry(
+        blinkRatePerMinute: 15.0,
+        averageEyeClosureDurationMs: 120.0,
+        headNodAngleDegrees: 2.0,
+        microsleepDetected: false,
+      ),
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 2. Drowsiness setting in
+    _sessionController.add(FatigueSession(
+      driverId: 'TRX-DRV-9941',
+      status: 'Drowsiness Detected (Early Warning)',
+      fatigueScore: 65.5,
+      recommendedAction: 'Consider taking a break soon.',
+      ocularData: OcularTelemetry(
+        blinkRatePerMinute: 28.0, // Blinking more frequently
+        averageEyeClosureDurationMs: 350.0, // Eyes staying closed longer
+        headNodAngleDegrees: 8.5,
+        microsleepDetected: false,
+      ),
+    ));
+    
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 3. Microsleep!
+    _sessionController.add(FatigueSession(
+      driverId: 'TRX-DRV-9941',
+      status: 'CRITICAL - MICROSLEEP ALARM TRIGGERED',
+      fatigueScore: 98.0,
+      recommendedAction: 'ROUTING TO NEAREST REST AREA (2.4 miles)',
+      ocularData: OcularTelemetry(
+        blinkRatePerMinute: 5.0,
+        averageEyeClosureDurationMs: 1500.0, // Eyes closed for 1.5 seconds!
+        headNodAngleDegrees: 25.0, // Head dropped
+        microsleepDetected: true,
+      ),
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #8516

This PR introduces the frontend UI and mock telemetry services for the Driver Fatigue Ocular Tracking Integration system. Relying solely on arbitrary Hours of Service (HOS) clocks to determine driver fatigue is dangerously inadequate. This feature shifts the safety paradigm from tracking *legal time* to tracking *actual biological state*. By integrating with dash-mounted infrared cameras, the app analyzes ocular patterns to detect microsleeps in real-time, instantly triggering alarms and rerouting drivers to prevent catastrophic highway accidents.

### Changes Made:
- **`driver_fatigue_model.dart`**: Established the `FatigueSession` and `OcularTelemetry` schemas to map complex biological data, specifically isolating critical markers like `averageEyeClosureDurationMs` and `headNodAngleDegrees`.
- **`driver_fatigue_service.dart`**: Implemented a mock `Stream` simulating the onset of dangerous driver fatigue. The service smoothly transitions from an "Alert" state into a "Drowsiness Warning", ultimately culminating in a "Critical Microsleep" trigger (eyes closed for 1.5s) that forces an immediate emergency reroute to a rest area.
- **`driver_fatigue_screen.dart`**: Built a high-urgency biological monitoring dashboard. The UI is designed for immediate peripheral awareness, utilizing aggressive red/green state shifts based on the driver's biological status. It prominently displays the AI's "SYSTEM DIRECTIVE" alongside a detailed metric grid of the live infrared ocular telemetry that informs those directives.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
