### PR TITLE
fix : added propagate err.code in sentry beforeSend error filter

### DIFF
--- a/backend/api/src/middleware/sentry.js
+++ b/backend/api/src/middleware/sentry.js
@@ -21,6 +21,7 @@ export function initSentry() {
     beforeSend(event) {
       if (event.exception?.values?.[0]?.value) {
         const err = new Error(event.exception.values[0].value);
+        err.code = event.exception.values[0].type || undefined;
         if (shouldIgnoreError(err)) return null;
       }
       return event;


### PR DESCRIPTION
Closes #9424.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
sentry.js beforeSend creates a new Error without copying the code property, so shouldIgnoreError never matches ECONNRESET/ECONNREFUSED/ETIMEDOUT.

Changes Made:
- backend/api/src/middleware/sentry.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.