### PR TITLE
fix(customer): add INTERNET permission to main AndroidManifest

### DIFF
--- a/apps/customer/android/app/src/main/AndroidManifest.xml
+++ b/apps/customer/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="freightfair"
         android:name="${applicationName}"


### PR DESCRIPTION
## Problem

The customer Android app's main `AndroidManifest.xml` declares no `android.permission.INTERNET`, so release APK builds cannot make any network request. The permission only existed in the debug and profile source sets (Flutter template hot-reload boilerplate), which are not merged into release builds — so the app is non-functional in release.

## Fix

Added `<uses-permission android:name="android.permission.INTERNET" />` to the customer app's main manifest (`apps/customer/android/app/src/main/AndroidManifest.xml`).

## Files changed

- `apps/customer/android/app/src/main/AndroidManifest.xml`

## Testing

- Release builds now merge the INTERNET permission from the main manifest; debug/profile builds are unaffected (the permission is already present there).

Closes #9610
