### PR TITLE
fix : added structured error logging for Digilocker sync failures

### DIFF
--- a/backend/api/src/routes/documentRoutes.js
+++ b/backend/api/src/routes/documentRoutes.js
@@ -81,7 +81,10 @@ router.post('/verify-digilocker', authenticate, userLimiter, async (req, res) =>
     const result = await digilockerService.verifyAndSyncDocuments(req.user.id, code);
     res.json(result);
   } catch (err) {
-    logger.error('[DocumentRoutes] Digilocker sync failed:', err.message);
+    logger.error(
+      { event: 'DOCUMENT_DIGILOCKER_SYNC_ERROR', requestId: req.requestId || req.id, userId: req.user && req.user.id, error: err && err.message },
+      '[DocumentRoutes] Digilocker sync failed',
+    );
     res.status(500).json({ error: err.message || 'Internal Server Error' });
   }
 });


### PR DESCRIPTION
Closes #9342.

Summary of What Has Been Done:
Added structured logger.error with event=DOCUMENT_DIGILOCKER_SYNC_ERROR, requestId, and userId in documentRoutes.js.

Changes Made:
- backend/api/src/routes/documentRoutes.js: Replaced non-structured logger call with structured logger.error.

Impact it Made:
- Better debugging of document sync failures.
- RequestId-linked traces.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.