### PR TITLE
fix(api): write real trucks columns in PUT/POST /api/driver/truck

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1743,8 +1743,14 @@ router.put('/truck', authenticate, userLimiter, requireDriverRole, async (req, r
   try {
     const { type, capacityWeight, capacityVolume, registrationNumber } = req.body;
 
+    const VALID_TRUCK_TYPES = ['Open Body', 'Closed Body', 'Container', 'Refrigerated'];
+
     if (!type || !registrationNumber) {
       return res.status(400).json({ error: 'type and registrationNumber are required.' });
+    }
+
+    if (!VALID_TRUCK_TYPES.includes(type)) {
+      return res.status(400).json({ error: 'type must be one of: Open Body, Closed Body, Container, Refrigerated.' });
     }
 
     // Check if driver has an existing truck assigned
@@ -1767,9 +1773,8 @@ router.put('/truck', authenticate, userLimiter, requireDriverRole, async (req, r
         .from('trucks')
         .update({
           truck_type: type,
-          capacity_weight_tonnes: capacityWeight || 0,
-          capacity_volume_m3: capacityVolume || 0,
-          registration_number: registrationNumber,
+          max_capacity_tons: capacityWeight || 0,
+          number_plate: registrationNumber,
           updated_at: new Date().toISOString()
         })
         .eq('id', truckId)
@@ -1785,10 +1790,8 @@ router.put('/truck', authenticate, userLimiter, requireDriverRole, async (req, r
         .insert({
           driver_id: req.user.id,
           truck_type: type,
-          capacity_weight_tonnes: capacityWeight || 0,
-          capacity_volume_m3: capacityVolume || 0,
-          registration_number: registrationNumber,
-          is_active: true
+          max_capacity_tons: capacityWeight || 0,
+          number_plate: registrationNumber
         })
         .select('*')
         .single();


### PR DESCRIPTION
## Problem

`PUT/POST /api/driver/truck` wrote `capacity_weight_tonnes`, `capacity_volume_m3`, `registration_number` and `is_active` onto the `trucks` table — none of these columns exist in any schema file (`docs/supabase_setup.sql` L140-157, confirmed by a repo-wide `.sql` search). Both endpoints always returned a PostgREST error (`Could not find the 'capacity_weight_tonnes' column of 'trucks' in the schema cache`), so truck registration from the driver app always failed. The `truck_type` check constraint (`('Open Body','Closed Body','Container','Refrigerated')`) was also unenforced while the API accepted free-form `type`.

## Fix

- Map `capacity_weight_tonnes` -> `max_capacity_tons`.
- Map `registration_number` -> `number_plate`.
- Drop the non-existent `capacity_volume_m3` and `is_active` fields (the schema has no such columns; sibling `truckRoutes.js` writes `max_capacity_tons`/`number_plate` for the same table).
- Validate `type` against the allowed truck types before writing, matching the `trucks` check constraint.

## Files changed

- `backend/api/src/routes/driverRoutes.js` (PUT/POST `/api/driver/truck`)

## Testing

- Static check: every column now written matches the `trucks` DDL (`truck_type`, `max_capacity_tons`, `number_plate`, `driver_id`, `updated_at`).
- Verified no remaining references to the removed column names in the routes.

Closes #8902
