### PR TITLE
fix(otel): add prometheus config referenced by compose

### DIFF
--- a/backend/otel/prometheus.yml
+++ b/backend/otel/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
## Problem

The docker-compose stack mounts `backend/otel/prometheus.yml` into the Prometheus container, but the file does not exist in the repository. `docker compose up` fails to start Prometheus because the bind mount source is missing.

## Fix

Add `backend/otel/prometheus.yml` with a minimal config: global 15s scrape interval and a self-scrape job for Prometheus.

## Files changed

- `backend/otel/prometheus.yml`

## Testing

- Config parses as valid YAML and matches the compose bind-mount path.

Closes #9555
