### PR TITLE
fix(api): page document expiry window sweep past PostgREST row cap

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -10,6 +10,7 @@ const REMINDER_WINDOWS = [
 ];
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DOCS_PAGE_SIZE = 1000;
 const LOCK_KEY = 'document:expiry:worker:lock';
 const LOCK_TTL_SECONDS = 600;
 const LEASE_EXTENSION_INTERVAL_MS = (LOCK_TTL_SECONDS * 1000) / 2;
@@ -127,21 +128,29 @@ export async function processDocumentExpiryBatch() {
 
       let documents = [];
       try {
-        const { data, error } = await supabaseAdmin
-          .from('documents')
-          .select('id, user_id, doc_type, valid_until')
-          .not('valid_until', 'is', null)
-          .gte('valid_until', windowStart.toISOString())
-          .lte('valid_until', windowEnd.toISOString());
+        let offset = 0;
+        let page = [];
+        do {
+          const { data, error } = await supabaseAdmin
+            .from('documents')
+            .select('id, user_id, doc_type, valid_until')
+            .not('valid_until', 'is', null)
+            .gte('valid_until', windowStart.toISOString())
+            .lte('valid_until', windowEnd.toISOString())
+            .order('valid_until', { ascending: true })
+            .order('id', { ascending: true })
+            .range(offset, offset + DOCS_PAGE_SIZE - 1);
 
-        if (error) {
-          logger.error(`[document-expiry] Failed to query documents for ${window.label} window:`, error.message);
-          continue;
-        }
+          if (error) {
+            throw new Error(error.message);
+          }
 
-        documents = data || [];
+          page = data || [];
+          documents.push(...page);
+          offset += page.length;
+        } while (page.length === DOCS_PAGE_SIZE);
       } catch (err) {
-        logger.error(`[document-expiry] Error querying documents for ${window.label} window:`, err.message);
+        logger.error(`[document-expiry] Failed to query documents for ${window.label} window:`, err.message);
         continue;
       }
 

--- a/backend/api/test/unit/documentExpiryService.test.js
+++ b/backend/api/test/unit/documentExpiryService.test.js
@@ -8,6 +8,8 @@ function makeBuilder(result) {
     not() { return this; },
     gte() { return this; },
     lte() { return this; },
+    order() { return this; },
+    range() { return this; },
     eq() { return this; },
     maybeSingle() { return this; },
     then(resolve) { return resolve(result); },
@@ -63,6 +65,50 @@ describe('documentExpiryService', () => {
       expect.any(String),
       'document',
       expect.objectContaining({ documentId: 'doc-1', daysRemaining: expect.any(Number) })
+    );
+  });
+
+  it('pages the window sweep past the PostgREST 1000-row cap until fewer than a full page remains', async () => {
+    const pageOf1000 = Array.from({ length: 1000 }, (_, i) => ({
+      id: `doc-${i + 1}`,
+      user_id: 'user-1',
+      doc_type: 'rc_book',
+      valid_until: '2099-01-01T00:00:00.000Z',
+    }));
+
+    const notificationsResult = { data: [], error: null };
+    const responses = [pageOf1000, [{ id: 'doc-tail', user_id: 'user-2', doc_type: 'insurance', valid_until: '2099-02-01T00:00:00.000Z' }]];
+
+    const paginatedBuilder = {
+      from: vi.fn((table) => {
+        if (table === 'documents') {
+          return makeBuilder({ data: responses.shift() ?? [], error: null });
+        }
+        return makeBuilder(notificationsResult);
+      }),
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      supabase: supabaseAnonBuilder,
+      supabaseAdmin: paginatedBuilder,
+      redisClient: {
+        set: vi.fn().mockResolvedValue('OK'),
+        eval: vi.fn().mockResolvedValue(1),
+      },
+    }));
+
+    const { processDocumentExpiryBatch } = await import('../../src/services/documentExpiryService.js');
+    await processDocumentExpiryBatch();
+
+    const docCalls = paginatedBuilder.from.mock.calls.filter(([table]) => table === 'documents');
+    expect(docCalls.length).toBeGreaterThan(1);
+    expect(sendPushNotificationMock).toHaveBeenCalledWith(
+      'user-2',
+      expect.any(String),
+      expect.any(String),
+      'document',
+      expect.objectContaining({ documentId: 'doc-tail' })
     );
   });
 });


### PR DESCRIPTION
Fixes #9218

## Summary

`processDocumentExpiryBatch` queried each reminder window's expiring documents with no `.limit()`, `.range()`, or `.order()`. Supabase/PostgREST caps a single response at 1000 rows, so when more than 1000 documents expired in one window, only the first 1000 were notified and the rest were silently dropped (never retried for that window).

## Changes

- `backend/api/src/services/documentExpiryService.js`
  - Page the window sweep with a deterministic `.order('valid_until')` / `.order('id')` and `.range(offset, offset + DOCS_PAGE_SIZE - 1)`, looping until fewer than a full page remains.
  - Added `DOCS_PAGE_SIZE` (1000) constant.
- `backend/api/test/unit/documentExpiryService.test.js`
  - Extended the builder mock with `order()`/`range()` chain methods.
  - Added a test that pages past a full 1000-row page and still notifies a document on the next page.

## Test

```
npx vitest run test/unit/documentExpiryService.test.js  -> 2 passed
```

### GSSOC Contribution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document expiry processing for large volumes of documents.
  * Ensured records beyond the first 1,000 are included when processing expiry reminders.
  * Maintained consistent ordering while processing documents across multiple batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->