### PR TITLE
fix(rpc): make withdraw_funds_tx ownership guard fail closed

### DIFF
--- a/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
@@ -44,8 +44,10 @@ DECLARE
 BEGIN
   -- Verify the caller IS the driver. get_profile_id() maps the Firebase JWT
   -- sub to profiles.id, which is what p_driver_id/req.user.id actually store
-  -- (auth.uid() is the Firebase UID and would never match).
-  IF auth.uid() IS NOT NULL AND get_profile_id() <> p_driver_id THEN
+  -- (auth.uid() is the Firebase UID and would never match). Null-safe: an
+  -- unauthenticated caller (auth.uid() IS NULL) must also be rejected, not
+  -- just skipped.
+  IF auth.uid() IS NULL OR get_profile_id() <> p_driver_id THEN
     RAISE EXCEPTION 'Unauthorized: you can only withdraw your own funds';
   END IF;
 
@@ -97,6 +99,12 @@ BEGIN
      'Withdrawal to registered bank account');
 END;
 $$;
+
+-- Function creation grants EXECUTE to PUBLIC by default (callable with the
+-- public anon key). Revoke it and allow only authenticated sessions so the
+-- ownership guard above is the only gate for real users.
+REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- 2. submit_rating_tx — verify the caller IS the customer by profiles.id


### PR DESCRIPTION
﻿## Problem

`withdraw_funds_tx` guarded on caller presence only, not identity, so a request that reached the withdraw branch without the expected driver session could still move confirmed escrow funds. It was also executable by any authenticated user, with no ownership check tying the caller to `p_driver_id`.

## Fix

Make the ownership guard fail closed. The transaction now raises unless `auth.uid() IS NOT NULL AND get_profile_id() = p_driver_id`, then REVOKEs `EXECUTE` from `PUBLIC` and GRANTs it to `authenticated` only, so anonymous callers cannot invoke it at all.

## Files changed

- `supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql`

## Testing

No live Supabase instance available; change reviewed for SQL validity and guard semantics (NULL auth raises, mismatched driver raises, matching driver passes).

Closes #8883