### PR TITLE
fix(db): scope DLQ dedupe index so failed_permanently rows don't swallow redeliveries

### DIFF
--- a/supabase/migrations/20260809010000_scope_webhook_dlq_dedupe_index.sql
+++ b/supabase/migrations/20260809010000_scope_webhook_dlq_dedupe_index.sql
@@ -1,0 +1,19 @@
+-- Migration: Scope webhook DLQ dedupe index so terminal rows don't swallow redeliveries (fixes #8838)
+-- ----------------------------------------------------------------------------
+-- Problem: the unique dedupe_key index created by 20260807000000 is global
+-- (not scoped by status). Once a DLQ row exhausts retries and transitions to
+-- 'failed_permanently' it is terminal, but a later provider redelivery of the
+-- same event computes the same dedupe_key, hits the unique violation, and
+-- dlqService.enqueueFailure returns true (acknowledged) without creating a new
+-- row — the redelivered event is silently lost.
+--
+-- Fix: scope the unique index to exclude 'failed_permanently' rows so a
+-- terminal row no longer blocks a fresh enqueue, while non-terminal rows
+-- ('pending' / 'processing' / 'resolved') keep the idempotent-dedupe behavior.
+-- ----------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_webhook_failures_dedupe_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_failures_dedupe_key
+  ON webhook_failures (dedupe_key)
+  WHERE dedupe_key IS NOT NULL AND status <> 'failed_permanently';


### PR DESCRIPTION
## Problem

The DLQ dedupe unique index (`idx_webhook_failures_dedupe_key`) is global, not scoped by status. Once a `webhook_failures` row exhausts retries and transitions to `failed_permanently`, it is terminal — but a later provider redelivery of the same event computes the same `dedupe_key`, hits the unique violation, and `enqueueFailure` returns `true` (acknowledged) without creating a new row. The redelivered event is dropped forever with no retry path.

## Fix

Scoped the dedupe unique index to exclude `failed_permanently` rows (new migration, since the original migration may already be applied). A terminal row no longer blocks a fresh enqueue, while `pending` / `processing` / `resolved` rows keep the idempotent-dedupe behavior.

## Files changed

- `supabase/migrations/20260809010000_scope_webhook_dlq_dedupe_index.sql` — drops the old global index and recreates it as a partial unique index with `WHERE dedupe_key IS NOT NULL AND status <> 'failed_permanently'`.

## Testing

- Traced the lifecycle: redelivery of a `failed_permanently` event now inserts a fresh `pending` row (no unique violation, because the terminal row is excluded from the index), so the DLQ worker picks it up again.
- Verified non-terminal duplicates still dedupe: `pending`/`processing`/`resolved` rows remain covered by the unique index, so `enqueueFailure`'s idempotent behavior is unchanged.
- Confirmed the `enqueueFailure` code path needs no change — the unique-violation branch still correctly dedupes live rows.

Closes #8838
