### PR TITLE
[FIX] nginx gateway proxies /api/v1/auth, /api/v1/ml, /api/v1/pricing to real upstream paths

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,6 +46,7 @@ http {
 
         # Node.js Auth Service
         location /api/v1/auth {
+            rewrite ^/api/v1/auth(/.*)?$ /api/auth$1 break;
             proxy_pass http://api:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -60,6 +61,7 @@ http {
 
         # FastAPI ML Service
         location /api/v1/ml {
+            rewrite ^/api/v1/ml(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -67,6 +69,7 @@ http {
 
         # FastAPI Pricing Service
         location /api/v1/pricing {
+            rewrite ^/api/v1/pricing(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Problem

The nginx gateway (`nginx/nginx.conf`, port 8080) proxies three of its four locations to request paths the upstream services do not expose. All locations used `proxy_pass http://<host>:<port>` with no URI rewrite, so the full request path is forwarded verbatim:

- `/api/v1/auth/...` → the Express API only mounts auth at `/api/auth` → 404
- `/api/v1/ml/...` → FastAPI exposes routes at the root (`/predict/*`, `/train/*`, etc.), no `/api/v1/ml` prefix → 404
- `/api/v1/pricing/...` → same ML engine, no `/api/v1/pricing` prefix → 404
- Only `/api/v1/trips` matches a real mount.

Since the gateway is the documented single entry point, all auth, ML and pricing calls were unreachable.

## Fix

Add `rewrite` rules to the nginx locations so they map to the actual upstream paths:

- `/api/v1/auth/*` → `/api/auth/*` on the API
- `/api/v1/ml/*` and `/api/v1/pricing/*` → the ML engine root routes (`/predict/*`, `/train/*`, `/health`, etc.)
- `/api/v1/trips` is unchanged (already matches a real mount)

## Files changed

- `nginx/nginx.conf`

## Testing

- `GET/POST http://localhost:8080/api/v1/auth/...` now reaches `/api/auth` on the Express API instead of 404.
- `http://localhost:8080/api/v1/ml/...` and `/api/v1/pricing/...` now reach the FastAPI root routes.
- Verified the rewrite regexes against both bare and sub-path requests (`/api/v1/auth` and `/api/v1/auth/login`, `/api/v1/ml` and `/api/v1/ml/predict/price`).

Closes #9645
