### PR TITLE
[FIX] supabase-backup workflow actually dumps and uploads the database

### DIFF
--- a/.github/workflows/supabase-backup.yml
+++ b/.github/workflows/supabase-backup.yml
@@ -12,10 +12,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run Supabase Backup Script
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Dump Supabase database
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
-          echo "Connecting to Supabase Database..."
-          echo "Starting daily backup process..."
-          echo "Backup completed successfully!"
+          if [ -z "$SUPABASE_DB_URL" ]; then
+            echo "::error::SUPABASE_DB_URL secret is not set"
+            exit 1
+          fi
+          pg_dump --no-owner --no-acl --format=custom "$SUPABASE_DB_URL" > supabase_backup.dump
+          ls -lh supabase_backup.dump
+
+      - name: Verify backup is non-empty
+        run: |
+          SIZE=$(wc -c < supabase_backup.dump)
+          echo "Backup size: $SIZE bytes"
+          if [ "$SIZE" -eq 0 ]; then
+            echo "::error::Backup is empty"
+            exit 1
+          fi
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-backup-${{ github.run_id }}
+          path: supabase_backup.dump
+          retention-days: 30


### PR DESCRIPTION
## Problem

The `.github/workflows/supabase-backup.yml` workflow, named "Supabase Database Backup" and scheduled daily, performed no backup at all. Its single step only echoed three strings; `SUPABASE_DB_URL` was provided but never used, and there was no `pg_dump`/upload step. The scheduled "backup" silently did nothing — a green checkmark with zero bytes of backup produced.

## Fix

- Install the PostgreSQL client on the runner.
- Dump the database with `pg_dump --format=custom` using the `SUPABASE_DB_URL` secret, and fail the job if the secret is unset.
- Verify the dump is non-empty and fail the job otherwise.
- Upload the dump as a workflow artifact with 30-day retention.

## Files changed

- `.github/workflows/supabase-backup.yml`

## Testing

- Manual `workflow_dispatch` now produces a non-empty `supabase_backup.dump` artifact.
- The job aborts with a clear error if `SUPABASE_DB_URL` is not configured or if the dump is empty.

Closes #9649
