### PR TITLE
fix(driver): bucket earnings chart by calendar date per reporting period

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1604,7 +1604,7 @@ router.get('/:id/earnings', authenticate, userLimiter, requirePolicy('driver:vie
       logger.warn('Failed to fetch trips for deadhead analysis:', adjacentError.message);
     }
 
-    const weeklyChart = buildWeeklyChart(trips);
+    const weeklyChart = buildWeeklyChart(trips, { period });
     const totalKm = sumDistanceKm(trips);
     const deadheadTripsSaved = countDeadheadTripsSaved(adjacentTrips);
 

--- a/backend/api/src/services/driver/earningsReportService.js
+++ b/backend/api/src/services/driver/earningsReportService.js
@@ -117,21 +117,27 @@ export function parseDistanceKm(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
 /**
- * Earnings bucketed by weekday for the past seven days.
+ * Daily earnings bucketed by calendar date for a reporting period.
+ *
+ * Every bucket is one real calendar date (`YYYY-MM-DD`), so trips from
+ * different weeks never merge into the same bar. The frame follows the
+ * period the route queried: `day` → 1 bar, `week` → 7 bars,
+ * `month` → 30 bars.
  *
  * @param {Array<object>} trips
- * @param {Date} [now]
+ * @param {object} [options]
+ * @param {'day'|'week'|'month'} [options.period='week']
+ * @param {Date} [options.now]
  * @returns {Array<{day: string, earnings: number}>}
  */
-export function buildWeeklyChart(trips, now = new Date()) {
+export function buildWeeklyChart(trips, { period = 'week', now = new Date() } = {}) {
+  const frameDays = period === 'day' ? 1 : period === 'month' ? 30 : 7;
   const buckets = {};
-  for (let i = 6; i >= 0; i -= 1) {
+  for (let i = frameDays - 1; i >= 0; i -= 1) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
-    buckets[DAYS_OF_WEEK[d.getDay()]] = 0;
+    buckets[toDateKey(d)] = 0;
   }
 
   for (const trip of Array.isArray(trips) ? trips : []) {
@@ -139,9 +145,9 @@ export function buildWeeklyChart(trips, now = new Date()) {
     if (Number.isNaN(tripDate.getTime())) {
       continue;
     }
-    const label = DAYS_OF_WEEK[tripDate.getDay()];
-    if (buckets[label] !== undefined) {
-      buckets[label] += toAmount(trip.total_earnings);
+    const key = toDateKey(tripDate);
+    if (buckets[key] !== undefined) {
+      buckets[key] += toAmount(trip.total_earnings);
     }
   }
 

--- a/backend/api/test/unit/earningsReportService.test.js
+++ b/backend/api/test/unit/earningsReportService.test.js
@@ -162,17 +162,23 @@ describe('sumEarnings', () => {
 });
 
 describe('buildWeeklyChart', () => {
-  it('always returns seven day buckets', () => {
-    expect(buildWeeklyChart([], BASE)).toHaveLength(7);
+  it('always returns seven day buckets for the week period', () => {
+    expect(buildWeeklyChart([], { period: 'week', now: BASE })).toHaveLength(7);
   });
 
-  it('buckets earnings onto the correct weekday', () => {
+  it('returns one bucket for the day period and thirty for the month period', () => {
+    expect(buildWeeklyChart([], { period: 'day', now: BASE })).toHaveLength(1);
+    expect(buildWeeklyChart([], { period: 'month', now: BASE })).toHaveLength(30);
+  });
+
+  it('buckets earnings onto the correct calendar date', () => {
     const chart = buildWeeklyChart(
       [{ trip_date: daysFrom(BASE, 0), total_earnings: 5000 }],
-      BASE
+      { period: 'week', now: BASE }
     );
-    const total = chart.reduce((sum, bucket) => sum + bucket.earnings, 0);
-    expect(total).toBe(5000);
+    const bucketsWithEarnings = chart.filter((b) => b.earnings > 0);
+    expect(bucketsWithEarnings).toHaveLength(1);
+    expect(bucketsWithEarnings[0].day).toBe(daysFrom(BASE, 0));
   });
 
   it('accumulates multiple trips on the same day', () => {
@@ -181,15 +187,31 @@ describe('buildWeeklyChart', () => {
         { trip_date: daysFrom(BASE, 0), total_earnings: 5000 },
         { trip_date: daysFrom(BASE, 0), total_earnings: 3000 },
       ],
-      BASE
+      { period: 'week', now: BASE }
     );
     expect(chart.reduce((s, b) => s + b.earnings, 0)).toBe(8000);
+  });
+
+  it('does not merge the same weekday across different weeks', () => {
+    // 2026-07-12 and 2026-08-02 are exactly 21 days apart, so they share a
+    // weekday. They must land in distinct date buckets.
+    const chart = buildWeeklyChart(
+      [
+        { trip_date: '2026-07-12', total_earnings: 1000 },
+        { trip_date: '2026-08-02', total_earnings: 2000 },
+      ],
+      { period: 'month', now: new Date('2026-08-10T00:00:00.000Z') }
+    );
+    const bucketsWithEarnings = chart.filter((b) => b.earnings > 0);
+    expect(bucketsWithEarnings).toHaveLength(2);
+    expect(bucketsWithEarnings[0].day).toBe('2026-07-12');
+    expect(bucketsWithEarnings[1].day).toBe('2026-08-02');
   });
 
   it('ignores trips with an unparseable date', () => {
     const chart = buildWeeklyChart(
       [{ trip_date: 'not-a-date', total_earnings: 5000 }],
-      BASE
+      { period: 'week', now: BASE }
     );
     expect(chart.reduce((s, b) => s + b.earnings, 0)).toBe(0);
   });
@@ -197,14 +219,14 @@ describe('buildWeeklyChart', () => {
   it('treats a null total_earnings as zero', () => {
     const chart = buildWeeklyChart(
       [{ trip_date: daysFrom(BASE, 0), total_earnings: null }],
-      BASE
+      { period: 'week', now: BASE }
     );
     expect(chart.every((b) => Number.isFinite(b.earnings))).toBe(true);
   });
 
   it('handles empty and non-array input', () => {
-    expect(buildWeeklyChart(null, BASE)).toHaveLength(7);
-    expect(buildWeeklyChart(undefined, BASE)).toHaveLength(7);
+    expect(buildWeeklyChart(null, { period: 'week', now: BASE })).toHaveLength(7);
+    expect(buildWeeklyChart(undefined, { period: 'week', now: BASE })).toHaveLength(7);
   });
 });
 


### PR DESCRIPTION
## Problem

The driver earnings "Weekly Chart" bucketed earnings by **weekday name** and always rendered a fixed last-7-calendar-days frame regardless of the `?period=` value. The Day/Month toggles barely changed the chart, and the Month view folded 30 days of trips into 7 weekday bars (with the same weekday from different weeks summed together into one misleading bar).

## Fix

- Buckets are now keyed by the real calendar date (`YYYY-MM-DD`) instead of the weekday name, so trips from different weeks never merge into the same bar and the labels correspond to distinct days.
- The chart frame now follows the period the route queried: `day` -> 1 bar, `week` -> 7 bars, `month` -> 30 bars, instead of always 7 bars.
- Unit tests updated to cover the per-period frame, same-weekday-across-weeks separation, and date-keyed bucketing.

## Files changed

- `backend/api/src/routes/driverRoutes.js`
- `backend/api/src/services/driver/earningsReportService.js`
- `backend/api/test/unit/earningsReportService.test.js`

## Testing

- `npx vitest run test/unit/earningsReportService.test.js` - 37/37 passing, including the new cross-week weekday-separation and per-period frame tests.

Closes #8929
