### PR TITLE
fix(escrow): pass expectedAmountWei on release reconciler retry

### DIFF
--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -1,6 +1,6 @@
 import os from 'os';
 import { supabaseAdmin } from '../config/db.js';
-import { escrowRelease, getEscrowBooking, getEscrowBookingId } from './escrow.js';
+import { escrowRelease, getEscrowBooking, getEscrowBookingId, resolveExpectedDepositAmount } from './escrow.js';
 import { acquireLock, releaseLock, renewLock, LockAcquisitionError } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
 
@@ -117,7 +117,7 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
 async function finalizeReleasedOrder(order, orderRepository) {
   const { data: fresh, error: readError } = await orderRepository.findOrderById(
     order.id,
-    'id, order_display_id, status, escrow_status, escrow_disabled, escrow_booking_id, escrow_release_attempts, escrow_release_last_attempt_at, escrow_release_error, release_tx_hash, escrow_released_at'
+    'id, order_display_id, status, escrow_status, escrow_disabled, escrow_booking_id, escrow_amount_wei, pending_bid_acceptance, escrow_release_attempts, escrow_release_last_attempt_at, escrow_release_error, release_tx_hash, escrow_released_at'
   );
 
   if (readError || !fresh) {
@@ -141,7 +141,11 @@ async function finalizeReleasedOrder(order, orderRepository) {
   if (!chainReleased) {
     if (fresh.escrow_status === 'release_failed') {
       // A previous release attempt failed before the tx landed — retry it.
-      const releaseResult = await escrowRelease(fresh.order_display_id);
+      const resolvedAmount = resolveExpectedDepositAmount(fresh);
+      if (resolvedAmount.error) {
+        throw new Error(resolvedAmount.error);
+      }
+      const releaseResult = await escrowRelease(fresh.order_display_id, resolvedAmount.expectedAmountWei);
       if (releaseResult.txHash) {
         await finalizeWithRelease(fresh, releaseResult.txHash, orderRepository);
       } else if (releaseResult.alreadyReleased) {

--- a/backend/api/test/unit/escrowReleaseReconciliation.test.js
+++ b/backend/api/test/unit/escrowReleaseReconciliation.test.js
@@ -26,6 +26,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockEscrowRelease = vi.hoisted(() => vi.fn());
 const mockGetEscrowBooking = vi.hoisted(() => vi.fn());
+const mockResolveExpectedDepositAmount = vi.hoisted(() => vi.fn());
 
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
@@ -62,6 +63,7 @@ vi.mock('../../src/services/escrow.js', () => ({
   escrowRelease: mockEscrowRelease,
   getEscrowBooking: mockGetEscrowBooking,
   getEscrowBookingId: (displayId) => displayId,
+  resolveExpectedDepositAmount: mockResolveExpectedDepositAmount,
 }));
 
 import {
@@ -106,6 +108,7 @@ describe('escrowReleaseReconciliation', () => {
     mockReleaseLock.mockResolvedValue(true);
     mockRenewLock.mockResolvedValue(true);
     mockGetEscrowBooking.mockResolvedValue({ paid: true });
+    mockResolveExpectedDepositAmount.mockReturnValue({ expectedAmountWei: 1000000000000000000n });
   });
 
   it('skips the cycle when no OrderRepository is provided', async () => {
@@ -207,11 +210,43 @@ describe('escrowReleaseReconciliation', () => {
 
     await reconcilePendingEscrowReleases(repo);
 
-    expect(mockEscrowRelease).toHaveBeenCalledWith('ORD-001');
+    expect(mockResolveExpectedDepositAmount).toHaveBeenCalled();
+    expect(mockEscrowRelease).toHaveBeenCalledWith('ORD-001', 1000000000000000000n);
     expect(repo.executeRpc).toHaveBeenCalledWith(
       'complete_trip_tx',
       { p_order_id: 'order-1', p_otp_id: null, p_release_tx_hash: '0xretry' },
       mockSupabaseAdmin,
+    );
+  });
+
+
+  it('records attempt error when release_failed retry cannot resolve escrow amount', async () => {
+    const repo = makeOrderRepositoryMock();
+    repo.findPendingEscrowReleases.mockResolvedValue({
+      data: [releasedOrder({ escrow_status: 'release_failed', release_tx_hash: null })],
+      error: null,
+    });
+    repo.findOrderById.mockResolvedValue({
+      data: releasedOrder({
+        escrow_status: 'release_failed',
+        release_tx_hash: null,
+        escrow_amount_wei: null,
+        pending_bid_acceptance: null,
+      }),
+      error: null,
+    });
+    mockGetEscrowBooking.mockResolvedValue({ paid: false });
+    mockResolveExpectedDepositAmount.mockReturnValueOnce({
+      error: 'No escrow amount is recorded for this order. Deposit cannot be verified.',
+      code: 'ESCROW_AMOUNT_MISSING',
+    });
+
+    await reconcilePendingEscrowReleases(repo);
+
+    expect(mockEscrowRelease).not.toHaveBeenCalled();
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      'order-1',
+      expect.objectContaining({ escrow_release_attempts: 1 }),
     );
   });
 


### PR DESCRIPTION
## Description
Release reconciler retried `escrowRelease(displayId)` with no amount, so the mismatch gate was skipped. It now resolves `expectedAmountWei` from the order and passes it into the retry, same as delivery verification.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** unit tests in `escrowReleaseReconciliation.test.js`
- **Expected Result:** release_failed retries include amount check; mismatch refuses release

### Test Environment
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #9284

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)