### PR TITLE
fix(blockchain): revert RingSignature.verify instead of accepting any signature

### DIFF
--- a/blockchain/contracts/RingSignature.sol
+++ b/blockchain/contracts/RingSignature.sol
@@ -12,10 +12,14 @@ contract RingSignature is Ownable {
     mapping(bytes32 => bool) public usedKeyImages;
     event RingSignatureVerified(bytes32 indexed keyImage, address[] ringMembers, bytes32 messageHash);
 
+    error NotImplemented();
+
     constructor() Ownable(msg.sender) {}
 
     /**
      * @dev Verifies LSAG ring signature for an anonymous shipper commitment.
+     *      Genuine LSAG verification is not implemented yet. This function
+     *      reverts instead of unconditionally accepting forged signatures.
      */
     function verifyRingSignature(
         bytes32 _messageHash,
@@ -24,14 +28,6 @@ contract RingSignature is Ownable {
         bytes32[] calldata _c,
         bytes32[] calldata _r
     ) external returns (bool) {
-        require(_pubKeys.length > 1, "Ring size must be > 1");
-        require(!usedKeyImages[_keyImage], "Key image already used (Double spending attempt)");
-        require(_c.length == _pubKeys.length && _r.length == _pubKeys.length, "Invalid signature vector dimensions");
-
-        // Mark key image as used to enforce linkability & prevent double booking
-        usedKeyImages[_keyImage] = true;
-
-        emit RingSignatureVerified(_keyImage, _pubKeys, _messageHash);
-        return true;
+        revert NotImplemented();
     }
 }


### PR DESCRIPTION
## Problem

`RingSignature.verifyRingSignature()` performs no cryptographic verification — it marks the key image as used and returns `true` unconditionally. Any caller can pass arbitrary `_c`/`_r` values and get `true`, so anonymous-freight-commitment forgery and double-booking prevention are both defeated. Because `usedKeyImages[_keyImage]` is set even for forged signatures, an attacker can also brick a victim out of legitimate use of a key image by front-running it.

There is no real LSAG implementation in the repository to port (the off-chain `backend/privacy/ring_sig.js` also fabricates `c`/`r` values).

## Fix

Per the issue's suggested fix, `verifyRingSignature()` now reverts with a `NotImplemented` custom error instead of accepting signatures unconditionally. Genuine LSAG verification can be implemented later without changing the function signature or ABI.

- Added `error NotImplemented();`
- Replaced the unconditional `return true` body (including the `usedKeyImages` marking) with `revert NotImplemented();`
- Kept the original signature (`_messageHash`, `_pubKeys`, `_keyImage`, `_c`, `_r`) so the ABI is unchanged
- Updated the natspec to document that the function reverts until real verification exists

## Files changed

- `blockchain/contracts/RingSignature.sol`

## Testing

- The change is a minimal, standard Solidity 0.8.20 construct (`error` declaration + `revert NotImplemented();`). No project test or backend file calls the contract's `verifyRingSignature` (verified via repo-wide search); the change is self-contained.

Closes #8807
