### PR TITLE
fix : added enable authFailureMonitor in production via explicit env flag

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -6,7 +6,10 @@ const DEFAULT_THRESHOLD = 5;
 const DEFAULT_WINDOW_MS = 60_000;
 
 export default function authFailureMonitor(req, res, next) {
-  if (process.env.NODE_ENV === 'production') {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.AUTH_FAILURE_MONITOR_ENABLED !== 'true'
+  ) {
     return next();
   }
 


### PR DESCRIPTION
Closes #9425.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
authFailureMonitor skips all monitoring when NODE_ENV=production. Use AUTH_FAILURE_MONITOR_ENABLED env var so teams can enable it in production.

Changes Made:
- backend/api/src/middleware/authFailureMonitor.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.