### PR TITLE
fix(orders): remove duplicate escrow_status key

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -736,7 +736,6 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
 
     const { data: updatedData, error: updateErr } = await orderRepository.updateOrderWithFilter(orderId, {
       escrow_status: 'funded',
-      escrow_status: 'funded',
     }, [{ op: 'eq', column: 'escrow_status', value: 'funding' }], 'id');
 
     if (updateErr) {


### PR DESCRIPTION
## Problem

The confirm-deposit handler in `orderRoutes.js` sets `escrow_status: 'funded'` twice in the same update object. The duplicate object key is silently dropped (the second occurrence wins in JS), which is fragile and confusing, and a linter catches it as a syntax-level defect.

## Fix

Remove the duplicate `escrow_status: 'funded'` key from the update payload.

## Files changed

- `backend/api/src/routes/orderRoutes.js`

## Testing

- `node --check` passes.

Closes #9556
