### PR TITLE
fix(payments): finalize accept_bid_tx after escrow lock

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -27,7 +27,7 @@ import { acquireLock, releaseLock, LockAcquisitionError } from '../lib/redisLock
 import { auditLog } from '../middleware/auditLog.js';
 import logger from '../middleware/logger.js';
 import { orderRepository, orderValidationService } from '../core/container.js';
-import { supabase } from '../config/db.js';
+import { supabase, createUserClient } from '../config/db.js';
 import {
   recordDepositTx,
   getEscrowBookingId,
@@ -35,6 +35,7 @@ import {
   isEscrowEnabled,
   escrowLockPayment,
   resolveExpectedDepositAmount,
+  submitEscrowRefund,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
 import upiPaymentService from '../services/payment/UpiPaymentService.js';
@@ -324,8 +325,88 @@ router.post(
         });
       }
 
-      // 7. Notify assigned driver that payment is now locked
-      if (order.driver_id) {
+      const pending = order.pending_bid_acceptance;
+      if (pending) {
+        const { error: acceptErr } = await orderRepository.executeRpc('accept_bid_tx', {
+          p_bid_id: pending.bid_id,
+          p_order_id: order.id,
+          p_load_id: pending.load_id,
+          p_driver_id: pending.driver_id,
+          p_truck_id: pending.truck_id,
+          p_driver_name: pending.driver_name,
+          p_driver_rating: pending.driver_rating,
+          p_truck_number: pending.truck_number,
+          p_bid_amount: pending.bid_amount,
+          p_order_display_id: pending.order_display_id,
+          p_expected_version: pending.version,
+          p_escrow_booking_id: bookingId,
+        }, req.token ? createUserClient(req.token) : undefined);
+
+        if (acceptErr) {
+          logger.error('[payments] accept_bid_tx failed after lock:', acceptErr.message);
+          let refundResult;
+          try {
+            refundResult = await submitEscrowRefund(order.order_display_id);
+          } catch (refundErr) {
+            logger.error('[payments] Escrow refund also failed:', refundErr.message);
+            refundResult = { error: refundErr.message };
+          }
+          let refundConfirmed = !!(refundResult && !refundResult.error && refundResult.txHash);
+          if (refundConfirmed && typeof refundResult.waitForConfirmation === 'function') {
+            try {
+              await refundResult.waitForConfirmation();
+            } catch (confirmErr) {
+              logger.error('[payments] Escrow refund confirmation failed:', confirmErr.message);
+              refundResult = { error: confirmErr.message, txHash: refundResult.txHash };
+              refundConfirmed = false;
+            }
+          } else if (refundConfirmed && typeof refundResult.waitForConfirmation !== 'function') {
+            refundConfirmed = false;
+            refundResult = {
+              error: refundResult.error || 'escrow refund confirmation is unavailable',
+              txHash: refundResult.txHash,
+            };
+          }
+
+          if (!refundConfirmed) {
+            const refundError = refundResult?.error || 'escrow refund was not submitted';
+            await orderRepository.updateOrder(order.id, {
+              escrow_status: 'funding',
+              escrow_funding_error: `escrow refund pending: ${refundError}`,
+            }).catch((stateErr) => {
+              logger.error('[payments] Failed to mark escrow refund pending:', stateErr.message);
+            });
+            return res.status(503).json({
+              error: 'Payment locked but the driver assignment could not be finalized. The escrow refund is pending and will be completed automatically. Please try again shortly.',
+              details: `${acceptErr.message}; escrow refund: ${refundError}`,
+            });
+          }
+
+          await orderRepository.revertEscrowStatus(order.id).catch((revertErr) => {
+            logger.error('[payments] Failed to revert escrow status:', revertErr.message);
+          });
+          return res.status(409).json({
+            error: 'Payment locked but the driver assignment could not be finalized. The escrow deposit has been refunded. Please try again.',
+            details: acceptErr.message,
+          });
+        }
+
+        sendPushNotification(
+          pending.driver_id,
+          'Bid Accepted!',
+          `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
+          'order_update',
+          { orderId: order.id, orderDisplayId: pending.order_display_id }
+        ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
+
+        sendPushNotification(
+          pending.driver_id,
+          '💰 Payment Locked',
+          `Customer payment for order ${order.order_display_id} is now locked in escrow. Proceed with delivery.`,
+          'payment',
+          { order_display_id: order.order_display_id, tx_hash }
+        ).catch(err => logger.warn('[payments] Driver FCM push failed:', err.message));
+      } else if (order.driver_id) {
         sendPushNotification(
           order.driver_id,
           '💰 Payment Locked',

--- a/backend/api/test/unit/paymentRoutesLockAcceptBid.test.js
+++ b/backend/api/test/unit/paymentRoutesLockAcceptBid.test.js
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for POST /api/payments/lock accept_bid_tx after funding (#9282).
+ *
+ * Run with: npx vitest run test/unit/paymentRoutesLockAcceptBid.test.js
+ */
+process.env.BYPASS_AUTH = 'true';
+process.env.ENABLE_TEST_AUTH = 'true';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mockFindOrderByIdOrDisplayId = vi.fn();
+const mockFindCustomerWallet = vi.fn();
+const mockUpdateOrderWithFilter = vi.fn();
+const mockExecuteRpc = vi.fn();
+const mockUpdateOrder = vi.fn();
+const mockRevertEscrowStatus = vi.fn();
+const mockRecordDepositTx = vi.fn();
+const mockResolveExpectedDepositAmount = vi.fn();
+const mockSubmitEscrowRefund = vi.fn();
+const mockSendPushNotification = vi.fn();
+
+vi.mock('../../src/core/container.js', () => ({
+  orderRepository: {
+    findCustomerWallet: (...args) => mockFindCustomerWallet(...args),
+    updateOrderWithFilter: (...args) => mockUpdateOrderWithFilter(...args),
+    executeRpc: (...args) => mockExecuteRpc(...args),
+    updateOrder: (...args) => mockUpdateOrder(...args),
+    revertEscrowStatus: (...args) => mockRevertEscrowStatus(...args),
+  },
+  orderValidationService: {
+    findOrderByIdOrDisplayId: (...args) => mockFindOrderByIdOrDisplayId(...args),
+  },
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {},
+  createUserClient: vi.fn(),
+}));
+
+vi.mock('../../src/lib/redisLock.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue('lock-token'),
+  releaseLock: vi.fn(),
+  LockAcquisitionError: class LockAcquisitionError extends Error {},
+}));
+
+vi.mock('../../src/services/escrow.js', () => ({
+  recordDepositTx: (...args) => mockRecordDepositTx(...args),
+  getEscrowBookingId: (id) => `booking-${id}`,
+  paisaToMaticWei: vi.fn(),
+  isEscrowEnabled: vi.fn(() => true),
+  escrowLockPayment: vi.fn(),
+  resolveExpectedDepositAmount: (...args) => mockResolveExpectedDepositAmount(...args),
+  submitEscrowRefund: (...args) => mockSubmitEscrowRefund(...args),
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: (...args) => mockSendPushNotification(...args),
+}));
+
+vi.mock('../../src/services/payment/UpiPaymentService.js', () => ({
+  default: {},
+}));
+
+vi.mock('../../src/middleware/idempotency.js', () => ({
+  requireIdempotency: () => (req, res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/auditLog.js', () => ({
+  auditLog: () => (req, res, next) => next(),
+}));
+
+const { default: paymentRouter } = await import('../../src/routes/paymentRoutes.js');
+
+const TX_HASH = '0x' + 'a'.repeat(64);
+const CUSTOMER_HEADERS = {
+  'x-user-id': 'customer-uuid-123',
+  'x-user-role': 'customer',
+  'x-user-name': 'Test Customer',
+};
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/payments', paymentRouter);
+  return app;
+}
+
+const pendingBid = {
+  bid_id: 'bid-1',
+  load_id: 'load-1',
+  driver_id: 'driver-pending',
+  truck_id: 'truck-1',
+  driver_name: 'Driver',
+  driver_rating: 4.5,
+  truck_number: 'TN-1',
+  bid_amount: 150000,
+  order_display_id: 'TX-1',
+  version: 2,
+};
+
+describe('POST /api/payments/lock pending bid acceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindCustomerWallet.mockResolvedValue({
+      data: { polygon_wallet_address: '0x' + 'b'.repeat(40) },
+    });
+    mockResolveExpectedDepositAmount.mockReturnValue({ expectedAmountWei: 100n });
+    mockRecordDepositTx.mockResolvedValue({ txHash: TX_HASH });
+    mockUpdateOrderWithFilter.mockResolvedValue({ error: null });
+    mockUpdateOrder.mockResolvedValue({ error: null });
+    mockRevertEscrowStatus.mockResolvedValue(undefined);
+    mockExecuteRpc.mockResolvedValue({ error: null });
+    mockSendPushNotification.mockResolvedValue(undefined);
+  });
+
+  it('runs accept_bid_tx and notifies pending.driver_id on success', async () => {
+    mockFindOrderByIdOrDisplayId.mockResolvedValue({
+      id: 'order-1',
+      order_display_id: 'TX-1',
+      customer_id: 'customer-uuid-123',
+      driver_id: null,
+      escrow_status: 'funding',
+      escrow_booking_id: 'booking-1',
+      escrow_driver_wallet: null,
+      pending_bid_acceptance: pendingBid,
+    });
+
+    const res = await request(buildApp())
+      .post('/api/payments/lock')
+      .set(CUSTOMER_HEADERS)
+      .send({ order_id: 'order-1', tx_hash: TX_HASH });
+
+    expect(res.status).toBe(201);
+    expect(mockExecuteRpc).toHaveBeenCalledWith(
+      'accept_bid_tx',
+      expect.objectContaining({ p_bid_id: 'bid-1', p_driver_id: 'driver-pending' }),
+      undefined,
+    );
+    expect(mockSendPushNotification).toHaveBeenCalledWith(
+      'driver-pending',
+      'Bid Accepted!',
+      expect.any(String),
+      'order_update',
+      expect.any(Object),
+    );
+    expect(mockSubmitEscrowRefund).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 and keeps funding when accept fails and refund is pending', async () => {
+    mockFindOrderByIdOrDisplayId.mockResolvedValue({
+      id: 'order-1',
+      order_display_id: 'TX-1',
+      customer_id: 'customer-uuid-123',
+      driver_id: null,
+      escrow_status: 'funding',
+      escrow_booking_id: 'booking-1',
+      escrow_driver_wallet: null,
+      pending_bid_acceptance: pendingBid,
+    });
+    mockExecuteRpc.mockResolvedValue({ error: { message: 'version conflict' } });
+    mockSubmitEscrowRefund.mockResolvedValue({ txHash: null, error: 'chain down' });
+
+    const res = await request(buildApp())
+      .post('/api/payments/lock')
+      .set(CUSTOMER_HEADERS)
+      .send({ order_id: 'order-1', tx_hash: TX_HASH });
+
+    expect(res.status).toBe(503);
+    expect(mockUpdateOrder).toHaveBeenCalledWith(
+      'order-1',
+      expect.objectContaining({ escrow_status: 'funding' }),
+    );
+  });
+});


### PR DESCRIPTION
## Description
`POST /api/payments/lock` was marking escrow as funded without running `accept_bid_tx`, so two-phase bid acceptance never completed on the lock path. After a successful fund update we now finalize `pending_bid_acceptance` the same way confirm-deposit does, including refund-on-failure with confirmation checks. Driver push goes to `pending.driver_id`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `npx vitest run test/unit/paymentRoutesLockAcceptBid.test.js` (when deps available)
- **Test Steps / Prerequisites:** unit coverage for accept success + refund pending path
- **Expected Result:** lock finalizes assignment or fails closed with refund handling

### Test Environment
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #9282

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)