### PR TITLE
fix(wasi): point cargo build at wasi/src/Cargo.toml

### DIFF
--- a/wasi/package.json
+++ b/wasi/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "WASI for Cross-Platform Edge Computing",
   "scripts": {
-    "build": "cargo build --target wasm32-wasi --release",
+    "build": "cargo build --manifest-path src/Cargo.toml --target wasm32-wasi --release",
     "test": "cargo test",
     "start": "node index.js"
   },


### PR DESCRIPTION
## Problem

The `wasi/package.json` `build` script ran `cargo build --target wasm32-wasi` from `wasi/`, but the `Cargo.toml` lives at `wasi/src/Cargo.toml`, so the build failed with a missing-manifest error.

## Fix

Pointed cargo at the actual manifest:

```json
"build": "cargo build --manifest-path src/Cargo.toml --target wasm32-wasi --release"
```


## Files changed

- `wasi/package.json`


## Testing

- JSON validates; `wasi/src/Cargo.toml` confirmed to exist.
- Full build requires the `wasm32-wasi` target and a Rust toolchain (not available locally).


Closes #9414
