### PR TITLE
fix : added validate cached profile with isValidCachedProfile before property access

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -20,7 +20,7 @@ export async function getProfile(userId) {
   if (isCacheEnabled()) {
     try {
       const cached = await getCachedSupabaseProfile(userId);
-      if (cached) {
+      if (cached && isValidCachedProfile(firebaseUid, cached)) {
         logger.debug({ userId }, 'Profile cache hit');
         return cached;
       }


### PR DESCRIPTION
Closes #9426.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
profileService.js accesses cached profile properties without calling isValidCachedProfile first, risking TypeErrors on corrupted cache entries.

Changes Made:
- backend/api/src/services/profileService.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.