### PR TITLE
fix: compute customer stats from orders via the service-role client

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -1,4 +1,4 @@
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { measureExecution } from '../core/performanceMetrics.js';
 import {
   getCachedSupabaseProfile, setCachedSupabaseProfile,
@@ -51,7 +51,8 @@ export async function getProfile(userId) {
 
 export async function getCustomerStats(userId) {
   return measureExecution('ProfileService.getCustomerStats', async () => {
-  if (!supabase) {
+  const client = supabaseAdmin || supabase;
+  if (!client) {
     throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_ANON_KEY');
   }
 
@@ -67,23 +68,33 @@ export async function getCustomerStats(userId) {
     }
   }
 
-  const { data, error } = await supabase
-    .from('customer_stats')
-    .select('*')
-    .eq('user_id', userId)
-    .maybeSingle();
+  // customer_stats was never populated by any write path, so stats are
+  // computed from the customer's orders at request time. Reads go through
+  // the service-role client when available (RLS would hide other orders).
+  const { data: orders, error } = await client
+    .from('orders')
+    .select('status, total_amount')
+    .eq('customer_id', userId);
 
   if (error) throw error;
 
-  if (isCacheEnabled() && data) {
+  const stats = {
+    user_id: userId,
+    total_orders: (orders || []).length,
+    // No broker-baseline data exists on orders to compute savings / CO2.
+    total_saved: 0,
+    co2_reduced_kg: 0,
+  };
+
+  if (isCacheEnabled()) {
     try {
-      await setCachedCustomerStats(userId, data);
+      await setCachedCustomerStats(userId, stats);
     } catch (err) {
       logger.warn({ err, userId }, 'Customer stats cache write failed');
     }
   }
 
-  return data;
+  return stats;
   });
 }
 

--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -10,9 +10,9 @@
  *   - getProfile populates cache after DB fetch
  *   - getProfile continues when cache write fails
  *   - getCustomerStats throws when supabase is null
- *   - getCustomerStats queries customer_stats table correctly
+ *   - getCustomerStats computes stats from the customer's orders
  *   - getCustomerStats returns cached data on cache hit
- *   - getCustomerStats falls back to DB when cache read fails
+ *   - getCustomerStats falls back to the orders query when cache read fails
  *   - getDriverDetails throws when supabase is null
  *   - getDriverDetails queries driver_details table correctly
  *   - getDriverDetails returns cached data on cache hit
@@ -28,7 +28,7 @@ vi.mock('../../src/middleware/logger.js', () => ({
 }));
 
 const mockEqProfileMaybeSingle = vi.fn();
-const mockEqStatsMaybeSingle = vi.fn();
+const mockEqOrders = vi.fn();
 const mockEqDriverMaybeSingle = vi.fn();
 const supabaseRef = vi.hoisted(() => ({ current: null }));
 
@@ -43,12 +43,10 @@ const defaultMockSupabase = {
         })),
       };
     }
-    if (table === 'customer_stats') {
+    if (table === 'orders') {
       return {
         select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            maybeSingle: mockEqStatsMaybeSingle,
-          })),
+          eq: mockEqOrders,
         })),
       };
     }
@@ -83,6 +81,8 @@ vi.mock('../../src/config/db.js', () => ({
   get supabase() {
     return supabaseRef.current;
   },
+  // No service-role key in tests — the service falls back to the anon mock.
+  supabaseAdmin: undefined,
 }));
 
 vi.mock('../../src/lib/profileCache.js', () => profileCacheRef);
@@ -202,29 +202,41 @@ describe('getCustomerStats', () => {
     await expect(getCustomerStats('user-123')).rejects.toThrow('Supabase client not configured');
   });
 
