### PR TITLE
test : added unit tests for utils apiResponse errorResponse helper

### DIFF
--- a/backend/api/test/unit/utils/apiResponse.test.js
+++ b/backend/api/test/unit/utils/apiResponse.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { errorResponse } from '../../../src/utils/apiResponse.js';
+
+describe('utils/apiResponse errorResponse', () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it('returns the standard error envelope with code and message', () => {
+    const response = errorResponse('NOT_FOUND', 'Resource not found');
+    expect(response).toEqual({
+      success: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Resource not found',
+      },
+    });
+  });
+
+  it('preserves a numeric code', () => {
+    const response = errorResponse(404, 'Not found');
+    expect(response.error.code).toBe(404);
+  });
+
+  it('omits details in production', () => {
+    process.env.NODE_ENV = 'production';
+    const response = errorResponse('BAD_REQUEST', 'Invalid payload', { field: 'lat' });
+    expect(response.error).toEqual({
+      code: 'BAD_REQUEST',
+      message: 'Invalid payload',
+    });
+    expect('details' in response.error).toBe(false);
+  });
+
+  it('includes details when not in production', () => {
+    delete process.env.NODE_ENV;
+    const response = errorResponse('BAD_REQUEST', 'Invalid payload', { field: 'lat' });
+    expect(response.error.details).toEqual({ field: 'lat' });
+  });
+
+  it('omits details when undefined even outside production', () => {
+    delete process.env.NODE_ENV;
+    const response = errorResponse('BAD_REQUEST', 'Invalid payload', undefined);
+    expect('details' in response.error).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #9695.

Summary of What Has Been Done:
Added a vitest unit test file pinning the `errorResponse` helper in `backend/api/src/utils/apiResponse.js`. The helper builds the standard error envelope used by several routes but previously had zero test coverage (the similar `src/lib/apiResponse.js` helpers were covered).

Changes Made:
- `backend/api/test/unit/utils/apiResponse.test.js` — 5 tests covering the standard envelope shape, numeric codes, the production details-omission behaviour, the dev-only details inclusion, and the undefined-details omission.

Impact it Made:
- Locks down the standard error envelope so a change to the response shape (or the dev-only details leak) is caught in CI.
- Verified locally with standalone vitest: 5/5 tests passing.

This Pull Request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.