### PR TITLE
fix(did): create dids and credentials tables

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import logger from '../api/src/middleware/logger.js';
-import { supabase } from '../api/src/config/db.js';
+import { supabase, supabaseAdmin } from '../api/src/config/db.js';
 
 class DIDService {
     constructor() {
@@ -263,14 +263,14 @@ class DIDService {
     }
 
     async storeDID(data) {
-        const { error } = await supabase
+        const { error } = await (supabaseAdmin || supabase)
             .from('dids')
             .insert([{ did: data.did, owner: data.owner, public_key: data.publicKey, created_at: new Date().toISOString() }]);
         if (error) throw error;
     }
 
     async storeCredential(data) {
-        const { error } = await supabase
+        const { error } = await (supabaseAdmin || supabase)
             .from('credentials')
             .insert([{
                 credential_id: data.credentialId,
@@ -286,7 +286,7 @@ class DIDService {
     }
 
     async updateCredentialStatus(credentialId, revoked) {
-        const { error } = await supabase
+        const { error } = await (supabaseAdmin || supabase)
             .from('credentials')
             .update({ revoked, revoked_at: new Date().toISOString() })
             .eq('credential_id', credentialId);
@@ -294,8 +294,8 @@ class DIDService {
     }
 
     async getDIDStats() {
-        const { data: dids, error: didsErr } = await supabase.from('dids').select('*').order('created_at', { ascending: false }).limit(100);
-        const { data: credentials, error: credsErr } = await supabase.from('credentials').select('*').order('issued_at', { ascending: false }).limit(100);
+        const { data: dids, error: didsErr } = await (supabaseAdmin || supabase).from('dids').select('*').order('created_at', { ascending: false }).limit(100);
+        const { data: credentials, error: credsErr } = await (supabaseAdmin || supabase).from('credentials').select('*').order('issued_at', { ascending: false }).limit(100);
 
         if (didsErr || credsErr) {
             logger.error('Failed to fetch DID stats', { didsErr, credsErr });

--- a/supabase/migrations/20260811010000_create_did_tables.sql
+++ b/supabase/migrations/20260811010000_create_did_tables.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- DID & CREDENTIAL RECORDS — self-sovereign identity + verifiable credentials
+-- ============================================================================
+-- Backend services (backend/did/did.service.js) persist issued DIDs and
+-- credentials here as an off-chain index of the DIDRegistry/IdentityWallet
+-- smart contracts. The on-chain contract state remains the source of truth.
+--
+-- SECURITY MODEL:
+--   - Written by backend services using the service_role key and never exposed
+--     to clients, so RLS allows service_role only.
+-- ============================================================================
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. DIDS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists dids (
+  did        varchar(255) primary key,       -- did:truxify:<uuid>
+  owner      varchar(255) not null,          -- polygon wallet address
+  public_key text,                           -- multibase-encoded public key
+  is_active  boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_dids_owner
+  on dids (owner);
+
+create index if not exists idx_dids_created_at
+  on dids (created_at);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. CREDENTIALS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists credentials (
+  credential_id  varchar(255) primary key,  -- on-chain bytes32 id
+  subject        varchar(255) not null,     -- polygon wallet address
+  credential_type text not null,
+  schema         jsonb,
+  issued_at      timestamptz not null default now(),
+  valid_until    timestamptz,
+  tx_hash        text,
+  proof          text,
+  revoked        boolean not null default false,
+  revoked_at     timestamptz
+);
+
+create index if not exists idx_credentials_subject
+  on credentials (subject);
+
+create index if not exists idx_credentials_issued_at
+  on credentials (issued_at);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table dids enable row level security;
+
+drop policy if exists "Service role full access on dids"
+  on dids;
+create policy "Service role full access on dids"
+  on dids
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table dids from anon, authenticated;
+
+alter table credentials enable row level security;
+
+drop policy if exists "Service role full access on credentials"
+  on credentials;
+create policy "Service role full access on credentials"
+  on credentials
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table credentials from anon, authenticated;


### PR DESCRIPTION
## Problem

`did.service.js` writes to `dids` and `credentials` tables that no migration or `docs/supabase_setup.sql` ever creates. Every DID store/credential operation fails with `PGRST202` and the DID/Verifiable-Credential flow is dead.

## Fix

- Add a migration creating `dids` and `credentials` tables with indexes and service-role-only RLS (anon/authenticated revoked).
- Switch `did.service.js` DB access to `(supabaseAdmin || supabase)` so writes are not blocked by RLS.

## Files changed

- `supabase/migrations/20260811010000_create_did_tables.sql`
- `backend/did/did.service.js`

## Testing

- `node --check` passes on `did.service.js`.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9470
