### PR TITLE
fix(wallet): add encrypted_wallet_keys table migration

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -109,7 +109,7 @@ class KeyManagementService {
         // Deactivate any previously active row for this user/wallet scope so
         // exactly one active row exists and retrieveEncryptedKey's
         // .eq('active', true).single() never 406s on multiple rows.
-        const { error: deactivateError } = await supabase
+        const { error: deactivateError } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .update({ active: false })
           .eq('user_id', userId)
@@ -124,7 +124,7 @@ class KeyManagementService {
         const keyId = crypto.randomUUID();
 
         // Deactivate any previously active key for this user+wallet
-        await supabase
+        await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .update({
             active: false,
@@ -135,7 +135,7 @@ class KeyManagementService {
           .eq('wallet_address', walletAddress)
           .eq('active', true);
 
-        const { data, error } = await supabase
+        const { data, error } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .insert([{
             key_id: keyId,
@@ -167,7 +167,7 @@ class KeyManagementService {
   async retrieveEncryptedKey(userId, walletAddress) {
     return measureExecution('KeyManagementService.retrieveEncryptedKey', async () => {
       try {
-        const { data: keys, error } = await supabase
+        const { data: keys, error } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .select('*')
           .eq('user_id', userId)
@@ -182,7 +182,7 @@ class KeyManagementService {
           return null;
         }
 
-        await supabase
+        await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .update({ last_used_at: new Date().toISOString() })
           .eq('key_id', keys.key_id);
@@ -199,7 +199,7 @@ class KeyManagementService {
   async archiveKey(keyId, reason = 'unknown') {
     return measureExecution('KeyManagementService.archiveKey', async () => {
       try {
-        const { error } = await supabase
+        const { error } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .update({
             active: false,
@@ -226,7 +226,7 @@ class KeyManagementService {
   async getKeyRotationHistory(userId, walletAddress, limit = 10) {
     return measureExecution('KeyManagementService.getKeyRotationHistory', async () => {
       try {
-        const { data: history, error } = await supabase
+        const { data: history, error } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
           .select('*')
           .eq('user_id', userId)

--- a/supabase/migrations/20260811030000_create_encrypted_wallet_keys_table.sql
+++ b/supabase/migrations/20260811030000_create_encrypted_wallet_keys_table.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- ENCRYPTED WALLET KEYS — per-device encrypted private keys
+-- ============================================================================
+-- Backend services (keyManagementService.js) persist wallet private keys that
+-- are encrypted with a device-derived AES-256-GCM key. The service writes via
+-- the service_role client and the table is never exposed to clients, so RLS
+-- allows service_role only.
+-- ============================================================================
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. ENCRYPTED WALLET KEYS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists encrypted_wallet_keys (
+  key_id         uuid primary key,
+  user_id        uuid not null references profiles(id) on delete cascade,
+  wallet_address varchar(255) not null,
+  encrypted_key  jsonb not null,               -- iv, encryptedKey, authTag, salt, algorithm
+  device_id      varchar(255),
+  version        int not null default 1,
+  active         boolean not null default true,
+  created_at     timestamptz not null default now(),
+  last_used_at   timestamptz,
+  archived_at    timestamptz,
+  archive_reason varchar(255)
+);
+
+create index if not exists idx_encrypted_keys_user_wallet
+  on encrypted_wallet_keys (user_id, wallet_address);
+
+create index if not exists idx_encrypted_keys_active
+  on encrypted_wallet_keys (active);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table encrypted_wallet_keys enable row level security;
+
+drop policy if exists "Service role full access on encrypted_wallet_keys"
+  on encrypted_wallet_keys;
+create policy "Service role full access on encrypted_wallet_keys"
+  on encrypted_wallet_keys
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table encrypted_wallet_keys from anon, authenticated;


### PR DESCRIPTION
## Problem

`keyManagementService.js` reads/writes `encrypted_wallet_keys` — a table documented in `docs/secure-key-management.md` but never created by any migration or `docs/supabase_setup.sql`. Every key-store/retrieve/revoke call fails with `PGRST202`, so encrypted wallet keys are never persisted.

## Fix

- Add a migration creating `encrypted_wallet_keys` exactly as documented (key_id PK, user_id FK → profiles, wallet_address, encrypted_key jsonb, device_id, version/active defaults, created_at/last_used_at/archived_at/archive_reason, user/wallet + active indexes) with service-role-only RLS.
- Switch `keyManagementService.js` DB access to `(supabaseAdmin || supabase)`.

## Files changed

- `supabase/migrations/20260811030000_create_encrypted_wallet_keys_table.sql`
- `backend/api/src/services/security/keyManagementService.js`

## Testing

- `node --check` passes on `keyManagementService.js`.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9544
