### PR TITLE
fix(graphql): replace corrupted log symbols

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -332,10 +332,10 @@ class GraphQLGateway {
                 }
             });
 
-            logger.info(`âœ… GraphQL Gateway running at ${url}`);
+           logger.info(`OK GraphQL Gateway running at ${url}`);
             return { url };
         } catch (error) {
-            logger.error('âŒ GraphQL Gateway startup failed:', error);
+            logger.error('ERROR GraphQL Gateway startup failed:', error);
             throw error;
         }
     }
@@ -359,7 +359,7 @@ class GraphQLGateway {
     async stop() {
         if (this.server) {
             await this.server.stop();
-            logger.info('âœ… GraphQL Gateway stopped');
+            logger.info('OK GraphQL Gateway stopped');
         }
     }
 }

--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -212,7 +212,7 @@ async function startDriverService() {
         listen: { port: 4002 }
     });
 
-    logger.info(`âœ… Driver GraphQL service running at ${url}`);
+    logger.info(`OK Driver GraphQL service running at ${url}`);
     return { url };
 }
 

--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -337,7 +337,7 @@ async function startOrderService() {
         }
     });
 
-    logger.info(`âœ… Order GraphQL service running at ${url}`);
+   logger.info(`OK Order GraphQL service running at ${url}`);
     return { url };
 }
 


### PR DESCRIPTION
## Summary

- Replace corrupted UTF-8 symbols in GraphQL service logs
- Use readable `OK` and `ERROR` messages
- Updated order service, driver service, and GraphQL gateway logs

## Testing

- Ran `node --check` on all three modified JavaScript files
- All syntax checks passed successfully

Fixes #8776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved startup and shutdown log messages for the GraphQL gateway and backend services.
  * Replaced corrupted symbols with clear `OK` and `ERROR` indicators for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->