### PR TITLE
fix(k8s): supply the webhook and Supabase env secrets the API actually reads

### DIFF
--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -11,7 +11,9 @@ data:
   ESCROW_CONTRACT_ADDRESS: <base64-encoded-escrow-address>
   RELAYER_WALLET_PRIVATE_KEY: <base64-encoded-private-key>
   SUPABASE_URL: <base64-encoded-supabase-url>
-  SUPABASE_KEY: <base64-encoded-supabase-key>
+  SUPABASE_ANON_KEY: <base64-encoded-supabase-anon-key>
+  SUPABASE_SERVICE_ROLE_KEY: <base64-encoded-supabase-service-role-key>
+  WEBHOOK_SECRET: <base64-encoded-webhook-secret>
   JWT_SECRET: <base64-encoded-jwt-secret>
   SHARD_PASSWORD_NORTH: <base64-encoded-shard-password-north>
   SHARD_PASSWORD_SOUTH: <base64-encoded-shard-password-south>


### PR DESCRIPTION
## Problem

The API's escrow webhook fails closed: `backend/api/src/index.js` fatals at startup when `WEBHOOK_SECRET` is unset, and `backend/api/src/config/db.js` reads `SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_ROLE_KEY`. `k8s/secrets.yaml` still shipped `SUPABASE_KEY` (which no code reads) and was missing all three variables, so a cluster install could never boot the API pod.

## Fix

Replace the unused `SUPABASE_KEY` with `SUPABASE_ANON_KEY` and add `SUPABASE_SERVICE_ROLE_KEY` and `WEBHOOK_SECRET`, matching exactly the names the API requires (already documented in `.env.example`).

## Files changed

- `k8s/secrets.yaml`

## Testing

Cross-checked the required env var names against `backend/api/src/config/db.js` and `backend/api/src/index.js`; `k8s/secrets.yaml` now supplies all three. No local cluster available for a full deploy test.

Closes #8967
