### PR TITLE
fix(shipment): query orders through the caller's user-scoped client

### DIFF
--- a/backend/api/src/controllers/shipmentController.js
+++ b/backend/api/src/controllers/shipmentController.js
@@ -1,4 +1,4 @@
-import { supabase } from '../config/db.js';
+import { createUserClient, supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
 export const getShipmentDetails = async (req, res) => {
@@ -8,8 +8,10 @@ export const getShipmentDetails = async (req, res) => {
       return res.status(400).json({ error: 'shipmentId is required' });
     }
 
+    const db = createUserClient(req.token) || supabase;
+
     // Fetch the order (shipment) from the database
-    const { data: shipment, error } = await supabase
+    const { data: shipment, error } = await db
       .from('orders')
       .select('*')
       .eq('id', shipmentId)

--- a/backend/api/test/unit/controllers/shipmentController.test.js
+++ b/backend/api/test/unit/controllers/shipmentController.test.js
@@ -32,6 +32,7 @@ describe('shipmentController.getShipmentDetails', () => {
     createUserClientMock.mockReturnValue(client);
 
     const req = {
+      query: {},
       token: 'user-jwt',
       params: { shipmentId: 'ship_1' },
       user: { id: 'user_1' },
@@ -51,6 +52,7 @@ describe('shipmentController.getShipmentDetails', () => {
     createUserClientMock.mockReturnValue(client);
 
     const req = {
+      query: {},
       token: 'driver-jwt',
       params: { shipmentId: 'ship_1' },
       user: { id: 'driver_1' },
@@ -67,6 +69,7 @@ describe('shipmentController.getShipmentDetails', () => {
     createUserClientMock.mockReturnValue(buildClient(null, { message: 'not found' }));
 
     const req = {
+      query: {},
       token: 'user-jwt',
       params: { shipmentId: 'missing' },
       user: { id: 'user_1' },
@@ -83,6 +86,7 @@ describe('shipmentController.getShipmentDetails', () => {
     createUserClientMock.mockReturnValue(buildClient({ id: 'ship_1', customer_id: 'user_1', driver_id: 'driver_1' }, null));
 
     const req = {
+      query: {},
       token: 'stranger-jwt',
       params: { shipmentId: 'ship_1' },
       user: { id: 'stranger' },
@@ -95,7 +99,7 @@ describe('shipmentController.getShipmentDetails', () => {
   });
 
   it('returns 400 when shipmentId is missing', async () => {
-    const req = { token: 'user-jwt', params: {}, user: { id: 'user_1' } };
+    const req = { query: {}, token: 'user-jwt', params: {}, user: { id: 'user_1' } };
     const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
 
     await getShipmentDetails(req, res);

--- a/backend/api/test/unit/controllers/shipmentController.test.js
+++ b/backend/api/test/unit/controllers/shipmentController.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { from, createUserClientMock } = vi.hoisted(() => ({
+  from: vi.fn(),
+  createUserClientMock: vi.fn(),
+}));
+
+vi.mock('../../../src/config/db.js', () => ({
+  supabase: { from },
+  createUserClient: createUserClientMock,
+}));
+
+import { getShipmentDetails } from '../../../src/controllers/shipmentController.js';
+
+const buildClient = (data, error) => ({
+  from: vi.fn(() => ({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn(async () => ({ data, error })),
+      })),
+    })),
+  })),
+});
+
+describe('shipmentController.getShipmentDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the shipment through the caller\'s JWT client (RLS-scoped), not the anon client', async () => {
+    const client = buildClient({ id: 'ship_1', customer_id: 'user_1', driver_id: null }, null);
+    createUserClientMock.mockReturnValue(client);
+
+    const req = {
+      token: 'user-jwt',
+      params: { shipmentId: 'ship_1' },
+      user: { id: 'user_1' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(createUserClientMock).toHaveBeenCalledWith('user-jwt');
+    expect(client.from).toHaveBeenCalledWith('orders');
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: expect.objectContaining({ id: 'ship_1' }) });
+  });
+
+  it('allows the assigned driver to view the shipment', async () => {
+    const client = buildClient({ id: 'ship_1', customer_id: 'user_1', driver_id: 'driver_1' }, null);
+    createUserClientMock.mockReturnValue(client);
+
+    const req = {
+      token: 'driver-jwt',
+      params: { shipmentId: 'ship_1' },
+      user: { id: 'driver_1' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: expect.objectContaining({ id: 'ship_1' }) });
+  });
+
+  it('returns 404 when the shipment is not found', async () => {
+    createUserClientMock.mockReturnValue(buildClient(null, { message: 'not found' }));
+
+    const req = {
+      token: 'user-jwt',
+      params: { shipmentId: 'missing' },
+      user: { id: 'user_1' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Shipment not found' });
+  });
+
+  it('returns 403 when the user is neither owner nor assigned driver', async () => {
+    createUserClientMock.mockReturnValue(buildClient({ id: 'ship_1', customer_id: 'user_1', driver_id: 'driver_1' }, null));
+
+    const req = {
+      token: 'stranger-jwt',
+      params: { shipmentId: 'ship_1' },
+      user: { id: 'stranger' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 400 when shipmentId is missing', async () => {
+    const req = { token: 'user-jwt', params: {}, user: { id: 'user_1' } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(createUserClientMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

`GET /api/v1/shipment/details` returned `404 Shipment not found` for every authenticated user — even the customer who owns the shipment — because `getShipmentDetails` queried `orders` through the shared session-less anon Supabase client.

`orders` has RLS enabled with `authenticated`-only policies (`supabase/migrations/20240101000000_rls.sql:165-180`). With the anon client, `auth.uid()` is `NULL`, so `get_profile_id()` evaluates to `NULL`, neither the "Customers access own orders" nor the "Drivers view assigned orders" policy ever matches, and the SELECT returns zero rows. The handler fell into the `404` branch before the authorization checks ever ran, making the assigned-driver ownership check added in #6702 unreachable dead code.

## Fix

- `backend/api/src/controllers/shipmentController.js`: query `orders` through `createUserClient(req.token)` (falling back to `supabase`), so the SELECT runs with the authenticated caller's identity and RLS permits the row. This is the same pattern already used at `driverRoutes.js:1001` and `orderRoutes.js:286/555/631`.
- Add unit tests for `getShipmentDetails` covering the customer-owner case, the assigned-driver case, `403` for unauthorized users, `404` for missing rows, and `400` for a missing `shipmentId`.

## Files changed

- `backend/api/src/controllers/shipmentController.js`
- `backend/api/test/unit/controllers/shipmentController.test.js`

## Testing

- Added `backend/api/test/unit/controllers/shipmentController.test.js` which asserts the user-scoped client is created with `req.token` and that the `orders` query goes through it (not the anon client).
- Run with: `npm test -- test/unit/controllers/shipmentController.test.js`

Closes #8945
