### PR TITLE
docs : updated k8s/README.md to remove reference to scripts/deploy-k8s.sh

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -16,8 +16,9 @@ docker push truxify/ml:latest
 
 2. Deploy to Kubernetes
 bash
-chmod +x scripts/deploy-k8s.sh
-./scripts/deploy-k8s.sh
+# Deploy using kubectl directly:
+kubectl apply -f api-deployment.yaml
+kubectl apply -f ml-deployment.yaml
 3. Check Status
 bash
 kubectl get pods -n truxify


### PR DESCRIPTION
Closes #9780.

Updated k8s/README.md to remove the reference to scripts/deploy-k8s.sh (which does not exist) and replaced it with direct kubectl apply commands.

Changes Made:
- k8s/README.md


Impact it Made:
Addresses the issue described in #9780.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).