### PR TITLE
fix(support): add migration creating and seeding the faqs table

### DIFF
--- a/supabase/migrations/20260810150000_create_faqs_table.sql
+++ b/supabase/migrations/20260810150000_create_faqs_table.sql
@@ -1,0 +1,64 @@
+-- =============================================================================
+-- Migration: create and seed the faqs reference table
+-- =============================================================================
+-- Problem:
+--   GET /api/support/faqs (backend/api/src/routes/supportRoutes.js:207) queries
+--   a `faqs` table that no migration ever creates. The RLS migration already
+--   declares policies on faqs (20240101000000_rls.sql:424-433) and
+--   revoke_anon_privileges.sql:27 revokes privileges on it, but the table itself
+--   was never provisioned, so every request returned PostgREST PGRST301 and the
+--   revoke statement errored on fresh provisioning.
+--
+-- Fix:
+--   Create faqs with the columns the route selects (id, question, answer,
+--   app_type, sort_order) plus is_active/created_at, enable RLS using the exact
+--   policy names declared in the RLS migration, and seed a starter set of FAQs.
+-- =============================================================================
+
+begin;
+
+create table if not exists faqs (
+  id          uuid primary key default gen_random_uuid(),
+  question    text not null,
+  answer      text not null,
+  app_type    text not null default 'both',
+  is_active   boolean not null default true,
+  sort_order  int not null default 0,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_faqs_active on faqs (is_active, sort_order);
+
+-- RLS policies mirror 20240101000000_rls.sql (which referenced faqs but could
+-- not attach policies to a nonexistent table). The route reads via the public
+-- anon client, so anon + authenticated get SELECT on active rows only.
+alter table faqs enable row level security;
+
+drop policy if exists "Service role full access on faqs" on faqs;
+create policy "Service role full access on faqs"
+  on faqs for all to service_role using (true) with check (true);
+
+drop policy if exists "Anyone can view active FAQs" on faqs;
+create policy "Anyone can view active FAQs"
+  on faqs for select to anon, authenticated
+  using (is_active = true);
+
+-- Seed starter FAQs (idempotent — no-ops if rows already exist).
+insert into faqs (question, answer, app_type, is_active, sort_order)
+select f.question, f.answer, f.app_type, true, f.sort_order
+from (values
+  ('How do I book a truck on Truxify?', 'Open the app, enter pickup and drop-off locations, choose a vehicle type, and submit your load. Nearby drivers receive the request and you can track the trip in real time.', 'customer', 1),
+  ('How is the fare calculated?', 'Fare is based on distance, vehicle type, and any additional services such as cold-chain or detention time. You always see the estimated fare before confirming a booking.', 'customer', 2),
+  ('Can I track my shipment live?', 'Yes. Once a driver accepts your load, you can follow the live location of the truck until delivery is completed.', 'customer', 3),
+  ('What happens if my shipment is damaged?', 'Report the issue through Help & Support immediately after delivery. Claims are reviewed with proof of condition and resolved within the SLA stated on your booking.', 'customer', 4),
+  ('How do I receive load requests?', 'When a load is posted in your area and matches your truck type, it appears in the Loads tab. Accept a load to start the trip.', 'driver', 1),
+  ('When do I get paid for a trip?', 'Earnings are credited to your wallet after a trip is completed and verified. You can withdraw to your bank account at any time.', 'driver', 2),
+  ('What documents do I need to drive on Truxify?', 'A valid driving licence, vehicle registration (RC book), and insurance. Upload them in your profile and they are verified before you can accept loads.', 'driver', 3),
+  ('What should I do if a trip is delayed?', 'Communicate with the customer through the in-app chat and notify support if the delay affects the agreed schedule.', 'driver', 4),
+  ('How do I contact support?', 'Use Help & Support in the app to raise a ticket, or browse FAQs for instant answers to common questions.', 'both', 5)
+) as f(question, answer, app_type, sort_order)
+where not exists (
+  select 1 from faqs where faqs.question = f.question
+);
+
+commit;


### PR DESCRIPTION
## Problem

`GET /api/support/faqs` returned `500 Failed to fetch FAQs.` for every request because the `faqs` table is never created by any migration.

- `backend/api/src/routes/supportRoutes.js:212` queries `.from('faqs')` → PostgREST `PGRST301` (table not in schema cache).
- `supabase/migrations/20240101000000_rls.sql:424-433` declares RLS policies on `faqs` (`ALTER TABLE IF EXISTS` → silent no-op; `CREATE POLICY` on a nonexistent table fails).
- `supabase/migrations/revoke_anon_privileges.sql:27` does `REVOKE ALL ON TABLE public.faqs FROM anon;` → errors on a fresh migration replay because the relation does not exist.

A repo-wide search found zero `CREATE TABLE` statements for `faqs`, so the reference table was never provisioned (unlike `vehicle_types`/`regions`).

## Fix

Add `supabase/migrations/20260810150000_create_faqs_table.sql` that:

- Creates `faqs` with the columns the route selects (`id, question, answer, app_type, sort_order`) plus `is_active` and `created_at`.
- Adds an index on `(is_active, sort_order)` matching the route's `eq('is_active', true)` + `order('sort_order')` query.
- Enables RLS and recreates the exact policies already declared in `20240101000000_rls.sql`:
  - `"Service role full access on faqs"` (all, service_role)
  - `"Anyone can view active FAQs"` (select, anon + authenticated, `is_active = true`)
- Seeds a starter set of FAQs across `customer` / `driver` / `both` app types (matching the route's `app_type` + `'both'` filtering), idempotently.

This also makes `revoke_anon_privileges.sql:27` resolve on a fresh migration replay.

## Files changed

- `supabase/migrations/20260810150000_create_faqs_table.sql`

## Testing

- All DDL is idempotent (`create table/index if not exists`, `drop policy if exists`, seeded with `where not exists`), safe to replay.
- Column names match `FAQ_COLUMNS` (`id, question, answer, app_type, sort_order`) plus the `is_active` filter used by `supportRoutes.js:213-214`.
- RLS policy names match the declarations already asserted by `backend/api/test/unit/rlsSecurity.test.js`.
- Route behavior (only active FAQs, sorted by `sort_order`, `app_type` + `'both'` filter) is already covered by `backend/api/test/integration/supportRoutes.test.js`.

Closes #8946
