### PR TITLE
fix(index): remove duplicate /api/webhooks router mount

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -513,7 +513,6 @@ app.use('/api/blockchain', (req, _res, next) => {
   req.escalationHandler = escalationHandler;
   next();
 }, blockchainMonitoringRoutes)
-app.use('/api/webhooks', webhookRoutes)
 
 // ============================================================================
 // 🆕 BLOCKCHAIN MONITORING ROUTES


### PR DESCRIPTION
## Problem

index.js mounts the webhook router twice: once at line ~504 (`app.use('/api/webhooks', webhookRoutes)`) and again at line ~516. The first (correct) mount sits before the rate limiters/middleware that were added later, and the duplicate means every webhook request is processed twice and the second registration shadows the first.

## Fix

Remove the second duplicate `app.use('/api/webhooks', webhookRoutes)` so the router is registered exactly once.

## Files changed

- backend/api/src/index.js

## Testing

- `node --check backend/api/src/index.js` passes.
- Verified there is exactly one `/api/webhooks` mount remaining in the file after the change.

Closes #8703
