### PR TITLE
fix(api): enforce ownership on GET /api/ml/eta (IDOR)

### DIFF
--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -54,7 +54,7 @@ router.get('/eta', authenticate, userLimiter, async (req, res) => {
     if (trip.order_id) {
       const { data: orderRes, error: orderErr } = await supabaseAdmin
         .from('orders')
-        .select('pickup_lat, pickup_lng, drop_lat, drop_lng')
+        .select('pickup_lat, pickup_lng, drop_lat, drop_lng, customer_id, driver_id')
         .eq('id', trip.order_id)
         .maybeSingle();
 
@@ -67,6 +67,14 @@ router.get('/eta', authenticate, userLimiter, async (req, res) => {
 
     if (!order || !order.drop_lat || !order.drop_lng) {
       return res.status(422).json({ error: 'Trip has no destination coordinates for ETA.' });
+    }
+
+    if (req.user.role !== 'admin') {
+      const isOwner =
+        order.customer_id === req.user.id || order.driver_id === req.user.id;
+      if (!isOwner) {
+        return res.status(404).json({ error: 'Trip not found.' });
+      }
     }
 
     const currentLat = parseCoord(lat, -90, 90);


### PR DESCRIPTION
## Problem

`GET /api/ml/eta` resolves any trip by primary key or display id and returns the remaining-route distance and a live ETA derived from the linked order's pickup/drop coordinates — with no ownership or authorization check. Any authenticated user can enumerate `tripId` values and retrieve route geometry and travel-time predictions for trips that belong to other customers/drivers (IDOR).

## Fix

After resolving the trip's linked order, the caller must now be the order's customer or the assigned driver (admins are allowed). Any other caller receives a `404`, matching the anti-enumeration pattern used elsewhere in the codebase. The order lookup now also selects `customer_id` and `driver_id` for the ownership check.

## Files changed

- `backend/api/src/routes/mlRoutes.js`

## Testing

- `node --check backend/api/src/routes/mlRoutes.js` passes.
- Ownership logic verified against the existing pattern used in `backend/api/src/routes/tripRoutes.js` (`orders.customer_id === req.user.id` / `orders.driver_id === req.user.id`).
- A caller who is neither the linked order's customer nor driver (and not an admin) now receives `404` instead of the victim's ETA/route data.

Closes #9603