-  it('returns customer stats on successful query', async () => {
+  it('computes stats from the customer\'s orders', async () => {
     useMockSupabase();
-    const mockData = { total_orders: 42, total_saved: 8, co2_reduced_kg: 156.5 };
-    mockEqStatsMaybeSingle.mockResolvedValueOnce({ data: mockData, error: null });
+    mockEqOrders.mockResolvedValueOnce({
+      data: [
+        { status: 'delivered', total_amount: 100 },
+        { status: 'in_transit', total_amount: 200 },
+        { status: 'cancelled', total_amount: 50 },
+      ],
+      error: null,
+    });
     const result = await getCustomerStats('user-456');
-    expect(result).toEqual(mockData);
+    expect(result).toEqual({
+      user_id: 'user-456',
+      total_orders: 3,
+      total_saved: 0,
+      co2_reduced_kg: 0,
+    });
   });
 
-  it('throws when supabase query returns an error', async () => {
+  it('throws when the orders query returns an error', async () => {
     useMockSupabase();
-    mockEqStatsMaybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'Row not found' } });
-    await expect(getCustomerStats('user-456')).rejects.toThrow('Row not found');
+    mockEqOrders.mockResolvedValueOnce({ data: null, error: { message: 'Permission denied' } });
+    await expect(getCustomerStats('user-456')).rejects.toThrow('Permission denied');
   });
 
-  it('returns null when no customer stats are found', async () => {
-    supabaseRef.current = {
-      from: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-    };
-    const result = await getCustomerStats('new-user-without-stats');
-    expect(result).toBeNull();
+  it('returns zeroed stats when the customer has no orders', async () => {
+    useMockSupabase();
+    mockEqOrders.mockResolvedValueOnce({ data: [], error: null });
+    const result = await getCustomerStats('new-user-without-orders');
+    expect(result).toEqual({
+      user_id: 'new-user-without-orders',
+      total_orders: 0,
+      total_saved: 0,
+      co2_reduced_kg: 0,
+    });
   });
 
   it('returns cached stats on cache hit', async () => {
@@ -237,23 +249,31 @@ describe('getCustomerStats', () => {
     expect(profileCacheRef.setCachedCustomerStats).not.toHaveBeenCalled();
   });
 
-  it('falls back to DB when cache read fails', async () => {
+  it('falls back to the orders query when cache read fails', async () => {
     profileCacheRef.getCachedCustomerStats.mockRejectedValueOnce(new Error('Redis down'));
     useMockSupabase();
-    const mockData = { total_orders: 42 };
-    mockEqStatsMaybeSingle.mockResolvedValueOnce({ data: mockData, error: null });
+    mockEqOrders.mockResolvedValueOnce({ data: [{ status: 'delivered' }], error: null });
 
     const result = await getCustomerStats('user-456');
-    expect(result).toEqual(mockData);
+    expect(result).toEqual({
+      user_id: 'user-456',
+      total_orders: 1,
+      total_saved: 0,
+      co2_reduced_kg: 0,
+    });
   });
 
-  it('populates cache after successful DB fetch', async () => {
+  it('populates cache after a successful orders query', async () => {
     useMockSupabase();
-    const mockData = { total_orders: 42 };
-    mockEqStatsMaybeSingle.mockResolvedValueOnce({ data: mockData, error: null });
+    mockEqOrders.mockResolvedValueOnce({ data: [{ status: 'delivered' }], error: null });
 
     await getCustomerStats('user-456');
-    expect(profileCacheRef.setCachedCustomerStats).toHaveBeenCalledWith('user-456', mockData);
+    expect(profileCacheRef.setCachedCustomerStats).toHaveBeenCalledWith('user-456', {
+      user_id: 'user-456',
+      total_orders: 1,
+      total_saved: 0,
+      co2_reduced_kg: 0,
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`customer_stats` is never written by any code, RPC or trigger — the only row in the repo is a seed in `docs/supabase_setup.sql:1888` for a specific test customer. Combined with the endpoint reading via the anon client (denied by RLS/`revoke_anon_privileges.sql`), `GET /api/profile/customer-stats` could never return real per-customer data; it always returned the static seed value or empty.

## Fix

`getCustomerStats` in `profileService.js` now computes stats at request time from the customer's own `orders` (`select status, total_amount where customer_id = userId`) instead of reading the never-populated `customer_stats` table:

- Orders read goes through `const client = supabaseAdmin || supabase` so RLS does not hide the customer's orders.
- Returns `{ user_id, total_orders, total_saved: 0, co2_reduced_kg: 0 }` — `total_saved`/`co2_reduced_kg` stay 0 because the `orders` table has no broker-baseline columns to compute savings/CO2 from.
- Cache read/write behavior is preserved (the computed stats payload is cached).
- Tests updated: mock switches `customer_stats` for an `orders` chain and exports `supabaseAdmin: undefined`; new expectations cover computed stats, zeroed stats for a customer with no orders, and error propagation.

## Files changed

- `backend/api/src/services/profileService.js`
- `backend/api/test/unit/profileService.test.js`

## Testing

- `npx vitest run test/unit/profileService.test.js` — 26 passed / 1 failed. The single failure is the pre-existing `getProfile` cache-hit test, which reproduces at HEAD on an untouched baseline (it references `isValidCachedProfile(firebaseUid, cached)` with an undefined `firebaseUid` — a bug in `git show HEAD`), and is out of scope for this issue.

Closes #9216
