### PR TITLE
fix(blockchain): convert remaining CommonJS test files to ESM

### DIFF
--- a/blockchain/contracts/StateChannel.test.js
+++ b/blockchain/contracts/StateChannel.test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+import { expect } from "chai";
+import { ethers } from "hardhat";
 
 const CHALLENGE_PERIOD = 24 * 60 * 60; // 1 day in seconds
 

--- a/blockchain/contracts/TruxifyEscrow.test.js
+++ b/blockchain/contracts/TruxifyEscrow.test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+import { expect } from "chai";
+import { ethers } from "hardhat";
 
 const AMOUNT = ethers.parseEther("1");
 const DISPUTE_TIMEOUT_SECS = 7 * 24 * 3600;

--- a/blockchain/contracts/zkEVM.test.js
+++ b/blockchain/contracts/zkEVM.test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+import { expect } from "chai";
+import { ethers } from "hardhat";
 
 const ZERO_DATA = "0x";
 const GAS_PRICE = 10n;

--- a/blockchain/test/DAO.test.js
+++ b/blockchain/test/DAO.test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+import { expect } from "chai";
+import { ethers } from "hardhat";
 
 describe("DAO Quadratic Voting", function () {
   it("Should calculate quadratic cost = votes^2 correctly", async function () {


### PR DESCRIPTION
## Problem

The deploy/test scripts in `blockchain/` use ESM `import` syntax, but four test files still used CommonJS (`require` / `module.exports`) under the module-type package, so loading them crashed (`npm run test`, `hardhat test`).

Note: the issue described `blockchain/package.json:51` as `"type": "commonjs"`; that manifest entry was already aligned to `"type": "module"` previously, so the remaining defect was the mixed CommonJS test files.

## Fix

Converted the four remaining CommonJS test files to ESM `import`:

- `blockchain/contracts/StateChannel.test.js`
- `blockchain/contracts/TruxifyEscrow.test.js`
- `blockchain/contracts/zkEVM.test.js`
- `blockchain/test/DAO.test.js`

`.cjs` files (e.g. `hardhat.config.cjs`, other `*.test.cjs`) remain CommonJS by design and are untouched.


## Files changed

- `blockchain/contracts/StateChannel.test.js`
- `blockchain/contracts/TruxifyEscrow.test.js`
- `blockchain/contracts/zkEVM.test.js`
- `blockchain/test/DAO.test.js`


## Testing

- `node --check` passes on all four converted files.
- Running the full hardhat suite requires installing the workspace dependencies (not performed in this PR).


Closes #9417
