### PR TITLE
fix : added requestId context to wimBypass route errors

### DIFF
--- a/backend/api/src/routes/wimBypass.js
+++ b/backend/api/src/routes/wimBypass.js
@@ -104,7 +104,7 @@ router.post('/request-bypass', async (req, res) => {
             wimPacket: signedPacket,
         });
     } catch (error) {
-        logger.error('[WIM] request-bypass error:', error.message);
+        logger.error({ err: error.message, requestId: req.requestId }, '[WIM] request-bypass error:');
         return res.status(500).json({ error: error.message });
     }
 });


### PR DESCRIPTION
Closes #9065.

Summary of What Has Been Done:
Include requestId in the WIM bypass route catch logs.

Changes Made:
- backend/api/src/routes/wimBypass.js

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.