### PR TITLE
fix : added validate order_display_id is non-empty string in order routes

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -210,6 +210,9 @@ router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
     return res.status(400).json({ error: 'Invalid driver_lat or driver_lng' });
   }
 
+  if (!id || !id.trim()) {
+    return res.status(400).json({ error: 'Invalid order id' });
+  }
   let geofenceRadiusM;
   if (geofence_radius_m !== undefined) {
     geofenceRadiusM = parseFloat(geofence_radius_m);


### PR DESCRIPTION
Closes #9438.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
Order routes use order_display_id without validating it is non-empty. Empty IDs could cause unexpected database queries.

Changes Made:
- backend/api/src/routes/orderRoutes.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.