### PR TITLE
fix: add key_ownership_transfers table and make receipt insert non-fatal

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -178,16 +178,27 @@ class KeyRotationService {
 
         const receipt = await tx.wait();
 
-        await supabase
-          .from('key_ownership_transfers')
-          .insert([{
-            old_key: oldPrivateKey.slice(0, 10) + '...',
-            new_key: newPrivateKey.slice(0, 10) + '...',
-            wallet_address: walletAddress,
-            tx_hash: receipt.hash,
-            block_number: receipt.blockNumber,
-            completed_at: new Date().toISOString(),
-          }]);
+        // Receipt-row persistence is best-effort: the on-chain transfer has
+        // already committed, so a failed audit write must not surface as a
+        // transfer failure or trigger a duplicate re-transfer on retry.
+        try {
+          const { error: insertError } = await supabase
+            .from('key_ownership_transfers')
+            .insert([{
+              old_key: oldPrivateKey.slice(0, 10) + '...',
+              new_key: newPrivateKey.slice(0, 10) + '...',
+              wallet_address: walletAddress,
+              tx_hash: receipt.hash,
+              block_number: receipt.blockNumber,
+              completed_at: new Date().toISOString(),
+            }]);
+
+          if (insertError) {
+            logger.error('[KeyRotationService] Failed to record on-chain ownership transfer receipt:', insertError.message);
+          }
+        } catch (insertErr) {
+          logger.error('[KeyRotationService] Failed to record on-chain ownership transfer receipt:', insertErr.message);
+        }
 
         logger.info('[KeyRotationService] On-chain key ownership transfer completed:', receipt.hash);
 

--- a/supabase/migrations/20260809000010_create_key_ownership_transfers_table.sql
+++ b/supabase/migrations/20260809000010_create_key_ownership_transfers_table.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- KEY OWNERSHIP TRANSFERS — audit trail for on-chain key ownership transfers
+-- ============================================================================
+-- keyRotationService.transferKeyOwnershipOnChain performs a successful on-chain
+-- transferKeyOwnership transaction and then writes a receipt row here so the
+-- audit trail of ownership transfers is persisted. No migration ever created
+-- this table, so the insert after a successful chain transfer raised
+-- `relation "key_ownership_transfers" does not exist` and the API reported
+-- failure for an operation that had already committed on-chain.
+--
+-- SECURITY MODEL:
+--   - Written by backend services using the service_role key and never exposed
+--     to clients, so RLS allows service_role only.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. KEY OWNERSHIP TRANSFERS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists key_ownership_transfers (
+  id             uuid primary key default gen_random_uuid(),
+  old_key        text not null,               -- truncated old key (e.g. '0x1234abcd...')
+  new_key        text not null,               -- truncated new key (e.g. '0x5678efgh...')
+  wallet_address varchar(255),                -- wallet whose ownership moved
+  tx_hash        varchar(255),                -- on-chain transfer transaction hash
+  block_number   bigint,                      -- block in which the transfer committed
+  completed_at   timestamptz not null default now()
+);
+
+create index if not exists idx_key_ownership_transfers_wallet
+  on key_ownership_transfers (wallet_address);
+
+create index if not exists idx_key_ownership_transfers_completed_at
+  on key_ownership_transfers (completed_at);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table key_ownership_transfers enable row level security;
+
+drop policy if exists "Service role full access on key_ownership_transfers"
+  on key_ownership_transfers;
+create policy "Service role full access on key_ownership_transfers"
+  on key_ownership_transfers
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table key_ownership_transfers from anon, authenticated;


### PR DESCRIPTION
## Problem

Key rotation fails at the final step: `backend/api/src/services/security/keyRotationService.js` performs the on-chain `transferKeyOwnership` call and then inserts a receipt row into a `key_ownership_transfers` table that does not exist. The insert throws (`PostgREST 404/PGRST205: table not found`), so the entire rotation request reports failure even though the on-chain ownership transfer already succeeded.

## Fix

- Added the missing `key_ownership_transfers` table via a new migration, with columns matching the insert in `keyRotationService.js` (`id`, `old_key`, `new_key`, `wallet_address`, `tx_hash`, `block_number`, `completed_at`), an index on `wallet_address`, and RLS that restricts access to `service_role` (as done for the related `key_rotations` / `key_rotation_audit_log` tables).
- Made the receipt-row insert best-effort in `keyRotationService.js`: a failed audit write now logs an error instead of failing the request, so a successful on-chain transfer is no longer reported as a failure and cannot trigger a duplicate re-transfer on retry.

## Files changed

- `supabase/migrations/20260809000010_create_key_ownership_transfers_table.sql` — new migration creating the table and its RLS policies.
- `backend/api/src/services/security/keyRotationService.js` — wrapped the `key_ownership_transfers` insert in a try/catch and made the `insertError` non-fatal.

## Testing

- `keyRotationService.js` passes `node --check` (syntax validation).
- The migration follows the same table/RLS pattern already used by `20260806050000` (`key_rotations`) and `20260806060000` (`key_rotation_audit_log`).
- With the fix, a failed insert can no longer throw out of the transfer flow; the service continues and reports the completed transfer.

Closes #8899
