### PR TITLE
fix(blockchain): create state divergence tables

### DIFF
--- a/backend/api/src/services/blockchain/stateDivergenceDetector.js
+++ b/backend/api/src/services/blockchain/stateDivergenceDetector.js
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import crypto from 'crypto';
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
-import { supabase } from '../../config/db.js';
+import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
 const FINALITY_THRESHOLD = 100; // Blocks after which transaction is considered finalized
@@ -164,7 +164,7 @@ class StateDivergenceDetector {
 
   async logDivergence(divergenceId, divergenceResult) {
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('blockchain_divergence_log')
         .insert([{
           divergence_id: divergenceId,
@@ -205,7 +205,7 @@ class StateDivergenceDetector {
       try {
         logger.warn('[StateDivergenceDetector] Triggering state reconciliation from block:', canonicalState.blockNumber);
 
-        await supabase
+        await (supabaseAdmin || supabase)
           .from('blockchain_reconciliation_jobs')
           .insert([{
             status: 'pending',
@@ -285,7 +285,7 @@ class StateDivergenceDetector {
         status: 'in_progress',
       };
 
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('state_reconciliations')
         .insert([reconciliation]);
 
@@ -317,7 +317,7 @@ class StateDivergenceDetector {
     divergence.resolutionDetails = resolutionDetails;
 
     try {
-      await supabase
+      await (supabaseAdmin || supabase)
         .from('blockchain_divergence_log')
         .update({
           resolved: true,

--- a/supabase/migrations/20260811050000_create_state_divergence_tables.sql
+++ b/supabase/migrations/20260811050000_create_state_divergence_tables.sql
@@ -1,0 +1,84 @@
+-- =============================================================================
+-- Migration: create state divergence reconciliation tables
+-- =============================================================================
+-- Problem:
+--   StateDivergenceDetector (backend/api/src/services/blockchain/
+--   stateDivergenceDetector.js) reads and writes three Supabase tables —
+--   blockchain_divergence_log, blockchain_reconciliation_jobs and
+--   state_reconciliations — that are documented in
+--   docs/state-divergence-detection.md but never created by any migration.
+--   Every divergence check errors with PGRST202, so on-chain vs DB divergence
+--   is never detected or reconciled.
+--
+-- Fix:
+--   Create the three tables and their indexes exactly as documented in
+--   docs/state-divergence-detection.md. All statements are idempotent so this
+--   migration is safe to run even if a previous migration already created them.
+-- =============================================================================
+
+begin;
+
+create table if not exists blockchain_divergence_log (
+  divergence_id varchar(255) primary key,
+  severity varchar(50),
+  block_divergence int,
+  node_states jsonb,
+  canonical_state jsonb,
+  detected_at timestamp,
+  resolved boolean default false,
+  resolved_at timestamp,
+  resolution_details jsonb
+);
+
+create index if not exists idx_divergence_log_severity on blockchain_divergence_log(severity);
+create index if not exists idx_divergence_log_detected_at on blockchain_divergence_log(detected_at);
+
+create table if not exists blockchain_reconciliation_jobs (
+  id uuid primary key default gen_random_uuid(),
+  status varchar(50),
+  source_block_number int,
+  canonical_state jsonb,
+  result jsonb,
+  created_at timestamp,
+  completed_at timestamp
+);
+
+create index if not exists idx_reconciliation_jobs_status on blockchain_reconciliation_jobs(status);
+
+create table if not exists state_reconciliations (
+  reconciliation_id varchar(255) primary key,
+  old_state jsonb,
+  new_state jsonb,
+  block_number_difference int,
+  initiated_at timestamp,
+  completed_at timestamp,
+  status varchar(50)
+);
+
+alter table blockchain_divergence_log enable row level security;
+alter table blockchain_reconciliation_jobs enable row level security;
+alter table state_reconciliations enable row level security;
+
+drop policy if exists "Service role full access on blockchain_divergence_log" on blockchain_divergence_log;
+create policy "Service role full access on blockchain_divergence_log"
+  on blockchain_divergence_log for all
+  to service_role
+  using (true) with check (true);
+
+drop policy if exists "Service role full access on blockchain_reconciliation_jobs" on blockchain_reconciliation_jobs;
+create policy "Service role full access on blockchain_reconciliation_jobs"
+  on blockchain_reconciliation_jobs for all
+  to service_role
+  using (true) with check (true);
+
+drop policy if exists "Service role full access on state_reconciliations" on state_reconciliations;
+create policy "Service role full access on state_reconciliations"
+  on state_reconciliations for all
+  to service_role
+  using (true) with check (true);
+
+revoke all on blockchain_divergence_log from anon, authenticated;
+revoke all on blockchain_reconciliation_jobs from anon, authenticated;
+revoke all on state_reconciliations from anon, authenticated;
+
+commit;


### PR DESCRIPTION
## Problem

`stateDivergenceDetector.js` reads/writes `blockchain_divergence_log`, `blockchain_reconciliation_jobs`, and `state_reconciliations` — three tables documented in `docs/state-divergence-detection.md` but never created by any migration or `docs/supabase_setup.sql`. Every divergence check fails with `PGRST202`, so on-chain vs DB divergence is never detected or reconciled.

## Fix

- Add a migration creating the three tables with their documented columns/indexes and service-role-only RLS (anon/authenticated revoked).
- Switch the service's writes to `(supabaseAdmin || supabase)`.

## Files changed

- `supabase/migrations/20260811050000_create_state_divergence_tables.sql`
- `backend/api/src/services/blockchain/stateDivergenceDetector.js`

## Testing

- `node --check` passes.
- Unit suite not runnable in this environment (vitest not installed).

Closes #9550
