### PR TITLE
chore(order): remove dead OrderLifecycleService.confirmDeposit (route owns the single implementation)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -6,11 +6,8 @@ import { measureExecution } from '../../core/performanceMetrics.js';
 import { supabaseAdmin } from '../../config/db.js';
 import {
   submitEscrowRefund,
-  recordDepositTx,
   submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
-  getEscrowBookingId,
-  resolveExpectedDepositAmount,
   paisaToMaticWei,
 } from '../escrow.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
@@ -859,109 +856,6 @@ export class OrderLifecycleService {
           status: 200,
           body: { message: 'Order cancelled successfully.', cancellation_fee: persistedCancellationFee, order: updatedOrder },
         };
-      } finally {
-        await releaseLock(lockKey, lockValue);
-      }
-    });
-  }
-
-  async confirmDeposit(orderId, userId, txHash, userClient) {
-    return measureExecution('OrderLifecycleService.confirmDeposit', async () => {
-      const lockKey = `escrow_lock:${orderId}`;
-      const lockValue = await acquireLock(lockKey, 30000);
-      if (!lockValue) {
-        throw new DomainError(409, { error: 'Order is currently being processed. Please try again later.' });
-      }
-
-      try {
-        const { data: order, error: fetchErr } = await this.orderRepository.findOrderById(
-          orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance'
-        );
-
-        if (fetchErr || !order) throw new DomainError(404, { error: 'Order not found' });
-        if (order.customer_id !== userId) {
-          throw new DomainError(403, { error: 'Access Denied: You do not own this order.' });
-        }
-        if (order.escrow_status !== 'funding') {
-          throw new DomainError(400, { error: 'Order is not in funding state' });
-        }
-
-        const { data: customerProfile } = await this.orderRepository.findCustomerWallet(userId);
-        const customerWallet = customerProfile?.polygon_wallet_address ?? null;
-
-        const bookingId = order.escrow_booking_id || getEscrowBookingId(order.order_display_id);
-
-        // Resolve the authoritative expected deposit amount (cross-checked
-        // against the server-written bid context) and reject the deposit if it
-        // cannot be pinned down or if the stored figures disagree.
-        const resolvedAmount = resolveExpectedDepositAmount(order);
-        if (resolvedAmount.error) {
-          throw new DomainError(422, { error: resolvedAmount.error, code: resolvedAmount.code });
-        }
-        const expectedAmountWei = resolvedAmount.expectedAmountWei;
-
-        const result = await recordDepositTx(
-          bookingId,
-          txHash,
-          customerWallet,
-          order.escrow_driver_wallet ?? null,
-          expectedAmountWei
-        );
-
-        if (result.error) throw new DomainError(422, { error: result.error, code: result.code });
-
-        const { error: updateErr } = await this.orderRepository.updateOrder(orderId, {
-          escrow_status: 'funded',
-        });
-
-        if (updateErr) {
-          logger.error('[confirm-deposit] DB update failed:', updateErr.message);
-          throw new DomainError(500, { error: 'Database update failed after deposit confirmation. Please contact support.' });
-        }
-
-        // Two-phase acceptance (#5724): finalize the driver assignment now that
-        // the escrow deposit is confirmed.
-        const pending = order.pending_bid_acceptance;
-        if (pending) {
-          const { error: acceptErr } = await this.orderRepository.executeRpc('accept_bid_tx', {
-            p_bid_id: pending.bid_id,
-            p_order_id: orderId,
-            p_load_id: pending.load_id,
-            p_driver_id: pending.driver_id,
-            p_truck_id: pending.truck_id,
-            p_driver_name: pending.driver_name,
-            p_driver_rating: pending.driver_rating,
-            p_truck_number: pending.truck_number,
-            p_bid_amount: pending.bid_amount,
-            p_order_display_id: pending.order_display_id,
-            p_expected_version: pending.version,
-            p_escrow_booking_id: bookingId,
-          }, userClient ?? supabaseAdmin);
-          if (acceptErr) {
-            logger.error('[confirm-deposit] accept_bid_tx failed:', acceptErr.message);
-            try {
-              await submitEscrowRefund(order.order_display_id);
-            } catch (refundErr) {
-              logger.error('[confirm-deposit] Escrow refund also failed:', refundErr.message);
-            }
-            await this.orderRepository.revertEscrowStatus(orderId).catch((revertErr) => {
-              logger.error('[confirm-deposit] Failed to revert escrow status:', revertErr.message);
-            });
-            throw new DomainError(409, {
-              error: 'Deposit confirmed but the driver assignment could not be finalized. The escrow deposit has been refunded. Please try again.',
-              details: acceptErr.message,
-            });
-          }
-          sendPushNotification(
-            pending.driver_id,
-            'Bid Accepted!',
-            `Your bid for order ${pending.order_display_id} has been accepted. You are now assigned to this load.`,
-            'order_update',
-            { orderId, orderDisplayId: pending.order_display_id }
-          ).catch((err) => logger.error(`[FCM] Failed to notify driver of bid acceptance: ${err.message}`));
-        }
-
-        return { message: 'Escrow deposit confirmed', txHash: result.txHash };
       } finally {
         await releaseLock(lockKey, lockValue);
       }


### PR DESCRIPTION
## Problem

`OrderLifecycleService.confirmDeposit` (`backend/api/src/services/order/orderLifecycleService.js`) had zero callers anywhere in the backend. The real `POST /:id/confirm-deposit` endpoint is implemented inline in `orderRoutes.js` behind `requireIdempotency(86400)`, `requirePolicy('order:confirm-deposit')`, `authenticate`, `userLimiter`, `auditLog`, and full param/body validation. The two implementations had already diverged, and the dead service copy was missing the route's hardening — a latent regression vector for any future refactor.

## Fix

Delete the dead `confirmDeposit` method from `orderLifecycleService.js` so there is exactly one deposit-confirmation implementation (the wired route handler). Also removed the imports that only the dead method used (`recordDepositTx`, `getEscrowBookingId`, `resolveExpectedDepositAmount`) so no unused imports remain.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js` — removed the dead `confirmDeposit` method and its now-unused imports.

## Testing

- `node --check` passes on the edited file.
- `grep -r confirmDeposit` now matches only the route handler in `orderRoutes.js`.
- `supabaseAdmin`, `acquireLock`/`releaseLock`, and `submitEscrowRefund` remain in use elsewhere in the service.

Closes #9661
