### PR TITLE
fix: secure DID credential proof generation

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -6,6 +6,9 @@ import { supabase, supabaseAdmin } from '../api/src/config/db.js';
 
 class DIDService {
     constructor() {
+        if (!process.env.DID_PROOF_SECRET) {
+            throw new Error('DID_PROOF_SECRET environment variable is required and must not be empty');
+        }
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
         this.wallet = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider);
         this.didRegistryAddress = process.env.DID_REGISTRY_ADDRESS;
@@ -108,8 +111,9 @@ class DIDService {
 
     async issueCredential(subject, credentialType, schema, validUntil) {
         try {
+            const issuedAtMs = Date.now();
             const schemaHash = ethers.keccak256(ethers.toUtf8Bytes(JSON.stringify(schema)));
-            const proof = this.generateProof(subject, credentialType, schema);
+            const proof = this.generateProof(subject, credentialType, schema, issuedAtMs);
             const proofHash = ethers.keccak256(ethers.toUtf8Bytes(proof));
 
             const validUntilTimestamp = validUntil || Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60;
@@ -157,7 +161,7 @@ class DIDService {
                 subject,
                 credentialType,
                 schema,
-                issuedAt: new Date().toISOString(),
+                issuedAt: new Date(issuedAtMs).toISOString(),
                 validUntil: new Date(validUntilTimestamp * 1000).toISOString(),
                 txHash: receipt.hash,
                 proof
@@ -210,11 +214,13 @@ class DIDService {
         }
     }
 
-    generateProof(subject, credentialType, schema) {
-        const secret = process.env.DID_PROOF_SECRET || 'default-proof-secret';
-        const payload = JSON.stringify({ subject, credentialType, schema, timestamp: Date.now() });
-        const proof = crypto.createHmac('sha256', secret).update(payload).digest('hex');
-        return proof;
+    generateProof(subject, credentialType, schema, issuedAtMs) {
+        const secret = process.env.DID_PROOF_SECRET;
+        if (!secret) {
+            throw new Error('DID_PROOF_SECRET is not configured; refusing to generate proof');
+        }
+        const payload = JSON.stringify({ subject, credentialType, schema, timestamp: issuedAtMs });
+        return crypto.createHmac('sha256', secret).update(payload).digest('hex');
     }
 
     async getDID(did) {


### PR DESCRIPTION
## Summary

Fix insecure DID credential proof generation by removing the hardcoded fallback HMAC secret and requiring `DID_PROOF_SECRET` to be configured.

## Changes

* Removed the insecure `default-proof-secret` fallback from `generateProof`.
* Added startup validation to ensure `DID_PROOF_SECRET` is configured.
* Added an additional runtime check before generating proofs.
* Reused a single `issuedAtMs` timestamp for both proof generation and credential persistence, ensuring the proof timestamp is tied to the credential's recorded issuance time.
* Updated credential storage to persist the same issuance timestamp used during proof generation.

## Security Impact

Previously, credentials could be signed using the publicly known `default-proof-secret` when `DID_PROOF_SECRET` was missing.

This change ensures the backend refuses to start without a configured secret and prevents credentials from being generated with a predictable public HMAC key.

## Testing

* Verified the project builds successfully.
* Verified the modified DID credential issuance flow.
* Confirmed that proof generation fails when `DID_PROOF_SECRET` is not configured.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/9847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential proof reliability by requiring a configured proof secret.
  - Ensured credential issuance uses a consistent timestamp for proof generation and storage.
  - Prevented proof creation when required security information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->