### PR TITLE
fix(security): bound key rotation history read

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -210,7 +210,7 @@ class KeyManagementService {
     });
   }
 
-  async getKeyRotationHistory(userId, walletAddress) {
+  async getKeyRotationHistory(userId, walletAddress, limit = 10) {
     return measureExecution('KeyManagementService.getKeyRotationHistory', async () => {
       try {
         const { data: history, error } = await supabase
@@ -218,7 +218,8 @@ class KeyManagementService {
           .select('*')
           .eq('user_id', userId)
           .eq('wallet_address', walletAddress)
-          .order('created_at', { ascending: false });
+          .order('created_at', { ascending: false })
+          .limit(limit);
 
         if (error) {
           logger.error('[KeyManagementService] Failed to fetch rotation history:', error);

--- a/backend/api/test/unit/keyManagementService.test.js
+++ b/backend/api/test/unit/keyManagementService.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const state = vi.hoisted(() => ({ builder: null }));
+
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -9,13 +11,25 @@ vi.mock('@sentry/node', () => ({
 }));
 
 vi.mock('../../src/config/db.js', () => ({
-  supabase: null,
+  supabase: { from: vi.fn(() => state.builder) },
   supabaseAdmin: null,
 }));
 
 vi.mock('../../src/core/performanceMetrics.js', () => ({
   measureExecution: vi.fn(async (_name, fn) => fn()),
 }));
+
+/** Thenable supabase query-builder mock that resolves to the given result. */
+function mockQuery(result) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+  };
+  builder.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return builder;
+}
 
 describe('KeyManagementService', () => {
   let KeyManagementService;
@@ -55,5 +69,40 @@ describe('KeyManagementService', () => {
     const keyB = await svc.deriveDeviceEncryptionKey('dev-1', secretB);
 
     expect(keyA.equals(keyB)).toBe(false);
+  });
+
+  it('bounds the rotation history to the default page size', async () => {
+    const rows = [
+      { key_id: 'k-2', created_at: '2026-08-10T10:00:00Z' },
+      { key_id: 'k-1', created_at: '2026-08-09T10:00:00Z' },
+    ];
+    const builder = mockQuery({ data: rows, error: null });
+    state.builder = builder;
+
+    const svc = new KeyManagementService();
+    const history = await svc.getKeyRotationHistory('user-1', 'wallet-1');
+
+    expect(history).toEqual(rows);
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(builder.limit).toHaveBeenCalledWith(10);
+  });
+
+  it('passes through an explicit limit', async () => {
+    const builder = mockQuery({ data: [{ key_id: 'k-1' }], error: null });
+    state.builder = builder;
+
+    const svc = new KeyManagementService();
+    await svc.getKeyRotationHistory('user-1', 'wallet-1', 25);
+
+    expect(builder.limit).toHaveBeenCalledWith(25);
+  });
+
+  it('returns an empty array on a fetch error', async () => {
+    state.builder = mockQuery({ data: null, error: new Error('db down') });
+
+    const svc = new KeyManagementService();
+    const history = await svc.getKeyRotationHistory('user-1', 'wallet-1');
+
+    expect(history).toEqual([]);
   });
 });


### PR DESCRIPTION
## Fix: bound the key rotation history read

Closes #9230

### Problem
`KeyManagementService.getKeyRotationHistory` (`keyManagementService.js:213`) selected the full `encrypted_wallet_keys` history for a user+wallet with **no `.limit()`**, while its sibling `keyRotationService.getRotationHistory` already defaults to a bounded page of 10. A wallet that rotated keys many times returned the entire history — an unbounded read and payload on every call, and inconsistent with the bounded sibling API.

### Changes
- `keyManagementService.js`: `getKeyRotationHistory(userId, walletAddress, limit = 10)` now applies `.limit(limit)` (default 10, matching `keyRotationService.js:207-215`), keeping `.order('created_at', { ascending: false })` so the newest rotations win.
- The method has no other call sites in the repo, so no caller depends on the unbounded behavior.
- `test/unit/keyManagementService.test.js`: new cases assert the default `.limit(10)`, explicit-limit passthrough, and the `[]` error path.

### Tests
`npx vitest run test/unit/keyManagementService.test.js` → 6/6 pass.

---
For GirlScript Summer of Code (GSSOC) 2025-2026
