### PR TITLE
fix(api): validate lat/lng on GET /api/ml/eta

### DIFF
--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -71,12 +71,28 @@ router.get('/eta', authenticate, userLimiter, async (req, res) => {
 
     const currentLat = parseCoord(lat, -90, 90);
     const currentLng = parseCoord(lng, -180, 180);
-    const hasLivePosition =
-      currentLat !== null && currentLng !== null;
 
-    const distanceKm = hasLivePosition
-      ? haversineKm(currentLat, currentLng, Number(order.drop_lat), Number(order.drop_lng))
-      : haversineKm(Number(order.pickup_lat), Number(order.pickup_lng), Number(order.drop_lat), Number(order.drop_lng));
+    const latProvided = lat !== undefined && lat !== null && lat !== '';
+    const lngProvided = lng !== undefined && lng !== null && lng !== '';
+
+    if (latProvided !== lngProvided) {
+      return res.status(400).json({ error: 'Both lat and lng must be provided together.' });
+    }
+
+    let positionSource = 'pickup';
+    let distanceKm;
+    if (latProvided) {
+      if (currentLat === null || currentLng === null) {
+        return res.status(400).json({ error: 'Invalid lat/lng: lat must be within [-90, 90] and lng within [-180, 180].' });
+      }
+      if (currentLat === 0 && currentLng === 0) {
+        return res.status(422).json({ error: 'lat/lng at (0,0) is not a valid live position.' });
+      }
+      positionSource = 'live';
+      distanceKm = haversineKm(currentLat, currentLng, Number(order.drop_lat), Number(order.drop_lng));
+    } else {
+      distanceKm = haversineKm(Number(order.pickup_lat), Number(order.pickup_lng), Number(order.drop_lat), Number(order.drop_lng));
+    }
 
     const now = new Date();
     const routeType = distanceKm > 20 ? 'highway' : 'city';
@@ -97,6 +113,7 @@ router.get('/eta', authenticate, userLimiter, async (req, res) => {
         distance_km: Math.round(distanceKm * 100) / 100,
         route_type: routeType,
         source: 'ml',
+        position_source: positionSource,
       });
     } catch (mlErr) {
       logger.warn('[MlEta] ML ETA prediction failed:', mlErr.message);


### PR DESCRIPTION
## Problem

`GET /api/ml/eta` silently ignores invalid, missing, or out-of-range `lat`/`lng` query parameters and computes the ETA from the trip's **pickup** coordinates instead — and also accepts the `(0,0)` sentinel as a "valid" live position. Callers receive a normal-looking `200` with a misleading ETA and no indication that their live position was rejected.

## Fix

- `lat`/`lng` must be provided together; a partially supplied pair returns `400`.
- Present-but-invalid coordinates (non-finite or out of range: `lat` ∉ [-90,90], `lng` ∉ [-180,180]) return `400`.
- The `(0,0)` sentinel is rejected with `422` as a plausibility failure.
- The response now includes `position_source: 'live' | 'pickup'` so callers can distinguish a live-position estimate from the pickup-coordinate fallback. The existing `source: 'ml'` field (ETA computation method) is preserved.

## Files changed

- `backend/api/src/routes/mlRoutes.js`

## Testing

- `node --check backend/api/src/routes/mlRoutes.js` passes.
- `lat=notanumber&lng=9.9` → `400`.
- `lat=0&lng=0` → `422`.
- `tripId` only (no lat/lng) → `200` with `position_source: 'pickup'`.
- Valid `lat`/`lng` → `200` with `position_source: 'live'`.

Closes #9607
