### PR TITLE
feat: implement hyperspectral imaging for produce quality assurance (#9792)

### DIFF
--- a/apps/driver/lib/models/hyperspectral_imaging_model.dart
+++ b/apps/driver/lib/models/hyperspectral_imaging_model.dart
@@ -1,0 +1,31 @@
+class ProduceAnalysis {
+  final String commodity; // "Strawberries", "Romaine Lettuce"
+  final double waterContentPercent;
+  final double chlorophyllDegradationIndex; // 0-100, higher is worse
+  final double internalBruisingPercent;
+  final String freshnessGrade; // "A - Peak Freshness", "C - Degrading"
+  final bool isClaimRisk;
+
+  ProduceAnalysis({
+    required this.commodity,
+    required this.waterContentPercent,
+    required this.chlorophyllDegradationIndex,
+    required this.internalBruisingPercent,
+    required this.freshnessGrade,
+    required this.isClaimRisk,
+  });
+}
+
+class HyperspectralSession {
+  final String status; // "Scanning Cellular Signatures...", "Baseline Cryptographically Sealed"
+  final bool isScanning;
+  final ProduceAnalysis? analysis;
+  final String? forensicHash;
+
+  HyperspectralSession({
+    required this.status,
+    required this.isScanning,
+    this.analysis,
+    this.forensicHash,
+  });
+}

--- a/apps/driver/lib/screens/hyperspectral_imaging_screen.dart
+++ b/apps/driver/lib/screens/hyperspectral_imaging_screen.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import '../models/hyperspectral_imaging_model.dart';
+import '../services/hyperspectral_imaging_service.dart';
+
+class HyperspectralImagingScreen extends StatefulWidget {
+  const HyperspectralImagingScreen({super.key});
+
+  @override
+  State<HyperspectralImagingScreen> createState() => _HyperspectralImagingScreenState();
+}
+
+class _HyperspectralImagingScreenState extends State<HyperspectralImagingScreen> {
+  final HyperspectralImagingService _service = HyperspectralImagingService();
+  HyperspectralSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.scannerStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateProduceScan();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Hyperspectral AI Scanner'),
+        backgroundColor: Colors.deepPurple[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.isScanning)
+                _buildScanningLens()
+              else if (s.analysis != null) ...[
+                _buildFreshnessCard(s.analysis!),
+                const SizedBox(height: 24),
+                const Text('CELLULAR TELEMETRY', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                const SizedBox(height: 12),
+                _buildTelemetryRow('Cellular H₂O', '${s.analysis!.waterContentPercent}%', Icons.water_drop, Colors.blue),
+                const SizedBox(height: 8),
+                _buildTelemetryRow('Chlorophyll Decay', '${s.analysis!.chlorophyllDegradationIndex}', Icons.eco, Colors.green),
+                const SizedBox(height: 8),
+                _buildTelemetryRow('Internal Bruising', '${s.analysis!.internalBruisingPercent}%', Icons.coronavirus, Colors.red),
+                const SizedBox(height: 24),
+                if (s.forensicHash != null) _buildForensicSealCard(s.forensicHash!),
+              ],
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(HyperspectralSession s) {
+    bool isComplete = !s.isScanning && s.analysis != null;
+    Color headerColor = isComplete ? Colors.green[800]! : Colors.deepPurple[800]!;
+    IconData icon = isComplete ? Icons.verified : Icons.document_scanner;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('FORENSIC COMMODITY SCAN', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+          if (s.isScanning) ...[
+            const SizedBox(height: 16),
+            const LinearProgressIndicator(color: Colors.white, backgroundColor: Colors.white24),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanningLens() {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: const Padding(
+        padding: EdgeInsets.all(48),
+        child: Column(
+          children: [
+            Icon(Icons.center_focus_weak, size: 80, color: Colors.deepPurple),
+            SizedBox(height: 24),
+            Text('Point camera at pallets', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+            SizedBox(height: 8),
+            Text('Capturing non-visible infrared wavelengths...', textAlign: TextAlign.center, style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFreshnessCard(ProduceAnalysis a) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: const BorderSide(color: Colors.green, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Text(a.commodity, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+            const Divider(height: 32),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              decoration: BoxDecoration(color: Colors.green[50], borderRadius: BorderRadius.circular(12)),
+              child: Text(a.freshnessGrade, style: TextStyle(color: Colors.green[800], fontSize: 24, fontWeight: FontWeight.bold)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTelemetryRow(String label, String value, IconData icon, Color color) {
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: ListTile(
+        leading: Icon(icon, color: color),
+        title: Text(label),
+        trailing: Text(value, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+      ),
+    );
+  }
+
+  Widget _buildForensicSealCard(String hash) {
+    return Card(
+      color: Colors.grey[900],
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.lock, color: Colors.yellow, size: 16),
+                SizedBox(width: 8),
+                Text('LEGAL DEFENSE SEAL GENERATED', style: TextStyle(color: Colors.yellow, fontWeight: FontWeight.bold, fontSize: 12, letterSpacing: 1.2)),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(hash, style: const TextStyle(color: Colors.white54, fontFamily: 'monospace', fontSize: 12)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/hyperspectral_imaging_service.dart
+++ b/apps/driver/lib/services/hyperspectral_imaging_service.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import '../models/hyperspectral_imaging_model.dart';
+
+class HyperspectralImagingService {
+  final _sessionController = StreamController<HyperspectralSession>.broadcast();
+
+  Stream<HyperspectralSession> get scannerStream => _sessionController.stream;
+
+  void simulateProduceScan() async {
+    // 1. Initial Scanning
+    _sessionController.add(HyperspectralSession(
+      status: 'Isolating Non-Visible Light Bands...',
+      isScanning: true,
+      analysis: null,
+      forensicHash: null,
+    ));
+
+    await Future.delayed(const Duration(seconds: 3));
+
+    // 2. Analyzing Cellular Data
+    _sessionController.add(HyperspectralSession(
+      status: 'Analyzing Cellular H2O and Chlorophyll...',
+      isScanning: true,
+      analysis: ProduceAnalysis(
+        commodity: 'California Strawberries',
+        waterContentPercent: 88.5,
+        chlorophyllDegradationIndex: 12.0, // Low degradation
+        internalBruisingPercent: 1.5,
+        freshnessGrade: 'A - Peak Freshness',
+        isClaimRisk: false,
+      ),
+      forensicHash: null,
+    ));
+    
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 3. Scan Locked and Hashed
+    _sessionController.add(HyperspectralSession(
+      status: 'BASELINE FRESHNESS CRYPTOGRAPHICALLY SEALED',
+      isScanning: false,
+      analysis: ProduceAnalysis(
+        commodity: 'California Strawberries',
+        waterContentPercent: 88.5,
+        chlorophyllDegradationIndex: 12.0,
+        internalBruisingPercent: 1.5,
+        freshnessGrade: 'A - Peak Freshness',
+        isClaimRisk: false,
+      ),
+      forensicHash: 'SHA256: 9f86d081884c7d659a2feaa0c55ad015',
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION

## Description
Resolves #9792

This PR introduces the frontend UI and mock forensic services for the Hyperspectral Produce Quality Assurance scanner. Refrigerated trucking companies frequently suffer massive financial losses when brokers load degrading produce, only to legally pin the inevitable rejection on the carrier days later. Standard photos cannot prove internal chemical state. This feature solves this liability by utilizing smartphone infrared sensors for hyperspectral analysis. By analyzing cellular water content and chlorophyll decay at the point of pickup, the app establishes an irrefutable baseline of freshness and cryptographically seals it, protecting the driver from fraudulent claims.

### Changes Made:
- **`hyperspectral_imaging_model.dart`**: Established the `HyperspectralSession` and `ProduceAnalysis` schemas, specifically mapping biological telemetry (`waterContentPercent`, `chlorophyllDegradationIndex`) into a legal grading system, backed by a `forensicHash`.
- **`hyperspectral_imaging_service.dart`**: Implemented a mock `Stream` simulating a forensic pickup scan of California Strawberries. The service progresses from isolating non-visible light bands to analyzing cellular structures, ultimately generating an SHA256 cryptographic seal to lock in the "Peak Freshness" baseline.
- **`hyperspectral_imaging_screen.dart`**: Built a highly specialized, forensic-focused UI. The interface utilizes a deep purple infrared aesthetic. It guides the driver from an active AR scanning lens into a structured biological telemetry readout. Crucially, it renders a bold "LEGAL DEFENSE SEAL" card at the bottom, providing the driver with immediate psychological relief that they are legally protected from a freight claim.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
