### PR TITLE
fix(ml): pin torch to 2.5.1

### DIFF
--- a/backend/ml/requirements.txt
+++ b/backend/ml/requirements.txt
@@ -19,7 +19,7 @@ scipy==1.11.3
 tensorflow==2.13.0
 
 # --- Deep Learning (PyTorch) ---
-torch==2.13.0
+torch==2.5.1
 torch_geometric==2.5.0
 
 # --- Async / HTTP ---


### PR DESCRIPTION
## Problem

`backend/ml/requirements.txt` pins `torch==2.13.0`, a version that does not exist on PyPI. The ML service cannot install its dependencies.

## Fix

Pin `torch` to `2.5.1`, a real released version compatible with the rest of the pinned stack.

## Files changed

- `backend/ml/requirements.txt`

## Testing

- Dependency pin verified against PyPI; no runtime change.

Closes #9539
