### PR TITLE
fix(health): probe Supabase through the service-role client

### DIFF
--- a/backend/api/src/core/health/checks/supabaseHealth.js
+++ b/backend/api/src/core/health/checks/supabaseHealth.js
@@ -1,13 +1,17 @@
-import { supabase } from '../../../config/db.js';
+import { supabase, supabaseAdmin } from '../../../config/db.js';
 import { HealthStatus, executeCheck } from '../HealthCheck.js';
 
 const NAME = 'supabase';
 
 async function check() {
-  if (!supabase) {
+  // Probe through the service-role client: the shipped schema revokes anon
+  // privileges on profiles (revoke_anon_privileges.sql), so an anon-keyed
+  // probe always reports 42501 permission denied even when Supabase is up.
+  const client = supabaseAdmin || supabase;
+  if (!client) {
     return { status: HealthStatus.UNHEALTHY, message: 'not_configured' };
   }
-  const { error } = await supabase.from('profiles').select('id').limit(1);
+  const { error } = await client.from('profiles').select('id').limit(1);
   if (error) {
     return { status: HealthStatus.UNHEALTHY, message: error.message };
   }

--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -58,7 +58,7 @@
  */
 
 import express from 'express';
-import { supabase, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
+import { supabase, supabaseAdmin, mongoDb, redisClient, firebaseAdmin } from '../config/db.js';
 import { healthLimiter } from '../middleware/rateLimiter.js';
 import { checkEscrowHealth } from '../services/escrow.js';
 import logger from '../middleware/logger.js';
@@ -82,10 +82,14 @@ function withTimeout(promise) {
 }
 
 async function checkSupabase() {
-  if (!supabase) return 'not_configured';
+  // Probe through the service-role client: anon privileges on profiles are
+  // revoked by revoke_anon_privileges.sql, so an anon-keyed probe would always
+  // report 42501 permission denied even when Supabase is reachable.
+  const client = supabaseAdmin || supabase;
+  if (!client) return 'not_configured';
   try {
     const { error } = await withTimeout(
-      supabase.from('profiles').select('id').limit(1)
+      client.from('profiles').select('id').limit(1)
     );
     return error ? 'failed' : 'connected';
   } catch (err) {

--- a/backend/api/test/integration/healthRoutes.test.js
+++ b/backend/api/test/integration/healthRoutes.test.js
@@ -4,12 +4,14 @@ import express from 'express';
 
 // Define mocks that we can mutate per-test
 let mockSupabase = null;
+let mockSupabaseAdmin = null;
 let mockMongoDb = null;
 let mockRedisClient = null;
 let mockFirebaseAdmin = null;
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return mockSupabase; },
+  get supabaseAdmin() { return mockSupabaseAdmin; },
   get mongoDb() { return mockMongoDb; },
   get redisClient() { return mockRedisClient; },
   get firebaseAdmin() { return mockFirebaseAdmin; }
@@ -46,6 +48,7 @@ describe('GET /api/health', () => {
       select: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({ error: null })
     };
+    mockSupabaseAdmin = null;
 
     mockMongoDb = {
       admin: () => ({
@@ -89,6 +92,24 @@ describe('GET /api/health', () => {
       '[health] Supabase check failed:',
       'Supabase network error'
     );
+  });
+
+  it('probes through supabaseAdmin when anon privileges are revoked', async () => {
+    const adminLimit = vi.fn().mockResolvedValue({ error: null });
+    mockSupabaseAdmin = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      limit: adminLimit,
+    };
+    // Anon client would return 42501 permission denied — it must not be used.
+    mockSupabase.limit.mockResolvedValue({ error: { message: '42501 permission denied' } });
+
+    const res = await request(app).get('/api/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.services.supabase).toBe('connected');
+    expect(adminLimit).toHaveBeenCalledWith(1);
   });
 
   it('returns 503 and degraded status when MongoDB ping fails with an exception', async () => {

--- a/backend/api/test/unit/core/healthChecks.test.js
+++ b/backend/api/test/unit/core/healthChecks.test.js
@@ -6,6 +6,7 @@ vi.mock('../../../src/middleware/logger.js', () => ({
 }));
 
 let mockSupabase = null;
+let mockSupabaseAdmin = null;
 let mockMongoDb = null;
 let mockRedisClient = null;
 let mockPgPool = null;
@@ -13,6 +14,7 @@ let mockFirebaseAdmin = null;
 
 vi.mock('../../../src/config/db.js', () => ({
   get supabase() { return mockSupabase; },
+  get supabaseAdmin() { return mockSupabaseAdmin; },
   get mongoDb() { return mockMongoDb; },
   get redisClient() { return mockRedisClient; },
   get pgPool() { return mockPgPool; },
@@ -27,6 +29,7 @@ describe('Individual health checks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSupabase = null;
+    mockSupabaseAdmin = null;
     mockMongoDb = null;
     mockRedisClient = null;
     mockPgPool = null;
@@ -68,6 +71,40 @@ describe('Individual health checks', () => {
       const { default: check } = await import('../../../src/core/health/checks/supabaseHealth.js');
       const result = await check();
       expect(result.status).toBe(HealthStatus.UNHEALTHY);
+    });
+
+    it('probes through supabaseAdmin (service role) so anon revocation does not false-flag', async () => {
+      const adminFrom = vi.fn().mockReturnThis();
+      const adminSelect = vi.fn().mockReturnThis();
+      const adminLimit = vi.fn().mockResolvedValue({ error: null });
+      mockSupabaseAdmin = {
+        from: adminFrom,
+        select: adminSelect,
+        limit: adminLimit,
+      };
+      // The anon client would fail (42501 permission denied) — it must not be used.
+      mockSupabase = {
+        from: vi.fn(() => {
+          throw new Error('anon client must not be used by the supabase health probe');
+        }),
+      };
+      const { default: check } = await import('../../../src/core/health/checks/supabaseHealth.js');
+      const result = await check();
+      expect(result.status).toBe(HealthStatus.HEALTHY);
+      expect(adminFrom).toHaveBeenCalledWith('profiles');
+      expect(adminLimit).toHaveBeenCalledWith(1);
+    });
+
+    it('falls back to the anon client when supabaseAdmin is not configured', async () => {
+      mockSupabaseAdmin = null;
+      mockSupabase = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ error: null }),
+      };
+      const { default: check } = await import('../../../src/core/health/checks/supabaseHealth.js');
+      const result = await check();
+      expect(result.status).toBe(HealthStatus.HEALTHY);
     });
   });
 


### PR DESCRIPTION
## Problem

Every Supabase health probe ran a `select` on `profiles` through the shared session-less anon-key client:

- `backend/api/src/core/health/checks/supabaseHealth.js:10` — `supabase.from('profiles').select('id').limit(1)`
- `backend/api/src/routes/healthRoutes.js:84-95` — `checkSupabase()` uses the same anon client

The shipped schema revokes **all** privileges on `profiles` from `anon` (`supabase/migrations/revoke_anon_privileges.sql`) and grants no `anon` RLS policy, so the probe always returned `42501 permission denied`. Since `supabase` is a **critical** health dependency:

- `/api/health` → 503 `degraded`
- `/api/health/ready` → 503 `not_ready` (K8s readiness probe permanently fails, restarting a healthy pod)
- `/api/health/full` → 503 `unhealthy`

…permanently, in a fully healthy system.

## Fix

- `supabaseHealth.js` and `healthRoutes.js checkSupabase()`: probe through `supabaseAdmin` (service-role client) when available — it is guaranteed access to `profiles` regardless of anon revocation — falling back to the anon client only when the service-role key is not configured.
- Add regression tests proving the probe goes through `supabaseAdmin` when anon privileges are revoked (and that the anon client is not used), plus the fallback path.

## Files changed

- `backend/api/src/core/health/checks/supabaseHealth.js`
- `backend/api/src/routes/healthRoutes.js`
- `backend/api/test/unit/core/healthChecks.test.js`
- `backend/api/test/integration/healthRoutes.test.js`

## Testing

- Unit (`test/unit/core/healthChecks.test.js`):
  - `supabaseHealth` probes `profiles` through `supabaseAdmin` (service role) when configured, even when the anon client would fail with 42501;
  - falls back to the anon client when `supabaseAdmin` is not configured;
  - existing not-configured / healthy / unhealthy cases still pass.
- Integration (`test/integration/healthRoutes.test.js`):
  - `GET /api/health` reports `supabase: connected` and HTTP 200 when `supabaseAdmin` answers the probe while the anon client returns `42501 permission denied`;
  - existing healthy / degraded / not_configured cases still pass.
- Run with:
  - `npm test -- test/unit/core/healthChecks.test.js`
  - `npm test -- test/integration/healthRoutes.test.js`

Closes #8949
