### PR TITLE
[FIX] Dockerfile.api mirrors repo layout so API image boots

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -20,7 +20,17 @@ COPY backend/api/package.json ./
 # --legacy-peer-deps matches backend/api/Dockerfile and the CI workflows.
 RUN npm install --omit=dev --legacy-peer-deps
 
-COPY --chown=appuser:appgroup backend/api/src ./src
+# The API source imports modules that live outside backend/api/src (the
+# earnings router, the did service, and the root subsystem routers), so the
+# repository layout is mirrored inside the image to keep those relative
+# imports valid.
+COPY --chown=appuser:appgroup backend/api ./backend/api
+COPY --chown=appuser:appgroup backend/did ./backend/did
+COPY --chown=appuser:appgroup ebpf ./ebpf
+COPY --chown=appuser:appgroup wasi ./wasi
+COPY --chown=appuser:appgroup wasm ./wasm
+COPY --chown=appuser:appgroup snyk ./snyk
+COPY --chown=appuser:appgroup database/liquibase ./database/liquibase
 
 # No .env is copied. Configuration is supplied at runtime through the
 # container environment (k8s Secret / ConfigMap, or `docker run --env-file`),
@@ -33,4 +43,4 @@ EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD ["node", "-e", "fetch('http://localhost:5000/api/health/live').then(r=>{if(!r.ok)throw 1}).catch(()=>process.exit(1))"]
 
-CMD ["node", "src/index.js"]
+CMD ["node", "backend/api/src/index.js"]


### PR DESCRIPTION
## Problem

The root-context image build `Dockerfile.api` copied only `backend/api/src` into the image, but `src/index.js` (and `escortWalletController.js`) import modules that live outside `src/` in the repository tree. The resulting `truxify/api:latest` image fails at boot with `MODULE_NOT_FOUND`:

- `backend/api/src/index.js` imports `../routes/earnings.js` (a sibling of `src/`)
- `backend/api/src/index.js` imports the root subsystem routers: `../../../ebpf/routes.js`, `../../../wasi/routes.js`, `../../../wasm/routes.js`, `../../../snyk/routes.js`, `../../../database/liquibase/routes.js`
- `backend/api/src/sockets/tracker.js` imports `../../../../ebpf/loader.js`
- `backend/api/src/controllers/escortWalletController.js` imports `../../../did/did.service.js`

Because `index.js` is ESM, these missing imports throw at module-load time and the container never listens on 5000.

## Fix

Mirror the repository layout inside the image so every relative import resolves, and start the API from the mirrored path:

- `COPY backend/api ./backend/api` (includes `src/` and `routes/`)
- `COPY backend/did ./backend/did`
- `COPY ebpf ./ebpf`, `wasi ./wasi`, `wasm ./wasm`, `snyk ./snyk`
- `COPY database/liquibase ./database/liquibase`
- `CMD ["node", "backend/api/src/index.js"]`

## Files changed

- `Dockerfile.api`

## Testing

- Verified every import that escapes `src/` (grep across `backend/api/src` for `../` escapes) now resolves under the mirrored `/app` layout.
- The root subsystem routers reference `../backend/api/src/middleware/...` relative to the repo root; those paths resolve because `backend/api` is now copied to `/app/backend/api`.
- `npm install --omit=dev --legacy-peer-deps` still runs from `/app` so `node_modules` is found via upward resolution from `/app/backend/api/src`.

Closes #9646
