### PR TITLE
fix(api): validate EIP-55 checksum before persisting wallet address

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -105,6 +105,7 @@ import {
   getDriverDetails
 } from '../services/profileService.js';
 import { supabase } from '../config/db.js';
+import { ethers } from 'ethers';
 import { ProfileModel } from '../models/ProfileModel.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfile, invalidateCachedSupabaseProfileAll } from '../lib/profileCache.js';
 import { auditLog } from '../middleware/auditLog.js';
@@ -283,6 +284,15 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
   const normalized = wallet_address.trim();
   if (!/^0x[a-fA-F0-9]{40}$/.test(normalized)) {
     return res.status(400).json({ error: 'Invalid wallet address' });
+  }
+  try {
+    // ethers.getAddress accepts all-lowercase / all-uppercase hex and throws
+    // for mixed-case addresses whose EIP-55 checksum is wrong, so a typo'd
+    // address can never be persisted and later fail escrow.isAddress() with
+    // a misleading "escrow not configured" error at bid acceptance time.
+    ethers.getAddress(normalized);
+  } catch {
+    return res.status(400).json({ error: 'Invalid wallet address: EIP-55 checksum is invalid.' });
   }
 
   try {

--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ethers } from 'ethers';
 import { VALID_LANGUAGES } from '../schemas/profile.js';
 
 // Generic field validation helpers
@@ -179,6 +180,16 @@ export const updateWalletSchema = z.object({
   wallet_address: z.string().regex(
     /^0x[a-fA-F0-9]{40}$/,
     'Must be a valid 0x-prefixed 42-character wallet address'
+  ).refine(
+    (address) => {
+      try {
+        ethers.getAddress(address);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Wallet address has an invalid EIP-55 checksum' }
   ),
 }).strict();
 

--- a/backend/api/test/integration/profileRoutes.test.js
+++ b/backend/api/test/integration/profileRoutes.test.js
@@ -390,7 +390,6 @@ describe('Profile Routes', () => {
 
       const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
       expect(profileUpdateCall.payload).toEqual({
-        wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
         polygon_wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
       });
     });
@@ -448,6 +447,46 @@ describe('Profile Routes', () => {
       expect(res.body.error).toBe('This wallet address is already registered to another account.');
 
       m.supabase.from = originalFrom;
+    });
+
+    it('rejects a mixed-case address with an invalid EIP-55 checksum', async () => {
+      const res = await request(buildApp())
+        .put('/api/profile/wallet')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          wallet_address: '0x52908400098527886E0F7030069857D2e4169EE7',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+      expect(res.body.details[0].field).toBe('wallet_address');
+      expect(res.body.details[0].message).toContain('EIP-55 checksum');
+    });
+
+    it('accepts a valid checksummed mixed-case address', async () => {
+      m.store.profiles.push({
+        id: 'customer-uuid-123',
+        firebase_uid: 'firebase-cust-uid',
+        role: 'customer',
+      });
+
+      const res = await request(buildApp())
+        .put('/api/profile/wallet')
+        .set(CUSTOMER_HEADERS)
+        .send({
+          wallet_address: '0x52908400098527886E0F7030069857D2E4169EE7',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        walletAddress: '0x52908400098527886E0F7030069857D2E4169EE7',
+      });
+
+      const profileUpdateCall = m.calls.find(c => c.table === 'profiles' && c.mode === 'update');
+      expect(profileUpdateCall.payload).toEqual({
+        polygon_wallet_address: '0x52908400098527886E0F7030069857D2E4169EE7',
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

`PUT /api/profile/wallet` validated wallet addresses with only the regex `/^0x[a-fA-F0-9]{40}$/`, which accepts **any** mixed-case hex — including addresses whose EIP-55 checksum is wrong (one character with the wrong case). Such an address is stored "successfully", but the escrow pipeline later rejects it with `ethers.isAddress()`, surfacing as a misleading `502 Escrow is not configured` at bid-acceptance time. The real cause — a typo'd stored wallet — is never surfaced to the driver or customer.

## Fix

Validate the EIP-55 checksum at entry so the typo is caught immediately with a clear 400:

- `backend/api/src/validation/requestSchemas.js` — `updateWalletSchema.wallet_address` now adds a `.refine()` that runs `ethers.getAddress(address)` (throws for mixed-case addresses with an invalid checksum; accepts all-lowercase / all-uppercase hex), returning the message `Wallet address has an invalid EIP-55 checksum`.
- `backend/api/src/routes/profileRoutes.js` — the handler keeps a defensive duplicate check using the same `ethers.getAddress` call so the route is still safe if invoked without schema validation, returning `400 Invalid wallet address: EIP-55 checksum is invalid.`.

No normalization is applied, so the stored format is unchanged (existing all-lowercase addresses, which `ethers.isAddress()` accepts, continue to work).

## Files changed

- `backend/api/src/validation/requestSchemas.js`
- `backend/api/src/routes/profileRoutes.js`
- `backend/api/test/integration/profileRoutes.test.js`

## Testing

- `node --check` passes on `profileRoutes.js` (the schema file also compiles via Vitest).
- `npx vitest run test/integration/profileRoutes.test.js` — the wallet suite passes:
  - new: rejects a mixed-case address with an invalid EIP-55 checksum (`0x52908400098527886E0F7030069857D2e4169EE7`) with 400,
  - new: accepts a valid checksummed mixed-case address (`0x52908400098527886E0F7030069857D2E4169EE7`) with 200,
  - corrected a pre-existing stale assertion in the wallet test (it expected a `wallet_address` key the route never writes; the route only writes `polygon_wallet_address`).

> Note: one unrelated pre-existing test in this file still fails on main (`GET /api/profile` driver-role test asserts an outdated response shape that now also includes `top_earner` / `kycStatus` fields). It is outside this issue's scope and untouched here.

Closes #9776
