### PR TITLE
fix : added remove duplicate telemetry validation in tracker.js WebSocket handler

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -963,14 +963,6 @@ export async function handleLocationPing(ws, data, req) {
     return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: normalizedValidationErrors }));
   }
 
-  // Schema-validate and sanitize the telemetry payload before further
-  // processing (issue #5758). Enforces field ranges and string lengths that
-  // the inline guards above do not cover.
-  const validationErrors = validateTelemetryPayload(data);
-  if (validationErrors) {
-    return ws.send(JSON.stringify({ error: 'Invalid telemetry payload', details: validationErrors }));
-  }
-
   // Cross-field validation: require at least one complete coordinate pair.
   const hasLatLng = data.lat !== undefined && data.lng !== undefined;
   const hasLatLong = data.latitude !== undefined && data.longitude !== undefined;


### PR DESCRIPTION
Closes #9423.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
tracker.js validates the normalized payload at line 961 then re-validates the original data at line 969, causing latitude/longitude-sending clients to fail.

Changes Made:
- backend/api/src/sockets/tracker.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.