### PR TITLE
fix: page stale funding orders deterministically

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -585,14 +585,16 @@ export class OrderRepository {
       }), 'cancelStaleOrder');
   }
 
-  async findStaleFundingOrders(cutoff) {
+  async findStaleFundingOrders(cutoff, { offset = 0, limit = 1000 } = {}) {
     return this._retryableQuery(() => this.supabase
       .from('orders')
       .select('id, order_display_id, customer_id, escrow_booking_id, escrow_amount_wei, pending_bid_acceptance, escrow_funding_attempts, escrow_funding_last_attempt_at')
       .eq('escrow_status', 'funding')
       .not('pending_bid_acceptance', 'is', null)
       .or('escrow_funding_attempts.lt.10,escrow_funding_attempts.is.null')
-      .or(`escrow_funding_started_at.lt.${cutoff},and(escrow_funding_started_at.is.null,updated_at.lt.${cutoff})`), 'findStaleFundingOrders');
+      .or(`escrow_funding_started_at.lt.${cutoff},and(escrow_funding_started_at.is.null,updated_at.lt.${cutoff})`)
+      .order('updated_at', { ascending: true })
+      .range(offset, offset + Math.max(1, limit) - 1), 'findStaleFundingOrders');
   }
 
   // ===================================================================

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -14,6 +14,11 @@ const MAX_ATTEMPTS = 10;
 const BASE_BACKOFF_MS = 60_000;
 const LOCK_KEY = 'escrow:funding:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;
+// PostgREST caps a single response at 1000 rows; page through the stale set
+// deterministically so a large stuck funding queue is drained rather than
+// only ever processing the leading slice (#9219).
+const STALE_FUNDING_PAGE_SIZE = 1000;
+const STALE_FUNDING_MAX_PAGES = 10;
 
 let fundingTimer = null;
 let fundingRunning = false;
@@ -241,26 +246,34 @@ export async function reconcileStaleFunding(orderRepository) {
     const fundingTtlMs = (Number.isFinite(ttlMinutes) && ttlMinutes > 0 ? ttlMinutes : DEFAULT_FUNDING_TTL_MINUTES) * 60 * 1000;
     const cutoff = new Date(Date.now() - fundingTtlMs).toISOString();
 
-    const { data: staleOrders, error } = await orderRepository.findStaleFundingOrders(cutoff);
-    if (error) {
-      logger.error('[escrow-funding] Failed to load stale funding orders:', error.message);
-      return;
-    }
+    for (let page = 0; page < STALE_FUNDING_MAX_PAGES; page += 1) {
+      const { data: staleOrders, error } = await orderRepository.findStaleFundingOrders(cutoff, {
+        offset: page * STALE_FUNDING_PAGE_SIZE,
+        limit: STALE_FUNDING_PAGE_SIZE,
+      });
+      if (error) {
+        logger.error('[escrow-funding] Failed to load stale funding orders:', error.message);
+        return;
+      }
+      if (!staleOrders || staleOrders.length === 0) break;
 
-    for (const order of staleOrders ?? []) {
-      const attempts = order.escrow_funding_attempts ?? 0;
-      if (attempts >= MAX_ATTEMPTS) {
-        continue;
-      }
-      if (!dueForRetry(order)) continue;
-      if (globalLockAcquired && redisClient) {
-        try {
-          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
-        } catch (err) {
-          logger.warn('[escrow-funding] Failed to refresh lock:', err.message);
+      for (const order of staleOrders) {
+        const attempts = order.escrow_funding_attempts ?? 0;
+        if (attempts >= MAX_ATTEMPTS) {
+          continue;
         }
+        if (!dueForRetry(order)) continue;
+        if (globalLockAcquired && redisClient) {
+          try {
+            await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+          } catch (err) {
+            logger.warn('[escrow-funding] Failed to refresh lock:', err.message);
+          }
+        }
+        await finalizeOrRevert(order, orderRepository);
       }
-      await finalizeOrRevert(order, orderRepository);
+
+      if (staleOrders.length < STALE_FUNDING_PAGE_SIZE) break;
     }
   } finally {
     if (globalLockAcquired && redisClient) {

--- a/backend/api/test/unit/escrowFundingReconciliation.test.js
+++ b/backend/api/test/unit/escrowFundingReconciliation.test.js
@@ -123,5 +123,31 @@ describe('escrowFundingReconciliation', () => {
         'DB error'
       );
     });
+
+    it('pages through the stale set in bounded chunks until a short page', async () => {
+      mockRedisClient.set.mockResolvedValue('locked');
+
+      const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+        id: `order-${i}`,
+        order_display_id: `DIS-${i}`,
+        escrow_status: 'funding',
+        escrow_funding_attempts: 10, // >= MAX_ATTEMPTS, so nothing is processed
+        escrow_funding_last_attempt_at: null,
+        pending_bid_acceptance: null,
+      }));
+      mockOrderRepository.findStaleFundingOrders
+        .mockResolvedValueOnce({ data: fullPage, error: null })
+        .mockResolvedValueOnce({ data: [fullPage[0]], error: null });
+
+      await reconcileStaleFunding(mockOrderRepository);
+
+      expect(mockOrderRepository.findStaleFundingOrders).toHaveBeenCalledTimes(2);
+      expect(mockOrderRepository.findStaleFundingOrders).toHaveBeenNthCalledWith(
+        1, expect.any(String), { offset: 0, limit: 1000 }
+      );
+      expect(mockOrderRepository.findStaleFundingOrders).toHaveBeenNthCalledWith(
+        2, expect.any(String), { offset: 1000, limit: 1000 }
+      );
+    });
   });
 });


### PR DESCRIPTION
## Problem

`findStaleFundingOrders` runs with no ordering or limit, so with more than 1000 stale orders PostgREST's row cap silently drops the tail of the queue and the escrow funding reconciler never processes those orders.

## Fix

- `findStaleFundingOrders(cutoff, { offset, limit })` now adds a deterministic `.order('updated_at', { ascending: true })` plus `.range(...)` so results are stable across pages.
- `escrowFundingReconciliation.js` loops up to 10 pages of 1000 (`STALE_FUNDING_PAGE_SIZE` / `STALE_FUNDING_MAX_PAGES`) so the entire stale queue is drained.

## Files changed

- `backend/api/src/repositories/orderRepository.js`
- `backend/api/src/services/escrowFundingReconciliation.js`
- `backend/api/test/unit/escrowFundingReconciliation.test.js`

## Testing

5/5 unit tests pass, including a new pagination test covering the paged loop.

Closes #9219
