### PR TITLE
fix(escortWalletRoutes): import requireRole from middleware/auth.js

### DIFF
--- a/backend/api/src/routes/escortWalletRoutes.js
+++ b/backend/api/src/routes/escortWalletRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import { body } from 'express-validator';
 import { loadCredential, handshake } from '../controllers/escortWalletController.js';
 import { authenticate } from '../middleware/auth.js';
-import { requireRole } from '../middleware/requireRole.js';
+import { requireRole } from '../middleware/auth.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Problem

escortWalletRoutes.js:5 imports `requireRole` from `../middleware/requireRole.js`, a file that does not exist. Every import of the escort wallet routes fails with "Cannot find module" as soon as the module is loaded.

## Fix

Point the `requireRole` import at the existing middleware that exports it (`../middleware/auth.js`), matching how every other route file imports it.

## Files changed

- backend/api/src/routes/escortWalletRoutes.js

## Testing

- `node --check backend/api/src/routes/escortWalletRoutes.js` passes.
- Confirmed `requireRole` is exported from `backend/api/src/middleware/auth.js` and no `requireRole.js` file exists under `backend/api/src/middleware/`.

Closes #8701
