### PR TITLE
fix(traceability): parse ShipmentCreated from receipt and use getTotalShipments fallback

### DIFF
--- a/backend/traceability/trace.service.js
+++ b/backend/traceability/trace.service.js
@@ -18,7 +18,8 @@ class TraceabilityService {
             'function getShipment(uint256 shipmentId) external view returns (tuple(uint256,uint256,address,address,uint256,uint256,string,string,bytes32,bool))',
             'function getProductEvents(uint256 productId) external view returns (tuple(uint256,uint256,uint256,string,string,string,address,uint256,bytes32)[])',
             'function getProductTrace(uint256 productId) external view returns (tuple(uint256,string,string,string,address,uint256,uint256,bool,string,bytes32), tuple(uint256,uint256,uint256,string,string,string,address,uint256,bytes32)[], tuple(uint256,uint256,address,uint256,bool,string,bytes32)[])',
-            'event ProductCreated(uint256 indexed productId, string name, address indexed manufacturer)'
+            'event ProductCreated(uint256 indexed productId, string name, address indexed manufacturer)',
+            'event ShipmentCreated(uint256 indexed shipmentId, uint256 productId, address indexed sender)'
         ];
 
         this.contract = new ethers.Contract(this.contractAddress, this.contractABI, this.wallet);
@@ -106,7 +107,7 @@ class TraceabilityService {
                 }
             }
             if (!shipmentId) {
-                shipmentId = await this.contract.getShipmentCount();
+                shipmentId = await this.contract.getTotalShipments();
             }
 
             await this.storeShipment({


### PR DESCRIPTION
## Problem

`TraceabilityService.createShipment()` always throws AFTER the on-chain transaction succeeds, so the shipment is never recorded in Supabase (`trace_shipments`) and the API returns HTTP 500 even though the shipment exists on-chain.

Two root causes:

1. The contract ABI in `trace.service.js` declared only the `ProductCreated` event — `ShipmentCreated` was never added to the ABI, so ethers v6 `Interface.parseLog()` threw for the `ShipmentCreated` log and `shipmentId` stayed `undefined`.
2. The fallback called `this.contract.getShipmentCount()` — a function that does not exist in `SupplyChain.sol` (the contract exposes `getTotalShipments()`), throwing `TypeError: this.contract.getShipmentCount is not a function`.

## Fix

- Added `event ShipmentCreated(uint256 indexed shipmentId, uint256 productId, address indexed sender)` to the ABI so the real on-chain `shipmentId` is parsed from the transaction receipt.
- Replaced the fallback `getShipmentCount()` call with the contract's actual `getTotalShipments()`.

## Files changed

- `backend/traceability/trace.service.js`

## Testing

- `node --check backend/traceability/trace.service.js` passes.
- Verified the ABI event/function signatures match `blockchain/contracts/SupplyChain.sol` (`ShipmentCreated` event and `getTotalShipments()`).

Closes #8795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shipment creation tracking by recognizing shipment-created events.
  * Updated fallback handling to reliably identify newly created shipments when an ID is not included in the transaction receipt.
  * Increased reliability of shipment creation workflows and shipment ID detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->