### PR TITLE
ci(flutter): restore google-services.json before release build

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -40,6 +40,13 @@ jobs:
         working-directory: ${{ matrix.app }}
         run: flutter test
 
+      - name: Restore google-services.json
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: ${{ matrix.app }}
+        shell: bash
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > android/app/google-services.json
+
       - name: Build APK
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: ${{ matrix.app }}


### PR DESCRIPTION
## Problem

`.github/workflows/flutter-build.yml` runs `flutter build apk --release` for both apps, but both apps apply the `com.google.gms.google-services` Gradle plugin, which requires `google-services.json` in the Android module. That file is gitignored (`**/google-services.json`) and the workflow has no step that generates or restores it, so the release build fails at `:app:processReleaseGoogleServices`.

## Fix

Add a `Restore google-services.json` step (before `Build APK`) that decodes a base64-encoded repo secret into `android/app/google-services.json` for the matrix app being built. Maintainers must configure the `GOOGLE_SERVICES_JSON` secret (base64 of the `google-services.json` file, e.g. from `base64 google-services.json`).

## Files changed

- `.github/workflows/flutter-build.yml` — add restore step for `google-services.json` before the build step.

## Testing

Not runnable locally (no Flutter toolchain on this machine). Change is declarative workflow YAML; the restore step runs in the same matrix context (`working-directory: ${{ matrix.app }}`) so each app gets its own `android/app/google-services.json`.

Closes #9616
