### PR TITLE
test : added pytest tests for NerfContainerDamageInspector

### DIFF
--- a/backend/ml/tests/test_nerf_inspector.py
+++ b/backend/ml/tests/test_nerf_inspector.py
@@ -1,0 +1,60 @@
+"""Unit tests for backend/ml/nerf/nerf_inspector.py.
+
+Run with: python3 -m pytest tests/test_nerf_inspector.py -v --no-header
+"""
+import numpy as np
+import pytest
+from nerf.nerf_inspector import NerfContainerDamageInspector
+
+
+class TestSynthesizePointCloud:
+    """Tests for the 3D point-cloud synthesis."""
+
+    def setup_method(self):
+        self.inspector = NerfContainerDamageInspector(volumetric_resolution=64)
+
+    def test_requires_at_least_two_views(self):
+        """Fewer than 2 views must raise ValueError."""
+        with pytest.raises(ValueError):
+            self.inspector.synthesize_3d_point_cloud(["hash1"])
+
+    def test_returns_10_cubed_grid(self):
+        """The voxel grid must be 10x10x10."""
+        grid = self.inspector.synthesize_3d_point_cloud(["a", "b"])
+        assert grid.shape == (10, 10, 10)
+
+    def test_dent_voxel_is_present(self):
+        """The simulated dent voxel at (2,5,3) must be the grid maximum."""
+        grid = self.inspector.synthesize_3d_point_cloud(["a", "b", "c"])
+        assert grid[2, 5, 3] == 0.85
+        assert grid.max() == 0.85
+
+
+class TestEvaluateContainerDamage:
+    """Tests for the container damage evaluation."""
+
+    def setup_method(self):
+        self.inspector = NerfContainerDamageInspector()
+
+    def test_returns_expected_keys(self):
+        """The evaluation must expose the documented fields."""
+        result = self.inspector.evaluate_container_damage(["a", "b"])
+        assert set(result.keys()) == {
+            "views_processed",
+            "max_dent_depth_cm",
+            "damaged_volume_cc",
+            "damage_severity",
+            "is_structural_damage_detected",
+        }
+
+    def test_views_processed_matches_input(self):
+        """The views_processed field must equal the number of photo hashes."""
+        result = self.inspector.evaluate_container_damage(["a", "b", "c"])
+        assert result["views_processed"] == 3
+
+    def test_damage_is_detected(self):
+        """The simulated dent (0.85 voxel) must exceed the structural threshold."""
+        result = self.inspector.evaluate_container_damage(["a", "b"])
+        assert result["is_structural_damage_detected"] is True
+        assert result["max_dent_depth_cm"] > 5.0
+        assert result["damage_severity"] == "MODERATE"


### PR DESCRIPTION
Closes #9735.

Summary of What Has Been Done:
Added a pytest test file pinning the `NerfContainerDamageInspector` contract in `backend/ml/nerf/nerf_inspector.py` — the 3D voxel-grid synthesis and container damage evaluation. The class previously had zero test coverage.

Changes Made:
- `backend/ml/tests/test_nerf_inspector.py` — 6 tests covering the two-view minimum (ValueError), the 10x10x10 grid shape, the simulated dent voxel, the evaluation result keys, the views_processed count, and the structural-damage detection + severity.

Impact it Made:
- Locks down the NeRF container-inspection pipeline so a regression in the damage evaluation is caught by the ML test job.
- Verified locally with pytest: 6/6 tests passing.

This Pull Request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.