### PR TITLE
[Bug] Call create_order_tx on supabaseAdmin instead of an undefined `db` in orderLifecycleService

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1034,7 +1034,7 @@ async function createOrderTransactional({ idempotencyKey, orderData, timelineDat
   }
 
   try {
-    const { data, error } = await db.rpc('create_order_tx', {
+    const { data, error } = await supabaseAdmin.rpc('create_order_tx', {
       p_idempotency_key: idempotencyKey,
       p_order_data: orderData,
       p_timeline_data: timelineData || { status: 'created', details: { note: 'Order initialized' } },


### PR DESCRIPTION
Closes #9392

`createOrderTransactional()` called `db.rpc('create_order_tx', …)`. There is no `db` binding in the module — `db` is the *filename* of `../../config/db.js`, not one of its exports.

```diff
-    const { data, error } = await db.rpc('create_order_tx', {
+    const { data, error } = await supabaseAdmin.rpc('create_order_tx', {
```

### Why `supabaseAdmin`

- The module already imports it (line 6) and already uses it at lines 612, 939 and 996. Line 1037 was the only outlier.
- The sibling caller of the *same* RPC uses the service-role client: `orderCreationService.js:207` does `await (supabaseAdmin ?? supabase).rpc('create_order_tx', …)`.
- `create_order_tx` (`supabase/migrations/20260723000003_create_order_tx.sql`, extended by `20260807000001_durable_idempotency_order_tx.sql`) writes the order, its timeline entry and the load offer in a single transaction — it needs the admin client.

### Verification

```
$ cd backend/api && ../../node_modules/.bin/eslint src/services/order/orderLifecycleService.js
```

Clean. Before the change:

```
  1037:35  error  'db' is not defined  no-undef
```

### Why there is no unit test in this PR, and what reviewers should know

The bug is **latent today**, and I want to be straight about why: the last line of this file is `module.exports.createOrderTransactional = createOrderTransactional`, which is a `ReferenceError` in an ESM module. The module never finishes evaluating, so nothing can reach `createOrderTransactional` at all — which is also why no test can currently exercise it.

That export defect is tracked separately (#8617 / #8813) with **PR #8625** already open, so I deliberately did not touch it here: two one-line fixes in separate PRs stay reviewable and can land in either order.

The consequence is worth stating explicitly for whoever reviews #8625: **fixing the export alone converts a load-time crash into a runtime crash on the first transactional order.** Both changes are needed. Once #8625 lands and the function is genuinely reachable, I'm happy to follow up with a unit test that mocks `config/db.js` and asserts the RPC is dispatched on the admin client with the right payload — it just cannot be written before then.

This PR touches one line and no test files.