### PR TITLE
fix(security): create wallet_locks/anomaly_log tables

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -1,6 +1,6 @@
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const ANOMALY_THRESHOLDS = {
@@ -277,7 +277,7 @@ class AnomalyDetectionService {
 
   async logAnomalies(userId, walletAddress, anomalies) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('anomaly_log')
         .insert([{
           user_id: userId,
@@ -315,7 +315,7 @@ class AnomalyDetectionService {
 
   async lockAccount(userId, walletAddress, reason, anomalies) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('wallet_locks')
         .insert([{
           user_id: userId,
@@ -334,7 +334,7 @@ class AnomalyDetectionService {
 
   async unlockAccount(userId, walletAddress) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('wallet_locks')
         .update({ unlocked_at: new Date().toISOString() })
         .eq('user_id', userId)

--- a/supabase/migrations/20260811040000_create_wallet_locks_and_anomaly_log_tables.sql
+++ b/supabase/migrations/20260811040000_create_wallet_locks_and_anomaly_log_tables.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- Migration: create wallet_locks and anomaly_log tables
+-- =============================================================================
+-- Problem:
+--   AnomalyDetectionService (backend/api/src/services/security/
+--   anomalyDetectionService.js) writes to two Supabase tables — wallet_locks
+--   and anomaly_log — that are documented in docs/secure-key-management.md but
+--   never created by any migration. Every lock/unlock call errors with PGRST202
+--   and the error is swallowed by catch blocks, so account auto-lock after
+--   detected anomalies never persists and the anomaly audit log is never
+--   written.
+--
+-- Fix:
+--   Create both tables and their indexes exactly as documented in
+--   docs/secure-key-management.md. All statements are idempotent so this
+--   migration is safe to run even if a previous migration already created them.
+-- =============================================================================
+
+begin;
+
+create table if not exists anomaly_log (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  wallet_address varchar(255),
+  anomalies jsonb,
+  risk_level varchar(50),
+  detected_at timestamp default now()
+);
+
+create index if not exists idx_anomaly_log_user_wallet on anomaly_log(user_id, wallet_address);
+create index if not exists idx_anomaly_log_risk_level on anomaly_log(risk_level);
+
+create table if not exists wallet_locks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  wallet_address varchar(255),
+  reason varchar(255),
+  anomalies jsonb,
+  locked_at timestamp,
+  locked_until timestamp,
+  unlocked_at timestamp
+);
+
+create index if not exists idx_wallet_locks_user_wallet on wallet_locks(user_id, wallet_address);
+create index if not exists idx_wallet_locks_active on wallet_locks(locked_at, unlocked_at);
+
+alter table anomaly_log enable row level security;
+alter table wallet_locks enable row level security;
+
+drop policy if exists "Service role full access on anomaly_log" on anomaly_log;
+create policy "Service role full access on anomaly_log"
+  on anomaly_log for all
+  to service_role
+  using (true) with check (true);
+
+drop policy if exists "Service role full access on wallet_locks" on wallet_locks;
+create policy "Service role full access on wallet_locks"
+  on wallet_locks for all
+  to service_role
+  using (true) with check (true);
+
+revoke all on anomaly_log from anon, authenticated;
+revoke all on wallet_locks from anon, authenticated;
+
+commit;


### PR DESCRIPTION
## Problem

`anomalyDetectionService.js` writes to `wallet_locks` and `anomaly_log` — two tables documented in `docs/secure-key-management.md` but never created by any migration or `docs/supabase_setup.sql`. Every lock/unlock call fails with `PGRST202` and the error is swallowed, so account auto-lock after detected anomalies never persists and the anomaly audit log is never written.

## Fix

- Add a migration creating `wallet_locks` and `anomaly_log` with the documented columns/indexes and service-role-only RLS (anon/authenticated revoked).
- Switch the service's writes to `(supabaseAdmin || supabase)`.

## Files changed

- `supabase/migrations/20260811040000_create_wallet_locks_and_anomaly_log_tables.sql`
- `backend/api/src/services/security/anomalyDetectionService.js`

## Testing

- `node --check` passes.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9547
