### PR TITLE
fix(api): fail closed on weigh-station bypass status instead of returning a random verdict (#8935)

### DIFF
--- a/apps/driver/lib/screens/shell_screen.dart
+++ b/apps/driver/lib/screens/shell_screen.dart
@@ -301,15 +301,18 @@ class _ShellScreenState extends State<ShellScreen> {
 
   void _showBypassAlert(WeighStationEvent event) {
     if (!mounted) return;
+    final isUnsupported = event.action == 'UNSUPPORTED' || event.simulated;
+    final isBypass = !isUnsupported && event.action == 'BYPASS';
     showDialog(
       context: context,
       barrierDismissible: false,
       builder: (context) {
-        final isBypass = event.action == 'BYPASS';
         return Dialog(
-          backgroundColor: isBypass
-              ? const Color(0xFF1E4620)
-              : const Color(0xFF5C1A1A),
+          backgroundColor: isUnsupported
+              ? const Color(0xFF6B5900)
+              : isBypass
+                  ? const Color(0xFF1E4620)
+                  : const Color(0xFF5C1A1A),
           shape:
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
           child: Padding(
@@ -318,15 +321,21 @@ class _ShellScreenState extends State<ShellScreen> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Icon(
-                  isBypass
-                      ? Icons.check_circle_outline
-                      : Icons.warning_amber_rounded,
+                  isUnsupported
+                      ? Icons.info_outline
+                      : isBypass
+                          ? Icons.check_circle_outline
+                          : Icons.warning_amber_rounded,
                   size: 80,
                   color: Colors.white,
                 ),
                 const SizedBox(height: 24),
                 Text(
-                  isBypass ? 'BYPASS CLEARED' : 'PULL IN REQUIRED',
+                  isUnsupported
+                      ? 'SIMULATED PREVIEW — NOT A REGULATORY VERDICT'
+                      : isBypass
+                          ? 'BYPASS CLEARED'
+                          : 'PULL IN REQUIRED',
                   textAlign: TextAlign.center,
                   style: const TextStyle(
                     fontSize: 28,
@@ -336,7 +345,9 @@ class _ShellScreenState extends State<ShellScreen> {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  'Station ID: ${event.stationId}\n${event.reason}',
+                  isUnsupported
+                      ? event.reason
+                      : 'Station ID: ${event.stationId}\n${event.reason}',
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 16, color: Colors.white70),
                 ),
@@ -347,9 +358,11 @@ class _ShellScreenState extends State<ShellScreen> {
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.white,
-                      foregroundColor: isBypass
-                          ? const Color(0xFF1E4620)
-                          : const Color(0xFF5C1A1A),
+                      foregroundColor: isUnsupported
+                          ? const Color(0xFF6B5900)
+                          : isBypass
+                              ? const Color(0xFF1E4620)
+                              : const Color(0xFF5C1A1A),
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(16)),
                     ),

--- a/apps/driver/lib/services/weigh_station_bypass_service.dart
+++ b/apps/driver/lib/services/weigh_station_bypass_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import '../models/weigh_in_motion_model.dart';
 
 class WeighStationBypassService {
@@ -18,12 +17,10 @@ class WeighStationBypassService {
     // Simulate transponder reading / PrePass network delay
     await Future.delayed(const Duration(seconds: 3));
 
-    final random = Random();
-    // 90% chance to bypass if compliant, 10% chance for random inspection
-    bool randomPullIn = random.nextDouble() > 0.90;
-    
+    // Verdict is driven only by the actual gross weight — never a random
+    // coin-flip, since this is rendered as a regulatory decision.
     String finalStatus;
-    if (grossWeight > 80000.0 || randomPullIn) {
+    if (grossWeight > 80000.0) {
       finalStatus = 'MUST_PULL_IN';
     } else {
       finalStatus = 'CLEARED_TO_BYPASS';

--- a/apps/driver/lib/services/weigh_station_service.dart
+++ b/apps/driver/lib/services/weigh_station_service.dart
@@ -1,18 +1,21 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:truxify_shared/src/services/api_client.dart';
 import 'location_service.dart';
 
 class WeighStationEvent {
-  final String action; // 'BYPASS' or 'PULL_IN'
+  final String action; // 'BYPASS', 'PULL_IN' or 'UNSUPPORTED'
   final String reason;
   final String stationId;
+  final bool simulated;
 
   WeighStationEvent({
     required this.action,
     required this.reason,
     required this.stationId,
+    this.simulated = false,
   });
 }
 
@@ -105,17 +108,50 @@ class WeighStationService {
         '/api/driver/weigh-stations/bypass-status?lat=${pos.latitude}&lng=${pos.longitude}'
       );
 
-      final event = WeighStationEvent(
+      if (response is Map<String, dynamic> && _isUnsupported(response)) {
+        _emitEvent(_unsupportedEvent(response));
+        return;
+      }
+
+      _emitEvent(WeighStationEvent(
         action: response['action'] ?? 'PULL_IN',
         reason: response['reason'] ?? 'Random check',
         stationId: response['stationId'] ?? stationKey,
+      ));
+    } catch (e) {
+      // The endpoint fails closed with 503 UNSUPPORTED until a real WIM
+      // provider is integrated. Surface that as a clearly-simulated preview;
+      // never show an authoritative BYPASS/PULL_IN verdict on a failure.
+      if (e is ApiException && e.body != null) {
+        try {
+          final decoded = jsonDecode(e.body!);
+          if (decoded is Map<String, dynamic> && _isUnsupported(decoded)) {
+            _emitEvent(_unsupportedEvent(decoded));
+            return;
+          }
+        } catch (_) {
+          // Not JSON — fall through to the generic debug log below.
+        }
+      }
+      debugPrint('[WeighStationService] Error checking bypass status: $e');
+    }
+  }
+
+  bool _isUnsupported(Map<String, dynamic> payload) =>
+      payload['supported'] == false || payload['action'] == 'UNSUPPORTED';
+
+  WeighStationEvent _unsupportedEvent(Map<String, dynamic> payload) =>
+      WeighStationEvent(
+        action: 'UNSUPPORTED',
+        reason: (payload['reason'] as String?) ??
+            'Weigh-in-motion bypass is not available.',
+        stationId: 'N/A',
+        simulated: true,
       );
 
-      if (!_eventController.isClosed) {
-        _eventController.add(event);
-      }
-    } catch (e) {
-      debugPrint('[WeighStationService] Error checking bypass status: $e');
+  void _emitEvent(WeighStationEvent event) {
+    if (!_eventController.isClosed) {
+      _eventController.add(event);
     }
   }
 

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1390,6 +1390,12 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
     }
 
     const status = await checkBypassEligibility(driverId, lat, lng);
+    // Fail closed: without a real WIM provider the result is explicitly
+    // unsupported — never present a fabricated BYPASS/PULL_IN verdict as
+    // authoritative.
+    if (status.supported === false || status.action === 'UNSUPPORTED') {
+      return res.status(503).json(status);
+    }
     return res.status(200).json(status);
   } catch (err) {
     logger.error(`[weigh-station] Error getting bypass status for driver ${req.user.id}: ${err.message}`);

--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -5,24 +5,21 @@
  */
 
 const SIMULATED_NETWORK_DELAY_MS = 800;
-const PULL_IN_PROBABILITY = 0.2;
 const STATION_ID_RANGE = 1000;
 
 const checkBypassEligibility = async (driverId, lat, lng) => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, SIMULATED_NETWORK_DELAY_MS));
-
-  // Determine bypass (80% chance) vs pull in (20% chance)
-  const isBypass = Math.random() > PULL_IN_PROBABILITY;
-  
-  // Randomly assign an ID for the station for logging
-  const stationId = 'WS-' + Math.floor(Math.random() * STATION_ID_RANGE);
-
+  // No real WIM/bypass provider (Drivewyze/PrePass) is integrated. The
+  // previous implementation returned a Math.random() coin-flip presented as a
+  // regulatory verdict, which a driver could legally rely on. There is no real
+  // integration to call, so this fails closed and reports itself as
+  // unsupported instead of inventing a BYPASS/PULL_IN decision.
   return {
-    action: isBypass ? 'BYPASS' : 'PULL_IN',
-    stationId,
-    reason: isBypass ? 'Excellent safety score.' : 'Random inspection required.',
-    timestamp: new Date().toISOString()
+    action: 'UNSUPPORTED',
+    supported: false,
+    simulated: true,
+    stationId: null,
+    reason: 'Weigh-in-motion bypass is not available: no WIM provider is configured. This is not a regulatory verdict.',
+    timestamp: new Date().toISOString(),
   };
 };
 

--- a/backend/api/test/integration/driverWim.test.js
+++ b/backend/api/test/integration/driverWim.test.js
@@ -82,4 +82,24 @@ describe('Driver WIM Sync Routes', () => {
     expect(res.body.action).toBe('BYPASS');
     expect(res.body.gross_weight_lbs).toBe(30000);
   });
+
+  it('GET /api/driver/weigh-stations/bypass-status returns 503 UNSUPPORTED (no real WIM provider)', async () => {
+    const res = await request(buildApp())
+      .get('/api/driver/weigh-stations/bypass-status?lat=19.076&lng=72.8777')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(503);
+    expect(res.body.action).toBe('UNSUPPORTED');
+    expect(res.body.supported).toBe(false);
+    expect(res.body.simulated).toBe(true);
+    expect(res.body.stationId).toBeNull();
+  });
+
+  it('GET /api/driver/weigh-stations/bypass-status returns 400 for invalid coordinates', async () => {
+    const res = await request(buildApp())
+      .get('/api/driver/weigh-stations/bypass-status?lat=abc&lng=72.8777')
+      .set(DRIVER_HEADERS);
+
+    expect(res.status).toBe(400);
+  });
 });

--- a/backend/api/test/unit/services/weighStationService.test.js
+++ b/backend/api/test/unit/services/weighStationService.test.js
@@ -2,9 +2,8 @@
  * Unit tests for backend/api/src/services/weighStationService.js
  *
  * Coverage:
- *   - checkBypassEligibility returns BYPASS with valid structure
- *   - checkBypassEligibility returns PULL_IN with valid structure
- *   - Result has required fields: action, stationId, reason, timestamp
+ *   - checkBypassEligibility fails closed (UNSUPPORTED, never BYPASS/PULL_IN)
+ *   - Result has required fields: action, supported, simulated, stationId, reason, timestamp
  *   - timestamp is a valid ISO 8601 string
  *
  * Run with: npx vitest run test/unit/services/weighStationService.test.js
@@ -32,57 +31,43 @@ describe('checkBypassEligibility', () => {
 
   const ISO_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/;
 
-  it('returns an object with action BYPASS when Math.random > 0.2', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.9);
-    const promise = checkBypassEligibility('driver-123', 28.6139, 77.2090);
-    vi.advanceTimersByTime(800);
-    const result = await promise;
+  it('fails closed as UNSUPPORTED instead of fabricating a verdict', async () => {
+    const result = await checkBypassEligibility('driver-123', 28.6139, 77.2090);
 
-    expect(result.action).toBe('BYPASS');
-    expect(result.reason).toBe('Excellent safety score.');
-    expect(result.stationId).toMatch(/^WS-\d+$/);
-    expect(result.timestamp).toMatch(ISO_REGEX);
+    expect(result.action).toBe('UNSUPPORTED');
+    expect(result.supported).toBe(false);
+    expect(result.simulated).toBe(true);
+    expect(result.stationId).toBeNull();
   });
 
-  it('returns an object with action PULL_IN when Math.random <= 0.2', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.1);
-    const promise = checkBypassEligibility('driver-456', 19.0760, 72.8777);
-    vi.advanceTimersByTime(800);
-    const result = await promise;
-
-    expect(result.action).toBe('PULL_IN');
-    expect(result.reason).toBe('Random inspection required.');
-    expect(result.stationId).toMatch(/^WS-\d+$/);
-    expect(result.timestamp).toMatch(ISO_REGEX);
+  it('never returns BYPASS or PULL_IN without a real WIM provider', async () => {
+    for (let i = 0; i < 10; i++) {
+      const result = await checkBypassEligibility('driver-123', 28.6139, 77.2090);
+      expect(['BYPASS', 'PULL_IN']).not.toContain(result.action);
+    }
   });
 
-  it('result contains required fields action, stationId, reason, timestamp', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const promise = checkBypassEligibility('driver-789', 25.5, 75.5);
-    vi.advanceTimersByTime(800);
-    const result = await promise;
+  it('result contains required fields action, supported, simulated, stationId, reason, timestamp', async () => {
+    const result = await checkBypassEligibility('driver-789', 25.5, 75.5);
 
     expect(result).toHaveProperty('action');
+    expect(result).toHaveProperty('supported');
+    expect(result).toHaveProperty('simulated');
     expect(result).toHaveProperty('stationId');
     expect(result).toHaveProperty('reason');
     expect(result).toHaveProperty('timestamp');
   });
 
   it('timestamp is a valid ISO 8601 string', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const promise = checkBypassEligibility('driver-abc', 12.9716, 77.5946);
-    vi.advanceTimersByTime(800);
-    const result = await promise;
+    const result = await checkBypassEligibility('driver-abc', 12.9716, 77.5946);
 
     expect(result.timestamp).toMatch(ISO_REGEX);
   });
 
-  it('stationId format is WS-{number}', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const promise = checkBypassEligibility('driver-xyz', 30.7320, 76.7748);
-    vi.advanceTimersByTime(800);
-    const result = await promise;
+  it('returns a non-empty reason that disclaims any regulatory verdict', async () => {
+    const result = await checkBypassEligibility('driver-xyz', 30.7320, 76.7748);
 
-    expect(result.stationId).toMatch(/^WS-\d+$/);
+    expect(typeof result.reason).toBe('string');
+    expect(result.reason.length).toBeGreaterThan(0);
   });
 });

--- a/backend/api/test/unit/weighStationService.test.js
+++ b/backend/api/test/unit/weighStationService.test.js
@@ -1,12 +1,33 @@
+/**
+ * Unit tests for backend/api/src/services/weighStationService.js
+ *
+ * Run with:  npm run test:unit -- test/unit/weighStationService.test.js
+ */
 import { describe, it, expect } from 'vitest';
 import { syncAndTransmitInternalWeights, checkBypassEligibility } from '../../src/services/weighStationService.js';
 
 describe('Weigh Station Service', () => {
   describe('checkBypassEligibility', () => {
-    it('returns a BYPASS or PULL_IN action', async () => {
+    it('fails closed as UNSUPPORTED instead of fabricating a verdict', async () => {
       const result = await checkBypassEligibility('driver-1', 40.0, -75.0);
-      expect(['BYPASS', 'PULL_IN']).toContain(result.action);
-      expect(result.stationId).toMatch(/^WS-\d+$/);
+      expect(result.action).toBe('UNSUPPORTED');
+      expect(result.supported).toBe(false);
+      expect(result.simulated).toBe(true);
+      expect(result.stationId).toBeNull();
+    });
+
+    it('never returns BYPASS or PULL_IN without a real WIM provider', async () => {
+      for (let i = 0; i < 10; i++) {
+        const result = await checkBypassEligibility('driver-1', 40.0, -75.0);
+        expect(['BYPASS', 'PULL_IN']).not.toContain(result.action);
+      }
+    });
+
+    it('returns a non-empty reason and an ISO timestamp', async () => {
+      const result = await checkBypassEligibility('driver-1', 40.0, -75.0);
+      expect(typeof result.reason).toBe('string');
+      expect(result.reason.length).toBeGreaterThan(0);
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
   });
 
@@ -20,7 +41,7 @@ describe('Weigh Station Service', () => {
       ]; // Gross: 47,500 lbs
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
-      
+
       expect(result.action).toBe('BYPASS');
       expect(result.gross_weight_lbs).toBe(47500);
       expect(result.axles.length).toBe(3);
@@ -30,12 +51,12 @@ describe('Weigh Station Service', () => {
       // 120 PSI * 250 + 5000 = 35,000 lbs (Over 34k tandem limit)
       const axles = [
         { position: 'steer', pressure_psi: 30 },
-        { position: 'drive', pressure_psi: 120 }, 
+        { position: 'drive', pressure_psi: 120 },
         { position: 'trailer', pressure_psi: 50 }
       ];
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
-      
+
       expect(result.action).toBe('PULL_IN');
       expect(result.reason).toContain('Axle drive overweight');
     });
@@ -44,120 +65,15 @@ describe('Weigh Station Service', () => {
       // 110 PSI * 250 + 5000 = 32,500 lbs each * 3 = 97,500 lbs (Over 80k gross limit)
       const axles = [
         { position: 'steer', pressure_psi: 110 },
-        { position: 'drive', pressure_psi: 110 }, 
+        { position: 'drive', pressure_psi: 110 },
         { position: 'trailer', pressure_psi: 110 }
       ];
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
-      
+
       expect(result.action).toBe('PULL_IN');
       expect(result.reason).toContain('Gross weight overweight');
       expect(result.gross_weight_lbs).toBe(97500);
-/**
- * Unit tests for backend/api/src/services/weighStationService.js
- *
- * Run with:  npm run test:unit -- test/unit/weighStationService.test.js
- */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-// Mock the sleep call so tests run instantly
-vi.useFakeTimers();
-
-const mockSleep = vi.fn(() => new Promise(resolve => setTimeout(resolve, 0)));
-vi.mock('../../src/services/weighStationService.js', async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual };
-});
-
-// Inline the service logic for testing (since it's a single exported function)
-const SIMULATED_NETWORK_DELAY_MS = 800;
-const PULL_IN_PROBABILITY = 0.2;
-
-const checkBypassEligibility = async (driverId, lat, lng) => {
-  await new Promise(resolve => setTimeout(resolve, SIMULATED_NETWORK_DELAY_MS));
-  const isBypass = Math.random() > PULL_IN_PROBABILITY;
-  const stationId = 'WS-' + Math.floor(Math.random() * 1000);
-  return {
-    action: isBypass ? 'BYPASS' : 'PULL_IN',
-    stationId,
-    reason: isBypass ? 'Excellent safety score.' : 'Random inspection required.',
-    timestamp: new Date().toISOString(),
-  };
-};
-
-describe('weighStationService', () => {
-  describe('checkBypassEligibility', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
-    it('returns an object with action field', async () => {
-      vi.setSystemTime(new Date('2026-01-01T12:00:00Z'));
-      // Fix random to return bypass
-      const originalRandom = Math.random;
-      Math.random = () => 0.01; // always bypass (< PULL_IN_PROBABILITY of 0.2)
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(result).toHaveProperty('action');
-      expect(['BYPASS', 'PULL_IN']).toContain(result.action);
-
-      Math.random = originalRandom;
-    });
-
-    it('returns stationId prefixed with WS-', async () => {
-      const originalRandom = Math.random;
-      Math.random = () => 0.5;
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(result.stationId).toMatch(/^WS-\d+$/);
-
-      Math.random = originalRandom;
-    });
-
-    it('returns a non-empty reason string', async () => {
-      const originalRandom = Math.random;
-      Math.random = () => 0.99; // force PULL_IN
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(typeof result.reason).toBe('string');
-      expect(result.reason.length).toBeGreaterThan(0);
-
-      Math.random = originalRandom;
-    });
-
-    it('returns an ISO timestamp string', async () => {
-      vi.setSystemTime(new Date('2026-07-15T10:00:00Z'));
-      const originalRandom = Math.random;
-      Math.random = () => 0.5;
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(result.timestamp).toBe('2026-07-15T10:00:00.000Z');
-
-      Math.random = originalRandom;
-    });
-
-    it('returns BYPASS when random is below probability threshold', async () => {
-      const originalRandom = Math.random;
-      Math.random = () => 0.05; // below 0.2 threshold
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(result.action).toBe('BYPASS');
-
-      Math.random = originalRandom;
-    });
-
-    it('returns PULL_IN when random is at or above probability threshold', async () => {
-      const originalRandom = Math.random;
-      Math.random = () => 0.25; // at or above 0.2 threshold
-
-      const result = await checkBypassEligibility('driver-123', 19.076, 72.8777);
-      expect(result.action).toBe('PULL_IN');
-
-      Math.random = originalRandom;
     });
   });
 });


### PR DESCRIPTION
## Fixes #8935

`GET /api/driver/weigh-stations/bypass-status` returned a **random coin-flip** (80% BYPASS / 20% PULL_IN) with a fake `stationId` as a regulatory verdict. The driver app polled it with real GPS and rendered "BYPASS — Excellent safety score." / "PULL IN TO WEIGH STATION", so a driver could legally rely on a fabricated instruction.

### Changes
- `backend/api/src/services/weighStationService.js`: `checkBypassEligibility` no longer uses `Math.random()`. With no real WIM/bypass provider (Drivewyze/PrePass) integrated, it **fails closed**: returns `{ action: 'UNSUPPORTED', supported: false, simulated: true, stationId: null, reason: '…no WIM provider is configured. This is not a regulatory verdict.', timestamp }`. `syncAndTransmitInternalWeights` (the real axle-pressure-based path) is unchanged.
- `backend/api/src/routes/driverRoutes.js`: the route responds **503** with the payload when `supported === false || action === 'UNSUPPORTED'`.
- `apps/driver/lib/services/weigh_station_service.dart`: handles the 503 body and emits an `UNSUPPORTED` event; never falls through to a fabricated BYPASS/PULL_IN on failure.
- `apps/driver/lib/screens/shell_screen.dart`: renders an amber **"SIMULATED PREVIEW — NOT A REGULATORY VERDICT"** dialog for unsupported/simulated events instead of a green BYPASS or red PULL IN instruction.
- `apps/driver/lib/services/weigh_station_bypass_service.dart`: the local WIM demo simulator's 10% `Random()` "random inspection" coin-flip is removed — its verdict now derives only from the actual gross weight.

### Tests
- `backend/api/test/integration/driverWim.test.js`: "returns 503 UNSUPPORTED (no real WIM provider)" and "returns 400 for invalid coordinates".
- `backend/api/test/unit/weighStationService.test.js`: rewritten (was two concatenated files with a shadowing inline copy of the service) — asserts the fail-closed contract and keeps the real `syncAndTransmitInternalWeights` tests.
- `backend/api/test/unit/services/weighStationService.test.js`: updated to the fail-closed contract.

Verified: 16/16 weigh-station tests pass (both unit files + integration). The Flutter changes couldn't be test-run (no Dart SDK in this environment).
