### PR TITLE
fix(driver): add INTERNET permission to main AndroidManifest

### DIFF
--- a/apps/driver/android/app/src/main/AndroidManifest.xml
+++ b/apps/driver/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:label="truxify_driver"


### PR DESCRIPTION
## Problem

The driver Android app's main `AndroidManifest.xml` declares location and audio permissions but **not** `android.permission.INTERNET`. Release APK builds therefore have no network permission and every API call fails at the OS level (`SocketException`). The INTERNET permission existed only in the debug/profile manifests, which release builds do not merge.

## Fix

Added `<uses-permission android:name="android.permission.INTERNET" />` to the driver app's main manifest (`apps/driver/android/app/src/main/AndroidManifest.xml`).

## Files changed

- `apps/driver/android/app/src/main/AndroidManifest.xml`

## Testing

- Release builds now merge the INTERNET permission from the main manifest; debug/profile builds are unaffected.

Closes #9611
