### PR TITLE
fix: align Env.apiBaseUrl with TRUXIFY_API_BASE_URL used by all call sites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -681,7 +681,7 @@ For local Supabase, use:
 flutter run --dart-define=ENV=dev \
             --dart-define=SUPABASE_URL=http://localhost:54321 \
             --dart-define=SUPABASE_ANON_KEY=your-local-key \
-            --dart-define=API_BASE_URL=http://localhost:3000
+            --dart-define=TRUXIFY_API_BASE_URL=http://localhost:5000
 ```
 
 **Windows PowerShell:**
@@ -690,5 +690,5 @@ flutter run `
   --dart-define=ENV=dev `
   --dart-define=SUPABASE_URL=http://localhost:54321 `
   --dart-define=SUPABASE_ANON_KEY=your-local-key `
-  --dart-define=API_BASE_URL=http://localhost:3000
+  --dart-define=TRUXIFY_API_BASE_URL=http://localhost:5000
 ```

--- a/dart_defines/dev.env.example
+++ b/dart_defines/dev.env.example
@@ -8,6 +8,6 @@
 ENV=dev
 SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=your-local-supabase-anon-key
-API_BASE_URL=http://localhost:3000
+TRUXIFY_API_BASE_URL=http://localhost:5000
 ML_ENGINE_URL=http://localhost:8000
 POLYGON_RPC_URL=https://rpc-amoy.polygon.technology

--- a/packages/truxify_shared/lib/src/config/env.dart
+++ b/packages/truxify_shared/lib/src/config/env.dart
@@ -44,7 +44,7 @@ class Env {
 
   // ── Backend API ────────────────────────────────────────────────────────────
   static const String apiBaseUrl = String.fromEnvironment(
-    'API_BASE_URL',
+    'TRUXIFY_API_BASE_URL',
     defaultValue: 'http://localhost:5000', // Local Express API
   );
 
@@ -81,7 +81,7 @@ class Env {
       errors.add('SUPABASE_ANON_KEY is not set');
     }
     if (apiBaseUrl.isEmpty) {
-      errors.add('API_BASE_URL is not set');
+      errors.add('TRUXIFY_API_BASE_URL is not set');
     }
 
     if (errors.isNotEmpty) {


### PR DESCRIPTION
## Problem

`Env.apiBaseUrl` in `packages/truxify_shared/lib/src/config/env.dart` reads the dart-define `API_BASE_URL`, but every actual API call site (`api_client.dart`, driver app services) reads `TRUXIFY_API_BASE_URL`. The documented dev setup (`dart_defines/dev.env.example` and the usage in `CONTRIBUTING.md`) passes the dead key `API_BASE_URL` on port 3000, so developers following the docs get no API override and the app silently falls back to defaults (e.g. `http://10.0.2.2:5000` on Android; a `StateError` in release mode).

## Fix

- Point `Env.apiBaseUrl` at `TRUXIFY_API_BASE_URL` (default `http://localhost:5000`), and update the `validate()` error message to name the correct key.
- Fix `dart_defines/dev.env.example` to use `TRUXIFY_API_BASE_URL=http://localhost:5000`.
- Fix the two `flutter run` examples in `CONTRIBUTING.md` that used the dead key and wrong port.

## Files changed

- `packages/truxify_shared/lib/src/config/env.dart`
- `dart_defines/dev.env.example`
- `CONTRIBUTING.md`

## Testing

Verified the config key is now consistent: all Flutter call sites (`api_client.dart`, driver/customer services), `generate_dart_defines.sh`, the Makefile, `.env.example`, and the fixed docs now reference `TRUXIFY_API_BASE_URL`. No Dart toolchain is available in this environment to run the analyzer.

Closes #9659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Flutter development commands to use the `TRUXIFY_API_BASE_URL` environment variable.
* **Configuration**
  * Renamed the backend API configuration key to `TRUXIFY_API_BASE_URL`.
  * Updated the default local development endpoint to port 5000.
  * Revised validation messages to reflect the new configuration name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->