### PR TITLE
fix(escortWalletController): import AppError from utils/errors.js

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -1,7 +1,7 @@
 import didService from '../../../did/did.service.js';
 import logger from '../middleware/logger.js';
 import { validationResult } from 'express-validator';
-import { AppError } from '../errors/AppError.js';
+import { AppError } from '../utils/errors.js';
 
 export const loadCredential = async (req, res, next) => {
     try {


### PR DESCRIPTION
## Problem

escortWalletController.js:4 imports `AppError` from `../errors/AppError.js`, a file that does not exist. Loading the escort wallet controller throws "Cannot find module", so the wallet routes can never be served.

## Fix

Point the `AppError` import at the existing module that exports it (`../utils/errors.js`), matching the import used by the rest of the codebase.

## Files changed

- backend/api/src/controllers/escortWalletController.js

## Testing

- `node --check backend/api/src/controllers/escortWalletController.js` passes.
- Confirmed `AppError` is exported from `backend/api/src/utils/errors.js` and no `errors/AppError.js` file exists.

Closes #8702
