### PR TITLE
fix(vdf): use fresh RSA modulus and real exponentiation check in allocator VDF

### DIFF
--- a/backend/vdf/vdf_allocator.py
+++ b/backend/vdf/vdf_allocator.py
@@ -1,13 +1,26 @@
 import time
 import hashlib
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+def _generate_rsa_modulus(bits: int = 2048) -> int:
+    """Generate a fresh RSA modulus N = p * q via OpenSSL and return only N.
+
+    The prime factors are discarded, so the factorization is not available to
+    the caller afterwards and the group order cannot be reduced to shortcut
+    the sequential squaring delay.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+    return key.public_key().public_numbers().n
 
 class WesolowskiVDF:
     """
     Wesolowski Verifiable Delay Function (VDF) Implementation.
     Forces a verifiable computational delay y = x^(2^T) mod N for fair load allocation.
     """
-    def __init__(self, modulus: int = 2047, iterations: int = 5000):
-        self.N = modulus
+    def __init__(self, modulus: int = None, iterations: int = 5000):
+        # Never fall back to a small hardcoded composite: use a freshly
+        # generated RSA modulus with unknown factorization when none is given.
+        self.N = modulus if modulus is not None else _generate_rsa_modulus()
         self.T = iterations
 
     def eval(self, input_seed: str):
@@ -25,17 +38,26 @@ class WesolowskiVDF:
         return y, proof
 
     def verify(self, input_seed: str, y: int, proof: str) -> bool:
-        """Verifies VDF output and proof in O(1) time."""
+        """Verifies VDF output by recomputing the full T squarings with the verifier-fixed parameters."""
         x = int(hashlib.sha256(input_seed.encode()).hexdigest(), 16) % self.N
         if x == 0:
             x = 2
-            
+
+        # Recompute y = x^(2^T) mod N for the verifier-fixed modulus/iterations.
+        # The claimed output must equal the recomputation; arbitrary y (e.g. a
+        # single squaring) can no longer be passed off as the VDF result.
+        expected_y = x
+        for _ in range(self.T):
+            expected_y = (expected_y * expected_y) % self.N
+        if y != expected_y:
+            return False
+
         expected_proof = hashlib.sha256(f"{x}:{y}:{self.T}".encode()).hexdigest()
         return proof == expected_proof
 
 class VdfLoadAllocator:
     def __init__(self):
-        self.vdf = WesolowskiVDF(modulus=2047, iterations=2000)
+        self.vdf = WesolowskiVDF(iterations=2000)
 
     def evaluate_bid_fairness(self, load_id: str, driver_id: str, bid_timestamp: float):
         seed = f"{load_id}:{driver_id}:{bid_timestamp}"


### PR DESCRIPTION
## Problem

`WesolowskiVDF` in `vdf_allocator.py` uses a **hardcoded tiny composite modulus `N = 2047 = 23 × 89`** (installed by `VdfLoadAllocator` for every allocation), and its `verify()` only re-hashes the prover-claimed `x:y:T` — it never checks the exponentiation. Anyone can factor the modulus to reduce `2^T mod λ(N)` and compute the output instantly, or simply submit any `y` (e.g. `x^2 mod N`, `T=1`) with a matching hash and pass verification. Every allocation self-verifies, so `is_fairly_allocated: true` is always reported regardless of actual delay.

## Fix

- **Real RSA modulus:** `WesolowskiVDF` now defaults to a freshly generated 2048-bit RSA modulus `N = p * q` via OpenSSL (`cryptography.hazmat.primitives.asymmetric.rsa`). The prime factors are discarded, so the factorization is not available to reduce the exponent. The `modulus` parameter is kept for explicit/testing use but is no longer a hardcoded composite default, and `VdfLoadAllocator` no longer passes `2047`.
- **Real verification:** `verify()` now recomputes the full `T` squarings `y = x^(2^T) mod N` using the verifier-fixed parameters (`self.N`, `self.T`) and requires the claimed `y` to equal the recomputation, in addition to the proof-hash check. A forged `y` (single squaring) is rejected regardless of the proof payload.

## Files changed

- `backend/vdf/vdf_allocator.py`

## Testing

- `py -m unittest test_vdf -v` → 3 tests pass (`test_vdf_evaluation_and_verification`, `test_vdf_tamper_rejection`, `test_allocator_evaluation`).
- Standalone checks:
  - honest round-trip verifies as `True`;
  - forged output `y = x^2 mod N` (i.e. `T=1`) with a matching forged proof is rejected;
  - `VdfLoadAllocator` modulus is 2048 bits (not `2047`);
  - allocator's `evaluate_bid_fairness` still reports `is_fairly_allocated: true` for honest evaluations.

Closes #8809
