### PR TITLE
fix(auth): return cached-profile uid/fullName correctly on cache hit

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -129,9 +129,9 @@ export async function verifyAuthToken(token) {
 
   return {
     id: userProfile.id,
-    uid: userProfile.firebase_uid,
+    uid: userProfile.uid ?? userProfile.firebase_uid,
     role: userProfile.role,
-    fullName: userProfile.full_name,
+    fullName: userProfile.fullName ?? userProfile.full_name,
     phone: userProfile.phone,
     isActive: true,
   };


### PR DESCRIPTION
## Problem

The `authenticate` middleware's auth-cache hit path read `userProfile.firebase_uid` and `userProfile.full_name` off the cached profile, but cached profiles expose `uid` and `fullName` (camelCase). On a cache hit `req.user.uid` and `req.user.fullName` were therefore `undefined`, breaking everything downstream that depends on the user id / display name.

## Fix

Fall back across both key variants when building the cached profile so either shape works:

- `uid: userProfile.uid ?? userProfile.firebase_uid`
- `fullName: userProfile.fullName ?? userProfile.full_name`


## Files changed

- `backend/api/src/middleware/auth.js`


## Testing

- `node --check backend/api/src/middleware/auth.js` passes.
- Reviewed both profile shapes (DB `firebase_uid`/`full_name` and cache `uid`/`fullName`); values now resolve on cache hits.


Closes #9407


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication compatibility for profiles using different field naming conventions.
  * Preserved existing fallback values when profile details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->