### PR TITLE
fix(fuelAdvisorService): query trip_events with correct columns

### DIFF
--- a/backend/api/src/services/fuelAdvisorService.js
+++ b/backend/api/src/services/fuelAdvisorService.js
@@ -85,25 +85,38 @@ export class FuelAdvisorService {
         return 50; // Default load if no active trip
       }
 
-      // Find recent gpsUpdate events in trip_events for this trip/driver
+      // Resolve the active trip for this order. trip_events.trip_id references
+      // trips.id (not orders.id), so we must look up the trip first.
+      const { data: trip, error: tripErr } = await this.supabase
+        .from('trips')
+        .select('id')
+        .eq('order_id', order.id)
+        .maybeSingle();
+
+      if (tripErr || !trip) {
+        this.logger?.debug(`[FuelAdvisorService] No trip found for order ${order.id}, assuming default load`);
+        return 50; // Default load if no trip exists yet
+      }
+
+      // Find recent gpsUpdate events in trip_events for this trip
       const { data: events, error: eventsErr } = await this.supabase
         .from('trip_events')
-        .select('payload')
-        .eq('trip_id', order.id) // trip_id is often order.id
+        .select('metadata')
+        .eq('trip_id', trip.id)
         .eq('event_type', 'gpsUpdate')
-        .order('occurred_at', { ascending: false })
+        .order('event_timestamp', { ascending: false })
         .limit(50);
 
       if (eventsErr || !events || events.length === 0) {
         return 50; // Default load
       }
 
-      // Extract engineLoad from payload and average
+      // Extract engineLoad from metadata and average
       let totalLoad = 0;
       let count = 0;
 
       for (const event of events) {
-        const load = event.payload?.engineLoad;
+        const load = event.metadata?.engineLoad;
         if (load !== undefined && load !== null && typeof load === 'number') {
           totalLoad += load;
           count++;


### PR DESCRIPTION
## Problem

`fuelAdvisorService.js` `_getAverageEngineLoad` queries `trip_events` with columns that do not exist (`payload`, `occurred_at`, `status`) and compares `trip_id` directly to `order.id`. `trip_events` stores `metadata`, `event_timestamp` and `event_type`, and the trip is linked to an order via `trips.order_id`. Every fuel-advisor run throws (relation/column not found), so average engine load always falls back to the hardcoded `return 50`.

## Fix

Resolve the trip for the order first (`trips.order_id = order.id`), then query `trip_events` using the real columns: select `metadata`, filter `event_type = 'gpsUpdate'`, order by `event_timestamp`, and read the engine load from `event.metadata.engineLoad`. Keep the 50 fallback when there is no usable data (GPS events only carry lat/lng/timestamp, not engine load).

## Files changed

- backend/api/src/services/fuelAdvisorService.js

## Testing

- `node --check backend/api/src/services/fuelAdvisorService.js` passes.
- Verified real `trip_events` schema from `supabase/migrations/20260805000010_create_trip_events.sql` (`event_id, user_id, trip_id, event_type, event_timestamp, latitude, longitude, metadata, created_at`) and that `trips` has an `order_id` column.

Closes #8707
