### PR TITLE
fix(asset-token): drop global totalSupply cap from purchaseFraction

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -175,8 +175,6 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         uint256 totalCost = (amount * asset.tokenPrice + 1e18 - 1) / 1e18;
         require(msg.value >= totalCost, "Insufficient payment");
 
-        require(totalSupply() + amount <= asset.totalTokens, "Exceeds total token cap");
-
         // Update asset
         asset.availableTokens -= amount;
         issuedTokens[assetId] += amount;


### PR DESCRIPTION
﻿## Problem

`purchaseFraction` enforced a global `totalSupply` cap instead of the per-asset cap, so a fully-minted asset blocked purchasing fractions of any other asset.

## Fix

Remove the erroneous global cap check from `purchaseFraction`; per-asset availability is enforced by the per-asset `issuedTokens`/cap logic.

## Files changed

- `blockchain/contracts/AssetToken.sol`

## Testing

`AssetToken.sol` compiles cleanly via solc 0.8.26 (11 sources, 0 errors).

Closes #8889