### PR TITLE
fix: commit supabase/config.toml so supabase start works in CI

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,48 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/reference/cli/config
+
+# A string used to distinguish different Supabase projects on the same host.
+# Defaults to the working directory name when running `supabase init`.
+project_id = "truxify"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+
+[db]
+enabled = true
+# Port to use for the local database URL.
+port = 54322
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+
+[inbucket]
+enabled = true
+# Port to use for the email testing web interface.
+port = 54324
+smtp_port = 54325
+pop3_port = 54326
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[realtime]
+enabled = true
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for
+# constructing URLs used by emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are allowed to redirect to after
+# authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+
+[analytics]
+enabled = false


### PR DESCRIPTION
## Problem

`.github/workflows/supabase-ci.yml` runs `supabase start` to validate migrations, but the repository contains no `supabase/config.toml`. The Supabase CLI refuses to start without it, so the "Start Supabase locally and run migrations" step fails on every PR touching `supabase/**` and `supabase db lint` never runs.

## Fix

Commit `supabase/config.toml` so `supabase start` works in CI. The config is minimal and secret-free (only `project_id` is required; all other sections use CLI defaults), enabling the standard local services (api, db, studio, inbucket, storage, realtime, auth).

## Files changed

- `supabase/config.toml`

## Testing

The file parses as valid TOML and `project_id` resolves to `truxify`. With it committed, the `supabase start` step in `supabase-ci.yml` can proceed to run migrations and `supabase db lint`.

Closes #9655
