### PR TITLE
fix(auth): prevent caching unprovisioned users as inactive (#9929)

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -377,31 +377,32 @@ export async function authenticate(req, res, next) {
         profileIsDeactivated = !!inactive;
       }
 
-      if (firebaseUid) {
-        try {
-          await setCachedProfile(
-            firebaseUid,
+      if (profileIsDeactivated) {
+        if (firebaseUid) {
+          try {
+            await setCachedProfile(
+              firebaseUid,
+              { isActive: false },
+              TOMBSTONE_TTL_SECONDS,
+            );
+          } catch (err) {
+            logger.error({ err }, "Cache set failed");
+          }
+        }
+        if (supabaseUserId) {
+          void setCachedSupabaseProfile(
+            supabaseUserId,
             { isActive: false },
             TOMBSTONE_TTL_SECONDS,
           );
-        } catch (err) {
-          logger.error({ err }, "Cache set failed");
         }
-      }
-      if (supabaseUserId) {
-        void setCachedSupabaseProfile(
-          supabaseUserId,
-          { isActive: false },
-          TOMBSTONE_TTL_SECONDS,
-        );
-      }
 
-      if (profileIsDeactivated) {
         return res.status(403).json({
           error: "User profile is inactive.",
           hint: "Contact support to reactivate your account.",
         });
       }
+
       return res.status(403).json({
         error: "User profile not found in database.",
         hint: "Register user in profiles table first.",


### PR DESCRIPTION
## Description
This PR fixes a caching bug in `src/middleware/auth.js` where unprovisioned users (users who exist in Auth but do not yet have a record in the `profiles` database table) were being incorrectly cached in Redis as inactive.

**Root Cause:**
When a profile lookup returned `null`, the `authenticate` middleware checked whether the profile was explicitly deactivated (`profileIsDeactivated`). However, the Redis tombstone cache write (`isActive: false`) was executing unconditionally, even when `profileIsDeactivated` was `false`. When an unprovisioned user was subsequently inserted into `profiles`, API requests continued to hit the Redis cache, returning `403 Forbidden: User profile is inactive` until the tombstone TTL expired.

**Solution:**
Wrapped `setCachedProfile` and `setCachedSupabaseProfile` inside the `if (profileIsDeactivated)` conditional block. Unprovisioned users now bypass Redis cache writes entirely and correctly receive `403 User profile not found in database`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:**
  - `npm test`
  - `npm run test:middleware`
- **Test Steps / Prerequisites:**
  1. Send an authenticated API request with a valid Auth token for a user ID not present in `profiles`.
  2. Confirm response is `403 Forbidden: User profile not found in database`.
  3. Insert the missing profile row into the `profiles` table.
  4. Re-send the API request with the same Auth token.
  5. Confirm response succeeds (`200 OK`) immediately without hitting a cached Redis tombstone.
- **Expected Result:**
  - Redis tombstones are only written for explicitly deactivated users (`is_active = false`). Unprovisioned users can authenticate as soon as their profile record is created.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #9929

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.