### PR TITLE
fix(customer): reconcile offline events orphaned in syncing state

### DIFF
--- a/apps/customer/lib/core/offline/db/offline_event_db.dart
+++ b/apps/customer/lib/core/offline/db/offline_event_db.dart
@@ -94,6 +94,19 @@ class OfflineEventDb {
     );
   }
 
+  /// Resets events left in the transient `syncing` state (e.g. because the app
+  /// was killed mid-upload) back to `pending` so they are re-queued on the next
+  /// sync pass instead of being orphaned forever.
+  Future<int> reconcileStuckSyncing() async {
+    final db = await open();
+    return db.update(
+      _tableName,
+      {'sync_status': 'pending'},
+      where: 'sync_status = ?',
+      whereArgs: ['syncing'],
+    );
+  }
+
   Future<void> markSynced(String id) async {
     final db = await open();
     await db.update(

--- a/apps/customer/lib/core/offline/offline_sync_manager.dart
+++ b/apps/customer/lib/core/offline/offline_sync_manager.dart
@@ -19,6 +19,9 @@ class OfflineSyncManager {
 
   Future<void> init() async {
     await _db.open();
+    // Recover events orphaned in the transient `syncing` state by a previous
+    // run being killed mid-upload; without this they would never be re-queued.
+    await _db.reconcileStuckSyncing();
     await _cacheManager.open();
     _syncEngine = SyncEngine(db: _db, apiBaseUrl: apiBaseUrl);
     await _syncEngine.startListening();

--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -100,7 +100,15 @@ class SyncEngine {
 
     await _markAsSyncing(resolved);
 
-    final uploadOutcome = await _uploadBatch(resolved);
+    final SyncUploadOutcome uploadOutcome;
+    try {
+      uploadOutcome = await _uploadBatch(resolved);
+    } catch (_) {
+      // An unexpected error during upload must never leave events stuck in the
+      // transient `syncing` state; fall through to failure handling below so
+      // they are re-queued on a later sync pass.
+      uploadOutcome = SyncUploadOutcome.retryableFailure;
+    }
     if (uploadOutcome == SyncUploadOutcome.success) {
       for (final event in resolved) {
         await db.markSynced(event.id);


### PR DESCRIPTION
## Problem

The customer app's `SyncEngine` marks offline events as `syncing` before uploading them, but nothing ever reconciles events left in that state. If the app is killed (force-stopped, crashed, or suspended) during the HTTP upload, the event stays `syncing` forever: `pendingEvents()` only selects `sync_status IN ('pending','failed')`, so the orphan is never re-queued — silent, permanent loss of the offline event.

## Fix

- Added `OfflineEventDb.reconcileStuckSyncing()` which resets any rows still in the transient `syncing` state back to `pending`.
- `OfflineSyncManager.init()` now runs that sweep after opening the DB, so events orphaned by a killed mid-upload run are re-queued on the next sync pass (server-side idempotency makes re-upload safe).
- The `syncing` → outcome transition in `SyncEngine._syncPendingInternal` now falls through to failure handling on unexpected exceptions, so events can never remain stuck in `syncing`.

## Files changed

- `apps/customer/lib/core/offline/db/offline_event_db.dart`
- `apps/customer/lib/core/offline/offline_sync_manager.dart`
- `apps/customer/lib/core/offline/sync/sync_engine.dart`

## Testing

- Existing offline sync tests (`apps/customer/test/core/offline/sync_engine_test.dart`) are unaffected — the new DB method is independent of `pendingEvents()`/`syncPending()`.
- Scenario: event stuck in `syncing` → on next app start `init()` resets it to `pending` → `syncPending()` re-uploads it.

Closes #9606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline synchronization recovery after interrupted uploads.
  * Events stuck during syncing are now returned to the pending queue automatically.
  * Unexpected upload errors are handled as retryable failures, preventing events from remaining stuck.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->