### PR TITLE
fix(security): bind credential issuance to the caller's own wallet

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -2,6 +2,48 @@ import didService from '../../../did/did.service.js';
 import logger from '../middleware/logger.js';
 import { validationResult } from 'express-validator';
 import { AppError } from '../utils/errors.js';
+import { supabase } from '../config/db.js';
+
+/**
+ * Resolve the resource for the 'escort:issue-credential' ownership check:
+ * the normalized subject from the body and the authenticated caller's own
+ * polygon wallet address. Administrators bypass the ownership check (see the
+ * policy definition), so drivers can only ever issue credentials for their own
+ * wallet address/DID.
+ */
+export const resolveCredentialSubject = async (req) => {
+    const { data: profile, error } = await supabase
+        .from('profiles')
+        .select('polygon_wallet_address')
+        .eq('id', req.user.id)
+        .maybeSingle();
+
+    if (error) {
+        throw new AppError('Failed to load profile', 500);
+    }
+
+    const callerWallet = (profile?.polygon_wallet_address || '').trim().toLowerCase();
+    const subject = typeof req.body.subject === 'string' ? req.body.subject.trim().toLowerCase() : '';
+    return { subject, callerWallet };
+};
+
+/**
+ * Credentials may not be backdated. Returns true when validUntil is omitted
+ * (the service applies its default one-year TTL) or is a future point in time.
+ */
+function isValidFutureValidUntil(validUntil) {
+    if (validUntil === undefined || validUntil === null) return true;
+    let ms;
+    if (typeof validUntil === 'number') {
+        // Unix timestamp in seconds, matching didService.issueCredential.
+        ms = validUntil * 1000;
+    } else if (typeof validUntil === 'string') {
+        ms = Date.parse(validUntil);
+    } else {
+        return false;
+    }
+    return Number.isFinite(ms) && ms > Date.now();
+}
 
 export const loadCredential = async (req, res, next) => {
     try {
@@ -14,6 +56,10 @@ export const loadCredential = async (req, res, next) => {
         
         // subject is the Escort Driver's address or DID
         // credentialType: e.g., 'EscortCertification', 'Insurance', 'StatePermit'
+
+        if (!isValidFutureValidUntil(validUntil)) {
+            return res.status(400).json({ error: 'validUntil must be a future date (unix timestamp in seconds or ISO string)' });
+        }
 
         const result = await didService.issueCredential(
             subject,

--- a/backend/api/src/routes/escortWalletRoutes.js
+++ b/backend/api/src/routes/escortWalletRoutes.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import { body } from 'express-validator';
-import { loadCredential, handshake } from '../controllers/escortWalletController.js';
+import { loadCredential, resolveCredentialSubject, handshake } from '../controllers/escortWalletController.js';
 import { authenticate } from '../middleware/auth.js';
 import { requireRole } from '../middleware/auth.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
 
 const router = express.Router();
 
@@ -10,13 +11,15 @@ const router = express.Router();
 router.post(
     '/credential',
     authenticate,
-    // Typically, an authority or the escort driver themselves might issue/upload this.
-    // For this feature, we'll allow authenticated users to post credentials.
     [
         body('subject').isString().notEmpty().withMessage('Subject address or DID is required'),
         body('credentialType').isString().notEmpty().withMessage('Credential type is required'),
         body('schema').isObject().withMessage('Schema must be a valid JSON object')
     ],
+    // Only the escort driver themselves (for their own wallet address) or an
+    // administrator may issue a credential — never any authenticated user for
+    // an arbitrary subject.
+    requirePolicy('escort:issue-credential', resolveCredentialSubject),
     loadCredential
 );
 

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -61,6 +61,8 @@ const POLICIES = {
   'delivery:verify':           { roles: [ROLES.DRIVER], ownership: (u, r) => r?.order && r.order.driver_id === u.id },
   'delivery:resend-otp':       { roles: [ROLES.DRIVER], ownership: (u, r) => r?.order && r.order.driver_id === u.id },
 
+  'escort:issue-credential':   { roles: [ROLES.DRIVER, ROLES.ADMIN], ownership: (u, r) => u.role === ROLES.ADMIN || (r?.callerWallet && r?.subject === r.callerWallet) },
+
   'load-offer:view-all':       {},
   'load-offer:browse':         { roles: [ROLES.DRIVER] },
 

--- a/backend/api/test/unit/escortWalletController.test.js
+++ b/backend/api/test/unit/escortWalletController.test.js
@@ -10,6 +10,10 @@ const { didMock } = vi.hoisted(() => ({
 
 vi.mock('../../../did/did.service.js', () => ({ default: didMock }));
 
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: vi.fn() },
+}));
+
 vi.mock('express-validator', () => ({
   validationResult: vi.fn(() => ({ isEmpty: () => true, array: () => [] })),
 }));
@@ -56,6 +60,14 @@ describe('escortWalletController', () => {
       const { req, res, next } = makeReqRes({ body: { subject: '0x1', credentialType: 'X', schema: {} } });
       await loadCredential(req, res, next);
       expect(next).toHaveBeenCalled();
+    });
+
+    it('rejects a backdated validUntil without issuing', async () => {
+      const { req, res, next } = makeReqRes({ body: { subject: '0x1', credentialType: 'T', schema: {}, validUntil: 1000 } });
+      await loadCredential(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(didMock.issueCredential).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/api/test/unit/escortWalletRoutes.test.js
+++ b/backend/api/test/unit/escortWalletRoutes.test.js
@@ -9,13 +9,33 @@ vi.mock('../middleware/requireRole.js', () => ({
 }));
 
 vi.mock('../../src/middleware/auth.js', () => ({
-  authenticate: (req, _res, next) => { req.user = req.user || { id: 'u1' }; next(); },
+  authenticate: (req, _res, next) => { req.user = req.user || { id: 'u1', role: 'driver' }; next(); },
+  requireRole: () => (_req, _res, next) => next(),
+}));
+
+const { policyMock, PolicyErrorMock } = vi.hoisted(() => {
+  class PolicyErrorMock extends Error {
+    constructor(status, message) {
+      super(message);
+      this.status = status;
+      this.name = 'PolicyError';
+    }
+  }
+  return { policyMock: { authorize: vi.fn() }, PolicyErrorMock };
+});
+
+// Mock the policy engine so the real requirePolicy middleware can be
+// exercised end-to-end (401/403 responses) without a live policy store.
+vi.mock('../../src/security/policyEngine.js', () => ({
+  PolicyError: PolicyErrorMock,
+  policy: policyMock,
 }));
 
 const { ctrlMock } = vi.hoisted(() => ({
   ctrlMock: {
     loadCredential: vi.fn(),
     handshake: vi.fn(),
+    resolveCredentialSubject: vi.fn(async () => ({ subject: '0x1', callerWallet: '0x1' })),
   },
 }));
 
@@ -37,6 +57,8 @@ function makeApp() {
 describe('escortWalletRoutes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    policyMock.authorize.mockImplementation(() => {});
+    ctrlMock.resolveCredentialSubject.mockResolvedValue({ subject: '0x1', callerWallet: '0x1' });
     ctrlMock.loadCredential.mockImplementation((req, res) => res.status(201).json({ ok: true }));
     ctrlMock.handshake.mockImplementation((req, res) => res.status(200).json({ ok: true }));
   });
@@ -45,6 +67,26 @@ describe('escortWalletRoutes', () => {
     const res = await request(makeApp()).post('/escort/credential').send({ subject: '0x1', credentialType: 'T', schema: {} });
     expect(res.status).toBe(201);
     expect(ctrlMock.loadCredential).toHaveBeenCalled();
+  });
+
+  it('runs the escort:issue-credential policy before issuing', async () => {
+    const res = await request(makeApp()).post('/escort/credential').send({ subject: '0x1', credentialType: 'T', schema: {} });
+    expect(res.status).toBe(201);
+    expect(policyMock.authorize).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'u1' }),
+      'escort:issue-credential',
+      expect.objectContaining({ subject: '0x1', callerWallet: '0x1' }),
+      expect.anything(),
+    );
+  });
+
+  it('returns 403 when the policy denies credential issuance', async () => {
+    policyMock.authorize.mockImplementation(() => {
+      throw new PolicyErrorMock(403, 'Forbidden: Insufficient privileges.');
+    });
+    const res = await request(makeApp()).post('/escort/credential').send({ subject: '0x1', credentialType: 'T', schema: {} });
+    expect(res.status).toBe(403);
+    expect(ctrlMock.loadCredential).not.toHaveBeenCalled();
   });
 
   it('routes POST /escort/handshake to handshake', async () => {


### PR DESCRIPTION
## Problem

`POST /api/escorts/wallet/credential` trusts the client-supplied `subject` DID with no ownership check, so any authenticated user can issue a credential for an arbitrary DID — a security hole.

## Fix

Bind credential issuance to the caller's own wallet:

- Add an `escort:issue-credential` policy in `policyEngine.js` that requires the driver or admin role and enforces ownership (`subject` must equal the caller's resolved wallet unless the caller is admin).
- Wire `requirePolicy('escort:issue-credential', resolveCredentialSubject)` into the route.
- Add `resolveCredentialSubject` to the controller (reads `profiles.polygon_wallet_address` for `req.user.id`) and reject backdated `validUntil` timestamps.

## Files changed

- `backend/api/src/security/policyEngine.js`
- `backend/api/src/routes/escortWalletRoutes.js`
- `backend/api/src/controllers/escortWalletController.js`
- `backend/api/test/unit/escortWalletController.test.js`
- `backend/api/test/unit/escortWalletRoutes.test.js`

## Testing

Escort wallet tests 10/10 pass; `policyEngine` + `requirePolicy` suites 70/70 pass; route tests exercise 401/403 paths against the new policy.

Closes #9227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Credential issuance now requires verified wallet ownership or administrator authorization.
  - Unauthorized requests are rejected before credential processing.

- **Validation**
  - Credential expiration dates must be valid future dates.
  - Invalid, unsupported, or past dates return a clear client error.

- **Bug Fixes**
  - Improved handling of authenticated wallet profile lookup failures.
  - Added coverage to ensure invalid requests do not issue credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->