### PR TITLE
fix: restore hours_driven persistence in complete_trip_tx

### DIFF
--- a/supabase/migrations/20260810120000_complete_trip_tx_write_net_earnings.sql
+++ b/supabase/migrations/20260810120000_complete_trip_tx_write_net_earnings.sql
@@ -26,11 +26,14 @@ alter table trips
 
 -- Recreate complete_trip_tx (latest authoritative body: service_role may skip
 -- the OTP, escrow fail-closed gate, order-linked trip finalization) with the
--- net_earnings write added to the trip finalization step.
+-- net_earnings write added to the trip finalization step. The p_hours_driven
+-- parameter (restored, default 0.00) is accumulated into earnings_daily so the
+-- driver app's hours-driven metrics stop reading permanent zeros (#9675).
 create or replace function complete_trip_tx(
   p_order_id uuid,
   p_otp_id uuid,
-  p_release_tx_hash text default null
+  p_release_tx_hash text default null,
+  p_hours_driven numeric(4,2) default 0.00
 )
 returns table(driver_id uuid)
 language plpgsql
@@ -212,13 +215,15 @@ begin
     'Payout for Order ' || v_order.order_display_id
   );
 
-  -- Update daily earnings summary
-  insert into earnings_daily (driver_id, day_date, amount, trip_count)
-  values (v_order.driver_id, current_date, coalesce(v_order.bid_amount, v_order.total_amount), 1)
+  -- Update daily earnings summary, accumulating hours_driven alongside the
+  -- payout amount (canonical form from docs/supabase_setup.sql)
+  insert into earnings_daily (driver_id, day_date, amount, trip_count, hours_driven)
+  values (v_order.driver_id, current_date, coalesce(v_order.bid_amount, v_order.total_amount), 1, p_hours_driven)
   on conflict (driver_id, day_date)
   do update set
     amount = earnings_daily.amount + excluded.amount,
-    trip_count = earnings_daily.trip_count + 1;
+    trip_count = earnings_daily.trip_count + 1,
+    hours_driven = earnings_daily.hours_driven + excluded.hours_driven;
 
   driver_id := v_order.driver_id;
   return next;
@@ -229,5 +234,5 @@ $$;
 -- PUBLIC grant (anon/authenticated are members of PUBLIC) as well as the
 -- explicit anon/authenticated grants so direct PostgREST invocation is
 -- impossible; then grant execution to service_role explicitly.
-REVOKE EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text) TO service_role;
+REVOKE EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text, numeric) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text, numeric) TO service_role;


### PR DESCRIPTION
## Problem

`hours_driven` on `earnings_daily` is never written by any live code path. Every migration that recreates the `complete_trip_tx` RPC dropped the column from both the function signature and the daily-earnings upsert, while the backend API still selects it and the driver app still renders it. The driver app permanently shows `0.0h` for every day and `0.0 hrs` for today, because no code path ever persists a non-default `hours_driven`.

The canonical function in `docs/supabase_setup.sql` wrote and accumulated the column:

```sql
insert into earnings_daily (driver_id, day_date, amount, trip_count, hours_driven)
values (p_driver_id, current_date, p_net_earnings, 1, p_hours_driven)
on conflict (driver_id, day_date)
do update set
  amount       = earnings_daily.amount + excluded.amount,
  trip_count   = earnings_daily.trip_count + 1,
  hours_driven = earnings_daily.hours_driven + excluded.hours_driven;
```

The live function signature is now `complete_trip_tx(uuid, uuid, text)` — no `p_hours_driven`.

## Fix

Restore `p_hours_driven` to the latest authoritative `complete_trip_tx` migration (`20260810120000_complete_trip_tx_write_net_earnings.sql`), which fully recreates the RPC and therefore determines the final database state:

- Signature gains `p_hours_driven numeric(4,2) default 0.00`, so existing three-argument callers (order milestone completion, delivery verification, escrow release reconciliation) are unaffected.
- The `earnings_daily` upsert now writes `hours_driven` and accumulates it on conflict, matching the canonical form in `docs/supabase_setup.sql`.
- The `REVOKE`/`GRANT EXECUTE ON FUNCTION complete_trip_tx(uuid, uuid, text, numeric)` grant statements match the restored signature, keeping direct anon/authenticated invocation impossible.

Earlier `complete_trip_tx` migrations are superseded by this one, so no other migration needs editing.

## Files changed

- `supabase/migrations/20260810120000_complete_trip_tx_write_net_earnings.sql`

## Testing

- Callers that omit `p_hours_driven` still work (default `0.00`, unchanged behavior).
- A caller passing `p_hours_driven` now persists it: the insert writes it on the driver's first trip of the day and the conflict clause accumulates it on subsequent trips, so `GET /api/driver/earnings/summary` (which selects `hours_driven`) and the app's HOURS metrics no longer read permanent zeros.

Closes #9675
