### PR TITLE
fix: exempt public reference tables from anon revoke

### DIFF
--- a/supabase/migrations/revoke_anon_privileges.sql
+++ b/supabase/migrations/revoke_anon_privileges.sql
@@ -31,8 +31,10 @@ REVOKE ALL ON TABLE public.delivery_otps FROM anon;
 REVOKE ALL ON TABLE public.driver_locations FROM anon;
 REVOKE ALL ON TABLE public.user_devices FROM anon;
 REVOKE ALL ON TABLE public.driver_documents FROM anon;
-REVOKE ALL ON TABLE public.vehicle_types FROM anon;
-REVOKE ALL ON TABLE public.regions FROM anon;
+-- vehicle_types and regions are intentionally public reference tables: their
+-- RLS policies in 20260805000050_create_vehicle_types_regions.sql grant SELECT
+-- to anon+authenticated so GET /api/v1/vehicle-types and /api/v1/regions work
+-- for unauthenticated clients. They are exempt from the revoke below.
 REVOKE ALL ON TABLE public.webhook_failures FROM anon;
 REVOKE ALL ON TABLE public.reputation_failures FROM anon;
 REVOKE ALL ON TABLE public.tracking_tokens FROM anon;


### PR DESCRIPTION
## Problem

`20260805000050_create_vehicle_types_regions.sql` creates `vehicle_types` and `regions` with explicit `anon`+`authenticated` SELECT RLS policies so the public reference endpoints work. But `revoke_anon_privileges.sql` (which sorts last in the migration set) runs `REVOKE ALL ON TABLE ... FROM anon` on both tables. With the table-level grant stripped, the anon-role SELECT that `lookupRoutes` relies on is denied, so `GET /api/v1/vehicle-types` and `GET /api/v1/regions` return permission-denied errors in any environment where the shipped migration set is applied.

## Fix

Remove the two REVOKE lines for `vehicle_types` and `regions` from `revoke_anon_privileges.sql`, with a comment explaining these are intentionally-public reference tables whose RLS policies already grant anon SELECT. All other anon revokes are unchanged.

## Files changed

- `supabase/migrations/revoke_anon_privileges.sql`

## Testing

- `npx vitest run test/unit/lookupRoutes.test.js` — 4/4 pass (no application code change; route tests confirm the lookup contract is intact).

Closes #9215
