### PR TITLE
fix : added input validation for userId in isValidCachedSupabaseProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -161,6 +161,9 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedSupabaseProfile(userId, cachedProfile) {
+  if (typeof userId !== "string" || !userId.trim()) {
+    return false;
+  }
   if (
     !cachedProfile ||
     typeof cachedProfile !== "object" ||

--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -532,4 +532,15 @@ describe('profileCache utility', () => {
       expect(logger.error).toHaveBeenCalled();
     });
   });
+
+  describe('isValidCachedSupabaseProfile', () => {
+    it('returns false when userId is not a non-empty string', async () => {
+      const { isValidCachedSupabaseProfile } = await import('../../src/lib/profileCache.js');
+      const validProfile = { id: 'user-123', role: 'driver', isActive: true };
+      expect(isValidCachedSupabaseProfile(null, validProfile)).toBe(false);
+      expect(isValidCachedSupabaseProfile('', validProfile)).toBe(false);
+      expect(isValidCachedSupabaseProfile(123, validProfile)).toBe(false);
+      expect(isValidCachedSupabaseProfile('   ', validProfile)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Closes #9845.

Summary of What Has Been Done:
Added non-empty string type validation for the `userId` parameter in `isValidCachedSupabaseProfile` within `backend/api/src/lib/profileCache.js`.

Changes Made:
- `backend/api/src/lib/profileCache.js`: Added `typeof userId !== 'string' || !userId.trim()` check.
- `backend/api/test/unit/profileCache.test.js`: Added unit tests verifying invalid `userId` values return `false`.

Impact it Made:
Improves profile cache validation robustness and eliminates edge-case type errors when handling invalid user identifiers.

Note: This pull request is submitted as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached profile validation by rejecting missing, blank, or invalid user IDs.
  * Prevents invalid cached profile data from being accepted.

* **Tests**
  * Added coverage for null, empty, whitespace-only, and non-string user IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->