### PR TITLE
fix(supabase): restore two-phase bid acceptance guard in accept_bid_tx

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -271,6 +271,31 @@ describe('accept_bid_tx — auth.uid() verification present in migration chain',
   });
 });
 
+describe('accept_bid_tx — two-phase acceptance guard preserved (issue #8971)', () => {
+  let ownershipFixContent;
+
+  beforeAll(async () => {
+    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql');
+    ownershipFixContent = await fs.readFile(p, 'utf8');
+  });
+
+  it('the latest accept_bid_tx definition still verifies the pending_bid_acceptance snapshot', () => {
+    // 20260805120000 redefined accept_bid_tx for the get_profile_id()
+    // ownership fix (issue #6275). It must not drop the two-phase guard from
+    // 20260802120000 (issue #5777): the order must carry a
+    // pending_bid_acceptance snapshot whose bid_amount still matches the
+    // stored bid before the bid is finalized.
+    expect(/v_pending_acceptance jsonb/i.test(ownershipFixContent)).toBe(true);
+    expect(/pending_bid_acceptance/.test(ownershipFixContent)).toBe(true);
+    expect(
+      /v_pending_bid_amount\s*:=\s*\(v_pending_acceptance\s*->>['"]bid_amount['"]\)::int/i.test(ownershipFixContent)
+    ).toBe(true);
+    expect(
+      /Bid amount was modified after acceptance; refusing to finalize/i.test(ownershipFixContent)
+    ).toBe(true);
+  });
+});
+
 describe('complete_trip_tx — order-linked trip finalization (issue #5756)', () => {
   it('the 20260704000001 migration selects the trip by order_id and raises when none exists', async () => {
     const p = path.resolve(__dirname, '../../../../supabase/migrations/20260704000001_add_auth_verification_to_complete_trip_tx.sql');

--- a/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
@@ -23,6 +23,9 @@
 --   already passes profiles.id (req.user.id) as p_driver_id/p_customer_id, so
 --   no API change is required. The service_role bypass on accept_bid_tx (used
 --   by escrow-funding reconciliation and confirm-deposit) is preserved.
+--   accept_bid_tx also keeps the Issue #5777 anti-tamper guard: the order must
+--   carry a pending_bid_acceptance snapshot whose bid_amount still matches the
+--   stored bid before the bid is finalized.
 -- =============================================================================
 
 -- ─────────────────────────────────────────────────────────────────────────────
@@ -196,6 +199,8 @@ DECLARE
   v_driver_rating    numeric;
   v_truck_id         uuid;
   v_truck_number     text;
+  v_pending_acceptance jsonb;
+  v_pending_bid_amount  int;
 BEGIN
   -- Resolve the bid by p_bid_id and derive the load/order chain from it.
   -- The caller-supplied p_load_id/p_order_id/p_order_display_id/p_driver_id/
@@ -219,14 +224,29 @@ BEGIN
     RAISE EXCEPTION 'Load offer is no longer available';
   END IF;
 
-  SELECT customer_id, status, version
-    INTO v_customer_id, v_order_status, v_current_version
+  SELECT customer_id, status, version, pending_bid_acceptance
+    INTO v_customer_id, v_order_status, v_current_version, v_pending_acceptance
     FROM orders
    WHERE order_display_id = v_order_display_id
      FOR UPDATE;
 
   IF v_customer_id IS NULL THEN
     RAISE EXCEPTION 'Order not found';
+  END IF;
+
+  -- Two-phase acceptance: the order must carry the snapshot the customer
+  -- agreed to and funded. Compare the snapshot amount with the amount still
+  -- stored on the bid row; if the bid was rewritten after acceptance (e.g. by
+  -- a driver inflating bid_amount), refuse to finalize so escrow can never pay
+  -- out more than was actually funded (Issue #5777).
+  IF v_pending_acceptance IS NULL THEN
+    RAISE EXCEPTION 'Pending bid acceptance snapshot is missing';
+  END IF;
+
+  v_pending_bid_amount := (v_pending_acceptance->>'bid_amount')::int;
+
+  IF v_pending_bid_amount IS NULL OR v_bid_amount <> v_pending_bid_amount THEN
+    RAISE EXCEPTION 'Bid amount was modified after acceptance; refusing to finalize';
   END IF;
 
   -- Ownership guard: the backend (service_role, e.g. confirm-deposit and


### PR DESCRIPTION
## Problem

The `20260805120000` migration fixed ownership checks on `accept_bid_tx` (Issue #6275) by switching to `get_profile_id()`, but it dropped the two-phase anti-tamper verification added by `20260802120000` (Issue #5777). The order's `pending_bid_acceptance` snapshot was nulled on finalize without ever being checked, so a bid whose `bid_amount` was rewritten after the customer funded the escrow would be accepted and paid out at the inflated amount.

## Fix

Restore the snapshot verification inside the latest definition of `accept_bid_tx`: the order must carry a `pending_bid_acceptance` whose `bid_amount` still matches the stored `load_bids` row, otherwise the function fails closed. The `get_profile_id()` ownership guard and the `service_role` bypass are unchanged.

## Files changed

- `supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql`
- `backend/api/test/unit/rlsSecurity.test.js`

## Testing

`vitest run test/unit/rlsSecurity.test.js` passes all 147 tests, including the new regression test asserting the guard is present in the latest `accept_bid_tx` migration.

Closes #8971
