### PR TITLE
ci(flutter): inject required dart-defines into release build

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -43,7 +43,16 @@ jobs:
       - name: Build APK
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: ${{ matrix.app }}
-        run: flutter build apk --release
+        env:
+          TRUXIFY_API_BASE_URL: ${{ secrets.TRUXIFY_API_BASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          flutter build apk --release \
+            --dart-define=ENV=prod \
+            --dart-define=TRUXIFY_API_BASE_URL=$TRUXIFY_API_BASE_URL \
+            --dart-define=SUPABASE_URL=$SUPABASE_URL \
+            --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
 
       - name: Upload APK Artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

`.github/workflows/flutter-build.yml` builds the release APK with no `--dart-define` flags, so the CI-produced release artifacts crash at startup / first network use:

- **Driver**: `Env.validate()` throws at `main()` because `SUPABASE_ANON_KEY` is empty → app exits before the first frame.
- **Customer**: the first `ApiClient()` construction throws `StateError` in release mode because `TRUXIFY_API_BASE_URL` is empty.

## Fix

Pass the required dart-defines (`ENV`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `TRUXIFY_API_BASE_URL`) to `flutter build apk --release`, sourced from repo secrets via the step `env:` block. Maintainers must configure the secrets:

- `TRUXIFY_API_BASE_URL`
- `SUPABASE_URL`
- `SUPABASE_ANON_KEY`

## Files changed

- `.github/workflows/flutter-build.yml` — inject dart-defines from secrets into the `Build APK` step.

## Testing

Not runnable locally (no Flutter toolchain on this machine). Change is declarative workflow YAML; the `flutter build apk` invocation now matches the pattern documented in `apps/*/README.md` and the root `Makefile`.

Closes #9615
