### PR TITLE
fix(api): add POST alias for /unregister to support older Flutter cli…

### DIFF
--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -103,6 +103,7 @@ router.post('/register', authenticate, deviceLimiter, validateBody(registerDevic
  *         description: Validation error
  */
 router.delete('/unregister', authenticate, deviceLimiter, validateBody(unregisterDeviceSchema), unregisterDeviceToken);
+router.post('/unregister', authenticate, deviceLimiter, validateBody(unregisterDeviceSchema), unregisterDeviceToken);
 
 // GET /api/devices/platforms
 router.get('/platforms', authenticate, getDevicePlatforms);


### PR DESCRIPTION
## Description
This PR fixes an issue where the Flutter shared FCM service unregisters device tokens using a `POST` request, but the backend only exposed a `DELETE` method for `/api/devices/unregister`. This discrepancy caused the logout flow to fail silently (returning a 404), leaving the FCM token registered server-side and causing previous users to continue receiving push notifications on shared devices.

Instead of modifying the Flutter `ApiClient` to support `DELETE` requests with bodies (which would require more invasive frontend refactoring), we have added a `POST` alias for the `/api/devices/unregister` endpoint on the backend. This safely resolves the issue while ensuring backwards compatibility with any older versions of the app currently in the wild.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `cd backend/api && npm run lint` and `npm test`.
- **Test Steps / Prerequisites:**
  1. Log in to the application on a physical device or emulator.
  2. Verify that the device FCM token is correctly registered in the database for the user.
  3. Log out of the application.
  4. Verify that the server successfully unregisters the token (no `404` error in the backend logs, and the database record is cleared).
- **Expected Result:** The API returns a `200 OK` on logout, the FCM token is successfully unregistered, and the device no longer receives push notifications intended for the previous user.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #8908

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
