### PR TITLE
fix : added cap maximum TTL at 86400 seconds in profile cache set functions

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -312,6 +312,7 @@ export async function setCachedSupabaseProfile(
   const redisClient = getRedisClient();
   if (!redisClient || !userId || !profile) return;
   if (ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       supabaseProfileKey(userId),
@@ -385,6 +386,7 @@ export async function setCachedCustomerStats(
   const redisClient = getRedisClient();
   if (!redisClient || !userId || !stats) return;
   if (ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       customerStatsKey(userId),
@@ -434,6 +436,7 @@ export async function setCachedDriverDetails(
   const redisClient = getRedisClient();
   if (!redisClient || !userId || !details) return;
   if (ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       driverDetailsKey(userId),


### PR DESCRIPTION
Closes #9439.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
setCachedProfile clamps minimum TTL but does not cap maximum. Add 86400-second cap to prevent Redis memory issues.

Changes Made:
- backend/api/src/lib/profileCache.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.