### PR TITLE
fix(db): add missing append_maintenance_photos RPC migration

### DIFF
--- a/supabase/migrations/20260809000000_add_append_maintenance_photos_rpc.sql
+++ b/supabase/migrations/20260809000000_add_append_maintenance_photos_rpc.sql
@@ -1,0 +1,57 @@
+-- Migration: Add append_maintenance_photos RPC (fixes #8835)
+-- POST /api/maintenance/:ticketId/photos calls supabase.rpc('append_maintenance_photos')
+-- with (p_ticket_id, p_new_paths, p_max_photos), but the function was never
+-- defined in any migration, so every upload failed with:
+--   '42883 function append_maintenance_photos(...) does not exist'
+-- This defines it: it locks the ticket row, re-verifies the caller owns the
+-- ticket, enforces the max-photo cap atomically (so concurrent uploads cannot
+-- exceed the limit), and appends the new storage paths to photo_urls.
+
+CREATE OR REPLACE FUNCTION public.append_maintenance_photos(
+  p_ticket_id   UUID,
+  p_new_paths   TEXT[],
+  p_max_photos  INTEGER
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing  TEXT[];
+  v_driver_id UUID;
+BEGIN
+  -- The controller checks ownership before uploading, but re-verify inside the
+  -- RPC so the row lock + write can only be performed on a ticket the caller
+  -- actually owns (auth.uid() is NULL for unauthenticated calls).
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  SELECT photo_urls, driver_id
+    INTO v_existing, v_driver_id
+    FROM truck_maintenance_tickets
+    WHERE id = p_ticket_id
+    FOR UPDATE;
+
+  IF v_driver_id IS NULL THEN
+    RAISE EXCEPTION 'Maintenance ticket not found';
+  END IF;
+
+  IF v_driver_id <> auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized: you can only add photos to your own tickets';
+  END IF;
+
+  IF coalesce(array_length(v_existing, 1), 0) + coalesce(array_length(p_new_paths, 1), 0) > p_max_photos THEN
+    RAISE EXCEPTION 'MAX_PHOTOS_EXCEEDED';
+  END IF;
+
+  UPDATE truck_maintenance_tickets
+    SET photo_urls = coalesce(v_existing, '{}') || p_new_paths
+    WHERE id = p_ticket_id;
+END;
+$$;
+
+-- Postgres grants EXECUTE to PUBLIC by default on function creation;
+-- granting to authenticated afterward does not revoke that. Revoke first.
+REVOKE EXECUTE ON FUNCTION public.append_maintenance_photos(UUID, TEXT[], INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.append_maintenance_photos(UUID, TEXT[], INTEGER) TO authenticated;


### PR DESCRIPTION
## Problem

`backend/api/src/controllers/maintenancePhotoController.js` calls `supabase.rpc('append_maintenance_photos', { p_ticket_id, p_new_paths, p_max_photos })` on `POST /api/maintenance/:ticketId/photos`, but the function was not defined in any migration. Every upload failed with Postgres `42883 function append_maintenance_photos(...) does not exist`, so the maintenance-photo upload feature was broken.

## Fix

Added a migration defining the missing `append_maintenance_photos` RPC matching the argument shape the controller passes. The function:
- Locks the ticket row (`SELECT ... FOR UPDATE`) so concurrent uploads cannot exceed the cap.
- Re-verifies via `auth.uid()` that the caller owns the ticket (matching the controller's existing ownership check and the repo's `set_default_address` RPC pattern).
- Raises `MAX_PHOTOS_EXCEEDED` when the cap would be exceeded (the controller already handles that error message).
- Atomically appends the new storage paths to `photo_urls`.
- Grants EXECUTE only to `authenticated` (revoking the default PUBLIC grant).

## Files changed

- `supabase/migrations/20260809000000_add_append_maintenance_photos_rpc.sql` — new migration defining the RPC.

## Testing

- Verified the RPC argument names/types (`p_ticket_id UUID`, `p_new_paths TEXT[]`, `p_max_photos INTEGER`) match the controller call.
- Verified the error-message contract: the controller checks `updateError.message.includes('MAX_PHOTOS_EXCEEDED')`, which the `RAISE EXCEPTION 'MAX_PHOTOS_EXCEEDED'` satisfies.
- Confirmed `photo_urls` is `TEXT[]` (added by `20260718000000_add_maintenance_photos.sql`) and that the function appends with `||`.

Closes #8835
