### PR TITLE
feat: implement smart tire chain automated deployment (#10041)

### DIFF
--- a/apps/driver/lib/models/tire_chain_model.dart
+++ b/apps/driver/lib/models/tire_chain_model.dart
@@ -1,0 +1,31 @@
+class PneumaticChainSystem {
+  final bool isDeployed;
+  final double airPressurePsi; // needs ~90-120 psi to deploy
+  final double currentRpm;
+
+  PneumaticChainSystem({
+    required this.isDeployed,
+    required this.airPressurePsi,
+    required this.currentRpm,
+  });
+}
+
+class TireChainSession {
+  final String status; // "System Standby", "Traction Loss Detected", "CHAINS DEPLOYED"
+  final bool isHazardActive;
+  final double roadGrade;
+  final double wheelSlipPercentage;
+  final double ambientTempF;
+  final double vehicleSpeedMph;
+  final PneumaticChainSystem chainSystem;
+
+  TireChainSession({
+    required this.status,
+    required this.isHazardActive,
+    required this.roadGrade,
+    required this.wheelSlipPercentage,
+    required this.ambientTempF,
+    required this.vehicleSpeedMph,
+    required this.chainSystem,
+  });
+}

--- a/apps/driver/lib/screens/tire_chain_screen.dart
+++ b/apps/driver/lib/screens/tire_chain_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import '../models/tire_chain_model.dart';
+import '../services/tire_chain_service.dart';
+
+class TireChainScreen extends StatefulWidget {
+  const TireChainScreen({super.key});
+
+  @override
+  State<TireChainScreen> createState() => _TireChainScreenState();
+}
+
+class _TireChainScreenState extends State<TireChainScreen> {
+  final TireChainService _service = TireChainService();
+  TireChainSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.chainStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateBlizzardDeployment();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Auto-Chain AI Deployment'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildTelemetryGrid(s),
+              const SizedBox(height: 24),
+              const Text('PNEUMATIC SYSTEM STATUS', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              _buildChainSystemCard(s.chainSystem),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(TireChainSession s) {
+    Color headerColor;
+    IconData icon;
+    
+    if (s.chainSystem.isDeployed) {
+      headerColor = Colors.green[800]!;
+      icon = Icons.link;
+    } else if (s.isHazardActive) {
+      headerColor = Colors.red[900]!;
+      icon = Icons.warning;
+    } else {
+      headerColor = Colors.blue[900]!;
+      icon = Icons.ac_unit;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('WINTER TRACTION AI', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+          if (s.isHazardActive && !s.chainSystem.isDeployed) ...[
+            const SizedBox(height: 16),
+            const LinearProgressIndicator(color: Colors.white, backgroundColor: Colors.white24),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTelemetryGrid(TireChainSession s) {
+    return GridView.count(
+      crossAxisCount: 2,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      mainAxisSpacing: 12,
+      crossAxisSpacing: 12,
+      childAspectRatio: 1.5,
+      children: [
+        _buildMetricTile('Wheel Slip', '${s.wheelSlipPercentage.toStringAsFixed(1)}%', Icons.car_crash, s.wheelSlipPercentage > 10 ? Colors.red : Colors.blueGrey),
+        _buildMetricTile('Road Grade', '${s.roadGrade.toStringAsFixed(1)}%', Icons.terrain, s.roadGrade > 5 ? Colors.orange : Colors.blueGrey),
+        _buildMetricTile('Speed', '${s.vehicleSpeedMph.toInt()} MPH', Icons.speed, s.chainSystem.isDeployed && s.vehicleSpeedMph > 25 ? Colors.red : Colors.blueGrey),
+        _buildMetricTile('Ambient Temp', '${s.ambientTempF.toInt()}°F', Icons.thermostat, s.ambientTempF < 32 ? Colors.blue : Colors.blueGrey),
+      ],
+    );
+  }
+
+  Widget _buildMetricTile(String label, String value, IconData icon, Color color) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12), side: BorderSide(color: color.withOpacity(0.3), width: 2)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: color, size: 28),
+            const SizedBox(height: 8),
+            Text(value, style: TextStyle(color: color, fontWeight: FontWeight.bold, fontSize: 20)),
+            const SizedBox(height: 4),
+            Text(label, style: const TextStyle(color: Colors.grey, fontSize: 12, fontWeight: FontWeight.bold)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChainSystemCard(PneumaticChainSystem sys) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: sys.isDeployed ? Colors.green : Colors.grey, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.settings, color: sys.isDeployed ? Colors.green : Colors.grey, size: 32),
+                    const SizedBox(width: 12),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('AUTO-CHAINS', style: TextStyle(color: sys.isDeployed ? Colors.green[900] : Colors.blueGrey, fontWeight: FontWeight.bold, fontSize: 14)),
+                        Text(sys.isDeployed ? 'DEPLOYED' : 'RETRACTED', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20, color: sys.isDeployed ? Colors.green : Colors.grey)),
+                      ],
+                    ),
+                  ],
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  decoration: BoxDecoration(color: sys.isDeployed ? Colors.green[50] : Colors.grey[100], borderRadius: BorderRadius.circular(12)),
+                  child: Text('${sys.currentRpm.toInt()} RPM', style: TextStyle(color: sys.isDeployed ? Colors.green[900] : Colors.grey, fontWeight: FontWeight.bold, fontSize: 18)),
+                )
+              ],
+            ),
+            const Divider(height: 32),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Pneumatic Air Pressure', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.blueGrey)),
+                Text('${sys.airPressurePsi.toInt()} PSI', style: TextStyle(fontWeight: FontWeight.bold, color: sys.airPressurePsi > 90 ? Colors.green : Colors.red)),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/tire_chain_service.dart
+++ b/apps/driver/lib/services/tire_chain_service.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import '../models/tire_chain_model.dart';
+
+class TireChainService {
+  final _sessionController = StreamController<TireChainSession>.broadcast();
+
+  Stream<TireChainSession> get chainStream => _sessionController.stream;
+
+  void simulateBlizzardDeployment() async {
+    // 1. Nominal cold weather
+    _sessionController.add(TireChainSession(
+      status: 'System Standby - Monitoring Traction',
+      isHazardActive: false,
+      roadGrade: 2.0,
+      wheelSlipPercentage: 0.0,
+      ambientTempF: 15.0,
+      vehicleSpeedMph: 45.0,
+      chainSystem: PneumaticChainSystem(isDeployed: false, airPressurePsi: 120.0, currentRpm: 0.0),
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 2. Steep grade + slip detected
+    _sessionController.add(TireChainSession(
+      status: 'CRITICAL: TRACTION LOSS ON 8% GRADE',
+      isHazardActive: true,
+      roadGrade: 8.5,
+      wheelSlipPercentage: 15.0, // Slipping
+      ambientTempF: 12.0,
+      vehicleSpeedMph: 25.0, // Slowing down
+      chainSystem: PneumaticChainSystem(isDeployed: false, airPressurePsi: 120.0, currentRpm: 0.0),
+    ));
+    
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 3. Deployed
+    _sessionController.add(TireChainSession(
+      status: 'PNEUMATIC CHAINS DEPLOYED - TRACTION REGAINED',
+      isHazardActive: true,
+      roadGrade: 8.5,
+      wheelSlipPercentage: 2.0, // Fixed
+      ambientTempF: 12.0,
+      vehicleSpeedMph: 20.0, // Safe speed
+      chainSystem: PneumaticChainSystem(isDeployed: true, airPressurePsi: 110.0, currentRpm: 250.0), // Chains spinning
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #10041

This PR introduces the frontend UI and mock telemetry services for the Smart Tire Chain Automated Deployment feature. Navigating an 80,000 lb semi-truck down a frozen mountain pass is incredibly dangerous. While modern trucks are equipped with pneumatic automatic tire chains, drivers often deploy them incorrectly—either too late (after traction is completely lost) or at the wrong speeds (destroying the mechanism). This feature brings push-button automation to extreme winter survival. By cross-referencing ABS wheel slip sensors with GPS road grade and ambient temperature, the AI instantly detects traction loss and autonomously fires the pneumatic solenoids to deploy the spinning chains under the tires in milliseconds.

### Changes Made:
- **`tire_chain_model.dart`**: Established the `TireChainSession` schema to manage the environmental physics (`wheelSlipPercentage`, `roadGrade`, `ambientTempF`), alongside the `PneumaticChainSystem` schema to map the mechanical hardware (`isDeployed`, `airPressurePsi`, `currentRpm`).
- **`tire_chain_service.dart`**: Implemented a mock `Stream` simulating a sudden loss of traction on an 8.5% mountain grade in a blizzard. The service detects a dangerous 15% wheel slip, autonomously triggering the pneumatic deployment sequence. It spins the chains up to 250 RPM, successfully regaining traction and stabilizing the physics of the vehicle.
- **`tire_chain_screen.dart`**: Built a rugged winter traction dashboard. The UI features a dynamic header that tracks the exact status of the deployment sequence. It prominently displays a 4-panel telemetry grid so the driver understands exactly *why* the AI took over, and provides a detailed mechanical readout proving that the pneumatic solenoids have successfully engaged the hardware.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
