### PR TITLE
fix : added requestId context to publicTrackingRoutes errors

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -113,7 +113,7 @@ router.get(
         driver_location: publicDriverLocation,
       });
     } catch (err) {
-      logger.error({ err }, 'Error fetching public tracking data');
+      logger.error({ err, requestId: req.requestId }, 'Error fetching public tracking data');
       return res.status(500).json({ error: 'Failed to load tracking information' });
     }
   }
@@ -183,7 +183,7 @@ router.get(
         properties: { fallback: true },
       });
     } catch (err) {
-      logger.error({ err }, 'Error fetching public route data');
+      logger.error({ err, requestId: req.requestId }, 'Error fetching public route data');
       return res.status(500).json({ error: 'Failed to load route information' });
     }
   }


### PR DESCRIPTION
Closes #9053.

Summary of What Has Been Done:
Include requestId in public tracking route catch logs.

Changes Made:
- backend/api/src/routes/publicTrackingRoutes.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.