### PR TITLE
fix(container): wire order services to service-role client in core/container.js

### DIFF
--- a/backend/api/src/services/order/orderValidationService.js
+++ b/backend/api/src/services/order/orderValidationService.js
@@ -1,22 +1,45 @@
 import { DomainError } from './domainError.js';
 import { policy } from '../../security/policyEngine.js';
+import { orderRepository } from '../../core/container.js';
 
 export class OrderValidationService {
-  constructor({ supabase, logger }) {
-    this.supabase = supabase;
+  constructor({ supabase, orderRepository, logger } = {}) {
+    this.supabase = supabase || null;
+    this.orderRepository = orderRepository || null;
     this.logger = logger;
+  }
+
+  async _unwrapOrderResult(result) {
+    const resolved = await result;
+    if (resolved && resolved.error) {
+      throw new DomainError(500, { error: 'Query failed.', details: resolved.error.message });
+    }
+    if (resolved && resolved.data !== undefined) return resolved.data;
+    return resolved;
   }
 
   async findOrderByIdOrDisplayId(identifier, select = '*') {
     const targetId = typeof identifier === 'string' && identifier.startsWith('TX-')
       ? identifier.slice(3)
       : identifier;
+
+    if (this.orderRepository) {
+      const byId = await this._unwrapOrderResult(this.orderRepository.findOrderById(targetId, select));
+      if (byId) return byId;
+      return (await this._unwrapOrderResult(this.orderRepository.findOrderByDisplayId(targetId, select))) || null;
+    }
+
     const { data: byId, error: errId } = await this.supabase.from('orders').select(select).eq('id', targetId).maybeSingle();
     if (errId) throw new DomainError(500, { error: 'Query failed.', details: errId.message });
     if (byId) return byId;
     const { data: byDisplay, error: errDisplay } = await this.supabase.from('orders').select(select).eq('order_display_id', targetId).maybeSingle();
     if (errDisplay) throw new DomainError(500, { error: 'Query failed.', details: errDisplay.message });
     return byDisplay || null;
+  }
+
+  validateOrderForBidAcceptance(order) {
+    if (!order) return false;
+    return ['pending'].includes(order.status);
   }
 
   assertOrderFound(order) {
@@ -202,3 +225,23 @@ export class OrderValidationService {
     }
   }
 }
+
+let defaultValidationService = null;
+
+function getDefaultValidationService() {
+  if (!defaultValidationService) {
+    defaultValidationService = new OrderValidationService({ orderRepository });
+  }
+  return defaultValidationService;
+}
+
+export default new Proxy({}, {
+  get(_target, prop) {
+    if (prop === 'then') return undefined;
+    return getDefaultValidationService()[prop];
+  },
+  set(_target, prop, value) {
+    getDefaultValidationService()[prop] = value;
+    return true;
+  },
+});


### PR DESCRIPTION
## Problem
`core/container.js` wires the order services to the session-less anon-key client. That client has no RLS policies on `orders`/`order_timeline`/`load_offers`, and `escrow_status`/`escrow_release_*` are REVOKE UPDATE for anon/authenticated — so every order-path read/write is a silent no-op (reads return nothing, writes drop), breaking orders, milestones, bids, tracking tokens, delivery verification and escrow release.

## Fix
Wire the order module off the service-role client (`supabaseAdmin`) in the container:
- `orderRepository` is now constructed from `supabaseAdmin` (falls back to anon only when no service-role key is configured); `adminOrderRepository` kept as a stable alias for release-path consumers.
- `OracleService`, `VerificationService`, `OrderValidationService`, and `TrackingTokenService` receive `supabase: supabaseAdmin || supabase`.
- `OrderValidationService` delegates `findOrderByIdOrDisplayId` to the injected `orderRepository` (direct-query path kept as fallback) and gains `validateOrderForBidAcceptance`; a lazy default export wired to the container repository keeps container mocks working.

## Files changed
- `backend/api/src/core/container.js`
- `backend/api/src/services/order/orderValidationService.js`

## Testing
- `test/unit/orderValidationService.test.js`: 5/5 pass (was 5/5 fail)
- `test/unit/orderRoutesGeofence.test.js`: 3/3, `rlsSecurity.test.js`: 146/146, `orderRepositoryStaleCancel.test.js`: 3/3, `services/orderTimelineService.test.js`: 13/13
- Full `test/unit` run: 1818 passed (was 1813); failures dropped 200→195 with no new failures introduced

Closes #8942
