### PR TITLE
feat(api): implement internal escrow-velocity and pause-escrow endpoints for the n8n circuit breaker

### DIFF
--- a/automation/n8n/workflows/circuit_breaker.json
+++ b/automation/n8n/workflows/circuit_breaker.json
@@ -20,13 +20,21 @@
     {
       "parameters": {
         "url": "http://api:5000/api/internal/escrow-velocity",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "method": "GET",
         "options": {}
       },
       "name": "Check Escrow Velocity",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 1,
-      "position": [450, 300]
+      "position": [450, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     },
     {
       "parameters": {
@@ -47,13 +55,21 @@
     {
       "parameters": {
         "url": "http://api:5000/api/internal/pause-escrow",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "method": "POST",
         "options": {}
       },
       "name": "Execute Emergency Pause",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 1,
-      "position": [850, 200]
+      "position": [850, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     }
   ],
   "connections": {
@@ -89,6 +105,12 @@
           }
         ]
       ]
+    }
+  },
+  "credentials": {
+    "httpHeaderAuth": {
+      "name": "Truxify Internal API Key",
+      "id": ""
     }
   }
 }

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -72,6 +72,7 @@ import mlRoutes from './routes/mlRoutes.js'
 // ============================================================================
 import verificationRoutes from './routes/verificationRoutes.js'
 import oracleRoutes from './routes/oracleRoutes.js'
+import internalRoutes from './routes/internalRoutes.js'
 import blockchainMonitoringRoutes from './routes/blockchainMonitoringRoutes.js'
 
 // ============================================================================
@@ -106,6 +107,7 @@ import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 import fraudRoutes from './routes/fraudRoutes.js'
 import { fraudDetectionMiddleware, networkAnalysisMiddleware } from './middleware/fraudMiddleware.js'
 import { authenticate, requireRole } from './middleware/auth.js'
+import { requireApiKey } from './middleware/apiKey.js'
 import fraudDetection from './services/fraud/FraudDetectionService.js'
 import headerSizeMonitor from './middleware/headerSizeMonitor.js';
 
@@ -533,6 +535,14 @@ app.use('/api/blockchain', (req, _res, next) => {
   req.supabase = supabaseAdmin
   next()
 }, blockchainMonitoringRoutes)
