### PR TITLE
fix: mount driver voice assistant route

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -61,6 +61,7 @@ import auditRoutes from './routes/auditRoutes.js'
 import paymentRoutes from './routes/paymentRoutes.js'
 import userRoutes from './routes/userRoutes.js'
 import voiceRoutes from './routes/voiceRoutes.js'
+import voiceAssistantRoutes from './routes/voice.routes.js'
 import demandRoutes from './routes/demandRoutes.js'
 import escortWalletRoutes from './routes/escortWalletRoutes.js'
 
@@ -495,6 +496,7 @@ app.use('/api/auth', authLimiter, authRoutes)
 app.use('/api/v1/admin', adminRoutes)
 app.use('/api/v1/admin/audit-logs', auditRoutes)
 app.use('/api/voice', voiceRoutes)
+app.use('/api/v1/voice', voiceAssistantRoutes)
 app.use('/api/demand-heatmap', demandRoutes)
 app.use('/api/escorts/wallet', escortWalletRoutes)
 

--- a/backend/api/test/unit/voiceAssistantRouteMount.test.js
+++ b/backend/api/test/unit/voiceAssistantRouteMount.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const indexSource = fs.readFileSync(path.resolve(__dirname, '../../src/index.js'), 'utf8');
+
+describe('voice assistant route mount', () => {
+  it('mounts the driver voice assistant endpoint at the documented API v1 path', () => {
+    expect(indexSource).toContain("import voiceAssistantRoutes from './routes/voice.routes.js'");
+    expect(indexSource).toContain("app.use('/api/v1/voice', voiceAssistantRoutes)");
+  });
+});


### PR DESCRIPTION
## Description
Mounts the existing voice assistant router at `/api/v1/voice`, matching the driver app endpoint and the route module Swagger path.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:**
  - `node --check backend/api/src/index.js`
  - `node --check backend/api/src/routes/voice.routes.js`
  - `npx vitest run test/unit/voiceAssistantRouteMount.test.js`
- **Test Steps / Prerequisites:** Run commands from the repository root and `backend/api` respectively.
- **Expected Result:** The backend parses cleanly and the route mount regression test passes.

### Test Environment
- [ ] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #8786

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.