### PR TITLE
fix(n8n): remove stray '=' in dispute_resolution URLs

### DIFF
--- a/automation/n8n/dispute_resolution.json
+++ b/automation/n8n/dispute_resolution.json
@@ -51,7 +51,7 @@
     },
     {
       "parameters": {
-        "url": "={{$node[\"Supabase Dispute Webhook\"].json.body.record.order_api_url}}/api/orders/={{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}/dispute-evidence",
+        "url": "={{$node[\"Supabase Dispute Webhook\"].json.body.record.order_api_url}}/api/orders/{{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}/dispute-evidence",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "options": {}
@@ -117,7 +117,7 @@
     },
     {
       "parameters": {
-        "url": "={{$node[\"Supabase Dispute Webhook\"].json.body.record.order_api_url}}/api/orders/={{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}/status",
+        "url": "={{$node[\"Supabase Dispute Webhook\"].json.body.record.order_api_url}}/api/orders/{{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}/status",
         "options": {}
       },
       "type": "n8n-nodes-base.httpRequest",


### PR DESCRIPTION
## Problem

`automation/n8n/dispute_resolution.json` built URLs like `/api/orders/=#json/...` — a stray `=` after the order id in both the dispute-evidence and dispute-status nodes — so those nodes 404'd.

## Fix

Removed the stray `=` from the URL templates in both nodes.


## Files changed

- `automation/n8n/dispute_resolution.json`


## Testing

- JSON validates via `ConvertFrom-Json`.
- URL templates inspected in the dispute-evidence and dispute-status nodes.


Closes #9419
