### PR TITLE
fix(driver): implement real backend sync in OfflineFirstSyncService

### DIFF
--- a/apps/driver/lib/services/offline_first_sync_service.dart
+++ b/apps/driver/lib/services/offline_first_sync_service.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
-import 'dart:math';
-import 'package:sqflite/sqflite.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as p;
 import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
 import '../models/offline_sync_event_model.dart';
 
 class OfflineFirstSyncService {
@@ -16,6 +20,18 @@ class OfflineFirstSyncService {
 
   Stream<bool> get connectionStream => _connectionController.stream;
   Stream<List<OfflineSyncEvent>> get databaseStream => _dbController.stream;
+
+  /// Backend base URL, injected at build time via --dart-define.
+  /// Mirrors SyncEngine.apiBaseUrl so this service targets the same API host.
+  static String get _apiBaseUrl {
+    const envUrl = String.fromEnvironment('TRUXIFY_API_BASE_URL');
+    if (envUrl.isNotEmpty) return envUrl;
+    if (kReleaseMode) throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');
+
+    if (kIsWeb) return 'http://localhost:8080';
+    if (Platform.isAndroid) return 'http://10.0.2.2:8080';
+    return 'http://localhost:8080';
+  }
 
   OfflineFirstSyncService() {
     _initDatabase();
@@ -116,8 +132,38 @@ class OfflineFirstSyncService {
 
   Future<bool> _syncSingleEvent(OfflineSyncEvent event) async {
     try {
-      await Future.delayed(const Duration(milliseconds: 200));
-      return true;
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return false;
+      final token = await user.getIdToken();
+
+      final tripId = event.payload['trip_id'];
+
+      final requestBody = {
+        'idempotencyKey': event.eventId,
+        'events': [
+          {
+            'id': event.eventId,
+            'type': event.eventType,
+            'trip_id': tripId,
+            'payload': event.payload,
+            'occurred_at': event.queuedAt.toUtc().toIso8601String(),
+          },
+        ],
+      };
+
+      // POST /api/v1/trips/events/batch — the same endpoint SyncEngine.attemptSync
+      // uses. Only a real 2xx response counts as success so the local queue is
+      // never marked synced (and never dropped) without reaching the backend.
+      final response = await http.post(
+        Uri.parse('$_apiBaseUrl/api/v1/trips/events/batch'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode(requestBody),
+      );
+
+      return response.statusCode == 200 || response.statusCode == 202;
     } catch (_) {
       return false;
     }


### PR DESCRIPTION
## Problem

`OfflineFirstSyncService._syncSingleEvent` was a no-op stub: it slept 200 ms and returned `true` without any HTTP call. `_processSyncQueue` then marked every event `is_synced = 1`, so offline events buffered in the local SQLite `sync_events` table were silently discarded and never reached the backend. The sync dashboard reported them as synced, masking the loss.

## Fix

Implement `_syncSingleEvent` to actually POST the event to `/api/v1/trips/events/batch` (the same endpoint `SyncEngine.attemptSync` uses), with:
- the same base-URL resolution (`TRUXIFY_API_BASE_URL` dart-define with localhost fallbacks),
- a Firebase auth bearer token,
- a single-event batch payload (`id`, `type`, `trip_id` from the payload, `payload`, `occurred_at` in UTC ISO-8601).

Success is only reported on a real 2xx (200/202) response, so unsynced events are retained in the queue and retried (up to the existing retry limit) instead of being dropped.

## Files changed

- apps/driver/lib/services/offline_first_sync_service.dart

## Testing

- Reviewed the backend batch contract in `backend/api/src/routes/tripRoutes.js` (`POST /api/v1/trips/events/batch`, 202 on success, `occurred_at` must be ISO-8601).
- Mirrors the proven `SyncEngine.attemptSync` request shape.

Closes #8715
