### PR TITLE
fix(scripts): check real createBooking(uint256,address,bytes) selector

### DIFF
--- a/scripts/check-escrow-abi.sh
+++ b/scripts/check-escrow-abi.sh
@@ -26,7 +26,7 @@ echo "🔍 Checking escrow ABI compatibility..."
 # Expected selectors (from backend/api/src/services/escrow.js)
 # These are keccak256(first 4 bytes) of the function signatures
 declare -A EXPECTED_SELECTORS
-EXPECTED_SELECTORS["createBooking(uint256,address)"]="490a3b30"
+EXPECTED_SELECTORS["createBooking(uint256,address,bytes)"]="0bb7aa51"
 EXPECTED_SELECTORS["releasePayment(uint256)"]="88685cd9"
 EXPECTED_SELECTORS["cancelBooking(uint256)"]="0dca825e"
 EXPECTED_SELECTORS["cancelWithPenalty(uint256,uint256)"]="ca9a63b1"


### PR DESCRIPTION
## Problem

`scripts/check-escrow-abi.sh` validated the selector for `createBooking(uint256,address)` (2 args), a signature that exists nowhere in the codebase. The deployed contract `blockchain/contracts/TruxifyEscrow.sol` declares `createBooking(uint256,address payable,bytes)` and the backend ABI in `backend/api/src/services/escrow.js` matches — so the CI guard never actually checked the `createBooking` selector the backend relies on and could pass even if the real 3-arg selector was wrong.

## Fix

Changed the guard's entry to the real signature `createBooking(uint256,address,bytes)` with its correct 4-byte selector `0bb7aa51` (computed via ethers keccak256). The CI guard now validates the actual selector the backend depends on.

## Files changed

- `scripts/check-escrow-abi.sh`

## Testing

- Verified the other 7 selectors in the script still match their computed keccak256 values (no other entries were stale).
- Confirmed `createBooking(uint256,address,bytes)` → `0bb7aa51` via `ethers.Interface.getFunction().selector`.

Closes #8840
