### PR TITLE
fix : added structured error logging for OSRM Redis errors

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -78,7 +78,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
         if (parsed !== null) return parsed;
       }
     } catch (err) {
-      logger.error('[osrm] Redis get error:', err.message);
+      logger.error({ event: 'OSRM_REDIS_GET_ERROR', error: err && err.message }, '[osrm] Redis get error');
     }
   }
 
@@ -122,7 +122,7 @@ export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng 
         try {
           await redisClient.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS);
         } catch (err) {
-          logger.error('[osrm] Redis set error:', err.message);
+          logger.error({ event: 'OSRM_REDIS_SET_ERROR', error: err && err.message }, '[osrm] Redis set error');
         }
       }
 
@@ -188,7 +188,7 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
         if (parsed !== null) return parsed;
       }
     } catch (err) {
-      logger.error('[osrm] Redis get error (geometry):', err.message);
+      logger.error({ event: 'OSRM_REDIS_GET_GEOMETRY_ERROR', error: err && err.message }, '[osrm] Redis get error (geometry)');
     }
   }
 


### PR DESCRIPTION
Closes #9346.

Summary of What Has Been Done:
Added structured logger.error calls with event names (OSRM_REDIS_GET_ERROR, OSRM_REDIS_SET_ERROR, OSRM_REDIS_GET_GEOMETRY_ERROR) in osrm.js.

Changes Made:
- backend/api/src/services/osrm.js: Replaced non-structured logger calls with structured logger.error.

Impact it Made:
- Better debugging of OSRM Redis caching failures.
- Easier correlation with monitoring dashboards.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.