### PR TITLE
fix: enable RLS on order_idempotency_records (world readable/writable)

### DIFF
--- a/supabase/migrations/20260807000001_durable_idempotency_order_tx.sql
+++ b/supabase/migrations/20260807000001_durable_idempotency_order_tx.sql
@@ -11,6 +11,19 @@ CREATE TABLE IF NOT EXISTS order_idempotency_records (
 
 CREATE INDEX IF NOT EXISTS idx_order_idempotency_status ON order_idempotency_records(status);
 
+-- The idempotency records hold per-tenant order data and must not be
+-- reachable over REST. Every tenant table in this repo is RLS-protected;
+-- this one was created without RLS, leaving it world-readable/writable and
+-- allowing cross-tenant key enumeration and replay poisoning. Restrict it to
+-- backend-only (service_role) access so the arbitration RPC stays the sole
+-- authority on idempotency state.
+ALTER TABLE order_idempotency_records ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role only" ON order_idempotency_records
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+REVOKE ALL ON order_idempotency_records FROM anon, authenticated;
+
 -- Extend or replace create_order_tx RPC for single atomic database transaction
 CREATE OR REPLACE FUNCTION create_order_tx(
     p_idempotency_key TEXT,


### PR DESCRIPTION
﻿## Problem

`order_idempotency_records` (introduced by `20260807000001_durable_idempotency_order_tx.sql`) was created **without RLS and without any policy**. Every other per-tenant table in this repo is explicitly RLS-enabled; without it, the default public-schema privileges expose the table to the `anon` and `authenticated` roles.

Consequences:
- Any caller can enumerate every idempotency key, its `order_id`, and `response_body` over REST.
- Any caller can `UPDATE` a key to `status='completed'` with attacker-controlled data, or flip it to `in_progress` ? poisoning the idempotency arbitration RPC and enabling cross-tenant replay / order suppression.

## Fix

In `supabase/migrations/20260807000001_durable_idempotency_order_tx.sql`, restrict the table to backend-only access:

- `ALTER TABLE order_idempotency_records ENABLE ROW LEVEL SECURITY;`
- `CREATE POLICY "service role only" ... FOR ALL TO service_role USING (true) WITH CHECK (true);`
- `REVOKE ALL ON order_idempotency_records FROM anon, authenticated;`

The `create_order_tx` RPC (SECURITY DEFINER) remains the sole authority on idempotency state.

## Files changed

- `supabase/migrations/20260807000001_durable_idempotency_order_tx.sql`

## Testing

- The migration now ships with RLS enabled and service-role-only access for the idempotency table, mirroring the repo's existing tenant-table security model.
