### PR TITLE
fix(orders): import submitEscrowRefund in orderRoutes.js

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -186,7 +186,7 @@ import {
   recordDepositTx,
   confirmEscrowRefund,
 } from '../core/container.js';
-import { getEscrowBookingId, resolveExpectedDepositAmount, paisaToMaticWei } from '../services/escrow.js';
+import { getEscrowBookingId, resolveExpectedDepositAmount, paisaToMaticWei, submitEscrowRefund } from '../services/escrow.js';
 
 import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
 import { computeOrderPricing } from '../lib/pricing.js';


### PR DESCRIPTION
## Problem

`orderRoutes.js` (confirm-deposit handler) calls `submitEscrowRefund` on `accept_bid_tx` failure, but it was not included in the escrow-service import list. When the deposit-acceptance step failed, the refund path threw a `ReferenceError` and the deposit was never refunded.

## Fix

Added `submitEscrowRefund` to the escrow import in `orderRoutes.js`, alongside the other escrow functions already imported from `services/escrow.js`.


## Files changed

- `backend/api/src/routes/orderRoutes.js`


## Testing

- Import list verified: `submitEscrowRefund` is a named export of `backend/api/src/services/escrow.js`.
- Note: `node --check` on the file is blocked by a separate, pre-existing duplicate `const order` declaration in the same file (a `SyntaxError` already present on `main`, fixed independently in PR #9415). This PR only fixes the missing import.


Closes #9421
