### PR TITLE
fix : added coordinate range bounds validation in reverseGeocode

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -19,6 +19,9 @@ function getTimeoutMs() {
  */
 export async function reverseGeocode(lat, lon) {
   if (lat == null || lon == null || Number.isNaN(Number(lat)) || Number.isNaN(Number(lon))) return null;
+  const numLat = Number(lat);
+  const numLon = Number(lon);
+  if (numLat < -90 || numLat > 90 || numLon < -180 || numLon > 180) return null;
 
   // Round coordinates to ~100m precision (3 decimal places) to maximize cache hits
   const roundedLat = Number(lat).toFixed(3);

--- a/backend/api/test/unit/reverseGeocode.test.js
+++ b/backend/api/test/unit/reverseGeocode.test.js
@@ -46,6 +46,16 @@ describe('reverseGeocode', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null for out-of-bounds lat (< -90 or > 90)', async () => {
+    expect(await reverseGeocode(95.0, 72.5)).toBeNull();
+    expect(await reverseGeocode(-95.0, 72.5)).toBeNull();
+  });
+
+  it('returns null for out-of-bounds lon (< -180 or > 180)', async () => {
+    expect(await reverseGeocode(23.0, 185.0)).toBeNull();
+    expect(await reverseGeocode(23.0, -185.0)).toBeNull();
+  });
+
   it('returns cached value from Redis when available', async () => {
     mockRedisGet.mockResolvedValue('MG Road, Mumbai');
     const result = await reverseGeocode(19.076, 72.8777);


### PR DESCRIPTION
Closes #9853.

Summary of What Has Been Done:
Added geographic range bounds check (`-90 <= lat <= 90` and `-180 <= lon <= 180`) to `reverseGeocode` in `backend/api/src/lib/reverseGeocode.js`.

Changes Made:
- `backend/api/src/lib/reverseGeocode.js`: Added bounds checking for latitude and longitude.
- `backend/api/test/unit/reverseGeocode.test.js`: Added unit tests verifying out-of-bound inputs return `null`.

Impact it Made:
Hardens geocoding service against invalid inputs and prevents unnecessary external API calls.

Note: This pull request is submitted as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.