### PR TITLE
fix(orders): add POST /api/orders create-order route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -255,6 +255,43 @@ router.post('/api/deliveries/:id/geofence-confirm', async (req, res) => {
 );
 
 // ============================================================================
+// 1. CREATE ORDER (CUSTOMER) — POST /api/orders
+// ============================================================================
+/**
+ * @openapi
+ * /api/orders:
+ *   post:
+ *     tags: [Orders]
+ *     summary: Create a new order
+ *     description: Creates an order with server-computed pricing, a default timeline, and a load-board offer.
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateOrderRequest'
+ *     responses:
+ *       201:
+ *         description: Order created
+ *       400:
+ *         description: Validation failed
+ */
+router.post('/', authenticate, userLimiter, requirePolicy('order:create'), validateBody(createOrderSchema), async (req, res) => {
+  try {
+    const result = await orderLifecycleService.createOrder(req.user.id, req.user.fullName, req.body);
+    return res.status(201).json(result);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(err.status).json(err.payload);
+    }
+    logger.error('Create order exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
 // 13c. DRIVER OTP CONFIRM ALIAS — POST /api/deliveries/:id/confirm-otp
 // ============================================================================
 /**
@@ -600,7 +637,6 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
   }
 
   try {
-    const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, total_amount');
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, status, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance');
     orderValidationService.assertOrderFound(order);
     orderValidationService.assertCustomerOwnership(order, req.user.id);

--- a/backend/api/test/integration/orders.test.js
+++ b/backend/api/test/integration/orders.test.js
@@ -76,6 +76,8 @@ afterEach(() => {
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
+  supabaseAdmin: m.supabase,
+  createUserClient: () => m.supabase,
   firebaseAdmin: null,
   get redisClient() {
     return mockRedis;


### PR DESCRIPTION
## Problem

The customer app's create-order flow posts to `POST /api/orders`, but `orderRoutes.js` had no `router.post('/')`, so every create-order request returned 404. Supporting dead code confirmed the handler was intended to exist: `createOrderSchema` was imported but never used, and both `orderLifecycleService.createOrder` and `orderCreationService.createOrder` were never called from any route — the entire create-order domain was dead.

## Fix

Added `POST /api/orders`:

```js
router.post('/', authenticate, userLimiter, requirePolicy('order:create'), validateBody(createOrderSchema), async (req, res) => { ... })
```

The handler validates the customer payload with `createOrderSchema`, then invokes `orderLifecycleService.createOrder(req.user.id, req.user.fullName, req.body)`, which persists the order with **server-computed pricing** (no client monetary fields), generates the default timeline, and publishes the load-board offer. Responds `201 { order }`.

Two minimal, required follow-ups in the same file/suite:
- Removed a duplicate `const order` declaration in the confirm-deposit handler that was a hard `SyntaxError` — the file could not be imported at all (this is why every route in the file, including the new one, was unreachable).
- Added the missing `supabaseAdmin`/`createUserClient` exports to the `db.js` mock in `orders.test.js` so the spec suite for this feature can actually load.


## Files changed

- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/integration/orders.test.js`


## Testing

- `node --check backend/api/src/routes/orderRoutes.js` passes.
- Ran `npx vitest run test/integration/orders.test.js -t "server-side pricing contract"`: **10 of 11 create-order tests pass**, including the happy path (`201`, server-computed pricing persisted, no client monetary fields), client-pricing rejection (`400`), OSRM road-distance pricing, coordinate/date/weight validation (`400` with structured details), and both no-client-monetary-field regression checks.
- One create-order test still fails: `load_offers exposes the total price while retaining component costs` asserts `fuel_cost + toll_cost + net_profit === base_freight`, which is impossible under the canonical pricing model in `src/lib/pricing.js` (toll is a pass-through added on top of `base = fuel + net`). This is a pre-existing test/assertion mismatch, unrelated to this change.


Closes #9415
