### PR TITLE
fix(offline-sync): resolve superseded event state desynchronization and storage leak (fixes #8295)

### DIFF
--- a/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
+++ b/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
@@ -1,6 +1,30 @@
 import '../models/trip_event.dart';
 
+class ConflictResolutionResult {
+  final List<TripEvent> resolved;
+  final List<String> supersededIds;
+
+  ConflictResolutionResult({
+    required this.resolved,
+    required this.supersededIds,
+  });
+}
+
 class ConflictResolver {
+  ConflictResolutionResult resolveWithDetails(List<TripEvent> events) {
+    final resolved = resolve(events);
+    final resolvedIds = resolved.map((e) => e.id).toSet();
+    final supersededIds = events
+        .map((e) => e.id)
+        .where((id) => !resolvedIds.contains(id))
+        .toList();
+
+    return ConflictResolutionResult(
+      resolved: resolved,
+      supersededIds: supersededIds,
+    );
+  }
+
   List<TripEvent> resolve(List<TripEvent> events) {
     final sorted = List<TripEvent>.of(events)
       ..sort((a, b) => _compareTimestamp(a.occurredAt, b.occurredAt));

--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -54,7 +54,15 @@ class SyncEngine {
       return 0;
     }
 
-    final resolved = resolver.resolve(eligible);
+    final resolution = resolver.resolveWithDetails(eligible);
+    final resolved = resolution.resolved;
+    final supersededIds = resolution.supersededIds;
+
+    // Clear superseded/deduplicated event IDs from SQLite to prevent orphan pending queue loops
+    for (final id in supersededIds) {
+      await db.markSynced(id);
+    }
+
     if (resolved.isEmpty) {
       return 0;
     }


### PR DESCRIPTION
## Description
This PR resolves an issue where superseded or deduplicated offline events were left in the SQLite pending queue, causing an orphan pending queue loop in the offline sync engine. The changes introduce a detailed conflict resolution result that explicitly tracks superseded events and marks them as synced in the local database to clear them out properly.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `flutter test` (offline sync engine tests)
- **Test Steps / Prerequisites:** 
  1. Trigger multiple offline events for the same trip (e.g. duplicate trip events) that would result in one or more being superseded.
  2. Let the `SyncEngine` process the pending queue.
- **Expected Result:** The engine correctly identifies the superseded events during conflict resolution, explicitly clears them from the SQLite database, and successfully completes the sync queue without entering an infinite loop.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #8295

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline synchronization by identifying and marking superseded events as synced before upload.
  - Prevented redundant or conflicting events from being uploaded during synchronization.
  - Added clearer conflict-resolution results to support more reliable event syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->