### PR TITLE
fix(vector-matcher): copy include/ and src/ into the Docker image

### DIFF
--- a/services/vector-matcher-cpp/Dockerfile
+++ b/services/vector-matcher-cpp/Dockerfile
@@ -3,6 +3,8 @@ FROM gcc:13 AS builder
 WORKDIR /app
 
 COPY CMakeLists.txt main.cpp ./
+COPY include/ ./include/
+COPY src/ ./src/
 
 RUN apt-get update && apt-get install -y cmake
 RUN cmake -B build -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Problem

`services/vector-matcher-cpp/Dockerfile` copied neither `include/` nor `src/` into the build stage, so `docker build` failed at the cmake step because `src/matcher.cpp` (and the required headers) were missing from the image.

## Fix

Added the missing source copies ahead of the cmake build step:

```dockerfile
COPY include/ ./include/
COPY src/ ./src/
```


## Files changed

- `services/vector-matcher-cpp/Dockerfile`


## Testing

- Building requires Docker plus a C++/Rust toolchain, so it was not run locally.
- Paths verified against the service directory layout (`include/`, `src/matcher.cpp`).


Closes #9412
