### PR TITLE
fix(orders): restore create_order_tx signature to match production caller

### DIFF
--- a/supabase/migrations/20260807000001_durable_idempotency_order_tx.sql
+++ b/supabase/migrations/20260807000001_durable_idempotency_order_tx.sql
@@ -1,4 +1,17 @@
--- Migration: Add durable idempotency table and extend create_order_tx RPC
+-- Migration: Add durable idempotency table and restore create_order_tx RPC
+--
+-- The previous revision of this migration replaced create_order_tx with an
+-- incompatible JSONB signature (p_idempotency_key / p_order_data /
+-- p_timeline_data / p_load_offer_data) whose body referenced columns that do
+-- not exist (orders.display_id, pickup_location, dropoff_location,
+-- accepted_bid_amount) and a table that does not exist (order_timelines).
+-- The only caller — orderCreationService — still invokes the original
+-- 30-parameter signature, so order creation failed end-to-end.
+--
+-- Restore create_order_tx to the original signature and body against the real
+-- schema (orders.order_display_id / pickup_address / drop_address,
+-- order_timeline), keeping the order_idempotency_records table as the
+-- foundation for future durable-idempotency wiring.
 
 CREATE TABLE IF NOT EXISTS order_idempotency_records (
     idempotency_key VARCHAR(255) PRIMARY KEY,
@@ -26,96 +39,123 @@ REVOKE ALL ON order_idempotency_records FROM anon, authenticated;
 
 -- Extend or replace create_order_tx RPC for single atomic database transaction
 CREATE OR REPLACE FUNCTION create_order_tx(
-    p_idempotency_key TEXT,
-    p_order_data JSONB,
-    p_timeline_data JSONB,
-    p_load_offer_data JSONB
+  p_order_display_id TEXT,
+  p_customer_id UUID,
+  p_customer_name TEXT,
+  p_pickup_address TEXT,
+  p_pickup_lat NUMERIC,
+  p_pickup_lng NUMERIC,
+  p_drop_address TEXT,
+  p_drop_lat NUMERIC,
+  p_drop_lng NUMERIC,
+  p_pickup_date TEXT,
+  p_pickup_time TEXT,
+  p_goods_type TEXT,
+  p_weight_tonnes NUMERIC,
+  p_length_ft NUMERIC,
+  p_width_ft NUMERIC,
+  p_height_ft NUMERIC,
+  p_is_stackable BOOLEAN,
+  p_is_fragile BOOLEAN,
+  p_special_requirements TEXT,
+  p_base_freight NUMERIC,
+  p_toll_estimate NUMERIC,
+  p_platform_fee NUMERIC,
+  p_total_amount NUMERIC,
+  p_estimated_price NUMERIC,
+  p_payment_method_id TEXT,
+  p_upi_id TEXT,
+  p_route_label TEXT,
+  p_route_subtitle TEXT,
+  p_weight_text TEXT,
+  p_fuel_cost NUMERIC,
+  p_net_profit NUMERIC,
+  p_extra_distance_km NUMERIC
 )
-RETURNS JSONB
+RETURNS json
 LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
-    v_existing_record RECORD;
-    v_order_id UUID;
-    v_result JSONB;
+  v_order_id UUID;
+  v_status TEXT;
+  v_created_at TIMESTAMPTZ;
+  v_customer_id UUID;
 BEGIN
-    -- 1. Check existing durable idempotency record
-    SELECT * INTO v_existing_record
-    FROM order_idempotency_records
-    WHERE idempotency_key = p_idempotency_key
-    FOR UPDATE;
-
-    IF FOUND THEN
-        IF v_existing_record.status = 'completed' THEN
-            RETURN v_existing_record.response_body;
-        ELSIF v_existing_record.status = 'in_progress' AND v_existing_record.created_at > (NOW() - INTERVAL '5 minutes') THEN
-            RAISE EXCEPTION 'ORDER_CREATION_IN_PROGRESS' USING ERRCODE = 'P0001';
-        END IF;
+  -- Resolve the customer identity: only the service-role backend may supply a
+  -- p_customer_id. Any other caller is bound to their own JWT-derived profile
+  -- id (get_profile_id maps the Firebase JWT sub to profiles.id), so clients
+  -- can never create orders or load offers as another customer.
+  IF auth.role() = 'service_role' THEN
+    v_customer_id := p_customer_id;
+  ELSE
+    v_customer_id := get_profile_id();
+    IF v_customer_id IS NULL THEN
+      RAISE EXCEPTION 'Unauthorized: could not resolve caller profile';
     END IF;
-
-    -- 2. Upsert in_progress status lock in DB
-    INSERT INTO order_idempotency_records (idempotency_key, status, updated_at)
-    VALUES (p_idempotency_key, 'in_progress', NOW())
-    ON CONFLICT (idempotency_key)
-    DO UPDATE SET status = 'in_progress', updated_at = NOW();
-
-    -- 3. Perform atomic Order Creation
-    INSERT INTO orders (
-        display_id, customer_id, pickup_location, dropoff_location, accepted_bid_amount, status
-    ) VALUES (
-        p_order_data->>'display_id',
-        (p_order_data->>'customer_id')::UUID,
-        p_order_data->'pickup_location',
-        p_order_data->'dropoff_location',
-        (p_order_data->>'accepted_bid_amount')::NUMERIC,
-        COALESCE(p_order_data->>'status', 'created')
-    )
-    RETURNING id INTO v_order_id;
-
-    -- 4. Insert Order Timeline record
-    INSERT INTO order_timelines (order_id, status, details, created_at)
-    VALUES (
-        v_order_id,
-        COALESCE(p_timeline_data->>'status', 'created'),
-        p_timeline_data->'details',
-        NOW()
-    );
-
-    -- 5. Insert Load Offer record if present
-    IF p_load_offer_data IS NOT NULL AND p_load_offer_data != 'null'::jsonb THEN
-        INSERT INTO load_offers (order_id, driver_id, offer_amount, status, created_at)
-        VALUES (
-            v_order_id,
-            (p_load_offer_data->>'driver_id')::UUID,
-            (p_load_offer_data->>'offer_amount')::NUMERIC,
-            COALESCE(p_load_offer_data->>'status', 'pending'),
-            NOW()
-        );
+    IF p_customer_id IS NOT NULL AND p_customer_id <> v_customer_id THEN
+      RAISE EXCEPTION 'Unauthorized: cannot create orders as another customer';
     END IF;
+  END IF;
 
-    -- 6. Store completed result
-    v_result := jsonb_build_object(
-        'success', true,
-        'order_id', v_order_id,
-        'display_id', p_order_data->>'display_id',
-        'status', COALESCE(p_order_data->>'status', 'created')
-    );
+  -- 1. Insert into orders
+  INSERT INTO orders (
+    order_display_id, customer_id, status,
+    pickup_address, pickup_lat, pickup_lng,
+    drop_address, drop_lat, drop_lng,
+    pickup_date, pickup_time,
+    goods_type, weight_tonnes, length_ft, width_ft, height_ft,
+    is_stackable, is_fragile, special_requirements,
+    base_freight, toll_estimate, platform_fee, total_amount, estimated_price,
+    payment_method_id, upi_id
+  ) VALUES (
+    p_order_display_id, v_customer_id, 'pending',
+    p_pickup_address, p_pickup_lat, p_pickup_lng,
+    p_drop_address, p_drop_lat, p_drop_lng,
+    p_pickup_date, p_pickup_time,
+    p_goods_type, p_weight_tonnes, p_length_ft, p_width_ft, p_height_ft,
+    p_is_stackable, p_is_fragile, p_special_requirements,
+    p_base_freight, p_toll_estimate, p_platform_fee, p_total_amount, p_estimated_price,
+    p_payment_method_id, p_upi_id
+  ) RETURNING id, status, created_at INTO v_order_id, v_status, v_created_at;
 
-    UPDATE order_idempotency_records
-    SET status = 'completed',
-        order_id = v_order_id,
-        response_body = v_result,
-        updated_at = NOW()
-    WHERE idempotency_key = p_idempotency_key;
+  -- 2. Insert into order_timeline
+  INSERT INTO order_timeline (order_display_id, milestone, milestone_time, completed, sort_order)
+  VALUES 
+    (p_order_display_id, 'Order Placed', NOW(), true, 10),
+    (p_order_display_id, 'Truck Assigned', null, false, 20),
+    (p_order_display_id, 'En Route to Pickup', null, false, 30),
+    (p_order_display_id, 'Arrived at Pickup', null, false, 35),
+    (p_order_display_id, 'Goods Loaded', null, false, 40),
+    (p_order_display_id, 'In Transit', null, false, 50),
+    (p_order_display_id, 'Arriving', null, false, 55),
+    (p_order_display_id, 'Delivered', null, false, 60);
 
-    RETURN v_result;
+  -- 3. Insert into load_offers
+  INSERT INTO load_offers (
+    order_display_id, customer_id, customer_name,
+    route_label, route_subtitle,
+    pickup_address, pickup_lat, pickup_lng,
+    drop_address, drop_lat, drop_lng,
+    goods_type, weight,
+    freight_value, fuel_cost, toll_cost, net_profit, extra_distance_km,
+    status
+  ) VALUES (
+    p_order_display_id, v_customer_id, p_customer_name,
+    p_route_label, p_route_subtitle,
+    p_pickup_address, p_pickup_lat, p_pickup_lng,
+    p_drop_address, p_drop_lat, p_drop_lng,
+    p_goods_type, p_weight_text,
+    p_total_amount, p_fuel_cost, p_toll_estimate, p_net_profit, p_extra_distance_km,
+    'available'
+  );
 
-EXCEPTION WHEN OTHERS THEN
-    -- On failure, mark idempotency record as failed
-    UPDATE order_idempotency_records
-    SET status = 'failed',
-        updated_at = NOW()
-    WHERE idempotency_key = p_idempotency_key;
-    RAISE;
+  RETURN json_build_object(
+    'id', v_order_id,
+    'order_display_id', p_order_display_id,
+    'status', v_status,
+    'created_at', v_created_at
+  );
 END;
 $$;


### PR DESCRIPTION
﻿## Problem

The replacement migration redefined `create_order_tx` with a different parameter list and referenced columns/table that do not match the production caller. `orderCreationService` invokes the RPC with 32 parameters, but the new signature was incompatible, so order creation would fail with a signature mismatch and non-existent columns.

## Fix

Restore the original 32-parameter `create_order_tx` signature that matches the caller in `orderCreationService.js`, with the correct schema columns (`orders.order_display_id`, `pickup_address`, `drop_address`, table `order_timeline`). The `order_idempotency_records` table is retained.

## Files changed

- `supabase/migrations/20260807000001_durable_idempotency_order_tx.sql`

## Testing

No live Supabase instance available; the restored signature was cross-checked against the exact 32-argument `create_order_tx` invocation in `orderCreationService.js` and the RLS table/column grants.

Closes #8886