### PR TITLE
fix(reconciliation): defer deletion until on-chain reputation updates succeed (fixes #9199)

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -77,23 +77,21 @@ export async function reconcileFailedReputationUpdates() {
       }
 
       try {
+        await awardReputationPoints(row.driver_wallet, row.stars);
+
         const { error: deleteError } = await supabaseAdmin.from('reputation_failures').delete().eq('id', row.id);
         if (deleteError) {
-          throw new Error(`Failed to claim reputation failure ${row.id} for processing: ${deleteError.message}`);
+          logger.error(`[reputation-reconciliation] Failed to delete resolved failure ${row.id}: ${deleteError.message}`);
         }
 
-        await awardReputationPoints(row.driver_wallet, row.stars);
         logger.info(`[reputation-reconciliation] Successfully retried reputation update for ${row.driver_wallet}`);
       } catch (err) {
         const newRetryCount = (row.retry_count ?? 0) + 1;
-        await supabaseAdmin.from('reputation_failures').upsert({
-          id: row.id,
-          driver_wallet: row.driver_wallet,
-          stars: row.stars,
+        await supabaseAdmin.from('reputation_failures').update({
           retry_count: newRetryCount,
           last_error: err.message,
           last_attempt_at: new Date().toISOString(),
-        });
+        }).eq('id', row.id);
         logger.warn(`[reputation-reconciliation] Retry ${newRetryCount}/${MAX_RETRIES} failed for ${row.driver_wallet}: ${err.message}`);
       }
     }

--- a/backend/api/test/unit/reputationReconciliation.test.js
+++ b/backend/api/test/unit/reputationReconciliation.test.js
@@ -43,6 +43,9 @@ function makeSupabaseMock() {
         eq: vi.fn(() => Promise.resolve({ error: null })),
       })),
       upsert: vi.fn(() => Promise.resolve({ error: null })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      })),
     })),
   };
 }
@@ -94,6 +97,9 @@ describe('reputationReconciliation', () => {
         eq: vi.fn(() => Promise.resolve({ error: null })),
       })),
       upsert: vi.fn(() => Promise.resolve({ error: null })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      })),
     };
     mockSupabaseAdmin.from = vi.fn(() => queryBuilder);
     return queryBuilder;


### PR DESCRIPTION
Description
This PR resolves an at-least-once delivery violation in the reputation reconciliation background service.

Previously, the worker reconcileFailedReputationUpdates deleted failure records from the database before attempting the on-chain update. If the server crashed or timed out during the slow execution of awardReputationPoints(), the database record was already gone and the catch block was never reached. This caused failed reputation updates to be permanently lost from the queue without ever being retried.

This PR restructures the worker loop so that we only delete the DB failure record after the on-chain update succeeds. If it fails, we update the existing record (instead of performing an upsert since it was not deleted) to increment the retry count and record the error message.

Key Changes:



reputationReconciliation.js
: Swapped execution order to call awardReputationPoints first, and perform the DB delete operation only on success.


reputationReconciliation.test.js
: Added mocks for the .update() Supabase query method to support the new database update logic.
This contribution is submitted as part of GSSoC'26 (GirlScript Summer of Code 2026).

Type of Change
 Bug fix (non-breaking change fixing an issue)
 New feature (non-breaking change adding functionality)
 Refactoring (code cleanup, performance, or structural changes)
 Documentation update
 CI/CD / DevOps / Infrastructure updates
How Has This Been Tested?
Test Commands:
bash
npx vitest run backend/api/test/unit/reputationReconciliation.test.js
Test Steps / Prerequisites: Ran the automated unit test suite inside the backend workspace.
Expected Result: Reconciliation unit tests pass completely.
Test Environment
 Local manual testing
 Unit / Integration tests (npm test, flutter test, etc.)
 Tested via Docker Compose
Related Issues
Closes #9199

PR Checklist
 My code follows the code style guidelines of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have updated corresponding documentation if applicable.
 My changes generate no new warnings or console errors.