### PR TITLE
[Bug] Drop the duplicate logger import in auditRoutes that stops the API booting

### DIFF
--- a/backend/api/src/routes/auditRoutes.js
+++ b/backend/api/src/routes/auditRoutes.js
@@ -1,4 +1,3 @@
-import logger from '../middleware/logger.js';
 import express from 'express';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';

--- a/backend/api/test/unit/auditRoutes.moduleLoad.test.js
+++ b/backend/api/test/unit/auditRoutes.moduleLoad.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * auditRoutes.js is statically imported by src/index.js and mounted at
+ * /api/v1/admin/audit-logs. A duplicate `import logger` made it a SyntaxError,
+ * which in ESM is raised at link time — so the whole API failed to boot, not
+ * just this router.
+ *
+ * This pins the one property that failure violated: the module links and
+ * exports a usable Express router.
+ */
+describe('auditRoutes module load', () => {
+  it('links without a SyntaxError and default-exports an Express router', async () => {
+    const mod = await import('../../src/routes/auditRoutes.js');
+
+    expect(typeof mod.default).toBe('function');
+    // Express routers are functions carrying a `stack` of layers.
+    expect(Array.isArray(mod.default.stack)).toBe(true);
+  });
+
+  it('registers at least one route layer', async () => {
+    const { default: router } = await import('../../src/routes/auditRoutes.js');
+
+    const routeLayers = router.stack.filter((layer) => layer.route);
+    expect(routeLayers.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #9390

`backend/api/src/routes/auditRoutes.js` imported `logger` twice — line 1 and line 10. In ESM a duplicate binding is a **link-time** `SyntaxError`, and `src/index.js:60` imports this module statically, so the failure was never scoped to the audit routes. Linking happens before any application code runs, so `npm start` could not get past it. Every endpoint was down.

### Before

```
$ cd backend/api
$ node --input-type=module -e "await import('./src/routes/auditRoutes.js')"

file:///.../src/routes/auditRoutes.js:10
import logger from '../middleware/logger.js';
^^^^^^^^^^^^^
SyntaxError: Identifier 'logger' has already been declared
```

### After

```
$ node --input-type=module -e "const m = await import('./src/routes/auditRoutes.js'); console.log('LOADED', typeof m.default)"
LOADED function
```

### The change

One line removed. I dropped the **line-1** copy rather than the line-10 one, so the surviving import stays grouped with the other middleware imports (`auth`, `requirePolicy`, `rateLimiter`, `auditLog`, `validate`) and the file opens with `express` like the other route modules. No behaviour change beyond the module now linking.

### Root cause

Merge artifact — two branches each added the missing `logger` import at a different position and the merge kept both sides. Same shape as the other "merge kept both halves" defects in this repo, so it is worth assuming there are more.

### Regression test

`test/unit/auditRoutes.moduleLoad.test.js` — a link-time `SyntaxError` is invisible to any suite that never imports the module, which is exactly why this reached `main`. The test imports it and asserts a usable Express router with at least one registered route layer.

```
$ ../../node_modules/.bin/vitest run --silent=true --reporter=dot test/unit/auditRoutes.moduleLoad.test.js

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`eslint src/routes/auditRoutes.js` is now clean (it previously reported the same duplicate binding as a hard parse error).