### PR TITLE
fix : added destroy method to CircuitBreaker for resource cleanup

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -53,6 +53,10 @@ export class CircuitBreaker {
     this.nextAttempt = Date.now();
   }
 
+  destroy() {
+    this.reset();
+  }
+
   async execute(fn, ...args) {
     const currentState = this.getState();
 

--- a/backend/api/test/unit/circuitBreaker.test.js
+++ b/backend/api/test/unit/circuitBreaker.test.js
@@ -84,4 +84,21 @@ describe('CircuitBreaker Unit Tests', () => {
     expect(res).toBe('recovered');
     expect(breaker.getState()).toBe(CircuitState.CLOSED);
   });
+
+  it('cleans up resources and resets state when destroy is called', () => {
+    const breaker = new CircuitBreaker('testDestroyBreaker', {
+      failureThreshold: 1,
+      resetTimeoutMs: 10000,
+      fallback: () => 'fallback',
+    });
+    breaker.onFailure(new Error('Fail'), []);
+    expect(breaker._halfOpenTimer).not.toBeNull();
+    expect(breaker.state).toBe(CircuitState.OPEN);
+
+    breaker.destroy();
+
+    expect(breaker._halfOpenTimer).toBeNull();
+    expect(breaker.state).toBe(CircuitState.CLOSED);
+    expect(breaker.failureCount).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes #9858.

Summary of What Has Been Done:
Added `destroy()` method to `CircuitBreaker` class in `backend/api/src/lib/circuitBreaker.js` for explicit timer and state cleanup.

Changes Made:
- `backend/api/src/lib/circuitBreaker.js`: Added `destroy()` method calling `reset()`.
- `backend/api/test/unit/circuitBreaker.test.js`: Added unit tests verifying timer clearance and state reset when `destroy()` is called.

Impact it Made:
Ensures clean shutdown of circuit breaker instances during teardown.

Note: This pull request is submitted as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.