### PR TITLE
fix: allow users to create and revoke their own tracking tokens

### DIFF
--- a/supabase/migrations/20260810000002_tracking_tokens_owner_rls.sql
+++ b/supabase/migrations/20260810000002_tracking_tokens_owner_rls.sql
@@ -1,0 +1,20 @@
+-- Fix #8937: allow authenticated users to create/revoke their own tracking tokens.
+--
+-- trackingRoutes.js now mints and revokes share links through
+-- createUserClient(req.token), but tracking_tokens only shipped
+-- service_role-ALL and authenticated-SELECT policies, so the INSERT (create)
+-- and UPDATE (revoke) still fail with 42501. These policies scope every
+-- write to tokens the caller created (created_by = own profile id).
+
+alter table tracking_tokens enable row level security;
+
+drop policy if exists "Customers insert own tracking tokens" on tracking_tokens;
+create policy "Customers insert own tracking tokens"
+  on tracking_tokens for insert to authenticated
+  with check (created_by = get_profile_id());
+
+drop policy if exists "Customers update own tracking tokens" on tracking_tokens;
+create policy "Customers update own tracking tokens"
+  on tracking_tokens for update to authenticated
+  using (created_by = get_profile_id())
+  with check (created_by = get_profile_id());


### PR DESCRIPTION
## Problem

Issue #8937's code side is already resolved at HEAD: `publicTrackingRoutes.js` reads through `supabaseAdmin` and `trackingRoutes.js` mints/revokes share links through `createUserClient(req.token)`. What is still broken is RLS: `tracking_tokens` only ships `service_role`-ALL and `authenticated`-SELECT policies (`20260716000000_add_public_tracking_tokens.sql:53-61`). So an authenticated user minting a token hits `42501` on INSERT and revoking hits `42501` on UPDATE — the create/revoke flows still fail even though the code already uses the right clients.

## Fix

New migration `20260810000002_tracking_tokens_owner_rls.sql` adds two `authenticated` policies scoped to the caller's own tokens via `get_profile_id()`:

- `Customers insert own tracking tokens` — INSERT with `with check (created_by = get_profile_id())`.
- `Customers update own tracking tokens` — UPDATE with `using`/`with check (created_by = get_profile_id())`, so a user can only revoke (or otherwise update) tokens they created.

## Files changed

- `supabase/migrations/20260810000002_tracking_tokens_owner_rls.sql` (new)

## Testing

- SQL applies cleanly against a fresh database (policy `drop if exists` + `create` guard re-runs).
- No application code change — the mint/revoke handlers already use `createUserClient(req.token)` at HEAD.

Closes #8937
