### PR TITLE
fix : added structured logging for JWT decode errors in authenticate middleware

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -272,7 +272,10 @@ export async function authenticate(req, res, next) {
     try {
       decoded = jwt.decode(token);
     } catch (err) {
-      // ignore decoding errors and let verification handle it
+      logger.warn(
+        { event: 'JWT_DECODE_ERROR', requestId: req.requestId || req.id },
+        'JWT decode failed',
+      );
     }
 
     const isSupabaseToken =


### PR DESCRIPTION
Closes #9326.

Summary of What Has Been Done:
Added a structured logger.warn call in the authenticate middleware when JWT decode fails, providing a requestId-linked audit trail for debugging authentication failures.

Changes Made:
- backend/api/src/middleware/auth.js: Added logger.warn with event=JWT_DECODE_ERROR and requestId context in the catch block for jwt.decode(), replacing the silent catch.

Impact it Made:
- Security monitoring can now detect repeated JWT decode failures.
- Audit trail links decode failures to specific request IDs.
- Consistent with existing structured logging patterns in the auth middleware.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.