### PR TITLE
fix: fix/issue-9594-mev-tables-migration

### DIFF
--- a/supabase/migrations/20260811000002_create_mev_tables.sql
+++ b/supabase/migrations/20260811000002_create_mev_tables.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- MEV PROTECTION — Commitment / Escrow / Flashbots Bundle Tables
+-- ============================================================================
+-- The MEV module (backend/mev/mev.service.js) persists commitments, MEV
+-- protected escrows and Flashbots bundle submissions into `mev_commitments`,
+-- `mev_escrows` and `flashbots_bundles`, and reads them back for stats. No
+-- migration previously created any of them, so every operation failed with
+-- `relation ... does not exist`. This migration creates all three tables with
+-- columns matching the inserts, updates and selects in mev.service.js.
+--
+-- SECURITY MODEL:
+--   - Written by backend services using service_role credentials and never
+--     exposed directly to clients, so RLS allows service_role only.
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. MEV COMMITMENTS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists mev_commitments (
+  id          bigint generated always as identity primary key,
+  user_id     text,                      -- storeCommitment: data.userId
+  secret_hash text,                      -- storeCommitment: data.secretHash
+  tx_hash     text,                      -- storeCommitment: data.txHash
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_mev_commitments_user_id
+  on mev_commitments (user_id);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. MEV ESCROWS TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists mev_escrows (
+  escrow_id         text not null,       -- storeEscrow: data.escrowId
+  customer          text,                -- storeEscrow: data.customer
+  driver            text,                -- storeEscrow: data.driver
+  amount            text,                -- storeEscrow: data.amount
+  commit_hash       text,                -- storeEscrow: data.commitHash
+  secret_hash       text,                -- storeEscrow: data.secretHash
+  tx_hash           text,                -- storeEscrow: data.txHash
+  status            text not null default 'pending', -- storeEscrow: status / updateEscrowStatus
+  released_tx_hash  text,                -- updateEscrowStatus: released_tx_hash
+  released_at       timestamptz,         -- updateEscrowStatus: released_at
+  created_at        timestamptz not null default now(),
+  primary key (escrow_id)
+);
+
+create index if not exists idx_mev_escrows_driver
+  on mev_escrows (driver);
+
+create index if not exists idx_mev_escrows_status
+  on mev_escrows (status);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. FLASHBOTS BUNDLES TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists flashbots_bundles (
+  id           bigint generated always as identity primary key,
+  escrow_id    text,                     -- storeBundle: data.escrowId
+  bundle_id    text,                     -- storeBundle: data.bundleId
+  block_number text,                     -- storeBundle: data.blockNumber
+  submitted_at timestamptz not null default now(), -- storeBundle: submitted_at
+  constraint fk_flashbots_bundles_escrow
+    foreign key (escrow_id)
+    references mev_escrows (escrow_id)
+    on delete set null
+);
+
+create index if not exists idx_flashbots_bundles_escrow_id
+  on flashbots_bundles (escrow_id);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table mev_commitments enable row level security;
+alter table mev_escrows enable row level security;
+alter table flashbots_bundles enable row level security;
+
+drop policy if exists "Service role full access on mev_commitments" on mev_commitments;
+create policy "Service role full access on mev_commitments"
+  on mev_commitments
+  for all to service_role
+  using (true)
+  with check (true);
+
+drop policy if exists "Service role full access on mev_escrows" on mev_escrows;
+create policy "Service role full access on mev_escrows"
+  on mev_escrows
+  for all to service_role
+  using (true)
+  with check (true);
+
+drop policy if exists "Service role full access on flashbots_bundles" on flashbots_bundles;
+create policy "Service role full access on flashbots_bundles"
+  on flashbots_bundles
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table mev_commitments from anon, authenticated;
+revoke all on table mev_escrows from anon, authenticated;
+revoke all on table flashbots_bundles from anon, authenticated;


### PR DESCRIPTION
## Problem

The MEV service (`backend/mev/mev.service.js`) queries `mev_commitments`, `mev_escrows` and `flashbots_bundles` — **no DDL exists anywhere** in the repo (no migration file, no `supabase_setup.sql` section). Every MEV operation (commitment, escrow storage, bundle persistence, stats) fails with `PGRST301/PGRST204` at the database layer, so the subsystem is inert.

## Fix

Add a migration creating the three tables with columns matching the insert/update/select shapes used in `mev.service.js`:

- `mev_commitments`: identity `id`, `user_id`, `secret_hash`, `tx_hash`, `created_at`
- `mev_escrows`: `escrow_id` (PK), `customer`, `driver`, `amount`, `commit_hash`, `secret_hash`, `tx_hash`, `status`, `released_tx_hash`, `released_at`, `created_at`
- `flashbots_bundles`: identity `id`, `escrow_id` (FK), `bundle_id`, `block_number`, `submitted_at`

Follows the security model of the existing zkid/traceability migrations (service_role only + RLS).

## Files changed

- `supabase/migrations/20260811000002_create_mev_tables.sql` (new)

## Testing

- Columns verified against every `mev.service.js` `.insert/.update/.select` call.
- SQL is idempotent (`create table if not exists`).

Closes #9594
