### PR TITLE
test : added unit tests for profileCache module

### DIFF
--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getCacheStats,
   resetCacheStats,
-} from '../../lib/profileCache.js';
+} from '../../src/lib/profileCache.js';
 
 describe('profileCache stats', () => {
   beforeEach(() => {
@@ -31,6 +31,30 @@ describe('profileCache stats', () => {
       expect(isValidCachedSupabaseProfile('', validProfile)).toBe(false);
       expect(isValidCachedSupabaseProfile(123, validProfile)).toBe(false);
       expect(isValidCachedSupabaseProfile('   ', validProfile)).toBe(false);
+    });
+
+    it('validates active and inactive Supabase profiles correctly', async () => {
+      const { isValidCachedSupabaseProfile } = await import('../../src/lib/profileCache.js');
+      const activeProfile = { id: 'user-123', role: 'driver', isActive: true, fullName: 'John Doe' };
+      const tombstoneProfile = { id: 'user-123', isActive: false };
+      const mismatchProfile = { id: 'user-999', role: 'driver', isActive: true };
+
+      expect(isValidCachedSupabaseProfile('user-123', activeProfile)).toBe(true);
+      expect(isValidCachedSupabaseProfile('user-123', tombstoneProfile)).toBe(true);
+      expect(isValidCachedSupabaseProfile('user-123', mismatchProfile)).toBe(false);
+    });
+  });
+
+  describe('isValidCachedProfile', () => {
+    it('validates Firebase profile UIDs and shapes', async () => {
+      const { isValidCachedProfile } = await import('../../src/lib/profileCache.js');
+      const validProfile = { uid: 'fb-123', id: 'profile-1', role: 'customer', isActive: true };
+      const tombstone = { isActive: false };
+
+      expect(isValidCachedProfile('fb-123', validProfile)).toBe(true);
+      expect(isValidCachedProfile('fb-123', tombstone)).toBe(true);
+      expect(isValidCachedProfile('fb-999', validProfile)).toBe(false);
+      expect(isValidCachedProfile(null, validProfile)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Summary of What Has Been Done:
Fixed relative import path in `test/unit/profileCache.test.js` from `../../lib/profileCache.js` to `../../src/lib/profileCache.js` and expanded unit test coverage for `isValidCachedProfile` and `isValidCachedSupabaseProfile`.

Changes Made:
- Modified `backend/api/test/unit/profileCache.test.js`: Corrected import path and added unit tests for active/inactive profile validation.

Impact it Made:
Ensures `vitest run test/unit/profileCache.test.js` executes cleanly without module resolution errors and validates tombstone caching logic.

Note: This pull request is created as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded profile cache validation coverage for active, inactive, mismatched, and invalid profiles.
  * Added checks for Firebase profile identifiers and data structure validation.
  * Updated test references to the current profile cache implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->