### PR TITLE
fix : implemented real trip validation in tripValidator middleware

### DIFF
--- a/backend/api/src/middleware/tripValidator.js
+++ b/backend/api/src/middleware/tripValidator.js
@@ -1,14 +1,66 @@
 import logger from '../middleware/logger.js';
 
+const TRIP_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Validates trip-related requests.
+ *
+ * Replaces the previous stub that only checked that `req.params.id` is a
+ * non-empty string. Current checks:
+ *   - `req.params.id` (when present) must be a short alphanumeric id.
+ *   - `req.body.odometer_km` / `req.body.odometerKm` (when present) must be a
+ *     finite non-negative number.
+ *   - When a prior odometer reading is available via `req.body.last_odometer_km`
+ *     (or a header `x-last-odometer-km`), the new reading must not decrease —
+ *     a monotonicity violation is treated as a client error.
+ */
 export const tripValidator = {
   validate: (req, res, next) => {
-    logger.warn('[tripValidator] Basic validation active - stub implementation');
-    if (req.params && req.params.id) {
-      const tripId = req.params.id;
-      if (typeof tripId !== 'string' || tripId.length < 1) {
-        return res.status(400).json({ error: 'Invalid trip ID' });
+    const tripId = req.params && req.params.id;
+    if (tripId !== undefined && tripId !== null) {
+      if (typeof tripId !== 'string' || !TRIP_ID_PATTERN.test(tripId)) {
+        return res.status(400).json({
+          error: 'Invalid trip ID',
+          details: 'Trip ID must be a string of 1-64 alphanumeric, underscore or hyphen characters.',
+        });
       }
     }
+
+    const odometerRaw = req.body && (req.body.odometer_km ?? req.body.odometerKm);
+    if (odometerRaw !== undefined && odometerRaw !== null) {
+      const odometer = Number(odometerRaw);
+      if (!Number.isFinite(odometer) || odometer < 0) {
+        return res.status(400).json({
+          error: 'Invalid odometer reading',
+          details: 'odometer_km must be a finite non-negative number.',
+        });
+      }
+
+      const lastRaw = req.body && (req.body.last_odometer_km ?? req.body.lastOdometerKm);
+      const lastFromHeader = req.headers && req.headers['x-last-odometer-km'];
+      const lastOdometerRaw = lastRaw ?? lastFromHeader;
+
+      if (lastOdometerRaw !== undefined && lastOdometerRaw !== null) {
+        const lastOdometer = Number(lastOdometerRaw);
+        if (Number.isFinite(lastOdometer) && odometer < lastOdometer) {
+          logger.warn(
+            {
+              event: 'TRIP_ODOMETER_MONOTONICITY_VIOLATION',
+              tripId,
+              odometerKm: odometer,
+              lastOdometerKm: lastOdometer,
+              requestId: req.requestId || req.id,
+            },
+            'Trip odometer reading regressed below the previous reading'
+          );
+          return res.status(400).json({
+            error: 'Invalid odometer reading',
+            details: 'odometer_km must not be less than the previous reading.',
+          });
+        }
+      }
+    }
+
     next();
-  }
+  },
 };

--- a/backend/api/test/unit/tripValidator.test.js
+++ b/backend/api/test/unit/tripValidator.test.js
@@ -10,4 +10,92 @@ describe('tripValidator Middleware', () => {
     tripValidator.validate(req, res, next);
     expect(next).toHaveBeenCalled();
   });
+
+  it('rejects a malformed trip ID', () => {
+    const req = { params: { id: 'trip id with spaces!' } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Invalid trip ID' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a missing trip ID', () => {
+    const req = { params: {} };
+    const res = {};
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects a negative odometer reading', () => {
+    const req = { params: {}, body: { odometer_km: -1 } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Invalid odometer reading' }));
+  });
+
+  it('rejects a non-numeric odometer reading', () => {
+    const req = { params: {}, body: { odometer_km: 'abc' } };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('accepts a finite non-negative odometer reading', () => {
+    const req = { params: {}, body: { odometer_km: 100.5 } };
+    const res = {};
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects an odometer reading that regresses below the previous reading', () => {
+    const req = {
+      params: {},
+      body: { odometer_km: 100, last_odometer_km: 120 },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.stringContaining('previous reading') })
+    );
+  });
+
+  it('accepts an odometer reading equal to the previous reading', () => {
+    const req = {
+      params: {},
+      body: { odometer_km: 120, last_odometer_km: 120 },
+    };
+    const res = {};
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('reads the previous odometer from the x-last-odometer-km header', () => {
+    const req = {
+      params: {},
+      body: { odometer_km: 90 },
+      headers: { 'x-last-odometer-km': '95' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });


### PR DESCRIPTION
Closes #9972.

Summary of What Has Been Done:
Replaced the tripValidator stub with real validation: trip IDs must match a strict format, odometer readings must be finite non-negative numbers, and readings that regress below a previous reading (from body or x-last-odometer-km header) are rejected with a 400. Expanded the test suite from 1 to 9 tests.

Changes Made:
- backend/api/src/middleware/tripValidator.js: full validation logic
- backend/api/test/unit/tripValidator.test.js: 8 new tests

Impact it Made:
Removes the stub implementation and enforces odometer monotonicity on trip updates; verified with `npx vitest run test/unit/tripValidator.test.js` (9/9 passed) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.