### PR TITLE
fix: derive escrow ABI selectors from contract ABI instead of tautological expected map

### DIFF
--- a/scripts/check-escrow-abi.sh
+++ b/scripts/check-escrow-abi.sh
@@ -2,18 +2,21 @@
 # ============================================================================
 # check-escrow-abi.sh
 # ============================================================================
-# CI guard that verifies the deployed smart contract's ABI selectors match
-# what the backend (escrow.js) expects.
+# CI guard that verifies the backend (escrow.js) ABI selectors match the
+# selectors actually present in the compiled TruxifyEscrow contract.
 #
 # Usage:
 #   bash scripts/check-escrow-abi.sh
 #
 # This script:
-#   1. Extracts the ABI function selectors from TruxifyEscrow.sol (via Hardhat)
-#   2. Compares them with the selectors defined in escrow.js
-#   3. Fails (exit 1) if there is a mismatch
-#
-# Run as part of CI to prevent deploying ABI-incompatible contracts.
+#   1. Reads the compiled contract ABI
+#      (blockchain/artifacts/contracts/TruxifyEscrow.sol/TruxifyEscrow.json)
+#      produced by `npx hardhat compile`; if it is absent, derives the
+#      function signatures from blockchain/contracts/TruxifyEscrow.sol.
+#   2. Computes the real selectors with `cast` (foundry) or node + ethers
+#      (blockchain/node_modules) — never from the expected strings themselves.
+#   3. Compares them with the selectors defined in escrow.js
+#   4. Fails (exit 1) on any mismatch or if the selectors cannot be verified.
 # ============================================================================
 
 set -euo pipefail
@@ -21,48 +24,138 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+SOL_FILE="$ROOT_DIR/blockchain/contracts/TruxifyEscrow.sol"
+ARTIFACT_FILE="$ROOT_DIR/blockchain/artifacts/contracts/TruxifyEscrow.sol/TruxifyEscrow.json"
+
 echo "🔍 Checking escrow ABI compatibility..."
 
-# Expected selectors (from backend/api/src/services/escrow.js)
-# These are keccak256(first 4 bytes) of the function signatures
+# Expected selectors (from backend/api/src/services/escrow.js ESCROW_ABI)
+# These are keccak256(first 4 bytes) of the function signatures.
 declare -A EXPECTED_SELECTORS
 EXPECTED_SELECTORS["createBooking(uint256,address,bytes)"]="0bb7aa51"
+EXPECTED_SELECTORS["lockPayment(uint256,address,address)"]="044e8539"
+EXPECTED_SELECTORS["commitmentNonces(address)"]="09135335"
 EXPECTED_SELECTORS["releasePayment(uint256)"]="88685cd9"
 EXPECTED_SELECTORS["cancelBooking(uint256)"]="0dca825e"
 EXPECTED_SELECTORS["cancelWithPenalty(uint256,uint256)"]="ca9a63b1"
+EXPECTED_SELECTORS["markBookingStarted(uint256)"]="1f683549"
 EXPECTED_SELECTORS["raiseDispute(uint256)"]="a5c1674e"
 EXPECTED_SELECTORS["resolveDispute(uint256,uint256)"]="bdc84ac3"
 EXPECTED_SELECTORS["resolveDisputeTimeout(uint256)"]="333edf12"
 EXPECTED_SELECTORS["bookings(uint256)"]="1dab301e"
 
-# Check if cast (foundry) is available for selector computation
-HAS_CAST=false
-if command -v cast &>/dev/null; then
-  HAS_CAST=true
+if ! command -v cast &>/dev/null && [ ! -d "$ROOT_DIR/blockchain/node_modules/ethers" ]; then
+  echo "❌ Neither cast (foundry) nor ethers (blockchain/node_modules) is available to compute selectors." >&2
+  echo "   Run 'npm ci' in blockchain/ (or install foundry) and re-run." >&2
+  exit 1
 fi
 
