### PR TITLE
fix: add kyc_status and kyc_doc_number to driver_details

### DIFF
--- a/supabase/migrations/20260809000020_add_driver_details_kyc_status.sql
+++ b/supabase/migrations/20260809000020_add_driver_details_kyc_status.sql
@@ -1,0 +1,33 @@
+-- Migration: add kyc_status and kyc_doc_number to driver_details
+-- ============================================================================
+-- The KYC flow (verificationRoutes.js, service-role) writes kyc_status
+-- ('Pending KYC' / 'Verified' / 'Rejected') and kyc_doc_number on
+-- driver_details, and the driver profile (driverRoutes.js, ProfileModel.js)
+-- reads kyc_status back with a fallback of 'Unverified'. Neither column was
+-- ever created, so every KYC review update failed (PostgREST PGRST204 unknown
+-- column) and the driver profile always reported 'Unverified'.
+--
+-- The new columns are covered by the existing RLS/column-privilege setup:
+-- service_role keeps full table access (20240101000000_rls.sql) so
+-- verificationRoutes.js can update them, and clients can read the status via
+-- the existing "Drivers select own driver_details" policy.
+-- ============================================================================
+
+alter table driver_details
+  add column if not exists kyc_status text not null default 'Unverified';
+
+alter table driver_details
+  add column if not exists kyc_doc_number text;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'driver_details_kyc_status_check'
+  ) then
+    alter table driver_details
+      add constraint driver_details_kyc_status_check
+      check (kyc_status in ('Unverified', 'Pending KYC', 'Verified', 'Rejected'));
+  end if;
+end
+$$;


### PR DESCRIPTION
## Problem

The driver KYC flow is broken end-to-end because `driver_details` has no `kyc_status` or `kyc_doc_number` columns:

- `verificationRoutes.js` updates `kyc_status` (`'Pending KYC'`, `'Verified'`, `'Rejected'`) and `kyc_doc_number` on `driver_details` — every update fails with `PGRST204: Could not find the 'kyc_status' column of 'driver_details'`, so admins cannot review or approve a driver's KYC.
- `driverRoutes.js` and `ProfileModel.js` read `kyc_status` back, but the column does not exist, so the profile always reports the fallback `'Unverified'` even after approval.

No SQL in the repo ever creates these columns (they exist only in code and test fixtures).

## Fix

Added a migration that:

- Adds `kyc_status text not null default 'Unverified'` to `driver_details`.
- Adds `kyc_doc_number text` to `driver_details`.
- Adds a `CHECK` constraint on `kyc_status` matching the values the app writes/reads (`'Unverified'`, `'Pending KYC'`, `'Verified'`, `'Rejected'`).

The new columns work with the existing RLS setup: `service_role` (used by `verificationRoutes.js`) retains full table access, and drivers keep reading their own `driver_details` rows through the existing policy.

## Files changed

- `supabase/migrations/20260809000020_add_driver_details_kyc_status.sql` — new migration adding the columns and the `kyc_status` check constraint.

## Testing

- Migration is additive/idempotent (`add column if not exists`, guarded constraint creation), following the same style as `20260807000010_add_driver_details_polygon_wallet.sql` (Fix #7532).
- Column names match the exact strings used by `verificationRoutes.js`, `driverRoutes.js`, and `ProfileModel.js`.

Closes #8901
