### PR TITLE
fix(driver): query trucks by driver_id in TruckRepository.fetchTruckForDriver

### DIFF
--- a/apps/driver/lib/services/truck_repository.dart
+++ b/apps/driver/lib/services/truck_repository.dart
@@ -22,7 +22,7 @@ class TruckRepository {
     final response = await _client
         .from('trucks')
         .select()
-        .eq('owner_id', driverId)
+        .eq('driver_id', driverId)
         .maybeSingle();
 
     if (response == null) {


### PR DESCRIPTION
## Problem

`TruckRepository.fetchTruckForDriver` queried `trucks.owner_id`, a column that does not exist — the schema uses `driver_id`. Every call threw a PostgREST `Could not find the 'owner_id' column of 'trucks'` error, so the "My Truck" screen always failed and truck specs were silently unavailable to the trips screen and deadhead-recommendation logic.

## Fix

- Query on `.eq('driver_id', driverId)` to match the real schema and the rest of the codebase (`Truck.fromJson` reads `driver_id`; `truckRoutes.js` filters on `driver_id`).

## Files changed

- `apps/driver/lib/services/truck_repository.dart`

## Testing

- Column name now matches the `trucks` DDL (`driver_id uuid not null`).
- Single-field query swap; no Dart CLI available locally.

Closes #8903
