### PR TITLE
fix: fix/issue-9589-driver-truck-insert-name

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1868,6 +1868,7 @@ router.put('/truck', authenticate, userLimiter, requireDriverRole, async (req, r
         .from('trucks')
         .insert({
           driver_id: req.user.id,
+          name: type,
           truck_type: type,
           max_capacity_tons: capacityWeight || 0,
           number_plate: registrationNumber


### PR DESCRIPTION
## Problem

The truck **insert** path in `PUT /api/driver/truck` omits the NOT NULL column `name` (and previously wrote phantom columns `capacity_weight_tonnes`/`capacity_volume_m3`/`registration_number`/`is_active`). The `trucks` DDL (`docs/supabase_setup.sql`) defines `name text not null`, so creating a truck when the driver has no assigned truck fails with `23502` (null value in column "name") even though the four phantom columns were already corrected to the real ones (`max_capacity_tons`, `number_plate`) in a prior fix.

## Fix

Include the required `name` column on truck insert, using the truck type as the display name (the request body has no separate name field):

```js
.insert({
  driver_id: req.user.id,
  name: type,
  truck_type: type,
  max_capacity_tons: capacityWeight || 0,
  number_plate: registrationNumber
})
```

## Files changed

- `backend/api/src/routes/driverRoutes.js`

## Testing

- Confirmed `name` and `number_plate` are the only NOT NULL columns in the `trucks` DDL besides `driver_id`/`truck_type` (which the insert already supplies).
- `node --check` passes.

Closes #9589
