### PR TITLE
fix: create phone_otps table that verify-otp reads/updates

### DIFF
--- a/supabase/migrations/20260805162012_add_otp_salt_to_phone_otps.sql
+++ b/supabase/migrations/20260805162012_add_otp_salt_to_phone_otps.sql
@@ -1,1 +1,6 @@
-ALTER TABLE phone_otps ADD COLUMN IF NOT EXISTS otp_salt text;
+-- Order-independent: the phone_otps table is created by
+-- 20260810160000_create_phone_otps_table.sql. Guard the ALTER with IF EXISTS so
+-- a fresh database where this migration runs before the table exists does not
+-- fail ("relation phone_otps does not exist"). The create migration includes
+-- the otp_salt column, so nothing is lost when this ALTER is a no-op.
+ALTER TABLE IF EXISTS phone_otps ADD COLUMN IF NOT EXISTS otp_salt text;

--- a/supabase/migrations/20260810160000_create_phone_otps_table.sql
+++ b/supabase/migrations/20260810160000_create_phone_otps_table.sql
@@ -1,0 +1,35 @@
+-- Fix #9243: create the phone_otps table that /api/auth/verify-otp reads and
+-- updates but no migration ever creates. The only prior SQL reference was
+-- 20260805162012_add_otp_salt_to_phone_otps.sql, an ALTER against a table that
+-- did not exist, so fresh databases failed with PGRST204 ("relation phone_otps
+-- does not exist") on every verification attempt. Mirrors the #7541
+-- delivery_otps fix.
+--
+-- The route uses the anon-key supabase client because verify-otp runs before a
+-- user is authenticated, so RLS policies let that client look up and consume
+-- unexpired OTP rows while keeping expired/verified rows invisible.
+create table if not exists phone_otps (
+  id          uuid primary key default gen_random_uuid(),
+  phone       text not null,
+  otp_hash    text not null,
+  otp_salt    text,
+  expires_at  timestamptz not null,
+  verified    boolean not null default false,
+  verified_at timestamptz,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_phone_otps_phone      on phone_otps (phone);
+create index if not exists idx_phone_otps_expires_at on phone_otps (expires_at);
+
+alter table phone_otps enable row level security;
+
+drop policy if exists "Anon read unexpired phone OTPs" on phone_otps;
+create policy "Anon read unexpired phone OTPs"
+  on phone_otps for select to anon, authenticated
+  using (verified = false and expires_at > now());
+
+drop policy if exists "Anon consume phone OTPs" on phone_otps;
+create policy "Anon consume phone OTPs"
+  on phone_otps for update to anon, authenticated
+  using (verified = false and expires_at > now());


### PR DESCRIPTION
## Problem

`POST /api/auth/verify-otp` reads and updates the `phone_otps` table, but no migration or `setup.sql` ever creates it and no code writes to it — every phone OTP verification fails against a missing table.

## Fix

Mirror the existing `delivery_otps` fix (#7541):

- New migration `20260810160000_create_phone_otps_table.sql` creates `phone_otps` (`phone text not null`, OTP columns, `expires_at`, `verified`), with indexes, RLS enabled, and anon/authenticated `SELECT` + `UPDATE` policies restricted to `verified = false and expires_at > now()`. The anon policies are required because `verify-otp` runs pre-auth on the anon-key `supabase` client.
- Harden the existing `add_otp_salt` migration with `ALTER TABLE IF EXISTS` so it can run before the table exists.

## Files changed

- `supabase/migrations/20260810160000_create_phone_otps_table.sql` (new)
- `supabase/migrations/20260805162012_add_otp_salt_to_phone_otps.sql`

## Testing

Migrations apply in order; RLS policies restrict reads/writes to unverified, unexpired rows for both anon and authenticated roles.

Closes #9243
