### PR TITLE
fix : added log structured error when ML prediction service returns non-JSON response

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -98,6 +98,7 @@ async function handleResponse(response) {
     try {
         return JSON.parse(text);
     } catch (err) {
+    logger.error({ status: response ? response.status : undefined, url }, 'ML service request failed');
         throw new Error(`[ML] Invalid JSON response from ML engine: ${err.message}`, { cause: err });
     }
 }


### PR DESCRIPTION
Closes #9440.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Summary of What Has Been Done:
ml.js does not log when the ML service returns non-JSON or empty responses, making debugging difficult.

Changes Made:
- backend/api/src/services/ml.js

Impact it Made:
This change improves the reliability, security, or test coverage of the Truxify backend.

Note: Please assign this PR to the `tmdeveloper007` account.