### PR TITLE
fix(driver): single startTrip and fail closed without trip id

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -1446,7 +1446,16 @@ class _HomeScreenState extends State<HomeScreen> {
                                 : null,
                             onStartTrip: () async {
                               if (_activeTripId == null) {
-                                setState(() => _isTripStarted = true);
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        AppLocalizations.of(context)!
+                                            .failedToStartTrip,
+                                      ),
+                                    ),
+                                  );
+                                }
                                 return;
                               }
                               try {
@@ -1457,26 +1466,19 @@ class _HomeScreenState extends State<HomeScreen> {
                                     _activeTripStatus = 'EN-ROUTE';
                                   });
                                 }
-                                try {
-                                  await _tripService
-                                      .startTrip(_activeTripId!);
-                                  if (mounted) {
-                                    setState(() {
-                                      _isTripStarted = true;
-                                      _activeTripStatus = 'EN-ROUTE';
-                                    });
-                                  }
-                                } catch (e) {
-                                  if (context.mounted) {
-                                    ScaffoldMessenger.of(context)
-                                        .showSnackBar(
-                                      SnackBar(
-                                          content: Text(
-                                              'Failed to start trip: $e')),
-                                    );
-                                  }
+                              } catch (e) {
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        AppLocalizations.of(context)!
+                                            .failedToStartTrip,
+                                      ),
+                                    ),
+                                  );
                                 }
-                              },
+                              }
+                            },
                               onCompleteTrip: _completeRide,
                               onCancel: _clearDestination,
                               onOpenMaps: _openGoogleMapsRoute,
@@ -2235,18 +2237,33 @@ class _HomeScreenState extends State<HomeScreen> {
               backgroundColor: TruxifyColors.accent,
               onConfirmed: () async {
                 if (_activeTripId == null) {
-                  setState(() => _isTripStarted = true);
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          AppLocalizations.of(context)!.failedToStartTrip,
+                        ),
+                      ),
+                    );
+                  }
                   return;
                 }
                 try {
                   await _tripService.startTrip(_activeTripId!);
                   if (mounted) {
-                    setState(() => _isTripStarted = true);
+                    setState(() {
+                      _isTripStarted = true;
+                      _activeTripStatus = 'EN-ROUTE';
+                    });
                   }
                 } catch (e) {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(AppLocalizations.of(context)!.failedToStartTrip)),
+                      SnackBar(
+                        content: Text(
+                          AppLocalizations.of(context)!.failedToStartTrip,
+                        ),
+                      ),
                     );
                   }
                 }


### PR DESCRIPTION
## Description
Home ActiveTripSheet `onStartTrip` had a broken outer try, called `startTrip` twice, and set en-route UI when `_activeTripId` was null. Both sheet and slide-to-start now use one try/catch and fail closed without a trip id.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Steps / Prerequisites:** start trip with valid id (one API call); start with cleared id (error snackbar, UI stays idle)
- **Expected Result:** no optimistic en-route without backend start

### Test Environment
- [x] Local manual testing

## Related Issues
Closes #9287

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)