### PR TITLE
fix: align truck search quote with charged price

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -543,6 +543,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
     let finalTollEstimate = pricing.tollEstimate;
     let finalPlatformFee = pricing.platformFee;
     let finalTotalAmount = pricing.totalAmount;
+    let estimatedPrice = null;
     let isAiEstimate = false;
 
     try {
@@ -555,12 +556,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
         trafficMultiplier,
       });
       if (mlResult && mlResult.estimatedPricePaisa > 0) {
-        finalTotalAmount = mlResult.estimatedPricePaisa;
-        finalPlatformFee = Math.round(mlResult.estimatedPricePaisa * 0.05);
-        finalBaseFreight = Math.max(0, mlResult.estimatedPricePaisa - finalPlatformFee - finalTollEstimate);
-        if (finalBaseFreight === 0) {
-          finalTollEstimate = Math.max(0, mlResult.estimatedPricePaisa - finalPlatformFee);
-        }
+        estimatedPrice = mlResult.estimatedPricePaisa;
         isAiEstimate = true;
       } else {
         logger.warn({ mlResult }, 'Invalid price prediction response during search');
@@ -652,6 +648,7 @@ router.get('/search', authenticate, userLimiter, async (req, res) => {
         capacityTons: truck.max_capacity_tons || 0,
         truckType: truck.truck_type || '',
         price: finalTotalAmount,
+        estimatedPrice,
         baseFreight: finalBaseFreight,
         tollEstimate: finalTollEstimate,
         platformFee: finalPlatformFee,


### PR DESCRIPTION
## Problem

The truck search endpoint quoted a price that diverges from the price actually charged at order creation.

`GET /api/trucks/search` (`truckRoutes.js`) showed customers the ML-predicted price (`mlResult.estimatedPricePaisa`, inflated by the live traffic multiplier) as the truck card `price`. Order creation (`orderCreationService.js`), however, always charges the deterministic formula price (`pricing.totalAmount`, from `computeOrderPricing`) and stores the ML value separately as `estimated_price`, which is never billed.

So the customer could see an AI-inflated fare during search (`price` read by `estimatePriceRange` in `order_service.dart`) that does not match the `total_amount` they are charged / escrowed when the order is created.

## Fix

Stop letting the ML prediction replace the quoted fare in the search response.

- `truckRoutes.js`: `price` (and the `baseFreight` / `tollEstimate` / `platformFee` breakdown) now always reflects the formula price from `computeOrderPricing` — the same `pricing.totalAmount` that `orderCreationService.js` uses for `p_total_amount` (the charged / escrowed amount).
- The ML estimate is kept purely informational: exposed as a new `estimatedPrice` field on the response card, with `isAiEstimate` flagging that an AI estimate exists — it is no longer substituted into the fare.
- `orderCreationService.js` already charges the formula `totalAmount` and files the ML value as `estimated_price`, so it needed no change; the quote now matches the charge on the backend alone.

## Files changed

- `backend/api/src/routes/truckRoutes.js`

## Testing

- `node --check` passes.
- The ML branch no longer overwrites `finalTotalAmount` / `finalPlatformFee` / `finalBaseFreight` / `finalTollEstimate`; when `estimatedPricePaisa > 0` it records `estimatedPrice` and `isAiEstimate` only.
- With the ML estimate absent, the response is unchanged from the previous formula fallback.

Closes #9670
