### PR TITLE
fix: resolve voice booking context via the service-role client

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import crypto from 'crypto';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
+const voiceDb = supabaseAdmin || supabase;
 import logger from '../middleware/logger.js';
 
 const MAX_CACHE_SIZE = 100;
@@ -48,7 +49,7 @@ async function getBookingContext(bookingId, userId) {
 
   // Orders table is the real order model (there is no bookings table).
   try {
-    let orderQuery = supabase.from('orders').select('*');
+    let orderQuery = voiceDb.from('orders').select('*');
     if (isUuid) {
       orderQuery = orderQuery.eq('id', bookingId);
     } else {

--- a/backend/api/test/unit/voiceService.test.js
+++ b/backend/api/test/unit/voiceService.test.js
@@ -37,6 +37,7 @@ vi.mock('../../src/config/db.js', () => ({
   supabase: {
     from: mockSupabaseFrom,
   },
+  supabaseAdmin: undefined,
 }));
 
 // Mock crypto


### PR DESCRIPTION
## Problem

`getBookingContext` in `voiceService.js` reads the `orders` table through the shared session-less anon `supabase`. The anon role has no `SELECT` on `orders` (RLS `20240101000000_rls.sql:167-179`; `revoke_anon_privileges.sql`), so the lookup always errors and the booking context is always null. Every voice intent that needs order details (booking status, cancellation, etc.) runs with no order data.

## Fix

- `getBookingContext` now queries `orders` through `const voiceDb = supabaseAdmin || supabase` (service-role client when available, anon fallback for tests). The existing `customer_id`/`driver_id` filter in the query still scopes the result to the current user's own order.
- Unit test mock exports `supabaseAdmin: undefined` so the fallback path is exercised.

## Files changed

- `backend/api/src/services/voiceService.js`
- `backend/api/test/unit/voiceService.test.js`

## Testing

- `npx vitest run test/unit/voiceService.test.js test/integration/voiceAudioAccess.test.js` — 19/19 pass.
- `test/unit/VoiceAiService.test.js` has 4 failures, but they are pre-existing at HEAD (unrelated `OPENAI_API_KEY` env setup in the standalone, unmounted service) and reproduce identically on an untouched baseline worktree.

Closes #9217
