### PR TITLE
fix(consul): query health by service name instead of service id

### DIFF
--- a/backend/consul/consul.service.js
+++ b/backend/consul/consul.service.js
@@ -178,7 +178,7 @@ class ConsulService {
                 const services = await this.discoverService(name, false);
                 for (const service of services) {
                     try {
-                        const health = await this.consul.health.checks(service.id);
+                        const health = await this.consul.health.checks(name);
                         const isHealthy = health.length > 0 && health.some(c => c.Status === 'passing');
 
                         results[service.id] = {
@@ -203,12 +203,35 @@ class ConsulService {
         return results;
     }
 
+    async _resolveServiceName(serviceId) {
+        if (this.services[serviceId]) {
+            return this.services[serviceId].name;
+        }
+        const agents = await this.consul.agent.services();
+        const entry = agents[serviceId];
+        if (entry && entry.Service) {
+            return entry.Service;
+        }
+        return null;
+    }
+
     async getServiceHealth(serviceId) {
         try {
-            const health = await this.consul.health.checks(serviceId);
+            const serviceName = await this._resolveServiceName(serviceId);
+            if (!serviceName) {
+                return {
+                    id: serviceId,
+                    healthy: false,
+                    error: `Unknown service id: ${serviceId}`,
+                    lastCheck: new Date().toISOString()
+                };
+            }
+
+            const health = await this.consul.health.checks(serviceName);
             const isHealthy = health.length > 0 && health.some(c => c.Status === 'passing');
             return {
                 id: serviceId,
+                serviceName,
                 healthy: isHealthy,
                 status: isHealthy ? 'passing' : 'critical',
                 lastCheck: new Date().toISOString()


### PR DESCRIPTION
## Problem

`ConsulService` queried health by **service ID** instead of **service name**. The Consul HTTP API `GET /v1/health/checks/{service}` is keyed by service name, so passing a service ID (e.g. `my-service-1234abcd`) returned no checks and every registered service was reported as unhealthy/critical. `getConsulStats().healthyServices` was therefore always 0.

## Fix

- `checkAllServices` now passes the catalog service **name** (the key being iterated) to `consul.health.checks(name)`.
- `getServiceHealth(serviceId)` resolves the service **name** from the id via `_resolveServiceName` (checks the locally registered services map first, then the agent catalog), and queries `consul.health.checks(name)` with it.

## Files changed

- `backend/consul/consul.service.js`

## Testing

- `node --check backend/consul/consul.service.js` passes.

Closes #8805
