### PR TITLE
fix(atomic-swap): align service ABI with AtomicSwap.sol

### DIFF
--- a/backend/atomic-swap/swap.service.js
+++ b/backend/atomic-swap/swap.service.js
@@ -11,18 +11,18 @@ class AtomicSwapService {
         this.swapAddress = process.env.ATOMIC_SWAP_ADDRESS;
 
         this.swapABI = [
-            'function createSwap(address counterparty, address tokenAddress, uint256 amount, bytes32 hashLock) external payable returns (uint256)',
-            'function executeSwap(uint256 swapId, bytes32 secret) external',
-            'function refundSwap(uint256 swapId) external',
-            'function createCrossChainSwap(uint256 destChainId, address counterparty, address tokenAddress, uint256 amount, bytes32 hashLock, bytes32 proof) external payable returns (uint256)',
-            'function executeCrossChainSwap(uint256 swapId, bytes32 secret, bytes32 proof) external',
-            'function refundCrossChainSwap(uint256 swapId) external',
-            'function getSwap(uint256 swapId) external view returns (tuple(uint256,address,address,address,uint256,bytes32,uint256,bool,bool,uint256,bytes32))',
-            'function getCrossChainSwap(uint256 swapId) external view returns (tuple(uint256,uint256,uint256,address,address,address,uint256,bytes32,uint256,bool,bool,bytes32,bytes32))',
-            'function getSwapCount() external view returns (uint256)',
-            'function getCrossChainSwapCount() external view returns (uint256)',
-            'function isHashLockUsed(bytes32 hashLock) external view returns (bool)'
+            'function openSwap(bytes32 swapId, address payable recipient, bytes32 hashLock, uint256 lockDuration) external payable returns (bytes32)',
+            'function claimSwap(bytes32 swapId, bytes preimage) external',
+            'function refundSwap(bytes32 swapId) external',
+            'function getUserSwaps(address user) external view returns (tuple(bytes32,bool)[])',
+            'function swaps(bytes32 swapId) external view returns (address sender, address recipient, uint256 amount, bytes32 hashLock, uint256 lockTime, bool claimed, bool refunded, bool isCrossChain)',
+            'function usedHashLocks(bytes32 hashLock) external view returns (bool)',
+            'event SwapOpened(bytes32 indexed swapId, address indexed sender, address indexed recipient, uint256 amount, bytes32 hashLock, uint256 lockTime)',
+            'event SwapClaimed(bytes32 indexed swapId, bytes preimage)',
+            'event SwapRefunded(bytes32 indexed swapId)'
         ];
+
+        this.lockDuration = 86400;
 
         this.swap = new ethers.Contract(this.swapAddress, this.swapABI, this.wallet);
 
@@ -31,21 +31,8 @@ class AtomicSwapService {
 
     // ============ Hash Lock Generation ============
 
-    // Derive the swap id from the swap-opened event emitted in the receipt,
-    // falling back to the transaction hash. The previously used
-    // getSwapCount()/getCrossChainSwapCount() are not part of the ABI.
-    async extractSwapId(receipt) {
-        for (const log of receipt.logs || []) {
-            const parsed = this.swap.interface.parseLog(log);
-            if (parsed && /swap/i.test(parsed.name) && parsed.args.length > 0) {
-                const id = parsed.args[0];
-                if (id && typeof id.toString === 'function') {
-                    return id.toString();
-                }
-                return String(id);
-            }
-        }
-        return receipt.hash;
+    generateSwapId() {
+        return '0x' + crypto.randomBytes(32).toString('hex');
     }
 
     generateHashLock(secret) {
@@ -62,20 +49,19 @@ class AtomicSwapService {
         try {
             const hashLock = this.generateHashLock(secret);
             const parsedAmount = ethers.parseEther(amount.toString());
+            const swapId = this.generateSwapId();
 
-            const tx = await this.swap.createSwap(
+            const tx = await this.swap.openSwap(
+                swapId,
                 counterparty,
-                tokenAddress || ethers.ZeroAddress,
-                parsedAmount,
                 hashLock,
+                this.lockDuration,
                 {
-                    value: tokenAddress === ethers.ZeroAddress ? parsedAmount : 0,
+                    value: parsedAmount,
                     gasLimit: 300000
                 }
             );
             const receipt = await tx.wait();
-
-            const swapId = await this.extractSwapId(receipt);
 
             await this.storeSwap({
                 swapId,
@@ -104,7 +90,7 @@ class AtomicSwapService {
 
     async executeSwap(swapId, secret) {
     try {
-        const tx = await this.swap.executeSwap(swapId, secret, {
+        const tx = await this.swap.claimSwap(swapId, ethers.toUtf8Bytes(secret), {
             gasLimit: 150000
         });
             const receipt = await tx.wait();
@@ -151,22 +137,19 @@ class AtomicSwapService {
             const hashLock = this.generateHashLock(secret);
             const parsedAmount = ethers.parseEther(amount.toString());
             const proof = ethers.keccak256(ethers.toUtf8Bytes(`${destChainId}:${counterparty}:${Date.now()}`));
+            const swapId = this.generateSwapId();
 
-            const tx = await this.swap.createCrossChainSwap(
-                destChainId,
+            const tx = await this.swap.openSwap(
+                swapId,
                 counterparty,
-                tokenAddress || ethers.ZeroAddress,
-                parsedAmount,
                 hashLock,
-                proof,
+                this.lockDuration,
                 {
-                    value: tokenAddress === ethers.ZeroAddress ? parsedAmount : 0,
+                    value: parsedAmount,
                     gasLimit: 350000
                 }
             );
             const receipt = await tx.wait();
-
-            const swapId = await this.extractSwapId(receipt);
 
             await this.storeCrossChainSwap({
                 swapId,
@@ -199,7 +182,7 @@ class AtomicSwapService {
 
     async executeCrossChainSwap(swapId, secret, proof) {
     try {
-        const tx = await this.swap.executeCrossChainSwap(swapId, secret, proof, {
+        const tx = await this.swap.claimSwap(swapId, ethers.toUtf8Bytes(secret), {
             gasLimit: 200000
         });
             const receipt = await tx.wait();
@@ -220,7 +203,7 @@ class AtomicSwapService {
 
     async refundCrossChainSwap(swapId) {
         try {
-            const tx = await this.swap.refundCrossChainSwap(swapId, {
+            const tx = await this.swap.refundSwap(swapId, {
                 gasLimit: 150000
             });
             const receipt = await tx.wait();
@@ -243,19 +226,17 @@ class AtomicSwapService {
 
     async getSwap(swapId) {
         try {
-            const swap = await this.swap.getSwap(swapId);
+            const swap = await this.swap.swaps(swapId);
             return {
-                id: swap[0].toString(),
-                initiator: swap[1],
-                counterparty: swap[2],
-                tokenAddress: swap[3],
-                amount: ethers.formatEther(swap[4]),
-                hashLock: swap[5],
-                timelock: swap[6].toString(),
-                executed: swap[7],
-                refunded: swap[8],
-                createdAt: swap[9].toString(),
-                secret: swap[10]
+                id: swapId,
+                sender: swap[0],
+                recipient: swap[1],
+                amount: ethers.formatEther(swap[2]),
+                hashLock: swap[3],
+                lockTime: swap[4].toString(),
+                claimed: swap[5],
+                refunded: swap[6],
+                isCrossChain: swap[7]
             };
         } catch (error) {
             logger.error('Swap fetch failed:', error);
@@ -265,21 +246,17 @@ class AtomicSwapService {
 
     async getCrossChainSwap(swapId) {
         try {
-            const swap = await this.swap.getCrossChainSwap(swapId);
+            const swap = await this.swap.swaps(swapId);
             return {
-                id: swap[0].toString(),
-                sourceChainId: swap[1].toString(),
-                destChainId: swap[2].toString(),
-                initiator: swap[3],
-                counterparty: swap[4],
-                tokenAddress: swap[5],
-                amount: ethers.formatEther(swap[6]),
-                hashLock: swap[7],
-                timelock: swap[8].toString(),
-                executed: swap[9],
-                refunded: swap[10],
-                secret: swap[11],
-                proof: swap[12]
+                id: swapId,
+                sender: swap[0],
+                recipient: swap[1],
+                amount: ethers.formatEther(swap[2]),
+                hashLock: swap[3],
+                lockTime: swap[4].toString(),
+                claimed: swap[5],
+                refunded: swap[6],
+                isCrossChain: swap[7]
             };
         } catch (error) {
             logger.error('Cross-chain swap fetch failed:', error);


### PR DESCRIPTION
## Problem

The `AtomicSwapService` in `backend/atomic-swap/swap.service.js` talks to a contract ABI that does not match the deployed `AtomicSwap.sol` contract. It calls `createSwap`, `executeSwap(uint256, bytes32)`, `refundSwap(uint256)`, `createCrossChainSwap`, `executeCrossChainSwap`, `refundCrossChainSwap`, `getSwap`, `getCrossChainSwap`, `getSwapCount`, `getCrossChainSwapCount` and `isHashLockUsed`, none of which exist in the contract (which exposes `openSwap`, `claimSwap`, `refundSwap(bytes32)`, `getUserSwaps`, `swaps`, `usedHashLocks`). Every swap operation therefore reverts. Additionally, the ABI declares no events while `extractSwapId()` calls `parseLog()` without a try/catch, so it throws for every log, and the ABI/comments contradict each other about `getSwapCount`/`getCrossChainSwapCount`.

## Fix

Rebuilt `swapABI` from `AtomicSwap.sol` (`openSwap`, `claimSwap`, `refundSwap(bytes32)`, `getUserSwaps`, `swaps`, `usedHashLocks`, plus the `SwapOpened`/`SwapClaimed`/`SwapRefunded` events).

- `createSwap` now generates a `swapId` (`generateSwapId()`), calls `openSwap(swapId, counterparty, hashLock, lockDuration)` with `msg.value`, and returns the swap.
- `executeSwap` now calls `claimSwap(swapId, preimage)` using the UTF-8 bytes of the secret, which matches how `generateHashLock` computes the lock hash.
- `refundSwap`/`refundCrossChainSwap` now call `refundSwap(bytes32)`.
- Cross-chain swaps use the same HTLC flow (`openSwap`/`claimSwap`) with chain metadata kept in the DB, since the contract has no separate cross-chain functions.
- `getSwap`/`getCrossChainSwap` read the real `swaps(swapId)` mapping instead of non-existent getters.
- Removed the unused `extractSwapId()` (which called `parseLog` without try/catch) in favor of generating the swap id before the transaction.

## Files changed

- `backend/atomic-swap/swap.service.js`

## Testing

- `node --check backend/atomic-swap/swap.service.js` passes.
- Routes in `backend/atomic-swap/routes.js` were reviewed and all still call methods that exist on the service with unchanged signatures.

Closes #8799
