### PR TITLE
fix : added timeout guard to escrowHealth check

### DIFF
--- a/backend/api/src/core/health/checks/escrowHealth.js
+++ b/backend/api/src/core/health/checks/escrowHealth.js
@@ -1,19 +1,26 @@
 import { checkEscrowHealth } from '../../../services/escrow.js';
-import { HealthStatus, executeCheck } from '../HealthCheck.js';
+import { HealthStatus, executeCheck, withTimeout } from '../HealthCheck.js';
+import logger from '../../../middleware/logger.js';
 
 const NAME = 'escrow';
+const ESCROW_CHECK_TIMEOUT_MS = 4000;
 
 async function check() {
-  const result = await checkEscrowHealth();
-  if (result.status === 'connected') {
-    return { status: HealthStatus.HEALTHY, metadata: { chainId: result.chainId } };
+  try {
+    const result = await withTimeout(checkEscrowHealth(), ESCROW_CHECK_TIMEOUT_MS);
+    if (result.status === 'connected') {
+      return { status: HealthStatus.HEALTHY, metadata: { chainId: result.chainId } };
+    }
+    if (result.status === 'not_configured') {
+      return { status: HealthStatus.DEGRADED, message: 'not_configured' };
+    }
+    return { status: HealthStatus.UNHEALTHY, message: result.error || result.status };
+  } catch (err) {
+    logger.warn({ err: err.message, check: NAME }, 'Escrow health probe failed or timed out');
+    return { status: HealthStatus.UNHEALTHY, message: err.message };
   }
-  if (result.status === 'not_configured') {
-    return { status: HealthStatus.DEGRADED, message: 'not_configured' };
-  }
-  return { status: HealthStatus.UNHEALTHY, message: result.error || result.status };
 }
 
 export default function escrowHealth(opts) {
-  return executeCheck(NAME, check, { critical: false, ...opts });
+  return executeCheck(NAME, check, { critical: false, timeoutMs: ESCROW_CHECK_TIMEOUT_MS + 1000, ...opts });
 }


### PR DESCRIPTION
Closes #9048.

Summary of What Has Been Done:
Bound the escrow health probe with an explicit timeout and structured logging.

Changes Made:
- backend/api/src/core/health/checks/escrowHealth.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.