### PR TITLE
fix(orderRoutes): add POST /api/orders/:id/ratings endpoint

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1174,6 +1174,32 @@ router.get('/:id/timeline', authenticate, userLimiter, requirePolicy('order:view
   }
 });
 
+// POST /api/orders/:id/ratings
+router.post('/:id/ratings', authenticate, userLimiter, requirePolicy('order:submit-rating', async (req) => {
+  const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
+  return { order };
+}), auditLog({ action: 'order:submit-rating', resourceType: 'order_rating' }), validateParams(paramIdSchema), validateBody(submitRatingSchema), async (req, res) => {
+  try {
+    const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id');
+    orderValidationService.assertOrderFound(order);
+
+    const result = await orderLifecycleService.submitRating(
+      order.id,
+      req.user.id,
+      req.body.stars,
+      req.body.comment ?? null,
+      req.token ? createUserClient(req.token) : undefined
+    );
+    return res.status(201).json(result);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(err.status).json(err.payload);
+    }
+    logger.error('Submit rating exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
 // GET /api/orders/:id
 router.get('/:id', authenticate, userLimiter, requirePolicy('order:view', async (req) => {
   const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');


### PR DESCRIPTION
## Problem

The customer app's `submitRating` (`order_service.dart:357-376`) calls `POST /api/orders/:id/ratings` with `{ stars, comment }`, but no `/:id/ratings` route exists in `orderRoutes.js`. Every rating submission 404'd, silently disabling the customer-side driver-reputation loop (which starves `awardReputationPoints`). `submitRatingSchema` and `awardReputationPoints` were imported but never used.

## Fix

Add `POST /api/orders/:id/ratings`:
- validates the body with `submitRatingSchema` (1-5 integer stars, optional comment),
- checks the caller via the existing `order:submit-rating` policy (customer-only, order ownership),
- resolves the order by id or display id, then delegates to `orderLifecycleService.submitRating`, which runs the hardened `submit_rating_tx` RPC (ownership + delivered/payment_released + driver-assignment checks) and emits the `rating:submitted` event.

On-chain reputation is awarded by the existing `reputationSubscriber` (`awardReputationPoints`) when that event fires — calling it directly in the route as well would double-award points, so it is left to the subscriber.

## Files changed

- backend/api/src/routes/orderRoutes.js

## Testing

- `node --check backend/api/src/routes/orderRoutes.js` passes.
- Verified `order:submit-rating` exists in `security/policyEngine.js` and the `auditLog` mapping for `order:submit-rating` already exists in `middleware/auditLog.js`.

Closes #8713
