### PR TITLE
[FIX] api-deployement startupProbe points at existing /api/health/live

### DIFF
--- a/k8s/deployements/api-deployement.yaml
+++ b/k8s/deployements/api-deployement.yaml
@@ -55,7 +55,7 @@ spec:
           failureThreshold: 2
         startupProbe:
           httpGet:
-            path: /api/health/startup
+            path: /api/health/live
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 10


### PR DESCRIPTION
## Problem

`k8s/deployements/api-deployement.yaml` defines a `startupProbe` that hits `GET /api/health/startup`, but the API's health router (`backend/api/src/routes/healthRoutes.js`, mounted at `/api/health` and `/api/v1/health`) only defines `/`, `/live`, `/ready`, `/full` and `/sentry-debug` — there is no `/startup` route. The probe always receives 404, so with `failureThreshold: 30` at `periodSeconds: 10` the kubelet restarts the container indefinitely and the pod never becomes Ready.

## Fix

Point the `startupProbe` at `/api/health/live`, a route that `healthRoutes.js` actually exposes.

## Files changed

- `k8s/deployements/api-deployement.yaml`

## Testing

The startup probe now hits an existing endpoint (`/api/health/live`), matching the same route already used by the `livenessProbe` in this Deployment. The pod can now pass startup and become Ready.

Closes #9647
