### PR TITLE
feat: implement LTL cross-docking ETA synchronization (#9799)

### DIFF
--- a/apps/driver/lib/models/cross_dock_sync_model.dart
+++ b/apps/driver/lib/models/cross_dock_sync_model.dart
@@ -1,37 +1,33 @@
-class TruckTelemetry {
+class InboundTruck {
   final String truckId;
-  final String role; // "Inbound" or "Outbound"
-  final double distanceToDockMiles;
-  final int estimatedArrivalMinutes;
+  final String origin;
   final double currentSpeedMph;
-  final double targetSpeedMph; // The recommended speed for perfect sync
+  final String eta;
+  final bool isDelayed;
 
-  TruckTelemetry({
+  InboundTruck({
     required this.truckId,
-    required this.role,
-    required this.distanceToDockMiles,
-    required this.estimatedArrivalMinutes,
+    required this.origin,
     required this.currentSpeedMph,
-    required this.targetSpeedMph,
+    required this.eta,
+    required this.isDelayed,
   });
 }
 
 class CrossDockSession {
-  final String facilityName;
-  final String facilityLocation;
-  final int syncDeltaMinutes; // Difference in ETA between the two trucks
-  final TruckTelemetry selfTruck;
-  final TruckTelemetry partnerTruck;
-  final String adviceText;
-  final String status; // "Out of Sync", "Synchronizing", "Perfect Sync"
+  final String status; // "Monitoring Inbound Fleet...", "Synchronizing Network Speeds"
+  final String targetTerminal;
+  final String synchronizedEta;
+  final double recommendedSpeedMph;
+  final bool isSpeedAdjusted;
+  final List<InboundTruck> networkTrucks;
 
   CrossDockSession({
-    required this.facilityName,
-    required this.facilityLocation,
-    required this.syncDeltaMinutes,
-    required this.selfTruck,
-    required this.partnerTruck,
-    required this.adviceText,
     required this.status,
+    required this.targetTerminal,
+    required this.synchronizedEta,
+    required this.recommendedSpeedMph,
+    required this.isSpeedAdjusted,
+    required this.networkTrucks,
   });
 }

--- a/apps/driver/lib/screens/cross_dock_sync_screen.dart
+++ b/apps/driver/lib/screens/cross_dock_sync_screen.dart
@@ -19,7 +19,7 @@ class _CrossDockSyncScreenState extends State<CrossDockSyncScreen> {
     _service.syncStream.listen((data) {
       if (mounted) setState(() => _session = data);
     });
-    _service.simulateSynchronization();
+    _service.simulateNetworkSync();
   }
 
   @override
@@ -32,10 +32,10 @@ class _CrossDockSyncScreenState extends State<CrossDockSyncScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('JIT Cross-Dock Sync'),
-        backgroundColor: Colors.blueGrey[900],
+        title: const Text('LTL Network Sync AI'),
+        backgroundColor: Colors.indigo[900],
       ),
-      backgroundColor: Colors.blueGrey[50],
+      backgroundColor: Colors.grey[200],
       body: _session == null
           ? const Center(child: CircularProgressIndicator())
           : _buildDashboard(),
@@ -44,36 +44,19 @@ class _CrossDockSyncScreenState extends State<CrossDockSyncScreen> {
 
   Widget _buildDashboard() {
     final s = _session!;
-    Color statusColor = Colors.orange;
-    if (s.status == 'Perfect Sync') statusColor = Colors.green;
-    if (s.status == 'Synchronizing') statusColor = Colors.blue;
 
     return Column(
       children: [
-        Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(24),
-          color: statusColor,
-          child: Column(
-            children: [
-              Text(s.status.toUpperCase(), style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold, letterSpacing: 2)),
-              const SizedBox(height: 8),
-              Text(s.adviceText, textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 16)),
-            ],
-          ),
-        ),
+        _buildStatusHeader(s),
         Expanded(
           child: ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              _buildFacilityHeader(s),
+              _buildTargetCard(s),
               const SizedBox(height: 24),
-              _buildDeltaVisualizer(s, statusColor),
-              const SizedBox(height: 24),
-              const Text('LIVE TELEMETRY', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
-              const SizedBox(height: 8),
-              _buildTruckCard(s.selfTruck, true),
-              _buildTruckCard(s.partnerTruck, false),
+              const Text('INBOUND FLEET TELEMETRY', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              ...s.networkTrucks.map((truck) => _buildTruckCard(truck)),
             ],
           ),
         )
@@ -81,97 +64,140 @@ class _CrossDockSyncScreenState extends State<CrossDockSyncScreen> {
     );
   }
 
-  Widget _buildFacilityHeader(CrossDockSession s) {
-    return Card(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: ListTile(
-        leading: Icon(Icons.compare_arrows, color: Colors.blueGrey[900], size: 36),
-        title: Text(s.facilityName, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
-        subtitle: Text(s.facilityLocation),
-      ),
-    );
-  }
+  Widget _buildStatusHeader(CrossDockSession s) {
+    Color headerColor;
+    IconData icon;
+    
+    if (s.isSpeedAdjusted) {
+      headerColor = Colors.orange[800]!;
+      icon = Icons.speed;
+    } else if (s.networkTrucks.any((t) => t.isDelayed)) {
+      headerColor = Colors.red[800]!;
+      icon = Icons.warning;
+    } else {
+      headerColor = Colors.indigo[800]!;
+      icon = Icons.device_hub;
+    }
 
-  Widget _buildDeltaVisualizer(CrossDockSession s, Color statusColor) {
-    return Container(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16), border: Border.all(color: Colors.grey[300]!)),
+      color: headerColor,
       child: Column(
         children: [
-          const Text('ETA DELTA', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
-          const SizedBox(height: 8),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
             children: [
-              Text('${s.syncDeltaMinutes}', style: TextStyle(color: statusColor, fontSize: 64, fontWeight: FontWeight.bold)),
-              const SizedBox(width: 8),
-              const Text('MINUTES', style: TextStyle(color: Colors.grey, fontSize: 18, fontWeight: FontWeight.bold)),
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('CROSS-DOCK MESH NETWORK', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
             ],
-          )
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+          if (s.isSpeedAdjusted) ...[
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(color: Colors.white24, borderRadius: BorderRadius.circular(12)),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.arrow_downward, color: Colors.white),
+                  const SizedBox(width: 8),
+                  Text('NEW TARGET: ${s.recommendedSpeedMph.toInt()} MPH', style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                ],
+              ),
+            )
+          ]
         ],
       ),
     );
   }
 
-  Widget _buildTruckCard(TruckTelemetry t, bool isSelf) {
+  Widget _buildTargetCard(CrossDockSession s) {
     return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12), side: isSelf ? BorderSide(color: Colors.blueGrey[300]!, width: 2) : BorderSide.none),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.indigo[50],
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.indigo, width: 2),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Row(
-                  children: [
-                    Icon(isSelf ? Icons.local_shipping : Icons.rv_hookup, color: Colors.blueGrey[700]),
-                    const SizedBox(width: 8),
-                    Text(t.truckId, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-                  ],
-                ),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-                  decoration: BoxDecoration(color: Colors.blueGrey[50], borderRadius: BorderRadius.circular(12)),
-                  child: Text(t.role, style: TextStyle(color: Colors.blueGrey[900], fontWeight: FontWeight.bold, fontSize: 12)),
-                )
+                const Text('TERMINAL DESTINATION', style: TextStyle(color: Colors.indigo, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+                const SizedBox(height: 4),
+                Text(s.targetTerminal, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
               ],
             ),
-            const Divider(height: 24),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                _buildMetric('Distance', '${t.distanceToDockMiles.toInt()} mi'),
-                _buildMetric('Arrival ETA', '${t.estimatedArrivalMinutes} min'),
-                _buildMetric('Target Speed', '${t.targetSpeedMph.toInt()} MPH', isHighlighted: true),
+                const Text('SYNC ETA', style: TextStyle(color: Colors.indigo, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+                const SizedBox(height: 4),
+                Text(s.synchronizedEta, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24, color: s.isSpeedAdjusted ? Colors.orange[800] : Colors.indigo[900])),
               ],
             ),
