### PR TITLE
fix(atomic-swap): enforce single-use hash locks

### DIFF
--- a/blockchain/contracts/AtomicSwap.sol
+++ b/blockchain/contracts/AtomicSwap.sol
@@ -43,6 +43,9 @@ contract AtomicSwap is ReentrancyGuard {
     ) external payable returns (bytes32) {
         require(msg.value > 0, "Amount must be > 0");
         require(swaps[swapId].sender == address(0), "Swap ID exists");
+        require(!usedHashLocks[hashLock], "Hash lock already used");
+
+        usedHashLocks[hashLock] = true;
 
         swaps[swapId] = Swap({
             sender: payable(msg.sender),
@@ -83,7 +86,6 @@ contract AtomicSwap is ReentrancyGuard {
         require(msg.sender == swap.sender, "Only sender can refund");
 
         swap.refunded = true;
-        usedHashLocks[swap.hashLock] = false;
         (bool sent, ) = swap.sender.call{value: swap.amount}("");
         require(sent, "Refund transfer failed");
 


### PR DESCRIPTION
﻿## Problem

`AtomicSwap.usedHashLocks` was populated but never enforced, so a hash lock used in one swap could be re-used in another, letting an actor replay/cross-collateralize the same secret.

## Fix

`openSwap` now requires `!usedHashLocks[hashLock]` and records it immediately, and the hash-lock entry is never reset on refund, so each hash lock is single-use for the contract lifetime.

## Files changed

- `blockchain/contracts/AtomicSwap.sol`

## Testing

`AtomicSwap.sol` compiles cleanly via solc 0.8.26 (3 sources, 0 errors).

Closes #8894