### PR TITLE
fix(blockchain): add migration creating blockchain tables

### DIFF
--- a/supabase/migrations/20260810140000_create_blockchain_tables.sql
+++ b/supabase/migrations/20260810140000_create_blockchain_tables.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- Migration: create blockchain tables
+-- =============================================================================
+-- Problem:
+--   The blockchain-monitoring service (backend/api/src/services/blockchain/*)
+--   writes to three Supabase tables — blockchain_metrics,
+--   blockchain_escalations and blockchain_monitoring_events — that were only
+--   documented in docs/blockchain-monitoring-setup.md and never created by any
+--   migration. On fresh provisioning the metrics aggregator fails every 60s and
+--   the admin monitoring routes error out.
+--
+-- Fix:
+--   Create the three tables and their indexes exactly as documented in
+--   docs/blockchain-monitoring-setup.md. All statements are idempotent so this
+--   migration is safe to run even if a previous migration already created them.
+-- =============================================================================
+
+begin;
+
+create table if not exists blockchain_monitoring_events (
+  id bigserial primary key,
+  type varchar(255) not null,
+  severity varchar(50) not null,
+  data jsonb,
+  created_at timestamp default now()
+);
+
+create index if not exists idx_monitoring_events_type on blockchain_monitoring_events(type);
+create index if not exists idx_monitoring_events_created_at on blockchain_monitoring_events(created_at);
+
+create table if not exists blockchain_escalations (
+  alert_id varchar(255) primary key,
+  alert_type varchar(255) not null,
+  severity varchar(50),
+  escalation_level int,
+  created_at timestamp,
+  resolved boolean default false,
+  resolved_at timestamp,
+  escalation_history jsonb,
+  data jsonb
+);
+
+create index if not exists idx_escalations_created_at on blockchain_escalations(created_at);
+create index if not exists idx_escalations_resolved on blockchain_escalations(resolved);
+
+create table if not exists blockchain_metrics (
+  id bigserial primary key,
+  timestamp timestamp default now(),
+  contract_call_success_rate int,
+  payment_processing_latency_avg int,
+  withdrawal_queue_depth int,
+  failed_transaction_count int,
+  driver_payout_delay_avg int,
+  blocks_scanned_per_day int,
+  geofence_breach_count int,
+  insurance_events_count int
+);
+
+create index if not exists idx_metrics_timestamp on blockchain_metrics(timestamp);
+
+commit;


### PR DESCRIPTION
## Problem

The blockchain-monitoring service writes to three Supabase tables — `blockchain_metrics`, `blockchain_escalations`, and `blockchain_monitoring_events` — that exist **only** in `docs/blockchain-monitoring-setup.md`. A repo-wide scan of `supabase/migrations/**/*.sql` found zero occurrences of any of the three names, so no migration ever created them.

Consequences on a fresh provisioning (`supabase db push` / migrations replay):

- `BlockchainMetrics` is constructed at API boot (`backend/api/src/index.js:180`) and attempts `INSERT INTO blockchain_metrics` every 60s (`blockchainMetrics.js:107-109`) — every insert fails and is only swallowed by the catch at `:115-117`.
- `GET /api/blockchain/events` (`blockchainMonitoringRoutes.js:107`) queries `blockchain_monitoring_events` → 500.
- `GET /api/blockchain/escalations/:alertId` (`blockchainMonitoringRoutes.js:152`) queries `blockchain_escalations` → misleading 404.
- `storeEscalation()` (`escalationHandler.js:188-200`) upserts `blockchain_escalations` with `onConflict: 'alert_id'` → always fails, so escalation state only lives in the in-process `activeAlerts` Map.

## Fix

Add `supabase/migrations/20260810140000_create_blockchain_tables.sql` that creates the three tables and their indexes exactly as documented in `docs/blockchain-monitoring-setup.md`:

- `blockchain_monitoring_events` (+ `idx_monitoring_events_type`, `idx_monitoring_events_created_at`)
- `blockchain_escalations` (+ `idx_escalations_created_at`, `idx_escalations_resolved`)
- `blockchain_metrics` (+ `idx_metrics_timestamp`)

Column names match exactly what the code writes (`alert_id`, `alert_type`, `severity`, `escalation_level`, `escalation_history`, `data`, etc.). Every statement uses `if not exists` so the migration is idempotent and safe to run alongside any other migration that provisions the same tables.

## Files changed

- `supabase/migrations/20260810140000_create_blockchain_tables.sql`

## Testing

- Migration is idempotent (`create table/index if not exists`) and can be replayed safely.
- Verified every column the writers reference exists in the migration:
  - `blockchainMetrics.js:95-105` → `timestamp`, `contract_call_success_rate`, `payment_processing_latency_avg`, `withdrawal_queue_depth`, `failed_transaction_count`, `driver_payout_delay_avg`, `blocks_scanned_per_day`, `geofence_breach_count`, `insurance_events_count`
  - `escalationHandler.js:190-200` → `alert_id`, `alert_type`, `severity`, `escalation_level`, `created_at`, `resolved`, `resolved_at`, `escalation_history`, `data`
  - `blockchainMonitor.js:269-274` → `type`, `severity`, `data`, `created_at`
- After applying the migration, `GET /api/blockchain/events`, `GET /api/blockchain/escalations/:alertId`, and the metrics insert path reference existing tables.

Closes #8953
