### PR TITLE
fix(driver): run trip items/stops/route-points ownership and data reads through the user client

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -708,10 +708,11 @@ router.get('/trips/:tripDisplayId/items', authenticate, userLimiter, requirePoli
   const { tripDisplayId } = req.params;
 
   try {
-    const { data: trip } = await supabase.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
+    const userClient = createUserClient(req.token);
+    const { data: trip } = await userClient.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
     if (!trip) return res.status(403).json({ error: 'Access Denied: Trip does not belong to you.' });
 
-    const { data: items, error } = await supabase.from('trip_items').select('*').eq('trip_display_id', tripDisplayId);
+    const { data: items, error } = await userClient.from('trip_items').select('*').eq('trip_display_id', tripDisplayId);
 
     if (error) return res.status(500).json({ error: 'Failed to fetch trip items.', details: error.message });
     res.json(items || []);
@@ -750,10 +751,11 @@ router.get('/trips/:tripDisplayId/stops', authenticate, userLimiter, requirePoli
   const { tripDisplayId } = req.params;
 
   try {
-    const { data: trip } = await supabase.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
+    const userClient = createUserClient(req.token);
+    const { data: trip } = await userClient.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
     if (!trip) return res.status(403).json({ error: 'Access Denied: Trip does not belong to you.' });
 
-    const { data: stops, error } = await supabase.from('trip_stops').select('*').eq('trip_display_id', tripDisplayId).order('sort_order', { ascending: true });
+    const { data: stops, error } = await userClient.from('trip_stops').select('*').eq('trip_display_id', tripDisplayId).order('sort_order', { ascending: true });
 
     if (error) return res.status(500).json({ error: 'Failed to fetch trip stops.', details: error.message });
     res.json(stops || []);
@@ -792,10 +794,11 @@ router.get('/trips/:tripDisplayId/route-points', authenticate, userLimiter, requ
   const { tripDisplayId } = req.params;
 
   try {
-    const { data: trip } = await supabase.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
+    const userClient = createUserClient(req.token);
+    const { data: trip } = await userClient.from('trips').select('id').eq('trip_display_id', tripDisplayId).eq('driver_id', req.user.id).maybeSingle();
     if (!trip) return res.status(403).json({ error: 'Access Denied: Trip does not belong to you.' });
 
-    const { data: points, error } = await supabase.from('route_map_points').select('*').eq('trip_display_id', tripDisplayId).order('sort_order', { ascending: true });
+    const { data: points, error } = await userClient.from('route_map_points').select('*').eq('trip_display_id', tripDisplayId).order('sort_order', { ascending: true });
 
     if (error) return res.status(500).json({ error: 'Failed to fetch route points.', details: error.message });
     res.json(points || []);


### PR DESCRIPTION
## Problem

Three driver endpoints — `GET /api/driver/trips/:tripDisplayId/items`, `/stops`, and `/route-points` — perform their ownership check (and the subsequent data reads) through the shared **session-less anon-key client** (`supabase` from `config/db.js`). Under this repo's RLS, `trips` has no `anon` policy (drivers read own trips via `authenticated` only), so the anon-client query always returns zero rows and every request returns `403 Access Denied: Trip does not belong to you.`, even for the assigned driver.

## Fix

Replace `supabase` with a per-request authenticated client in the three handlers (`driverRoutes.js`), mirroring the existing pattern at `driverRoutes.js:1001` (`createUserClient(req.token)`):

- `GET /trips/:tripDisplayId/items` — ownership check and `trip_items` read run through the user client.
- `GET /trips/:tripDisplayId/stops` — ownership check and `trip_stops` read run through the user client.
- `GET /trips/:tripDisplayId/route-points` — ownership check and `route_map_points` read run through the user client.

With the caller's JWT attached, `get_profile_id()` resolves to the driver's own profile id and RLS permits the ownership check and the reads.

## Files changed

- `backend/api/src/routes/driverRoutes.js`

## Testing

- Ownership queries now run under `createUserClient(req.token)` exactly like the withdrawal RPC at `driverRoutes.js:1001`, so RLS resolves to the authenticated driver.

Closes #8943
