### PR TITLE
fix: validate correct createBooking ABI selector

### DIFF
--- a/scripts/check-escrow-abi.sh
+++ b/scripts/check-escrow-abi.sh
@@ -26,7 +26,7 @@ echo "🔍 Checking escrow ABI compatibility..."
 # Expected selectors (from backend/api/src/services/escrow.js)
 # These are keccak256(first 4 bytes) of the function signatures
 declare -A EXPECTED_SELECTORS
-EXPECTED_SELECTORS["createBooking(uint256,address)"]="490a3b30"
+EXPECTED_SELECTORS["createBooking(uint256,address,bytes)"]="0bb7aa51"
 EXPECTED_SELECTORS["releasePayment(uint256)"]="88685cd9"
 EXPECTED_SELECTORS["cancelBooking(uint256)"]="0dca825e"
 EXPECTED_SELECTORS["cancelWithPenalty(uint256,uint256)"]="ca9a63b1"


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR. -->
Fixes the escrow ABI validation script so that it validates the correct `createBooking` function signature used by the Solidity contract and backend.

The existing CI guard checked the selector for `createBooking(uint256,address)`, even though the actual escrow contract and backend use `createBooking(uint256,address,bytes)`. This meant the ABI check could pass without validating the selector used by the real `createBooking` entry point.

This change updates the expected signature and selector to match the actual contract and backend ABI.

## Type of Change
<!-- Select all that apply: -->
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- **Test Commands:**
- **Test Steps / Prerequisites:**
- **Expected Result:**

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
<!-- Link the issue(s) resolved or referenced by this PR. -->
<!-- Examples: Closes #1234, Related to #5678 -->
Closes https://github.com/KanishJebaMathewM/Truxify/issues/8840

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

