### PR TITLE
fix(verification): align delivery status check with oracle

### DIFF
--- a/backend/api/src/services/verification/VerificationService.js
+++ b/backend/api/src/services/verification/VerificationService.js
@@ -4,9 +4,15 @@ import logger from '../../middleware/logger.js';
 
 const REQUIRED_DOCUMENT_TYPES = ['rc_book', 'driving_licence'];
 
+// Statuses that represent an in-progress delivery. This must mirror the
+// OracleService's DELIVERY_IN_PROGRESS_STATUSES: confirmDelivery runs BEFORE
+// the order is marked 'delivered'/'payment_released', so requiring a terminal
+// status here would make deliveryVerified unreachable even when the oracle
+// reaches 2-of-3 provider consensus.
 const ACTIVE_DELIVERY_STATUSES = new Set([
-  'delivered',
-  'payment_released',
+  'picked_up',
+  'in_transit',
+  'arriving',
 ]);
 
 class VerificationService {


### PR DESCRIPTION
## Problem

`VerificationService.js` treats `verified` and `payment_released` as "active" delivery statuses. The delivery OTP (and verification) flow therefore blocks verification until the order reaches a terminal state, while `OracleService` confirms delivery when the truck is in `picked_up`/`in_transit`/`arriving`. The two services disagree, so active trips can never be verified.

## Fix

Align `VerificationService.ACTIVE_DELIVERY_STATUSES` with `OracleService.DELIVERY_IN_PROGRESS_STATUSES`: `picked_up`, `in_transit`, `arriving`. A comment explains that the oracle confirms delivery before the order reaches a terminal status.

## Files changed

- `backend/api/src/services/VerificationService.js`

## Testing

- `node --check` passes.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9537
