### PR TITLE
fix(rpc): make submit_rating_tx ownership guard fail closed

### DIFF
--- a/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
@@ -117,8 +117,10 @@ DECLARE
 BEGIN
   -- Verify the caller IS the customer. get_profile_id() maps the Firebase JWT
   -- sub to profiles.id, which is what p_customer_id/req.user.id actually store
-  -- (auth.uid() is the Firebase UID and would never match).
-  IF auth.uid() IS NOT NULL AND get_profile_id() <> p_customer_id THEN
+  -- (auth.uid() is the Firebase UID and would never match). Null-safe: an
+  -- unauthenticated caller (auth.uid() IS NULL) must also be rejected, not
+  -- just skipped.
+  IF auth.uid() IS NULL OR get_profile_id() <> p_customer_id THEN
     RAISE EXCEPTION 'Unauthorized: you can only submit ratings for yourself';
   END IF;
 
@@ -161,6 +163,12 @@ BEGIN
   WHERE user_id = p_driver_id;
 END;
 $$;
+
+-- Function creation grants EXECUTE to PUBLIC by default (callable with the
+-- public anon key). Revoke it and allow only authenticated sessions so the
+-- ownership guard above is the only gate for real users.
+REVOKE EXECUTE ON FUNCTION submit_rating_tx(TEXT, UUID, UUID, SMALLINT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION submit_rating_tx(TEXT, UUID, UUID, SMALLINT, TEXT) TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- 3. accept_bid_tx — verify the caller IS the order's customer by profiles.id


### PR DESCRIPTION
﻿## Problem

`submit_rating_tx` guarded on caller presence only, not identity, so anonymous or wrong-user callers could submit ratings on behalf of another customer (`p_customer_id`), corrupting driver ratings.

## Fix

Make the ownership guard fail closed. The transaction now raises unless `auth.uid() IS NOT NULL AND get_profile_id() = p_customer_id`, then REVOKEs `EXECUTE` from `PUBLIC` and GRANTs it to `authenticated` only.

## Files changed

- `supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql`

## Testing

No live Supabase instance available; change reviewed for SQL validity and guard semantics (NULL auth raises, mismatched customer raises, matching customer passes).

Closes #8884