### PR TITLE
feat: implement truck stop wifi mesh network offloading (#9797)

### DIFF
--- a/apps/driver/lib/models/mesh_offload_model.dart
+++ b/apps/driver/lib/models/mesh_offload_model.dart
@@ -1,0 +1,29 @@
+class OffloadData {
+  final String dataType; // "Dashcam Video (4K)", "ECM Telemetry"
+  final double sizeMb;
+  final bool isUploaded;
+
+  OffloadData({
+    required this.dataType,
+    required this.sizeMb,
+    required this.isUploaded,
+  });
+}
+
+class MeshSession {
+  final String status; // "Holding on Cellular...", "Connecting to Truck Stop Wi-Fi...", "Bulk Offload Complete"
+  final bool isConnectedToMesh;
+  final String? networkName; // "Pilot Flying J - Secure", "Truxify Mesh (Truck 492)"
+  final double uploadSpeedMbps;
+  final double cellularDataSavedMb;
+  final List<OffloadData> dataQueue;
+
+  MeshSession({
+    required this.status,
+    required this.isConnectedToMesh,
+    this.networkName,
+    required this.uploadSpeedMbps,
+    required this.cellularDataSavedMb,
+    required this.dataQueue,
+  });
+}

--- a/apps/driver/lib/screens/mesh_offload_screen.dart
+++ b/apps/driver/lib/screens/mesh_offload_screen.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import '../models/mesh_offload_model.dart';
+import '../services/mesh_offload_service.dart';
+
+class MeshOffloadScreen extends StatefulWidget {
+  const MeshOffloadScreen({super.key});
+
+  @override
+  State<MeshOffloadScreen> createState() => _MeshOffloadScreenState();
+}
+
+class _MeshOffloadScreenState extends State<MeshOffloadScreen> {
+  final MeshOffloadService _service = MeshOffloadService();
+  MeshSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.meshStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateMeshOffload();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mesh Data Offload'),
+        backgroundColor: Colors.teal[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildNetworkCard(s),
+              const SizedBox(height: 24),
+              const Text('DATA QUEUE', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              ...s.dataQueue.map((item) => _buildQueueItem(item)),
+              const SizedBox(height: 24),
+              if (s.cellularDataSavedMb > 0) _buildSavingsCard(s.cellularDataSavedMb),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(MeshSession s) {
+    bool isComplete = s.status.contains('COMPLETE');
+    bool isUploading = s.status.contains('UPLOADING');
+    
+    Color headerColor;
+    IconData icon;
+    
+    if (isComplete) {
+      headerColor = Colors.green[800]!;
+      icon = Icons.cloud_done;
+    } else if (isUploading) {
+      headerColor = Colors.teal[700]!;
+      icon = Icons.cloud_upload;
+    } else if (s.isConnectedToMesh) {
+      headerColor = Colors.orange[800]!;
+      icon = Icons.wifi_protected_setup;
+    } else {
+      headerColor = Colors.blueGrey[800]!;
+      icon = Icons.cell_tower;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('DISTRIBUTED MESH NETWORK', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+          if (isUploading) ...[
+            const SizedBox(height: 16),
+            const LinearProgressIndicator(color: Colors.white, backgroundColor: Colors.white24),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNetworkCard(MeshSession s) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(color: s.isConnectedToMesh ? Colors.teal[50] : Colors.blueGrey[50], borderRadius: BorderRadius.circular(12)),
+              child: Icon(s.isConnectedToMesh ? Icons.wifi : Icons.cell_tower, color: s.isConnectedToMesh ? Colors.teal[900] : Colors.blueGrey[900], size: 32),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(s.networkName ?? 'Cellular (5G)', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+                  Text(s.isConnectedToMesh ? 'Speed: ${s.uploadSpeedMbps} Mbps' : 'Bandwidth Restricted', style: TextStyle(color: s.isConnectedToMesh ? Colors.teal[900] : Colors.blueGrey[900])),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQueueItem(OffloadData item) {
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: ListTile(
+        leading: Icon(
+          item.isUploaded ? Icons.check_circle : Icons.data_usage,
+          color: item.isUploaded ? Colors.green : Colors.grey,
+        ),
+        title: Text(item.dataType, style: TextStyle(fontWeight: item.isUploaded ? FontWeight.normal : FontWeight.bold)),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text('${(item.sizeMb / 1024).toStringAsFixed(2)} GB', style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(item.isUploaded ? 'UPLOADED' : 'QUEUED', style: TextStyle(fontSize: 10, color: item.isUploaded ? Colors.green : Colors.grey)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSavingsCard(double savedMb) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.green[50],
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.green, width: 2),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('COST AVOIDANCE', style: TextStyle(color: Colors.green, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+                SizedBox(height: 4),
+                Text('5G Cellular Data Saved', style: TextStyle(color: Colors.grey, fontSize: 12)),
+              ],
+            ),
+            Text('${(savedMb / 1024).toStringAsFixed(1)} GB', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 32, color: Colors.green[800])),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/mesh_offload_service.dart
+++ b/apps/driver/lib/services/mesh_offload_service.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import '../models/mesh_offload_model.dart';
+
+class MeshOffloadService {
+  final _sessionController = StreamController<MeshSession>.broadcast();
+
+  Stream<MeshSession> get meshStream => _sessionController.stream;
+
+  void simulateMeshOffload() async {
+    final queue = [
+      OffloadData(dataType: 'Dashcam Video (4K) - Last 8 Hrs', sizeMb: 4250.0, isUploaded: false),
+      OffloadData(dataType: 'ECM Telemetry Logs', sizeMb: 120.5, isUploaded: false),
+      OffloadData(dataType: 'Driver HOS Logs', sizeMb: 15.2, isUploaded: false),
+    ];
+
+    // 1. On Cellular (Holding)
+    _sessionController.add(MeshSession(
+      status: 'On Cellular (5G). Holding large files.',
+      isConnectedToMesh: false,
+      networkName: null,
+      uploadSpeedMbps: 0.0,
+      cellularDataSavedMb: 0.0,
+      dataQueue: List.from(queue),
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 2. Connecting to Mesh
+    _sessionController.add(MeshSession(
+      status: 'Establishing Peer-to-Peer Mesh Connection...',
+      isConnectedToMesh: true,
+      networkName: 'Truxify Mesh (Truck #4922)', // Connected to another truck nearby
+      uploadSpeedMbps: 0.0,
+      cellularDataSavedMb: 0.0,
+      dataQueue: List.from(queue),
+    ));
+    
+    await Future.delayed(const Duration(seconds: 3));
+
+    // 3. Uploading
+    _sessionController.add(MeshSession(
+      status: 'BULK UPLOADING VIA MESH NETWORK',
+      isConnectedToMesh: true,
+      networkName: 'Truxify Mesh (Truck #4922)',
+      uploadSpeedMbps: 145.5,
+      cellularDataSavedMb: 2100.0, // Mid-upload
+      dataQueue: [
+        OffloadData(dataType: 'Dashcam Video (4K) - Last 8 Hrs', sizeMb: 4250.0, isUploaded: false), // In progress
+        OffloadData(dataType: 'ECM Telemetry Logs', sizeMb: 120.5, isUploaded: true),
+        OffloadData(dataType: 'Driver HOS Logs', sizeMb: 15.2, isUploaded: true),
+      ],
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 4. Complete
+    _sessionController.add(MeshSession(
+      status: 'OFFLOAD COMPLETE. QUEUE CLEARED.',
+      isConnectedToMesh: true,
+      networkName: 'Truxify Mesh (Truck #4922)',
+      uploadSpeedMbps: 0.0,
+      cellularDataSavedMb: 4385.7,
+      dataQueue: [
+        OffloadData(dataType: 'Dashcam Video (4K) - Last 8 Hrs', sizeMb: 4250.0, isUploaded: true),
+        OffloadData(dataType: 'ECM Telemetry Logs', sizeMb: 120.5, isUploaded: true),
+        OffloadData(dataType: 'Driver HOS Logs', sizeMb: 15.2, isUploaded: true),
+      ],
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #9797

This PR introduces the frontend UI and mock networking services for the Truck Stop Wi-Fi Mesh Network Offloading feature. Modern commercial fleets are drowning in data costs, generating gigabytes of 4K dashcam video and ECM telemetry daily. Uploading this over standard 5G cellular networks is prohibitively expensive. This feature implements an intelligent data queuing system. The app holds large data payloads while on cellular networks and dynamically establishes high-speed, peer-to-peer mesh connections when parked at major truck stops, offloading the data in bulk and avoiding massive cellular overage fees.

### Changes Made:
- **`mesh_offload_model.dart`**: Established the `MeshSession` and `OffloadData` schemas, mapping the logical network state (`isConnectedToMesh`, `uploadSpeedMbps`) directly to the file payload queue (`isUploaded`, `sizeMb`).
- **`mesh_offload_service.dart`**: Implemented a mock `Stream` simulating an end-of-day data dump. The service holds 4.3 GB of dashcam video while on a cellular connection, successfully bridges to a nearby Truxify peer-to-peer mesh, and executes a high-speed bulk upload, directly tracking the `cellularDataSavedMb`.
- **`mesh_offload_screen.dart`**: Built a technical networking dashboard. The UI provides transparent visibility into the app's background data management. It utilizes dynamic color shifts to indicate network transition (from restricted cellular to active mesh), renders the live data queue, and prominently features a "COST AVOIDANCE" card to prove the financial ROI of the system.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
