### PR TITLE
fix(blockchain): normalize secondary-market order cost to the 1e18-scaled price

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -332,7 +332,7 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         require(order.expiresAt > block.timestamp, "Order expired");
         require(order.seller != msg.sender, "Cannot buy own order");
 
-        uint256 totalCost = order.amount * order.price;
+        uint256 totalCost = (order.amount * order.price) / 1e18;
         require(msg.value >= totalCost, "Insufficient payment");
 
         // Increment buyer's fractional ownership. The escrowed tokens keep

--- a/blockchain/test/AssetToken.test.js
+++ b/blockchain/test/AssetToken.test.js
@@ -421,4 +421,83 @@ describe("AssetToken", function () {
     assert.equal(await assetToken.getIssuedTokens(1), 0n);
     assert.equal(await assetToken.totalSupply(), 0n);
   });
+
+  it("should charge the 1e18-normalized cost on an exact secondary-market trade", async function () {
+    const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    // tokenPrice = 1 ETH/token. buyer1 funds 10 tokens.
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("10"), {
+      value: ethers.parseEther("10")
+    });
+
+    // List 10 tokens at 1.5 ETH/token (price is stored in the 1e18-scaled unit).
+    await assetToken.connect(buyer1).createTradeOrder(1, ethers.parseEther("10"), ethers.parseEther("1.5"), "sell");
+
+    // Correct cost = 10 tokens * 1.5 ETH = 15 ETH. Before the 1e18
+    // normalization the contract demanded 1e18x this value and every
+    // secondary-market execution reverted with "Insufficient payment".
+    const sellerBalanceBefore = await ethers.provider.getBalance(buyer1.address);
+    await assetToken.connect(buyer2).executeTradeOrder(1, 0, {
+      value: ethers.parseEther("15")
+    });
+    const sellerBalanceAfter = await ethers.provider.getBalance(buyer1.address);
+
+    // The seller receives exactly 15 ETH (the seller pays no gas on execution).
+    assert.equal(sellerBalanceAfter - sellerBalanceBefore, ethers.parseEther("15"));
+
+    // The order is filled and buyer2 holds the escrowed tokens.
+    const order = (await assetToken.getTradeOrders(1))[0];
+    assert.equal(order.isActive, false);
+    assert.equal(order.buyer, buyer2.address);
+    const buyer2Ownership = await assetToken.getFractionalOwnership(1, buyer2.address);
+    assert.equal(buyer2Ownership.amount, ethers.parseEther("10"));
+  });
+
+  it("should floor the 1e18-normalized cost and refund excess on non-exact trade amounts", async function () {
+    const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    // tokenPrice = 1 ETH/token. buyer1 funds a fractional 1.5 tokens.
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("1.5"), {
+      value: ethers.parseEther("1.5")
+    });
+
+    // List the 1.5 tokens at price = 3 wei per token. The 1e18-normalized
+    // cost is floor(1.5e18 * 3 / 1e18) = floor(4.5) = 4 wei.
+    await assetToken.connect(buyer1).createTradeOrder(1, ethers.parseEther("1.5"), 3, "sell");
+
+    // Underpaying by even one wei must still revert.
+    await assert.rejects(
+      assetToken.connect(buyer2).executeTradeOrder(1, 0, { value: 3n }),
+      /Insufficient payment/
+    );
+
+    const sellerBalanceBefore = await ethers.provider.getBalance(buyer1.address);
+    await assetToken.connect(buyer2).executeTradeOrder(1, 0, {
+      value: 10n
+    });
+    const sellerBalanceAfter = await ethers.provider.getBalance(buyer1.address);
+
+    // The seller receives the floored 4 wei, never the 1e18x inflated value.
+    assert.equal(sellerBalanceAfter - sellerBalanceBefore, 4n);
+
+    const order = (await assetToken.getTradeOrders(1))[0];
+    assert.equal(order.isActive, false);
+    assert.equal(order.buyer, buyer2.address);
+  });
 });


### PR DESCRIPTION
## Problem

`executeTradeOrder` computed `totalCost = order.amount * order.price`, but `order.price` is stored in the 1e18-scaled unit, so the contract demanded 1e18x the real cost. Every secondary-market execution reverted with `Insufficient payment`, making the whole trade feature unusable.

## Fix

Normalize the product by 1e18 before the `msg.value` check (`uint256 totalCost = (order.amount * order.price) / 1e18;`), matching the existing `purchaseFraction` calculation. Added two tests covering an exact trade and a non-exact trade (including a 1-wei underpayment revert and the floored payout).

## Files changed

- `blockchain/contracts/AssetToken.sol`
- `blockchain/test/AssetToken.test.js`

## Testing

`hardhat test` passes all 14 tests (12 pre-existing + 2 new). Reverting only the one-line fix makes the two new tests fail with `Insufficient payment`, confirming they reproduce the bug. Verified in an isolated Hardhat 2 + ethers v6 sandbox because the repo's current `devDependencies` are not installable as-is (pre-existing peer conflict: `hardhat@^2.28.6` vs `hardhat-verify@^3` which requires Hardhat 3).

Closes #8969
