### PR TITLE
fix(escrow): revert cancelBooking on started trips and guard the refund worker

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -1,6 +1,6 @@
 import { redisClient } from '../config/db.js';
 import logger from '../middleware/logger.js';
-import { confirmEscrowRefund, submitEscrowRefund, submitEscrowCancelWithPenalty, paisaToMaticWei } from './escrow.js';
+import { confirmEscrowRefund, submitEscrowRefund, submitEscrowCancelWithPenalty, paisaToMaticWei, getEscrowBooking, getEscrowBookingId } from './escrow.js';
 import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import os from 'os';
 
@@ -120,6 +120,25 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         let receipt;
 
         if (!refundTxHash) {
+          // Issue #8891: verify the on-chain booking state before choosing the
+          // cancel path. TruxifyEscrow.cancelBooking now reverts for started
+          // bookings, and cancelWithPenalty also reverts on started bookings,
+          // so submitting either would waste gas and revert on every retry.
+          // Escalate for manual review instead of retrying forever.
+          const escrowBooking = await getEscrowBooking(getEscrowBookingId(order.order_display_id));
+          if (escrowBooking && escrowBooking.started) {
+            logger.error(
+              `[escrow-reconciliation] Order ${order.order_display_id} booking is started on-chain — full-refund/penalty cancel is not allowed; escalating to manual review.`
+            );
+            await orderRepository.updateOrder(order.id, {
+              escrow_refund_attempts: MAX_RETRIES,
+              escrow_refund_error: 'Booking started on-chain — cancel/refund reverted; requires manual review.',
+              reconciled_by: null,
+              updated_at: new Date().toISOString(),
+            });
+            continue;
+          }
+
           const cancellationFee = Number(order.cancellation_fee ?? 0);
           let driverFeeWei = 0n;
           if (cancellationFee > 0) {

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -376,6 +376,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
+        require(!booking.started, "TruxifyEscrow: Trip already started");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
 
         // ── EFFECTS ───────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Problem

`TruxifyEscrow.cancelBooking` full-refunded started bookings — there was no `require(!booking.started, ...)` guard — so a trip already in progress could be cancelled and refunded. The refund worker would then submit a reverting transaction and spin in retries.

## Fix

Add `require(!booking.started, "TruxifyEscrow: Trip already started");` to `cancelBooking` (matching `cancelWithPenalty`). The backend refund reconciliation now reads the on-chain booking and, if it is `started`, escalates to manual review (`escrow_refund_attempts: MAX_RETRIES`) instead of submitting a tx that is guaranteed to revert.

## Files changed

- `blockchain/contracts/TruxifyEscrow.sol`
- `backend/api/src/services/escrowRefundReconciliation.js`

## Testing

Contracts compile cleanly via solc 0.8.26 (6 sources, 0 errors). The existing hardhat test "reverts once the trip has started" now matches the new behavior.

Closes #8891