### PR TITLE
fix : added empty-string validation guard for support ticket subject

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -326,6 +326,9 @@ router.get('/categories', (_req, res) => {
  */
 router.post('/tickets', authenticate, userLimiter, validateBody(createTicketSchema), async (req, res) => {
   const subject = normalizeRequiredText(req.body.subject);
+  if (!subject) {
+    return res.status(400).json({ error: 'subject is required and cannot be empty' });
+  }
   const category = normalizeRequiredText(req.body.category);
   const description = normalizeRequiredText(req.body.description) || subject;
 


### PR DESCRIPTION
Closes #9336.

Summary of What Has Been Done:
Added explicit validation guard to reject empty-string or whitespace-only support ticket subjects with 400 Bad Request.

Changes Made:
- backend/api/src/routes/supportRoutes.js: Added empty-string check for subject after normalization.

Impact it Made:
- No invalid tickets with empty subjects can be created.
- Clear 400 error response for API consumers.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.