### PR TITLE
fix : added negative distance check to convertKmToMiles in pricing.js

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -190,8 +190,11 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
 }
 
 export function convertKmToMiles(km) {
-  if (typeof km !== 'number' || Number.isNaN(km)) {
-    throw new TypeError('km must be a number');
+  if (typeof km !== 'number' || Number.isNaN(km) || !Number.isFinite(km)) {
+    throw new TypeError('km must be a finite number');
+  }
+  if (km < 0) {
+    throw new RangeError('km must be non-negative');
   }
   return km * 0.621371;
 }

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -227,11 +227,17 @@ describe('Pricing Service Unit Tests', () => {
       expect(convertKmToMiles(100)).toBeCloseTo(62.1371, 4);
     });
 
-    it('throws TypeError for non-numeric or NaN', () => {
+    it('throws TypeError for non-numeric, NaN, or non-finite', () => {
       expect(() => convertKmToMiles('100')).toThrow(TypeError);
       expect(() => convertKmToMiles(null)).toThrow(TypeError);
       expect(() => convertKmToMiles(undefined)).toThrow(TypeError);
       expect(() => convertKmToMiles(NaN)).toThrow(TypeError);
+      expect(() => convertKmToMiles(Infinity)).toThrow(TypeError);
+    });
+
+    it('throws RangeError for negative km values', () => {
+      expect(() => convertKmToMiles(-5)).toThrow(RangeError);
+      expect(() => convertKmToMiles(-100)).toThrow(RangeError);
     });
   });
 });


### PR DESCRIPTION
Closes #9856.

Summary of What Has Been Done:
Updated `convertKmToMiles` in `backend/api/src/lib/pricing.js` to reject non-finite and negative distance inputs (`km < 0`).

Changes Made:
- `backend/api/src/lib/pricing.js`: Added finite and non-negative range validations.
- `backend/api/test/unit/pricing.test.js`: Added unit tests for RangeError and TypeError on invalid `km` inputs.

Impact it Made:
Ensures pricing helper functions fail safely when provided invalid or negative distance values.

Note: This pull request is submitted as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.