### PR TITLE
fix(userRoutes): drop fcmTokenSchema regex that rejects real FCM tokens

### DIFF
--- a/backend/api/src/routes/userRoutes.js
+++ b/backend/api/src/routes/userRoutes.js
@@ -44,8 +44,7 @@ const fcmTokenSchema = z.object({
   fcmToken: z
     .string({ required_error: 'fcmToken is required' })
     .min(10, 'fcmToken must be at least 10 characters')
-    .max(4096, 'fcmToken must be at most 4096 characters')
-    .regex(/^[a-zA-Z0-9\-_:]+$/, 'fcmToken contains invalid characters'),
+    .max(4096, 'fcmToken must be at most 4096 characters'),
 });
 
 // ============================================================================


### PR DESCRIPTION
## Problem

`userRoutes.js` validates `fcmToken` with `/^[a-zA-Z0-9\-_:]+$/`. Real FCM registration tokens contain `/`, `=`, `+` and `.` characters, so every legitimate token is rejected and customers can never register their device for push notifications.

## Fix

Remove the `.regex(...)` from `fcmTokenSchema` so any non-empty string is accepted, matching the sibling `updateFcmTokenSchema` in `requestSchemas.js` (which only checks length).

## Files changed

- backend/api/src/routes/userRoutes.js

## Testing

- `node --check backend/api/src/routes/userRoutes.js` passes.
- Cross-checked `updateFcmTokenSchema` in `backend/api/src/validation/requestSchemas.js` (line ~201) — it applies no regex, only length bounds; the fix brings `fcmTokenSchema` in line with it.

Closes #8706
