### PR TITLE
fix(customer): guard SyncEngine.syncPending against re-entrancy

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -30,6 +30,8 @@ class SyncEngine {
   final int maxRetries;
   final int batchSize;
 
+  bool _isSyncing = false;
+
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   final Connectivity _connectivity = Connectivity();
 
@@ -48,6 +50,16 @@ class SyncEngine {
   }
 
   Future<int> syncPending() async {
+    if (_isSyncing) return 0;
+    _isSyncing = true;
+    try {
+      return await _syncPendingInternal();
+    } finally {
+      _isSyncing = false;
+    }
+  }
+
+  Future<int> _syncPendingInternal() async {
     final pending = await db.pendingEvents(limit: batchSize);
     if (pending.isEmpty) {
       return 0;


### PR DESCRIPTION
## Description
Customer `syncPending` had no re-entrancy guard, so connectivity flaps could overlap uploads and race markSynced/markFailed. Added `_isSyncing` with try/finally.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Steps / Prerequisites:** flap connectivity with pending offline events; ensure only one sync runs at a time
- **Expected Result:** concurrent callers no-op while a sync is in flight

### Test Environment
- [x] Local manual testing

## Related Issues
Closes #9290

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)