### PR TITLE
fix: read driver profile through the authenticated client

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1727,8 +1727,13 @@ router.get('/profile', authenticate, userLimiter, async (req, res) => {
   try {
     const userId = req.user.id;
 
+    // Read through the caller's authenticated client so RLS lets the driver
+    // see their own profile, driver_details (including kyc_status), truck
+    // and documents. The shared anon client is denied on all of these.
+    const db = createUserClient(req.token);
+
     // 1. Fetch base profile
-    const { data: profile, error: profileErr } = await supabase
+    const { data: profile, error: profileErr } = await db
       .from('profiles')
       .select('id, full_name, phone, email')
       .eq('id', userId)
@@ -1739,7 +1744,7 @@ router.get('/profile', authenticate, userLimiter, async (req, res) => {
     }
 
     // 2. Fetch driver details
-    const { data: details, error: detailsErr } = await supabase
+    const { data: details, error: detailsErr } = await db
       .from('driver_details')
       .select('rating, total_trips, completion_rate, is_online, kyc_status, truck_id')
       .eq('user_id', userId)
@@ -1748,7 +1753,7 @@ router.get('/profile', authenticate, userLimiter, async (req, res) => {
     // 3. Fetch truck details if assigned
     let truck = null;
     if (details && details.truck_id) {
-      const { data: truckData } = await supabase
+      const { data: truckData } = await db
         .from('trucks')
         .select('*')
         .eq('id', details.truck_id)
@@ -1757,7 +1762,7 @@ router.get('/profile', authenticate, userLimiter, async (req, res) => {
     }
 
     // 4. Fetch documents and map their status
-    const { data: docs } = await supabase
+    const { data: docs } = await db
       .from('driver_documents')
       .select('document_type, status, is_govt_verified')
       .eq('driver_id', userId);


### PR DESCRIPTION
## Problem

`GET /api/driver/profile` (driverRoutes.js) reads `profiles`, `driver_details` (including `kyc_status`), `trucks` and `driver_documents` through the shared session-less anon client. Those tables only have `authenticated`/`service_role` RLS policies and are revoked from `anon` (`revoke_anon_privileges.sql`), so every read is denied and the profile endpoint errors out / returns empty. The `kyc_status` select also feeds the KYC OCR flow from #9262, so this blocks the driver app's profile page.

## Fix

- Switch the `GET /profile` handler to `const db = createUserClient(req.token)` and run all four reads (profiles, driver_details, trucks, driver_documents) through the caller's authenticated client, so RLS resolves the driver's own rows.
- `createUserClient` was already imported in driverRoutes.js and is the established auth-scoped pattern used by several other handlers in the same file.

## Files changed

- `backend/api/src/routes/driverRoutes.js`

## Testing

- `npx vitest run test/integration/driverRoutes.test.js test/integration/driverProfile.test.js` — 40 passed / 6 failed; the 6 failures reproduce identically on an untouched baseline worktree at the same HEAD, confirming they are pre-existing and unrelated. The `GET /profile` test passes.

Closes #9262
