### PR TITLE
fix : added structured error logging for health aggregation failure in healthRoutes.js

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -288,7 +288,7 @@ const aggregator = createDefaultAggregator();
  *       503:
  *         description: One or more critical services degraded
  */
-router.get('/full', healthLimiter, async (_req, res) => {
+router.get('/full', healthLimiter, async (req, res) => {
   try {
     const result = await aggregator.aggregate();
     // 200 = system operational (healthy or degraded with non-critical failures)
@@ -296,7 +296,10 @@ router.get('/full', healthLimiter, async (_req, res) => {
     const httpStatus = result.status === 'unhealthy' ? 503 : 200;
     return res.status(httpStatus).json(result);
   } catch (err) {
-    logger.error('[health] Aggregated health check failed:', err.message);
+    logger.error(
+      { event: 'HEALTH_AGGREGATION_ERROR', requestId: req.requestId || req.id, error: err && err.message },
+      '[health] Aggregated health check failed',
+    );
     return res.status(500).json({
       status: 'unhealthy',
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
Closes #9334.

Summary of What Has Been Done:
Added structured logger.error with event=HEALTH_AGGREGATION_ERROR and requestId in the /api/health/full endpoint catch block.

Changes Made:
- backend/api/src/routes/healthRoutes.js: Replaced non-structured logger call with structured logger.error in the health aggregation error handler.

Impact it Made:
- Health check failures can now be traced back to specific requests.
- Better production debugging.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.