### PR TITLE
fix: read admin dashboard stats via the service-role client

### DIFF
--- a/backend/api/src/routes/adminRoutes.js
+++ b/backend/api/src/routes/adminRoutes.js
@@ -14,7 +14,7 @@
  */
 
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
@@ -22,6 +22,11 @@ import { auditLog } from '../middleware/auditLog.js';
 import logger from '../middleware/logger.js';
 
 const router = express.Router();
+
+// Dashboard aggregates span every profile/order, so they must be read with a
+// client that bypasses per-row RLS. Fall back to the anon client only when no
+// service-role key is configured (e.g. tests), matching the repo convention.
+const dashboardDb = supabaseAdmin || supabase;
 
 /**
  * @openapi
@@ -46,7 +51,7 @@ const router = express.Router();
  */
 router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-dashboard'), auditLog({ action: 'admin:view-dashboard' }), async (req, res) => {
   try {
-    const { count: activeDrivers, error: driversErr } = await supabase
+    const { count: activeDrivers, error: driversErr } = await dashboardDb
       .from('profiles')
       .select('*', { count: 'exact', head: true })
       .eq('role', 'driver')
@@ -57,7 +62,7 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
       return res.status(500).json({ error: 'Failed to fetch drivers count.' });
     }
 
-    const { count: pendingOrders, error: ordersErr } = await supabase
+    const { count: pendingOrders, error: ordersErr } = await dashboardDb
       .from('orders')
       .select('*', { count: 'exact', head: true })
       .eq('status', 'pending');
@@ -73,7 +78,7 @@ router.get('/dashboard', authenticate, userLimiter, requirePolicy('admin:view-da
     const istNow = new Date(now.getTime() + IST_OFFSET_MS);
     istNow.setUTCHours(0, 0, 0, 0);
     const today = new Date(istNow.getTime() - IST_OFFSET_MS);
-    const { data: todayOrders, error: revErr } = await supabase
+    const { data: todayOrders, error: revErr } = await dashboardDb
       .from('orders')
       .select('total_amount')
       .gte('created_at', today.toISOString())

--- a/backend/api/test/unit/adminRoutesDashboard.test.js
+++ b/backend/api/test/unit/adminRoutesDashboard.test.js
@@ -22,6 +22,8 @@ const { mockSupabase } = vi.hoisted(() => ({
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return mockSupabase; },
+  // No service-role key in tests — the route must fall back to the anon mock.
+  supabaseAdmin: undefined,
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
## Problem

`GET /api/v1/admin/dashboard` (adminRoutes.js) counts `profiles` and reads `orders` through the shared session-less anon client. The anon role has no `SELECT` on `profiles`/`orders` (RLS is `authenticated`-only and `revoke_anon_privileges.sql` revokes them), so the dashboard always reports 0 active drivers, 0 pending orders and 0 revenue regardless of actual data.

## Fix

- Add `const dashboardDb = supabaseAdmin || supabase` and run all three dashboard reads (active drivers count, pending orders count, today's revenue from `orders.total_amount`) through it. `supabaseAdmin` bypasses per-row RLS, which is what a cross-tenant admin aggregate needs; the fallback keeps tests running without a service key.
- Test mock updated to export `supabaseAdmin: undefined` so the route exercises the fallback.

## Files changed

- `backend/api/src/routes/adminRoutes.js`
- `backend/api/test/unit/adminRoutesDashboard.test.js`

## Testing

- `npx vitest run test/unit/adminRoutesDashboard.test.js` — 2/2 pass.

Closes #9225
