### PR TITLE
fix(webhook): remove simulateFailure test hook from escrow processor

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -238,10 +238,6 @@ export async function processEscrowWebhookEvent(eventType, payload = {}) {
   const orderId = payload.orderId || 'unknown';
   logger.info(`[Webhook] Processing escrow event ${eventType} for order ${orderId}`);
 
-  if (payload.simulateFailure === true) {
-    throw new Error('Simulated database lock or processing failure');
-  }
-
   const handler = EVENT_HANDLERS[eventType];
   if (!handler) {
     logger.warn(`[Webhook] No handler registered for escrow event ${eventType} — acknowledging without state change.`);

--- a/backend/api/test/integration/webhookRoutes.test.js
+++ b/backend/api/test/integration/webhookRoutes.test.js
@@ -44,10 +44,7 @@ describe('Webhook Routes', () => {
       const res = await request(app)
         .post('/api/webhooks/escrow')
         .send({
-          eventType: 'EscrowRefunded',
-          orderId: 'test-123',
-          txHash: '0x123',
-          simulateFailure: true
+          eventType: 'PaymentReleased'
         });
 
       expect(res.status).toBe(500);
@@ -190,10 +187,7 @@ describe('Webhook Routes — HMAC Signature Verification', () => {
 
     it('returns 202 and enqueues to DLQ on processing failure with valid signature', async () => {
       const payload = {
-        eventType: 'EscrowReleased',
-        orderId: 'order-789',
-        txHash: '0xdef',
-        simulateFailure: true
+        eventType: 'PaymentReleased'
       };
       const signature = signPayload(payload);
 
@@ -208,7 +202,7 @@ describe('Webhook Routes — HMAC Signature Verification', () => {
 
       expect(mockEnqueueFailure).toHaveBeenCalledWith(
         'escrow',
-        'EscrowReleased',
+        'PaymentReleased',
         expect.any(Object),
         expect.any(Error)
       );
@@ -218,10 +212,7 @@ describe('Webhook Routes — HMAC Signature Verification', () => {
       mockEnqueueFailure.mockResolvedValueOnce(false);
 
       const payload = {
-        eventType: 'EscrowReleased',
-        orderId: 'order-999',
-        txHash: '0xdef',
-        simulateFailure: true
+        eventType: 'PaymentReleased'
       };
       const signature = signPayload(payload);
 

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -58,11 +58,8 @@ describe('processEscrowWebhookEvent', () => {
 
   it('keeps processor failures visible to the DLQ retry loop', async () => {
     await expect(
-      processEscrowWebhookEvent('EscrowDeposited', {
-        orderId: 'order-1',
-        simulateFailure: true,
-      })
-    ).rejects.toThrow('Simulated database lock or processing failure');
+      processEscrowWebhookEvent('PaymentReleased', {})
+    ).rejects.toThrow('Missing orderId in escrow webhook payload');
   });
 
   it('rejects payloads without an event type', async () => {


### PR DESCRIPTION
## Problem

`backend/api/src/services/webhook/escrowWebhookProcessor.js` carries a test-only escape hatch: if the payload contains `simulateFailure === true`, it throws a fabricated `Simulated database lock or processing failure` error. Anyone who can reach a non-production webhook endpoint could force every escrow event into the dead-letter queue, and the hook has no value in production.

## Fix

Removed the `simulateFailure` branch entirely — the route already enforces an HMAC `WEBHOOK_SECRET`, so no production path relied on it. Updated the tests that used `simulateFailure: true` to trigger a genuine processing failure instead:

- Unit test now calls `processEscrowWebhookEvent('PaymentReleased', {})`, which fails with `Missing orderId in escrow webhook payload` — proving processor failures still propagate to the DLQ retry loop without a fabricated flag.
- Integration tests (`returns 202 and enqueues to DLQ on processing failure`, `returns 500 instead of 202 when the DLQ enqueue fails`, and the no-secret fail-closed test) now send `eventType: 'PaymentReleased'` with no order ID, which throws for real before touching the database.

## Files changed

- `backend/api/src/services/webhook/escrowWebhookProcessor.js`
- `backend/api/test/unit/escrowWebhookProcessor.test.js`
- `backend/api/test/integration/webhookRoutes.test.js`

## Testing

- `npx vitest run test/unit/escrowWebhookProcessor.test.js` → 13/13 passed
- `npx vitest run test/integration/webhookRoutes.test.js` → 11/11 passed

Closes #8841
