### PR TITLE
test : added pytest tests for ModelExporter

### DIFF
--- a/backend/ml/tests/test_exporter.py
+++ b/backend/ml/tests/test_exporter.py
@@ -1,0 +1,48 @@
+"""Unit tests for backend/ml/nas/exporter.py.
+
+Run with: python3 -m pytest tests/test_exporter.py -v --no-header
+"""
+import json
+import os
+import tempfile
+
+from nas.exporter import ModelExporter
+
+
+class TestExportQuantizedManifest:
+    """Tests for the INT8 quantized manifest export."""
+
+    def setup_method(self):
+        self.exporter = ModelExporter()
+
+    def test_returns_manifest_with_expected_keys(self):
+        """The manifest must expose the documented fields."""
+        manifest = self.exporter.export_quantized_manifest([0.5, -0.5])
+        assert set(manifest.keys()) == {
+            "format",
+            "quant_scale",
+            "weights",
+            "pruned_channels",
+            "accuracy_drop_pct",
+        }
+        assert manifest["format"] == "INT8_QUANTIZED_ONNX"
+        assert manifest["quant_scale"] == 127
+
+    def test_weights_are_scaled_to_int8(self):
+        """Weights must be quantized as int(w * 127)."""
+        manifest = self.exporter.export_quantized_manifest([0.5, -0.5, 1.0])
+        assert manifest["weights"] == [63, -63, 127]
+
+    def test_writes_manifest_to_file(self):
+        """The manifest must be written as JSON to the output filename."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "model.json")
+            self.exporter.export_quantized_manifest([0.25, 0.75], output_filename=path)
+            with open(path, "r") as f:
+                loaded = json.load(f)
+            assert loaded["weights"] == [31, 95]
+
+    def test_empty_weights_produce_empty_list(self):
+        """An empty weight list must yield an empty quantized list."""
+        manifest = self.exporter.export_quantized_manifest([])
+        assert manifest["weights"] == []


### PR DESCRIPTION
Closes #9734.

Summary of What Has Been Done:
Added a pytest test file pinning the `ModelExporter` contract in `backend/ml/nas/exporter.py` — the INT8-quantized manifest export used by the NAS pipeline. The class previously had zero test coverage.

Changes Made:
- `backend/ml/tests/test_exporter.py` — 4 tests covering the manifest keys, the int(w*127) quantization, the JSON file write, and the empty-weights edge case.

Impact it Made:
- Locks down the quantized-manifest export so a regression in the quantization or manifest format is caught by the ML test job.
- Verified locally with pytest: 4/4 tests passing.

This Pull Request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.