### PR TITLE
fix(wasm): reference truxify_wasm_routing.wasm in edge-runtime

### DIFF
--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -21,7 +21,7 @@ class EdgeRuntime {
         if (this.isInitialized) return;
 
         try {
-            const wasmPath = process.env.WASM_MODULE_PATH || './wasm/truxify_wasm.wasm';
+            const wasmPath = process.env.WASM_MODULE_PATH || './wasm/truxify_wasm_routing.wasm';
             if (fs.existsSync(wasmPath)) {
                 const wasmBytes = fs.readFileSync(wasmPath);
                 const wasi = new WASI({
@@ -146,7 +146,7 @@ class EdgeRuntime {
             }
         `;
 
-            const wasmPath = process.env.WASM_MODULE_PATH || './wasm/truxify_wasm.wasm';
+            const wasmPath = process.env.WASM_MODULE_PATH || './wasm/truxify_wasm_routing.wasm';
 
             const worker = new Worker(workerCode, {
                 eval: true,


### PR DESCRIPTION
## Problem

`wasm/edge-runtime.js` looked for `truxify_wasm.wasm`, but the wasm crate builds `truxify_wasm_routing.wasm`. The WASM module therefore never loaded.

## Fix

Updated both occurrences in `wasm/edge-runtime.js` from `truxify_wasm.wasm` to `truxify_wasm_routing.wasm`.


## Files changed

- `wasm/edge-runtime.js`


## Testing

- `node --check wasm/edge-runtime.js` passes.
- Grep confirms no remaining `truxify_wasm.wasm` references; the filename now matches the crate's build output.


Closes #9413
