### PR TITLE
test : added unit tests for core auth barrel exports

### DIFF
--- a/backend/api/test/unit/core/auth/index.test.js
+++ b/backend/api/test/unit/core/auth/index.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ROLES,
+  isValidRole,
+  allRoles,
+  Permission,
+  BasePolicy,
+  PolicyRegistry,
+  registry,
+  PolicyEvaluator,
+  AuthorizationError,
+  AuthorizationEngine,
+  authorizationEngine,
+  logAuthGrant,
+  logAuthDenial,
+  logUnknownAction,
+  logAuthFailure,
+  createRequestAuthLogger,
+} from '../../../../src/core/auth/index.js';
+
+vi.mock('../../../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('core/auth barrel exports', () => {
+  it('exports the role constants and helpers', () => {
+    expect(ROLES).toEqual({ CUSTOMER: 'customer', DRIVER: 'driver', ADMIN: 'admin' });
+    expect(isValidRole('customer')).toBe(true);
+    expect(isValidRole('superuser')).toBe(false);
+    expect(allRoles()).toEqual(['customer', 'driver', 'admin']);
+  });
+
+  it('exports the permission and policy classes', () => {
+    expect(typeof Permission).toBe('function');
+    expect(typeof BasePolicy).toBe('function');
+    expect(typeof PolicyRegistry).toBe('function');
+    expect(typeof PolicyEvaluator).toBe('function');
+    expect(typeof AuthorizationError).toBe('function');
+    expect(typeof AuthorizationEngine).toBe('function');
+  });
+
+  it('exports the shared registry and engine singletons', () => {
+    expect(registry).toBeInstanceOf(PolicyRegistry);
+    expect(authorizationEngine).toBeInstanceOf(AuthorizationEngine);
+  });
+
+  it('exports the authorization logger helpers', () => {
+    expect(typeof logAuthGrant).toBe('function');
+    expect(typeof logAuthDenial).toBe('function');
+    expect(typeof logUnknownAction).toBe('function');
+    expect(typeof logAuthFailure).toBe('function');
+    expect(typeof createRequestAuthLogger).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #9710.

Summary of What Has Been Done:
Added a vitest unit test file pinning the `core/auth/index.js` barrel exports — the single import surface for the authorization system. The barrel previously had zero test coverage.

Changes Made:
- `backend/api/test/unit/core/auth/index.test.js` — 4 tests covering the role constants/helpers (ROLES, isValidRole, allRoles), the permission/policy classes (Permission, BasePolicy, PolicyRegistry, PolicyEvaluator, AuthorizationError, AuthorizationEngine), the shared registry/engine singletons, and the five authorization logger helpers.

Impact it Made:
- Locks down the authorization barrel contract so a renamed or dropped export is caught in CI before any consumer breaks.
- Verified locally with standalone vitest: 4/4 tests passing.

This Pull Request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.