### PR TITLE
feat: implement over-the-air engine remapping (#10048)

### DIFF
--- a/apps/driver/lib/models/engine_remapping_model.dart
+++ b/apps/driver/lib/models/engine_remapping_model.dart
@@ -1,0 +1,31 @@
+class EngineTune {
+  final String profileName; // "Midwest Eco-Cruiser", "Rocky Mountain Hauler"
+  final int maxHorsepower;
+  final int peakTorqueLbFt;
+  final String jakeBrakeProfile; // "Low-Aggression", "Max-Retardation"
+  final String shiftingLogic; // "Early Up-shift (Fuel Save)", "Hold Gears (Climb)"
+
+  EngineTune({
+    required this.profileName,
+    required this.maxHorsepower,
+    required this.peakTorqueLbFt,
+    required this.jakeBrakeProfile,
+    required this.shiftingLogic,
+  });
+}
+
+class RemappingSession {
+  final String status; // "Active Tune: Eco", "FIRMWARE FLASH IN PROGRESS"
+  final String currentRegion; // "Kansas Plains", "Colorado Rockies"
+  final double upcomingGradePercent;
+  final EngineTune activeTune;
+  final bool isFlashing;
+
+  RemappingSession({
+    required this.status,
+    required this.currentRegion,
+    required this.upcomingGradePercent,
+    required this.activeTune,
+    required this.isFlashing,
+  });
+}

--- a/apps/driver/lib/screens/engine_remapping_screen.dart
+++ b/apps/driver/lib/screens/engine_remapping_screen.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import '../models/engine_remapping_model.dart';
+import '../services/engine_remapping_service.dart';
+
+class EngineRemappingScreen extends StatefulWidget {
+  const EngineRemappingScreen({super.key});
+
+  @override
+  State<EngineRemappingScreen> createState() => _EngineRemappingScreenState();
+}
+
+class _EngineRemappingScreenState extends State<EngineRemappingScreen> {
+  final EngineRemappingService _service = EngineRemappingService();
+  RemappingSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.mapStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.simulateTopologyChange();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dynamic OTA Remapping'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildRegionCard(s),
+              const SizedBox(height: 24),
+              const Text('ACTIVE ENGINE ECM PROFILE', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              _buildTuneCard(s.activeTune, s.isFlashing),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(RemappingSession s) {
+    Color headerColor;
+    IconData icon;
+    
+    if (s.isFlashing) {
+      headerColor = Colors.orange[800]!;
+      icon = Icons.system_update_alt;
+    } else if (s.activeTune.profileName.contains('Mountain')) {
+      headerColor = Colors.deepPurple[900]!;
+      icon = Icons.terrain;
+    } else {
+      headerColor = Colors.green[800]!;
+      icon = Icons.eco;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: headerColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('ECM TOPOLOGY SYNC', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+          if (s.isFlashing) ...[
+            const SizedBox(height: 16),
+            const LinearProgressIndicator(color: Colors.white, backgroundColor: Colors.white24),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRegionCard(RemappingSession s) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('GPS Topology Region', style: TextStyle(color: Colors.blueGrey, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(s.currentRegion, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              ],
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(color: s.upcomingGradePercent > 4.0 ? Colors.red[50] : Colors.blueGrey[50], borderRadius: BorderRadius.circular(8)),
+              child: Text('${s.upcomingGradePercent.toStringAsFixed(1)}% Grade', style: TextStyle(color: s.upcomingGradePercent > 4.0 ? Colors.red[900] : Colors.blueGrey, fontWeight: FontWeight.bold)),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTuneCard(EngineTune tune, bool isFlashing) {
+    bool isMountain = tune.profileName.contains('Mountain');
+
+    return Card(
+      elevation: isFlashing ? 1 : 8,
+      color: isMountain ? Colors.deepPurple[50] : Colors.green[50],
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: isFlashing ? Colors.orange : (isMountain ? Colors.deepPurple : Colors.green), width: 2),
+      ),
+      child: Opacity(
+        opacity: isFlashing ? 0.5 : 1.0,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              Text(tune.profileName.toUpperCase(), style: TextStyle(color: isMountain ? Colors.deepPurple[900] : Colors.green[900], fontSize: 24, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const Divider(height: 32),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _buildSpecMetric('Max Power', '${tune.maxHorsepower} HP', isMountain ? Colors.deepPurple : Colors.green),
+                  _buildSpecMetric('Peak Torque', '${tune.peakTorqueLbFt} lb-ft', isMountain ? Colors.deepPurple : Colors.green),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('Transmission Logic', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.blueGrey)),
+                  Text(tune.shiftingLogic, style: TextStyle(fontWeight: FontWeight.bold, color: isMountain ? Colors.deepPurple[900] : Colors.green[900])),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('Jake Brake Profile', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.blueGrey)),
+                  Text(tune.jakeBrakeProfile, style: TextStyle(fontWeight: FontWeight.bold, color: isMountain ? Colors.deepPurple[900] : Colors.green[900])),
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSpecMetric(String label, String value, Color color) {
+    return Column(
+      children: [
+        Text(value, style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold, color: color, fontFamily: 'monospace')),
+        const SizedBox(height: 4),
+        Text(label, style: const TextStyle(color: Colors.blueGrey, fontWeight: FontWeight.bold)),
+      ],
+    );
+  }
+}

--- a/apps/driver/lib/services/engine_remapping_service.dart
+++ b/apps/driver/lib/services/engine_remapping_service.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import '../models/engine_remapping_model.dart';
+
+class EngineRemappingService {
+  final _sessionController = StreamController<RemappingSession>.broadcast();
+
+  Stream<RemappingSession> get mapStream => _sessionController.stream;
+
+  void simulateTopologyChange() async {
+    final ecoTune = EngineTune(
+      profileName: 'Midwest Eco-Cruiser',
+      maxHorsepower: 400,
+      peakTorqueLbFt: 1450,
+      jakeBrakeProfile: 'Low-Aggression',
+      shiftingLogic: 'Early Up-shift (Fuel Save)',
+    );
+
+    final mountainTune = EngineTune(
+      profileName: 'Rocky Mountain Hauler',
+      maxHorsepower: 505,
+      peakTorqueLbFt: 1850,
+      jakeBrakeProfile: 'Max-Retardation',
+      shiftingLogic: 'Hold Gears (Climb)',
+    );
+
+    // 1. Cruising Kansas
+    _sessionController.add(RemappingSession(
+      status: 'Active Tune: Maximum MPG',
+      currentRegion: 'Kansas Interstate (Flat)',
+      upcomingGradePercent: 0.5,
+      activeTune: ecoTune,
+      isFlashing: false,
+    ));
+
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 2. Approaching Rockies, flashing ECM
+    _sessionController.add(RemappingSession(
+      status: 'TOPOLOGY SHIFT: OTA FIRMWARE FLASH IN PROGRESS...',
+      currentRegion: 'Approaching Colorado Rockies',
+      upcomingGradePercent: 6.5,
+      activeTune: ecoTune,
+      isFlashing: true,
+    ));
+    
+    await Future.delayed(const Duration(seconds: 4));
+
+    // 3. Flash complete, mountain mode
+    _sessionController.add(RemappingSession(
+      status: 'ECM FLASHED: MOUNTAIN TUNE ACTIVE',
+      currentRegion: 'Colorado Rockies (Steep Climb)',
+      upcomingGradePercent: 6.5,
+      activeTune: mountainTune,
+      isFlashing: false,
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #10048

This PR introduces the frontend UI and mock telemetry services for the Over-The-Air (OTA) Engine Remapping feature. Currently, commercial truck engines are flashed with a single "compromise" software tune at the factory—one that is neither perfectly efficient on flat land, nor powerful enough for extreme mountain climbs. This feature dynamically alters the physical performance characteristics of the truck based on its geography. By syncing the Engine Control Module (ECM) with the GPS routing topology, the app autonomously flashes new performance maps over the air. It runs a low-horsepower, high-MPG "Eco" tune in the Midwest, and instantly flashes a high-horsepower, aggressive-shifting "Mountain" tune the moment the truck begins climbing the Rockies.

### Changes Made:
- **`engine_remapping_model.dart`**: Established the `RemappingSession` schema to manage the live geographic state (`currentRegion`, `upcomingGradePercent`), alongside the `EngineTune` schema to track the exact mechanical parameters of the flashed software (`maxHorsepower`, `peakTorqueLbFt`, `shiftingLogic`).
- **`engine_remapping_service.dart`**: Implemented a mock `Stream` simulating a cross-country route from Kansas into Colorado. The service monitors the GPS topology, detecting the approaching 6.5% mountain grade. It autonomously triggers an OTA firmware flash, instantly swapping the 400 HP Eco-Tune for a massive 505 HP Mountain Hauler map.
- **`engine_remapping_screen.dart`**: Built a dynamic ECM topology dashboard. The UI utilizes a highly reactive state that shifts entire color palettes (Eco Green to Mountain Purple) based on the active engine map. It prominently displays the live horsepower and torque figures, giving the driver complete confidence in their engine's physical capability before they hit the mountain.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
