### PR TITLE
fix : corrected logger import paths in authFailureMonitor.test.js

### DIFF
--- a/backend/api/test/unit/authFailureMonitor.test.js
+++ b/backend/api/test/unit/authFailureMonitor.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import logger from '../../middleware/logger.js';
+import logger from '../../src/middleware/logger.js';
 
-vi.mock('../../middleware/logger.js', () => ({
+vi.mock('../../src/middleware/logger.js', () => ({
   default: {
     warn: vi.fn(),
     info: vi.fn(),


### PR DESCRIPTION
Closes #10023.

Summary of What Has Been Done:
Corrected the logger import path in authFailureMonitor.test.js from '../../middleware/logger.js' to '../../src/middleware/logger.js'. Also corrected the vi.mock path to match. The test was using an incorrect relative path to the logger middleware.

Changes Made:
- backend/api/test/unit/authFailureMonitor.test.js: corrected both import and vi.mock paths to use '../../src/middleware/logger.js'

Impact it Made:
- Test suite now resolves the logger module correctly
- authFailureMonitor middleware has test coverage restored

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
