### PR TITLE
fix(driver): fix offline sync TOCTOU and stable idempotency key

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -82,20 +82,21 @@ class SyncEngine {
   /// Flushes the queue to the backend.
   static Future<void> attemptSync() async {
     if (_isSyncing) return;
-    final connectivityResults = await Connectivity().checkConnectivity();
-    if (connectivityResults.contains(ConnectivityResult.none)) return;
-
-    final db = await database;
-    final events = await db.query('sync_queue', orderBy: 'occurred_at ASC');
-    if (events.isEmpty) return;
-
     _isSyncing = true;
     try {
+      final connectivityResults = await Connectivity().checkConnectivity();
+      if (connectivityResults.contains(ConnectivityResult.none)) return;
+
+      final db = await database;
+      final events = await db.query('sync_queue', orderBy: 'occurred_at ASC');
+      if (events.isEmpty) return;
+
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return;
       final token = await user.getIdToken();
 
-      final idempotencyKey = const Uuid().v4();
+      final eventIds = events.map((e) => e['id'] as String).toList()..sort();
+      final idempotencyKey = eventIds.join(',');
 
       final requestBody = {
         'idempotencyKey': idempotencyKey,


### PR DESCRIPTION
## Description
`attemptSync` set `_isSyncing` after awaits, so overlapping callers could both upload. Also used a fresh Uuid idempotency key per attempt. Mutex is now set immediately; key is sorted event ids (same idea as customer sync).

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Steps / Prerequisites:** queue events while online / concurrent attemptSync; confirm single in-flight upload and stable key
- **Expected Result:** no duplicate batch application from raced syncs

### Test Environment
- [x] Local manual testing

## Related Issues
Closes #9289

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)