### PR TITLE
fix(escrow): pass authoritative escrow amount to escrowRelease on OTP verify-delivery release path

### DIFF
--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -17,7 +17,7 @@ import {
   OTP_LOCKOUT_MINUTES,
   DELIVERY_OTP_READY_STATUSES
 } from './orderNotificationService.js';
-import { escrowRelease, markEscrowBookingStarted, paisaToMaticWei } from '../escrow.js';
+import { escrowRelease, markEscrowBookingStarted, paisaToMaticWei, resolveExpectedDepositAmount } from '../escrow.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 import { broadcastOrderMilestone } from '../../sockets/tracker.js';
@@ -160,7 +160,7 @@ export class OrderMilestoneService {
 
       const { data: order, error: orderErr } = await this.orderRepository.findOrderById(
         orderId,
-        'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, total_amount'
+        'id, order_display_id, driver_id, customer_id, escrow_status, escrow_release_attempts, status, total_amount, escrow_amount_wei, pending_bid_acceptance'
       );
       if (orderErr || !order) throw new DomainError(404, { error: 'Order not found.' });
       if (order.driver_id !== driverId)
@@ -217,9 +217,14 @@ export class OrderMilestoneService {
 
       if (order.escrow_status === 'funded' || order.escrow_status === 'release_failed') {
         try {
+          const resolvedAmount = resolveExpectedDepositAmount(order);
+          let expectedAmountWei = resolvedAmount.expectedAmountWei ?? null;
+          if (expectedAmountWei === null && order.total_amount != null) {
+            expectedAmountWei = paisaToMaticWei(order.total_amount);
+          }
           const releaseResult = await escrowRelease(
             order.order_display_id,
-            order.total_amount != null ? paisaToMaticWei(order.total_amount) : null,
+            expectedAmountWei,
           );
           if (releaseResult.txHash) {
             releaseTxHash = releaseResult.txHash;


### PR DESCRIPTION
## Problem

`OrderMilestoneService.verifyDelivery` released escrow on the OTP-verified path without the authoritative amount guard: `escrowRelease` was called with only `paisaToMaticWei(total_amount)` (a fallback) instead of the resolved authoritative `escrow_amount_wei`. If an on-chain booking was funded with an amount that does not match the app's authoritative figure, the defense-in-depth guard introduced by #9284 (which protects the release reconciler and the delivery-verification service) was bypassed on the most common release path.

## Fix

Mirror the reconciler / `deliveryVerificationService`: resolve the authoritative expected deposit amount via `resolveExpectedDepositAmount(order)` (which prefers `orders.escrow_amount_wei`, cross-checked against the server-written `pending_bid_acceptance.bid_amount`) and pass it as `expectedAmountWei` to `escrowRelease`. `total_amount` is kept only as a fallback when no authoritative figure exists. The order fetch now selects `escrow_amount_wei` and `pending_bid_acceptance` so the resolution can run.

## Files changed

- `backend/api/src/services/order/orderMilestoneService.js` — resolve and pass the authoritative escrow amount to `escrowRelease` on the OTP verify-delivery release path.

## Testing

- Existing unit tests for the milestone service still pass (no assertions depended on the old release arguments).
- Release path now behaves like the reconciler and delivery-verification service: a booking funded with an amount that differs from `escrow_amount_wei` is refused (`DEPOSIT_AMOUNT_MISMATCH`) instead of paid.

Closes #9660


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery verification for escrow orders by accurately determining the expected deposit amount.
  * Added a fallback calculation when the expected deposit amount is unavailable.
  * Ensured escrow releases use the verified deposit amount rather than relying solely on the order total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->