### PR TITLE
fix: grant EXECUTE on register_device_token to service_role

### DIFF
--- a/supabase/migrations/20260810000004_grant_register_device_token_execute_service_role.sql
+++ b/supabase/migrations/20260810000004_grant_register_device_token_execute_service_role.sql
@@ -1,0 +1,13 @@
+-- Fix #8938: grant EXECUTE on register_device_token to service_role.
+--
+-- deviceController.registerDeviceToken invokes the SECURITY DEFINER RPC
+-- through supabaseAdmin (the service-role key), but the only grant in the
+-- repo targets the `authenticated` role
+-- (20260809000000_grant_register_device_token_execute.sql). With EXECUTE
+-- revoked from PUBLIC and never granted to service_role, every service-role
+-- call still fails with 42501 (permission denied for function
+-- register_device_token). This grant matches the intent documented in
+-- 20260807000010_register_device_token_tx.sql: only the service-role key may
+-- call this function directly.
+
+GRANT EXECUTE ON FUNCTION register_device_token(uuid, text, text, jsonb, uuid) TO service_role;


### PR DESCRIPTION
## Problem

`register_device_token` — the atomic RPC from `20260807000010_register_device_token_tx.sql` — revokes `EXECUTE` from `PUBLIC`, `anon` and `authenticated` but only re-grants it to `authenticated` (via `20260809000000_grant_register_device_token_execute.sql`). At HEAD the controller already invokes it through `supabaseAdmin` (the service-role key, deviceController.js:94), but no migration ever grants `EXECUTE` to `service_role`, so every service-role call still fails with `42501 permission denied for function register_device_token` and FCM device registration remains broken.

## Fix

New migration `20260810000004_grant_register_device_token_execute_service_role.sql` adds:

```sql
GRANT EXECUTE ON FUNCTION register_device_token(uuid, text, text, jsonb, uuid) TO service_role;
```

This matches the intent documented in the original migration — "only the service-role key may call this function directly" — and completes the grant matrix for both clients the controller uses.

## Files changed

- `supabase/migrations/20260810000004_grant_register_device_token_execute_service_role.sql` (new)

## Testing

- SQL applies cleanly on a fresh database and re-runs safely.
- No application code change — `deviceController.js` already calls the RPC through `supabaseAdmin` at HEAD.

Closes #8938
