### PR TITLE
test : added unit tests for PolicyRegistry

### DIFF
--- a/backend/api/test/unit/core/auth/PolicyRegistry.test.js
+++ b/backend/api/test/unit/core/auth/PolicyRegistry.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import PolicyRegistry, { registry } from '../../../../src/core/auth/PolicyRegistry.js';
+import { Permission } from '../../../../src/core/auth/Permission.js';
+
+describe('PolicyRegistry', () => {
+  it('registers a Permission instance', () => {
+    const reg = new PolicyRegistry();
+    const perm = new Permission({ action: 'order:read', roles: ['customer'] });
+    reg.register(perm);
+    expect(reg.get('order:read')).toBe(perm);
+  });
+
+  it('constructs a Permission from a plain object', () => {
+    const reg = new PolicyRegistry();
+    reg.register({ action: 'order:create', roles: ['customer'] });
+    expect(reg.get('order:create')).toBeInstanceOf(Permission);
+  });
+
+  it('throws when registering a duplicate action', () => {
+    const reg = new PolicyRegistry();
+    reg.register({ action: 'order:read', roles: ['customer'] });
+    expect(() =>
+      reg.register({ action: 'order:read', roles: ['driver'] })
+    ).toThrow(/already registered/);
+  });
+
+  it('registerAll registers every permission', () => {
+    const reg = new PolicyRegistry();
+    reg.registerAll([
+      { action: 'a:read', roles: ['admin'] },
+      { action: 'b:read', roles: ['admin'] },
+    ]);
+    expect(reg.size).toBe(2);
+  });
+
+  it('registerPolicy registers permissions from a BasePolicy module', () => {
+    const reg = new PolicyRegistry();
+    const policyModule = {
+      getPermissions: () => [
+        { action: 'truck:register', roles: ['driver'] },
+      ],
+    };
+    reg.registerPolicy(policyModule);
+    expect(reg.has('truck:register')).toBe(true);
+  });
+
+  it('has returns false for unregistered actions', () => {
+    const reg = new PolicyRegistry();
+    expect(reg.has('nope:read')).toBe(false);
+  });
+
+  it('listActions returns sorted action names', () => {
+    const reg = new PolicyRegistry();
+    reg.registerAll([
+      { action: 'zeta:read', roles: ['admin'] },
+      { action: 'alpha:read', roles: ['admin'] },
+    ]);
+    expect(reg.listActions()).toEqual(['alpha:read', 'zeta:read']);
+  });
+
+  it('listPermissions returns all registered permissions', () => {
+    const reg = new PolicyRegistry();
+    reg.register({ action: 'a:read', roles: ['admin'] });
+    reg.register({ action: 'b:read', roles: ['admin'] });
+    const perms = reg.listPermissions();
+    expect(perms).toHaveLength(2);
+    expect(perms[0]).toBeInstanceOf(Permission);
+  });
+
+  it('snapshot returns a serializable summary', () => {
+    const reg = new PolicyRegistry();
+    reg.register({ action: 'order:read', roles: ['customer'] });
+    const snap = reg.snapshot();
+    expect(snap.totalPermissions).toBe(1);
+    expect(snap.policies['order:read']).toBeDefined();
+  });
+
+  it('exports a default singleton registry', () => {
+    expect(registry).toBeInstanceOf(PolicyRegistry);
+  });
+});


### PR DESCRIPTION
Closes #9981.

Summary of What Has Been Done:
Added a dedicated unit test file for PolicyRegistry covering registration semantics, duplicate rejection, registerAll/registerPolicy, listing APIs, snapshot serialization, and the singleton export. Previously these behaviors were only covered indirectly through AuthorizationEngine tests.

Changes Made:
- backend/api/test/unit/core/auth/PolicyRegistry.test.js: new test file (10 tests)

Impact it Made:
Direct regression coverage for the policy registry API; verified with `npx vitest run test/unit/core/auth/PolicyRegistry.test.js` (10/10 passed) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.