### PR TITLE
fix : added defensive guard in CacheKeyBuilder parse for empty key

### DIFF
--- a/backend/api/src/cache/CacheKeyBuilder.js
+++ b/backend/api/src/cache/CacheKeyBuilder.js
@@ -172,6 +172,9 @@ export const CacheKeyBuilder = {
    * @returns {{ namespace: string, version: string|null, entityId: string, subKey: string|null }}
    */
   parse(key) {
+    if (typeof key !== 'string' || key.length === 0) {
+      return { namespace: null, version: null, entityId: null, subKey: null };
+    }
     const parts = key.split(SEP);
     return {
       namespace: parts[0] || null,


### PR DESCRIPTION
Closes #9051.

Summary of What Has Been Done:
Return null components when key is empty string.

Changes Made:
- backend/api/src/cache/CacheKeyBuilder.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.