-            if (isSelf && t.currentSpeedMph != t.targetSpeedMph) ...[
-              const SizedBox(height: 16),
-              LinearProgressIndicator(
-                value: t.currentSpeedMph / 80,
-                backgroundColor: Colors.grey[200],
-                color: t.currentSpeedMph > t.targetSpeedMph ? Colors.red : Colors.orange,
-              ),
-              const SizedBox(height: 4),
-              Text('Current Speed: ${t.currentSpeedMph.toInt()} MPH (Adjust to Target)', style: const TextStyle(color: Colors.red, fontSize: 12, fontWeight: FontWeight.bold)),
-            ]
           ],
         ),
       ),
     );
   }
 
-  Widget _buildMetric(String label, String value, {bool isHighlighted = false}) {
-    return Column(
-      children: [
-        Text(value, style: TextStyle(color: isHighlighted ? Colors.blueGrey[900] : Colors.black87, fontSize: 18, fontWeight: FontWeight.bold)),
-        const SizedBox(height: 4),
-        Text(label, style: const TextStyle(color: Colors.grey, fontSize: 12)),
-      ],
+  Widget _buildTruckCard(InboundTruck t) {
+    bool isMe = t.truckId.contains('You');
+    Color cardColor = isMe ? Colors.blue[50]! : Colors.white;
+    Color statusColor = t.isDelayed ? Colors.red : Colors.green;
+
+    return Card(
+      color: cardColor,
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: isMe ? 2 : 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: isMe ? Colors.blue : Colors.transparent, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(t.truckId, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, color: isMe ? Colors.blue[900] : Colors.black87)),
+                Text('From: ${t.origin}', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.speed, size: 16, color: Colors.grey[600]),
+                    const SizedBox(width: 4),
+                    Text('${t.currentSpeedMph.toInt()} mph', style: const TextStyle(fontWeight: FontWeight.bold)),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(color: statusColor.withOpacity(0.1), borderRadius: BorderRadius.circular(4)),
+                  child: Text('ETA: ${t.eta}', style: TextStyle(color: statusColor, fontWeight: FontWeight.bold, fontSize: 12)),
+                )
+              ],
+            )
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/driver/lib/services/cross_dock_sync_service.dart
+++ b/apps/driver/lib/services/cross_dock_sync_service.dart
@@ -6,42 +6,51 @@ class CrossDockSyncService {
 
   Stream<CrossDockSession> get syncStream => _sessionController.stream;
 
-  void simulateSynchronization() async {
-    // 1. Out of Sync: Self is arriving 45 mins early
+  void simulateNetworkSync() async {
+    // 1. Normal Routing
     _sessionController.add(CrossDockSession(
-      facilityName: 'Dallas X-Dock Hub',
-      facilityLocation: 'Dock Door 42',
-      syncDeltaMinutes: 45,
-      status: 'Out of Sync',
-      adviceText: 'You are arriving 45 minutes ahead of the outbound truck. Reduce speed to save fuel and prevent dock congestion.',
-      selfTruck: TruckTelemetry(truckId: 'TRX-Self (You)', role: 'Inbound', distanceToDockMiles: 120.0, estimatedArrivalMinutes: 110, currentSpeedMph: 65.0, targetSpeedMph: 45.0),
-      partnerTruck: TruckTelemetry(truckId: 'TRX-Prtnr-B', role: 'Outbound', distanceToDockMiles: 155.0, estimatedArrivalMinutes: 155, currentSpeedMph: 60.0, targetSpeedMph: 60.0),
+      status: 'Tracking Inbound Fleet ETA...',
+      targetTerminal: 'Memphis Super-Hub (MEM1)',
+      synchronizedEta: '14:30 EST',
+      recommendedSpeedMph: 65.0,
+      isSpeedAdjusted: false,
+      networkTrucks: [
+        InboundTruck(truckId: 'TRK-104 (You)', origin: 'Nashville, TN', currentSpeedMph: 65.0, eta: '14:30', isDelayed: false),
+        InboundTruck(truckId: 'TRK-992', origin: 'Little Rock, AR', currentSpeedMph: 62.0, eta: '14:30', isDelayed: false),
+        InboundTruck(truckId: 'TRK-411', origin: 'Jackson, MS', currentSpeedMph: 68.0, eta: '14:30', isDelayed: false),
+      ],
     ));
 
     await Future.delayed(const Duration(seconds: 4));
 
-    // 2. Synchronizing: Driver slowed down to 45 mph
+    // 2. Delay Detected
     _sessionController.add(CrossDockSession(
-      facilityName: 'Dallas X-Dock Hub',
-      facilityLocation: 'Dock Door 42',
-      syncDeltaMinutes: 15,
-      status: 'Synchronizing',
-      adviceText: 'ETA delta reducing. Maintain current speed of 45 MPH.',
-      selfTruck: TruckTelemetry(truckId: 'TRX-Self (You)', role: 'Inbound', distanceToDockMiles: 90.0, estimatedArrivalMinutes: 120, currentSpeedMph: 45.0, targetSpeedMph: 45.0),
-      partnerTruck: TruckTelemetry(truckId: 'TRX-Prtnr-B', role: 'Outbound', distanceToDockMiles: 130.0, estimatedArrivalMinutes: 135, currentSpeedMph: 60.0, targetSpeedMph: 60.0),
+      status: 'WEATHER DELAY DETECTED ON TRK-411',
+      targetTerminal: 'Memphis Super-Hub (MEM1)',
+      synchronizedEta: '14:30 EST',
+      recommendedSpeedMph: 65.0,
+      isSpeedAdjusted: false,
+      networkTrucks: [
+        InboundTruck(truckId: 'TRK-104 (You)', origin: 'Nashville, TN', currentSpeedMph: 65.0, eta: '14:30', isDelayed: false),
+        InboundTruck(truckId: 'TRK-992', origin: 'Little Rock, AR', currentSpeedMph: 62.0, eta: '14:30', isDelayed: false),
+        InboundTruck(truckId: 'TRK-411', origin: 'Jackson, MS', currentSpeedMph: 45.0, eta: '15:15', isDelayed: true), // Heavy rain
+      ],
     ));
-
+    
     await Future.delayed(const Duration(seconds: 4));
 
-    // 3. Perfect Sync achieved
+    // 3. Network Resync
     _sessionController.add(CrossDockSession(
-      facilityName: 'Dallas X-Dock Hub',
-      facilityLocation: 'Dock Door 42',
-      syncDeltaMinutes: 0,
-      status: 'Perfect Sync',
-      adviceText: 'JIT Sync Achieved. Both trucks will arrive at the exact same minute.',
-      selfTruck: TruckTelemetry(truckId: 'TRX-Self (You)', role: 'Inbound', distanceToDockMiles: 50.0, estimatedArrivalMinutes: 60, currentSpeedMph: 50.0, targetSpeedMph: 50.0),
-      partnerTruck: TruckTelemetry(truckId: 'TRX-Prtnr-B', role: 'Outbound', distanceToDockMiles: 60.0, estimatedArrivalMinutes: 60, currentSpeedMph: 60.0, targetSpeedMph: 60.0),
+      status: 'SYNCHRONIZING NETWORK: SLOW DOWN TO SAVE FUEL',
+      targetTerminal: 'Memphis Super-Hub (MEM1)',
+      synchronizedEta: '15:15 EST', // Pushed back to match the delayed truck
+      recommendedSpeedMph: 52.0, // Slow down
+      isSpeedAdjusted: true,
+      networkTrucks: [
+        InboundTruck(truckId: 'TRK-104 (You)', origin: 'Nashville, TN', currentSpeedMph: 52.0, eta: '15:15', isDelayed: false),
+        InboundTruck(truckId: 'TRK-992', origin: 'Little Rock, AR', currentSpeedMph: 50.0, eta: '15:15', isDelayed: false),
+        InboundTruck(truckId: 'TRK-411', origin: 'Jackson, MS', currentSpeedMph: 45.0, eta: '15:15', isDelayed: true),
+      ],
     ));
   }
 


### PR DESCRIPTION
## Description
Resolves #9799

This PR introduces the frontend UI and mock networking services for the LTL Cross-Docking ETA Synchronization feature. Less-Than-Truckload (LTL) terminals require absolute precision; if one inbound truck is delayed, the entire outbound fleet is stalled. Without this feature, on-time trucks rush to the terminal burning expensive diesel, only to sit idle for hours waiting for the delayed truck. This feature acts as a "Just-In-Time" network controller. By tracking the entire inbound fleet, the AI detects delays instantly and dynamically slows down the rest of the fleet, saving massive amounts of fuel while ensuring all trucks hit the cross-dock at the exact same synchronized minute.

### Changes Made:
- **`cross_dock_sync_model.dart`**: Established the `CrossDockSession` schema to manage the global `synchronizedEta`, and the `InboundTruck` schema to track peer telemetry (`currentSpeedMph`, `isDelayed`).
- **`cross_dock_sync_service.dart`**: Implemented a mock `Stream` simulating a synchronized run to a Memphis hub. The service detects a weather delay on a peer truck, instantly pushing the global ETA back by 45 minutes and commanding the user to drop their speed to 52 mph to conserve fuel rather than "hurry up and wait."
- **`cross_dock_sync_screen.dart`**: Built a logistics telemetry dashboard. The UI translates macro-network decisions to the individual driver. It features a bold, dynamic command header instructing the driver to lower their speed. Crucially, it displays the real-time status of the other trucks in the network, providing transparency so the driver understands *why* the AI is asking them to alter their driving habits.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
