### PR TITLE
fix : added whitespace guard to demand config parseNumberList

### DIFF
--- a/backend/api/src/config/demand.js
+++ b/backend/api/src/config/demand.js
@@ -4,8 +4,10 @@ const parseNumber = (value, fallback) => {
 };
 
 const parseNumberList = (value, fallback) => {
-  if (!value) return fallback;
-  const parsed = value.split(',').map((entry) => entry.trim()).filter(Boolean);
+  if (value === undefined || value === null) return fallback;
+  const trimmed = String(value).trim();
+  if (trimmed === '') return fallback;
+  const parsed = trimmed.split(',').map((entry) => entry.trim()).filter(Boolean);
   return parsed.length > 0 ? parsed : fallback;
 };
 


### PR DESCRIPTION
Closes #9050.

Summary of What Has Been Done:
Return fallback when the env list is whitespace-only.

Changes Made:
- backend/api/src/config/demand.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.