### PR TITLE
fix(earnings): query trips through the caller's user-scoped client

### DIFF
--- a/backend/api/routes/earnings.js
+++ b/backend/api/routes/earnings.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { supabase } from '../src/config/db.js';
+import { createUserClient } from '../src/config/db.js';
 import { authenticate } from '../src/middleware/auth.js';
 import { userLimiter } from '../src/middleware/rateLimiter.js';
 import { requirePolicy } from '../src/middleware/requirePolicy.js';
@@ -57,7 +57,12 @@ router.get(
     try {
       const periodStart = getPeriodStart(period);
 
-      const { data: trips, error } = await supabase
+      // Query trips through the caller's user-scoped client so the trips RLS
+      // policy (driver_id = get_profile_id()) sees the authenticated driver's
+      // identity. The shared anon client has no identity and can never return
+      // the driver's rows.
+      const userClient = createUserClient(req.token);
+      const { data: trips, error } = await userClient
         .from('trips')
         .select('trip_display_id, trip_date, distance, total_earnings, fuel_deducted')
         .eq('driver_id', driverId)

--- a/backend/api/test/unit/earningsRoute.test.js
+++ b/backend/api/test/unit/earningsRoute.test.js
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for backend/api/routes/earnings.js — GET /api/earnings/summary
+ *
+ * Coverage:
+ *   - trips are queried through the caller's user-scoped client
+ *     (createUserClient(req.token)), never the shared anon client
+ *
+ * Run with:  npm test -- test/unit/earningsRoute.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+
+const { userClientFrom, createUserClientMock } = vi.hoisted(() => ({
+  userClientFrom: vi.fn(),
+  createUserClientMock: vi.fn(),
+}))
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: vi.fn(() => {
+    throw new Error('shared anon client must not be used by /api/earnings/summary')
+  }) },
+  createUserClient: createUserClientMock,
+}))
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = { id: 'driver-123', role: 'driver' }
+    req.token = 'driver-jwt'
+    next()
+  },
+}))
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+}))
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}))
+
+vi.mock('../../src/middleware/validate.js', () => ({
+  validateQuery: () => (_req, _res, next) => next(),
+}))
+
+const buildChain = (data, error) => ({
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  gte: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  then: (resolve) => resolve({ data, error }),
+})
+
+import earningsRouter from '../../routes/earnings.js'
+
+const app = express()
+app.use('/api/earnings', earningsRouter)
+
+describe('GET /api/earnings/summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries trips through createUserClient(req.token), not the anon client', async () => {
+    userClientFrom.mockReturnValue(buildChain([], null))
+    createUserClientMock.mockReturnValue({ from: userClientFrom })
+
+    const res = await request(app).get('/api/earnings/summary?period=monthly')
+
+    expect(res.status).toBe(200)
+    expect(createUserClientMock).toHaveBeenCalledWith('driver-jwt')
+    expect(userClientFrom).toHaveBeenCalledWith('trips')
+  })
+
+  it('returns 500 when the trips query fails', async () => {
+    userClientFrom.mockReturnValue(buildChain(null, { message: 'permission denied' }))
+    createUserClientMock.mockReturnValue({ from: userClientFrom })
+
+    const res = await request(app).get('/api/earnings/summary?period=monthly')
+
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to fetch earnings summary.')
+  })
+})


### PR DESCRIPTION
## Problem

`GET /api/earnings/summary` read `trips` through the shared session-less anon-key Supabase client (`backend/api/routes/earnings.js:60-67`). The `trips` table has RLS with an `authenticated` policy only (`driver_id = get_profile_id()`, `supabase/migrations/20240101000000_rls.sql:256-272`), no `anon` policy, and `revoke_anon_privileges.sql` also revokes anon privileges on `trips`.

With the anon client, `auth.uid()` is `NULL`, so:

- RLS-only environment: the SELECT returns `[]` → HTTP 200 with a zeroed summary → permanently empty earnings dashboard.
- Repo's shipped schema (revoke applied): the SELECT errors `42501 permission denied` → HTTP 500.

Either way the endpoint can never surface the driver's actual completed trips, even though the route already has `authenticate` + `requirePolicy('driver:view-earnings')` and `req.user.id` is available.

## Fix

- `backend/api/routes/earnings.js`: query `trips` through `createUserClient(req.token)` (per-request client carrying the caller's JWT, so `get_profile_id()` resolves to the driver). This matches the established pattern in `driverRoutes.js:1001`, `orderRoutes.js:286/555/631`.
- Add a route unit test asserting `createUserClient` is called with `req.token` and that the `trips` query goes through the user-scoped client, plus the 500 path when the query errors.

## Files changed

- `backend/api/routes/earnings.js`
- `backend/api/test/unit/earningsRoute.test.js`

## Testing

- Added `backend/api/test/unit/earningsRoute.test.js`:
  - asserts `createUserClient('driver-jwt')` is invoked and the `trips` table is queried through the returned user client (the mocked shared anon client throws if used);
  - asserts `500 Failed to fetch earnings summary.` when the trips query returns an error.
- Run with: `npm test -- test/unit/earningsRoute.test.js`

Closes #8947
