### PR TITLE
fix(blockchain): remove global totalSupply cap check blocking cross-asset purchase

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -175,8 +175,6 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         uint256 totalCost = (amount * asset.tokenPrice + 1e18 - 1) / 1e18;
         require(msg.value >= totalCost, "Insufficient payment");
 
-        require(totalSupply() + amount <= asset.totalTokens, "Exceeds total token cap");
-
         // Update asset
         asset.availableTokens -= amount;
         issuedTokens[assetId] += amount;


### PR DESCRIPTION
## Problem

`AssetToken.purchaseFraction()` caps the **global** ERC20 `totalSupply()` against a **single asset's** `totalTokens`:

```solidity
require(totalSupply() + amount <= asset.totalTokens, "Exceeds total token cap");
```

`totalSupply()` is the sum of tokens minted across **all** assets (single ERC20 contract), so once any asset is fully sold, purchasing fractions of any smaller asset always reverts. Cross-asset fractionalization is blocked by the first asset to reach its cap (DoS of the entire tokenization module).

## Fix

Removed the redundant and wrong global-supply check. The per-asset invariant is already enforced correctly by:

```solidity
require(issuedTokens[assetId] + amount <= asset.totalTokens, "Supply cap exceeded");
```

and by the `availableTokens` accounting — both scoped to the current asset only. The global check added nothing and broke legitimate purchases of other assets.

## Files changed

- `blockchain/contracts/AssetToken.sol` (`purchaseFraction`)

## Testing

- The change is a two-line deletion of a redundant `require`; the per-asset supply invariant remains enforced by the existing `issuedTokens[assetId] + amount <= asset.totalTokens` check. No repo test references the removed check or the `"Exceeds total token cap"` revert path.

Closes #8808
