### PR TITLE
fix(ml): remove duplicate python-multipart pin

### DIFF
--- a/backend/ml/requirements.txt
+++ b/backend/ml/requirements.txt
@@ -63,4 +63,3 @@ networkx==3.2.1
 pytest==9.0.3
 
 pytesseract==0.3.10
-python-multipart==0.0.9


### PR DESCRIPTION
## Problem

`backend/ml/requirements.txt` lists `python-multipart==0.0.9` twice. Pip rejects duplicate requirement lines and the ML service cannot install.

## Fix

Remove the duplicate `python-multipart==0.0.9` entry.

## Files changed

- `backend/ml/requirements.txt`

## Testing

- Dependency list sanity-checked; no runtime change.

Closes #9540
