### PR TITLE
fix(tracker): accept latitude/longitude alternate names in telemetry

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -948,6 +948,12 @@ export async function handleLocationPing(ws, data, req) {
     return ws.send(JSON.stringify({ error: 'Invalid telemetry payload.', details: ['lat and lng are required'] }));
   }
 
+  // Normalize the alternate latitude/longitude names into the canonical
+  // lat/lng keys so schema validation, sanitization and persistence
+  // downstream all operate on the resolved coordinates.
+  data.lat = lat;
+  data.lng = lng;
+
   // Fix 3 + dead-code fix: run the payload through the schema validator/
   const normalizedForValidation = {
     lat,


### PR DESCRIPTION
## Problem

`backend/api/src/sockets/tracker.js` validates the raw telemetry payload against a schema that requires `lat`/`lng`, but clients send `latitude`/`longitude` (the alternate names the schema also supports). Validation at line ~958 ran on the raw payload, so valid telemetry was rejected before the aliases were normalized.

## Fix

After normalizing `lat`/`lng` from `latitude`/`longitude`, also assign:

```js
data.lat = lat;
data.lng = lng;
```

so validation and persistence always see the canonical `lat`/`lng` keys.


## Files changed

- `backend/api/src/sockets/tracker.js`


## Testing

- `node --check backend/api/src/sockets/tracker.js` passes.
- Normalization path reviewed: canonical keys are set before payload validation runs.


Closes #9418
