### PR TITLE
fix(api): stop folding null order fields into performance stats (#8933)

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -756,15 +756,26 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
 
     const trips = orders || [];
     const totalDeliveries = trips.length;
-    const totalDistance = trips.reduce((acc, t) => acc + (Number(t.distance_km) || 0), 0);
-    
-    // Calculate average rating
-    const ratings = trips.map(t => Number(t.customer_rating)).filter(r => !isNaN(r) && r > 0);
-    const averageRating = ratings.length > 0 ? Number((ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1)) : 0;
 
-    // Calculate on-time percentage
-    const onTimeCount = trips.filter(t => t.on_time !== false).length;
-    const onTimePercentage = totalDeliveries > 0 ? Number(((onTimeCount / totalDeliveries) * 100).toFixed(1)) : 0;
+    // Distance — orders without a recorded distance_km are excluded, never guessed
+    const distancedTrips = trips.filter(t => t.distance_km !== null && t.distance_km !== undefined);
+    const totalDistance = distancedTrips.reduce((acc, t) => acc + (Number(t.distance_km) || 0), 0);
+
+    // Average rating — orders without a recorded rating are excluded, never guessed
+    const ratedTrips = trips.filter(t => t.customer_rating !== null && t.customer_rating !== undefined);
+    const ratings = ratedTrips.map(t => Number(t.customer_rating)).filter(r => !isNaN(r) && r > 0);
+    const averageRating = ratings.length > 0 ? Number((ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1)) : null;
+
+    // On-time percentage — an unset (null) on_time flag is not proof of being on-time
+    const onTimeTrips = trips.filter(t => t.on_time !== null && t.on_time !== undefined);
+    const onTimeCount = onTimeTrips.filter(t => t.on_time === true).length;
+    const onTimePercentage = onTimeTrips.length > 0 ? Number(((onTimeCount / onTimeTrips.length) * 100).toFixed(1)) : null;
+
+    const insufficientData = {
+      distanceKm: distancedTrips.length < totalDeliveries,
+      rating: ratedTrips.length === 0,
+      onTime: onTimeTrips.length === 0,
+    };
 
     // Lifetime earnings
     const lifetimeEarnings = trips.reduce((acc, t) => acc + (Number(t.base_freight) || 0), 0);
@@ -794,7 +805,8 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
       onTimePercentage,
       lifetimeEarnings: Number(lifetimeEarnings.toFixed(2)),
       monthlyPerformanceSummary,
-      achievementBadges: badges
+      achievementBadges: badges,
+      insufficientData,
     });
   } catch (err) {
     logger.error(err);

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -56,6 +56,7 @@ describe('Profile Routes', () => {
     m.store.profiles = [];
     m.store.customer_stats = [];
     m.store.driver_details = [];
+    m.store.orders = [];
     m.calls.length = 0;
     vi.clearAllMocks();
   });
@@ -652,10 +653,48 @@ describe('Profile Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.totalDeliveries).toBe(0);
       expect(res.body.totalDistanceKm).toBe(0);
-      expect(res.body.averageRating).toBe(0);
-      expect(res.body.onTimePercentage).toBe(0);
+      expect(res.body.averageRating).toBeNull();
+      expect(res.body.onTimePercentage).toBeNull();
       expect(res.body.lifetimeEarnings).toBe(0);
       expect(res.body.achievementBadges).toEqual([]);
+      expect(res.body.insufficientData).toEqual({ distanceKm: false, rating: true, onTime: true });
+    });
+
+    it('does not count null distance/rating/on_time as real data', async () => {
+      const currentMonth = new Date().toISOString().slice(0, 7);
+      m.store.orders.push(
+        {
+          id: 'order-incomplete',
+          driver_id: 'driver-uuid-456',
+          status: 'delivered',
+          distance_km: null,
+          customer_rating: null,
+          on_time: null,
+          base_freight: 1000,
+          created_at: `${currentMonth}-05T00:00:00Z`,
+        },
+        {
+          id: 'order-complete',
+          driver_id: 'driver-uuid-456',
+          status: 'payment_released',
+          distance_km: 10,
+          customer_rating: 5,
+          on_time: true,
+          base_freight: 2000,
+          created_at: `${currentMonth}-10T00:00:00Z`,
+        }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/profile/driver/performance-stats')
+        .set(DRIVER_HEADERS);
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalDeliveries).toBe(2);
+      expect(res.body.totalDistanceKm).toBe(10);
+      expect(res.body.averageRating).toBe(5);
+      expect(res.body.onTimePercentage).toBe(100);
+      expect(res.body.insufficientData).toEqual({ distanceKm: true, rating: false, onTime: false });
     });
   });
 });


### PR DESCRIPTION
## Fixes #8933

`GET /api/profile/driver/performance-stats` presented invented data as real performance metrics: orders without a recorded `distance_km`/`customer_rating`/`on_time` were folded into aggregates (0 km, 0 rating, null `on_time` counted as on-time pushing the percentage toward 100), and achievements could be influenced by those fallback values.

### Changes
- `backend/api/src/routes/profileRoutes.js`:
  - Orders without a `distance_km` are excluded from the distance aggregate — never guessed.
  - Orders without a `customer_rating` are excluded from the rating aggregate; `averageRating` is `null` when there is no underlying data.
  - An unset (`null`) `on_time` flag is no longer counted as on-time; `onTimePercentage` is `null` when no `on_time` data exists.
  - New `insufficientData` flag (`{ distanceKm, rating, onTime }`) lets clients render "—" instead of invented numbers.
  - Badges (`long_hauler`, `top_rated`) can no longer be earned from fallback data.

### Tests
- `backend/api/test/integration/profileRoutes.test.js`:
  - New test "does not count null distance/rating/on_time as real data".
  - Updated "returns zeros instead of fabricated values when there is no data" to expect `null` stats + `insufficientData`.
  - `beforeEach` now clears `m.store.orders` — the shared harness was accumulating orders across tests, making the stats assertions non-deterministic (left 2 unrelated tests red at HEAD).

Verified: the 2 stats tests pass; the remaining 2 failures in the file (`truckId` field set, wallet address) are pre-existing on `main` (same failures at `origin/main`).
