### PR TITLE
fix(ml-dashboard): send X-API-Key and use reachable rollback URL

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -16,6 +16,12 @@ class _MLDashboardState extends State<MLDashboard> {
     defaultValue: 'http://localhost:8000',
   );
 
+  static const String _apiKey = String.fromEnvironment('ML_API_KEY');
+
+  Map<String, String> _headers() => {
+    if (_apiKey.isNotEmpty) 'X-API-Key': _apiKey,
+  };
+
   @override
   void initState() {
     super.initState();
@@ -26,6 +32,7 @@ class _MLDashboardState extends State<MLDashboard> {
     try {
       final response = await http.get(
         Uri.parse('$_baseUrl/ab-testing/status'),
+        headers: _headers(),
       );
       if (response.statusCode == 200) {
         setState(() {
@@ -142,7 +149,8 @@ class _MLDashboardState extends State<MLDashboard> {
         if (testId != null) {
           try {
             final response = await http.post(
-              Uri.parse('http://ml-engine:8000/ab-testing/rollback/$testId'),
+              Uri.parse('$_baseUrl/ab-testing/rollback/$testId'),
+              headers: _headers(),
             );
             if (response.statusCode == 200) {
               ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Problem

`cutomer_app/lib/screens/ml_dashboard.dart` called the ML engine endpoints without an `X-API-Key` header (rejected with 401), and the "rollback" call used the hardcoded, unreachable `http://ml-engine:8000/...` host.

## Fix

- Added `_apiKey` sourced from `String.fromEnvironment('ML_API_KEY')`.
- Added a `_headers()` helper that attaches `X-API-Key` when a key is configured.
- Wired the headers into both the `http.get(status)` and `http.post(rollback)` calls.
- Changed the rollback URL from the hardcoded `http://ml-engine:8000/...` to `$_baseUrl/...`, matching the status call.


## Files changed

- `cutomer_app/lib/screens/ml_dashboard.dart`


## Testing

- Dart/Flutter toolchain not available locally; change reviewed against the file's existing `_baseUrl` and request patterns.


Closes #9416
