### PR TITLE
fix : added explicit blank-orderId guard to oracleRoutes authorizeOrderAccess

### DIFF
--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -22,6 +22,12 @@ const oracleVerificationLimiter = rateLimit({
 });
 
 async function authorizeOrderAccess(req, orderId) {
+  if (!orderId || typeof orderId !== 'string' || orderId.trim() === '') {
+    const err = new Error('Order ID is required');
+    err.status = 400;
+    throw err;
+  }
+
   const { data: order, error } = await supabase
     .from('orders')
     .select('id, customer_id, driver_id')


### PR DESCRIPTION
Closes #9054.

Summary of What Has Been Done:
Reject blank orderId early with 400.

Changes Made:
- backend/api/src/routes/oracleRoutes.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.