### PR TITLE
fix(api): expose POST /api/devices/unregister alias for the shared FCM app

### DIFF
--- a/backend/api/src/routes/deviceRoutes.js
+++ b/backend/api/src/routes/deviceRoutes.js
@@ -103,6 +103,7 @@ router.post('/register', authenticate, deviceLimiter, validateBody(registerDevic
  *         description: Validation error
  */
 router.delete('/unregister', authenticate, deviceLimiter, validateBody(unregisterDeviceSchema), unregisterDeviceToken);
+router.post('/unregister', authenticate, deviceLimiter, validateBody(unregisterDeviceSchema), unregisterDeviceToken);
 
 // GET /api/devices/platforms
 router.get('/platforms', authenticate, getDevicePlatforms);

--- a/backend/api/test/integration/devices.test.js
+++ b/backend/api/test/integration/devices.test.js
@@ -306,4 +306,41 @@ describe('Device Routes Integration Tests', () => {
       expect(res.body.error).toBe('Failed to unregister device');
     });
   });
+
+  describe('POST /api/devices/unregister', () => {
+    const UNREGISTER_HEADERS = {
+      'x-user-id': 'unregister-test-user-uuid',
+      'x-user-role': 'customer',
+      'x-user-name': 'Test Customer',
+    };
+
+    it('unregisters the device token via POST (shared app contract)', async () => {
+      m.store.user_devices.push({
+        user_id: 'unregister-test-user-uuid',
+        fcm_token: 'logout-token-123456',
+        platform: 'android',
+      });
+      m.store.profiles.push({
+        id: 'unregister-test-user-uuid',
+        fcm_token: 'logout-token-123456',
+        fcm_token_updated_at: '2026-01-01T00:00:00.000Z',
+      });
+
+      const res = await request(buildApp())
+        .post('/api/devices/unregister')
+        .set(UNREGISTER_HEADERS)
+        .send({ fcmToken: 'logout-token-123456' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: 'Device token unregistered',
+      });
+
+      const remainingDevice = m.store.user_devices.find(
+        (d) => d.user_id === 'unregister-test-user-uuid' && d.fcm_token === 'logout-token-123456'
+      );
+      expect(remainingDevice).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The shared Flutter `FcmService` unregisters device tokens with `POST /api/devices/unregister`, but the backend only exposed `DELETE /api/devices/unregister`. Every logout 404'd (the error is swallowed by the try/catch), so `user_devices` rows and `profiles.fcm_token` were never cleared — the previous user kept receiving push notifications on shared devices.

## Fix

- Add `router.post('/unregister', ...)` as an alias to the same `unregisterDeviceToken` handler, which already expects the `fcmToken` body field the app sends. Only the HTTP method needed aligning.

## Files changed

- `backend/api/src/routes/deviceRoutes.js`
- `backend/api/test/integration/devices.test.js`

## Testing

- Added an integration test for `POST /api/devices/unregister` asserting a 200 response and that the `user_devices` row is removed; the suite passes alongside the existing DELETE tests.

Closes #8908
