### PR TITLE
fix(smpc): compare Lagrange-reconstructed secrets in _secure_compare

### DIFF
--- a/backend/smpc/smpc_service.py
+++ b/backend/smpc/smpc_service.py
@@ -263,12 +263,12 @@ class SMPCProtocol:
         return list(max_share.values())
 
     def _secure_compare(self, shares1: Dict[str, bytes], shares2: Dict[str, bytes]) -> Dict[str, bytes]:
-        """Secure comparison of two shared values"""
-        vals1 = [self._deserialize_result(self.cipher.decrypt(v)) for v in shares1.values()]
-        vals2 = [self._deserialize_result(self.cipher.decrypt(v)) for v in shares2.values()]
-        sum1 = sum(v[1] for v in vals1) % self.secret_sharing.prime
-        sum2 = sum(v[1] for v in vals2) % self.secret_sharing.prime
-        return shares1 if sum1 > sum2 else shares2
+        """Secure comparison of two shared values via Lagrange reconstruction"""
+        shares1_points = [self._deserialize_result(self.cipher.decrypt(v)) for v in shares1.values()]
+        shares2_points = [self._deserialize_result(self.cipher.decrypt(v)) for v in shares2.values()]
+        val1 = self.secret_sharing.reconstruct_secret(shares1_points)
+        val2 = self.secret_sharing.reconstruct_secret(shares2_points)
+        return shares1 if val1 > val2 else shares2
 
     def get_party_stats(self) -> Dict:
         return {


### PR DESCRIPTION
## Problem

`SMPCProtocol._secure_compare()` summed the raw share y-coordinates to compare two shared values. For Shamir shares the secret is the polynomial evaluated at 0 (recovered via Lagrange interpolation), not the sum of the y-values, so `secure_aggregate(operation='max')` compared meaningless sums and returned the wrong maximum — with `success: true` and no error.

## Fix

`_secure_compare` now reconstructs each value from its shares via `SecretSharing.reconstruct_secret` (Lagrange interpolation at x=0) inside the enclave-equivalent, matching how `compute_multiplication` already reconstructs, and returns the shares of the larger value. `_aggregate_max` then reconstructs the correct maximum.

## Files changed

- `backend/smpc/smpc_service.py`

## Testing

- Verified with an inline check: split values `42` and `98765` into shares, ran `_secure_compare`, reconstructed the winning shares → `98765` (the true max). The old sum-of-y implementation returned the wrong value.

Closes #8801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure comparison accuracy by reconstructing shared values before determining which value is larger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->