### PR TITLE
fix(supabase): make updated_at server-managed in update_order_and_load_offer

### DIFF
--- a/supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql
+++ b/supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql
@@ -59,7 +59,8 @@ BEGIN
       drop_address = COALESCE(p_order_updates->>'drop_address', drop_address),
       drop_lat     = COALESCE((p_order_updates->>'drop_lat')::NUMERIC, drop_lat),
       drop_lng     = COALESCE((p_order_updates->>'drop_lng')::NUMERIC, drop_lng),
-      updated_at   = COALESCE((p_order_updates->>'updated_at')::TIMESTAMPTZ, updated_at)
+      -- updated_at is a server-managed audit field; never trust client input.
+      updated_at   = NOW()
     WHERE id = p_order_id
     RETURNING row_to_json(orders.*) INTO v_updated_order;
 
@@ -82,7 +83,8 @@ BEGIN
       platform_fee  = COALESCE((p_order_updates->>'platform_fee')::NUMERIC, platform_fee),
       total_amount  = COALESCE((p_order_updates->>'total_amount')::NUMERIC, total_amount),
       escrow_amount_wei = COALESCE(p_order_updates->>'escrow_amount_wei', escrow_amount_wei),
-      updated_at    = COALESCE((p_order_updates->>'updated_at')::TIMESTAMPTZ, updated_at)
+      -- updated_at is a server-managed audit field; never trust client input.
+      updated_at    = NOW()
     WHERE id = p_order_id
     RETURNING row_to_json(orders.*) INTO v_updated_order;
 


### PR DESCRIPTION
## Problem

The change-drop branch of `update_order_and_load_offer` lets an authenticated caller set an arbitrary `updated_at` on their own order: the authenticated UPDATE takes `updated_at` directly from the client-supplied JSON payload instead of the server clock. The same pattern exists in the `service_role` branch. `updated_at` is a server-managed audit field, so any time-based reconciliation, staleness sweep, or "last activity" logic keyed on it can be spoofed.

## Fix

`updated_at` is now set to `NOW()` in both the authenticated and `service_role` branches of `update_order_and_load_offer`, regardless of any client-supplied `updated_at` value.

## Files changed

- `supabase/migrations/20260806000000_rebalance_escrow_amount_wei_on_change_drop.sql`

## Testing

- SQL syntax verified (CREATE OR REPLACE FUNCTION body updated in place).
- Both UPDATE statements now assign `updated_at = NOW()`; the `COALESCE(...->>'updated_at', ...)` pattern is removed for this column.

Closes #9609
