### PR TITLE
fix(asset-token): block plain ERC20 transfer/transferFrom to keep asset ledgers in sync

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -444,6 +444,21 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         _transfer(msg.sender, to, amount);
     }
 
+    /// @notice Disabled. TXAT fractions are tracked per-asset in the
+    ///         fractionalOwnership ledger (and their buy-back backing in
+    ///         backedTokens), so plain ERC20 transfers would move tokens
+    ///         without updating that ledger and desynchronize it from the
+    ///         ERC20 balance. Use transferWithCompliance(assetId, to, amount)
+    ///         instead, which keeps the ledgers in sync.
+    function transfer(address, uint256) public virtual override returns (bool) {
+        revert("AssetToken: plain ERC20 transfers disabled - use transferWithCompliance(assetId, to, amount)");
+    }
+
+    /// @notice Disabled for the same reason as transfer().
+    function transferFrom(address, address, uint256) public virtual override returns (bool) {
+        revert("AssetToken: plain ERC20 transferFrom disabled - use transferWithCompliance(assetId, to, amount)");
+    }
+
     // ============ View Functions ============
 
     function getAsset(uint256 assetId) external view returns (Asset memory) {

--- a/blockchain/test/AssetToken.test.js
+++ b/blockchain/test/AssetToken.test.js
@@ -252,6 +252,49 @@ describe("AssetToken", function () {
     assert.equal(await ethers.provider.getBalance(assetToken.target), 0n);
   });
 
+  it("should block plain ERC20 transfer/transferFrom so the fractional-ownership ledger cannot desync", async function () {
+    const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("10"), {
+      value: ethers.parseEther("10")
+    });
+
+    // Plain ERC20 transfer must revert with guidance instead of moving tokens
+    // without updating fractionalOwnership/backedTokens.
+    await assert.rejects(
+      assetToken.connect(buyer1).transfer(buyer2.address, ethers.parseEther("4")),
+      /plain ERC20 transfers disabled/
+    );
+
+    // transferFrom must be blocked the same way.
+    await assert.rejects(
+      assetToken.connect(buyer1).transferFrom(buyer1.address, buyer2.address, ethers.parseEther("4")),
+      /plain ERC20 transferFrom disabled/
+    );
+
+    // The ledgers are unchanged and buyer2 received nothing.
+    const buyer1Ownership = await assetToken.getFractionalOwnership(1, buyer1.address);
+    const buyer2Ownership = await assetToken.getFractionalOwnership(1, buyer2.address);
+    assert.equal(buyer1Ownership.amount, ethers.parseEther("10"));
+    assert.equal(buyer1Ownership.backedTokens, ethers.parseEther("10"));
+    assert.equal(buyer2Ownership.amount, 0n);
+    assert.equal(await assetToken.balanceOf(buyer2.address), 0n);
+
+    // The asset-aware path still works and keeps the ledger in sync.
+    await assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4"));
+    assert.equal((await assetToken.getFractionalOwnership(1, buyer1.address)).amount, ethers.parseEther("6"));
+    assert.equal((await assetToken.getFractionalOwnership(1, buyer2.address)).amount, ethers.parseEther("4"));
+    assert.equal(await assetToken.balanceOf(buyer2.address), ethers.parseEther("4"));
+  });
+
   it("should keep the buy-back backing for tokens acquired via a secondary-market trade", async function () {
     const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
     await assetToken.connect(owner).createAsset(


### PR DESCRIPTION
﻿## Problem

`AssetToken` inherits plain ERC20 `transfer`/`transferFrom`, which move TXAT tokens without updating the per-asset `fractionalOwnership` ledger or the buy-back `backedTokens` accounting. Recipients get an ERC20 balance but no fractional ownership (stranded tokens, no sell rights), while senders still show ownership, permanently desyncing issued/available token bookkeeping. Any exchange/approval integration using the standard interface corrupts asset accounting.

## Fix

Since `_transfer` carries no `assetId`, block the public ERC20 paths with a clear revert directing callers to `transferWithCompliance(assetId, to, amount)`, the only path that keeps the ledgers in sync. Internal `_transfer` calls (trades, escrow) are unaffected.

## Files changed

- `blockchain/contracts/AssetToken.sol`
- `blockchain/test/AssetToken.test.js`

## Testing

`AssetToken.sol` compiles cleanly via solc 0.8.26 (11 sources, 0 errors). Regression test added asserting `transfer`/`transferFrom` revert and that `transferWithCompliance` keeps `fractionalOwnership`/`backedTokens` in sync.

Closes #8890