### PR TITLE
fix(customer): unwrap nested profile in home screen

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -81,8 +81,11 @@ class _HomeScreenState extends State<HomeScreen> {
         _orderService.fetchHistoryOrders(),
       ]);
       if (!mounted) return;
-      final profile = results[0] is Map<String, dynamic>
+      final profileResponse = results[0] is Map<String, dynamic>
           ? results[0] as Map<String, dynamic>
+          : <String, dynamic>{};
+      final profile = profileResponse['profile'] is Map<String, dynamic>
+          ? profileResponse['profile'] as Map<String, dynamic>
           : <String, dynamic>{};
       final orders = results[1] is List
           ? List<Map<String, dynamic>>.from(results[1] as List)
@@ -94,9 +97,7 @@ class _HomeScreenState extends State<HomeScreen> {
           : <Map<String, dynamic>>[];
 
       setState(() {
-        _customerName =
-            (profile['full_name']?.toString() ?? profile['name']?.toString() ?? '')
-                .trim();
+        _customerName = (profile['fullName']?.toString() ?? '').trim();
         _activeOrders = orders;
         _customerStats = stats;
         _usualRoutes = _computeUsualRoutes(history);


### PR DESCRIPTION
## Problem

The customer home screen assumed `profileResponse['profile']` was the profile object and read `_customerName` from `profileResponse['fullName']`. The API returns the profile nested under `profile`, so the driver name was always null/blank on the home screen.

## Fix

Unwrap `profileResponse['profile']` once and read `_customerName` from `profile['fullName']` (camelCase). The stats fields (`totalSaved`/`totalOrders`) were already read from the correct shape and are unchanged.

## Files changed

- `apps/customer/lib/screens/home_screen.dart`

## Testing

- Verified against the API response shape (`profile` → `fullName`).

Closes #9553
