### PR TITLE
fix : added bounded limit to getKeyRotationHistory query

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -218,7 +218,8 @@ class KeyManagementService {
           .select('*')
           .eq('user_id', userId)
           .eq('wallet_address', walletAddress)
-          .order('created_at', { ascending: false });
+          .order('created_at', { ascending: false })
+          .limit(10);
 
         if (error) {
           logger.error('[KeyManagementService] Failed to fetch rotation history:', error);


### PR DESCRIPTION
Closes #9276.

Summary of What Has Been Done:
Added .limit(10) to the getKeyRotationHistory() query in keyManagementService.js. The query was previously unbounded, returning the entire rotation history for a wallet with no limit. This is inconsistent with the sibling keyRotationService.getRotationHistory() which already defaults to limit=10.

Changes Made:
- backend/api/src/services/security/keyManagementService.js: Added .limit(10) to the supabase query in getKeyRotationHistory().

Impact it Made:
- Consistent API contract with the sibling keyRotationService.getRotationHistory() method.
- Prevents unbounded memory growth for wallets with many rotation entries.
- Makes response size deterministic for API consumers.

This PR is submitted as part of GSSOC contributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Key-rotation history now displays only the 10 most recent records, making results more focused and manageable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->