### PR TITLE
fix : corrected function name in driverEarningsService.test.js

### DIFF
--- a/backend/api/test/unit/driverEarningsService.test.js
+++ b/backend/api/test/unit/driverEarningsService.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import driverEarningsService from '../../src/services/driverEarningsService.js';
 
-describe('driverEarningsService.aggregateTripEarnings', () => {
+describe('driverEarningsService.calculateEarningsAggregation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -12,7 +12,7 @@ describe('driverEarningsService.aggregateTripEarnings', () => {
       { total_earnings: 2000, net_earnings: 1800 },
     ];
 
-    const result = driverEarningsService.aggregateTripEarnings(trips);
+    const result = driverEarningsService.calculateEarningsAggregation(trips);
 
     expect(result).toEqual({
       totalEarnings: 3000,
@@ -27,7 +27,7 @@ describe('driverEarningsService.aggregateTripEarnings', () => {
       { total_earnings: 1500, net_earnings: null },
     ];
 
-    const result = driverEarningsService.aggregateTripEarnings(trips);
+    const result = driverEarningsService.calculateEarningsAggregation(trips);
 
     expect(result).toEqual({
       totalEarnings: 1500,
@@ -42,7 +42,7 @@ describe('driverEarningsService.aggregateTripEarnings', () => {
       { total_earnings: 1000, net_earnings: Number('invalid') },
     ];
 
-    const result = driverEarningsService.aggregateTripEarnings(trips);
+    const result = driverEarningsService.calculateEarningsAggregation(trips);
 
     expect(result).toEqual({
       totalEarnings: 1000,
@@ -57,7 +57,7 @@ describe('driverEarningsService.aggregateTripEarnings', () => {
       { total_earnings: 500, net_earnings: 400 },
     ];
 
-    const result = driverEarningsService.aggregateTripEarnings(trips);
+    const result = driverEarningsService.calculateEarningsAggregation(trips);
 
     expect(result.totalEarnings).not.toBeNaN();
     expect(result.netEarnings).not.toBeNaN();
@@ -65,7 +65,7 @@ describe('driverEarningsService.aggregateTripEarnings', () => {
   });
 
   it('should return zeros for empty trip lists', () => {
-    const result = driverEarningsService.aggregateTripEarnings([]);
+    const result = driverEarningsService.calculateEarningsAggregation([]);
 
     expect(result).toEqual({
       totalEarnings: 0,


### PR DESCRIPTION
Closes #10024.

Summary of What Has Been Done:
Renamed all references to driverEarningsService.aggregateTripEarnings() to driverEarningsService.calculateEarningsAggregation() in the unit test. The service module exports calculateEarningsAggregation, not aggregateTripEarnings, so all 5 tests were failing with TypeError.

Changes Made:
- backend/api/test/unit/driverEarningsService.test.js: renamed aggregateTripEarnings to calculateEarningsAggregation in describe block and all test calls

Impact it Made:
- All 5 tests now call the correct exported function
- TypeError: Cannot read properties of undefined (reading aggregateTripEarnings) is eliminated
- driverEarningsService.calculateEarningsAggregation is now properly tested

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
