### PR TITLE
[FIX] backend CI job: use npm install --legacy-peer-deps (no lockfile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: backend/api/package-lock.json
 
       - name: Install dependencies
         working-directory: backend/api
-        run: npm ci --workspaces=false --legacy-peer-deps
+        run: npm install --workspaces=false --legacy-peer-deps
 
       - name: Run unit tests
         working-directory: backend/api


### PR DESCRIPTION
﻿## Problem

The `backend` job in `.github/workflows/ci.yml` runs `npm ci` against `backend/api`, but no `package-lock.json` exists anywhere in `backend/api`. The only lockfile in the repo is `blockchain/package-lock.json`. `npm ci` fails with "The `npm ci` command can only install with an existing package-lock.json", so the backend unit + integration test jobs fail on every PR and push. The `cache-dependency-path` also points at the missing lockfile.

## Fix

- Replace `npm ci --workspaces=false --legacy-peer-deps` with `npm install --workspaces=false --legacy-peer-deps` in the backend CI job, matching the repo's own Dockerfiles (`Dockerfile.api` and `backend/api/Dockerfile`) which use `npm install --legacy-peer-deps` for the same reason.
- Remove the `cache` / `cache-dependency-path` inputs that reference `backend/api/package-lock.json`, since that file does not exist.

## Files changed

- `.github/workflows/ci.yml`

## Testing

The backend CI job will now be able to install dependencies. No lockfile is required and the setup-node step no longer points at a missing file.

Closes #9644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependency installation in the CI pipeline.
  * Removed npm cache configuration from automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->