### PR TITLE
fix : added TX- prefix stripping before storing trip_id in batch events upsert

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -379,7 +379,9 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
       return {
         event_id: event.id,
         user_id: userId,
-        trip_id: event.trip_id || null,
+        trip_id: (typeof event.trip_id === 'string' && event.trip_id.startsWith('TX-'))
+          ? event.trip_id.slice(3)
+          : (event.trip_id || null),
         event_type: event.type,
         event_timestamp: event.occurred_at,
         latitude: event.payload?.lat !== undefined ? Number(event.payload.lat) : null,


### PR DESCRIPTION
Closes #9759.

Modified the batch events upsert in tripRoutes.js to strip the 'TX-' prefix from trip_id before storing, consistent with the ownership lookup that already handles the format.

Changes Made:
- backend/api/src/routes/tripRoutes.js


Impact it Made:
Addresses the issue described in #9759.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).