### PR TITLE
fix : updated Env.apiBaseUrl to read TRUXIFY_API_BASE_URL in truxify_shared

### DIFF
--- a/packages/truxify_shared/lib/src/config/env.dart
+++ b/packages/truxify_shared/lib/src/config/env.dart
@@ -44,7 +44,7 @@ class Env {
 
   // ── Backend API ────────────────────────────────────────────────────────────
   static const String apiBaseUrl = String.fromEnvironment(
-    'API_BASE_URL',
+    'TRUXIFY_API_BASE_URL',
     defaultValue: 'http://localhost:5000', // Local Express API
   );
 


### PR DESCRIPTION
Closes #9770.

Changed String.fromEnvironment key from 'API_BASE_URL' to 'TRUXIFY_API_BASE_URL' in env.dart so the dart define actually matches the key used by all call sites.

Changes Made:
- packages/truxify_shared/lib/src/config/env.dart


Impact it Made:
Addresses the issue described in #9770.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).