### PR TITLE
fix(zkp): declare bulletproofs module in lib.rs

### DIFF
--- a/services/zkp-verifier-rust/src/lib.rs
+++ b/services/zkp-verifier-rust/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod bulletproofs;
+pub mod bulletproofs;
 pub mod verifier;
 pub mod weight_proof;


### PR DESCRIPTION
## Problem

The `zkp-verifier-rust` tests reference the `bulletproofs` module, but it was never declared in `lib.rs`, so `cargo test` failed to compile.

## Fix

Added the missing module declaration:

```rust
pub mod bulletproofs;
```


## Files changed

- `services/zkp-verifier-rust/src/lib.rs`


## Testing

- A Rust toolchain is not available on the local machine, so `cargo test` could not be run here.
- The change is a single module declaration required by the existing `bulletproofs` test files.


Closes #9411
