### PR TITLE
fix(zkp): back zkp flow with profiles and real tables

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { acquireLock, releaseLock, LockAcquisitionError } from '../../lib/redisLock.js';
 
 /**
@@ -114,8 +114,8 @@ class ZKPService {
   }
 
   async getUserAddress(userId) {
-    const { data, error } = await supabase
-      .from('users')
+    const { data, error } = await (supabaseAdmin || supabase)
+      .from('profiles')
       .select('wallet_address')
       .eq('id', userId)
       .single();
@@ -124,7 +124,7 @@ class ZKPService {
   }
 
   async storeProof(userId, proofData) {
-    const { error } = await supabase
+    const { error } = await (supabaseAdmin || supabase)
       .from('zk_proofs')
       .insert([{
         user_id: userId,
@@ -136,8 +136,8 @@ class ZKPService {
   }
 
   async updateVerificationStatus(userId, verified, txHash) {
-    const { error } = await supabase
-      .from('users')
+    const { error } = await (supabaseAdmin || supabase)
+      .from('profiles')
       .update({
         kyc_verified: verified,
         kyc_verified_at: new Date().toISOString(),
@@ -164,8 +164,8 @@ class ZKPService {
    * an on-chain call and sufficient for the idempotency guard).
    */
   async isVerifiedInDb(userId) {
-    const { data, error } = await supabase
-      .from('users')
+    const { data, error } = await (supabaseAdmin || supabase)
+      .from('profiles')
       .select('kyc_verified')
       .eq('id', userId)
       .single();
@@ -269,7 +269,7 @@ class ZKPService {
   }
 
   async logVerification(userId, result) {
-    const { error } = await supabase
+    const { error } = await (supabaseAdmin || supabase)
       .from('kyc_audit_logs')
       .insert([{
         user_id: userId,
@@ -283,8 +283,8 @@ class ZKPService {
 
   async getVerificationStats() {
     const [verifiedResult, unverifiedResult] = await Promise.all([
-      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', true),
-      supabase.from('users').select('id', { count: 'exact', head: true }).eq('kyc_verified', false),
+      (supabaseAdmin || supabase).from('profiles').select('id', { count: 'exact', head: true }).eq('kyc_verified', true),
+      (supabaseAdmin || supabase).from('profiles').select('id', { count: 'exact', head: true }).eq('kyc_verified', false),
     ]);
     if (verifiedResult.error) throw verifiedResult.error;
     if (unverifiedResult.error) throw unverifiedResult.error;

--- a/supabase/migrations/20260811020000_create_zkp_tables.sql
+++ b/supabase/migrations/20260811020000_create_zkp_tables.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- ZKP KYC VERIFICATION — proofs, audit log, and profile status columns
+-- ============================================================================
+-- Backend services (backend/api/src/services/zkp/zkp.service.js) persist
+-- generated ZK proofs and verification audit rows here and track KYC status
+-- on the real user table (`profiles`). The app has no `users` table, so the
+-- service reads/writes `profiles` instead.
+--
+-- SECURITY MODEL:
+--   - Backend services write via the service_role key; zk_proofs and
+--     kyc_audit_logs are never exposed to clients, so RLS allows
+--     service_role only. profile status columns are only written by the
+--     service_role client too (users must not self-flag as kyc_verified).
+-- ============================================================================
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. PROFILE KYC STATUS COLUMNS
+-- ────────────────────────────────────────────────────────────────────────────
+alter table profiles
+  add column if not exists kyc_verified   boolean not null default false,
+  add column if not exists kyc_verified_at timestamptz,
+  add column if not exists kyc_tx_hash    text;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ZK PROOFS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists zk_proofs (
+  id             uuid primary key default gen_random_uuid(),
+  user_id        uuid not null references profiles(id) on delete cascade,
+  proof          jsonb not null,
+  public_signals jsonb,
+  created_at     timestamptz not null default now()
+);
+
+create index if not exists idx_zk_proofs_user_id
+  on zk_proofs (user_id);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. KYC AUDIT LOG TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists kyc_audit_logs (
+  id        uuid primary key default gen_random_uuid(),
+  user_id   uuid not null references profiles(id) on delete cascade,
+  action    varchar(100) not null,
+  status    varchar(50) not null,
+  tx_hash   text,
+  timestamp timestamptz not null default now()
+);
+
+create index if not exists idx_kyc_audit_logs_user_id
+  on kyc_audit_logs (user_id);
+
+create index if not exists idx_kyc_audit_logs_timestamp
+  on kyc_audit_logs (timestamp);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table zk_proofs enable row level security;
+
+drop policy if exists "Service role full access on zk_proofs"
+  on zk_proofs;
+create policy "Service role full access on zk_proofs"
+  on zk_proofs
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table zk_proofs from anon, authenticated;
+
+alter table kyc_audit_logs enable row level security;
+
+drop policy if exists "Service role full access on kyc_audit_logs"
+  on kyc_audit_logs;
+create policy "Service role full access on kyc_audit_logs"
+  on kyc_audit_logs
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table kyc_audit_logs from anon, authenticated;


### PR DESCRIPTION
## Problem

`zkp.service.js` reads from the `users` table (which does not exist; profiles is the real table) and writes to `zk_proofs`/`kyc_audit_logs` tables that no migration ever creates. ZKP verification fails with `PGRST202`/`PGRST205`.

## Fix

- Add a migration that adds `kyc_verified`, `kyc_verified_at`, `kyc_tx_hash` to `profiles` and creates `zk_proofs` + `kyc_audit_logs` with service-role-only RLS.
- Switch `zkp.service.js` from `users` to `profiles` and use `(supabaseAdmin || supabase)` for all DB methods.

## Files changed

- `supabase/migrations/20260811020000_create_zkp_tables.sql`
- `backend/api/src/services/zkp/zkp.service.js`

## Testing

- `node --check` passes on `zkp.service.js`.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9471
