### PR TITLE
[Bug] Restore the supersede lookup and limits documentController relies on — every KYC upload was 500ing

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -15,6 +15,17 @@ const ALLOWED_DOCUMENT_TYPES = Object.freeze([
   'other',
 ]);
 
+// Mirrors the multer limit in routes/documentRoutes.js, which reads the same
+// env var and falls back to the same 8MB. multer rejects oversized multipart
+// bodies before the controller runs; this is the guard for the buffer itself,
+// whose length can disagree with the reported size.
+const MAX_FILE_SIZE_BYTES =
+  Number(process.env.MULTIPART_FILE_LIMIT_BYTES) || 8 * 1024 * 1024;
+
+// Mirrors the scanner's own deadline in lib/malwareScanner.js, so the
+// AbortController below cannot fire before or long after the scanner gives up.
+const SCAN_TIMEOUT_MS = Number(process.env.SCAN_TIMEOUT_MS) || 30000;
+
 const MIME_EXTENSION_MAP = Object.freeze({
   'application/pdf': 'pdf',
   'image/png': 'png',
@@ -123,6 +134,33 @@ export async function uploadDriverDocument(req, res) {
       });
     }
 
+    // A driver re-uploading the same document type supersedes the previous
+    // one: the metadata row below is updated in place and the superseded file
+    // removed once the new row is committed. Ordered newest-first and limited
+    // to one row because there is no unique constraint on
+    // (driver_id, document_type) — see the create_driver_documents migration.
+    const { data: existingDoc, error: lookupError } = await supabase
+      .from('driver_documents')
+      .select('id, storage_path')
+      .eq('driver_id', driverId)
+      .eq('document_type', documentType)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (lookupError) {
+      logger.error(
+        '[DocumentController] Failed to look up existing document:',
+        lookupError.message,
+      );
+      return res.status(500).json({ error: 'Failed to store document' });
+    }
+
+    // Captured before the row is updated below: the update rewrites
+    // storage_path, so reading it afterwards would point at the file that was
+    // just uploaded rather than the one being replaced.
+    const supersededStoragePath = existingDoc?.storage_path ?? null;
+
     const storagePath = `${driverId}/${documentType}-${Date.now()}.${extension}`;
 
     const { error: storageError } = await supabase.storage
@@ -191,10 +229,10 @@ export async function uploadDriverDocument(req, res) {
     }
 
     // Clean up old file from storage to prevent orphaned files
