### PR TITLE
fix: grant EXECUTE on register_device_token to authenticated

### DIFF
--- a/supabase/migrations/20260809000000_grant_register_device_token_execute.sql
+++ b/supabase/migrations/20260809000000_grant_register_device_token_execute.sql
@@ -1,0 +1,16 @@
+-- Migration: restore EXECUTE on register_device_token for the authenticated role
+-- ============================================================================
+-- deviceController.registerDeviceToken calls this SECURITY DEFINER RPC through
+-- the anon-key (supabase) client, which presents the `authenticated` role when a
+-- logged-in user's JWT is attached. The original migration
+-- (20260807000010_register_device_token_tx.sql) revoked EXECUTE from PUBLIC,
+-- anon and authenticated without ever re-granting it to the role the API uses,
+-- so every FCM device registration failed with a PostgREST permission error
+-- (PGRST203) and device tokens were never stored.
+--
+-- Granting EXECUTE to `authenticated` lets the function run as its definer
+-- (SECURITY DEFINER) so it can still mutate user_devices / profiles on the
+-- caller's behalf while remaining invisible to the public `anon` role.
+-- ============================================================================
+
+GRANT EXECUTE ON FUNCTION register_device_token(uuid, text, text, jsonb, uuid) TO authenticated;


### PR DESCRIPTION
## Problem

The device token registration endpoint fails with a permission error whenever a user attempts to register a device token.

`supabase/migrations/20260807000010_register_device_token_tx.sql` creates the `register_device_token(uuid, text, text, jsonb, uuid)` RPC with `SECURITY DEFINER` but then revokes `EXECUTE` from `PUBLIC`, `anon`, and `authenticated` without ever re-granting it. `backend/api/src/controllers/deviceController.js` calls this RPC through the anon-key Supabase client with the user's JWT attached (the `authenticated` role), so every call is rejected with `permission denied for function register_device_token`.

## Fix

Added a migration that re-grants `EXECUTE` on `register_device_token` to the `authenticated` role, so authenticated users can register device tokens while the anon/public roles remain locked out (the function itself is `SECURITY DEFINER`, so it still runs with elevated privileges).

## Files changed

- `supabase/migrations/20260809000000_grant_register_device_token_execute.sql` — new migration granting `EXECUTE ON FUNCTION register_device_token(uuid, text, text, jsonb, uuid) TO authenticated`.

## Testing

- SQL is a single, idempotent `GRANT` statement; verified against the current schema definition of the function.
- The migration is additive only and does not touch the existing function body or its other permissions.

Closes #8898


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated users can now register device tokens successfully.
  * Device-token registration remains restricted from unauthenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->