### PR TITLE
fix: fix/issue-9598-swap-stats-route-order

### DIFF
--- a/backend/atomic-swap/routes.js
+++ b/backend/atomic-swap/routes.js
@@ -129,6 +129,17 @@ router.post('/swap/cross-chain/refund', async (req, res) => {
     }
 });
 
+// Get stats
+router.get('/swap/stats', async (req, res) => {
+    try {
+        const stats = await swapService.getSwapStats();
+        res.json({ success: true, data: stats });
+    } catch (error) {
+        logger.error('Stats error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+});
+
 // Get swap
 router.get('/swap/:swapId', async (req, res) => {
     try {
@@ -149,17 +160,6 @@ router.get('/swap/cross-chain/:swapId', async (req, res) => {
         res.json({ success: true, data: swap });
     } catch (error) {
         logger.error('Cross-chain swap fetch error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Get stats
-router.get('/swap/stats', async (req, res) => {
-    try {
-        const stats = await swapService.getSwapStats();
-        res.json({ success: true, data: stats });
-    } catch (error) {
-        logger.error('Stats error:', error);
         res.status(500).json({ success: false, error: error.message });
     }
 });


### PR DESCRIPTION
## Problem

`GET /api/swap/stats` is declared **after** `GET /api/swap/:swapId` in `backend/atomic-swap/routes.js`. Express matches routes in declaration order, so `/stats` is swallowed by `/:swapId` (`req.params.swapId === 'stats'`), the swap lookup fails, and the endpoint returns a lookup error instead of aggregate stats. The issue's body text was additionally mangled by route-order bugs in the spec, but the fix is the classic specificity-ordering problem.

## Fix

Move `GET /swap/stats` above `GET /swap/:swapId` so Express evaluates the literal path first.

## Files changed

- `backend/atomic-swap/routes.js`

## Testing

- `node --check` passes.
- `GET /api/swap/stats` now hits the stats handler; `GET /api/swap/:swapId` still matches real swap ids.

Closes #9598
