### PR TITLE
fix : corrected userId reference in isValidCachedProfile call in profileService

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -20,7 +20,7 @@ export async function getProfile(userId) {
   if (isCacheEnabled()) {
     try {
       const cached = await getCachedSupabaseProfile(userId);
-      if (cached && isValidCachedProfile(firebaseUid, cached)) {
+      if (cached && isValidCachedProfile(userId, cached)) {
         logger.debug({ userId }, 'Profile cache hit');
         return cached;
       }


### PR DESCRIPTION
Closes #9766.

Fixed the undefined firebaseUid variable reference in the profileService.getProfile cache-hit branch to use the correct userId parameter.

Changes Made:
- backend/api/src/services/profileService.js


Impact it Made:
Addresses the issue described in #9766.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).