### PR TITLE
fix(state-channels): align ABI and routes with StateChannel.sol, decode bytes32 channelId from ChannelOpened

### DIFF
--- a/backend/state-channels/channel.service.js
+++ b/backend/state-channels/channel.service.js
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers';
-import { randomUUID } from 'crypto';
 import logger from '../api/src/middleware/logger.js';
-import { supabase } from '../api/src/config/db.js';
+import { channelManager } from './channel_manager.js';
 
 class StateChannelService {
     constructor() {
@@ -10,16 +9,15 @@ class StateChannelService {
         this.channelAddress = process.env.STATE_CHANNEL_ADDRESS;
 
         this.channelABI = [
-            'function openChannel(address participantB) external returns (uint256)',
-            'function fundChannel(uint256 channelId) external payable',
-            'function updateState(uint256 channelId, uint256 newBalanceA, uint256 newBalanceB, uint256 nonce, bytes memory signatureA, bytes memory signatureB) external',
-            'function closeChannel(uint256 channelId) external',
-            'function raiseDispute(uint256 channelId, bytes32 stateHash) external',
-            'function batchSettle(uint256[] calldata channelIds) external',
-            'function getChannel(uint256 channelId) external view returns (tuple(uint256,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bool,bool,bytes32))',
-            'function getChannelStates(uint256 channelId) external view returns (tuple(uint256,uint256,uint256,uint256,bytes32,uint256)[])',
-            'function getUserChannels(address user) external view returns (uint256[])',
-            'function isChannelActive(uint256 channelId) external view returns (bool)'
+            'function openChannel(address userB) external payable returns (bytes32)',
+            'function initiateUnilateralExit(bytes32 channelId, uint256 sequence, uint256 balanceA, uint256 balanceB, bytes sig) external',
+            'function cooperativeClose(bytes32 channelId, uint256 balanceA, uint256 balanceB, bytes sigA, bytes sigB) external',
+            'function finalizeExit(bytes32 channelId) external',
+            'function channels(bytes32 channelId) external view returns (address userA, address userB, uint256 balanceA, uint256 balanceB, uint256 sequence, uint256 challengeExpiry, bool isDisputed, bool isClosed)',
+            'function channelCounter() external view returns (uint256)',
+            'event ChannelOpened(bytes32 indexed channelId, address indexed userA, address indexed userB, uint256 deposit)',
+            'event DisputeInitiated(bytes32 indexed channelId, uint256 sequence, uint256 challengeExpiry)',
+            'event ChannelClosed(bytes32 indexed channelId, uint256 finalBalanceA, uint256 finalBalanceB)'
         ];
 
         this.channel = new ethers.Contract(
@@ -36,25 +34,25 @@ class StateChannelService {
 
     // ============ Channel Operations ============
 
-    async openChannel(participantA, participantB) {
+    async openChannel(participantA, participantB, amount) {
         try {
-            const tx = await this.channel.openChannel(participantA, participantB, {
+            const tx = await this.channel.openChannel(participantB, {
+                value: ethers.parseEther(amount.toString()),
                 gasLimit: 200000
             });
             const receipt = await tx.wait();
 
-            // Parse channel ID from ChannelOpened event
-            const eventLog = receipt.logs.find(log => {
-                try {
-                    const parsed = this.channel.interface.parseLog(log);
-                    return parsed.name === 'ChannelOpened';
-                } catch {
-                    return false;
-                }
-            });
-            const channelId = eventLog
-                ? this.channel.interface.parseLog(eventLog).args[0].toString()
-                : (await this.getUserChannels(participantA))[0]?.toString() ?? null;
+            // Parse the bytes32 channel ID from the ChannelOpened event
+            const channelId = this._parseChannelOpened(receipt);
+
+            // Track the opened channel in the off-chain ledger
+            channelManager.createChannelState(
+                channelId,
+                this.wallet.address,
+                participantB,
+                ethers.parseEther(amount.toString()),
+                0
+            );
 
             logger.info(`✅ Channel opened: ${channelId}`);
             return {
@@ -65,6 +63,110 @@ class StateChannelService {
         } catch (error) {
             logger.error('Channel open failed:', error);
             throw error;
+        }
+    }
+
+    _parseChannelOpened(receipt) {
+        for (const log of receipt.logs) {
+            try {
+                const parsed = this.channel.interface.parseLog(log);
+                if (parsed && parsed.name === 'ChannelOpened') {
+                    return parsed.args.channelId;
+                }
+            } catch (e) {
+                continue;
+            }
+        }
+        throw new Error('ChannelOpened event not found in receipt');
+    }
+
+    // ============ Dispute ============
+
+    async raiseDispute(channelId, sequence, balanceA, balanceB, signature) {
+        try {
+            const tx = await this.channel.initiateUnilateralExit(
+                channelId,
+                sequence,
+                balanceA,
+                balanceB,
+                signature,
+                { gasLimit: 200000 }
+            );
+            const receipt = await tx.wait();
+
+            logger.info(`✅ Dispute raised for channel ${channelId}`);
+            return {
+                success: true,
+                channelId,
+                txHash: receipt.hash
+            };
+        } catch (error) {
+            logger.error('Raise dispute failed:', error);
+            throw error;
+        }
+    }
+
+    // ============ Close Channel ============
+
+    async closeChannel(channelId, balanceA, balanceB, signatureA, signatureB) {
+        try {
+            const tx = await this.channel.cooperativeClose(
+                channelId,
+                balanceA,
+                balanceB,
+                signatureA,
+                signatureB,
+                { gasLimit: 200000 }
+            );
+            const receipt = await tx.wait();
+
+            logger.info(`✅ Channel closed: ${channelId}`);
+            return {
+                success: true,
+                channelId,
+                txHash: receipt.hash
+            };
+        } catch (error) {
+            logger.error('Channel close failed:', error);
+            throw error;
+        }
+    }
+
+    // ============ View Functions ============
+
+    async getChannel(channelId) {
+        try {
+            const channel = await this.channel.channels(channelId);
+            return {
+                channelId,
+                userA: channel[0],
+                userB: channel[1],
+                balanceA: channel[2].toString(),
+                balanceB: channel[3].toString(),
+                sequence: channel[4].toString(),
+                challengeExpiry: channel[5].toString(),
+                isDisputed: channel[6],
+                isClosed: channel[7]
+            };
+        } catch (error) {
+            logger.error('Get channel failed:', error);
+            return null;
+        }
+    }
+
+    // ============ Statistics ============
+
+    async getChannelStats() {
+        try {
+            const totalChannels = await this.channel.channelCounter();
+            return {
+                totalChannels: totalChannels.toString(),
+                activeChannels: channelManager.activeChannels.size,
+                timestamp: new Date().toISOString()
+            };
+        } catch (error) {
+            logger.error('Channel stats fetch failed:', error);
+            return null;
         }
     }
 }

--- a/backend/state-channels/routes.js
+++ b/backend/state-channels/routes.js
@@ -7,58 +7,18 @@ const router = express.Router();
 // Open channel
 router.post('/channels/open', async (req, res) => {
     try {
-        const { participantA, participantB } = req.body;
-        if (!participantA || !participantB) {
+        const { participantA, participantB, amount } = req.body;
+        if (!participantA || !participantB || !amount) {
             return res.status(400).json({
                 success: false,
-                error: 'participantA and participantB required'
+                error: 'participantA, participantB, and amount required'
             });
         }
 
-        const result = await channelService.openChannel(participantA, participantB);
+        const result = await channelService.openChannel(participantA, participantB, amount);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Open channel error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Fund channel
-router.post('/channels/fund/:channelId', async (req, res) => {
-    try {
-        const { channelId } = req.params;
-        const { amount, participant } = req.body;
-        if (!amount || !participant) {
-            return res.status(400).json({
-                success: false,
-                error: 'amount and participant required'
-            });
-        }
-
-        const result = await channelService.fundChannel(channelId, amount, participant);
-        res.json({ success: true, data: result });
-    } catch (error) {
-        logger.error('Fund channel error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Update state
-router.post('/channels/update/:channelId', async (req, res) => {
-    try {
-        const { channelId } = req.params;
-        const { balances, nonce, signatures } = req.body;
-        if (!balances || nonce === undefined || !signatures) {
-            return res.status(400).json({
-                success: false,
-                error: 'balances, nonce, and signatures required'
-            });
-        }
-
-        const result = await channelService.updateState(channelId, balances, nonce, signatures);
-        res.json({ success: true, data: result });
-    } catch (error) {
-        logger.error('Update state error:', error);
         res.status(500).json({ success: false, error: error.message });
     }
 });
@@ -67,7 +27,15 @@ router.post('/channels/update/:channelId', async (req, res) => {
 router.post('/channels/close/:channelId', async (req, res) => {
     try {
         const { channelId } = req.params;
-        const result = await channelService.closeChannel(channelId);
+        const { balanceA, balanceB, signatureA, signatureB } = req.body;
+        if (balanceA === undefined || balanceB === undefined || !signatureA || !signatureB) {
+            return res.status(400).json({
+                success: false,
+                error: 'balanceA, balanceB, signatureA, and signatureB required'
+            });
+        }
+
+        const result = await channelService.closeChannel(channelId, balanceA, balanceB, signatureA, signatureB);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Close channel error:', error);
@@ -79,37 +47,18 @@ router.post('/channels/close/:channelId', async (req, res) => {
 router.post('/channels/dispute/:channelId', async (req, res) => {
     try {
         const { channelId } = req.params;
-        const { stateHash } = req.body;
-        if (!stateHash) {
+        const { sequence, balanceA, balanceB, signature } = req.body;
+        if (sequence === undefined || balanceA === undefined || balanceB === undefined || !signature) {
             return res.status(400).json({
                 success: false,
-                error: 'stateHash required'
+                error: 'sequence, balanceA, balanceB, and signature required'
             });
         }
 
-        const result = await channelService.raiseDispute(channelId, stateHash);
+        const result = await channelService.raiseDispute(channelId, sequence, balanceA, balanceB, signature);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Raise dispute error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Batch settle
-router.post('/channels/batch-settle', async (req, res) => {
-    try {
-        const { channelIds } = req.body;
-        if (!channelIds || !Array.isArray(channelIds)) {
-            return res.status(400).json({
-                success: false,
-                error: 'channelIds array required'
-            });
-        }
-
-        const result = await channelService.batchSettle(channelIds);
-        res.json({ success: true, data: result });
-    } catch (error) {
-        logger.error('Batch settle error:', error);
         res.status(500).json({ success: false, error: error.message });
     }
 });
@@ -122,30 +71,6 @@ router.get('/channels/:channelId', async (req, res) => {
         res.json({ success: true, data: channel });
     } catch (error) {
         logger.error('Get channel error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Get channel states
-router.get('/channels/:channelId/states', async (req, res) => {
-    try {
-        const { channelId } = req.params;
-        const states = await channelService.getChannelStates(channelId);
-        res.json({ success: true, data: states });
-    } catch (error) {
-        logger.error('Get channel states error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Get user channels
-router.get('/channels/user/:address', async (req, res) => {
-    try {
-        const { address } = req.params;
-        const channels = await channelService.getUserChannels(address);
-        res.json({ success: true, data: channels });
-    } catch (error) {
-        logger.error('Get user channels error:', error);
         res.status(500).json({ success: false, error: error.message });
     }
 });


### PR DESCRIPTION
## Problem

The state-channels module was non-functional:

- `routes.js` called `channelService.fundChannel`, `.updateState`, `.closeChannel`, `.raiseDispute`, `.batchSettle`, `.getChannel`, `.getChannelStates`, `.getUserChannels`, `.getChannelStats` — none of these are declared on `StateChannelService` (only `openChannel` existed), so every such endpoint threw `TypeError: channelService.fundChannel is not a function`.
- `openChannel(participantA, participantB)` passed two arguments to the ABI's one-argument `openChannel(address participantB)` — ethers v6 rejects the extra argument, so opening a channel always failed.
- The ABI declared `openChannel(...) returns (uint256)` and no events, but `StateChannel.sol` returns `bytes32 channelId` and emits `ChannelOpened`, so the fallback path could not decode the real channel id either.

## Fix

- Rebuilt the ABI from `StateChannel.sol`: `openChannel(address userB)` returning `bytes32`, `initiateUnilateralExit`, `cooperativeClose`, `finalizeExit`, `channels(bytes32)`, `channelCounter()` and the `ChannelOpened` / `DisputeInitiated` / `ChannelClosed` events.
- `openChannel` now calls the contract with a single participant argument (the relayer wallet is `userA`), sends the deposit `value`, decodes the `bytes32 channelId` from the `ChannelOpened` event, and records the channel in the off-chain `StateChannelManager`.
- Implemented the routes against the contract's actual operations: `closeChannel` → `cooperativeClose`, `raiseDispute` → `initiateUnilateralExit`, `getChannel` → `channels(bytes32)`, `getChannelStats` → `channelCounter()` plus off-chain active channels.
- Removed routes with no contract or off-chain equivalent (`fund`, `update`, `batch-settle`, `channel states`, `user channels`).

## Files changed

- `backend/state-channels/channel.service.js`
- `backend/state-channels/routes.js`

## Testing

- `node --check backend/state-channels/channel.service.js` passes.
- `node --check backend/state-channels/routes.js` passes.
- Verified every ABI function/event signature matches `blockchain/contracts/StateChannel.sol`.

Closes #8797
