### PR TITLE
fix(n8n): define BACKEND_API_URL for dispute-resolution workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,11 @@ SENTRY_DSN=
 N8N_ENCRYPTION_KEY=<generate-a-secure-random-key>
 N8N_USER_MANAGEMENT_JWT_SECRET=<generate-a-secure-random-key>
 
+# Base URL of the backend Express API as reachable from the n8n container on
+# the internal Docker network (service name `api`, port 5000). Used by the
+# dispute-resolution workflow's HTTP nodes ({{$env.BACKEND_API_URL}}).
+BACKEND_API_URL=http://api:5000
+
 # Dedicated database credentials for n8n. Provisioned at DB init time into the
 # `truxify_n8n` database owned by the `n8n` role (never the app `truxify` DB).
 N8N_DB_PASSWORD=<generate-a-secure-random-password>

--- a/automation/n8n/README.md
+++ b/automation/n8n/README.md
@@ -24,6 +24,7 @@ When importing workflows into your n8n instance, ensure the following environmen
 | `INTERNAL_RELAYER_KEY` | HMAC secret for relayer API calls to backend Express service | `local_relayer_secret` |
 | `ML_API_KEY` | API Key for authenticating against the FastAPI ML Engine | `local_ml_secret` |
 | `ML_ENGINE_URL` | Base URL of the ML service container | `http://ml-engine:8000` |
+| `BACKEND_API_URL` | Base URL of the backend Express API, reachable from the n8n container on the internal Docker network | `http://api:5000` |
 | `N8N_ENCRYPTION_KEY` | Master encryption key for n8n credentials | Configured in `docker-compose.prod.yml` |
 
 ---

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -255,6 +255,7 @@ services:
       EXECUTIONS_DATA_PRUNE: "true"
       EXECUTIONS_DATA_MAX_AGE: 336
       N8N_METRICS: "true"
+      BACKEND_API_URL: ${BACKEND_API_URL:?BACKEND_API_URL is required}
     volumes:
       - n8n_data:/home/node/.n8n
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,6 +261,7 @@ services:
       - INTERNAL_RELAYER_KEY=${INTERNAL_RELAYER_KEY:-local_relayer_secret}
       - ML_API_KEY=${ML_API_KEY:-local_ml_secret}
       - ML_ENGINE_URL=http://ml-engine:8000
+      - BACKEND_API_URL=${BACKEND_API_URL:-http://api:5000}
     volumes:
       - n8n_data:/home/node/.n8n
     healthcheck:


### PR DESCRIPTION
## Problem

`automation/n8n/dispute-resolution.json` uses `{{$env.BACKEND_API_URL}}`, but `BACKEND_API_URL` was never defined anywhere in the repo, so all five backend calls had no host and failed.

## Fix

Defined the variable in every place the workflow relies on:

- `.env.example`: `BACKEND_API_URL=http://api:5000`
- `docker-compose.yml`: added `BACKEND_API_URL`
- `docker-compose.prod.yml`: added `BACKEND_API_URL: ${BACKEND_API_URL:?BACKEND_API_URL is required}`
- `automation/n8n/README.md`: documented the variable


## Files changed

- `.env.example`
- `docker-compose.yml`
- `docker-compose.prod.yml`
- `automation/n8n/README.md`


## Testing

- Compose/ENV syntax reviewed; n8n expressions now resolve to the compose network host (`api:5000`).


Closes #9420
