### PR TITLE
fix(api): page getUserConnections past the PostgREST row cap

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -1,6 +1,8 @@
 import logger from '../../middleware/logger.js';
 import { redisClient, supabaseAdmin } from '../../config/db.js';
 
+const CONNECTION_PAGE_SIZE = 1000;
+
 class FraudDetectionService {
   constructor() {
     this.redis = redisClient;
@@ -329,28 +331,32 @@ class FraudDetectionService {
     const safeUserId = this.sanitizeUserId(userId);
     if (!safeUserId) return [];
     // Get all connections (orders, trips, shared routes)
-    const { data: orders, error } = await supabaseAdmin
-      .from('orders')
-      .select('customer_id, driver_id')
-      .or(`customer_id.eq.${safeUserId},driver_id.eq.${safeUserId}`);
-
-    if (error) {
-      logger.error('Failed to load user fraud connections:', error);
-      return [];
-    }
-
-    if (!Array.isArray(orders)) {
-      return [];
-    }
-
     const connections = new Set();
-    orders.forEach(order => {
-      if (order.customer_id === userId && order.driver_id) {
-        connections.add(order.driver_id);
-      } else if (order.driver_id === userId && order.customer_id) {
-        connections.add(order.customer_id);
+    let offset = 0;
+    let page = [];
+    do {
+      const { data: orders, error } = await supabaseAdmin
+        .from('orders')
+        .select('customer_id, driver_id')
+        .or(`customer_id.eq.${safeUserId},driver_id.eq.${safeUserId}`)
+        .order('id', { ascending: true })
+        .range(offset, offset + CONNECTION_PAGE_SIZE - 1);
+
+      if (error) {
+        logger.error('Failed to load user fraud connections:', error);
+        return [];
       }
-    });
+
+      page = Array.isArray(orders) ? orders : [];
+      page.forEach(order => {
+        if (order.customer_id === userId && order.driver_id) {
+          connections.add(order.driver_id);
+        } else if (order.driver_id === userId && order.customer_id) {
+          connections.add(order.customer_id);
+        }
+      });
+      offset += page.length;
+    } while (page.length === CONNECTION_PAGE_SIZE);
 
     return Array.from(connections);
   }

--- a/backend/api/test/unit/fraudDetectionConnections.test.js
+++ b/backend/api/test/unit/fraudDetectionConnections.test.js
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for getUserConnections pagination in FraudDetectionService
+ *
+ * Run with:  npm run test:unit -- test/unit/fraudDetectionConnections.test.js
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const CONNECTION_PAGE_SIZE = 1000;
+
+function buildOrdersBuilder(orderPages) {
+  let index = 0;
+  const builder = {
+    select() { return this; },
+    or() { return this; },
+    order() { return this; },
+    range(offset, end) {
+      const page = orderPages[index++] ?? [];
+      return Promise.resolve({ data: page, error: null });
+    },
+  };
+  return builder;
+}
+
+function mockDbWith(builder, trace) {
+  const from = vi.fn((table) => {
+    if (trace) trace.from = table;
+    return builder;
+  });
+  const supabaseAdminMock = { from };
+  vi.doMock('../../src/config/db.js', () => ({
+    supabaseAdmin: supabaseAdminMock,
+    redisClient: {},
+  }));
+  return supabaseAdminMock;
+}
+
+afterEach(() => {
+  vi.doUnmock('../../src/config/db.js');
+});
+
+describe('FraudDetectionService.getUserConnections', () => {
+  it('pages past a full page of orders and dedupes connections', async () => {
+    const fullPage = Array.from({ length: CONNECTION_PAGE_SIZE }, (_, i) => ({
+      customer_id: i % 2 === 0 ? 'user-1' : `driver-${i}`,
+      driver_id: i % 2 === 0 ? `driver-${i}` : 'user-1',
+    }));
+    const tailPage = [
+      { customer_id: 'user-1', driver_id: 'tail-driver' },
+      { customer_id: 'user-1', driver_id: 'driver-0' },
+    ];
+
+    vi.resetModules();
+    const builder = buildOrdersBuilder([fullPage, tailPage]);
+    const supabaseMock = mockDbWith(builder);
+
+    const fraudDetection = (await import('../../src/services/fraud/FraudDetectionService.js')).default;
+
+    const connections = await fraudDetection.getUserConnections('user-1');
+
+    expect(supabaseMock.from).toHaveBeenCalledWith('orders');
+    expect(connections).toContain('tail-driver');
+    expect(connections).toContain('driver-0');
+    expect(connections).toContain('driver-999');
+  });
+
+  it('stops paging once fewer than a full page remains', async () => {
+    const ranges = [];
+    const builder = {
+      select() { return this; },
+      or() { return this; },
+      order() { return this; },
+      range(offset, end) {
+        ranges.push([offset, end]);
+        return Promise.resolve({ data: [], error: null });
+      },
+    };
+
+    vi.resetModules();
+    mockDbWith(builder);
+
+    const fraudDetection = (await import('../../src/services/fraud/FraudDetectionService.js')).default;
+
+    const connections = await fraudDetection.getUserConnections('user-1');
+
+    expect(ranges.length).toBe(1);
+    expect(ranges[0]).toEqual([0, CONNECTION_PAGE_SIZE - 1]);
+    expect(connections).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #9220

## Summary

`getUserConnections` read a user's orders with no `.limit()`, `.range()`, or `.order()`. PostgREST caps a single response at 1000 rows, so high-volume users produced a truncated fraud-ring graph — edges beyond the cap were silently missing.

## Changes

- `backend/api/src/services/fraud/FraudDetectionService.js`
  - `getUserConnections`: page with a deterministic `.order('id')` + `.range()`, folding the connection-extraction loop into each page, until fewer than a full page remains. Dedup via the existing `Set`.
- `backend/api/test/unit/fraudDetectionConnections.test.js` (new)
  - Pages past a full 1000-row page and dedupes; stops after a single page when fewer than a full page remains.

## Test

```
npx vitest run test/unit/fraudDetectionConnections.test.js  ->  2 passed
```

### GSSOC Contribution
