### PR TITLE
fix: persist FCM token through the authenticated client

### DIFF
--- a/backend/api/src/routes/userRoutes.js
+++ b/backend/api/src/routes/userRoutes.js
@@ -30,7 +30,7 @@
  */
 
 import express from 'express';
-import { supabase } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { validateBody } from '../middleware/validate.js';
 import { deviceLimiter } from '../middleware/rateLimiter.js';
@@ -118,16 +118,27 @@ router.post(
     const { fcmToken } = req.body;
 
     try {
-      const { error } = await supabase
+      // Update through the caller's authenticated client. The anon client has
+      // no UPDATE on profiles, so a session-less UPDATE silently matches 0
+      // rows (null error) and the token is never persisted.
+      const { data, error } = await createUserClient(req.token)
         .from('profiles')
         .update({
           fcm_token: fcmToken,
           fcm_token_updated_at: new Date().toISOString(),
         })
-        .eq('id', userId);
+        .eq('id', userId)
+        .select('id');
 
       if (error) {
         logger.error('[UserRoutes] Failed to update FCM token in profiles:', error.message);
+        return res.status(500).json({ error: 'Failed to update FCM token.' });
+      }
+
+      // A 0-row match means the caller's identity did not resolve to a
+      // profile row — treat that as a failure rather than a silent no-op.
+      if (!data || data.length === 0) {
+        logger.error(`[UserRoutes] No profile row matched for user ${userId}; FCM token not persisted.`);
         return res.status(500).json({ error: 'Failed to update FCM token.' });
       }
 

--- a/backend/api/test/unit/userRoutes.test.js
+++ b/backend/api/test/unit/userRoutes.test.js
@@ -20,6 +20,7 @@ const { dbMock } = vi.hoisted(() => ({
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return dbMock.supabase; },
+  createUserClient: vi.fn(() => dbMock.supabase),
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({
@@ -41,9 +42,9 @@ describe('userRoutes', () => {
   });
 
   describe('POST /users/fcm-token', () => {
-    it('returns success when the update succeeds', async () => {
+    it('returns success when the update persists a matching profile row', async () => {
       dbMock.supabase.from.mockReturnValue({
-        update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+        update: vi.fn(() => ({ eq: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ error: null, data: [{ id: 'u1' }] }) })) })),
       });
       const res = await request(makeApp())
         .post('/users/fcm-token')
@@ -54,7 +55,18 @@ describe('userRoutes', () => {
 
     it('returns 500 when the update errors', async () => {
       dbMock.supabase.from.mockReturnValue({
-        update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: { message: 'db down' } }) })),
+        update: vi.fn(() => ({ eq: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ error: { message: 'db down' } }) })) })),
+      });
+      const res = await request(makeApp())
+        .post('/users/fcm-token')
+        .send({ fcmToken: 'valid-token-12345' });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Failed to update FCM token.');
+    });
+
+    it('returns 500 when the update matches no profile row (0-row no-op)', async () => {
+      dbMock.supabase.from.mockReturnValue({
+        update: vi.fn(() => ({ eq: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ error: null, data: [] }) })) })),
       });
       const res = await request(makeApp())
         .post('/users/fcm-token')


### PR DESCRIPTION
## Problem

`POST /api/users/fcm-token` runs an UPDATE against `profiles` through the session-less anon client. The anon role has no `UPDATE` on `profiles` (RLS `20240101000000_rls.sql:22-50` is `authenticated`-only; `revoke_anon_privileges.sql` REVOKEs `ALL FROM anon`), so the UPDATE matches 0 rows. The handler checks `error` — null for a 0-row update — and responds 200 with a success log while `fcm_token` is never persisted. Push notifications later resolve no device token.

## Fix

- Update through the caller's authenticated client: `createUserClient(req.token)` instead of the shared anon `supabase`.
- Add `.select('id')` to the update and treat a 0-row match as a failure (`500 Failed to update FCM token.`) instead of a silent success, so a missing profile row can never masquerade as a persisted token.
- Tests updated: db mock exports `createUserClient`; the success/error cases now exercise the select chain, plus a new case asserting 500 on a 0-row no-op.

## Files changed

- `backend/api/src/routes/userRoutes.js`
- `backend/api/test/unit/userRoutes.test.js`

## Testing

- `npx vitest run test/unit/userRoutes.test.js` — all pass (3 cases for fcm-token: success, DB error, 0-row no-op).

Closes #9226
