### PR TITLE
fix(demand-heatmap): read load_offers through the caller's user-scoped client

### DIFF
--- a/backend/api/src/routes/demandRoutes.js
+++ b/backend/api/src/routes/demandRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
@@ -16,7 +16,12 @@ const router = express.Router();
 router.get('/', authenticate, userLimiter, requirePolicy('demand:view-heatmap'), async (req, res) => {
   try {
     // 1. Fetch recent load offers (historical/current volume)
-    const { data: loads, error } = await supabase
+    // Read through the caller's user-scoped client so the load_offers RLS
+    // policy (status = 'available' OR customer_id = get_profile_id()) sees the
+    // authenticated user's identity. The shared anon client has no identity and
+    // can never return the offers.
+    const userClient = createUserClient(req.token);
+    const { data: loads, error } = await userClient
       .from('load_offers')
       .select('pickup_address, drop_address, status, pickup_lat, pickup_lng')
       .in('status', ['available', 'claimed'])

--- a/backend/api/test/unit/demandHeatmapRoute.test.js
+++ b/backend/api/test/unit/demandHeatmapRoute.test.js
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for backend/api/src/routes/demandRoutes.js — GET /api/demand-heatmap
+ *
+ * Coverage:
+ *   - load_offers are read through the caller's user-scoped client
+ *     (createUserClient(req.token)), never the shared anon client
+ *
+ * Run with:  npm test -- test/unit/demandHeatmapRoute.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+
+const { loadOffersFrom, createUserClientMock } = vi.hoisted(() => ({
+  loadOffersFrom: vi.fn(),
+  createUserClientMock: vi.fn(),
+}))
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: vi.fn(() => {
+    throw new Error('shared anon client must not be used by /api/demand-heatmap')
+  }) },
+  createUserClient: createUserClientMock,
+}))
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = { id: 'driver-123', role: 'driver' }
+    req.token = 'driver-jwt'
+    next()
+  },
+}))
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+}))
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}))
+
+vi.mock('../../src/services/ml.js', () => ({
+  predictDemand: vi.fn(async () => ({ predicted_demand: 0.5 })),
+}))
+
+const buildChain = (data, error) => ({
+  select: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  then: (resolve) => resolve({ data, error }),
+})
+
+import demandRoutes from '../../src/routes/demandRoutes.js'
+
+const app = express()
+app.use('/api/demand-heatmap', demandRoutes)
+
+describe('GET /api/demand-heatmap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reads load_offers through createUserClient(req.token), not the anon client', async () => {
+    loadOffersFrom.mockReturnValue(buildChain([], null))
+    createUserClientMock.mockReturnValue({ from: loadOffersFrom })
+
+    const res = await request(app).get('/api/demand-heatmap')
+
+    expect(res.status).toBe(200)
+    expect(createUserClientMock).toHaveBeenCalledWith('driver-jwt')
+    expect(loadOffersFrom).toHaveBeenCalledWith('load_offers')
+    expect(res.body.features).toEqual([])
+  })
+
+  it('returns 500 when the load_offers query fails', async () => {
+    loadOffersFrom.mockReturnValue(buildChain(null, { message: 'permission denied' }))
+    createUserClientMock.mockReturnValue({ from: loadOffersFrom })
+
+    const res = await request(app).get('/api/demand-heatmap')
+
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to fetch heatmap data.')
+  })
+})


### PR DESCRIPTION
## Problem

`GET /api/demand-heatmap` fetched its market data from `load_offers` through the shared session-less anon-key Supabase client (`backend/api/src/routes/demandRoutes.js:19-23`). The `load_offers` table has RLS with an `authenticated` policy only (`status = 'available' OR customer_id = get_profile_id()`, `supabase/migrations/20240101000000_rls.sql:199-220`), no `anon` policy, and `revoke_anon_privileges.sql` also revokes anon privileges on the table.

With the anon client, `auth.uid()` is `NULL`, so:

- RLS-only environment: the SELECT returns `[]` → HTTP 200 with `features: []` and `routeSuggestions`/`estimatedEarningPotential` computed from zero data.
- Repo's shipped schema (revoke applied): the SELECT errors `42501 permission denied` → HTTP 500.

Either way the heatmap never reflects real load-offer volume, yet `estimatedEarningPotential` is still returned, misleading drivers with numbers derived from zero market data.

## Fix

- `backend/api/src/routes/demandRoutes.js`: read `load_offers` through `createUserClient(req.token)` (per-request client carrying the caller's JWT, so the RLS policy can evaluate `get_profile_id()`). This matches the established pattern in `loadRoutes.js` and the driver feed.
- Add a route unit test asserting `createUserClient` is called with `req.token` and that the `load_offers` query goes through the user-scoped client, plus the 500 path when the query errors.

## Files changed

- `backend/api/src/routes/demandRoutes.js`
- `backend/api/test/unit/demandHeatmapRoute.test.js`

## Testing

- Added `backend/api/test/unit/demandHeatmapRoute.test.js`:
  - asserts `createUserClient('driver-jwt')` is invoked and the `load_offers` table is queried through the returned user client (the mocked shared anon client throws if used);
  - asserts `500 Failed to fetch heatmap data.` when the query returns an error.
- Run with: `npm test -- test/unit/demandHeatmapRoute.test.js`

Closes #8948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demand heatmap data requests now use the authenticated session, improving access control and data isolation.
  * Improved error handling when demand data cannot be retrieved.

* **Tests**
  * Added coverage for authenticated data access, successful empty results, and database query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->