### PR TITLE
fix: fix/issue-9590-did-multibase-key

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -4,6 +4,31 @@ import crypto from 'crypto';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
 
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58btc(input) {
+    const bytes = Buffer.isBuffer(input) ? input : Buffer.from(input);
+    let zeros = 0;
+    while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+    let digits = [0];
+    for (const byte of bytes) {
+        let carry = byte;
+        for (let i = 0; i < digits.length; i++) {
+            carry += digits[i] << 8;
+            digits[i] = carry % 58;
+            carry = (carry / 58) | 0;
+        }
+        while (carry > 0) {
+            digits.push(carry % 58);
+            carry = (carry / 58) | 0;
+        }
+    }
+    let output = '';
+    for (let i = 0; i < zeros; i++) output += '1';
+    for (let i = digits.length - 1; i >= 0; i--) output += BASE58_ALPHABET[digits[i]];
+    return output;
+}
+
 class DIDService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
@@ -64,10 +89,10 @@ class DIDService {
             if (!publicKeyMultibase) {
                 const keyPair = crypto.generateKeyPairSync('rsa', {
                     modulusLength: 2048,
-                    publicKeyEncoding: { type: 'spki', format: 'pem' },
+                    publicKeyEncoding: { type: 'spki', format: 'der' },
                     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
                 });
-                publicKeyMultibase = Buffer.from(keyPair.publicKey).toString('base64');
+                publicKeyMultibase = `z${base58btc(keyPair.publicKey)}`;
                 privateKey = Buffer.from(keyPair.privateKey).toString('base64');
             }
             await this.addVerificationMethod(did, 'key-1', 'RsaVerificationKey2018', did, publicKeyMultibase);


### PR DESCRIPTION
## Problem

`DIDService.createDID` fabricates the verification-method key as **base64 of the PEM text**, not a **multibase**-encoded public key, and registers it against the contract ABI parameter named `publicKeyMultibase`. Since `keyPair.publicKey` is a PEM string, `Buffer.from(keyPair.publicKey).toString('base64')` is a doubly-encoded value with no multibase prefix (`z`/`m`/`u`/...). Conformant DID resolvers cannot decode the verification method, so DID/credential verification fails.

## Fix

Generate the RSA key with the public key as raw **SPKI/DER** bytes and encode them as **base58btc** with the multibase `z` prefix:

```js
const keyPair = crypto.generateKeyPairSync('rsa', {
    modulusLength: 2048,
    publicKeyEncoding: { type: 'spki', format: 'der' },
    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
});
publicKeyMultibase = `z${base58btc(keyPair.publicKey)}`;
```

A small self-contained `base58btc` encoder is added to the module (no new dependency).

## Files changed

- `backend/did/did.service.js`

## Testing

- `node --check` passes.
- Generated output format is `z` + base58btc of the raw SPKI bytes, i.e. a real multibase value as the ABI parameter name implies.

Closes #9590
