### PR TITLE
docs : added API documentation for lookupRoutes endpoints

### DIFF
--- a/docs/LOOKUP_ROUTES.md
+++ b/docs/LOOKUP_ROUTES.md
@@ -1,0 +1,29 @@
+# Lookup Routes
+
+Public lookup endpoints for reference data, served with a two-tier cache.
+
+## GET /api/lookup/vehicle-types
+
+Returns the list of supported vehicle types.
+
+## GET /api/lookup/regions
+
+Returns the list of supported regions.
+
+### Caching
+
+Responses are cached in two tiers:
+
+- **L1** — in-memory LRU (max 1000 keys, 5 minute TTL).
+- **L2** — Redis (1 hour TTL), when `redisClient` is configured.
+
+An in-flight request map ensures a cache stampede cannot hit the database
+multiple times for the same key; only the first caller fetches, the rest
+await the same promise.
+
+### Errors
+
+| Status | Meaning                          |
+| ------ | -------------------------------- |
+| 200    | `{ data: [...] }`                |
+| 500    | `{ error: "Failed to fetch ..." }` |


### PR DESCRIPTION
Closes #9069.

Summary of What Has Been Done:
Document vehicle-types and regions endpoints with caching notes.

Changes Made:
- docs/LOOKUP_ROUTES.md

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.