### PR TITLE
fix(security): bound anomaly detection transactions reads

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -10,6 +10,15 @@ const ANOMALY_THRESHOLDS = {
   UNUSUAL_DESTINATION: true, // New wallet destination
 };
 
+/**
+ * Defensive row cap on the 30-day withdrawal statistic pulls. PostgREST
+ * silently caps a single response at 1000 rows, so without an explicit
+ * bound the average/std-dev baseline would be computed from a truncated,
+ * non-deterministic sample for wallets with more than 1000 withdrawals in
+ * the window. Ordered by recency so the cap keeps the newest rows.
+ */
+const ANOMALY_STATS_MAX_ROWS = 1000;
+
 const ANOMALY_SEVERITY = {
   LOW: 'LOW',
   MEDIUM: 'MEDIUM',
@@ -106,7 +115,9 @@ class AnomalyDetectionService {
         .eq('user_id', userId)
         .eq('wallet_address', walletAddress)
         .eq('type', 'withdrawal')
-        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
+        .order('created_at', { ascending: false })
+        .limit(ANOMALY_STATS_MAX_ROWS);
 
       if (error || !data || data.length === 0) {
         return ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 2;
@@ -128,7 +139,9 @@ class AnomalyDetectionService {
         .eq('user_id', userId)
         .eq('wallet_address', walletAddress)
         .eq('type', 'withdrawal')
-        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
+        .order('created_at', { ascending: false })
+        .limit(ANOMALY_STATS_MAX_ROWS);
 
       if (error || !data || data.length < 2) {
         return ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 4;
@@ -169,18 +182,18 @@ class AnomalyDetectionService {
     try {
       const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
 
-      const { data, error } = await supabase
+      const { count, error } = await supabase
         .from('transactions')
-        .select('id')
+        .select('id', { count: 'exact', head: true })
         .eq('user_id', userId)
         .eq('wallet_address', walletAddress)
         .gte('created_at', tenMinutesAgo);
 
-      if (error || !data) {
+      if (error) {
         return null;
       }
 
-      const transferCount = data.length;
+      const transferCount = count || 0;
 
       if (transferCount >= ANOMALY_THRESHOLDS.MULTIPLE_TRANSFERS) {
         return {

--- a/backend/api/test/unit/anomalyDetectionService.test.js
+++ b/backend/api/test/unit/anomalyDetectionService.test.js
@@ -35,6 +35,23 @@ vi.mock('../../src/config/db.js', () => ({
 }));
 
 import AnomalyDetectionService, { ANOMALY_THRESHOLDS, ANOMALY_SEVERITY } from '../../src/services/security/anomalyDetectionService.js';
+import { supabase } from '../../src/config/db.js';
+
+/**
+ * Build a thenable supabase query-builder mock that records the chain and
+ * resolves to the given result. Mirrors awaiting the real PostgREST client.
+ */
+function mockQuery(result) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    gte: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+  };
+  builder.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return builder;
+}
 
 describe('AnomalyDetectionService', () => {
   let service;
@@ -165,6 +182,76 @@ describe('AnomalyDetectionService', () => {
     it('never scores a credit/refund transaction as LARGE_WITHDRAWAL', async () => {
       const transaction = { type: 'credit', amount: 50000 };
       const result = await service.detectLargeWithdrawal('user-1', 'wallet-1', transaction);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserAverageWithdrawal', () => {
+    it('averages the recent bounded window and orders by recency', async () => {
+      const builder = mockQuery({
+        data: [{ amount: '1000' }, { amount: '2000' }],
+        error: null,
+      });
+      supabase.from.mockReturnValue(builder);
+
+      const avg = await service.getUserAverageWithdrawal('user-1', 'wallet-1');
+
+      expect(avg).toBe(1500);
+      expect(supabase.from).toHaveBeenCalledWith('transactions');
+      expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(builder.limit).toHaveBeenCalledWith(1000);
+    });
+
+    it('falls back to half the threshold when the window is empty', async () => {
+      supabase.from.mockReturnValue(mockQuery({ data: [], error: null }));
+
+      const avg = await service.getUserAverageWithdrawal('user-1', 'wallet-1');
+
+      expect(avg).toBe(ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 2);
+    });
+  });
+
+  describe('getUserWithdrawalStdDev', () => {
+    it('computes the standard deviation from the bounded window', async () => {
+      const builder = mockQuery({
+        data: [{ amount: '100' }, { amount: '200' }, { amount: '300' }],
+        error: null,
+      });
+      supabase.from.mockReturnValue(builder);
+
+      const stdDev = await service.getUserWithdrawalStdDev('user-1', 'wallet-1');
+
+      const expected = Math.sqrt(((100 - 200) ** 2 + (200 - 200) ** 2 + (300 - 200) ** 2) / 3);
+      expect(stdDev).toBeCloseTo(expected, 6);
+      expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(builder.limit).toHaveBeenCalledWith(1000);
+    });
+
+    it('falls back to a quarter of the threshold with fewer than two rows', async () => {
+      supabase.from.mockReturnValue(mockQuery({ data: [{ amount: '100' }], error: null }));
+
+      const stdDev = await service.getUserWithdrawalStdDev('user-1', 'wallet-1');
+
+      expect(stdDev).toBe(ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 4);
+    });
+  });
+
+  describe('detectMultipleTransfers', () => {
+    it('uses an exact head count and flags transfers at or above the threshold', async () => {
+      const builder = mockQuery({ count: 7, error: null });
+      supabase.from.mockReturnValue(builder);
+
+      const result = await service.detectMultipleTransfers('user-1', 'wallet-1', { amount: '1' });
+
+      expect(builder.select).toHaveBeenCalledWith('id', { count: 'exact', head: true });
+      expect(result).toEqual(expect.objectContaining({ type: 'MULTIPLE_TRANSFERS', count: 7, severity: 'MEDIUM' }));
+    });
+
+    it('returns null when the exact count is below the threshold', async () => {
+      supabase.from.mockReturnValue(mockQuery({ count: 3, error: null }));
+
+      const result = await service.detectMultipleTransfers('user-1', 'wallet-1', { amount: '1' });
+
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
## Fix: bound unbounded transactions reads in anomaly detection

Closes #9229

### Problem
`backend/api/src/services/security/anomalyDetectionService.js` ran `transactions` queries with **no `.limit()`/`.range()`**. PostgREST caps a single response at 1000 rows, so for wallets with more than 1000 transactions in a window:
- `getUserAverageWithdrawal` / `getUserWithdrawalStdDev` computed the 30-day baseline (which drives the `LARGE_WITHDRAWAL` threshold via z-score) from a truncated, non-deterministic sample;
- `detectMultipleTransfers` examined only the first 1000 rows in the 10-minute window.

### Changes
- `getUserAverageWithdrawal` / `getUserWithdrawalStdDev`: `.order('created_at', { ascending: false }).limit(ANOMALY_STATS_MAX_ROWS)` (new `ANOMALY_STATS_MAX_ROWS = 1000`), so the statistics are computed over a deterministic, documented recent window.
- `detectMultipleTransfers`: switched to `select('id', { count: 'exact', head: true })` — returns the true count with **zero rows transferred**, keeping the reported count in the anomaly message accurate. Same pattern already used in `driverRoutes.js:1577`.
- `detectUnusualDestination` already had `.limit(1)`; left unchanged.

### Tests
`npx vitest run test/unit/anomalyDetectionService.test.js` → 23/23 pass (new cases assert the bounded chains, the head-count select, and the fallback values).

---
For GirlScript Summer of Code (GSSOC) 2025-2026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved anomaly detection for withdrawal activity by limiting historical transaction analysis to the most recent 1,000 records.
  - Enhanced multiple-transfer detection to use precise transaction counts while preserving existing thresholds and fallback behavior.
- **Tests**
  - Added coverage for withdrawal averages, standard deviations, query ordering and limits, fallback values, and multiple-transfer thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->