### PR TITLE
fix: use PostGIS ST_DWithin index for nearby-driver search instead of full-table scan

### DIFF
--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -21,45 +21,37 @@ const NEW_TRIP_NOTIFY_BATCH_SIZE = Number(process.env.NEW_TRIP_NOTIFY_BATCH_SIZE
   : 25;
 const DRIVER_LOCATION_FRESHNESS_MS = 15 * 60 * 1000;
 
-function haversineDistanceKm(lat1, lng1, lat2, lng2) {
-  const toRad = deg => (deg * Math.PI) / 180;
-  const R = 6371;
-  const dLat = toRad(lat2 - lat1);
-  const dLng = toRad(lng2 - lng1);
-  const a = Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
-  return 2 * R * Math.asin(Math.sqrt(a));
-}
-
 /**
  * Find drivers that should be notified about a new trip: those online and
  * located within the configured radius of the pickup, whose truck can carry
- * the load (by weight capacity). Falls back to in-memory filtering when the
- * drivers are not filterable in a single SQL query.
+ * the load (by weight capacity).
+ *
+ * The radius+freshness search is pushed into Postgres via the
+ * get_nearby_active_drivers RPC, which runs ST_DWithin against the indexed
+ * driver_locations.location geography column (idx_driver_locations_location)
+ * instead of pulling every active driver nationwide and filtering by
+ * haversine distance in JS.
  *
  * @param {{pickupLat: number, pickupLng: number, weightTonnes: number}} args
  * @returns {Promise<string[]>} driver ids, bounded by NEW_TRIP_NOTIFY_MAX_DRIVERS
  */
-async function findTargetDrivers({ pickupLat, pickupLng, weightTonnes }) {
-  const { data: locations } = await supabase
-    .from('driver_locations')
-    .select('driver_id, latitude, longitude')
-    .eq('is_active', true)
-    .gte('last_updated_at', new Date(Date.now() - DRIVER_LOCATION_FRESHNESS_MS).toISOString())
-    .not('latitude', 'is', null);
+export async function findTargetDrivers({ pickupLat, pickupLng, weightTonnes }) {
+  const { data: nearbyDrivers, error: nearbyError } = await supabaseAdmin.rpc('get_nearby_active_drivers', {
+    origin_lat: pickupLat,
+    origin_lng: pickupLng,
+    radius_meters: NEW_TRIP_NOTIFY_RADIUS_KM * 1000,
+    freshness_seconds: DRIVER_LOCATION_FRESHNESS_MS / 1000,
+  });
 
-  if (!locations || locations.length === 0) return [];
+  if (nearbyError) {
+    logger.error(`[orders] get_nearby_active_drivers RPC failed: ${nearbyError.message}`);
+    return [];
+  }
 
-  const nearbyDriverIds = locations
-    .filter(loc => {
-      if (!Number.isFinite(Number(loc.latitude)) || !Number.isFinite(Number(loc.longitude))) return false;
-      return haversineDistanceKm(pickupLat, pickupLng, Number(loc.latitude), Number(loc.longitude)) <= NEW_TRIP_NOTIFY_RADIUS_KM;
-    })
-    .map(loc => loc.driver_id);
-
+  const nearbyDriverIds = (nearbyDrivers ?? []).map(row => row.driver_id);
   if (nearbyDriverIds.length === 0) return [];
 
-  const { data: driverDetails } = await supabase
+  const { data: driverDetails } = await supabaseAdmin
     .from('driver_details')
     .select('user_id, truck_id')
     .eq('is_online', true)
@@ -71,7 +63,7 @@ async function findTargetDrivers({ pickupLat, pickupLng, weightTonnes }) {
   const truckIds = driverDetails.map(d => d.truck_id).filter(Boolean);
   if (truckIds.length === 0) return [];
 
-  const { data: trucks } = await supabase
+  const { data: trucks } = await supabaseAdmin
     .from('trucks')
     .select('id, max_capacity_tons')
     .in('id', truckIds);

--- a/backend/api/test/unit/orderCreationService.findTargetDrivers.test.js
+++ b/backend/api/test/unit/orderCreationService.findTargetDrivers.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/services/order/bidAcceptanceService.js', () => ({
+  DomainError: class DomainError extends Error {},
+}));
+vi.mock('../../src/services/ml.js', () => ({
+  predictPrice: vi.fn(),
+}));
+
+function makeBuilder(result) {
+  const builder = {
+    select() { return this; },
+    eq() { return this; },
+    not() { return this; },
+    in() { return this; },
+    then(resolve) { return resolve(result); },
+  };
+  return builder;
+}
+
+const rpcMock = vi.fn();
+const resultsByTable = {
+  driver_details: {
+    data: [
+      { user_id: 'driver-1', truck_id: 'truck-1' },
+      { user_id: 'driver-2', truck_id: 'truck-2' },
+    ],
+    error: null,
+  },
+  trucks: {
+    data: [
+      { id: 'truck-1', max_capacity_tons: 10 },
+      { id: 'truck-2', max_capacity_tons: 2 },
+    ],
+    error: null,
+  },
+};
+
+const supabaseAdminBuilder = {
+  from: vi.fn((table) => makeBuilder(resultsByTable[table] ?? { data: [], error: null })),
+  rpc: rpcMock,
+};
+const supabaseAnonBuilder = {
+  from: vi.fn(() => makeBuilder({ data: [], error: null })),
+  rpc: vi.fn(),
+};
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: supabaseAnonBuilder,
+  supabaseAdmin: supabaseAdminBuilder,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+describe('findTargetDrivers', () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+    supabaseAdminBuilder.from.mockClear();
+    supabaseAnonBuilder.from.mockClear();
+  });
+
+  it('queries nearby drivers via the get_nearby_active_drivers RPC on the service-role client, not a full-table scan on the anon client', async () => {
+    rpcMock.mockResolvedValue({
+      data: [{ driver_id: 'driver-1' }, { driver_id: 'driver-2' }],
+      error: null,
+    });
+
+    const { findTargetDrivers } = await import('../../src/services/order/orderCreationService.js');
+
+    const result = await findTargetDrivers({ pickupLat: 19.076, pickupLng: 72.8777, weightTonnes: 5 });
+
+    expect(rpcMock).toHaveBeenCalledWith('get_nearby_active_drivers', expect.objectContaining({
+      origin_lat: 19.076,
+      origin_lng: 72.8777,
+      radius_meters: expect.any(Number),
+      freshness_seconds: expect.any(Number),
+    }));
+    expect(supabaseAnonBuilder.from).not.toHaveBeenCalled();
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('driver_details');
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('trucks');
+    // driver-2's truck only carries 2 tons, below the 5-tonne load, so it's filtered out
+    expect(result).toEqual(['driver-1']);
+  });
+
+  it('returns an empty list and logs instead of throwing when the RPC errors', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'boom' } });
+
+    const { findTargetDrivers } = await import('../../src/services/order/orderCreationService.js');
+
+    const result = await findTargetDrivers({ pickupLat: 19.076, pickupLng: 72.8777, weightTonnes: 5 });
+
+    expect(result).toEqual([]);
+    expect(supabaseAdminBuilder.from).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/migrations/20260809000000_add_get_nearby_active_drivers_rpc.sql
+++ b/supabase/migrations/20260809000000_add_get_nearby_active_drivers_rpc.sql
@@ -1,0 +1,51 @@
+-- Migration: Add get_nearby_active_drivers RPC (fixes findTargetDrivers full
+-- table scan in orderCreationService.js)
+--
+-- Problem:
+--   findTargetDrivers() pulled every active, recently-updated driver location
+--   nationwide from driver_locations, then filtered by haversine distance in
+--   JS. The GIST index on driver_locations.location
+--   (idx_driver_locations_location, added in
+--   20260727120000_add_postgis_geospatial_indexes.sql) was built for exactly
+--   this radius search but was never queried via ST_DWithin -- every order
+--   creation paid for a full-table row fetch instead of an index scan.
+--
+-- Fix:
+--   Push the is_active / freshness / radius filtering into Postgres via
+--   ST_DWithin against the indexed geography column, so the GIST index is
+--   actually used and only matching rows cross the wire.
+--
+-- SECURITY DEFINER + service_role-only grant, mirroring the existing
+-- backend-only RPCs (e.g. complete_trip_tx): driver_locations has no anon
+-- privileges (see revoke_anon_privileges.sql) and the backend API talks to
+-- Supabase via the service_role key, so this RPC is only ever invoked
+-- server-side.
+
+CREATE OR REPLACE FUNCTION get_nearby_active_drivers(
+  origin_lat        DOUBLE PRECISION,
+  origin_lng        DOUBLE PRECISION,
+  radius_meters      DOUBLE PRECISION,
+  freshness_seconds INTEGER
+)
+RETURNS TABLE (driver_id UUID)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT dl.driver_id
+  FROM driver_locations dl
+  WHERE dl.is_active = true
+    AND dl.last_updated_at >= (now() - make_interval(secs => freshness_seconds))
+    AND dl.location IS NOT NULL
+    AND ST_DWithin(
+          dl.location,
+          ST_SetSRID(ST_MakePoint(origin_lng, origin_lat), 4326)::geography,
+          radius_meters
+        );
+$$;
+
+-- Postgres grants EXECUTE to PUBLIC by default on function creation;
+-- granting to service_role afterward does not revoke that. Revoke first.
+REVOKE EXECUTE ON FUNCTION get_nearby_active_drivers(DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_nearby_active_drivers(DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER) TO service_role;


### PR DESCRIPTION
## Problem
findTargetDrivers() in orderCreationService.js fetched every active driver nationwide from driver_locations on every order creation, then filtered by haversine distance in JS. A GIST index for exactly this radius search already exists (idx_driver_locations_location, added in 20260727120000_add_postgis_geospatial_indexes.sql) but was never queried via ST_DWithin.

## Fix
- Added a new RPC, get_nearby_active_drivers, that runs ST_DWithin against the indexed driver_locations.location geography column so the GIST index is actually used and only matching rows are returned.
- SECURITY DEFINER, granted to service_role only — mirrors the existing complete_trip_tx pattern.
- Updated findTargetDrivers() to call the RPC via supabaseAdmin instead of pulling all rows and filtering in JS. Removed the now-unused haversineDistanceKm helper.
- Also switched the driver_details and trucks lookups in the same function from the anon supabase client to supabaseAdmin. Note: driver_locations has zero anon privileges (see revoke_anon_privileges.sql), so the original anon-client query was already broken independent of the perf issue — this fix addresses both.

## Testing
Added backend/api/test/unit/orderCreationService.findTargetDrivers.test.js, covering:
- the RPC is called with correct params on the service-role client (not anon)
- truck-capacity filtering still works
- RPC error path returns [] without throwing

Ran locally: npx vitest run backend/api/test/unit/orderCreationService.findTargetDrivers.test.js — both tests pass.

## Files changed
- supabase/migrations/20260809000000_add_get_nearby_active_drivers_rpc.sql (new)
- backend/api/src/services/order/orderCreationService.js
- backend/api/test/unit/orderCreationService.findTargetDrivers.test.js (new)

Closes #8723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Nearby driver matching now more reliably considers location freshness, distance, and truck capacity.
  * Driver searches gracefully return no results when availability information cannot be retrieved.
* **Security**
  * Nearby-driver lookup access is restricted to authorized service operations.
* **Tests**
  * Added coverage for nearby-driver filtering, capacity requirements, and lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->