### PR TITLE
feat : added isValidOrderDisplayId validation helper in orderDisplayId.js

### DIFF
--- a/backend/api/src/lib/orderDisplayId.js
+++ b/backend/api/src/lib/orderDisplayId.js
@@ -34,3 +34,8 @@ export function generateOrderDisplayId() {
   ).join('');
   return `${DISPLAY_ID_PREFIX}${dateStr}${random}`;
 }
+
+export function isValidOrderDisplayId(displayId) {
+  if (typeof displayId !== 'string') return false;
+  return /^#FF\d{8}[A-Z0-9]{12}$/.test(displayId);
+}

--- a/backend/api/test/unit/orderDisplayId.test.js
+++ b/backend/api/test/unit/orderDisplayId.test.js
@@ -12,7 +12,7 @@ vi.mock('crypto', () => ({
   },
 }));
 
-const { generateOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } = await import('../../src/lib/orderDisplayId.js');
+const { generateOrderDisplayId, isValidOrderDisplayId, ORDER_DISPLAY_ID_MAX_RETRIES } = await import('../../src/lib/orderDisplayId.js');
 
 describe('orderDisplayId', () => {
   describe('generateOrderDisplayId', () => {
@@ -56,6 +56,22 @@ describe('orderDisplayId', () => {
     it('ORDER_DISPLAY_ID_MAX_RETRIES is defined and positive', () => {
       expect(ORDER_DISPLAY_ID_MAX_RETRIES).toBeGreaterThan(0);
       expect(typeof ORDER_DISPLAY_ID_MAX_RETRIES).toBe('number');
+    });
+  });
+
+  describe('isValidOrderDisplayId', () => {
+    it('returns true for a valid generated display ID', () => {
+      const id = generateOrderDisplayId();
+      expect(isValidOrderDisplayId(id)).toBe(true);
+    });
+
+    it('returns false for invalid inputs (null, non-string, wrong prefix, incorrect length)', () => {
+      expect(isValidOrderDisplayId(null)).toBe(false);
+      expect(isValidOrderDisplayId(12345)).toBe(false);
+      expect(isValidOrderDisplayId('#XX20260802AAAAAAAAAAAA')).toBe(false);
+      expect(isValidOrderDisplayId('#FF20260802SHORT')).toBe(false);
+      expect(isValidOrderDisplayId('#FF20260802AAAAAAAAAAAAEXTRA')).toBe(false);
+      expect(isValidOrderDisplayId('#FF20260802AAAAAA!AAAAA')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Closes #9861.

Summary of What Has Been Done:
Added `isValidOrderDisplayId` helper function in `backend/api/src/lib/orderDisplayId.js` for checking order display ID formatting.

Changes Made:
- `backend/api/src/lib/orderDisplayId.js`: Exported `isValidOrderDisplayId(displayId)` regex validator matching `#FF<YYYYMMDD><12-char alphanumeric>`.
- `backend/api/test/unit/orderDisplayId.test.js`: Added unit tests for valid and invalid display ID inputs.

Impact it Made:
Provides reusable display ID format validation across API and socket handlers.

Note: This pull request is submitted as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.