### PR TITLE
Fix: Add Retry and Error Handling to Dispute Resolution Workflows

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -38,6 +38,26 @@
       "position": [
         450,
         300
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Freeze Payment Contract Failed for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
+        "textBody": "=CRITICAL: The Freeze Payment Contract step failed after 3 retries for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}. Disputed funds were not frozen on-chain. Immediate manual intervention required.",
+        "options": {}
+      },
+      "id": "alert-freeze-failed",
+      "name": "Alert Admin — Escrow Freeze Failed",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        450,
+        500
       ]
     },
     {
@@ -265,6 +285,26 @@
       "position": [
         500,
         600
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Release Escrow Payment Failed for Booking {{$json.body.bookingId}}",
+        "textBody": "=CRITICAL: The Release Escrow Payment step failed after 3 retries for Booking {{$json.body.bookingId}}. Escrow payment was not released on-chain. Immediate manual intervention required.",
+        "options": {}
+      },
+      "id": "alert-release-failed",
+      "name": "Alert Admin — Escrow Release Failed",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        500,
+        800
       ]
     }
   ],
@@ -290,6 +330,13 @@
           },
           {
             "node": "Query Supabase OTP Logs",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Alert Admin — Escrow Freeze Failed",
             "type": "main",
             "index": 0
           }
@@ -383,6 +430,18 @@
         [
           {
             "node": "Release Escrow Payment",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Release Escrow Payment": {
+      "main": [
+        [],
+        [
+          {
+            "node": "Alert Admin — Escrow Release Failed",
             "type": "main",
             "index": 0
           }

--- a/automation/n8n/dispute_resolution.json
+++ b/automation/n8n/dispute_resolution.json
@@ -47,7 +47,27 @@
         0
       ],
       "id": "freeze-escrow",
-      "name": "Freeze Smart Contract Escrow"
+      "name": "Freeze Smart Contract Escrow",
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Freeze Smart Contract Escrow Failed for Trip {{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}",
+        "textBody": "=CRITICAL: The Freeze Smart Contract Escrow step failed after 3 retries for Trip {{$node[\"Supabase Dispute Webhook\"].json.body.record.id}}. Smart contract payment was not frozen. Immediate manual intervention required.",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        200,
+        -200
+      ],
+      "id": "alert-admin-freeze-failed",
+      "name": "Alert Admin — Escrow Freeze Failed"
     },
     {
       "parameters": {
@@ -227,7 +247,27 @@
         200
       ],
       "id": "release-or-refund",
-      "name": "Release or Refund Smart Contract Escrow"
+      "name": "Release or Refund Smart Contract Escrow",
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Release or Refund Escrow Failed for Trip {{$json.body.record.id}}",
+        "textBody": "=CRITICAL: The Release or Refund Smart Contract Escrow step failed after 3 retries for Trip {{$json.body.record.id}}. Smart contract payment was not released/refunded. Immediate manual intervention required.",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        400,
+        200
+      ],
+      "id": "alert-admin-release-failed",
+      "name": "Alert Admin — Escrow Release Failed"
     }
   ],
   "connections": {
@@ -247,6 +287,13 @@
         [
           {
             "node": "fetch-evidence",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "alert-admin-freeze-failed",
             "type": "main",
             "index": 0
           }
@@ -313,6 +360,18 @@
         [
           {
             "node": "release-or-refund",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "release-or-refund": {
+      "main": [
+        [],
+        [
+          {
+            "node": "alert-admin-release-failed",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Problem

Neither `dispute-resolution.json` nor `dispute_resolution.json` sets `retryOnFail`, `onError`, or `continueOnFail` on any node, and `settings` is `{}` at the workflow level. A transient failure on the `Freeze Payment Contract` or `Release Escrow Payment` steps causes the workflow to silently halt — no retry, no alert — which can leave disputed funds stuck (never frozen during an active dispute, or resolved but never paid out on-chain).

## Fix

- Added `retryOnFail` (`maxTries: 3`, `waitBetweenTries: 5000ms`) to the escrow-freeze and escrow-release nodes in both workflow files.
- Added an error-output branch on both nodes that routes to a new admin-alert node (reusing the existing notification node's type/credential pattern already used elsewhere in the workflow), reporting which dispute/order failed and which step needs manual intervention.
- Verified both files remain valid JSON and that every connection reference (by id or name, matching each file's existing convention) resolves to an actual node — no orphaned nodes or dangling references.

## Scope note

This only touches the two dispute-resolution workflow files. No backend code or other n8n workflows were modified.

## Testing

Validated JSON well-formedness and connections-graph consistency via script (all connections resolve to real nodes, no orphans). n8n workflow JSON has no automated test suite in this repo, so this was verified statically; recommend a maintainer do a visual import check in a running n8n instance before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of payment freezes and escrow releases by adding automatic retries.
  * Added administrator email alerts when these operations continue to fail, including booking details and required manual actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->