### PR TITLE
fix: replace top-level bash 'local' with plain assignments in analyze-app action

### DIFF
--- a/.github/actions/analyze-app/action.yml
+++ b/.github/actions/analyze-app/action.yml
@@ -429,7 +429,7 @@ runs:
           R_HTTP=$(cat "$R_STATUS" 2>/dev/null || echo "000")
 
           # ── Gemini fallback to OpenRouter / backoff ─────────────────────────
-          local g_attempt=1
+          g_attempt=1
           while { is_quota_err "$G_RAW" || [ "$G_HTTP" != "200" ]; } && [ $g_attempt -le 3 ]; do
             if [ $g_attempt -eq 1 ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
               echo "  Gemini failed/quota exceeded (HTTP $G_HTTP) — trying OpenRouter fallback..." >&2
@@ -460,7 +460,7 @@ runs:
           done
 
           # ── Groq rate limit backoff + retry ────────────────────────────
-          local r_attempt=1
+          r_attempt=1
           while [ "$R_HTTP" = "429" ] && [ $r_attempt -le 3 ]; do
             echo "  Groq rate limit — waiting 30s then retrying (Attempt $r_attempt/3)..." >&2
             sleep 30


### PR DESCRIPTION
## Problem

`.github/actions/analyze-app/action.yml` declares bash `local` variables (`local g_attempt=1`, `local r_attempt=1`) at the top level of the Layer 2 `run:` script — inside the `for FILE` loop but outside any function. In bash, `local` is only valid inside a function and returns non-zero otherwise; under `set -euo pipefail` the first iteration aborts the whole AI semantic analysis step.

## Fix

Replace the two top-level `local` declarations with plain assignments (`g_attempt=1`, `r_attempt=1`). The variables are only read later in the same script scope. The `local` usages inside the function definitions (`call_gemini_to_file`, `call_groq_to_file`, `call_openrouter_to_file`, `get_retry_wait`) are left unchanged.

## Files changed

- `.github/actions/analyze-app/action.yml`

## Testing

The affected run block still only uses `g_attempt`/`r_attempt` within the same top-level scope. All remaining `local` usages in the file are inside function bodies.

Closes #9656
