### PR TITLE
fix(did): return the RSA private key so the verification method is usable

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -49,7 +49,7 @@ class DIDService {
         logger.info('✅ DID Service initialized');
     }
 
-    async createDID(userAddress) {
+    async createDID(userAddress, publicKey) {
         try {
             const did = `did:truxify:${uuidv4()}`;
 
@@ -59,12 +59,17 @@ class DIDService {
             await this.addServiceEndpoint(did, 'identity', 'IdentityService', `${process.env.API_URL}/api/did/identity`, 'Main identity service');
             await this.addServiceEndpoint(did, 'credentials', 'CredentialService', `${process.env.API_URL}/api/did/credentials`, 'Credential management service');
 
-            const keyPair = crypto.generateKeyPairSync('rsa', {
-                modulusLength: 2048,
-                publicKeyEncoding: { type: 'spki', format: 'pem' },
-                privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
-            });
-            const publicKeyMultibase = Buffer.from(keyPair.publicKey).toString('base64');
+            let publicKeyMultibase = publicKey;
+            let privateKey = null;
+            if (!publicKeyMultibase) {
+                const keyPair = crypto.generateKeyPairSync('rsa', {
+                    modulusLength: 2048,
+                    publicKeyEncoding: { type: 'spki', format: 'pem' },
+                    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+                });
+                publicKeyMultibase = Buffer.from(keyPair.publicKey).toString('base64');
+                privateKey = Buffer.from(keyPair.privateKey).toString('base64');
+            }
             await this.addVerificationMethod(did, 'key-1', 'RsaVerificationKey2018', did, publicKeyMultibase);
 
             await this.identityWallet.createWallet(did);
@@ -72,7 +77,7 @@ class DIDService {
             await this.storeDID({ did, owner: userAddress, publicKey: publicKeyMultibase });
 
             logger.info(`✅ DID created: ${did}`);
-            return { success: true, did, publicKey: publicKeyMultibase, txHash: receipt.hash };
+            return { success: true, did, publicKey: publicKeyMultibase, privateKey, txHash: receipt.hash };
         } catch (error) {
             logger.error('DID creation failed:', error);
             throw error;

--- a/backend/did/routes.js
+++ b/backend/did/routes.js
@@ -6,10 +6,10 @@ const router = express.Router();
 
 router.post('/did/create', async (req, res) => {
     try {
-        const { userAddress } = req.body;
+        const { userAddress, publicKey } = req.body;
         if (!userAddress) return res.status(400).json({ success: false, error: 'userAddress required' });
 
-        const result = await didService.createDID(userAddress);
+        const result = await didService.createDID(userAddress, publicKey);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('DID creation error:', error);


### PR DESCRIPTION
## Problem

`DIDService.createDID()` generated an RSA-2048 keypair server-side, published only the public key as a `RsaVerificationKey2018` verification method, and discarded the private key. The DID owner was never given the private key, so the verification method could never be used to sign anything — every created DID was inert.

## Fix

- `POST /did/create` now accepts an optional `publicKey` from the client. When provided, the client holds the private key and the service simply publishes the submitted public key as the verification method (per the suggested fix: "Have the client generate the keypair and submit only the public key").
- When no `publicKey` is provided (backward compatible), the service still generates the keypair server-side but now returns the private key (base64 PKCS#8) in the response so it is no longer discarded.

## Files changed

- `backend/did/did.service.js`
- `backend/did/routes.js`

## Testing

- `node --check backend/did/did.service.js` passes.
- `node --check backend/did/routes.js` passes.

Closes #8802
