### PR TITLE
fix : added structured validation error logging in validate.js middleware

### DIFF
--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -1,3 +1,5 @@
+import logger from './logger.js';
+
 export function formatValidationIssues(error) {
   return error.issues.map((issue) => ({
     field: issue.path.length > 0 ? issue.path.join(".") : "body",
@@ -31,6 +33,10 @@ export function validateBody(schema) {
     const result = schema.safeParse(req.body);
 
     if (!result.success) {
+      logger.warn(
+        { event: 'VALIDATION_ERROR', type: 'body', requestId: req.requestId || req.id, details: formatValidationIssues(result.error) },
+        'Body validation failed',
+      );
       return res.status(400).json({
         error: "Validation failed",
         details: formatValidationIssues(result.error),
@@ -47,6 +53,10 @@ export function validateParams(schema) {
     const result = schema.safeParse(req.params);
 
     if (!result.success) {
+      logger.warn(
+        { event: 'VALIDATION_ERROR', type: 'params', requestId: req.requestId || req.id, details: formatValidationIssues(result.error) },
+        'Params validation failed',
+      );
       return res.status(400).json({
         error: "Validation failed",
         details: formatValidationIssues(result.error),
@@ -64,6 +74,10 @@ export function validateQuery(schema) {
       const result = schema.safeParse(req.query);
 
       if (!result.success) {
+        logger.warn(
+          { event: 'VALIDATION_ERROR', type: 'query', requestId: req.requestId || req.id, details: formatValidationIssues(result.error) },
+          'Query validation failed',
+        );
         return res.status(400).json({
           error: "Validation failed",
           details: formatValidationIssues(result.error),


### PR DESCRIPTION
Closes #9348.

Summary of What Has Been Done:
Added structured logger.warn calls with event=VALIDATION_ERROR, type, requestId, and field details in validate.js for validation failures.

Changes Made:
- backend/api/src/middleware/validate.js: Added logger import and structured logging for validation failures in validateBody, validateParams, and validateQuery.

Impact it Made:
- Audit trail for validation failures.
- Better debugging of client-side input issues.

This PR is submitted as part of GSSOC (GirlScript Summer of Code) contributions.

Note: Please assign this PR to the `tmdeveloper007` account.