### PR TITLE
fix : corrected import path in normalizePhone.test.js

### DIFF
--- a/backend/api/test/unit/normalizePhone.test.js
+++ b/backend/api/test/unit/normalizePhone.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizePhone } from '../../utils/phone.js';
+import { normalizePhone } from '../../src/utils/phone.js';
 
 describe('normalizePhone', () => {
   it('normalizes E.164 format with + prefix and space', () => {


### PR DESCRIPTION
Closes #10022.

Summary of What Has Been Done:
Changed the import path in normalizePhone.test.js from '../../utils/phone.js' to '../../src/utils/phone.js'. The former path does not exist in the project structure.

Changes Made:
- backend/api/test/unit/normalizePhone.test.js: corrected import from '../../utils/phone.js' to '../../src/utils/phone.js'

Impact it Made:
- Test suite now resolves the normalizePhone module correctly
- Eliminates 'Cannot find module' error that caused 0 tests to be counted
- normalizePhone utility is now properly covered by unit tests

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
