### PR TITLE
fix : added authenticated INSERT/UPDATE RLS policies for tracking_tokens

### DIFF
--- a/supabase/migrations/20260811000000_add_tracking_tokens_authenticated_policies.sql
+++ b/supabase/migrations/20260811000000_add_tracking_tokens_authenticated_policies.sql
@@ -1,0 +1,33 @@
+-- Add INSERT and UPDATE policies for authenticated role on tracking_tokens
+-- Fixes: POST /api/orders/:id/share-tracking returns 500 because the route uses
+-- createUserClient(req.token) (authenticated role) but the table only had
+-- INSERT/UPDATE policies for service_role.
+create policy "authenticated_insert_tracking_tokens"
+  on tracking_tokens
+  for insert
+  to authenticated
+  with check (
+    created_by = (
+      select id from profiles
+      where firebase_uid = (auth.jwt() ->> 'sub')
+      limit 1
+    )
+  );
+create policy "authenticated_update_tracking_tokens"
+  on tracking_tokens
+  for update
+  to authenticated
+  using (
+    created_by = (
+      select id from profiles
+      where firebase_uid = (auth.jwt() ->> 'sub')
+      limit 1
+    )
+  )
+  with check (
+    created_by = (
+      select id from profiles
+      where firebase_uid = (auth.jwt() ->> 'sub')
+      limit 1
+    )
+  );


### PR DESCRIPTION
Closes #9760.

Added INSERT and UPDATE RLS policies for the authenticated role on tracking_tokens, scoped to the calling user. This allows POST /api/orders/:id/share-tracking to work for authenticated customers.

Changes Made:
- supabase/migrations/20260811000000_add_tracking_tokens_authenticated_policies.sql


Impact it Made:
Addresses the issue described in #9760.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).