### PR TITLE
fix : added structured event field to redis set error log in osrm.js geometry cache

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -229,7 +229,7 @@ export async function getRouteGeometry({ originLat, originLng, destLat, destLng 
       try {
         await redisClient.set(cacheKey, JSON.stringify(feature), 'EX', ROUTE_CACHE_TTL_SECONDS);
       } catch (err) {
-        logger.error('[osrm] Redis set error (geometry):', err.message);
+        logger.error({ event: 'OSRM_REDIS_SET_GEOMETRY_ERROR', error: err && err.message }, '[osrm] Redis set error (geometry)');
       }
     }
     return feature;


### PR DESCRIPTION
Closes #9506.

Summary of What Has Been Done:
Changed the catch block in backend/api/src/services/osrm.js line 232 from non-structured template-string logging to structured logging with an event field, matching the pattern used by all other catch blocks in the same file.

Changes Made:
- backend/api/src/services/osrm.js: changed logger.error('[osrm] Redis set error (geometry):', err.message) to logger.error({ event: 'OSRM_REDIS_SET_GEOMETRY_ERROR', error: err && err.message }, '[osrm] Redis set error (geometry)')

Impact it Made:
- Consistent structured error logging across all osrm.js catch blocks
- Production monitoring can aggregate Redis geometry cache write failures by event type
- Node.js syntax check passed

Note: This pull request is made from a GSSOC contribution.