### PR TITLE
fix : added pagination to document expiry window queries

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -134,14 +134,19 @@ export async function processDocumentExpiryBatch() {
         let hasMore = true;
 
         while (hasMore) {
-          const { data, error, count } = await supabaseAdmin
+          // Fetch one page of documents (PostgREST caps at 1000 rows per response).
+          // If the result has exactly PAGE_SIZE rows, fetch the next page recursively
+          // until fewer rows are returned (end of window) or the count is exhausted.
+          const result = await supabaseAdmin
             .from('documents')
             .select('id, user_id, doc_type, valid_until', { count: 'exact' })
             .not('valid_until', 'is', null)
             .gte('valid_until', windowStart.toISOString())
             .lte('valid_until', windowEnd.toISOString())
             .order('valid_until', { ascending: true })
-            .then(q => q.range(offset, offset + PAGE_SIZE - 1));
+            .range(offset, offset + PAGE_SIZE - 1);
+
+          const { data, error, count } = result;
 
           if (error) {
             logger.error(`[document-expiry] Failed to query documents for ${window.label} window (offset=${offset}):`, error.message);

--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -127,19 +127,34 @@ export async function processDocumentExpiryBatch() {
 
       let documents = [];
       try {
-        const { data, error } = await supabaseAdmin
-          .from('documents')
-          .select('id, user_id, doc_type, valid_until')
-          .not('valid_until', 'is', null)
-          .gte('valid_until', windowStart.toISOString())
-          .lte('valid_until', windowEnd.toISOString());
+        // Paginate through the window using .range() to handle PostgREST's
+        // 1000-row cap — without pagination, documents beyond row 1000 never
+        // receive expiry reminders.
+        const PAGE_SIZE = 1000;
+        let offset = 0;
+        let hasMore = true;
 
-        if (error) {
-          logger.error(`[document-expiry] Failed to query documents for ${window.label} window:`, error.message);
-          continue;
+        while (hasMore) {
+          const { data, error, count } = await supabaseAdmin
+            .from('documents')
+            .select('id, user_id, doc_type, valid_until', { count: 'exact' })
+            .not('valid_until', 'is', null)
+            .gte('valid_until', windowStart.toISOString())
+            .lte('valid_until', windowEnd.toISOString())
+            .order('valid_until', { ascending: true })
+            .range(offset, offset + PAGE_SIZE - 1);
+
+          if (error) {
+            logger.error(`[document-expiry] Failed to query documents for ${window.label} window (offset=${offset}):`, error.message);
+            hasMore = false;
+            continue;
+          }
+
+          const page = data || [];
+          documents.push(...page);
+          offset += PAGE_SIZE;
+          hasMore = page.length === PAGE_SIZE && (!count || offset < count);
         }
-
-        documents = data || [];
       } catch (err) {
         logger.error(`[document-expiry] Error querying documents for ${window.label} window:`, err.message);
         continue;

--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -127,9 +127,8 @@ export async function processDocumentExpiryBatch() {
 
       let documents = [];
       try {
-        // Paginate through the window using .range() to handle PostgREST's
-        // 1000-row cap — without pagination, documents beyond row 1000 never
-        // receive expiry reminders.
+        // Paginate through the window to handle PostgREST's 1000-row cap —
+        // without pagination, documents beyond row 1000 never receive reminders.
         const PAGE_SIZE = 1000;
         let offset = 0;
         let hasMore = true;
@@ -142,7 +141,7 @@ export async function processDocumentExpiryBatch() {
             .gte('valid_until', windowStart.toISOString())
             .lte('valid_until', windowEnd.toISOString())
             .order('valid_until', { ascending: true })
-            .range(offset, offset + PAGE_SIZE - 1);
+            .then(q => q.range(offset, offset + PAGE_SIZE - 1));
 
           if (error) {
             logger.error(`[document-expiry] Failed to query documents for ${window.label} window (offset=${offset}):`, error.message);

--- a/backend/api/test/unit/documentExpiryService.test.js
+++ b/backend/api/test/unit/documentExpiryService.test.js
@@ -10,6 +10,8 @@ function makeBuilder(result) {
     lte() { return this; },
     eq() { return this; },
     maybeSingle() { return this; },
+    order() { return this; },
+    range() { return this; },
     then(resolve) { return resolve(result); },
   };
   return builder;


### PR DESCRIPTION
Closes #9279.

Summary of What Has Been Done:
Replaced the single unbounded query in documentExpiryService with a paginated .range() loop (1000 rows per page) ordered by valid_until. Without pagination, PostgREST silently caps results at 1000 rows and documents beyond that cap never receive expiry reminders.

Changes Made:
- backend/api/src/services/documentExpiryService.js: Replaced single supabaseAdmin query with a while loop that pages through results using .range(offset, offset + 999). Added .order('valid_until', { ascending: true }) for deterministic ordering. Each page is accumulated into the documents array.

Impact it Made:
- All documents expiring in each reminder window are now processed, not just the first 1000.
- Large fleet expiry sweeps are complete and reliable.
- Documents beyond the PostgREST cap no longer silently miss reminders.

This PR is submitted as part of GSSOC contributions.