### PR TITLE
feat(api): add GET /api/driver/active endpoint and fix n8n document-integrity workflow

### DIFF
--- a/automation/n8n/document-integrity-workflow.json
+++ b/automation/n8n/document-integrity-workflow.json
@@ -22,7 +22,7 @@
     },
     {
       "parameters": {
-        "url": "http://api:5000/api/drivers/active",
+        "url": "http://api:5000/api/driver/active",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "options": {}
@@ -34,12 +34,18 @@
         0
       ],
       "id": "fetch-active-drivers",
-      "name": "Fetch Active Drivers"
+      "name": "Fetch Active Drivers",
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     },
     {
       "parameters": {
         "mode": "runOnceForEachItem",
-        "jsCode": "const driver = $input.item.json;\nconst docs = driver.documents || [];\nconst requiredDocs = ['RC', 'License', 'Insurance'];\nconst missingOrTampered = [];\n\nfor (const docType of requiredDocs) {\n  const doc = docs.find(d => d.type === docType);\n  if (!doc) {\n    missingOrTampered.push({ type: docType, reason: 'missing' });\n  } else if (doc.status !== 'verified' || (doc.expiry_date && new Date(doc.expiry_date) < new Date())) {\n    missingOrTampered.push({ type: docType, reason: doc.status !== 'verified' ? 'unverified' : 'expired' });\n  }\n}\n\nreturn {\n  driver_id: driver.id || driver.driver_id,\n  driver_name: driver.name || 'Unknown',\n  has_issues: missingOrTampered.length > 0,\n  issues: missingOrTampered,\n  checked_at: new Date().toISOString()\n};"
+        "jsCode": "const driver = $input.item.json;\nconst docs = driver.documents || [];\nconst requiredDocs = ['rc_book', 'driving_licence', 'insurance'];\nconst missingOrTampered = [];\n\nfor (const docType of requiredDocs) {\n  const doc = docs.find(d => d.type === docType);\n  if (!doc) {\n    missingOrTampered.push({ type: docType, reason: 'missing' });\n  } else if (doc.status !== 'approved' || (doc.expiry_date && new Date(doc.expiry_date) < new Date())) {\n    missingOrTampered.push({ type: docType, reason: doc.status !== 'approved' ? 'unverified' : 'expired' });\n  }\n}\n\nreturn {\n  driver_id: driver.id || driver.driver_id,\n  driver_name: driver.name || 'Unknown',\n  has_issues: missingOrTampered.length > 0,\n  issues: missingOrTampered,\n  checked_at: new Date().toISOString()\n};"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -137,5 +143,11 @@
   "active": true,
   "settings": {},
   "versionId": "doc-integrity-v1",
-  "id": "document-integrity-workflow"
+  "id": "document-integrity-workflow",
+  "credentials": {
+    "httpHeaderAuth": {
+      "name": "Truxify Internal API Key",
+      "id": ""
+    }
+  }
 }

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -127,10 +127,11 @@
  */
 
 import express from 'express';
-import { supabase, redisClient, createUserClient } from '../config/db.js';
+import { supabase, supabaseAdmin, redisClient, createUserClient } from '../config/db.js';
 import { getDriverReputation } from '../services/reputation.js';
 import { predictDriverProfit } from '../services/ml.js';
 import { authenticate } from '../middleware/auth.js';
+import { requireApiKey } from '../middleware/apiKey.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import {
   DEADHEAD_COLUMNS,
@@ -160,6 +161,111 @@ const router = express.Router();
 router.use(userLimiter);
 const hosStatusSchema = z.object({
   status: z.enum(['off_duty', 'on_duty', 'driving', 'resting'])
+});
+
+// ============================================================================
+// ACTIVE DRIVERS (B2B, consumed by the n8n document-integrity workflow)
+// ============================================================================
+/**
+ * @openapi
+ * /api/driver/active:
+ *   get:
+ *     tags: [Driver]
+ *     summary: List active drivers with their documents
+ *     description: Returns drivers currently online (driver_details.is_online = true) with their KYC documents. Auth-gated for backend-to-backend callers (x-api-key / VALID_API_KEYS); the n8n document-integrity workflow polls this daily.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of active drivers with documents
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     format: uuid
+ *                   driver_id:
+ *                     type: string
+ *                     format: uuid
+ *                   name:
+ *                     type: string
+ *                     nullable: true
+ *                   documents:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         type:
+ *                           type: string
+ *                         status:
+ *                           type: string
+ *                         expiry_date:
+ *                           type: string
+ *                           format: date
+ *                           nullable: true
+ *       401:
+ *         description: Missing or invalid API key
+ *       502:
+ *         description: Supabase query failed
+ */
+router.get('/active', requireApiKey, userLimiter, async (req, res) => {
+  try {
+    const client = supabaseAdmin || supabase;
+    if (!client) {
+      return res.status(503).json({ error: 'Supabase is not configured.' });
+    }
+
+    const { data: activeDrivers, error: driversError } = await client
+      .from('driver_details')
+      .select('user_id')
+      .eq('is_online', true);
+
+    if (driversError) {
+      return res.status(502).json({ error: 'Failed to fetch active drivers.', details: driversError.message });
+    }
+
+    const driverIds = (activeDrivers || []).map((d) => d.user_id);
+    if (driverIds.length === 0) {
+      return res.json([]);
+    }
+
+    const [profilesRes, docsRes] = await Promise.all([
+      client.from('profiles').select('id, full_name').in('id', driverIds),
+      client.from('driver_documents').select('driver_id, document_type, status').in('driver_id', driverIds),
+    ]);
+
+    if (profilesRes.error || docsRes.error) {
+      return res.status(502).json({ error: 'Failed to fetch active driver details.' });
+    }
+
+    const nameById = Object.fromEntries((profilesRes.data || []).map((p) => [p.id, p.full_name]));
+    const docsByDriver = {};
+    for (const doc of docsRes.data || []) {
+      (docsByDriver[doc.driver_id] = docsByDriver[doc.driver_id] || []).push({
+        type: doc.document_type,
+        status: doc.status,
+        // driver_documents has no expiry column; documents expire via the
+        // `documents` table consumed by documentExpiryService.
+        expiry_date: null,
+      });
+    }
+
+    const drivers = (activeDrivers || []).map((d) => ({
+      id: d.user_id,
+      driver_id: d.user_id,
+      name: nameById[d.user_id] || null,
+      documents: docsByDriver[d.user_id] || [],
+    }));
+
+    return res.json(drivers);
+  } catch (err) {
+    logger.error({ requestId: req.requestId }, 'Active drivers fetch error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
 });
 
 // Driver role authorization guard middleware


### PR DESCRIPTION
## Problem

The n8n `document-integrity-workflow.json` polls `GET http://api:5000/api/drivers/active` every 24h, but `driverRoutes` never defines an `active` route — and the workflow also uses the wrong plural path (`/api/drivers/...`) while the router is mounted at `/api/driver` (singular). The first request always 404s, so active-driver status is never fetched and KYC/document expiry alerts never fire.

## Fix

- Add `GET /api/driver/active` to `backend/api/src/routes/driverRoutes.js`: returns drivers currently online (`driver_details.is_online = true`) together with their KYC documents (`driver_documents`: `type`, `status`, `expiry_date`), auth-gated with the existing `requireApiKey` middleware for backend-to-backend callers. A bare array is returned so n8n creates one item per driver for the per-driver check.
- Update `document-integrity-workflow.json`:
  - Point at the correct singular path `http://api:5000/api/driver/active`.
  - Attach an `httpHeaderAuth` credential (Truxify Internal API Key) so the workflow can authenticate against the gated endpoint.
  - Align the document-matching logic with the real schema: required docs `rc_book` / `driving_licence` / `insurance` and review status `approved` (instead of the non-existent `RC`/`License`/`Insurance` types and `verified` status), so the check stops flagging every document as missing/unverified.

## Files changed

- `backend/api/src/routes/driverRoutes.js`
- `automation/n8n/document-integrity-workflow.json`

## Testing

- `node --check` passes on `driverRoutes.js`; the updated workflow JSON parses.
- Note: `driver_documents` has no expiry column, so the endpoint returns `expiry_date: null` and the workflow only flags expiry when a value is present (document expiry reminders are handled separately by `documentExpiryService` via the `documents` table).

Closes #9651
