### PR TITLE
docs : added documentation for the cache namespace registry

### DIFF
--- a/docs/CACHE_NAMESPACES.md
+++ b/docs/CACHE_NAMESPACES.md
@@ -1,0 +1,35 @@
+# Cache Namespaces
+
+Centralized registry of Redis cache namespaces used by `CacheKeyBuilder`,
+`CacheNamespace`, and the cache invalidation system.
+
+## Registered namespaces
+
+| Namespace     | Prefix        | Default TTL | Pub/Sub |
+| ------------- | ------------- | ----------- | ------- |
+| `profile`     | `user:profile`| 900s (env `REDIS_CACHE_TTL`) | yes |
+| `order`       | `order`       | 300s        | yes |
+| `driver`      | `driver`      | 300s        | yes |
+| `lookup`      | `lookup`      | 3600s       | yes |
+| `osrm`        | `osrm`        | 86400s      | yes |
+| `fraud`       | `fraud`       | 3600s       | yes |
+| `idempotency` | `idempotency` | 3600s       | yes |
+| `shard`       | `shard`       | 300s        | yes |
+| `rate_limit`  | `rate_limit`  | 900s        | no  |
+| `lock`        | `lock`        | 10s         | no  |
+| `tracker`     | `tracker`     | 86400s      | yes |
+| `load_offer`  | `load_offer`  | 120s        | yes |
+| `otp`         | `otp`         | 3600s       | no  |
+| `version`     | `version`     | 0s          | no  |
+
+## Key formats
+
+- Unversioned: `{prefix}:{entityId}[:{subKey}]`
+- Versioned: `{prefix}:v{version}:{entityId}[:{subKey}]`
+- Version counter: `{prefix}:version:{entityId}`
+- Pub/Sub channel: `cache:invalidate:{namespace}`
+
+## Usage
+
+Register new domains in `CacheNamespace.register(...)` before using them;
+pattern-based invalidation (SCAN) relies on the registry staying accurate.


### PR DESCRIPTION
Closes #9078.

Summary of What Has Been Done:
Document registered namespaces, TTLs, and usage.

Changes Made:
- docs/CACHE_NAMESPACES.md

Impact it Made:
This change is submitted under GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.