### PR TITLE
fix : added NaN guard to weatherService lat conversion

### DIFF
--- a/backend/api/src/services/weatherService.js
+++ b/backend/api/src/services/weatherService.js
@@ -31,7 +31,12 @@ export class WeatherService {
     let tempC = 15; // default warm
     let condition = 'clear';
 
-    if (numLat > 40 || numLat < -40) {
+    // Number('abc') -> NaN; NaN comparisons are always false so a bad
+    // latitude would silently fall through to the warm default. Guard it
+    // explicitly so the intent is clear.
+    const validLat = Number.isFinite(numLat);
+
+    if (validLat && (numLat > 40 || numLat < -40)) {
       tempC = -5;
       condition = 'snow';
     }


### PR DESCRIPTION
Closes #9037.

Summary of What Has Been Done:
Number('abc') is NaN; make NaN lat fall back to warm default explicitly.

Changes Made:
- backend/api/src/services/weatherService.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.