### PR TITLE
fix(api): make /api/health/sentry-debug capture and gate the sample error (#8934)

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -52,6 +52,14 @@ export function captureException(err) {
   }
 }
 
+export function captureDebugException(err) {
+  if (!process.env.SENTRY_DSN) return null;
+  return Sentry.withScope((scope) => {
+    scope.setTag('debug', 'true');
+    return Sentry.captureException(err);
+  });
+}
+
 export function sentryErrorHandler() {
   if (typeof Sentry.Handlers?.errorHandler === 'function') {
     return Sentry.Handlers.errorHandler();

--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -63,6 +63,7 @@ import { healthLimiter } from '../middleware/rateLimiter.js';
 import { checkEscrowHealth } from '../services/escrow.js';
 import logger from '../middleware/logger.js';
 import { createDefaultAggregator } from '../core/health/index.js';
+import { captureDebugException } from '../middleware/sentry.js';
 
 const router = express.Router();
 
@@ -313,7 +314,19 @@ router.get('/full', healthLimiter, async (req, res) => {
 });
 
 router.get('/sentry-debug', healthLimiter, (req, res) => {
-  throw new Error('Sentry Test Error from Node.js Backend');
+  // Debug-only route: fail-closed unless explicitly enabled outside production.
+  if (process.env.SENTRY_DEBUG_ENABLED !== 'true' || process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
+  const err = new Error('Sentry Test Error from Node.js Backend');
+  err.name = 'SentryDebugTestError';
+  const eventId = captureDebugException(err);
+
+  if (eventId) {
+    return res.status(200).json({ sent: true, eventId });
+  }
+  return res.status(503).json({ sent: false, error: 'Sentry is not configured (SENTRY_DSN unset).' });
 });
 
 export default router;

--- a/backend/api/test/integration/healthRoutes.test.js
+++ b/backend/api/test/integration/healthRoutes.test.js
@@ -26,6 +26,11 @@ vi.mock('../../src/middleware/logger.js', () => ({
   }
 }));
 
+const mockCaptureDebugException = vi.fn();
+vi.mock('../../src/middleware/sentry.js', () => ({
+  captureDebugException: (...args) => mockCaptureDebugException(...args),
+}));
+
 const { default: healthRouter } = await import('../../src/routes/healthRoutes.js');
 
 function buildApp() {
@@ -216,10 +221,30 @@ describe('GET /api/health/sentry-debug', () => {
 
   beforeEach(() => {
     app = buildApp();
+    mockCaptureDebugException.mockReset();
   });
 
-  it('triggers a Sentry debug error and returns 500', async () => {
+  it('returns 404 when the debug route is not enabled', async () => {
+    delete process.env.SENTRY_DEBUG_ENABLED;
     const res = await request(app).get('/api/health/sentry-debug');
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(404);
+    expect(mockCaptureDebugException).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when enabled but Sentry is not configured', async () => {
+    process.env.SENTRY_DEBUG_ENABLED = 'true';
+    mockCaptureDebugException.mockReturnValue(null);
+    const res = await request(app).get('/api/health/sentry-debug');
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ sent: false, error: 'Sentry is not configured (SENTRY_DSN unset).' });
+    expect(mockCaptureDebugException).toHaveBeenCalled();
+  });
+
+  it('captures a sample event and returns its id when enabled', async () => {
+    process.env.SENTRY_DEBUG_ENABLED = 'true';
+    mockCaptureDebugException.mockReturnValue('test-event-id');
+    const res = await request(app).get('/api/health/sentry-debug');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ sent: true, eventId: 'test-event-id' });
   });
 });

--- a/backend/api/test/unit/sentry.test.js
+++ b/backend/api/test/unit/sentry.test.js
@@ -17,6 +17,7 @@ import {
   flushSentry,
   sentryErrorHandler,
   shouldIgnoreError,
+  captureDebugException,
 } from "../../src/middleware/sentry.js";
 
 vi.mock("../../src/middleware/logger.js", () => ({
@@ -28,6 +29,8 @@ vi.mock("@sentry/node", async (real) => ({
   init: vi.fn(),
   flush: vi.fn(),
   expressErrorHandler: () => vi.fn(),
+  withScope: vi.fn((fn) => fn({ setTag: vi.fn() })),
+  captureException: vi.fn(() => "mock-event-id"),
 }));
 
 const Sentry = SentryModule;
@@ -70,6 +73,27 @@ describe("flushSentry", () => {
     vi.stubEnv("SENTRY_DSN", "https://abc@sentry.io/123");
     vi.mocked(Sentry.flush).mockRejectedValue(new Error("flush failed"));
     await expect(flushSentry(2000)).resolves.toBeUndefined();
+  });
+});
+
+describe("captureDebugException", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("returns null when SENTRY_DSN is not set", () => {
+    expect(captureDebugException(new Error("x"))).toBeNull();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("captures the error with a debug tag and returns the event id", () => {
+    vi.stubEnv("SENTRY_DSN", "https://abc@sentry.io/123");
+    const err = new Error("Sentry Test Error from Node.js Backend");
+    const id = captureDebugException(err);
+    expect(Sentry.withScope).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(err);
+    expect(id).toBe("mock-event-id");
   });
 });
 


### PR DESCRIPTION
## Fixes #8934

`GET /api/health/sentry-debug` unconditionally threw, so the error only reached the generic Express error handler (after `sentryErrorHandler` had already run): no tagged Sentry sample event was produced, just an unhandled `500`. The route was also publicly reachable on both `/api/health` and `/api/v1/health`.

### Changes
- `backend/api/src/middleware/sentry.js`: new `captureDebugException(err)` helper — `Sentry.withScope` + `setTag('debug', 'true')` + `Sentry.captureException`, returns the event id (or `null` when `SENTRY_DSN` is unset).
- `backend/api/src/routes/healthRoutes.js`: the handler now captures the error via `captureDebugException` and returns a structured `200 { sent, eventId }` when captured, or `503 { sent: false }` when Sentry isn't configured. The route is fail-closed: `404` unless `SENTRY_DEBUG_ENABLED=true` and `NODE_ENV` is not `production`, so it can no longer be triggered by anonymous callers in normal deployments.

### Tests
- `backend/api/test/integration/healthRoutes.test.js`: 404 when not enabled; 503 when enabled but Sentry unconfigured; 200 with event id when captured (mocks `captureDebugException` from `middleware/sentry.js`).
- `backend/api/test/unit/sentry.test.js`: `captureDebugException` returns null without `SENTRY_DSN`; captures with the debug tag and returns the event id.

Verified: `healthRoutes.test.js` (13) and `sentry.test.js` (12, including the 2 new `captureDebugException` tests) pass. The 2 failing `sentryErrorHandler` tests are pre-existing on `main` (identical failures at `origin/main`).
