### PR TITLE
fix(blockchain): remove duplicate /api/blockchain mount shadowing the supabaseAdmin attach

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -516,16 +516,13 @@ app.use('/api/webhooks', webhookRoutes)
 app.use('/api/verify', verificationRoutes)
 app.use('/api/oracle', oracleRoutes)
 app.use('/api/ml', mlRoutes)
-app.use('/api/blockchain', (req, _res, next) => {
-  req.blockchainMetrics = blockchainMetrics;
-  req.escalationHandler = escalationHandler;
-  next();
-}, blockchainMonitoringRoutes)
 
 // ============================================================================
 // 🆕 BLOCKCHAIN MONITORING ROUTES
 // Attach the monitoring services and service-role client per request so the
 // handlers never fall back to the anon-key client (RLS would hide all rows).
+// NOTE: /api/blockchain must be mounted exactly once — a duplicate mount
+// registered earlier shadows this one and leaves req.supabase undefined.
 // ============================================================================
 app.use('/api/blockchain', (req, _res, next) => {
   req.blockchainMetrics = blockchainMetrics

--- a/backend/api/test/unit/blockchainMonitoringRoutes.test.js
+++ b/backend/api/test/unit/blockchainMonitoringRoutes.test.js
@@ -8,10 +8,16 @@
  *
  * Run with:  npm test -- test/unit/blockchainMonitoringRoutes.test.js
  */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import blockchainMonitoringRoutes from '../../src/routes/blockchainMonitoringRoutes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = path.resolve(__dirname, '../../src/index.js');
 
 vi.mock('../../src/middleware/auth.js', () => ({
   authenticate: (req, _res, next) => next(),
@@ -136,5 +142,15 @@ describe('blockchainMonitoringRoutes', () => {
     expect(res.status).toBe(200);
     expect(supabase.from).toHaveBeenCalledWith('blockchain_escalations');
     expect(res.body.escalation.alert_id).toBe('abc123');
+  });
+
+  it('regression: index.js mounts /api/blockchain exactly once with req.supabase = supabaseAdmin', () => {
+    const src = fs.readFileSync(INDEX_PATH, 'utf8');
+
+    const mountMatches = src.match(/app\.use\('\/api\/blockchain'/g) || [];
+    expect(mountMatches.length).toBe(1);
+
+    const mountSegment = src.slice(src.indexOf("app.use('/api/blockchain'"));
+    expect(mountSegment).toMatch(/req\.supabase\s*=\s*supabaseAdmin/);
   });
 });


### PR DESCRIPTION
## Problem

The `/api/blockchain` router was mounted **twice at the same path** in `backend/api/src/index.js`. Express evaluates `app.use` layers in registration order, so the first mount (which never attaches `req.supabase`) handled every request and the second mount — the only one attaching the service-role client added by #7336 — never ran. Every handler hit `req.supabase` being `undefined`:

- `GET /api/blockchain/events` → `TypeError: Cannot read properties of undefined (reading 'from')` → always `500 Failed to fetch events` (`blockchainMonitoringRoutes.js:106`)
- `GET /api/blockchain/escalations/:alertId` → same `TypeError` → always `404 Escalation not found` (`blockchainMonitoringRoutes.js:151`)

## Fix

- `backend/api/src/index.js`: delete the first mount (`:511-515`) and keep the single mount that attaches `req.blockchainMetrics`, `req.escalationHandler`, and `req.supabase = supabaseAdmin` (`:520-528`). Added a `NOTE` comment documenting that `/api/blockchain` must be mounted exactly once.
- `backend/api/test/unit/blockchainMonitoringRoutes.test.js`: added a regression test that reads `index.js` and asserts `/api/blockchain` is mounted exactly once **and** that the single mount attaches `req.supabase = supabaseAdmin`. This fails if a duplicate mount is ever re-added.

## Files changed

- `backend/api/src/index.js`
- `backend/api/test/unit/blockchainMonitoringRoutes.test.js`

## Testing

- New regression test `regression: index.js mounts /api/blockchain exactly once with req.supabase = supabaseAdmin` — asserts the mount count and the attach source directly.
- Existing route tests (mounted with `req.supabase`) still pass — they verify handlers query `blockchain_monitoring_events` / `blockchain_escalations` through the attached client.
- Run with: `npm test -- test/unit/blockchainMonitoringRoutes.test.js`

Closes #8951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate mounting of blockchain monitoring endpoints.
  * Ensured blockchain monitoring requests use the administrative data service correctly.

* **Tests**
  * Added regression coverage to verify the endpoint is mounted once and receives the required service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->