### PR TITLE
fix : added maximum scan size guard to malware scanner

### DIFF
--- a/backend/api/src/lib/malwareScanner.js
+++ b/backend/api/src/lib/malwareScanner.js
@@ -15,6 +15,21 @@ const DANGEROUS_EXTENSIONS = new Set([
   'vb', 'vbe', 'ws', 'wsb',
 ]);
 
+/**
+ * Maximum payload size forwarded to the virus scanner. Files larger than this
+ * are rejected before a single byte reaches the ClamAV daemon, protecting it
+ * from memory exhaustion on oversized uploads (configurable via
+ * MAX_SCAN_SIZE_BYTES, default 10 MB).
+ */
+export const MAX_SCAN_SIZE_BYTES = 10 * 1024 * 1024;
+
+function getMaxScanSizeBytes() {
+  const configured = Number(process.env.MAX_SCAN_SIZE_BYTES);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : MAX_SCAN_SIZE_BYTES;
+}
+
 const ALLOWED_MIME_TYPES = new Set([
   'image/jpeg',
   'image/png',
@@ -57,6 +72,12 @@ function validateFileContent(buffer, filename) {
 
   if (!buffer || !Buffer.isBuffer(buffer) || buffer.length === 0) {
     throw new MalwareScanError('Rejected file: empty or invalid content.');
+  }
+
+  if (buffer.length > getMaxScanSizeBytes()) {
+    throw new MalwareScanError(
+      `Rejected file: size ${buffer.length} bytes exceeds the ${getMaxScanSizeBytes()} byte scan limit.`
+    );
   }
 
   const detectedMime = detectMimeType(buffer);

--- a/backend/api/test/unit/malwareScanner.test.js
+++ b/backend/api/test/unit/malwareScanner.test.js
@@ -141,5 +141,48 @@ describe('malwareScanner', () => {
       await expect(scanDocument(buf)).rejects.toThrow(MalwareScanError);
       connectSpy.mockRestore();
     });
+
+    it('rejects a buffer larger than the scan size limit before contacting ClamAV', async () => {
+      const connectSpy = vi.spyOn(net, 'createConnection');
+      const { MAX_SCAN_SIZE_BYTES } = await import('../../src/lib/malwareScanner.js');
+      const oversized = Buffer.alloc(MAX_SCAN_SIZE_BYTES + 1);
+      // Valid JPEG magic bytes so only the size check can trip it.
+      Buffer.from([0xff, 0xd8, 0xff]).copy(oversized, 0);
+
+      await expect(scanDocument(oversized)).rejects.toThrow(/exceeds the .* scan limit/);
+      expect(connectSpy).not.toHaveBeenCalled();
+      connectSpy.mockRestore();
+    });
+
+    it('accepts a buffer exactly at the scan size limit', async () => {
+      const { socket, connectHandler } = createMockSocket({ response: 'stream: OK\0' });
+      connectSpy = vi.spyOn(net, 'createConnection').mockImplementation(() => {
+        process.nextTick(connectHandler);
+        return socket;
+      });
+
+      const { MAX_SCAN_SIZE_BYTES } = await import('../../src/lib/malwareScanner.js');
+      const atLimit = Buffer.alloc(MAX_SCAN_SIZE_BYTES);
+      Buffer.from([0xff, 0xd8, 0xff]).copy(atLimit, 0);
+
+      const result = await scanDocument(atLimit);
+      expect(result.clean).toBe(true);
+      connectSpy.mockRestore();
+    });
+
+    it('respects a custom MAX_SCAN_SIZE_BYTES environment override', async () => {
+      process.env.MAX_SCAN_SIZE_BYTES = '1024';
+      const { socket, connectHandler } = createMockSocket({ response: 'stream: OK\0' });
+      connectSpy = vi.spyOn(net, 'createConnection').mockImplementation(() => {
+        process.nextTick(connectHandler);
+        return socket;
+      });
+
+      const buf = Buffer.alloc(2048);
+      Buffer.from([0xff, 0xd8, 0xff]).copy(buf, 0);
+      await expect(scanDocument(buf)).rejects.toThrow(/exceeds the 1024 byte scan limit/);
+      delete process.env.MAX_SCAN_SIZE_BYTES;
+      connectSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
Closes #9967.

Summary of What Has Been Done:
Added a configurable maximum scan size guard to the malware scanner so oversized uploads are rejected before a single byte is forwarded to the ClamAV daemon. The default limit is 10 MB and can be overridden with MAX_SCAN_SIZE_BYTES. Added regression tests covering oversized rejection, exact-limit acceptance, and the env override.

Changes Made:
- backend/api/src/lib/malwareScanner.js: exported MAX_SCAN_SIZE_BYTES constant, getMaxScanSizeBytes() env override, size check in validateFileContent()
- backend/api/test/unit/malwareScanner.test.js: 3 new tests for the size guard

Impact it Made:
Hardens the upload path against memory-exhaustion on the virus scanner; verified locally with `npx vitest run test/unit/malwareScanner.test.js` (10/10 passed) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.