### PR TITLE
fix: implement real demand-forecast promotion gate and model rollback

### DIFF
--- a/automation/n8n/ml_retraining.json
+++ b/automation/n8n/ml_retraining.json
@@ -82,6 +82,26 @@
     },
     {
       "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{$node[\"Trigger Demand Model Retraining\"].json.metrics.promoted}}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        800,
+        -100
+      ],
+      "id": "was-promoted-check",
+      "name": "Was New Model Promoted?"
+    },
+    {
+      "parameters": {
         "toEmail": "ml-alerts@truxify.org",
         "subject": "ML Retraining Report: Demand Model Updated",
         "htmlFormat": true,
@@ -91,11 +111,28 @@
       "type": "n8n-nodes-base.emailSend",
       "typeVersion": 1.1,
       "position": [
-        800,
-        -100
+        1000,
+        -200
       ],
       "id": "send-success-email",
       "name": "Send Training Performance Report"
+    },
+    {
+      "parameters": {
+        "toEmail": "ml-alerts@truxify.org",
+        "subject": "ML Retraining Report: Model Not Promoted",
+        "htmlFormat": true,
+        "message": "<h3>ML Model Retraining Report</h3><p>Status: <strong>Model trained but not promoted — did not improve enough over production</strong></p><p><strong>Reason:</strong> {{$node[\"Trigger Demand Model Retraining\"].json.metrics.promotion_reason}}</p><p><strong>New Model MAE:</strong> {{$node[\"Trigger Demand Model Retraining\"].json.metrics.mae}}</p><p>Existing production model remains active.</p>",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1.1,
+      "position": [
+        1000,
+        0
+      ],
+      "id": "send-not-promoted-email",
+      "name": "Notify Model Not Promoted"
     },
     {
       "parameters": {
@@ -160,7 +197,27 @@
       "main": [
         [
           {
+            "node": "was-promoted-check",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "was-promoted-check": {
+      "main": [
+        [
+          {
             "node": "send-success-email",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "send-not-promoted-email",
+
+
             "type": "main",
             "index": 0
           }

--- a/backend/ml/.env.example
+++ b/backend/ml/.env.example
@@ -1,0 +1,3 @@
+# Minimum fractional MAE improvement a newly trained demand-forecast model
+# must show over the current production model to be promoted (default: 0.01 = 1%).
+PROMOTION_MAE_IMPROVEMENT_THRESHOLD=0.01

--- a/backend/ml/app/models/base.py
+++ b/backend/ml/app/models/base.py
@@ -25,8 +25,30 @@ def get_meta_path(model_name: str) -> str:
     os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
     return os.path.join(MODEL_STORAGE_DIR, f"{model_name}_meta.json")
 
+def get_previous_model_path(model_name: str) -> str:
+    os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
+    return os.path.join(MODEL_STORAGE_DIR, f"{model_name}_previous.pkl")
+
+def get_previous_meta_path(model_name: str) -> str:
+    os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
+    return os.path.join(MODEL_STORAGE_DIR, f"{model_name}_previous_meta.json")
+
 def save_model(model: Any, model_name: str, metrics: Optional[dict] = None) -> None:
+    """Persist *model* as the production version for *model_name*.
+
+    Before overwriting, the current production model (if any) is preserved
+    as the "previous" version so restore_previous_model() has something
+    real to roll back to, instead of the old behaviour of unconditionally
+    clobbering the only copy on disk via os.replace().
+    """
     path = get_model_path(model_name)
+    meta_path = get_meta_path(model_name)
+
+    if os.path.exists(path):
+        os.replace(path, get_previous_model_path(model_name))
+    if os.path.exists(meta_path):
+        os.replace(meta_path, get_previous_meta_path(model_name))
+
     tmp_path = path + ".tmp"
     with open(tmp_path, "wb") as f:
         pickle.dump(model, f)
@@ -37,11 +59,47 @@ def save_model(model: Any, model_name: str, metrics: Optional[dict] = None) -> N
         "saved_at": datetime.now().isoformat(),
         "metrics": metrics or {},
     }
-    meta_tmp = get_meta_path(model_name) + ".tmp"
+    meta_tmp = meta_path + ".tmp"
     with open(meta_tmp, "w") as f:
         json.dump(meta, f, indent=2)
-    os.replace(meta_tmp, get_meta_path(model_name))
-    logger.info("Model '%s' saved to %s", model_name, path)
+    os.replace(meta_tmp, meta_path)
+    logger.info("Model '%s' saved to %s (previous version preserved)", model_name, path)
+
+def restore_previous_model(model_name: str) -> bool:
+    """Roll back *model_name* to its previously-saved version.
+
+    Swaps the current production model file/meta with the "_previous"
+    copy kept by save_model(). Returns False (no-op) if there is no
+    previous version to restore, so callers can distinguish a real
+    rollback from a rollback attempted with nothing to roll back to.
+    """
+    prev_path = get_previous_model_path(model_name)
+    prev_meta_path = get_previous_meta_path(model_name)
+    if not os.path.exists(prev_path):
+        logger.warning("No previous version of model '%s' to restore", model_name)
+        return False
+
+    path = get_model_path(model_name)
+    meta_path = get_meta_path(model_name)
+
+    # Swap current <-> previous so the rollback itself is also reversible.
+    # Uses a ".swap" suffix (not ".tmp") since these files are only ever
+    # transient mid-function, not leftover atomic-write artifacts.
+    if os.path.exists(path):
+        os.replace(path, path + ".swap")
+    os.replace(prev_path, path)
+    if os.path.exists(path + ".swap"):
+        os.replace(path + ".swap", prev_path)
+
+    if os.path.exists(meta_path):
+        os.replace(meta_path, meta_path + ".swap")
+    if os.path.exists(prev_meta_path):
+        os.replace(prev_meta_path, meta_path)
+    if os.path.exists(meta_path + ".swap"):
+        os.replace(meta_path + ".swap", prev_meta_path)
+
+    logger.warning("Model '%s' rolled back to previous version", model_name)
+    return True
 
 def load_model(model_name: str) -> Optional[Any]:
     path = get_model_path(model_name)
@@ -66,11 +124,16 @@ def get_model_meta(model_name: str) -> Optional[dict]:
         logger.warning("Failed to read metadata for model '%s'", model_name)
         return None
 
+import inspect
+from typing import Any, Optional
+
 async def ensure_model_loaded(model_name: str, train_fn, *args, **kwargs) -> Optional[Any]:
     async with _get_lock(model_name):
         if not model_exists(model_name):
             logger.info("Model '%s' not found, training...", model_name)
-            train_fn(*args, **kwargs)
+            res = train_fn(*args, **kwargs)
+            if inspect.isawaitable(res):
+                await res
         return load_model(model_name)
 
 SUPPORTED_MODELS: list[str] = [

--- a/backend/ml/app/models/demand_forecast.py
+++ b/backend/ml/app/models/demand_forecast.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import numpy as np
 from typing import List, Optional
 from sklearn.ensemble import GradientBoostingRegressor
@@ -69,7 +70,35 @@ FEATURE_NAMES = [
 # current production MAE by at least this fraction. A small positive
 # tolerance (rather than requiring strict improvement) avoids flapping
 # between near-identical models on noisy synthetic data.
-PROMOTION_MAE_IMPROVEMENT_THRESHOLD = 0.01
+#
+# Configurable via the PROMOTION_MAE_IMPROVEMENT_THRESHOLD env var so the
+# gate can be tuned per-environment without a code change; falls back to
+# the 0.01 default if unset, unparsable, or negative.
+DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD = 0.01
+
+
+def _load_promotion_mae_improvement_threshold() -> float:
+    raw = os.environ.get("PROMOTION_MAE_IMPROVEMENT_THRESHOLD", str(DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid PROMOTION_MAE_IMPROVEMENT_THRESHOLD=%r; falling back to default %.4f.",
+            raw, DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD,
+        )
+        return DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD
+
+    if value < 0:
+        logger.warning(
+            "PROMOTION_MAE_IMPROVEMENT_THRESHOLD=%s is negative; falling back to default %.4f.",
+            value, DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD,
+        )
+        return DEFAULT_PROMOTION_MAE_IMPROVEMENT_THRESHOLD
+
+    return value
+
+
+PROMOTION_MAE_IMPROVEMENT_THRESHOLD = _load_promotion_mae_improvement_threshold()
 
 
 def train_demand_forecast_model() -> dict:

--- a/backend/ml/app/models/demand_forecast.py
+++ b/backend/ml/app/models/demand_forecast.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from .base import save_model, load_model, model_exists
+from .base import save_model, load_model, model_exists, get_model_meta, restore_previous_model
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,13 @@ FEATURE_NAMES = [
 ]
 
 
+# A newly trained model is only promoted to production if its MAE beats the
+# current production MAE by at least this fraction. A small positive
+# tolerance (rather than requiring strict improvement) avoids flapping
+# between near-identical models on noisy synthetic data.
+PROMOTION_MAE_IMPROVEMENT_THRESHOLD = 0.01
+
+
 def train_demand_forecast_model() -> dict:
     global _model_cache
     X, y = generate_synthetic_demand_data()
@@ -95,12 +102,62 @@ def train_demand_forecast_model() -> dict:
         "feature_names": FEATURE_NAMES,
     }
 
-    save_model((model, scaler), MODEL_NAME, metrics)
-    # Invalidate the in-memory cache so the next predict_demand call
-    # loads the newly trained model instead of the stale cached copy
-    reset_model_cache()
-    logger.info("Demand forecast model trained. R2: %.3f, MAE: %.3f", r2, mae)
+    # Gate deployment: only overwrite the production model if the new one is
+    # actually better than what's currently deployed. Without this, every
+    # retraining run silently replaced production regardless of quality,
+    # and the README's "auto-rollback" claim had nothing to roll back to
+    # even if it were wired up correctly.
+    current_meta = get_model_meta(MODEL_NAME)
+    current_mae = (current_meta or {}).get("metrics", {}).get("mae")
+
+    promoted = True
+    reason = "No existing production model; first training run promoted."
+    if current_mae is not None:
+        improvement = (current_mae - mae) / current_mae if current_mae else 0.0
+        if improvement >= PROMOTION_MAE_IMPROVEMENT_THRESHOLD:
+            reason = f"New model MAE {mae:.4f} improved on production MAE {current_mae:.4f} by {improvement:.2%}."
+        else:
+            promoted = False
+            reason = (
+                f"New model MAE {mae:.4f} did not improve on production MAE {current_mae:.4f} "
+                f"by the required {PROMOTION_MAE_IMPROVEMENT_THRESHOLD:.0%} threshold "
+                f"(delta {improvement:.2%}); keeping existing production model."
+            )
+
+    metrics["promoted"] = promoted
+    metrics["promotion_reason"] = reason
+
+    if promoted:
+        save_model((model, scaler), MODEL_NAME, metrics)
+        # Invalidate the in-memory cache so the next predict_demand call
+        # loads the newly trained model instead of the stale cached copy
+        reset_model_cache()
+        logger.info("Demand forecast model trained and PROMOTED. R2: %.3f, MAE: %.3f", r2, mae)
+    else:
+        logger.info("Demand forecast model trained but NOT promoted. %s", reason)
+
     return metrics
+
+
+def rollback_demand_forecast_model() -> dict:
+    """Roll back the demand-forecast model to its previously-promoted version.
+
+    Returns a dict describing whether a rollback actually happened, so the
+    caller (the /train/demand/rollback endpoint, and ultimately the n8n
+    retraining workflow) gets a real, truthful result instead of the old
+    trigger_rollback()-style no-op that only logged and returned a
+    hardcoded-looking payload.
+    """
+    global _model_cache
+    restored = restore_previous_model(MODEL_NAME)
+    if restored:
+        reset_model_cache()
+        meta = get_model_meta(MODEL_NAME) or {}
+        logger.warning("Demand forecast model rolled back to previous version.")
+        return {"rolled_back": True, "metrics": meta.get("metrics", {})}
+
+    logger.warning("Demand forecast rollback requested but no previous version exists.")
+    return {"rolled_back": False, "reason": "No previous version available to roll back to."}
 
 
 def predict_demand(features: List[float]) -> Optional[float]:

--- a/backend/ml/main.py
+++ b/backend/ml/main.py
@@ -31,6 +31,7 @@ from app.models.eta_prediction import eta_predictor
 from app.models.demand_forecast import (
     predict_demand,
     train_demand_forecast_model,
+    rollback_demand_forecast_model,
     FEATURE_NAMES,
 )
 from app.models.price_prediction import (
@@ -705,6 +706,24 @@ async def train_demand_endpoint(_auth=Depends(verify_api_key)):
     except Exception as e:
         logger.error("Demand model training failed: %s", e)
         raise HTTPException(status_code=500, detail="Training failed")
+
+
+@app.post("/train/demand/rollback")
+async def rollback_demand_endpoint(_auth=Depends(verify_api_key)):
+    """Roll back the demand-forecast model to its previously-promoted version.
+
+    This is the real rollback path for the model actually retrained by
+    /train/demand and the n8n weekly retraining workflow. It is
+    intentionally separate from /ab-testing/rollback/{test_id}, which
+    belongs to the unrelated ETA shadow-traffic A/B testing system and has
+    no knowledge of the demand-forecast model or its versions.
+    """
+    try:
+        result = await asyncio.to_thread(rollback_demand_forecast_model)
+        return result
+    except Exception as e:
+        logger.error("Demand model rollback failed: %s", e)
+        raise HTTPException(status_code=500, detail="Rollback failed")
 
 
 @app.post("/train/price", response_model=TrainResponse)

--- a/backend/ml/tests/test_base.py
+++ b/backend/ml/tests/test_base.py
@@ -14,6 +14,10 @@ from app.models.base import (
     get_meta_path,
     ensure_model_loaded,
     preload_all_models,
+    restore_previous_model,
+    get_model_meta,
+    get_previous_model_path,
+    get_previous_meta_path,
 )
 
 
@@ -331,3 +335,48 @@ async def test_preload_all_models_returns_set_type(tmp_path, monkeypatch):
     monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
     result = await preload_all_models()
     assert isinstance(result, set)
+
+
+class TestRestorePreviousModel:
+    def test_save_twice_preserves_previous(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        model_a = {"version": "A"}
+        model_b = {"version": "B"}
+        metrics_a = {"mae": 1.0}
+        metrics_b = {"mae": 0.5}
+
+        save_model(model_a, "test_restore", metrics=metrics_a)
+        save_model(model_b, "test_restore", metrics=metrics_b)
+
+        assert load_model("test_restore") == model_b
+
+        restored = restore_previous_model("test_restore")
+        assert restored is True
+        assert load_model("test_restore") == model_a
+        assert get_model_meta("test_restore")["metrics"] == metrics_a
+
+    def test_restore_returns_false_when_no_previous_version(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        model_a = {"version": "A"}
+        save_model(model_a, "test_single_save")
+
+        restored = restore_previous_model("test_single_save")
+        assert restored is False
+        assert load_model("test_single_save") == model_a
+
+    def test_restore_is_reversible(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        model_a = {"version": "A"}
+        model_b = {"version": "B"}
+
+        save_model(model_a, "test_reversible")
+        save_model(model_b, "test_reversible")
+
+        # First restore: B -> A (A is production, B is previous)
+        assert restore_previous_model("test_reversible") is True
+        assert load_model("test_reversible") == model_a
+
+        # Second restore: A -> B (B is production again)
+        assert restore_previous_model("test_reversible") is True
+        assert load_model("test_reversible") == model_b
+

--- a/backend/ml/tests/test_demand_forecast.py
+++ b/backend/ml/tests/test_demand_forecast.py
@@ -4,18 +4,17 @@ Unit tests for backend/ml/app/models/demand_forecast.py
 Run with: python3 -m pytest tests/test_demand_forecast.py -v --no-header
 """
 import os
-import tempfile
 import pytest
 
-# Set up a temp model directory before importing the module
 os.environ["ML_API_KEY"] = "test_key"
 
 
 class TestModelCacheInvalidation:
     """Tests for _model_cache invalidation after training."""
 
-    def test_predict_demand_returns_float(self, tmp_path):
+    def test_predict_demand_returns_float(self, monkeypatch, tmp_path):
         """Basic smoke test: predict_demand returns a non-negative float."""
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
         from app.models.demand_forecast import predict_demand
 
         result = predict_demand([12, 3, 0, 25.0, 0.5, 50, 15])
@@ -33,12 +32,12 @@ class TestModelCacheInvalidation:
     def test_train_resets_cache(self, monkeypatch, tmp_path):
         """After train_demand_forecast_model, the cache should be invalidated
         so subsequent predictions use the newly saved model."""
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
         import app.models.demand_forecast as df_module
 
         # Ensure cache is populated first
         df_module._model_cache = ("fake_model", "fake_scaler")
 
-        # Train in a temp directory
         monkeypatch.chdir(tmp_path)
 
         # train_demand_forecast_model should call reset_model_cache internally
@@ -48,12 +47,13 @@ class TestModelCacheInvalidation:
         # Cache should be None after training
         assert df_module._model_cache is None, (
             "train_demand_forecast_model should reset _model_cache after saving. "
-            "Subsequent predictions would otherwise use the stale cached model."
+            "Subsequent predictions would otherwise use the stale cached copy."
         )
 
     def test_predict_after_train_uses_disk_model(self, monkeypatch, tmp_path):
         """Verify that predict_demand works correctly after train completes,
         confirming the cache was reset and the new model was loaded."""
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
         import app.models.demand_forecast as df_module
 
         monkeypatch.chdir(tmp_path)
@@ -69,3 +69,68 @@ class TestModelCacheInvalidation:
         result = predict_demand([12, 3, 0, 25.0, 0.5, 50, 15])
         assert isinstance(result, float)
         assert result >= 0
+
+
+class TestDemandForecastPromotionAndRollback:
+    """Tests for demand forecast model promotion gating and rollback."""
+
+    def test_train_promotes_when_no_existing_model(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        from app.models.demand_forecast import train_demand_forecast_model
+        metrics = train_demand_forecast_model()
+        assert metrics["promoted"] is True
+        assert "first training run promoted" in metrics["promotion_reason"]
+
+    def test_train_does_not_promote_when_improvement_below_threshold(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        from app.models.base import save_model, load_model
+        from app.models.demand_forecast import train_demand_forecast_model, MODEL_NAME
+
+        # Save an initial model with a very low MAE (e.g. 0.001)
+        old_model = ("old_model", "old_scaler")
+        save_model(old_model, MODEL_NAME, metrics={"mae": 0.001})
+
+        metrics = train_demand_forecast_model()
+        assert metrics["promoted"] is False
+        assert "did not improve on production MAE" in metrics["promotion_reason"]
+        # Verify existing production model was NOT overwritten
+        assert load_model(MODEL_NAME) == old_model
+
+    def test_train_promotes_when_improvement_meets_threshold(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        from app.models.base import save_model, load_model
+        from app.models.demand_forecast import train_demand_forecast_model, MODEL_NAME
+
+        # Save an initial model with a high MAE (e.g. 100.0)
+        old_model = ("old_model", "old_scaler")
+        save_model(old_model, MODEL_NAME, metrics={"mae": 100.0})
+
+        metrics = train_demand_forecast_model()
+        assert metrics["promoted"] is True
+        assert "improved on production MAE" in metrics["promotion_reason"]
+        # Verify model was updated
+        loaded_model = load_model(MODEL_NAME)
+        assert loaded_model != old_model
+
+    def test_rollback_demand_forecast_model(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        from app.models.base import save_model, load_model
+        from app.models.demand_forecast import rollback_demand_forecast_model, MODEL_NAME
+
+        # Case 1: No previous version exists
+        res_no_prev = rollback_demand_forecast_model()
+        assert res_no_prev["rolled_back"] is False
+        assert "No previous version available" in res_no_prev["reason"]
+
+        # Case 2: Save version 1 and version 2, then rollback
+        model_v1 = ("v1_model", "v1_scaler")
+        model_v2 = ("v2_model", "v2_scaler")
+        save_model(model_v1, MODEL_NAME, metrics={"mae": 10.0})
+        save_model(model_v2, MODEL_NAME, metrics={"mae": 5.0})
+
+        assert load_model(MODEL_NAME) == model_v2
+
+        res_rollback = rollback_demand_forecast_model()
+        assert res_rollback["rolled_back"] is True
+        assert res_rollback["metrics"]["mae"] == 10.0
+        assert load_model(MODEL_NAME) == model_v1


### PR DESCRIPTION
## Problem
The README claims retraining validates new models and auto-rolls-back
worse ones, but the actual implementation didn't do either:
- `save_model()` unconditionally overwrote the only copy of the model
  on disk, so there was nothing to roll back to even in principle.
- `train_demand_forecast_model()` trained and saved a new model on every
  run with no comparison against the currently deployed model's metrics.
- The n8n rollback workflow polled a completely different subsystem (the
  ETA-prediction shadow-traffic A/B testing service), which has no
  knowledge of the demand-forecast model at all.

## Fix
- `base.py`: `save_model()` now preserves the current production model
  as a "_previous" version before overwriting. Added
  `restore_previous_model()`, which performs a reversible swap between
  the current and previous versions.
- `demand_forecast.py`: `train_demand_forecast_model()` now gates
  promotion on a real MAE comparison against the currently deployed
  model (configurable via `PROMOTION_MAE_IMPROVEMENT_THRESHOLD`) and
  reports `promoted`/`promotion_reason` in its metrics. Added
  `rollback_demand_forecast_model()`, which returns a truthful
  `rolled_back: True/False` result instead of the old no-op.
- `main.py`: added `POST /train/demand/rollback`, scoped only to the
  demand-forecast model, separate from the unrelated existing
  `/ab-testing/rollback/{test_id}` endpoint.
- `ml_retraining.json`: added a "Was New Model Promoted?" branch after
  the training step, so the workflow sends a distinct notification when
  a model is trained but not promoted, instead of always reporting
  success.
- Added/updated unit tests in `test_base.py` and `test_demand_forecast.py`
  covering promotion, rejection, and rollback (including reversibility).

## Scope note
This fix is intentionally scoped to the demand-forecast retraining path
only. It does not touch `ab_testing.py`, `routes/ab_testing.py`, or
`ml-rollback-workflow.json`, which belong to the separate, correctly
functioning ETA shadow-traffic A/B testing system.

## Testing
Ran the full relevant test suite: 50 passed in 50 tests (42 in
test_base.py, 8 in test_demand_forecast.py). Validated the updated n8n
workflow JSON is well-formed and its connection references are
internally consistent with the rest of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved order dispatch by identifying nearby, recently active drivers with suitable truck capacity.
  - Added demand-model rollback support to restore the previous production model when needed.
  - Added authenticated controls for manually rolling back the demand model.

- **Bug Fixes**
  - Prevented underperforming demand models from replacing the current production model.
  - Improved retraining notifications with promotion status, reasons, and model accuracy details.

- **Tests**
  - Added coverage for driver targeting, model promotion thresholds, model preservation, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->