### PR TITLE
fix : added token-lifetime clamp on cached profile TTL

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -110,7 +110,9 @@ export async function verifyAuthToken(token) {
       userProfile = profile;
 
       if (userProfile) {
-        const cacheTtl = Math.min(TTL_SECONDS, Math.max(1, tokenRemaining));
+        // Clamp the cached profile TTL to the token's remaining lifetime so a
+        // cached profile can never outlive the access token that authorised it.
+        const cacheTtl = Math.max(1, Math.min(TTL_SECONDS, tokenRemaining));
         await setCachedProfile(firebaseUid, {
           id: userProfile.id,
           uid: userProfile.firebase_uid,
@@ -267,6 +269,7 @@ export async function authenticate(req, res, next) {
     let firebaseUid = null;
     let supabaseUserId = null;
     let userClient = null;
+    let decodedToken = null;
 
     let decoded;
     try {
@@ -345,9 +348,10 @@ export async function authenticate(req, res, next) {
           error: "Firebase Auth verification is not configured on this server.",
         });
       }
-      const decodedToken = await firebaseAdmin
+      const verifiedFirebaseToken = await firebaseAdmin
         .auth()
         .verifyIdToken(token, true);
+      decodedToken = verifiedFirebaseToken;
       firebaseUid = decodedToken.uid;
 
       // Check Redis cache first.
@@ -467,7 +471,14 @@ export async function authenticate(req, res, next) {
     // Populate cache on successful DB fetch
     if (userProfile.firebase_uid) {
       try {
-        await setCachedProfile(userProfile.firebase_uid, req.user);
+        // Clamp the cached profile TTL to the token's remaining lifetime so a
+        // cached profile can never outlive the access token that authorised it.
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const firebaseTokenRemaining = decodedToken.exp
+          ? decodedToken.exp - nowSeconds
+          : TTL_SECONDS;
+        const firebaseTtl = Math.max(1, Math.min(TTL_SECONDS, firebaseTokenRemaining));
+        await setCachedProfile(userProfile.firebase_uid, req.user, firebaseTtl);
       } catch (err) {
         logger.error({ err }, "Cache set failed");
       }

--- a/backend/api/test/unit/auth.test.js
+++ b/backend/api/test/unit/auth.test.js
@@ -1182,4 +1182,68 @@ describe('authenticate middleware - Redis caching', () => {
     expect(ttl).toBeGreaterThan(0);
     expect(ttl).toBeLessThanOrEqual(120);
   });
+
+  it('caches a firebase profile bounded by the token remaining lifetime', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const expSeconds = nowSeconds + 90; // token expires in 90 seconds
+    const token = jwt.sign({ exp: expSeconds }, 'secret');
+
+    const dbProfile = {
+      id: 'firebase-user-1',
+      firebase_uid: 'firebase-user',
+      role: 'driver',
+      full_name: 'Fresh Fire',
+      phone: '+913333333333',
+    };
+
+    const redisClientMock = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue('OK'),
+    };
+
+    const firebaseAdminMock = {
+      auth: () => ({
+        verifyIdToken: vi.fn().mockResolvedValue({
+          uid: 'firebase-user',
+          exp: expSeconds,
+        }),
+      }),
+    };
+
+    const supabaseMock = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: dbProfile, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    vi.doMock('../../src/config/db.js', () => ({
+      createUserClient: () => null,
+      firebaseAdmin: firebaseAdminMock,
+      supabase: supabaseMock,
+      redisClient: redisClientMock,
+    }));
+
+    const { authenticate } = await import('../../src/middleware/auth.js');
+
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const setCall = redisClientMock.set.mock.calls.find(
+      ([key]) => key === 'user:profile:firebase-user'
+    );
+    expect(setCall).toBeDefined();
+    const ttl = setCall[3];
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(90);
+  });
 });


### PR DESCRIPTION
Closes #9930.

Summary of What Has Been Done:
Clamped the Firebase cached-profile TTL in the authenticate middleware to the access token's remaining lifetime, so a cached profile can never outlive the token that authorised it. The same clamp is applied in the verifyAuthToken helper for consistency. Added a unit test asserting the cache TTL is bounded by the verified token expiry.

Changes Made:
- backend/api/src/middleware/auth.js: hoist decodedToken to the try-block scope and clamp the Firebase profile cache TTL to min(TTL_SECONDS, decodedToken.exp - now)
- backend/api/test/unit/auth.test.js: added test for firebase profile cache bounded by token remaining lifetime

Impact it Made:
Prevents stale cached profiles from surviving past token expiry (fixes the near-expired-JWT caching bug class), verified with `npx vitest run test/unit/auth.test.js` (29/29 passed).

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.