### PR TITLE
fix(payments): use Redis store for lock/status rate limiters

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -26,6 +26,7 @@ import { requireIdempotency } from '../middleware/idempotency.js';
 import { acquireLock, releaseLock, LockAcquisitionError } from '../lib/redisLock.js';
 import { auditLog } from '../middleware/auditLog.js';
 import logger from '../middleware/logger.js';
+import { createStore } from '../middleware/rateLimiter.js';
 import { orderRepository, orderValidationService } from '../core/container.js';
 import { supabase } from '../config/db.js';
 import {
@@ -47,6 +48,8 @@ const router = express.Router();
 const PAYMENT_LOCK_TTL_MS = 30_000; // 30 seconds
 
 // ─── Rate Limiters ────────────────────────────────────────────────────────────
+// Redis-backed stores so multi-replica deploys share one budget (MemoryStore
+// would allow N× the limit across N API pods).
 
 const lockLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -54,6 +57,7 @@ const lockLimiter = rateLimit({
   message: { error: 'Too many payment requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
+  store: createStore('rl:payment-lock:'),
 });
 
 const statusLimiter = rateLimit({
@@ -61,6 +65,7 @@ const statusLimiter = rateLimit({
   max: 60,
   standardHeaders: true,
   legacyHeaders: false,
+  store: createStore('rl:payment-status:'),
 });
 
 // ─── Validation Schemas ───────────────────────────────────────────────────────

--- a/backend/api/test/unit/paymentRoutesRateLimit.test.js
+++ b/backend/api/test/unit/paymentRoutesRateLimit.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for Redis-backed payment rate limiters in paymentRoutes.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const limiterConfigs = vi.hoisted(() => []);
+const mockCreateStore = vi.hoisted(() =>
+  vi.fn((prefix) => ({ prefix, type: 'redis-store-stub' })),
+);
+
+vi.mock('express-rate-limit', () => ({
+  default: vi.fn((config) => {
+    limiterConfigs.push(config);
+    return (_req, _res, next) => next();
+  }),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  createStore: mockCreateStore,
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/validate.js', () => ({
+  validateBody: () => (_req, _res, next) => next(),
+  validateParams: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/idempotency.js', () => ({
+  requireIdempotency: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/auditLog.js', () => ({
+  auditLog: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/lib/redisLock.js', () => ({
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+  LockAcquisitionError: class LockAcquisitionError extends Error {},
+}));
+
+vi.mock('../../src/core/container.js', () => ({
+  orderRepository: {},
+  orderValidationService: {},
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: {},
+}));
+
+vi.mock('../../src/services/escrow.js', () => ({
+  recordDepositTx: vi.fn(),
+  getEscrowBookingId: vi.fn(),
+  paisaToMaticWei: vi.fn(),
+  isEscrowEnabled: vi.fn(() => false),
+  escrowLockPayment: vi.fn(),
+  resolveExpectedDepositAmount: vi.fn(),
+}));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendPushNotification: vi.fn(),
+}));
+
+vi.mock('../../src/services/payment/UpiPaymentService.js', () => ({
+  default: {},
+}));
+
+describe('paymentRoutes rate limiters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limiterConfigs.length = 0;
+    vi.resetModules();
+  });
+
+  it('wires Redis createStore for lock and status limiters', async () => {
+    await import('../../src/routes/paymentRoutes.js');
+
+    expect(mockCreateStore).toHaveBeenCalledWith('rl:payment-lock:');
+    expect(mockCreateStore).toHaveBeenCalledWith('rl:payment-status:');
+
+    const stores = limiterConfigs.map((c) => c.store).filter(Boolean);
+    expect(stores).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ prefix: 'rl:payment-lock:' }),
+        expect.objectContaining({ prefix: 'rl:payment-status:' }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Description
Payment lock/status limiters used default MemoryStore, so each API pod had its own counter. Wired `createStore('rl:payment-lock:')` / `rl:payment-status:` like the other sensitive limiters.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Commands:** `test/unit/paymentRoutesRateLimit.test.js`
- **Expected Result:** both limiters receive Redis-backed stores at module load

### Test Environment
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)

## Related Issues
Closes #9285

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)