### PR TITLE
fix(webhook): detect zero-row updates in escrow reconciliation

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -54,7 +54,7 @@ async function reconcileWalletLedger(order, txHash) {
   if (!order.driver_id) {
     return;
   }
-  const { error: walletError } = await requireDb()
+  const { data, error } = await requireDb()
     .from('wallet_transactions')
     .update({
       status: 'confirmed',
@@ -62,10 +62,18 @@ async function reconcileWalletLedger(order, txHash) {
     })
     .eq('driver_id', order.driver_id)
     .eq('order_display_id', order.order_display_id)
-    .eq('txn_type', 'credit');
+    .eq('txn_type', 'credit')
+    .select('id');
 
-  if (walletError) {
-    throw new Error(`Failed to reconcile wallet ledger for ${order.order_display_id}: ${walletError.message}`);
+  if (error) {
+    throw new Error(`Failed to reconcile wallet ledger for ${order.order_display_id}: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error(
+      `Wallet ledger reconciliation matched no credit transaction for order ${order.order_display_id} ` +
+        `(driver ${order.driver_id}) — driver payout may be unconfirmed`
+    );
   }
 }
 
@@ -124,7 +132,7 @@ async function handlePaymentReleased(payload) {
     return;
   }
 
-  const { error } = await requireDb()
+  const { data: updatedOrders, error } = await requireDb()
     .from('orders')
     .update({
       escrow_status: 'released',
@@ -134,10 +142,18 @@ async function handlePaymentReleased(payload) {
       updated_at: now,
     })
     .eq('id', order.id)
-    .in('escrow_status', RELEASE_RECONCILABLE_STATUSES);
+    .in('escrow_status', RELEASE_RECONCILABLE_STATUSES)
+    .select('id');
 
   if (error) {
     throw new Error(`Failed to mark order ${order.order_display_id} as released: ${error.message}`);
+  }
+
+  if (!updatedOrders || updatedOrders.length === 0) {
+    throw new Error(
+      `Order ${order.order_display_id} was not updated when marking as released — ` +
+        `escrow_status not in reconcilable set (${RELEASE_RECONCILABLE_STATUSES.join(', ')})`
+    );
   }
 
   await reconcileWalletLedger(order, payload.txHash);
@@ -153,7 +169,7 @@ async function handleBookingCancelled(payload) {
     return;
   }
 
-  const { error } = await requireDb()
+  const { data: updatedOrders, error } = await requireDb()
     .from('orders')
     .update({
       escrow_status: 'refunded',
@@ -161,10 +177,18 @@ async function handleBookingCancelled(payload) {
       updated_at: now,
     })
     .eq('id', order.id)
-    .in('escrow_status', REFUND_RECONCILABLE_STATUSES);
+    .in('escrow_status', REFUND_RECONCILABLE_STATUSES)
+    .select('id');
 
   if (error) {
     throw new Error(`Failed to mark order ${order.order_display_id} as refunded: ${error.message}`);
+  }
+
+  if (!updatedOrders || updatedOrders.length === 0) {
+    throw new Error(
+      `Order ${order.order_display_id} was not updated when marking as refunded — ` +
+        `escrow_status not in reconcilable set (${REFUND_RECONCILABLE_STATUSES.join(', ')})`
+    );
   }
 
   logger.info(`[Webhook] Order ${order.order_display_id} marked escrow refunded (tx: ${payload.txHash})`);
@@ -203,17 +227,25 @@ async function handleWithdrawalSettled(payload) {
         escrow_release_error: null,
       };
 
-  const { error } = await requireDb()
+  const { data: updatedOrders, error } = await requireDb()
     .from('orders')
     .update({
       ...settlement,
       updated_at: now,
     })
     .eq('id', order.id)
-    .in('escrow_status', [...REFUND_RECONCILABLE_STATUSES, ...RELEASE_RECONCILABLE_STATUSES]);
+    .in('escrow_status', [...REFUND_RECONCILABLE_STATUSES, ...RELEASE_RECONCILABLE_STATUSES])
+    .select('id');
 
   if (error) {
     throw new Error(`Failed to settle order ${order.order_display_id} from withdrawal webhook: ${error.message}`);
+  }
+
+  if (!updatedOrders || updatedOrders.length === 0) {
+    throw new Error(
+      `Order ${order.order_display_id} was not updated when settling from withdrawal webhook — ` +
+        `escrow_status not in reconcilable set (${[...REFUND_RECONCILABLE_STATUSES, ...RELEASE_RECONCILABLE_STATUSES].join(', ')})`
+    );
   }
 
   if (!isRefund) {


### PR DESCRIPTION
## Problem

`reconcileWalletLedger` in `escrowWebhookProcessor.js` performed an `.update()` without checking how many rows were matched. When the update affected zero rows it returned success anyway, so the webhook's crash-heal path could silently miss confirming the driver's payout credit — with no retry, because the webhook was already acknowledged. The same zero-row-blind pattern existed in the order updates in `handlePaymentReleased`, `handleBookingCancelled`, and `handleWithdrawalSettled` (they log "marked released/refunded/settled" and proceed even when 0 rows matched).

## Fix

Added `.select('id')` to each of the four updates and inspect the returned rows; when zero rows match, an error is thrown so the webhook is not acknowledged as success and the DLQ retries the event, surfacing the inconsistency instead of silently dropping it.

- `reconcileWalletLedger` — throws when no matching `wallet_transactions` credit row exists for the driver/order.
- `handlePaymentReleased` — throws when the order's `escrow_status` is not in the reconcilable set (`funded`, `release_failed`).
- `handleBookingCancelled` — throws when the order's `escrow_status` is not in the reconcilable set (`funded`, `refund_pending`, `refund_failed`).
- `handleWithdrawalSettled` — throws when the order update matches zero rows.

## Files changed

- `backend/api/src/services/webhook/escrowWebhookProcessor.js`

## Testing

- `node --check backend/api/src/services/webhook/escrowWebhookProcessor.js` passes.
- Traced each call site: the idempotency short-circuit paths still call `reconcileWalletLedger`, which now surfaces (via throw → DLQ retry) the case where the crash window cannot actually be healed because the credit row is missing/drifted.

Closes #8839
