### PR TITLE
fix : added null guard for lat/lng inputs in pricing.js computeOrderPricing

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -149,6 +149,10 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
     throw new RangeError(`weightTonnes must be a positive number, got ${weightTonnes}`);
   }
 
+  if (pickupLat == null || pickupLng == null || dropLat == null || dropLng == null) {
+    throw new TypeError('computeOrderPricing: pickupLat, pickupLng, dropLat, and dropLng are required and cannot be null');
+  }
+
   const fallbackDistanceKm = haversineKm(pickupLat, pickupLng, dropLat, dropLng);
   const distanceKm = Number.isFinite(roadDistanceKm) && roadDistanceKm >= 0
     ? roadDistanceKm


### PR DESCRIPTION
Closes #9332.

Summary of What Has Been Done:
Added explicit null/undefined guards for pickupLat, pickupLng, dropLat, dropLng in computeOrderPricing to prevent silent NaN propagation.

Changes Made:
- backend/api/src/lib/pricing.js: Added null/undefined guards with TypeError for lat/lng inputs before passing to haversineKm.

Impact it Made:
- No more silent NaN in pricing calculations for null/undefined inputs.
- Clear TypeError messages for debugging.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.