### PR TITLE
fix : added request schema validation for weigh-station sync-weight route

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1512,7 +1512,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -411,3 +411,17 @@ export const reportGripDataSchema = z.object({
       .nonnegative({ message: 'slip_events_count must be >= 0' })
   ).optional().default(0),
 }).strict();
+
+
+/**
+ * Schema for POST /api/driver/weigh-stations/sync-weight
+ */
+export const syncWeightSchema = z.object({
+  vehicleId: z.string().min(1, 'vehicleId is required'),
+  truckId: z.string().min(1, 'truckId is required'),
+  axles: z.array(z.object({
+    position: z.number().int().min(0),
+    pressure_psi: z.number().positive('pressure_psi must be a positive number'),
+  })).min(1, 'At least one axle is required'),
+  timestamp: z.string().datetime({ message: 'timestamp must be ISO 8601' }).optional(),
+});


### PR DESCRIPTION
Closes #9777.

Added syncWeightSchema Zod schema to requestSchemas.js and wired it into the POST /api/driver/weigh-stations/sync-weight route handler for input validation.

Changes Made:
- backend/api/src/validation/requestSchemas.js
- backend/api/src/routes/driverRoutes.js


Impact it Made:
Addresses the issue described in #9777.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).