+
+// ============================================================================
+// 🆕 INTERNAL B2B ROUTES (n8n circuit breaker workflow)
+// Auth-gated internal endpoints consumed by automation/n8n workflows:
+//   GET  /api/internal/escrow-velocity
+//   POST /api/internal/pause-escrow
+// ============================================================================
+app.use('/api/internal', requireApiKey, internalRoutes)
 
 // 🆕 Oracle Health Check Endpoint
 app.get('/api/oracle/health', (req, res) => {

--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -1,0 +1,159 @@
+/**
+ * Internal B2B API routes consumed by the n8n "Truxify Emergency Smart Contract
+ * Circuit Breaker" workflow (automation/n8n/workflows/circuit_breaker.json).
+ *
+ *   GET  /api/internal/escrow-velocity  — reports escrow event counts over a
+ *                                         rolling window and whether the rate
+ *                                         exceeds the anomaly threshold.
+ *   POST /api/internal/pause-escrow     — opens (or closes) the escrow circuit
+ *                                         breaker; while open, every on-chain
+ *                                         escrow submission in services/escrow.js
+ *                                         is refused.
+ *
+ * Both endpoints are gated by requireApiKey (x-api-key header / api_key query
+ * against VALID_API_KEYS) so they are only reachable by authenticated B2B
+ * callers such as the n8n workflow.
+ */
+
+import express from 'express';
+import logger from '../middleware/logger.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
+import {
+  setEscrowPaused,
+  getPauseState,
+} from '../services/escrowCircuitBreaker.js';
+
+const router = express.Router();
+
+const DEFAULT_WINDOW_MINUTES = 5;
+const DEFAULT_ANOMALY_THRESHOLD = 20;
+
+function intFromEnv(raw, fallback) {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function getDbClient() {
+  return supabaseAdmin || supabase;
+}
+
+/**
+ * @openapi
+ * /api/internal/escrow-velocity:
+ *   get:
+ *     tags: [Internal]
+ *     summary: Escrow velocity monitor
+ *     description: Counts escrow deposits, releases and refunds within a rolling window and reports whether the combined rate exceeds the anomaly threshold configured via ESCROW_VELOCITY_WINDOW_MINUTES / ESCROW_ANOMALY_THRESHOLD.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Escrow velocity snapshot
+ *       401:
+ *         description: Missing or invalid API key
+ *       503:
+ *         description: Supabase not configured
+ */
+router.get('/escrow-velocity', async (req, res) => {
+  try {
+    const client = getDbClient();
+    if (!client) {
+      return res.status(503).json({ error: 'Supabase is not configured.' });
+    }
+
+    const windowMinutes = intFromEnv(process.env.ESCROW_VELOCITY_WINDOW_MINUTES, DEFAULT_WINDOW_MINUTES);
+    const threshold = intFromEnv(process.env.ESCROW_ANOMALY_THRESHOLD, DEFAULT_ANOMALY_THRESHOLD);
+    const cutoff = new Date(Date.now() - windowMinutes * 60_000).toISOString();
+
+    const [deposits, releases, refunds] = await Promise.all([
+      client.from('orders').select('id', { count: 'exact', head: true }).gte('escrow_deposited_at', cutoff),
+      client.from('orders').select('id', { count: 'exact', head: true }).gte('escrow_released_at', cutoff),
+      client.from('orders').select('id', { count: 'exact', head: true }).gte('escrow_refunded_at', cutoff),
+    ]);
+
+    if (deposits.error || releases.error || refunds.error) {
+      logger.error(
+        {
+          event: 'ESCROW_VELOCITY_QUERY_ERROR',
+          depositsError: deposits.error && deposits.error.message,
+          releasesError: releases.error && releases.error.message,
+          refundsError: refunds.error && refunds.error.message,
+        },
+        '[internal] Escrow velocity query failed.'
+      );
+      return res.status(502).json({ error: 'Failed to read escrow velocity.' });
+    }
+
+    const counts = {
+      deposits: deposits.count || 0,
+      releases: releases.count || 0,
+      refunds: refunds.count || 0,
+    };
+    counts.total = counts.deposits + counts.releases + counts.refunds;
+
+    const pauseState = await getPauseState();
+
+    return res.json({
+      isAnomalyDetected: counts.total >= threshold,
+      windowMinutes,
+      threshold,
+      counts,
+      escrowPaused: pauseState.paused,
+      pausedAt: pauseState.pausedAt,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'ESCROW_VELOCITY_ERROR' },
+      '[internal] Escrow velocity check failed.'
+    );
+    return res.status(500).json({ error: 'Failed to compute escrow velocity.' });
+  }
+});
+
+/**
+ * @openapi
+ * /api/internal/pause-escrow:
+ *   post:
+ *     tags: [Internal]
+ *     summary: Open or close the escrow circuit breaker
+ *     description: Sets the Redis-backed pause flag that services/escrow.js consults before every on-chain escrow submission. Send {"paused": false} to close the circuit.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               paused:
+ *                 type: boolean
+ *                 default: true
+ *     responses:
+ *       200:
+ *         description: Circuit breaker state updated
+ *       401:
+ *         description: Missing or invalid API key
+ *       500:
+ *         description: Failed to persist pause state
+ */
+router.post('/pause-escrow', async (req, res) => {
+  try {
+    const paused = req.body?.paused !== false;
+    const result = await setEscrowPaused(paused);
+    return res.json({
+      paused: result.paused,
+      updatedAt: result.updatedAt,
+      persisted: result.persisted !== false,
+    });
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'ESCROW_PAUSE_ERROR' },
+      '[internal] Failed to update escrow circuit breaker.'
+    );
+    return res.status(500).json({ error: 'Failed to update escrow circuit breaker.' });
+  }
+});
+
+export default router;

--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -43,6 +43,7 @@ import { ethers } from 'ethers'
 import * as Sentry from '@sentry/node'
 import logger from '../middleware/logger.js'
 import { measureExecution } from '../core/performanceMetrics.js'
+import { isEscrowPaused, escrowPausedResult } from './escrowCircuitBreaker.js'
 
 const ESCROW_ABI = [
   'function createBooking(uint256 bookingId, address payable driver, bytes signature) external payable',
@@ -372,6 +373,11 @@ export async function buildDepositTx (orderDisplayId, customerWalletAddress, dri
     return { txData: null, bookingId }
   }
 
+  if (await isEscrowPaused()) {
+    logger.warn(`[escrow] Circuit breaker paused — refusing to build deposit tx for booking ${orderDisplayId}.`)
+    return escrowPausedResult(bookingId, { txData: null })
+  }
+
   if (!ethers.isAddress(driverWalletAddress) || !ethers.isAddress(customerWalletAddress)) {
     return { txData: null, bookingId }
   }
@@ -549,6 +555,11 @@ export async function markEscrowBookingStarted (orderDisplayId) {
     return { txHash: null, bookingId }
   }
 
+  if (await isEscrowPaused()) {
+    logger.warn(`[escrow] Circuit breaker paused — refusing to mark booking started for ${orderDisplayId}.`)
+    return escrowPausedResult(bookingId)
+  }
+
   try {
     const tx = await escrowContract.markBookingStarted(bookingId)
     logger.info(`[escrow] markBookingStarted tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
@@ -592,6 +603,11 @@ export async function escrowRelease (orderDisplayId, expectedAmountWei = null) {
   if (!escrowContract) {
     logger.warn('[escrow] Contract not initialised — skipping releaseFunds.')
     return { txHash: null, bookingId }
+  }
+
+  if (await isEscrowPaused()) {
+    logger.warn(`[escrow] Circuit breaker paused — refusing to release funds for booking ${orderDisplayId}.`)
+    return escrowPausedResult(bookingId)
   }
 
   try {
@@ -649,6 +665,11 @@ export async function submitEscrowRefund (orderDisplayId) {
   if (!escrowContract) {
     logger.warn('[escrow] Contract not initialised — skipping refundFunds.')
     return { txHash: null, bookingId }
+  }
+
+  if (await isEscrowPaused()) {
+    logger.warn(`[escrow] Circuit breaker paused — refusing to refund booking ${orderDisplayId}.`)
+    return escrowPausedResult(bookingId)
   }
 
   let tx
@@ -712,6 +733,11 @@ export async function escrowLockPayment(orderDisplayId, customerWalletAddress, d
       return { txHash: null, bookingId };
     }
 
+    if (await isEscrowPaused()) {
+      logger.warn(`[escrow] Circuit breaker paused — refusing to lock payment for booking ${orderDisplayId}.`);
+      return escrowPausedResult(bookingId);
+    }
+
     try {
       const tx = await escrowContract.lockPayment(
         bookingId,
@@ -749,6 +775,11 @@ export async function submitEscrowCancelWithPenalty (orderDisplayId, driverFeeWe
       return { txHash: null, bookingId }
     }
 
+    if (await isEscrowPaused()) {
+      logger.warn(`[escrow] Circuit breaker paused — refusing to cancel booking ${orderDisplayId} with penalty.`)
+      return escrowPausedResult(bookingId)
+    }
+
     try {
       const tx = await escrowContract.cancelWithPenalty(bookingId, driverFeeWei)
       logger.info(`[escrow] cancelWithPenalty tx submitted: ${tx.hash} for booking ${orderDisplayId}`)
@@ -782,6 +813,11 @@ export async function submitEscrowRaiseDispute (orderDisplayId) {
     if (!escrowContract) {
       logger.warn('[escrow] Contract not initialised — skipping raiseDispute.')
       return { txHash: null, bookingId }
+    }
+
+    if (await isEscrowPaused()) {
+      logger.warn(`[escrow] Circuit breaker paused — refusing to raise dispute for booking ${orderDisplayId}.`)
+      return escrowPausedResult(bookingId)
     }
 
     let tx
@@ -824,6 +860,11 @@ export async function submitEscrowResolveDispute (orderDisplayId, driverAmountWe
       return { txHash: null, bookingId }
     }
 
+    if (await isEscrowPaused()) {
+      logger.warn(`[escrow] Circuit breaker paused — refusing to resolve dispute for booking ${orderDisplayId}.`)
+      return escrowPausedResult(bookingId)
+    }
+
     let tx
     try {
       tx = await escrowContract.resolveDispute(bookingId, driverAmountWei)
@@ -858,6 +899,11 @@ export async function submitEscrowResolveDisputeTimeout (orderDisplayId) {
     if (!escrowContract) {
       logger.warn('[escrow] Contract not initialised — skipping resolveDisputeTimeout.')
       return { txHash: null, bookingId }
+    }
+
+    if (await isEscrowPaused()) {
+      logger.warn(`[escrow] Circuit breaker paused — refusing to resolve dispute timeout for booking ${orderDisplayId}.`)
+      return escrowPausedResult(bookingId)
     }
 
     let tx

--- a/backend/api/src/services/escrowCircuitBreaker.js
+++ b/backend/api/src/services/escrowCircuitBreaker.js
@@ -1,0 +1,112 @@
+/**
+ * Escrow Circuit Breaker
+ *
+ * Backing store for the emergency smart-contract pause used by the n8n
+ * circuit_breaker workflow (GET /api/internal/escrow-velocity and
+ * POST /api/internal/pause-escrow).
+ *
+ * The pause flag is persisted in Redis so every API replica sees the same
+ * state. All on-chain escrow submissions in services/escrow.js consult
+ * isEscrowPaused() before building/sending a transaction.
+ *
+ * Fail-open semantics: if Redis is unreachable the flag cannot be read, so
+ * escrow submissions proceed (a Redis outage must not freeze all payments).
+ */
+
+import logger from '../middleware/logger.js';
+import { redisClient } from '../config/db.js';
+
+const PAUSE_KEY = 'escrow:circuit-breaker:paused';
+const PAUSED_AT_KEY = 'escrow:circuit-breaker:paused-at';
+
+/**
+ * @returns {Promise<boolean>} — true when the escrow circuit breaker is open
+ */
+export async function isEscrowPaused() {
+  if (!redisClient) {
+    return false;
+  }
+  try {
+    const value = await redisClient.get(PAUSE_KEY);
+    return value === '1';
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'ESCROW_CIRCUIT_BREAKER_READ_ERROR' },
+      '[escrow-circuit-breaker] Failed to read pause flag from Redis — failing open.'
+    );
+    return false;
+  }
+}
+
+/**
+ * Open or close the escrow circuit breaker.
+ *
+ * @param {boolean} paused
+ * @returns {Promise<{paused: boolean, updatedAt: string}>}
+ */
+export async function setEscrowPaused(paused) {
+  const now = new Date().toISOString();
+  if (!redisClient) {
+    logger.warn(
+      '[escrow-circuit-breaker] Redis unavailable — pause state is not persisted.'
+    );
+    return { paused, updatedAt: now, persisted: false };
+  }
+  try {
+    if (paused) {
+      await redisClient.set(PAUSE_KEY, '1');
+      await redisClient.set(PAUSED_AT_KEY, now);
+      logger.warn(`[escrow-circuit-breaker] Circuit opened at ${now}`);
+    } else {
+      await redisClient.del(PAUSE_KEY);
+      await redisClient.del(PAUSED_AT_KEY);
+      logger.info(`[escrow-circuit-breaker] Circuit closed at ${now}`);
+    }
+    return { paused, updatedAt: now, persisted: true };
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'ESCROW_CIRCUIT_BREAKER_WRITE_ERROR' },
+      `[escrow-circuit-breaker] Failed to persist pause=${paused}.`
+    );
+    throw err;
+  }
+}
+
+/**
+ * @returns {Promise<{paused: boolean, pausedAt: string|null}>}
+ */
+export async function getPauseState() {
+  if (!redisClient) {
+    return { paused: false, pausedAt: null };
+  }
+  try {
+    const [value, pausedAt] = await Promise.all([
+      redisClient.get(PAUSE_KEY),
+      redisClient.get(PAUSED_AT_KEY),
+    ]);
+    return { paused: value === '1', pausedAt: pausedAt || null };
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'ESCROW_CIRCUIT_BREAKER_READ_ERROR' },
+      '[escrow-circuit-breaker] Failed to read pause state — reporting as not paused.'
+    );
+    return { paused: false, pausedAt: null };
+  }
+}
+
+/**
+ * Result shape returned by escrow service functions when the circuit breaker
+ * is open.
+ *
+ * @param {string} bookingId
+ * @param {object} [extra={}]
+ * @returns {object}
+ */
+export function escrowPausedResult(bookingId, extra = {}) {
+  return {
+    ...extra,
+    bookingId,
+    error: 'Escrow is paused by the circuit breaker.',
+    code: 'ESCROW_PAUSED',
+  };
+}


### PR DESCRIPTION
## Problem

The n8n "Truxify Emergency Smart Contract Circuit Breaker" workflow (`automation/n8n/workflows/circuit_breaker.json`) calls two internal endpoints that the API never exposes:

- `GET http://api:5000/api/internal/escrow-velocity`
- `POST http://api:5000/api/internal/pause-escrow`

Both return 404, so the escrow velocity monitor and the automated pause circuit breaker never actually take effect. The API also has no pause mechanism for on-chain escrow submissions, and the workflow sends no authentication, so even a plain implementation would be an unauthenticated backdoor.

## Fix

- Add `backend/api/src/routes/internalRoutes.js`, mounted at `/api/internal` in `index.js` and gated with the existing `requireApiKey` middleware (`x-api-key` header / `api_key` query against `VALID_API_KEYS`).
- `GET /api/internal/escrow-velocity` counts escrow deposits, releases and refunds within a rolling window (`ESCROW_VELOCITY_WINDOW_MINUTES`, default 5) and returns `isAnomalyDetected` when the combined count reaches `ESCROW_ANOMALY_THRESHOLD` (default 20). It also reports the current `escrowPaused` state.
- `POST /api/internal/pause-escrow` opens (or closes, via `{"paused": false}`) a Redis-backed circuit breaker flag.
- Add `backend/api/src/services/escrowCircuitBreaker.js`: `isEscrowPaused()`, `setEscrowPaused()`, `getPauseState()`, plus a shared `escrowPausedResult()` shape. It fails open when Redis is unavailable so a Redis outage cannot freeze all payments.
- `backend/api/src/services/escrow.js` now consults the breaker before every on-chain submission (deposit, lock, release, refund, cancel-with-penalty, mark-started, and all dispute operations), returning `{ error, code: 'ESCROW_PAUSED' }` while paused.
- Update `circuit_breaker.json` so both HTTP nodes authenticate with an `httpHeaderAuth` credential instead of calling the endpoints unauthenticated.

## Files changed

- `backend/api/src/routes/internalRoutes.js` (new)
- `backend/api/src/services/escrowCircuitBreaker.js` (new)
- `backend/api/src/services/escrow.js`
- `backend/api/src/index.js`
- `automation/n8n/workflows/circuit_breaker.json`

## Testing

- `node --check` passes on all modified/new JS files; the updated workflow JSON parses.
- Backend ESLint could not run locally because `node_modules` is not installed in the worktree (the repo has no committed lockfile, cf. #9644).

Closes #9650
