### PR TITLE
fix(apps): permit cleartext HTTP to dev hosts via network security config

### DIFF
--- a/apps/customer/android/app/src/main/AndroidManifest.xml
+++ b/apps/customer/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="freightfair"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/apps/customer/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/customer/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dev-only: permit cleartext HTTP to the documented local/emulator backend
+     hosts. All other traffic keeps the default no-cleartext policy. -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/apps/driver/android/app/src/main/AndroidManifest.xml
+++ b/apps/driver/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
     <application
         android:label="truxify_driver"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/apps/driver/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/driver/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dev-only: permit cleartext HTTP to the documented local/emulator backend
+     hosts. All other traffic keeps the default no-cleartext policy. -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Problem

Both Android apps use plain `http://` API base URLs for the documented local/emulator dev setup (default `http://10.0.2.2:5000` on Android, `http://localhost:5000` otherwise), but neither main manifest allows cleartext HTTP. Since `targetSdk >= 28` (34), Android blocks cleartext by default, so every request to the documented dev/emulator URL fails with "CLEARTEXT communication ... not permitted".

## Fix

Added a `network_security_config.xml` in both apps' `res/xml/` that permits cleartext **only** for the documented dev hosts (`10.0.2.2`, `localhost`), while the `base-config` keeps cleartext disabled for all other hosts so production HTTPS traffic stays restricted. Both main manifests now reference it via `android:networkSecurityConfig="@xml/network_security_config"`.

## Files changed

- `apps/customer/android/app/src/main/AndroidManifest.xml`
- `apps/customer/android/app/src/main/res/xml/network_security_config.xml`
- `apps/driver/android/app/src/main/AndroidManifest.xml`
- `apps/driver/android/app/src/main/res/xml/network_security_config.xml`

## Testing

- Emulator/dev requests to `http://10.0.2.2:5000` / `http://localhost:5000` are now permitted; all other cleartext traffic (and HTTPS) remains governed by the default no-cleartext policy.

Closes #9614
