### PR TITLE
fix: route public tracking share-link reads through service-role / user clients (public share-links always 400/404)

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 
 import { TrackingTokenService } from '../services/trackingTokenService.js';
-import { supabase } from '../config/db.js';
+import { supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { validateParams } from '../middleware/validate.js';
 import { createStore, safeIpKeyGenerator } from '../middleware/rateLimiter.js';
@@ -10,7 +10,13 @@ import { publicTrackingTokenSchema } from '../validation/requestSchemas.js';
 
 const router = express.Router();
 
-const trackingTokenService = new TrackingTokenService({ supabase, logger });
+// The public tracking endpoints are unauthenticated, so they must resolve
+// tracking tokens and order data through the service-role client, which
+// bypasses RLS. The token store migration documents this architecture:
+// "The public GET endpoint uses the service_role key (bypasses RLS) and
+// performs its own authorization checks". Authorization is still enforced at
+// the app level (hashed-token lookup, expiry/revocation, order-status guards).
+const trackingTokenService = new TrackingTokenService({ supabase: supabaseAdmin, logger });
 
 function parseFiniteCoordinate(value) {
   if (value === null || value === undefined || value === '') return null;
@@ -39,6 +45,10 @@ router.get(
   validateParams(publicTrackingTokenSchema),
   async (req, res) => {
     try {
+      if (!supabaseAdmin) {
+        return res.status(503).json({ error: 'Tracking service not available' });
+      }
+
       const { token } = req.params;
 
       const validation = await trackingTokenService.validateToken(token);
@@ -129,6 +139,10 @@ router.get(
   validateParams(publicTrackingTokenSchema),
   async (req, res) => {
     try {
+      if (!supabaseAdmin) {
+        return res.status(503).json({ error: 'Tracking service not available' });
+      }
+
       const { token } = req.params;
 
       const validation = await trackingTokenService.validateToken(token);
@@ -143,7 +157,7 @@ router.get(
 
       const { orderDisplayId } = validation;
 
-      const { data: order, error: orderError } = await supabase
+      const { data: order, error: orderError } = await supabaseAdmin
         .from('orders')
         .select('pickup_lat, pickup_lng, drop_lat, drop_lng, driver_id')
         .eq('order_display_id', orderDisplayId)

--- a/backend/api/src/routes/trackingRoutes.js
+++ b/backend/api/src/routes/trackingRoutes.js
@@ -5,14 +5,12 @@ import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateBody } from '../middleware/validate.js';
 import { shareTrackingSchema } from '../validation/requestSchemas.js';
-import { supabase, redisClient } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 import { TrackingTokenService } from '../services/trackingTokenService.js';
 import logger from '../middleware/logger.js';
 import { createStore, safeIpKeyGenerator } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
-
-const trackingTokenService = new TrackingTokenService({ supabase, logger });
 
 // Rate limiters
 const publicTrackingLimiter = rateLimit({
@@ -48,8 +46,13 @@ router.post(
       const orderDisplayId = req.params.id;
       const userId = req.user.id;
 
+      // Run the ownership pre-check and token writes through a per-request
+      // client carrying the caller's identity so RLS resolves correctly.
+      const userClient = createUserClient(req.token);
+      const trackingTokenService = new TrackingTokenService({ supabase: userClient, logger });
+
       // Verify the order exists and belongs to the requesting customer
-      const { data: order, error: orderError } = await supabase
+      const { data: order, error: orderError } = await userClient
         .from('orders')
         .select('order_display_id, customer_id, status')
         .eq('order_display_id', orderDisplayId)
@@ -106,7 +109,10 @@ router.post(
       const orderDisplayId = req.params.id;
       const userId = req.user.id;
 
-      const { data: order, error: orderError } = await supabase
+      const userClient = createUserClient(req.token);
+      const trackingTokenService = new TrackingTokenService({ supabase: userClient, logger });
+
+      const { data: order, error: orderError } = await userClient
         .from('orders')
         .select('order_display_id, customer_id')
         .eq('order_display_id', orderDisplayId)

--- a/backend/api/test/integration/publicTracking.test.js
+++ b/backend/api/test/integration/publicTracking.test.js
@@ -70,6 +70,12 @@ vi.mock('../../src/config/db.js', () => ({
   supabase: {
     from(table) { return buildChainable(table); },
   },
+  supabaseAdmin: {
+    from(table) { return buildChainable(table); },
+  },
+  createUserClient: () => ({
+    from(table) { return buildChainable(table); },
+  }),
   redisClient: {},
   mongoDb: {},
   firebaseAdmin: { auth: () => ({ verifyIdToken: async () => ({ uid: 'test-user' }) }) },


### PR DESCRIPTION
﻿## Problem

`GET /api/public/tracking/:token` and `GET /api/public/tracking/:token/route` can never succeed: every DB read goes through the shared session-less anon-key client, while the shipped schema gives `anon` zero access to `tracking_tokens`, `orders`, `order_timeline`, and `driver_locations`. The token-store migration explicitly documents that the public GET endpoints use the `service_role` key (bypasses RLS) and perform their own authorization checks, but the code wired the token service to the anon client instead.

The authenticated create/revoke paths (`POST /api/orders/:id/share-tracking` and `/revoke`) were equally dead: they ran their ownership pre-check and token writes through the same anon client, so every request returned `404 Order not found`.

## Fix

- `backend/api/src/routes/publicTrackingRoutes.js`: route the unauthenticated public endpoints through `supabaseAdmin` (service-role client) as the migration documents, keeping all app-level authorization (hashed-token lookup, expiry/revocation, order-status guards) intact. Added a `503` guard when the service-role client is unavailable.
- `backend/api/src/routes/trackingRoutes.js`: run the ownership pre-check and the `TrackingTokenService` create/revoke calls through a per-request `createUserClient(req.token)` client so RLS resolves to the caller's identity.
- Updated the integration test mock (`test/integration/publicTracking.test.js`) to provide `supabaseAdmin` and `createUserClient` and exercise the new wiring.

## Files changed

- `backend/api/src/routes/publicTrackingRoutes.js`
- `backend/api/src/routes/trackingRoutes.js`
- `backend/api/test/integration/publicTracking.test.js`

## Testing

- Existing `publicTracking.test.js` integration suite now exercises the service-role and per-request user clients (create ? public read ? revoke ? 410 flows).
- `node --check` passed on all modified files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking authorization by ensuring requests use the appropriate caller permissions.
  * Public tracking endpoints now handle unavailable tracking services gracefully with a service-unavailable response.
  * Improved reliability when retrieving order location details for public tracking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->