### PR TITLE
fix : added PII scrubbing to audit log entries

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -141,6 +141,51 @@ export function auditLog(options = {}) {
 }
 
 /**
+ * Keys whose values must never reach the audit log. Matching is
+ * case-insensitive on the final path segment so nested payloads are covered
+ * too (e.g. `body.password`, `headers.authorization`).
+ */
+const SENSITIVE_KEY_PATTERN = /(password|passwd|secret|token|otp|authorization|api[_-]?key|access[_-]?key|cookie|cvv|pin)\b/i;
+
+/**
+ * Recursively redacts sensitive fields before an audit entry is persisted.
+ *
+ * beforeState / afterState / metadata are developer-supplied snapshots that
+ * can echo request bodies verbatim. Scrub here — not at the call sites — so a
+ * future getAfterState callback cannot accidentally leak credentials into the
+ * audit trail.
+ *
+ * @param {unknown} value
+ * @param {string} [path] - current object path, used for key matching
+ * @returns {unknown} the value with sensitive fields replaced by "[REDACTED]"
+ */
+export function scrubPii(value, path = '') {
+  if (value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => scrubPii(item, `${path}[${index}]`));
+  }
+
+  if (typeof value === 'object') {
+    const scrubbed = {};
+    for (const [key, item] of Object.entries(value)) {
+      const keyPath = path ? `${path}.${key}` : key;
+      const isSensitive = SENSITIVE_KEY_PATTERN.test(key);
+      scrubbed[key] = isSensitive ? '[REDACTED]' : scrubPii(item, keyPath);
+    }
+    return scrubbed;
+  }
+
+  if (typeof value === 'string') {
+    // Redact 16-digit card numbers that may be embedded in strings.
+    const CARD_NUMBER_PATTERN = /\b\d{4}[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}\b/g;
+    return value.replace(CARD_NUMBER_PATTERN, '[REDACTED]');
+  }
+
+  return value;
+}
+
+/**
  * Writes the audit entry to the database.
  */
 async function writeAuditEntry(req, res, {
@@ -193,9 +238,9 @@ async function writeAuditEntry(req, res, {
     correlationId: req.correlationId,
     requestId: req.requestId,
     statusCode: res.statusCode,
-    beforeState,
-    afterState,
-    metadata,
+    beforeState: scrubPii(beforeState),
+    afterState: scrubPii(afterState),
+    metadata: scrubPii(metadata),
   });
 }
 

--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -1,6 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// ── Mock the audit service ──────────────────────────────────────
 const mockLog = vi.fn().mockResolvedValue({ id: 'mock-log-id' });
 
 vi.mock('../../src/services/auditLogService.js', () => ({
@@ -405,5 +403,57 @@ describe('auditWithState convenience', () => {
   it('should return a middleware function', () => {
     const middleware = auditWithState('order:cancel', 'orders');
     expect(typeof middleware).toBe('function');
+  });
+});
+
+describe('scrubPii', () => {
+  let scrubPii;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../../src/middleware/auditLog.js');
+    scrubPii = mod.scrubPii;
+  });
+
+  it('redacts sensitive keys at the top level', () => {
+    const input = { password: 'hunter2', name: 'Alice', token: 'abc' };
+    expect(scrubPii(input)).toEqual({
+      password: '[REDACTED]',
+      name: 'Alice',
+      token: '[REDACTED]',
+    });
+  });
+
+  it('redacts sensitive keys nested in objects and arrays', () => {
+    const input = {
+      user: { otp: '123456', phone: '+911234567890' },
+      headers: [{ authorization: 'Bearer xyz' }],
+    };
+    const result = scrubPii(input);
+    expect(result.user.otp).toBe('[REDACTED]');
+    expect(result.user.phone).toBe('+911234567890');
+    expect(result.headers[0].authorization).toBe('[REDACTED]');
+  });
+
+  it('redacts card numbers embedded in strings', () => {
+    const input = { card: 'my card is 4111 1111 1111 1111 and expires soon' };
+    expect(scrubPii(input).card).toBe('my card is [REDACTED] and expires soon');
+  });
+
+  it('matches case-insensitively', () => {
+    const input = { Password: 'x', API_KEY: 'y', 'Otp': 'z' };
+    expect(scrubPii(input)).toEqual({
+      Password: '[REDACTED]',
+      API_KEY: '[REDACTED]',
+      Otp: '[REDACTED]',
+    });
+  });
+
+  it('leaves null, primitives and non-sensitive data untouched', () => {
+    expect(scrubPii(null)).toBeNull();
+    expect(scrubPii(undefined)).toBeUndefined();
+    expect(scrubPii(42)).toBe(42);
+    expect(scrubPii('plain text')).toBe('plain text');
+    expect(scrubPii({ name: 'Bob', age: 30 })).toEqual({ name: 'Bob', age: 30 });
   });
 });


### PR DESCRIPTION
Closes #9970.

Summary of What Has Been Done:
Added a recursive PII scrubber to the audit log middleware so before-state, after-state, and metadata snapshots are redacted before they are persisted. Sensitive keys (password, token, otp, authorization, api_key, cvv, pin, etc.) are replaced with [REDACTED], and 16-digit card numbers embedded in strings are masked. Added five unit tests covering nested/array redaction and card masking.

Changes Made:
- backend/api/src/middleware/auditLog.js: scrubPii() helper applied at the audit write boundary
- backend/api/test/unit/auditLog.test.js: 5 new tests

Impact it Made:
Prevents credentials and card numbers from leaking into the persisted audit trail; verified with `npx vitest run test/unit/auditLog.test.js` (20/20 passed) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.