### PR TITLE
test : added unit tests for AuthorizationError Permission and Role primitives

### DIFF
--- a/backend/api/eslint.config.js
+++ b/backend/api/eslint.config.js
@@ -13,6 +13,22 @@ export default [
         fetch: 'readonly',
       }
     },
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+        vi: 'writable',
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        test: 'readonly',
+      }
+    },
+  },
     rules: {
       'no-unused-vars': 'off',
       'no-undef': 'error',
@@ -20,6 +36,38 @@ export default [
       'no-useless-escape': 'off',
       'no-dupe-keys': 'off',
       'no-duplicate-imports': 'warn',
+    },
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+        vi: 'writable',
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        test: 'readonly',
+      }
+    },
+  },
+  },
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+        vi: 'writable',
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        test: 'readonly',
+      }
     },
   },
 ];

--- a/backend/api/eslint.config.js
+++ b/backend/api/eslint.config.js
@@ -13,22 +13,6 @@ export default [
         fetch: 'readonly',
       }
     },
-  {
-    files: ['test/**/*.js'],
-    languageOptions: {
-      globals: {
-        ...globals.node,
-        ...globals.jest,
-        vi: 'writable',
-        describe: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        test: 'readonly',
-      }
-    },
-  },
     rules: {
       'no-unused-vars': 'off',
       'no-undef': 'error',
@@ -37,22 +21,6 @@ export default [
       'no-dupe-keys': 'off',
       'no-duplicate-imports': 'warn',
     },
-  {
-    files: ['test/**/*.js'],
-    languageOptions: {
-      globals: {
-        ...globals.node,
-        ...globals.jest,
-        vi: 'writable',
-        describe: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        test: 'readonly',
-      }
-    },
-  },
   },
   {
     files: ['test/**/*.js'],

--- a/backend/api/test/unit/core/auth/authorizationError.test.js
+++ b/backend/api/test/unit/core/auth/authorizationError.test.js
@@ -1,0 +1,34 @@
+/* eslint-env vitest */
+/* eslint-disable no-unused-vars */
+import { describe, it, expect } from 'vitest';
+import { AuthorizationError } from '../../../../src/core/auth/AuthorizationError.js';
+
+describe('AuthorizationError', () => {
+  it('should create an error with a message', () => {
+    const error = new AuthorizationError('Not authorized');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AuthorizationError);
+    expect(error.message).toBe('Not authorized');
+  });
+
+  it('should have AuthorizationError as name', () => {
+    const error = new AuthorizationError('Forbidden');
+    expect(error.name).toBe('AuthorizationError');
+  });
+
+  it('should have the code property set when provided', () => {
+    const error = new AuthorizationError('Access denied', 'ERR_ACCESS_DENIED');
+    expect(error.code).toBe('ERR_ACCESS_DENIED');
+  });
+
+  it('should default code to undefined when not provided', () => {
+    const error = new AuthorizationError('No access');
+    expect(error.code).toBeUndefined();
+  });
+
+  it('should capture a stack trace', () => {
+    const error = new AuthorizationError('Stack trace test');
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain('AuthorizationError');
+  });
+});

--- a/backend/api/test/unit/core/auth/authorizationError.test.js
+++ b/backend/api/test/unit/core/auth/authorizationError.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { AuthorizationError } from '../../../../src/core/auth/AuthorizationError.js';
 

--- a/backend/api/test/unit/core/auth/authorizationError.test.js
+++ b/backend/api/test/unit/core/auth/authorizationError.test.js
@@ -1,5 +1,4 @@
-/* eslint-env vitest */
-/* eslint-disable no-unused-vars */
+/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { AuthorizationError } from '../../../../src/core/auth/AuthorizationError.js';
 

--- a/backend/api/test/unit/core/auth/permission.test.js
+++ b/backend/api/test/unit/core/auth/permission.test.js
@@ -1,5 +1,4 @@
-/* eslint-env vitest */
-/* eslint-disable no-unused-vars */
+/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { Permission } from '../../../../src/core/auth/Permission.js';
 

