### PR TITLE
fix : fixed undefined url reference in ml service error logging

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -98,7 +98,7 @@ async function handleResponse(response) {
     try {
         return JSON.parse(text);
     } catch (err) {
-    logger.error({ status: response ? response.status : undefined, url }, 'ML service request failed');
+        logger.error({ status: response ? response.status : undefined, bodyPreview: text.slice(0, 200) }, 'ML service request failed');
         throw new Error(`[ML] Invalid JSON response from ML engine: ${err.message}`, { cause: err });
     }
 }

--- a/backend/api/test/unit/ml.test.js
+++ b/backend/api/test/unit/ml.test.js
@@ -147,6 +147,19 @@ describe('ml service — predictDemand', () => {
       .rejects
       .toThrow('Network unreachable');
   });
+
+  it('throws a descriptive error when the ML engine returns invalid JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('not-json{{{'),
+    });
+
+    await expect(predictDemand({ hour: 12, day_of_week: 1, temperature: 25, precipitation: 0, historical_volume: 100, nearby_drivers: 10 }))
+      .rejects
+      .toThrow('[ML] Invalid JSON response from ML engine');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
 });
 
 describe('ml service — predictPrice', () => {


### PR DESCRIPTION
Closes #9974.

Summary of What Has Been Done:
Fixed a latent ReferenceError in the ml service: the module-level handleResponse() catch block referenced an undefined `url` variable, which would throw while handling a JSON parse error and mask the real failure. The error log now includes a bounded body preview instead. Added a unit test covering the malformed-JSON response path.

Changes Made:
- backend/api/src/services/ml.js: replaced undefined `url` with `bodyPreview: text.slice(0, 200)`
- backend/api/test/unit/ml.test.js: new test for invalid JSON response handling

Impact it Made:
Makes ML-engine failures diagnosable and removes a crash in the error path; verified with `npx vitest run test/unit/ml.test.js` (49/54 passed — the 5 failures are pre-existing on main) and eslint (the no-undef error at line 101 is resolved).

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.