### PR TITLE
fix(notificationService): return FCM result from sendDeliveryOtpNotification

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -277,6 +277,17 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');
   }
 
-    // Push notification logic placeholder / dispatch
-    return { success: true };
+    // Return the actual push-delivery result so callers can branch on it.
+    // The notification row is persisted independently of push delivery, so
+    // overall success is driven by the FCM outcome.
+    const fcmOk = Boolean(fcmResult?.success);
+    return {
+      success: fcmOk,
+      dbSuccess,
+      fcm: {
+        success: fcmOk,
+        messageId: fcmResult?.messageId ?? null,
+        error: fcmResult?.error ?? (fcmResult ? null : 'Unexpected sendFcmNotification error'),
+      },
+    };
   }


### PR DESCRIPTION
## Problem

`sendDeliveryOtpNotification` always returns `{ success: true }` and discards the actual FCM push result. Callers in `orderNotificationService.js` and `orderMilestoneService.js` already branch on `notifResult.success` and read `notifResult.fcm?.error`, but those were always true/undefined, so a failed push was never detected and the resend/update fallback branches never ran.

## Fix

Return the real push-delivery outcome: `{ success, dbSuccess, fcm: { success, messageId, error } }` derived from the `sendFcmNotification` result (including a false/error result when `sendFcmNotification` itself threw). The DB notification row is still persisted independently of push delivery.

## Files changed

- backend/api/src/services/notificationService.js

## Testing

- `node --check backend/api/src/services/notificationService.js` passes.
- Confirmed callers (`orderNotificationService.js:135-144`, `orderMilestoneService.js:135-143`) consume exactly `success` and `fcm?.error`.

Closes #8711
