### PR TITLE
fix: fix/issue-9588-order-owner-policy-resolver

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -826,7 +826,7 @@ router.post('/predict-demand', authenticate, userLimiter, requirePolicy('order:p
  *               $ref: '#/components/schemas/DriverLocationResponse'
  */
 router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-driver-location', async (req) => {
-  const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
+  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
   return { order };
 }), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
@@ -898,7 +898,7 @@ router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, 
  *               $ref: '#/components/schemas/OrderRouteResponse'
  */
 router.get('/:id/route', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-route', async (req) => {
-  const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
+  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
   return { order };
 }), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
@@ -1164,7 +1164,7 @@ router.get('/my/history', authenticate, userLimiter, requirePolicy('order:view-h
 
 // GET /api/orders/:id/timeline
 router.get('/:id/timeline', authenticate, userLimiter, requirePolicy('order:view-timeline', async (req) => {
-  const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
+  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
   return { order };
 }), validateParams(paramIdSchema), async (req, res) => {
   try {
@@ -1181,7 +1181,7 @@ router.get('/:id/timeline', authenticate, userLimiter, requirePolicy('order:view
 
 // GET /api/orders/:id
 router.get('/:id', authenticate, userLimiter, requirePolicy('order:view', async (req) => {
-  const { data: order } = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
+  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
   return { order };
 }), validateParams(paramIdSchema), async (req, res) => {
   try {


### PR DESCRIPTION
## Problem

`GET /api/orders/:id/driver-location`, `GET /api/orders/:id/route`, `GET /api/orders/:id/timeline` and `GET /api/orders/:id` always return **403 for the legitimate owner** (only admins pass). Their `requirePolicy` resource resolvers destructure `{ data: order }` from `orderValidationService.findOrderByIdOrDisplayId`, but that method returns a **plain row** (or `null`) — not a `{ data, error }` envelope. Destructuring `data` yields `order === undefined`, so the resource becomes `{ order: undefined }`, the ownership rule in `policyEngine.js` (`r?.order && ...`) short-circuits, and every non-admin is denied.

## Fix

Stop destructuring the plain-row result in the four policy resolvers so the real order row is passed to `requirePolicy`:

```js
const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
return { order };
```

The inline handler bodies already used the correct (non-destructured) form.

## Files changed

- `backend/api/src/routes/orderRoutes.js` (4 policy resolvers)

## Testing

- Verified `orderValidationService.findOrderByIdOrDisplayId` returns a plain row/null (orderValidationService.js) and matches the non-destructured call sites at lines 834/907.
- `node --check` passes on the modified file (no new syntax issues).

Closes #9588
