### PR TITLE
docs: fix Flutter app setup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Note: Truxify is in active development (Phase 2). The core platform features are
 ### Run the Customer App
 ```bash
 git clone https://github.com/KanishJebaMathewM/Truxify.git
-cd Truxify/customer_app  # (or driver_app)
+cd Truxify/apps/customer  # or Truxify/apps/driver
 flutter pub get
 flutter run
 ```


### PR DESCRIPTION
## Summary
- update the README customer app setup command to use the actual `apps/customer` path
- mention the matching `apps/driver` path for the driver app

## Verification
- checked that the stale `customer_app` / `driver_app` references are gone from README.md

Closes #8770