### PR TITLE
fix(#8896): remove IndentationError in price_prediction.py that blocked ML service boot

### DIFF
--- a/backend/ml/app/models/price_prediction.py
+++ b/backend/ml/app/models/price_prediction.py
@@ -406,16 +406,6 @@ async def _get_weather_multiplier_async(client: httpx.AsyncClient, city: str) ->
         multiplier = _parse_weather_multiplier(response)
         _cache_weather_multiplier(city, multiplier)
         return multiplier
-        url = f"https://api.openweathermap.org/data/2.5/weather?q={city}&appid={api_key}"
-        with httpx.Client(timeout=5.0) as client:
-        response = client.get(url, timeout=2.0)
-        response = httpx.get(url, timeout=2.0)
-        if response.status_code == 200:
-            weather_main = response.json().get("weather", [{}])[0].get("main", "").lower()
-            if weather_main in ["rain", "snow", "thunderstorm", "extreme", "squall", "tornado"]:
-                return 1.2
-            elif weather_main in ["drizzle", "mist", "fog", "haze", "dust", "sand", "ash"]:
-                return 1.1
     except Exception as e:
         logger.warning("Weather API failed for %s: %s", city, e)
         _cache_weather_multiplier(city, 1.0)

--- a/backend/ml/tests/test_price_prediction.py
+++ b/backend/ml/tests/test_price_prediction.py
@@ -248,3 +248,19 @@ def test_get_weather_multiplier_async_empty_city():
             return await pp._get_weather_multiplier_async(client, "")
     result = asyncio.run(run())
     assert result == 1.0
+
+
+# Regression tests for issue #8896 - price_prediction.py had an IndentationError
+# (leftover dead code after an early return), so the module could not be imported.
+def test_price_prediction_module_parses():
+    """The module must be syntactically valid Python (no IndentationError)."""
+    import ast, pathlib
+    source = pathlib.Path(pp.__file__).read_text()
+    ast.parse(source)
+
+
+def test_price_prediction_module_importable():
+    """The module must be importable - the ML service loads it on boot."""
+    import importlib
+    module = importlib.import_module("app.models.price_prediction")
+    assert hasattr(module, "train_price_model")


### PR DESCRIPTION
## Problem

Issue #8896 reports that the Truxify ML service cannot start because `backend/ml/app/models/price_prediction.py` raises an `IndentationError` on import. Since the FastAPI app in `backend/ml/main.py` imports `price_prediction` during startup, a syntax error in this module takes the entire ML service down — every `/ml/*` endpoint (price prediction, weather-adjusted freight pricing) is unavailable.\n
## Root Cause

In `_get_weather_multiplier_async`, the correct async implementation ends with an early `return multiplier`. Immediately after that return statement, a block of **dead, leftover code from an older synchronous implementation** was left behind:

```python
        response = await client.get(url, timeout=ML_WEATHER_TIMEOUT_SECONDS)
        multiplier = _parse_weather_multiplier(response)
        _cache_weather_multiplier(city, multiplier)
        return multiplier                       # <- function returns here
        url = f"[link removed for security]"
        with httpx.Client(timeout=5.0) as client:
        response = client.get(url, timeout=2.0)   # <- IndentationError
        response = httpx.get(url, timeout=2.0)
        if response.status_code == 200:
            ...
```

Two problems were packed into this dead block:

1. **It is unreachable** — it sits after `return multiplier`, so it can never execute.
2. **It is syntactically invalid** — the `with httpx.Client(timeout=5.0) as client:` statement has no indented body; the next line (`response = client.get(...)`) is at the same indentation level as the `with`, so Python raises `IndentationError: expected an indented block after 'with' statement on line 410`.

Because the error occurs at parse time, the module fails to import regardless of whether the function is ever called. `python3 -m py_compile backend/ml/app/models/price_prediction.py` reproduced the error before this fix:

```
Sorry: IndentationError: expected an indented block after 'with' statement on line 410 (price_prediction.py, line 411)
```

## Fix

Removed the dead block entirely. The correct, working async implementation — which uses the shared async `client`, the `ML_WEATHER_TIMEOUT_SECONDS` constant, `_parse_weather_multiplier`, and `_cache_weather_multiplier` — is already present above the `return` and is retained unchanged. Nothing about the live behaviour changed; only unreachable, broken code was deleted.

After the fix:

- `python3 -m py_compile backend/ml/app/models/price_prediction.py` → exits 0 (clean).
- `python3 -c "import ast; ast.parse(open(...).read())"` → OK.
- The module imports successfully and the ML service can boot again.

## Tests

Added two regression tests to the existing `backend/ml/tests/test_price_prediction.py`:

1. `test_price_prediction_module_parses` — reads the module source and runs `ast.parse`, failing immediately if any `SyntaxError`/`IndentationError` is reintroduced.
2. `test_price_prediction_module_importable` — imports `app.models.price_prediction` via `importlib` and asserts `train_price_model` is present, proving the module loads (which it could not before).

Both tests pass. Note that the entire pre-existing `test_price_prediction.py` suite already does `from app.models import price_prediction as pp` at module top level — so before this fix the whole file could not even be collected by pytest (the import raised `IndentationError`). With the fix, collection succeeds and the new tests run green.

## Files Changed

- `backend/ml/app/models/price_prediction.py` — removed the dead, syntactically invalid code block after `return multiplier` in `_get_weather_multiplier_async`.
- `backend/ml/tests/test_price_prediction.py` — added parse + import regression tests.

## Impact

Restores ML service boot. The IndentationError prevented `price_prediction` (and therefore the whole ML FastAPI app) from importing, taking down all ML endpoints. No runtime behaviour changes — only unreachable broken code was removed.

Closes #8896

> ⚠️ **Security Notice:** Links posted by non-contributors have been automatically removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather data retrieval reliability by using the shared response handling and caching flow.
  * Preserved fallback behavior when weather lookup fails.

* **Tests**
  * Added regression coverage to verify the pricing prediction module loads correctly and exposes its training functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->