-ERRORS=0
-
-for sig in "${!EXPECTED_SELECTORS[@]}"; do
-  expected="${EXPECTED_SELECTORS[$sig]}"
-
-  if $HAS_CAST; then
-    # Use foundry's cast to compute the selector
-    actual=$(cast keccak "$sig" | cut -c1-10 | sed 's/^0x//')
+# Compute the real selector for a signature using cast or node + ethers.
+# Prints the 8-char hex selector (no 0x prefix).
+compute_selector() {
+  local sig="$1"
+  if command -v cast &>/dev/null; then
+    cast keccak "$sig" | cut -c1-10 | sed 's/^0x//'
   else
-    # Fallback: use node.js with ethers
-    actual=$(node -e "
+    NODE_PATH="$ROOT_DIR/blockchain/node_modules" node -e "
       const { ethers } = require('ethers');
       const iface = new ethers.Interface(['function $sig']);
-      const selector = iface.getFunction('${sig%%(*}').selector.slice(2);
-      console.log(selector);
-    ")
+      console.log(iface.getFunction('${sig%%(*}').selector.slice(2));
+    "
   fi
+}
 
-  if [ "$actual" = "$expected" ]; then
+# Extract the signatures exposed by the contract. Reads the compiled ABI when
+# available, otherwise parses the .sol source for function declarations and
+# public/constant state getters. Prints one signature per line.
+extract_signatures() {
+  if [ -f "$ARTIFACT_FILE" ]; then
+    NODE_PATH="$ROOT_DIR/blockchain/node_modules" node -e '
+      const fs = require("fs");
+      const artifact = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+      const seen = new Set();
+      for (const item of artifact.abi || []) {
+        if (item.type !== "function") continue;
+        const sig = `${item.name}(${(item.inputs || []).map((i) => i.type).join(",")})`;
+        if (!seen.has(sig)) { seen.add(sig); console.log(sig); }
+      }
+    ' node "$ARTIFACT_FILE"
+  else
+    echo "⚠️  Compiled artifact not found — deriving selectors from $SOL_FILE." >&2
+    [ -f "$SOL_FILE" ] || { echo "❌ Contract source not found at $SOL_FILE" >&2; exit 1; }
+    NODE_PATH="$ROOT_DIR/blockchain/node_modules" node -e '
+      const fs = require("fs");
+      const src = fs.readFileSync(process.argv[2], "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "");
+      const seen = new Set();
+      const add = (sig) => { if (!seen.has(sig)) { seen.add(sig); console.log(sig); } };
+
+      // External/public function declarations (skip private/internal helpers).
+      const fnRe = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+      let m;
+      while ((m = fnRe.exec(src)) !== null) {
+        const open = src.indexOf("(", m.index);
+        let depth = 0;
+        let close = -1;
+        for (let i = open; i < src.length; i++) {
+          if (src[i] === "(") depth++;
+          else if (src[i] === ")") { depth--; if (depth === 0) { close = i; break; } }
+        }
+        if (close === -1) continue;
+        const tail = src.slice(close + 1, src.indexOf("{", close));
+        if (/\b(private|internal)\b/.test(tail)) continue;
+
+        const params = src.slice(open + 1, close).split(",").map((p) => {
+          let s = p.trim().replace(/\b(payable|memory|calldata|storage)\b/g, " ").replace(/\s+/g, " ");
+          const words = s.split(" ");
+          if (words.length > 1) {
+            const last = words[words.length - 1];
+            if (/^[a-z_$][\w$]*$/i.test(last)) words.pop();
+          }
+          return words.join(" ").trim();
+        }).filter((p) => p.length > 0);
+
+        add(`${m[1]}(${params.join(",")})`);
+      }
+
+      // Public/constant state variables expose getters (e.g. mapping -> key getter).
+      const varRe = /(?:mapping\s*\(\s*([A-Za-z_$][\w$]*)\s*=>\s*[^)]*\)|([A-Za-z_$][\w$]*(?:\s*\[\s*\])*))\s+(?:(constant\s+)?public|public\s+constant)\s+([A-Za-z_$][\w$]*)/g;
+      let v;
+      while ((v = varRe.exec(src)) !== null) {
+        add(v[1] ? `${v[4]}(${v[1]})` : `${v[4]}()`);
+      }
+    ' node "$SOL_FILE"
+  fi
+}
+
+TMP_SIGS="$(mktemp)"
+trap 'rm -f "$TMP_SIGS"' EXIT
+extract_signatures > "$TMP_SIGS"
+
+if [ ! -s "$TMP_SIGS" ]; then
+  echo "❌ No signatures could be extracted from the contract. Cannot verify ABI selectors." >&2
+  exit 1
+fi
+
+# Build the map of actual selectors from the contract.
+declare -A ACTUAL_SELECTORS
+while IFS= read -r sig; do
+  [ -z "$sig" ] && continue
+  ACTUAL_SELECTORS["$sig"]="$(compute_selector "$sig")"
+done < "$TMP_SIGS"
+
+ERRORS=0
+for sig in "${!EXPECTED_SELECTORS[@]}"; do
+  expected="${EXPECTED_SELECTORS[$sig]}"
+  actual="${ACTUAL_SELECTORS[$sig]:-}"
+  if [ -z "$actual" ]; then
+    echo "  ❌ $sig → not present in the compiled contract"
+    ERRORS=$((ERRORS + 1))
+  elif [ "$actual" = "$expected" ]; then
     echo "  ✅ $sig → 0x$expected"
   else
-    echo "  ❌ $sig → expected 0x$expected, got 0x$actual"
+    echo "  ❌ $sig → expected 0x$expected, contract has 0x$actual"
     ERRORS=$((ERRORS + 1))
   fi
 done


### PR DESCRIPTION
## Problem

`scripts/check-escrow-abi.sh` derived the expected function selectors from a hard-coded map and then verified the contract against that same map, so the check was tautological: it could never catch selectors that changed in the source contract, and it silently ignored the actual ABI emitted by the compiler.

## Fix

Rewrite the script to compute selectors from the contract itself and compare against the expected map as a cross-check, instead of deriving the expected values from a local copy of the signatures:

- Read `blockchain/artifacts/contracts/TruxifyEscrow.sol/TruxifyEscrow.json` when present; otherwise parse `blockchain/contracts/TruxifyEscrow.sol` for function signatures and public state-variable getters.
- Compute selectors with `cast` if available, falling back to `node` + `ethers`.
- Fail if the required tooling or source is missing, or if any selector mismatch is found.
- Add `lockPayment`, `commitmentNonces`, and `markBookingStarted` to the expected map.

## Files changed

- `scripts/check-escrow-abi.sh`

## Testing

Selectors for `createBooking`, `releasePayment`, `cancelBooking`, `cancelWithPenalty`, `raiseDispute`, `resolveDispute`, `resolveDisputeTimeout`, `bookings`, `lockPayment`, `commitmentNonces`, and `markBookingStarted` were computed with ethers and verified against the expected map. The script exits non-zero when a selector is wrong or a signature is missing.

Closes #9653


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of escrow contract selectors against compiled contract interfaces.
  * Added clearer reporting for missing function signatures and selector mismatches.
  * Added fallback validation when compiled contract artifacts are unavailable.
  * Expanded validation coverage for payment locking, commitment nonce tracking, and booking status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->