### PR TITLE
fix(api): page each batch in getBatchUserConnections past the row cap

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -362,28 +362,36 @@ class FraudDetectionService {
     if (safeIds.length === 0) return {};
 
     const BATCH_SIZE = 100;
+    const PAGE_SIZE = 1000;
     const allOrders = [];
 
     // Query in batches to avoid unbounded OR filter URL-length limits
     for (let i = 0; i < safeIds.length; i += BATCH_SIZE) {
       const batch = safeIds.slice(i, i + BATCH_SIZE);
-      const { data: batchOrders, error } = await supabaseAdmin
-        .from('orders')
-        .select('customer_id, driver_id')
-        .or(
-          batch.map(id => `customer_id.eq.${id}`).join(',') +
-          ',' +
-          batch.map(id => `driver_id.eq.${id}`).join(',')
-        );
+      const batchFilter = batch.map(id => `customer_id.eq.${id}`).join(',') + ',' +
+        batch.map(id => `driver_id.eq.${id}`).join(',');
 
-      if (error) {
-        logger.error('Failed to load batch user fraud connections:', error.message);
-        return {};
-      }
+      // Each batch's row set is paged too, since a single prolific user can
+      // still push one batch past PostgREST's 1000-row response cap.
+      let offset = 0;
+      let page = [];
+      do {
+        const { data: batchOrders, error } = await supabaseAdmin
+          .from('orders')
+          .select('customer_id, driver_id')
+          .or(batchFilter)
+          .order('id', { ascending: true })
+          .range(offset, offset + PAGE_SIZE - 1);
 
-      if (Array.isArray(batchOrders)) {
-        allOrders.push(...batchOrders);
-      }
+        if (error) {
+          logger.error('Failed to load batch user fraud connections:', error.message);
+          return {};
+        }
+
+        page = Array.isArray(batchOrders) ? batchOrders : [];
+        allOrders.push(...page);
+        offset += page.length;
+      } while (page.length === PAGE_SIZE);
     }
 
     if (!Array.isArray(allOrders)) {

--- a/backend/api/test/unit/fraudDetectionBatchConnections.test.js
+++ b/backend/api/test/unit/fraudDetectionBatchConnections.test.js
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for getBatchUserConnections pagination in FraudDetectionService
+ *
+ * Run with:  npm run test:unit -- test/unit/fraudDetectionBatchConnections.test.js
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const CONNECTION_PAGE_SIZE = 1000;
+
+function buildOrdersBuilder(orderPages) {
+  let index = 0;
+  const builder = {
+    select() { return this; },
+    or() { return this; },
+    order() { return this; },
+    range() {
+      const page = orderPages[index++] ?? [];
+      return Promise.resolve({ data: page, error: null });
+    },
+  };
+  return builder;
+}
+
+function mockDbWith(builder, trace) {
+  const from = vi.fn((table) => {
+    if (trace) trace.from = table;
+    return builder;
+  });
+  const supabaseAdminMock = { from };
+  vi.doMock('../../src/config/db.js', () => ({
+    supabaseAdmin: supabaseAdminMock,
+    redisClient: {},
+  }));
+  return supabaseAdminMock;
+}
+
+afterEach(() => {
+  vi.doUnmock('../../src/config/db.js');
+});
+
+describe('FraudDetectionService.getBatchUserConnections', () => {
+  it('pages a batch past a full page and returns all connections', async () => {
+    const fullPage = Array.from({ length: CONNECTION_PAGE_SIZE }, (_, i) => ({
+      customer_id: 'user-1',
+      driver_id: `driver-${i}`,
+    }));
+    const tailPage = [
+      { customer_id: 'user-1', driver_id: 'tail-driver' },
+      { customer_id: 'user-2', driver_id: 'driver-0' },
+    ];
+
+    vi.resetModules();
+    const builder = buildOrdersBuilder([fullPage, tailPage]);
+    const supabaseMock = mockDbWith(builder);
+
+    const fraudDetection = (await import('../../src/services/fraud/FraudDetectionService.js')).default;
+
+    const result = await fraudDetection.getBatchUserConnections(['user-1', 'user-2']);
+
+    expect(supabaseMock.from).toHaveBeenCalledWith('orders');
+    expect(result['user-1']).toContain('tail-driver');
+    expect(result['user-1']).toContain('driver-999');
+    expect(result['user-2']).toContain('driver-0');
+  });
+
+  it('stops paging a batch once fewer than a full page remains', async () => {
+    const ranges = [];
+    const builder = {
+      select() { return this; },
+      or() { return this; },
+      order() { return this; },
+      range(offset, end) {
+        ranges.push([offset, end]);
+        return Promise.resolve({ data: [], error: null });
+      },
+    };
+
+    vi.resetModules();
+    mockDbWith(builder);
+
+    const fraudDetection = (await import('../../src/services/fraud/FraudDetectionService.js')).default;
+
+    const result = await fraudDetection.getBatchUserConnections(['user-1']);
+
+    expect(ranges).toEqual([[0, CONNECTION_PAGE_SIZE - 1]]);
+    expect(result['user-1']).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #9222

## Summary

`getBatchUserConnections` batched the OR filter 100 ids at a time, but each batch query itself had no `.limit()`, `.range()`, or `.order()`. PostgREST caps a single response at 1000 rows, so a single prolific user in a batch could push the batch past the cap and truncate the edge set for the entire batch.

## Changes

- `backend/api/src/services/fraud/FraudDetectionService.js`
  - `getBatchUserConnections`: page each batch's rows with a deterministic `.order('id')` + `.range()` until fewer than a full page remains (`PAGE_SIZE = 1000`).
- `backend/api/test/unit/fraudDetectionBatchConnections.test.js` (new)
  - Pages a batch past a full 1000-row page and returns all connections; stops after one page when fewer than a full page remains.

## Test

```
npx vitest run test/unit/fraudDetectionBatchConnections.test.js  ->  2 passed
```

### GSSOC Contribution
