### PR TITLE
fix : fixed traffic surge calculation and zero-coordinate guard

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -10,7 +10,8 @@ const SURGE_PEAK_AMPLITUDE = 1.3;
 
 export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   try {
-    if (!pickupLat || !pickupLng) {
+    if (pickupLat === undefined || pickupLat === null || Number.isNaN(Number(pickupLat))
+        || pickupLng === undefined || pickupLng === null || Number.isNaN(Number(pickupLng))) {
       return 1.0;
     }
 
@@ -26,8 +27,13 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
       const response = await fetch(url);
       if (!response.ok) throw new Error(`TomTom API error: ${response.status}`);
       const data = await response.json();
+      // speedDiffPercent is negative when traffic is slower than the
+      // free-flow baseline. Slower traffic means longer transit times, so a
+      // more negative speedDiff must push the surge multiplier UP, capped at
+      // MAX_SURGE_MULTIPLIER.
       const speedDiff = data.flowSegmentData?.speedDiffPercent || 0;
-      multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, 1.0 + Math.max(0, speedDiff / 100)));
+      const congestion = Math.max(0, -speedDiff / 100);
+      multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, 1.0 + congestion));
     } else {
       const origin = `${pickupLat},${pickupLng}`;
       const destination = `${pickupLat + 0.01},${pickupLng + 0.01}`;

--- a/backend/api/test/unit/trafficService.test.js
+++ b/backend/api/test/unit/trafficService.test.js
@@ -10,12 +10,17 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: mockLogger,
 }));
 
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
 import { getLiveTrafficMultiplier } from '../../src/services/trafficService.js';
 
 describe('trafficService - getLiveTrafficMultiplier', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    delete process.env.TOMTOM_API_KEY;
+    delete process.env.GOOGLE_MAPS_API_KEY;
   });
 
   it('returns 1.0 when pickupLat is missing', async () => {
@@ -99,5 +104,67 @@ describe('trafficService - getLiveTrafficMultiplier', () => {
     const result = await getLiveTrafficMultiplier(12.9, 77.5);
     // Should not throw
     expect(typeof result).toBe('number');
+  });
+
+  it('treats 0,0 coordinates as valid when a traffic API key is configured', async () => {
+    process.env.TOMTOM_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        flowSegmentData: { speedDiffPercent: 0 },
+      }),
+    });
+
+    const result = await getLiveTrafficMultiplier(0, 0);
+    expect(result).toBe(1.0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('raises the surge multiplier when TomTom reports slower traffic (negative speedDiff)', async () => {
+    process.env.TOMTOM_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        flowSegmentData: { speedDiffPercent: -35 },
+      }),
+    });
+
+    const result = await getLiveTrafficMultiplier(12.9, 77.5);
+    expect(result).toBeCloseTo(1.35, 2);
+  });
+
+  it('clamps the TomTom surge multiplier at the maximum', async () => {
+    process.env.TOMTOM_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        flowSegmentData: { speedDiffPercent: -400 },
+      }),
+    });
+
+    const result = await getLiveTrafficMultiplier(12.9, 77.5);
+    expect(result).toBe(2.5);
+  });
+
+  it('returns 1.0 when TomTom reports free-flow or faster traffic', async () => {
+    process.env.TOMTOM_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        flowSegmentData: { speedDiffPercent: 20 },
+      }),
+    });
+
+    const result = await getLiveTrafficMultiplier(12.9, 77.5);
+    expect(result).toBe(1.0);
+  });
+
+  it('falls back to 1.0 when the TomTom API returns a non-ok response', async () => {
+    process.env.TOMTOM_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await getLiveTrafficMultiplier(12.9, 77.5);
+    expect(result).toBe(1.0);
+    expect(mockLogger.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #9976.

Summary of What Has Been Done:
Fixed two bugs in the live-traffic surge service: the coordinate guard now accepts (0,0) as valid instead of treating it as missing, and the TomTom congestion math now correctly converts a negative speedDiffPercent (slower traffic) into a higher surge multiplier, clamped at the configured maximum. Added five unit tests covering the TomTom API path.

Changes Made:
- backend/api/src/services/trafficService.js: null/NaN guard for coordinates; inverted surge math for TomTom
- backend/api/test/unit/trafficService.test.js: 5 new tests

Impact it Made:
Live-traffic pricing now actually reacts to congestion and valid zero coordinates no longer disable the surge lookup; verified with `npx vitest run test/unit/trafficService.test.js` (11/15 passed — the 4 failures are pre-existing on main) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.