### PR TITLE
feat: implement platoon drafting synchronization (#9785)

### DIFF
--- a/apps/driver/lib/models/platoon_drafting_model.dart
+++ b/apps/driver/lib/models/platoon_drafting_model.dart
@@ -1,0 +1,29 @@
+class PlatoonTruck {
+  final String truckId; // "Lead Truck (Unit 409)", "Drafting (Unit 812)"
+  final double followingDistanceFeet;
+  final double currentSpeedMph;
+  final double brakeSyncLatencyMs;
+
+  PlatoonTruck({
+    required this.truckId,
+    required this.followingDistanceFeet,
+    required this.currentSpeedMph,
+    required this.brakeSyncLatencyMs,
+  });
+}
+
+class PlatoonSession {
+  final String status; // "Searching for Platoon Partners...", "V2V SYNC ACTIVE"
+  final bool isPlatoonActive;
+  final double aerodynamicFuelSavingsPercent;
+  final PlatoonTruck? leadTruck;
+  final PlatoonTruck? selfTruck;
+
+  PlatoonSession({
+    required this.status,
+    required this.isPlatoonActive,
+    required this.aerodynamicFuelSavingsPercent,
+    this.leadTruck,
+    this.selfTruck,
+  });
+}

--- a/apps/driver/lib/screens/platoon_drafting_screen.dart
+++ b/apps/driver/lib/screens/platoon_drafting_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import '../models/platoon_drafting_model.dart';
+import '../services/platoon_drafting_service.dart';
+
+class PlatoonDraftingScreen extends StatefulWidget {
+  const PlatoonDraftingScreen({super.key});
+
+  @override
+  State<PlatoonDraftingScreen> createState() => _PlatoonDraftingScreenState();
+}
+
+class _PlatoonDraftingScreenState extends State<PlatoonDraftingScreen> {
+  final PlatoonDraftingService _service = PlatoonDraftingService();
+  PlatoonSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.platoonStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulatePlatooning();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('V2V Platoon Sync'),
+        backgroundColor: Colors.cyan[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.isPlatoonActive) ...[
+                _buildSavingsCard(s.aerodynamicFuelSavingsPercent),
+                const SizedBox(height: 24),
+              ],
+              const Text('V2V TELEMETRY LINK', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              _buildTelemetryRadar(s),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(PlatoonSession s) {
+    Color headerColor = s.isPlatoonActive ? Colors.green[700]! : Colors.cyan[800]!;
+    IconData icon = s.isPlatoonActive ? Icons.multiple_stop : Icons.radar;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('COOPERATIVE ADAS', style: TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status, textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSavingsCard(double fuelSavings) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.green[50],
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.green, width: 2),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('AERODYNAMIC DRAFT', style: TextStyle(color: Colors.green, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+                SizedBox(height: 4),
+                Text('Active Fuel Savings', style: TextStyle(color: Colors.grey, fontSize: 12)),
+              ],
+            ),
+            Text('+${fuelSavings.toStringAsFixed(1)}%', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 32, color: Colors.green[800])),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTelemetryRadar(PlatoonSession s) {
+    bool hasLead = s.leadTruck != null;
+
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            if (hasLead) ...[
+              _buildTruckIcon(s.leadTruck!.truckId, Colors.blueGrey, true),
+              _buildConnectionLink(s.isPlatoonActive, s.selfTruck!.followingDistanceFeet, s.selfTruck!.brakeSyncLatencyMs),
+            ] else ...[
+               const Padding(
+                 padding: EdgeInsets.symmetric(vertical: 40),
+                 child: Icon(Icons.search, size: 48, color: Colors.grey),
+               )
+            ],
+            _buildTruckIcon(s.selfTruck!.truckId, s.isPlatoonActive ? Colors.green : Colors.cyan[900]!, false),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildConnectionLink(bool isActive, double distance, double latency) {
+    Color linkColor = isActive ? Colors.green : Colors.orange;
+    
+    return Column(
+      children: [
+        Container(
+          width: 4,
+          height: 60,
+          color: linkColor,
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: linkColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: linkColor),
+          ),
+          child: Column(
+            children: [
+              Text('${distance.toInt()} ft GAP', style: TextStyle(fontWeight: FontWeight.bold, color: linkColor, fontSize: 16)),
+              Text('Brake Sync: ${latency.toStringAsFixed(1)} ms', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+            ],
+          ),
+        ),
+        Container(
+          width: 4,
+          height: 60,
+          color: linkColor,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTruckIcon(String label, Color color, bool isLead) {
+    return Column(
+      children: [
+        Icon(Icons.local_shipping, size: 64, color: color),
+        Text(label, style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.grey)),
+        if (isLead) const Text('Lead Windbreaker', style: TextStyle(fontSize: 10, color: Colors.blueGrey)),
+      ],
+    );
+  }
+}

--- a/apps/driver/lib/services/platoon_drafting_service.dart
+++ b/apps/driver/lib/services/platoon_drafting_service.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import '../models/platoon_drafting_model.dart';
+
+class PlatoonDraftingService {
+  final _sessionController = StreamController<PlatoonSession>.broadcast();
+
+  Stream<PlatoonSession> get platoonStream => _sessionController.stream;
+
+  void simulatePlatooning() async {
+    // 1. Searching
+    _sessionController.add(PlatoonSession(
+      status: 'Scanning Highway for Truxify Convoys...',
+      isPlatoonActive: false,
+      aerodynamicFuelSavingsPercent: 0.0,
+      leadTruck: null,
+      selfTruck: PlatoonTruck(
+        truckId: 'Self (Unit 994)',
+        followingDistanceFeet: 0.0,
+        currentSpeedMph: 65.0,
+        brakeSyncLatencyMs: 0.0,
+      ),
+    ));
+
+    await Future.delayed(const Duration(seconds: 3));
+
+    // 2. Establishing Sync
+    _sessionController.add(PlatoonSession(
+      status: 'V2V Handshake in Progress...',
+      isPlatoonActive: false,
+      aerodynamicFuelSavingsPercent: 0.0,
+      leadTruck: PlatoonTruck(
+        truckId: 'Lead (Unit 409)',
+        followingDistanceFeet: 150.0,
+        currentSpeedMph: 65.0,
+        brakeSyncLatencyMs: 8.5,
+      ),
+      selfTruck: PlatoonTruck(
+        truckId: 'Self (Unit 994)',
+        followingDistanceFeet: 150.0,
+        currentSpeedMph: 67.0, // Closing the gap
+        brakeSyncLatencyMs: 8.5,
+      ),
+    ));
+    
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 3. Active Platooning
+    _sessionController.add(PlatoonSession(
+      status: 'AUTONOMOUS PLATOON DRAFTING ACTIVE',
+      isPlatoonActive: true,
+      aerodynamicFuelSavingsPercent: 12.5, // 12.5% fuel savings from drafting
+      leadTruck: PlatoonTruck(
+        truckId: 'Lead (Unit 409)',
+        followingDistanceFeet: 35.0,
+        currentSpeedMph: 65.0,
+        brakeSyncLatencyMs: 2.1, // Ultra-low latency V2V braking
+      ),
+      selfTruck: PlatoonTruck(
+        truckId: 'Self (Unit 994)',
+        followingDistanceFeet: 35.0, // Extremely close following distance made safe by AI
+        currentSpeedMph: 65.0,
+        brakeSyncLatencyMs: 2.1,
+      ),
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #9785

This PR introduces the frontend UI and mock telemetry services for the Platoon Drafting Synchronization (V2V Communication) system. Aerodynamic drag burns massive amounts of diesel. While drafting saves fuel, human reaction times make tailgating lethal in commercial trucking. This feature brings autonomous-level efficiency to human drivers via Vehicle-to-Vehicle (V2V) ADAS. By syncing the radar and braking systems of multiple Truxify trucks, the app allows drivers to safely draft just 35 feet apart at 65mph, relying on ultra-low latency machine-to-machine communication to instantly apply brakes across the entire platoon if the lead truck stops.

### Changes Made:
- **`platoon_drafting_model.dart`**: Established the `PlatoonSession` and `PlatoonTruck` schemas to map complex V2V telemetry, specifically tracking the critical `brakeSyncLatencyMs` and `followingDistanceFeet` to ensure the safety threshold is maintained while calculating the `aerodynamicFuelSavingsPercent`.
- **`platoon_drafting_service.dart`**: Implemented a mock `Stream` simulating a highway drafting maneuver. The service manages the transition from a "Scanning" state to an active "Handshake" where the trailing truck closes the physical gap, finally locking into an "Autonomous Platoon" state at a 35-foot gap with a 2.1ms brake sync latency.
- **`platoon_drafting_screen.dart`**: Built a futuristic, radar-driven ADAS dashboard. The UI focuses on driver trust, utilizing a vertical radar visualization that explicitly shows the physical gap and the millisecond brake latency between the trucks. When the V2V link secures, the interface locks into a green safe state and populates a dedicated savings card to show the driver exactly how much fuel the aerodynamic draft is saving them in real-time.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
