### PR TITLE
fix : passed expectedAmountWei to escrowRelease in verifyDelivery OTP path

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -17,7 +17,7 @@ import {
   OTP_LOCKOUT_MINUTES,
   DELIVERY_OTP_READY_STATUSES
 } from './orderNotificationService.js';
-import { escrowRelease, markEscrowBookingStarted } from '../escrow.js';
+import { escrowRelease, markEscrowBookingStarted, paisaToMaticWei } from '../escrow.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 import { broadcastOrderMilestone } from '../../sockets/tracker.js';
@@ -160,7 +160,7 @@ export class OrderMilestoneService {
 
       const { data: order, error: orderErr } = await this.orderRepository.findOrderById(
         orderId,
-        'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status'
+        'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, total_amount'
       );
       if (orderErr || !order) throw new DomainError(404, { error: 'Order not found.' });
       if (order.driver_id !== driverId)
@@ -217,7 +217,10 @@ export class OrderMilestoneService {
 
       if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
         try {
-          const releaseResult = await escrowRelease(order.order_display_id);
+          const releaseResult = await escrowRelease(
+            order.order_display_id,
+            order.total_amount != null ? paisaToMaticWei(order.total_amount) : null,
+          );
           if (releaseResult.txHash) {
             releaseTxHash = releaseResult.txHash;
           } else if (releaseResult.alreadyReleased) {


### PR DESCRIPTION
Closes #9761.

Added total_amount to the order projection in verifyDelivery and passes paisaToMaticWei(total_amount) as expectedAmountWei to escrowRelease, protecting the OTP delivery path with the amount guard.

Changes Made:
- backend/api/src/services/order/orderMilestoneService.js


Impact it Made:
Addresses the issue described in #9761.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).