### PR TITLE
fix(api): authorise offline trip-event batches by order display id and replay stop completions

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -141,6 +141,66 @@ function deepSanitize(obj, keys) {
   return clean;
 }
 
+/**
+ * Replays an offline 'markStopCompleted' event so a stop completed while the
+ * driver was offline is actually persisted once the batch syncs. Mirrors the
+ * online PUT /api/trips/:id/stops/:stopId/complete behaviour.
+ */
+async function replayMarkStopCompleted(tripId, payload) {
+  const stopId = payload?.stopId;
+  if (!stopId) {
+    logger.warn('[SyncEngine] markStopCompleted event missing stopId');
+    return;
+  }
+
+  const { data: stop, error: stopErr } = await supabaseAdmin
+    .from('trip_stops')
+    .select('id, is_completed')
+    .eq('id', stopId)
+    .eq('trip_display_id', tripId)
+    .maybeSingle();
+  if (stopErr) {
+    logger.error('[SyncEngine] Failed to fetch stop for markStopCompleted replay:', stopErr.message);
+    return;
+  }
+  if (!stop || stop.is_completed) return;
+
+  const { error: updateErr } = await supabaseAdmin
+    .from('trip_stops')
+    .update({
+      is_completed: true,
+      is_current: false,
+      status_label: 'Delivered',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', stop.id);
+  if (updateErr) {
+    logger.error('[SyncEngine] Failed to complete stop during replay:', updateErr.message);
+    return;
+  }
+
+  // Advance the current-stop marker to the next uncompleted stop.
+  const { data: nextStops, error: nextErr } = await supabaseAdmin
+    .from('trip_stops')
+    .select('id')
+    .eq('trip_display_id', tripId)
+    .eq('is_completed', false)
+    .order('sort_order', { ascending: true })
+    .limit(1);
+  if (nextErr) {
+    logger.error('[SyncEngine] Failed to resolve next stop during replay:', nextErr.message);
+  } else if (nextStops && nextStops.length > 0) {
+    await supabaseAdmin
+      .from('trip_stops')
+      .update({
+        is_current: true,
+        status_label: 'In Progress',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', nextStops[0].id);
+  }
+}
+
 // Schema for an individual Trip Event from the Flutter offline database
 const tripEventSchema = z.object({
   id: z.string().min(1, "Event ID is required"),
@@ -266,20 +326,28 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       const tripIds = [...new Set(events.map(event => event.trip_id).filter(Boolean))];
 
       if (tripIds.length > 0) {
+        // Trip ids sent by the app are trip display ids ('TX-' + order display id),
+        // not the orders.id uuid. Map them back to the bare order display id before
+        // looking up the owning order, otherwise every batch is rejected with 403.
+        const orderDisplayIds = tripIds.map(tripId =>
+          typeof tripId === 'string' && tripId.startsWith('TX-') ? tripId.slice(3) : tripId
+        );
+
         const { data: ownedOrders, error: ownershipError } = await supabase
           .from('orders')
-          .select('id, driver_id, customer_id')
-          .in('id', tripIds);
+          .select('order_display_id, driver_id, customer_id')
+          .in('order_display_id', orderDisplayIds);
 
         if (ownershipError) {
           logger.error('[SyncEngine] Failed to verify trip ownership:', ownershipError.message);
           return res.status(500).json({ error: 'Internal Server Error' });
         }
 
-        const orderById = new Map((ownedOrders || []).map(order => [order.id, order]));
+        const orderByDisplayId = new Map((ownedOrders || []).map(order => [order.order_display_id, order]));
 
         for (const tripId of tripIds) {
-          const order = orderById.get(tripId);
+          const orderDisplayId = typeof tripId === 'string' && tripId.startsWith('TX-') ? tripId.slice(3) : tripId;
+          const order = orderByDisplayId.get(orderDisplayId);
           const isDriver = order?.driver_id === userId;
           const isCustomer = order?.customer_id === userId;
           if (!order || (!isDriver && !isCustomer)) {
@@ -332,6 +400,14 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       logger.error('[SyncEngine] Bulk Insert Failed:', insertError.message);
       // Return 500 so the Flutter app knows to apply exponential backoff and retry later
       return res.status(500).json({ error: 'Database failed to process batch.' });
+    }
+
+    // 3.5 Replay actionable trip events (e.g. offline stop completions) so an
+    // event queued while offline has its effect applied once connectivity returns.
+    for (const event of events) {
+      if (event.type === 'markStopCompleted' && event.trip_id) {
+        await replayMarkStopCompleted(event.trip_id, event.payload || {});
+      }
     }
 
     // 4. Log the successful batch using the idempotency key

--- a/backend/api/test/integration/tripRoutes.test.js
+++ b/backend/api/test/integration/tripRoutes.test.js
@@ -32,7 +32,7 @@ const validPayload = {
     events: [
         {
             id: 'event-1',
-            trip_id: 'trip-1',
+            trip_id: 'TX-ORDER1',
             type: 'location_update',
             occurred_at: new Date().toISOString(),
             payload: {
@@ -50,7 +50,7 @@ describe('Trip Routes', () => {
         m.store.trip_events = [];
         m.store.processed_batches = [];
         m.store.orders = [
-            { id: 'trip-1', driver_id: 'driver-1', customer_id: 'customer-1' },
+            { id: 'trip-1', order_display_id: 'ORDER1', driver_id: 'driver-1', customer_id: 'customer-1' },
         ];
         m.calls.length = 0;
     });
@@ -91,7 +91,7 @@ describe('Trip Routes', () => {
                 events: [
                     {
                         id: 'event-1',
-                        trip_id: 'trip-1',
+                        trip_id: 'TX-ORDER1',
                         type: 'location_update',
                         occurred_at: 'invalid-date',
                         payload: {},
@@ -185,7 +185,7 @@ describe('Trip Routes', () => {
             expect.objectContaining({
                 event_id: 'event-1',
                 user_id: 'driver-1',
-                trip_id: 'trip-1',
+                trip_id: 'TX-ORDER1',
                 event_type: 'location_update',
                 latitude: 19.076,
                 longitude: 72.8777,
@@ -247,7 +247,7 @@ describe('Trip Routes', () => {
 
     it('POST /events/batch returns 403 when the caller owns only some of the trips', async () => {
         m.store.orders = [
-            { id: 'trip-1', driver_id: 'driver-1', customer_id: 'customer-1' },
+            { id: 'trip-1', order_display_id: 'ORDER1', driver_id: 'driver-1', customer_id: 'customer-1' },
         ];
 
         const res = await request(buildApp())
@@ -260,7 +260,7 @@ describe('Trip Routes', () => {
                     {
                         ...validPayload.events[0],
                         id: 'event-other-trip',
-                        trip_id: 'other-trip',
+                        trip_id: 'TX-OTHER',
                     },
                 ],
             });
@@ -290,7 +290,7 @@ describe('Trip Routes', () => {
                 events: [
                     {
                         id: 'event-otp-leak',
-                        trip_id: 'trip-1',
+                        trip_id: 'TX-ORDER1',
                         type: 'otpDelivery',
                         occurred_at: new Date().toISOString(),
                         payload: {
@@ -314,7 +314,7 @@ describe('Trip Routes', () => {
                 events: [
                     {
                         id: 'event-gps-oob',
-                        trip_id: 'trip-1',
+                        trip_id: 'TX-ORDER1',
                         type: 'gpsUpdate',
                         occurred_at: new Date().toISOString(),
                         payload: {
@@ -355,7 +355,7 @@ describe('Trip Routes', () => {
                 events: [
                     {
                         id: 'event-sensitive',
-                        trip_id: 'trip-1',
+                        trip_id: 'TX-ORDER1',
                         type: 'gpsUpdate',
                         occurred_at: new Date().toISOString(),
                         payload: {
@@ -406,7 +406,7 @@ describe('Trip Routes', () => {
                 events: [
                     {
                         id: 'event-otp',
-                        trip_id: 'trip-1',
+                        trip_id: 'TX-ORDER1',
                         type: 'otpDelivery',
                         occurred_at: new Date().toISOString(),
                         payload: {
@@ -432,6 +432,68 @@ describe('Trip Routes', () => {
                 metadata: { stopId: 'stop-1' },
             })
         );
+    });
+
+    it('POST /events/batch replays markStopCompleted by completing the stop and advancing the current stop', async () => {
+        m.store.trip_stops = [
+            {
+                id: 'stop-1',
+                trip_display_id: 'TX-ORDER1',
+                is_completed: false,
+                is_current: true,
+                status_label: 'In Progress',
+                sort_order: 1,
+            },
+            {
+                id: 'stop-2',
+                trip_display_id: 'TX-ORDER1',
+                is_completed: false,
+                is_current: false,
+                status_label: 'Pending',
+                sort_order: 2,
+            },
+        ];
+
+        const originalFrom = m.supabase.from.bind(m.supabase);
+        m.supabase.from = table => {
+            const builder = originalFrom(table);
+            if (table === 'trip_events') {
+                builder.upsert = vi.fn(async payload => {
+                    m.store.trip_events.push(...payload);
+                    return { data: payload, error: null };
+                });
+            }
+            return builder;
+        };
+
+        const res = await request(buildApp())
+            .post('/api/v1/trips/events/batch')
+            .set(DRIVER_HEADERS)
+            .send({
+                idempotencyKey: 'batch-mark-stop-completed',
+                events: [
+                    {
+                        id: 'event-stop-completed',
+                        trip_id: 'TX-ORDER1',
+                        type: 'markStopCompleted',
+                        occurred_at: new Date().toISOString(),
+                        payload: { stopId: 'stop-1' },
+                    },
+                ],
+            });
+
+        m.supabase.from = originalFrom;
+
+        expect(res.status).toBe(202);
+
+        const completedStop = m.store.trip_stops.find((s) => s.id === 'stop-1');
+        expect(completedStop.is_completed).toBe(true);
+        expect(completedStop.is_current).toBe(false);
+        expect(completedStop.status_label).toBe('Delivered');
+
+        const nextStop = m.store.trip_stops.find((s) => s.id === 'stop-2');
+        expect(nextStop.is_current).toBe(true);
+        expect(nextStop.status_label).toBe('In Progress');
     });
 });
 


### PR DESCRIPTION
## Problem

`POST /api/v1/trips/events/batch` rejected every offline trip-event batch carrying a `trip_id` with `403 Access Denied`. The app sends trip **display ids** (`'TX-' + order display id`), but the ownership check compared them against `orders.id` (a UUID), so the lookup never matched and every offline stop-completion sync failed - the stop was never marked complete and the driver's local queue was never cleared (infinite retry loop).

## Fix

- Map `trip_id` (`TX-<order display id>`) back to the bare `order_display_id` before the ownership query, and look up owning orders by `order_display_id` instead of `id`.
- Replay `markStopCompleted` events after a successful batch insert so a stop completed while offline is actually persisted (mirrors the online `PUT /api/trips/:id/stops/:stopId/complete` behaviour) and the current-stop marker advances to the next uncompleted stop.
- Updated the integration tests to use `TX-`-prefixed trip ids and added a regression test for the replay path.

## Files changed

- `backend/api/src/routes/tripRoutes.js`
- `backend/api/test/integration/tripRoutes.test.js`

## Testing

- `npx vitest run test/integration/tripRoutes.test.js` - 26/26 passing, including the new `markStopCompleted` replay regression test.

Closes #8927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline replay support for stop-completion events.
  * Completing a stop now marks it delivered and advances the trip to the next uncompleted stop.
  * Batch trip-event processing replays applicable stop-completion actions after synchronization.

* **Bug Fixes**
  * Improved ownership validation for trips using display IDs, preventing incorrect order matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->