### PR TITLE
fix(security): bound getKeyRotationHistory with default limit (#9230)

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -210,7 +210,7 @@ class KeyManagementService {
     });
   }
 
-  async getKeyRotationHistory(userId, walletAddress) {
+  async getKeyRotationHistory(userId, walletAddress, limit = 10) {
     return measureExecution('KeyManagementService.getKeyRotationHistory', async () => {
       try {
         const { data: history, error } = await supabase
@@ -218,7 +218,8 @@ class KeyManagementService {
           .select('*')
           .eq('user_id', userId)
           .eq('wallet_address', walletAddress)
-          .order('created_at', { ascending: false });
+          .order('created_at', { ascending: false })
+          .limit(limit);
 
         if (error) {
           logger.error('[KeyManagementService] Failed to fetch rotation history:', error);

--- a/backend/api/test/unit/keyManagementService.rotationHistory.test.js
+++ b/backend/api/test/unit/keyManagementService.rotationHistory.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Bounded rotation-history read (issue #9230): getKeyRotationHistory must
+// apply a .limit() so a wallet with many rotations does not return an
+// unbounded payload / unbounded DB read on every call. Mirrors the bounded
+// sibling keyRotationService.getRotationHistory (default limit 10).
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
+
+vi.mock('../../src/core/performanceMetrics.js', () => ({
+  measureExecution: vi.fn(async (_name, fn) => fn()),
+}));
+
+// Chainable supabase stub that records the terminal call chain.
+let lastLimitArg = undefined;
+let resolveWith = { data: [], error: null };
+
+function chainable() {
+  const chain = {};
+  const methods = ['from', 'select', 'eq', 'order'];
+  for (const m of methods) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.limit = vi.fn((n) => {
+    lastLimitArg = n;
+    return chain;
+  });
+  // The query is awaited; make the chain thenable.
+  chain.then = (resolve) => Promise.resolve(resolveWith).then((r) => resolve(r));
+  return chain;
+}
+
+// Mutable supabase holder shared between the test and the mocked db module.
+// vi.mock factories are hoisted above `let` declarations, so we cannot close
+// over a test-scope variable directly; instead the factory returns an object
+// whose `supabase` property the test reassigns.
+const dbMock = { supabase: null, supabaseAdmin: null };
+vi.mock('../../src/config/db.js', () => ({
+  get supabase() {
+    return dbMock.supabase;
+  },
+  get supabaseAdmin() {
+    return dbMock.supabaseAdmin;
+  },
+}));
+
+async function makeService() {
+  vi.resetModules();
+  const mod = await import('../../src/services/security/keyManagementService.js');
+  return new mod.default();
+}
+
+describe('KeyManagementService.getKeyRotationHistory bounded read (#9230)', () => {
+  beforeEach(() => {
+    lastLimitArg = undefined;
+    resolveWith = { data: [], error: null };
+    dbMock.supabase = chainable();
+  });
+
+  it('applies a default limit of 10 (matching keyRotationService)', async () => {
+    resolveWith = { data: [{ key_id: 'k1' }], error: null };
+    const svc = await makeService();
+    const out = await svc.getKeyRotationHistory('user-1', '0xabc');
+    expect(lastLimitArg).toBe(10);
+    expect(out).toEqual([{ key_id: 'k1' }]);
+  });
+
+  it('honours an explicit limit argument', async () => {
+    const svc = await makeService();
+    await svc.getKeyRotationHistory('user-1', '0xabc', 25);
+    expect(lastLimitArg).toBe(25);
+  });
+
+  it('honours limit=1 for callers that only need the latest rotation', async () => {
+    resolveWith = { data: [{ key_id: 'latest' }], error: null };
+    const svc = await makeService();
+    const out = await svc.getKeyRotationHistory('user-1', '0xabc', 1);
+    expect(lastLimitArg).toBe(1);
+    expect(out).toHaveLength(1);
+  });
+
+  it('still returns [] on a supabase error (no throw)', async () => {
+    resolveWith = { data: null, error: { message: 'boom' } };
+    const svc = await makeService();
+    const out = await svc.getKeyRotationHistory('user-1', '0xabc');
+    expect(out).toEqual([]);
+    expect(lastLimitArg).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary

`KeyManagementService.getKeyRotationHistory` (`backend/api/src/services/security/keyManagementService.js`) read the **entire** key-rotation history for a given user + wallet with no `.limit()`:

```js
const { data: history, error } = await supabase
  .from('encrypted_wallet_keys')
  .select('*')
  .eq('user_id', userId)
  .eq('wallet_address', walletAddress)
  .order('created_at', { ascending: false });   // no .limit() / .range()
```

This is the unbounded counterpart of `keyRotationService.getRotationHistory` (`keyRotationService.js:207`), which already accepts a `limit` (default 10) and caps the query with `.limit(limit)`. The two rotation-history surfaces therefore behave inconsistently, and consumers cannot rely on a stable result size.

## Impact

- A wallet that has rotated keys many times (or been re-encrypted per session) returns the **whole** history in a single response — an unbounded payload for the client and an unbounded read on every call.
- Callers that only need the latest rotation (`created_at` descending) fetch everything to look at row 0.
- Behavior is inconsistent with the bounded sibling API, so consumers cannot rely on a stable result size.

## Fix

Add an optional `limit` parameter defaulting to **10** (matching `keyRotationService.getRotationHistory`) and apply `.limit(limit)` to the query, which is already ordered newest-first:

```js
async getKeyRotationHistory(userId, walletAddress, limit = 10) {
  // ...
  const { data: history, error } = await supabase
    .from('encrypted_wallet_keys')
    .select('*')
    .eq('user_id', userId)
    .eq('wallet_address', walletAddress)
    .order('created_at', { ascending: false })
    .limit(limit);
  // ...
}
```

This makes the two rotation-history surfaces consistent. Existing two-argument callers are unaffected (they get the new default of 10 instead of an unbounded read — a strictly safer behavior). Callers that need only the most recent rotation can pass `limit=1`. The default matches the issue's suggested fix (default bounded page of 10).

A search of the codebase shows no in-tree callers of `getKeyRotationHistory` today, so the signature change (adding an optional third parameter with a default) is backward-compatible and breaks nothing.

## Verification

New regression tests, **4 tests, all passing** (`backend/api/test/unit/keyManagementService.rotationHistory.test.js`):

- `applies a default limit of 10 (matching keyRotationService)` — with no explicit limit, `.limit(10)` is applied to the Supabase query and the resolved rows are returned.
- `honours an explicit limit argument` — `getKeyRotationHistory(userId, wallet, 25)` results in `.limit(25)`.
- `honours limit=1 for callers that only need the latest rotation` — `limit=1` yields `.limit(1)` and a single-row result.
- `still returns [] on a supabase error (no throw)` — when Supabase returns `{ error }`, the method returns `[]` rather than throwing, and the bounded `.limit(10)` is still applied (the read itself is bounded even on the error path).

The test stubs `config/db.js` with a chainable Supabase mock that records the `limit` argument, and uses `vi.resetModules()` + dynamic import per test so the mocked `supabase` binding is live when the service module loads.

**Existing `keyManagementService` unit suite stays green: 3/3** (run together with the new file: **7/7 passing**).

```
Test Files  2 passed (2)
     Tests  7 passed (7)
```

## Changes

- `backend/api/src/services/security/keyManagementService.js` — `getKeyRotationHistory` gains an optional `limit = 10` parameter and applies `.limit(limit)`.
- `backend/api/test/unit/keyManagementService.rotationHistory.test.js` — new (4 tests).

Closes #9230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Key-rotation history now returns up to 10 records by default.
  * Callers can specify a custom maximum number of history records to retrieve.
  * Results continue to be ordered from newest to oldest.

* **Bug Fixes**
  * Empty results remain handled consistently when history retrieval encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->