### PR TITLE
fix(db): create blockchain monitoring tables and write via service-role client

### DIFF
--- a/backend/api/src/services/blockchain/blockchainMetrics.js
+++ b/backend/api/src/services/blockchain/blockchainMetrics.js
@@ -1,5 +1,5 @@
 import logger from '../../middleware/logger.js';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 class BlockchainMetrics {
@@ -104,7 +104,7 @@ class BlockchainMetrics {
           insurance_events_count: this.metrics.insuranceEventsCount,
         };
 
-        await supabase
+        await (supabaseAdmin || supabase)
           .from('blockchain_metrics')
           .insert([aggregatedMetrics]);
 

--- a/backend/api/src/services/blockchain/blockchainMonitor.js
+++ b/backend/api/src/services/blockchain/blockchainMonitor.js
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const PAYMENT_RECEIVED_EVENT = 'PaymentReceived(address indexed driver, uint256 amount, uint256 timestamp)';
@@ -264,7 +264,7 @@ class BlockchainMonitor {
 
   async storeEvent(alert) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('blockchain_monitoring_events')
         .insert([{
           type: alert.type,

--- a/backend/api/src/services/blockchain/escalationHandler.js
+++ b/backend/api/src/services/blockchain/escalationHandler.js
@@ -1,6 +1,6 @@
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const ESCALATION_THRESHOLDS = {
@@ -185,7 +185,7 @@ class EscalationHandler {
 
   async storeEscalation(record) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('blockchain_escalations')
         .upsert([{
           alert_id: record.alertId,

--- a/backend/api/test/unit/blockchainMonitoringMigration.test.js
+++ b/backend/api/test/unit/blockchainMonitoringMigration.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = '20260810130000_create_blockchain_monitoring_tables.sql';
+const readMigration = () =>
+  readFileSync(path.resolve(__dirname, `../../../../supabase/migrations/${MIGRATION}`), 'utf8');
+
+describe(`Migration ${MIGRATION} — blockchain monitoring tables`, () => {
+  const content = readMigration();
+
+  it('creates the three tables documented in blockchain-monitoring-setup.md', () => {
+    expect(content).toMatch(/create table if not exists blockchain_monitoring_events/);
+    expect(content).toMatch(/create table if not exists blockchain_escalations/);
+    expect(content).toMatch(/create table if not exists blockchain_metrics/);
+  });
+
+  it('does not drop existing tables', () => {
+    expect(content).not.toMatch(/DROP TABLE/);
+  });
+
+  it('defines the blockchain_monitoring_events columns the monitor inserts', () => {
+    expect(content).toMatch(/type varchar/);
+    expect(content).toMatch(/severity varchar/);
+    expect(content).toMatch(/data jsonb/);
+    expect(content).toMatch(/created_at/);
+  });
+
+  it('defines the blockchain_escalations columns the escalation handler upserts', () => {
+    expect(content).toMatch(/alert_id varchar\(255\) primary key/);
+    expect(content).toMatch(/alert_type varchar/);
+    expect(content).toMatch(/escalation_level int/);
+    expect(content).toMatch(/escalation_history jsonb/);
+  });
+
+  it('defines the blockchain_metrics columns the metrics aggregator inserts', () => {
+    expect(content).toMatch(/contract_call_success_rate int/);
+    expect(content).toMatch(/payment_processing_latency_avg int/);
+    expect(content).toMatch(/withdrawal_queue_depth int/);
+    expect(content).toMatch(/failed_transaction_count int/);
+    expect(content).toMatch(/driver_payout_delay_avg int/);
+    expect(content).toMatch(/blocks_scanned_per_day int/);
+    expect(content).toMatch(/geofence_breach_count int/);
+    expect(content).toMatch(/insurance_events_count int/);
+  });
+
+  it('adds lookup indexes for the API and monitor queries', () => {
+    expect(content).toMatch(/create index if not exists idx_monitoring_events_type/i);
+    expect(content).toMatch(/create index if not exists idx_monitoring_events_created_at/i);
+    expect(content).toMatch(/create index if not exists idx_metrics_timestamp/i);
+  });
+
+  it('enables RLS and grants service_role full access (admin-only data)', () => {
+    expect(content).toMatch(/alter table blockchain_monitoring_events enable row level security/);
+    expect(content).toMatch(/alter table blockchain_escalations enable row level security/);
+    expect(content).toMatch(/alter table blockchain_metrics enable row level security/);
+    expect(content).toMatch(/to service_role using \(true\) with check \(true\)/);
+  });
+});

--- a/supabase/migrations/20260810130000_create_blockchain_monitoring_tables.sql
+++ b/supabase/migrations/20260810130000_create_blockchain_monitoring_tables.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- Migration: create blockchain monitoring tables
+-- =============================================================================
+-- Problem:
+--   The /api/blockchain/* API (wired in #7336) queries blockchain_monitoring_events,
+--   blockchain_escalations and blockchain_metrics, but no migration ever created
+--   them. Fresh provisioning returned PostgREST PGRST301 for every table-backed
+--   endpoint, and the background metrics aggregator logged an error every 60s.
+--
+-- Fix:
+--   Create the three tables exactly as documented in
+--   docs/blockchain-monitoring-setup.md, enable RLS and grant service_role full
+--   access (the background writers use the service-role client and the API reads
+--   through supabaseAdmin), so monitoring data is admin-only.
+-- =============================================================================
+
+begin;
+
+create table if not exists blockchain_monitoring_events (
+  id bigserial primary key,
+  type varchar(255) not null,
+  severity varchar(50) not null,
+  data jsonb,
+  created_at timestamp default now()
+);
+
+create index if not exists idx_monitoring_events_type on blockchain_monitoring_events(type);
+create index if not exists idx_monitoring_events_created_at on blockchain_monitoring_events(created_at);
+
+create table if not exists blockchain_escalations (
+  alert_id varchar(255) primary key,
+  alert_type varchar(255) not null,
+  severity varchar(50),
+  escalation_level int,
+  created_at timestamp,
+  resolved boolean default false,
+  resolved_at timestamp,
+  escalation_history jsonb,
+  data jsonb
+);
+
+create index if not exists idx_escalations_created_at on blockchain_escalations(created_at);
+create index if not exists idx_escalations_resolved on blockchain_escalations(resolved);
+
+create table if not exists blockchain_metrics (
+  id bigserial primary key,
+  timestamp timestamp default now(),
+  contract_call_success_rate int,
+  payment_processing_latency_avg int,
+  withdrawal_queue_depth int,
+  failed_transaction_count int,
+  driver_payout_delay_avg int,
+  blocks_scanned_per_day int,
+  geofence_breach_count int,
+  insurance_events_count int
+);
+
+create index if not exists idx_metrics_timestamp on blockchain_metrics(timestamp);
+
+alter table blockchain_monitoring_events enable row level security;
+alter table blockchain_escalations enable row level security;
+alter table blockchain_metrics enable row level security;
+
+drop policy if exists "Service role full access on blockchain_monitoring_events" on blockchain_monitoring_events;
+create policy "Service role full access on blockchain_monitoring_events"
+  on blockchain_monitoring_events for all to service_role using (true) with check (true);
+
+drop policy if exists "Service role full access on blockchain_escalations" on blockchain_escalations;
+create policy "Service role full access on blockchain_escalations"
+  on blockchain_escalations for all to service_role using (true) with check (true);
+
+drop policy if exists "Service role full access on blockchain_metrics" on blockchain_metrics;
+create policy "Service role full access on blockchain_metrics"
+  on blockchain_metrics for all to service_role using (true) with check (true);
+
+commit;


### PR DESCRIPTION
## Problem

`/api/blockchain/*` (wired in #7336) queries three tables — `blockchain_monitoring_events`, `blockchain_escalations` and `blockchain_metrics` — but no migration ever created them. On a freshly provisioned database every table-backed endpoint returned PostgREST `PGRST301` (relation does not exist), and the background metrics aggregator logged an error every 60s.

## Fix

- New migration `20260810130000_create_blockchain_monitoring_tables.sql` creates the three tables with the exact schema documented in `docs/blockchain-monitoring-setup.md` (`CREATE TABLE IF NOT EXISTS`), adds lookup indexes, enables RLS and grants `service_role` full access so monitoring data stays admin-only.
- The background writers (`blockchainMonitor.storeEvent`, `escalationHandler.storeEscalation`, `blockchainMetrics.aggregateMetrics`) now write through the service-role client (`supabaseAdmin || supabase`) so they persist once the tables exist — matching the `staleOrderWorker` pattern.
- The API read path already uses `req.supabase` (the admin client injected by the route middleware), so reads need no change.

## Files changed

- `supabase/migrations/20260810130000_create_blockchain_monitoring_tables.sql`
- `backend/api/src/services/blockchain/blockchainMonitor.js`
- `backend/api/src/services/blockchain/escalationHandler.js`
- `backend/api/src/services/blockchain/blockchainMetrics.js`
- `backend/api/test/unit/blockchainMonitoringMigration.test.js`

## Testing

- New `blockchainMonitoringMigration.test.js` asserts the three tables, their columns, indexes and RLS policies are created and nothing is dropped (7/7 pass).
- `blockchainMonitoringRoutes.test.js` (5/5) and `services/blockchainMonitoring.test.js` (8/8) pass.
- ESLint clean on all changed files.

Closes #8944
