### PR TITLE
fix: fix/issue-9602-mount-orphan-routers

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -75,6 +75,15 @@ import oracleRoutes from './routes/oracleRoutes.js'
 import blockchainMonitoringRoutes from './routes/blockchainMonitoringRoutes.js'
 
 // ============================================================================
+// 🆕 WEB3 SUBSYSTEM ROUTES
+// ============================================================================
+import zkidRoutes from '../../zkid/routes.js'
+import daoRoutes from '../../dao/routes.js'
+import mevRoutes from '../../mev/routes.js'
+import tokenizationRoutes from '../../tokenization/routes.js'
+import atomicSwapRoutes from '../../atomic-swap/routes.js'
+
+// ============================================================================
 // 🆕 GEOGRAPHIC SHARDING ROUTES
 // ============================================================================
 import trackingRoutes from './routes/trackingRoutes.js'
@@ -504,6 +513,17 @@ app.use('/api/v1/voice', voiceAssistantRoutes)
 app.use('/api/demand-heatmap', demandRoutes)
 app.use('/api/road-conditions', roadConditionRoutes)
 app.use('/api/escorts/wallet', escortWalletRoutes)
+
+// ============================================================================
+// 🆕 WEB3 SUBSYSTEM ROUTES
+// Each router already declares its own full path prefix (e.g. `/zkid/...`,
+// `/swap/...`), so they are mounted on the `/api` base only.
+// ============================================================================
+app.use('/api', zkidRoutes)
+app.use('/api', daoRoutes)
+app.use('/api', mevRoutes)
+app.use('/api', tokenizationRoutes)
+app.use('/api', atomicSwapRoutes)
 
 // ============================================================================
 // WEBHOOK ROUTES


### PR DESCRIPTION
## Problem

Five routers are defined but never mounted, so all of their endpoints 404:

- `backend/zkid/routes.js` (declares `/zkid/*`)
- `backend/dao/routes.js` (declares `/dao/*`)
- `backend/mev/routes.js` (declares `/mev/*`)
- `backend/tokenization/routes.js` (declares `/tokenization/*`)
- `backend/atomic-swap/routes.js` (declares `/swap/*`)

`backend/api/src/index.js` has no reference to any of them, while the rest of the API (orders, users, auth, escrow, etc.) is served from this app.

## Fix

Mount the five routers under `/api` in `backend/api/src/index.js`. Because each router already declares its full prefix (`/zkid/...`, `/dao/...`, `/mev/...`, `/tokenization/...`, `/swap/...`), they are mounted directly rather than double-prefixed:

```js
const zkidRoutes = require('../../zkid/routes');
const daoRoutes = require('../../dao/routes');
const mevRoutes = require('../../mev/routes');
const tokenizationRoutes = require('../../tokenization/routes');
const atomicSwapRoutes = require('../../atomic-swap/routes');

app.use('/api', zkidRoutes);
app.use('/api', daoRoutes);
app.use('/api', mevRoutes);
app.use('/api', tokenizationRoutes);
app.use('/api', atomicSwapRoutes);
```

## Files changed

- `backend/api/src/index.js`

## Testing

- `node --check` passes.
- Router files each export an Express router and their `app.<verb>('/...')` prefixes line up with the `/api` mount (no prefix collision with existing routes, e.g. `/api/swap/stats` vs `/api/orders/...`).

Closes #9602
