### PR TITLE
fix : unref scheduled half-open timer in CircuitBreaker service

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -32,6 +32,7 @@ export class CircuitBreaker {
       }
       this._halfOpenTimer = null;
     }, this.resetTimeoutMs);
+    this._halfOpenTimer.unref?.();
   }
 
   getState() {

--- a/backend/api/test/unit/circuitBreaker.test.js
+++ b/backend/api/test/unit/circuitBreaker.test.js
@@ -101,4 +101,27 @@ describe('CircuitBreaker Unit Tests', () => {
     expect(breaker.state).toBe(CircuitState.CLOSED);
     expect(breaker.failureCount).toBe(0);
   });
+
+  it('triggers request timeout when execution exceeds requestTimeoutMs', async () => {
+    const breaker = new CircuitBreaker('testTimeoutBreaker', {
+      requestTimeoutMs: 50,
+    });
+    const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+    await expect(breaker.execute(slowFn)).rejects.toThrow('Request timed out after 50ms');
+  });
+
+  it('passes arguments to fallback function on failure', async () => {
+    const fallback = vi.fn((arg1, arg2) => `fallback:${arg1}:${arg2}`);
+    const breaker = new CircuitBreaker('testFallbackArgsBreaker', {
+      failureThreshold: 1,
+      fallback,
+    });
+    const fnFail = vi.fn().mockRejectedValue(new Error('Failure'));
+
+    const result = await breaker.execute(fnFail, 'val1', 42);
+
+    expect(result).toBe('fallback:val1:42');
+    expect(fallback).toHaveBeenCalledWith('val1', 42);
+  });
 });


### PR DESCRIPTION
Summary of What Has Been Done:
Called `this._halfOpenTimer.unref?.()` on the scheduled half-open timer in `backend/api/src/lib/circuitBreaker.js` to ensure background timers do not retain Node.js process event loops during graceful server shutdown or test teardown.

Changes Made:
- Modified `backend/api/src/lib/circuitBreaker.js`: Unreferenced half-open transition timer.
- Modified `backend/api/test/unit/circuitBreaker.test.js`: Added unit tests for `requestTimeoutMs` and fallback argument passing.

Impact it Made:
Prevents dangling event loop handles and process exit delays during server shutdown or test suite cleanup.

Note: This pull request is created as part of GSSOC. Please assign this PR to the `tmdeveloper007` account.