### PR TITLE
fix(index): mount wimBypassRouter before the notFound handler

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -579,6 +579,7 @@ app.use('/api', wasiRoutes)
 app.use('/api', wasmRoutes)
 app.use('/api', snykRoutes)
 app.use('/api', liquibaseRoutes)
+app.use('/api/wim', wimBypassRouter)
 
 // 🆕 WebRTC Health Check Endpoint
 app.get('/api/webrtc/status', (req, res) => {
@@ -853,5 +854,3 @@ app.use((err, req, res, next) => {
 
   next(err);
 });
-
-app.use('/api/wim', wimBypassRouter);


### PR DESCRIPTION
## Problem

The WIM bypass router (`wimBypassRouter`) was mounted at the end of `index.js`, AFTER the `notFound` handler. Express runs middleware in registration order, so every `/api/wim` request fell through to the 404 handler and was never routed — the whole WIM bypass feature 404'd.

## Fix

Move `app.use('/api/wim', wimBypassRouter)` above the `notFound` handler and remove the trailing duplicate mount at the bottom of the file, so `/api/wim` requests reach the router.

## Files changed

- backend/api/src/index.js

## Testing

- `node --check backend/api/src/index.js` passes.
- Confirmed the router is registered before the `notFound` handler and only once.

Closes #8705
