### PR TITLE
fix: fix/issue-9591-trace-shipment-owner-columns

### DIFF
--- a/supabase/migrations/20260811000000_add_trace_shipment_owner_columns.sql
+++ b/supabase/migrations/20260811000000_add_trace_shipment_owner_columns.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- TRACEABILITY — Shipment Owner Columns
+-- ============================================================================
+-- `TraceabilityService.verifyShipmentOwnership` selects `user_id` and
+-- `allowed_users` from `trace_shipments` (backend/traceability/trace.service.js)
+-- as a DB-level ownership fallback. The original traceability migration
+-- (20260806040000_create_traceability_tables.sql) never created those columns,
+-- so the select errored and the fallback silently denied every non-admin.
+-- This migration adds them, keeping the table aligned with the select shape.
+-- ============================================================================
+
+alter table trace_shipments
+  add column if not exists user_id       text,    -- verifyShipmentOwnership: dbShipment.user_id
+  add column if not exists allowed_users jsonb not null default '[]'::jsonb; -- verifyShipmentOwnership: dbShipment.allowed_users


### PR DESCRIPTION
## Problem

`TraceabilityService.isShipmentOwner` selects `user_id` and `allowed_users` from the `trace_shipments` table, but those columns have **no DDL anywhere** in the repo. The `trace_shipments` table created by `supabase/migrations/20260806040000_create_traceability_tables.sql` only defines `shipment_id, product_id, receiver, location, status, tx_hash, updated_tx_hash, created_at, updated_at`. The select therefore errors and the DB-level ownership fallback silently never grants access.

## Fix

Add the two missing columns to `trace_shipments` via a new idempotent migration so the ownership select no longer fails:

```sql
alter table trace_shipments
  add column if not exists user_id       text,
  add column if not exists allowed_users jsonb not null default '[]'::jsonb;
```

## Files changed

- `supabase/migrations/20260811000000_add_trace_shipment_owner_columns.sql` (new)

## Testing

- Migration is idempotent (`add column if not exists`) and matches the select shape in `trace.service.js:388-392`.
- `storeShipment`/`updateShipmentInDB` writes remain unaffected.

Closes #9591
