### PR TITLE
fix(test): correct 4 broken relative imports so test suites can load

### DIFF
--- a/backend/api/test/helpers/testApp.js
+++ b/backend/api/test/helpers/testApp.js
@@ -5,8 +5,7 @@
  * setup) and provide the `x-user-id` / `x-user-role` headers.
  *
  * Usage:
- *   import { createSupabaseMock } from './helpers/supabaseMock.js';
- *   import { buildTestApp } from './helpers/testApp.js';
+ *   import { createSupabaseMock } from './supabaseMock.js';
  *
  *   const m = createSupabaseMock();
  *   vi.mock('../../src/config/db.js', () => ({ supabase: m.supabase }));

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import notificationService from '../../src/services/notificationService.js';
-import DomainError from '../../src/errors/DomainError.js';
+import { DomainError } from '../../src/services/order/domainError.js';
 
 describe('notificationService allowlist validation', () => {
   it('should throw DomainError for invalid notif_type in insertNotification', async () => {

--- a/backend/api/test/unit/services/workZoneService.test.js
+++ b/backend/api/test/unit/services/workZoneService.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { predictWorkZoneDelays, generateBypassWaypoint } from '../../../../src/services/workZoneService.js';
-import logger from '../../../../src/middleware/logger.js';
+import { predictWorkZoneDelays, generateBypassWaypoint } from '../../../src/services/workZoneService.js';
+import logger from '../../../src/middleware/logger.js';
 
-vi.mock('../../../../src/middleware/logger.js', () => ({
+vi.mock('../../../src/middleware/logger.js', () => ({
   default: {
     info: vi.fn(),
     warn: vi.fn(),

--- a/backend/kafka/test/processedEvent.repository.test.js
+++ b/backend/kafka/test/processedEvent.repository.test.js
@@ -41,7 +41,7 @@ vi.mock('../../api/src/middleware/logger.js', () => ({
   },
 }));
 
-import processedEventRepository from '../../repositories/processedEvent.repository.js';
+import processedEventRepository from '../repositories/processedEvent.repository.js';
 import { supabaseAdmin } from '../../api/src/config/db.js';
 
 describe('ProcessedEventRepository.claimProcessed', () => {


### PR DESCRIPTION
## Problem

The backend test suite cannot load: four relative imports across the tests pointed at paths that do not exist, so those test files failed at import time with `ERR_MODULE_NOT_FOUND` / `Cannot find module`, masking the behavior under test.

## Fix

Corrected each broken relative path:

1. `test/helpers/testApp.js` — the doc-comment example imported `./helpers/supabaseMock.js` (and itself via `./helpers/testApp.js`); since `testApp.js` already lives in `helpers/`, the `helpers/` segment duplicates the directory. Fixed the example to `./supabaseMock.js` and removed the self-import line.
2. `test/unit/services/workZoneService.test.js` — `../../../../src/...` was one level too deep for a file in `test/unit/services/`; changed to `../../../src/...` for the two imports and the `vi.mock` path.
3. `kafka/test/processedEvent.repository.test.js` — `../../repositories/...` was one level too deep for a file in `kafka/test/`; changed to `../repositories/processedEvent.repository.js`.
4. `test/unit/notificationService.test.js` — imported `../../src/errors/DomainError.js` which does not exist; pointed it at the real module `../../src/services/order/domainError.js`, which exports `DomainError` as a named export.

## Files changed

- `backend/api/test/helpers/testApp.js`
- `backend/api/test/unit/services/workZoneService.test.js`
- `backend/kafka/test/processedEvent.repository.test.js`
- `backend/api/test/unit/notificationService.test.js`

## Testing

- Verified every corrected path resolves to an existing file:
  - `backend/api/src/services/workZoneService.js`
  - `backend/api/src/middleware/logger.js`
  - `backend/kafka/repositories/processedEvent.repository.js`
  - `backend/api/src/services/order/domainError.js`
  - `backend/api/test/helpers/supabaseMock.js`

Closes #8836
