### PR TITLE
fix: persist WebRTC offline GPS via authenticated client keyed by owner profile

### DIFF
--- a/backend/api/src/routes/webrtcRoutes.js
+++ b/backend/api/src/routes/webrtcRoutes.js
@@ -112,7 +112,7 @@ router.get('/webrtc/offline/:peerId', authenticate, userLimiter, requirePolicy('
       });
     }
 
-    const data = await signaling.getOfflineGPSData(peerId, since, req.user);
+    const data = await signaling.getOfflineGPSData(peerId, since, req.user, req.token);
     res.json({
       success: true,
       data
@@ -145,7 +145,7 @@ router.post('/webrtc/sync/:peerId', authenticate, userLimiter, requirePolicy('we
       });
     }
 
-    await signaling.syncOfflineData(peerId, req.user);
+    await signaling.syncOfflineData(peerId, req.user, req.token);
     res.json({
       success: true,
       message: 'Offline data synced'

--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -2,7 +2,7 @@ import { WebSocketServer } from 'ws';
 import crypto from 'crypto';
 import { verifyAuthToken } from '../../middleware/auth.js';
 import logger from '../../middleware/logger.js';
-import { supabase, redisClient, createUserClient } from '../../config/db.js';
+import { supabase, supabaseAdmin, redisClient, createUserClient } from '../../config/db.js';
 
 class WebRTCSignalingServer {
   constructor(server) {
@@ -230,14 +230,23 @@ class WebRTCSignalingServer {
     const userClient = peer.token ? createUserClient(peer.token) : null;
     const gpsClient = userClient || supabase;
 
+    // gps_offline_data is RLS-scoped by `peerId = get_profile_id()::text`, so
+    // rows must be keyed by the authenticated user's profile id (peer.userId),
+    // never the ephemeral WebRTC session id. Fail closed when the owner cannot
+    // be established so an un-owned frame is never written.
+    if (!peer.userId) {
+      logger.warn(`[WebRTC] GPS data dropped for peer ${peerId}: no authenticated user id`);
+      return;
+    }
+
     const normalizedData = {
       ...data,
       location: this.normalizeLocation(data.location)
     };
 
-    // Store GPS data in MongoDB with offline sync flag
+    // Store GPS data with offline sync flag, keyed by the owner's profile id
     const gpsEntry = {
-      peerId,
+      peerId: peer.userId,
       data: normalizedData,
       timestamp: Date.now(),
       synced: false
@@ -409,31 +418,38 @@ class WebRTCSignalingServer {
     return Boolean(peer && peer.userId === user?.id);
   }
 
-  async getOfflineGPSData(peerId, since, requestingUser) {
+  async getOfflineGPSData(peerId, since, requestingUser, token) {
     if (!requestingUser || !this.canUserAccessPeer(peerId, requestingUser)) {
       logger.warn(`[WebRTC] Unauthorized offline GPS data access attempt for peer ${peerId}`);
       return [];
     }
-    const { data } = await supabase
+    // Rows are keyed by the owning profile id (matches the `peerId =
+    // get_profile_id()` RLS policy); resolve it from the active peer session
+    // and fall back to the caller's own id.
+    const ownerId = this.peers.get(peerId)?.userId || requestingUser.id;
+    const client = requestingUser.role === 'admin' ? supabaseAdmin : (token ? createUserClient(token) : supabase);
+    const { data } = await client
       .from('gps_offline_data')
       .select('*')
-      .eq('peerId', peerId)
+      .eq('peerId', ownerId)
       .gt('timestamp', since || 0)
       .order('timestamp', { ascending: true });
-    
+
     return data || [];
   }
 
-  async syncOfflineData(peerId, requestingUser) {
+  async syncOfflineData(peerId, requestingUser, token) {
     if (!requestingUser || !this.canUserAccessPeer(peerId, requestingUser)) {
       logger.warn(`[WebRTC] Unauthorized sync offline data attempt for peer ${peerId}`);
       return;
     }
+    const ownerId = this.peers.get(peerId)?.userId || requestingUser.id;
+    const client = requestingUser.role === 'admin' ? supabaseAdmin : (token ? createUserClient(token) : supabase);
     // Mark data as synced for this peer
-    await supabase
+    await client
       .from('gps_offline_data')
       .update({ synced: true })
-      .eq('peerId', peerId)
+      .eq('peerId', ownerId)
       .eq('synced', false);
   }
 }

--- a/backend/api/test/unit/WebRTCSignalingServer.test.js
+++ b/backend/api/test/unit/WebRTCSignalingServer.test.js
@@ -399,15 +399,15 @@ describe('WebRTCSignalingServer', () => {
       expect(supabaseMock.from).not.toHaveBeenCalled();
     });
 
-    it('queries the owning user\'s data', async () => {
-      supabaseQuery.order.mockResolvedValue({ data: [{ peerId: 'peer-1' }] });
+    it('queries the owning user\'s data by their profile id', async () => {
+      supabaseQuery.order.mockResolvedValue({ data: [{ peerId: 'user-1' }] });
 
       const result = await server.getOfflineGPSData('peer-1', 100, { id: 'user-1' });
 
       expect(supabaseMock.from).toHaveBeenCalledWith('gps_offline_data');
-      expect(supabaseQuery.eq).toHaveBeenCalledWith('peerId', 'peer-1');
+      expect(supabaseQuery.eq).toHaveBeenCalledWith('peerId', 'user-1');
       expect(supabaseQuery.gt).toHaveBeenCalledWith('timestamp', 100);
-      expect(result).toEqual([{ peerId: 'peer-1' }]);
+      expect(result).toEqual([{ peerId: 'user-1' }]);
     });
 
     it('falls back to timestamp 0 when no cursor is given', async () => {
@@ -433,14 +433,36 @@ describe('WebRTCSignalingServer', () => {
       expect(supabaseMock.from).not.toHaveBeenCalled();
     });
 
-    it('marks only the unsynced rows of the owning peer', async () => {
+    it('marks only the unsynced rows of the owning peer by their profile id', async () => {
       supabaseQuery.eq.mockReturnValue(supabaseQuery);
 
       await server.syncOfflineData('peer-1', { id: 'user-1' });
 
       expect(supabaseQuery.update).toHaveBeenCalledWith({ synced: true });
-      expect(supabaseQuery.eq).toHaveBeenCalledWith('peerId', 'peer-1');
+      expect(supabaseQuery.eq).toHaveBeenCalledWith('peerId', 'user-1');
       expect(supabaseQuery.eq).toHaveBeenCalledWith('synced', false);
+    });
+  });
+
+  describe('handleGPSData() persistence', () => {
+    it('keys the offline GPS row by the owning profile id, not the session peerId', async () => {
+      addPeer(server, 'peer-1', { userId: 'user-1' });
+
+      await server.handleGPSData('peer-1', { location: { lat: 12.97, lng: 77.59 } });
+
+      expect(supabaseMock.from).toHaveBeenCalledWith('gps_offline_data');
+      const [entry] = supabaseQuery.insert.mock.calls[0][0];
+      expect(entry.peerId).toBe('user-1');
+      expect(entry.synced).toBe(false);
+      expect(entry.data.location).toEqual({ lat: 12.97, lng: 77.59 });
+    });
+
+    it('drops the frame when the peer has no authenticated user id', async () => {
+      addPeer(server, 'peer-anon', { userId: undefined });
+
+      await server.handleGPSData('peer-anon', { location: { lat: 12.97, lng: 77.59 } });
+
+      expect(supabaseMock.from).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Problem

WebRTC offline GPS buffering never persists. `gps_offline_data` is RLS-scoped by the policy `gps_offline_data_owner ... USING ("peerId" = get_profile_id()::text) WITH CHECK ("peerId" = get_profile_id()::text)` (migration `20260804232103_secure_gps_offline_data_rls.sql`), which requires every row's `peerId` to equal the calling user's `profiles.id` (UUID). The WebRTC signaling server violated this two ways:

1. `handleGPSData()` wrote the ephemeral WebRTC session id (`peer_<uuid>`) into the `peerId` column — that can never equal a profile UUID, so the `WITH CHECK` rejected every insert even after #9807 switched the client to an authenticated one.
2. `getOfflineGPSData()` and `syncOfflineData()` queried the shared anon-key `supabase` client, which has no JWT. With no `auth.jwt()`, `get_profile_id()` returns NULL and the `USING` clause rejects every read/update, so `GET/POST /api/webrtc/offline/:peerId` and `/api/webrtc/sync/:peerId` returned `[]` / updated nothing.

## Fix

Key `gps_offline_data` rows by the authenticated user's profile id (the value `get_profile_id()` returns) and always access the table through a client carrying that user's identity:

- `WebRTCSignalingServer.handleGPSData()` now writes `peerId: peer.userId` (the profile id bound to the peer at connection from the verified JWT) instead of the session id, via the per-connection authenticated client. If no authenticated user id can be established the frame is dropped (fail closed) — only the authenticated user's own `peerId` is ever written.
- `getOfflineGPSData()` / `syncOfflineData()` resolve the owner's profile id from the active peer session (falling back to the caller's id) and use the requesting user's authenticated client (`createUserClient(req.token)`), so the RLS `USING` clause passes; admins keep the service-role client.
- `webrtcRoutes.js` passes `req.token` through to the two methods.

## Files changed

- `backend/api/src/services/webrtc/WebRTCSignalingServer.js`
- `backend/api/src/routes/webrtcRoutes.js`
- `backend/api/test/unit/WebRTCSignalingServer.test.js`

## Testing

- `node --check` passes on all three files.
- Updated unit tests now assert rows are keyed/queried by the owner's profile id, and added tests covering: the insert writes `peerId = <owner profile id>` (not the session id) and a frame is dropped when the peer has no authenticated user id.

Closes #9701
