### PR TITLE
fix(oracle): use per-request user client for authorization (fixes #9499)

### DIFF
--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 import { oracleService } from '../core/container.js';
-import { supabase } from '../config/db.js';
+import { supabase, createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateBody } from '../middleware/validate.js';
@@ -22,7 +22,8 @@ const oracleVerificationLimiter = rateLimit({
 });
 
 async function authorizeOrderAccess(req, orderId) {
-  const { data: order, error } = await supabase
+  const client = req.token ? createUserClient(req.token) : supabase;
+  const { data: order, error } = await client
     .from('orders')
     .select('id, customer_id, driver_id')
     .eq('id', orderId)


### PR DESCRIPTION
## Description
Updated `authorizeOrderAccess` in `oracleRoutes.js` to execute queries using the per-request authenticated client (`createUserClient(req.token)`) instead of the global anonymous `supabase` client. This ensures Row Level Security (RLS) policies accurately evaluate the user's context, resolving the issue where valid authorization checks were returning 0 rows and resulting in consistent 404 errors.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `npx vitest run test/integration/oracleVerificationSecurity.test.js test/unit/oracleRoutes.test.js`
- **Test Steps / Prerequisites:** Ensure a valid testing environment is configured and run the Oracle integration test suite which simulates requests to the Oracle endpoints with and without authentication.
- **Expected Result:** `POST /api/oracle/confirm` passes authorization checks with valid user credentials instead of returning a 404, and the order is correctly fetched leveraging RLS.

### Test Environment
- [ ] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #9499

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.