### PR TITLE
fix : enabled real TomTom/Google traffic API in getLiveTrafficMultiplier

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -8,47 +8,48 @@ const MIN_SURGE_MULTIPLIER = 1.2;
 const MAX_SURGE_MULTIPLIER = 2.5;
 const SURGE_PEAK_AMPLITUDE = 1.3;
 
-/**
- * Fetches live traffic congestion metrics.
- * Uses a mock implementation for TomTom / Google Maps Distance Matrix.
- * Returns a traffic multiplier >= 1.0 based on current congestion.
- * 
- * @param {number} pickupLat 
- * @param {number} pickupLng 
- * @returns {Promise<number>}
- */
 export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   try {
     if (!pickupLat || !pickupLng) {
       return 1.0;
     }
 
-    // In a real production scenario, this would call TomTom or Google Maps Distance Matrix API:
-    // const url = `https://api.tomtom.com/traffic/services/4/flowSegmentData/absolute/10/json?key=${process.env.TOMTOM_API_KEY}&point=${pickupLat},${pickupLng}`;
-    // const response = await fetch(url);
-    // if (!response.ok) throw new Error("Request failed");
-    // const data = await response.json();
-    // return calculateMultiplierFromData(data);
-
-    // Mocking a live traffic integration:
-    // If it's rush hour, dynamically generate a surge multiplier (1.2 to 2.5) based on coordinates hash to simulate localized congestion
-    const hour = new Date().getHours();
-    const isRushHour =
-      (hour >= RUSH_HOUR_START_AM && hour <= RUSH_HOUR_END_AM) ||
-      (hour >= RUSH_HOUR_START_PM && hour <= RUSH_HOUR_END_PM);
-
-    if (isRushHour) {
-      // sin(x) + cos(y) ranges over [-2, 2], so after Math.abs it's [0, 2] — normalize to [0, 1] before scaling
-      const geoHash = Math.abs(Math.sin(pickupLat) + Math.cos(pickupLng)) / 2;
-      const surgeMultiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(MIN_SURGE_MULTIPLIER, MIN_SURGE_MULTIPLIER + (geoHash * SURGE_PEAK_AMPLITUDE))); // clamped to 1.2–2.5
-      logger.info(`[TrafficService] Live traffic surge detected at ${pickupLat},${pickupLng}: x${surgeMultiplier.toFixed(2)}`);
-      return Number(surgeMultiplier.toFixed(2));
+    const apiKey = process.env.TOMTOM_API_KEY || process.env.GOOGLE_MAPS_API_KEY;
+    if (!apiKey) {
+      logger.warn('[TrafficService] No traffic API key configured -- returning 1.0 (no surge)');
+      return 1.0;
     }
 
-    return 1.0;
+    let multiplier;
+    if (process.env.TOMTOM_API_KEY) {
+      const url = `https://api.tomtom.com/traffic/services/4/flowSegmentData/absolute/10/json?key=${process.env.TOMTOM_API_KEY}&point=${pickupLat},${pickupLng}`;
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`TomTom API error: ${response.status}`);
+      const data = await response.json();
+      const speedDiff = data.flowSegmentData?.speedDiffPercent || 0;
+      multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, 1.0 + Math.max(0, speedDiff / 100)));
+    } else {
+      const origin = `${pickupLat},${pickupLng}`;
+      const destination = `${pickupLat + 0.01},${pickupLng + 0.01}`;
+      const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${origin}&destinations=${destination}&key=${process.env.GOOGLE_MAPS_API_KEY}`;
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`Google API error: ${response.status}`);
+      const data = await response.json();
+      const duration = data.rows?.[0]?.elements?.[0]?.duration_in_traffic?.value;
+      const normalDuration = data.rows?.[0]?.elements?.[0]?.duration?.value;
+      if (duration && normalDuration && normalDuration > 0) {
+        multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, duration / normalDuration));
+      } else {
+        multiplier = 1.0;
+      }
+    }
+
+    if (multiplier > 1.0) {
+      logger.info(`[TrafficService] Live traffic data at ${pickupLat},${pickupLng}: x${Number(multiplier).toFixed(2)}`);
+    }
+    return Number(multiplier.toFixed(2));
   } catch (error) {
-    logger.error({ err: error }, '[TrafficService] Error fetching live traffic data');
-    // Fail open, return normal multiplier
+    logger.error({ err: error }, '[TrafficService] Error fetching live traffic data -- returning 1.0');
     return 1.0;
   }
 }


### PR DESCRIPTION
Closes #9765.

Enabled the TomTom API (or Google Distance Matrix fallback) in getLiveTrafficMultiplier with proper error handling. Falls back to 1.0 when no API key is configured.

Changes Made:
- backend/api/src/services/trafficService.js


Impact it Made:
Addresses the issue described in #9765.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).