### PR TITLE
fix(ebpf): fix malformed template literal in load command (fixes #7273)

### DIFF
--- a/ebpf/routes.js
+++ b/ebpf/routes.js
@@ -207,7 +207,7 @@ router.post('/ebpf/load', authenticate, requirePolicy('ebpf:manage'), ebpfAction
         }
 
         // Execute with sanitized input
-        const result = await execAsync(`sudo bpftool prog load "${process.env.EBPF_PROGRAMS_PATH || path.join(process.cwd(), "ebpf", "programs")}/${program}.o /sys/fs/bpf/truxify_${program}`);
+        const result = await execAsync(`sudo bpftool prog load "${path.join(process.env.EBPF_PROGRAMS_PATH || process.cwd(), 'ebpf', 'programs', program + '.o')}" /sys/fs/bpf/truxify_${program}`);
         
         res.json({
             success: true,


### PR DESCRIPTION
## Description
Fixes a malformed template literal in `ebpf/routes.js` that caused an invalid command evaluation when executing `sudo bpftool prog load`. Previously, an unbalanced quote within the template literal caused the javascript path variables to be captured as literal text, which resulted in a bash parsing failure (`unexpected EOF while looking for matching '"'`) and broke the `POST /ebpf/load` endpoint. This PR resolves the issue by securely injecting the file path parameters with `path.join()`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `curl -X POST http://localhost:<port>/ebpf/load -H "Content-Type: application/json" -d '{"program": "trace_syscalls"}'`
- **Test Steps / Prerequisites:** Call the `POST /ebpf/load` endpoint with a valid allowed program name (e.g., `trace_syscalls`). Make sure you pass authentication and `ebpf:manage` policy requirements.
- **Expected Result:** The endpoint successfully executes the BPF tool load command without throwing a `500 Internal Server Error` due to malformed quotes.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #7273

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
