### PR TITLE
fix : corrected EscalationHandler import in escalationHandler.test.js

### DIFF
--- a/backend/api/test/unit/escalationHandler.test.js
+++ b/backend/api/test/unit/escalationHandler.test.js
@@ -15,7 +15,7 @@ vi.mock('../../middleware/logger.js', () => ({
   default: mockLogger,
 }));
 
-const { EscalationHandler } = require('../../src/services/blockchain/escalationHandler.js');
+const { default: EscalationHandler, ESCALATION_LEVELS, ESCALATION_THRESHOLDS } = require('../../src/services/blockchain/escalationHandler.js');
 
 describe('EscalationHandler', () => {
   let handler;


### PR DESCRIPTION
Closes #10029.

Summary of What Has Been Done:
Changed the require import from a destructured named export ({ EscalationHandler }) to include the default export fallback ({ default: EscalationHandler, ESCALATION_LEVELS, ESCALATION_THRESHOLDS }). The module exports EscalationHandler as a default export, not a named export, so the destructured value was undefined.

Changes Made:
- backend/api/test/unit/escalationHandler.test.js: changed require destructuring to include .default fallback

Impact it Made:
- Both tests now instantiate EscalationHandler correctly
- TypeError: EscalationHandler is not a constructor eliminated

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
