### PR TITLE
fix(api): call append_maintenance_photos with the caller's identity

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { supabase } from '../config/db.js';
+import { supabase, createUserClient } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import {
   validateDocumentBuffer,
@@ -39,6 +39,14 @@ export async function uploadMaintenancePhotos(req, res) {
     if (!driverId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
+
+    // The append_maintenance_photos RPC is SECURITY DEFINER and calls
+    // auth.uid(), so it must be invoked with the caller's JWT attached rather
+    // than through the shared anon client (which would make auth.uid() NULL).
+    if (!req.token) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+    const userClient = createUserClient(req.token);
 
     const { ticketId } = req.params;
     if (!ticketId) {
@@ -166,7 +174,7 @@ export async function uploadMaintenancePhotos(req, res) {
     }
 
     // Atomically append new paths via PostgreSQL RPC to enforce MAX_PHOTOS and prevent race conditions
-    const { error: updateError } = await supabase.rpc('append_maintenance_photos', {
+    const { error: updateError } = await userClient.rpc('append_maintenance_photos', {
       p_ticket_id: ticketId,
       p_new_paths: uploadedPaths,
       p_max_photos: MAX_PHOTOS,


### PR DESCRIPTION
## Problem

`POST /api/maintenance/:ticketId/photos` still cannot persist photo metadata: the controller invokes the `append_maintenance_photos` RPC through the shared anon Supabase client, which carries no user identity. The RPC is `SECURITY DEFINER`, requires `auth.uid()` to be set, and is only executable by the `authenticated` role — so with the anon client every upload reaches the final step, uploads all files, fails the RPC, rolls the files back via `cleanupStorage`, and returns `500`. The feature is completely non-functional.

## Fix

The RPC is now invoked through `createUserClient(req.token)` (the per-request client that attaches the caller's JWT, matching the pattern used in `driverRoutes.js` / `trackingRoutes.js` / `paymentRoutes.js`). `auth.uid()` now resolves to the caller and the `authenticated`-role EXECUTE grant applies, so the RPC's ownership re-verification and atomic `MAX_PHOTOS` cap are reachable. A missing token returns `401` before any upload happens.

## Files changed

- `backend/api/src/controllers/maintenancePhotoController.js`

## Testing

- `node --check backend/api/src/controllers/maintenancePhotoController.js` passes.
- `req.token` is populated by the `authenticate` middleware (`backend/api/src/middleware/auth.js:263`).
- Ownership checks (`ticket.driver_id === driverId`) and storage uploads remain on the shared client; only the identity-dependent RPC call now uses the user client.

Closes #9608
