### PR TITLE
docs : created scripts/deploy-k8s.sh referenced by k8s/README.md

### DIFF
--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Kubernetes deployment script for Truxify API and ML services.
+set -e
+
+NAMESPACE="${1:-truxify}"
+MANIFESTS_DIR="$(dirname "${BASH_SOURCE[0]}")/../k8s"
+
+echo "[deploy-k8s] Deploying Truxify to namespace '${NAMESPACE}'..."
+
+if [ ! -d "${MANIFESTS_DIR}" ]; then
+  echo "[deploy-k8s] Error: k8s manifests directory not found at ${MANIFESTS_DIR}"
+  exit 1
+fi
+
+kubectl apply -f "${MANIFESTS_DIR}/" --namespace="${NAMESPACE}"
+echo "[deploy-k8s] Deployment complete."


### PR DESCRIPTION
Closes #9769.

Created scripts/deploy-k8s.sh as a minimal stub that runs kubectl apply on the k8s manifests directory, resolving the missing file referenced in k8s/README.md.

Changes Made:
- scripts/deploy-k8s.sh


Impact it Made:
Addresses the issue described in #9769.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).