### PR TITLE
[Test] phone.test.js: fix stale pre-fix assertion for 0-prefixed numbers

### DIFF
--- a/backend/api/test/unit/phone.test.js
+++ b/backend/api/test/unit/phone.test.js
@@ -13,8 +13,8 @@ describe('normalizePhone', () => {
     expect(normalizePhone('919876543210')).toBe('+919876543210');
   });
 
-  it('returns null for a 0-prefixed 11-digit number (not handled)', () => {
-    expect(normalizePhone('09876543210')).toBeNull();
+  it('strips a leading trunk-prefix 0 from an 11-digit number', () => {
+    expect(normalizePhone('09876543210')).toBe('+919876543210');
   });
 
   it('strips spaces and punctuation', () => {


### PR DESCRIPTION
Closes #10725

Superseded/rebased: main already independently fixed the underlying \`normalizePhone\` trunk-prefix bug this PR originally targeted. What's left after rebasing onto main is a single leftover stale test — \`test/unit/phone.test.js\` still asserted the **pre-fix** behavior:

\`\`\`js
it('returns null for a 0-prefixed 11-digit number (not handled)', () => {
  expect(normalizePhone('09876543210')).toBeNull();
});
\`\`\`

This fails against current main (\`normalizePhone('09876543210')\` now correctly returns \`'+919876543210'\`). Updated the test to assert the correct, current behavior.

10/10 passing.