### PR TITLE
fix(api): export sendPushNotification from notificationService

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -122,6 +122,46 @@ export async function sendFcmNotification(userId, notification, data = {}) {
   };
 }
 
+export async function sendPushNotification(userId, title, body, notifType = 'order_update', data = {}) {
+  if (!userId || !title || !body) {
+    logger.warn('[NotificationService] sendPushNotification skipped — missing required fields.');
+    return { success: false, error: 'Missing required fields' };
+  }
+
+  let dbSuccess = false;
+  try {
+    if (!supabaseAdmin) {
+      logger.error('[NotificationService] Service-role client not configured — cannot persist notification.');
+    } else {
+      const { error } = await supabaseAdmin.from('notifications').insert({
+        user_id: userId,
+        title,
+        body,
+        notif_type: notifType,
+        metadata: data
+      });
+
+      if (error) {
+        logger.error({ err: error }, '[NotificationService] Database insert failed');
+      } else {
+        logger.info(`[NotificationService] Notification inserted for user ${userId}`);
+        dbSuccess = true;
+      }
+    }
+  } catch (dbErr) {
+    logger.error({ err: dbErr }, '[NotificationService] Database connection error during notification insert');
+  }
+
+  let fcmResult;
+  try {
+    fcmResult = await sendFcmNotification(userId, { title, body }, data);
+  } catch (err) {
+    logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');
+  }
+
+  return { success: true, persisted: dbSuccess, fcm: fcmResult };
+}
+
 export const hashDeliveryOtp = hashOtp;
 export const verifyDeliveryOtpHash = verifyOtpHash;
 


### PR DESCRIPTION
## Problem

Several modules import `sendPushNotification` from `backend/api/src/services/notificationService.js`, but that function was never exported — the file only exported `sendFcmNotification` and the OTP helpers. The ESM named-import mismatch raised `SyntaxError: The requested module ... does not provide an export named 'sendPushNotification'` and the API process exited at boot.

## Fix

Added the missing `sendPushNotification(userId, title, body, notifType, data)` export to `notificationService.js`. It matches the call signature used by all 7 importers (title/body as strings plus a notification type and metadata), persists a row in the `notifications` table (same columns as `sendDeliveryOtpNotification`), and sends the push via the existing `sendFcmNotification`.

## Files changed

- `backend/api/src/services/notificationService.js` — export the missing `sendPushNotification` function.

## Testing

- Confirmed all importers (`orderRoutes.js`, `paymentRoutes.js`, `documentExpiryService.js`, `escrowFundingReconciliation.js`, `deliveryVerificationService.js`, `staleOrderWorker.js`, `orderLifecycleService.js`) call it with `(userId, title, body, notifType, data)`.
- Verified no other export name mismatch remains between the import sites and `notificationService.js`.

Closes #8834
