### PR TITLE
[FIX] istio VirtualService routes 100% of /api/orders to api-service

### DIFF
--- a/k8s/istio/virtual-service.yaml
+++ b/k8s/istio/virtual-service.yaml
@@ -15,12 +15,7 @@ spec:
         host: api-service
         port:
           number: 80
-      weight: 90
-    - destination:
-        host: api-service-v2
-        port:
-          number: 5000
-      weight: 10
+      weight: 100
     retries:
       attempts: 3
       perTryTimeout: 2s


### PR DESCRIPTION
## Problem

`k8s/istio/virtual-service.yaml` (`truxify-api`) routes 10% of `/api/orders` traffic to a destination host `api-service-v2:5000`, but no Service or Deployment named `api-service-v2` exists anywhere in the repository. The only Services are `api-service` and the internal services (`ml-engine-service`, `redis-service`, `shard-*-service`). Istio can only route to hosts with real Endpoints, so those requests fail with 503 and 10% of order requests are broken.

## Fix

Remove the `api-service-v2` destination and route 100% of `/api/orders` traffic to the existing `api-service` host.

## Files changed

- `k8s/istio/virtual-service.yaml`

## Testing

The VirtualService now only references hosts that exist (`api-service`), so all `/api/orders` requests route to real endpoints and no traffic is dropped to a nonexistent service.

Closes #9648