-    if (existingDoc?.storage_path) {
+    if (supersededStoragePath) {
       await supabase.storage
         .from('driver-documents')
-        .remove([existingDoc.storage_path])
+        .remove([supersededStoragePath])
         .catch((cleanupErr) => {
           logger.warn('[DocumentController] Failed to delete superseded storage file:', cleanupErr.message);
         });

--- a/backend/api/test/integration/documentRoutes.test.js
+++ b/backend/api/test/integration/documentRoutes.test.js
@@ -152,6 +152,92 @@ describe('Document Routes Integration Tests', () => {
       expect(m.store.__storageObjects.length).toBe(0);
     });
 
+    it('supersedes an existing document of the same type instead of inserting a second row', async () => {
+      const app = buildApp();
+      const upload = () =>
+        request(app)
+          .post('/api/driver/documents')
+          .set(DRIVER_HEADERS)
+          .field('documentType', 'aadhaar_card')
+          .attach('document', JPEG_BYTES, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+      const first = await upload();
+      expect(first.status).toBe(201);
+      const firstPath = m.store.__storageObjects.at(-1).path;
+
+      const second = await upload();
+
+      // 200, not 201: the metadata row is updated in place rather than a
+      // second row being inserted for the same (driver, document type).
+      expect(second.status).toBe(200);
+      expect(second.body.success).toBe(true);
+      expect(m.store.driver_documents.length).toBe(1);
+      expect(m.store.driver_documents[0].storage_path).not.toBe(firstPath);
+
+      // The superseded file is removed so storage does not accumulate orphans.
+      expect(m.store.__storageObjects.some((o) => o.path === firstPath)).toBe(false);
+    });
+
+    it('keeps documents of different types side by side', async () => {
+      const app = buildApp();
+      const upload = (documentType) =>
+        request(app)
+          .post('/api/driver/documents')
+          .set(DRIVER_HEADERS)
+          .field('documentType', documentType)
+          .attach('document', JPEG_BYTES, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+      expect((await upload('aadhaar_card')).status).toBe(201);
+      expect((await upload('pan_card')).status).toBe(201);
+
+      expect(m.store.driver_documents.length).toBe(2);
+      expect(m.store.driver_documents.map((d) => d.document_type).sort()).toEqual([
+        'aadhaar_card',
+        'pan_card',
+      ]);
+    });
+
+    it('does not treat another driver\'s document as the one being superseded', async () => {
+      m.store.driver_documents.push({
+        id: 'other-driver-doc',
+        driver_id: 'driver-uuid-999',
+        document_type: 'aadhaar_card',
+        storage_path: 'driver-uuid-999/aadhaar_card-1.jpg',
+        mime_type: 'image/jpeg',
+        status: 'pending_review',
+        created_at: new Date().toISOString(),
+      });
+
+      const res = await request(buildApp())
+        .post('/api/driver/documents')
+        .set(DRIVER_HEADERS)
+        .field('documentType', 'aadhaar_card')
+        .attach('document', JPEG_BYTES, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+      expect(res.status).toBe(201);
+      expect(m.store.driver_documents.length).toBe(2);
+      const other = m.store.driver_documents.find((d) => d.id === 'other-driver-doc');
+      expect(other.storage_path).toBe('driver-uuid-999/aadhaar_card-1.jpg');
+    });
+
+    it('rejects a buffer larger than the configured limit with 413', async () => {
+      const oversized = Buffer.concat([
+        JPEG_BYTES,
+        Buffer.alloc(Number(process.env.MULTIPART_FILE_LIMIT_BYTES) || 8 * 1024 * 1024),
+      ]);
+
+      const res = await request(buildApp())
+        .post('/api/driver/documents')
+        .set(DRIVER_HEADERS)
+        .field('documentType', 'aadhaar_card')
+        .attach('document', oversized, { filename: 'id.jpg', contentType: 'image/jpeg' });
+
+      // multer's own limit fires first for a real multipart body; either way
+      // the upload must not reach storage.
+      expect([413, 500]).toContain(res.status);
+      expect(m.store.__storageObjects.length).toBe(0);
+    });
+
     it('returns 500 when malware scanner throws an unexpected error', async () => {
       scanDocument.mockRejectedValue(new Error('Unexpected scanner failure'));
 


### PR DESCRIPTION
Closes #9394
Closes #8581

`documentController.js` referenced three identifiers declared nowhere in the module. A merge kept the code that *consumes* the supersede lookup and dropped the code that *produces* it.

### Impact before this PR

The handler wraps everything in a `try/catch` that maps the unexpected to `500 { error: 'An unexpected error occurred' }`, so:

- **Every driver KYC upload failed** — Aadhaar, PAN, licence, RC book. The whole KYC flow was dead.
- The `existingDoc` ReferenceError fires at line 143, **after** `supabase.storage.upload()` at line 128 has already succeeded. The storage-cleanup path only runs on a `dbError`, and a `ReferenceError` is not one — so **every attempt orphaned a file** in the private `driver-documents` bucket with no metadata row pointing at it.
- `MAX_FILE_SIZE_BYTES` throws first at line 46, so even the validation responses were wrong: a bad `documentType` returned 500 instead of 400.

### The existing test suite was already red

`test/integration/documentRoutes.test.js` is committed and **6 of its 9 tests fail on `main`**:

```
 FAIL  returns 400 for an unrecognized documentType          expected 500 to be 400
 FAIL  accepts a real JPEG declared as image/jpeg            expected 500 to be 201
 FAIL  rejects an executable renamed to .jpg with a 422      expected 500 to be 422
 FAIL  rejects a file whose content ≠ declared Content-Type  expected 500 to be 422
 FAIL  returns 500 if storage upload fails (no leakage)
 FAIL  rejects upload when malware scanner detects a threat  expected 500 to be 422

 Tests  6 failed | 3 passed (9)
```

Worth dwelling on the third and sixth: the tests asserting **a renamed executable is rejected** and **a malware-flagged file is rejected** were red. The magic-byte and malware defences were unverified on `main`. Same "suites exist but never run in CI" gap as #8551.

### The changes

**1. The two constants**, mirroring limits their neighbours already use rather than inventing new ones:

```js
const MAX_FILE_SIZE_BYTES =
  Number(process.env.MULTIPART_FILE_LIMIT_BYTES) || 8 * 1024 * 1024;   // matches routes/documentRoutes.js
const SCAN_TIMEOUT_MS = Number(process.env.SCAN_TIMEOUT_MS) || 30000;  // matches lib/malwareScanner.js
```

**2. The supersede lookup.** The surviving code reads `existingDoc.id`, reads `existingDoc.storage_path`, and returns `200` vs `201` off its truthiness — so the intent was unambiguous. It is ordered newest-first and limited to one row rather than assuming uniqueness, because `driver_documents` has **no unique constraint** on `(driver_id, document_type)` (`20260702000000_create_driver_documents.sql`) — which also makes the existing `23505` handler aspirational rather than dead code.

**3. A latent bug in the surviving code.** The cleanup read `existingDoc.storage_path` *after* the update had rewritten that column. Restoring the lookup alone would have made the handler **delete the file it just uploaded and leave the old one orphaned**. The path is now captured before the update:

```js
const supersededStoragePath = existingDoc?.storage_path ?? null;
```

### New tests

Four added to the existing integration suite:

- supersedes same-type re-upload → `200`, one row, old storage object removed
- different document types coexist → two rows
- another driver's same-type document is untouched
- oversized buffer never reaches storage

```
 Test Files  1 passed (1)
      Tests  13 passed (13)      # was: 6 failed | 3 passed
```

`eslint` clean on both files (previously 10 `no-undef` errors).

### One note for reviewers

I dropped an `expect(second.body.document.id).toBe(firstId)` assertion from the supersede test. The reason is a quirk in `test/helpers/supabaseMock.js`: `insert().select().single()` returns a *synthetic* `id` but pushes the payload **without** it into the store, so the stored row has no `id` at all. The test asserts the store-level invariants instead (one row, storage_path rotated, old object gone), which is what actually matters here. Happy to file that mock gap separately if it'd be useful.