--- a/backend/api/test/unit/core/auth/permission.test.js
+++ b/backend/api/test/unit/core/auth/permission.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { Permission } from '../../../../src/core/auth/Permission.js';
 

--- a/backend/api/test/unit/core/auth/permission.test.js
+++ b/backend/api/test/unit/core/auth/permission.test.js
@@ -1,0 +1,35 @@
+/* eslint-env vitest */
+/* eslint-disable no-unused-vars */
+import { describe, it, expect } from 'vitest';
+import { Permission } from '../../../../src/core/auth/Permission.js';
+
+describe('Permission', () => {
+  it('should create a permission with a resource and action', () => {
+    const perm = new Permission('orders', 'create');
+    expect(perm.resource).toBe('orders');
+    expect(perm.action).toBe('create');
+  });
+
+  it('should generate a string representation', () => {
+    const perm = new Permission('drivers', 'read');
+    expect(perm.toString()).toBe('drivers:read');
+  });
+
+  it('should be equal to another permission with the same resource and action', () => {
+    const perm1 = new Permission('orders', 'update');
+    const perm2 = new Permission('orders', 'update');
+    expect(perm1.equals(perm2)).toBe(true);
+  });
+
+  it('should not be equal to a permission with different resource', () => {
+    const perm1 = new Permission('orders', 'delete');
+    const perm2 = new Permission('drivers', 'delete');
+    expect(perm1.equals(perm2)).toBe(false);
+  });
+
+  it('should handle wildcard action', () => {
+    const perm = new Permission('orders', '*');
+    expect(perm.action).toBe('*');
+    expect(perm.toString()).toBe('orders:*');
+  });
+});

--- a/backend/api/test/unit/core/auth/role.test.js
+++ b/backend/api/test/unit/core/auth/role.test.js
@@ -1,0 +1,32 @@
+/* eslint-env vitest */
+/* eslint-disable no-unused-vars */
+import { describe, it, expect } from 'vitest';
+import { Role } from '../../../../src/core/auth/Role.js';
+import { Permission } from '../../../../src/core/auth/Permission.js';
+
+describe('Role', () => {
+  it('should create a role with a name', () => {
+    const role = new Role('admin');
+    expect(role.name).toBe('admin');
+  });
+
+  it('should add permissions to the role', () => {
+    const role = new Role('editor');
+    const perm = new Permission('articles', 'write');
+    role.addPermission(perm);
+    expect(role.hasPermission(perm)).toBe(true);
+  });
+
+  it('should check if role has a permission', () => {
+    const role = new Role('viewer');
+    role.addPermission(new Permission('orders', 'read'));
+    expect(role.hasPermission(new Permission('orders', 'read'))).toBe(true);
+    expect(role.hasPermission(new Permission('orders', 'write'))).toBe(false);
+  });
+
+  it('should support wildcard permissions', () => {
+    const role = new Role('superuser');
+    role.addPermission(new Permission('*', '*'));
+    expect(role.hasPermission(new Permission('anything', 'any_action'))).toBe(true);
+  });
+});

--- a/backend/api/test/unit/core/auth/role.test.js
+++ b/backend/api/test/unit/core/auth/role.test.js
@@ -1,5 +1,4 @@
-/* eslint-env vitest */
-/* eslint-disable no-unused-vars */
+/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { Role } from '../../../../src/core/auth/Role.js';
 import { Permission } from '../../../../src/core/auth/Permission.js';

--- a/backend/api/test/unit/core/auth/role.test.js
+++ b/backend/api/test/unit/core/auth/role.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect } from 'vitest';
 import { Role } from '../../../../src/core/auth/Role.js';
 import { Permission } from '../../../../src/core/auth/Permission.js';


### PR DESCRIPTION
Closes #9768.

Added unit tests for AuthorizationError (construction, inheritance, code property), Permission (construction, equality, toString), and Role (permissions aggregation, wildcard support).

Changes Made:
- backend/api/test/unit/core/auth/authorizationError.test.js
- backend/api/test/unit/core/auth/permission.test.js
- backend/api/test/unit/core/auth/role.test.js


Impact it Made:
Addresses the issue described in #9768.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).