### PR TITLE
fix(driver): add accessible activate path for SlideToConfirmButton

### DIFF
--- a/apps/driver/lib/widgets/slide_to_confirm_button.dart
+++ b/apps/driver/lib/widgets/slide_to_confirm_button.dart
@@ -25,98 +25,114 @@ class _SlideToConfirmButtonState extends State<SlideToConfirmButton> {
   double _dragProgress = 0.0;
   bool _confirmed = false;
 
+  void _confirm() {
+    if (_confirmed) return;
+    setState(() {
+      _dragProgress = 1.0;
+      _confirmed = true;
+    });
+    widget.onConfirmed();
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (mounted) {
+        setState(() {
+          _dragProgress = 0.0;
+          _confirmed = false;
+        });
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final double maxDragWidth =
-            constraints.maxWidth - 50; 
-        return Container(
-          height: 52,
-          width: double.infinity,
-          decoration: BoxDecoration(
-            color: widget.backgroundColor.withValues(alpha: 0.08),
-            borderRadius: BorderRadius.circular(26),
-            border: Border.all(color: widget.backgroundColor.withValues(alpha: 0.2)),
-          ),
-          child: Stack(
-            children: [
-              Center(
-                child: Opacity(
-                  opacity: (1.0 - _dragProgress).clamp(0.2, 1.0),
-                  child: Text(
-                    widget.label,
-                    style: GoogleFonts.dmSans(
-                      fontSize: 14,
-                      fontWeight: FontWeight.bold,
-                      color: widget.backgroundColor,
-                    ),
-                  ),
+    return Semantics(
+      button: true,
+      label: widget.label,
+      onTap: _confirm,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final double maxDragWidth = constraints.maxWidth - 50;
+          return GestureDetector(
+            onDoubleTap: _confirm,
+            onLongPress: _confirm,
+            behavior: HitTestBehavior.opaque,
+            child: Container(
+              height: 52,
+              width: double.infinity,
+              decoration: BoxDecoration(
+                color: widget.backgroundColor.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(26),
+                border: Border.all(
+                  color: widget.backgroundColor.withValues(alpha: 0.2),
                 ),
               ),
-              Positioned(
-                left: _dragProgress * maxDragWidth + 3,
-                top: 3,
-                bottom: 3,
-                child: GestureDetector(
-                  onHorizontalDragUpdate: (details) {
-                    if (_confirmed) return;
-                    setState(() {
-                      _dragProgress =
-                          (_dragProgress + (details.delta.dx / maxDragWidth))
-                              .clamp(0.0, 1.0);
-                    });
-                  },
-                  onHorizontalDragEnd: (details) {
-                    if (_confirmed) return;
-                    if (_dragProgress >= 0.9) {
-                      setState(() {
-                        _dragProgress = 1.0;
-                        _confirmed = true;
-                      });
-                      widget.onConfirmed();
-                      Future.delayed(const Duration(milliseconds: 500), () {
-                        if (mounted) {
+              child: Stack(
+                children: [
+                  Center(
+                    child: Opacity(
+                      opacity: (1.0 - _dragProgress).clamp(0.2, 1.0),
+                      child: Text(
+                        widget.label,
+                        style: GoogleFonts.dmSans(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: widget.backgroundColor,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: _dragProgress * maxDragWidth + 3,
+                    top: 3,
+                    bottom: 3,
+                    child: GestureDetector(
+                      onHorizontalDragUpdate: (details) {
+                        if (_confirmed) return;
+                        setState(() {
+                          _dragProgress =
+                              (_dragProgress + (details.delta.dx / maxDragWidth))
+                                  .clamp(0.0, 1.0);
+                        });
+                      },
+                      onHorizontalDragEnd: (details) {
+                        if (_confirmed) return;
+                        if (_dragProgress >= 0.9) {
+                          _confirm();
+                        } else {
                           setState(() {
                             _dragProgress = 0.0;
-                            _confirmed = false;
                           });
                         }
-                      });
-                    } else {
-                      setState(() {
-                        _dragProgress = 0.0;
-                      });
-                    }
-                  },
-                  child: Container(
-                    width: 46,
-                    height: 46,
-                    decoration: BoxDecoration(
-                      color: widget.backgroundColor,
-                      shape: BoxShape.circle,
-                      boxShadow: [
-                        BoxShadow(
-                          color: widget.backgroundColor.withValues(alpha: 0.3),
-                          blurRadius: 6,
-                          offset: const Offset(0, 2),
+                      },
+                      child: Container(
+                        width: 46,
+                        height: 46,
+                        decoration: BoxDecoration(
+                          color: widget.backgroundColor,
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color: widget.backgroundColor.withValues(alpha: 0.3),
+                              blurRadius: 6,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
-                    child: Icon(
-                      _confirmed
-                          ? Icons.check_rounded
-                          : Icons.chevron_right_rounded,
-                      color: widget.foregroundColor,
-                      size: 20,
+                        child: Icon(
+                          _confirmed
+                              ? Icons.check_rounded
+                              : Icons.chevron_right_rounded,
+                          color: widget.foregroundColor,
+                          size: 20,
+                        ),
+                      ),
                     ),
                   ),
-                ),
+                ],
               ),
-            ],
-          ),
-        );
-      },
+            ),
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
## Description
Start/complete trip slide control was drag-only. Wrapped with Semantics button + onTap, shared `_confirm()`, and double-tap/long-press on the track as non-drag alternatives.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Test Steps / Prerequisites:** TalkBack/VoiceOver focus start/complete control; activate via semantics; also double-tap/long-press and drag
- **Expected Result:** confirm works without requiring a horizontal drag

### Test Environment
- [x] Local manual testing

## Related Issues
Closes #9291

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

Made with [Cursor](https://cursor.com)