### PR TITLE
fix : added null guard for missing gpsCoordinates in OracleService._verifyGPS

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -85,7 +85,16 @@ class OracleService {
   }
 
   async _verifyGPS(orderId, gpsCoordinates) {
-    const hasValidCoords = gpsCoordinates &&
+    if (!gpsCoordinates) {
+      return {
+        confirmed: false,
+        provider: 'GPSVerifier',
+        reason: 'No GPS coordinates provided',
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    const hasValidCoords =
       typeof gpsCoordinates.lat === 'number' &&
       typeof gpsCoordinates.lng === 'number' &&
       gpsCoordinates.lat >= -90 && gpsCoordinates.lat <= 90 &&


### PR DESCRIPTION
Closes #10119.

Summary of What Has Been Done:
Added an explicit null/undefined guard at the top of the _verifyGPS method in OracleService. If gpsCoordinates is null or undefined, the method now returns a structured rejection with reason 'No GPS coordinates provided' instead of throwing a TypeError when accessing gpsCoordinates.lat.

Changes Made:
- backend/api/src/oracle/OracleService.js: added null guard at start of _verifyGPS

Impact it Made:
- Prevents TypeError crash when gpsCoordinates is null/undefined
- Returns structured rejection: { confirmed: false, provider: 'GPSVerifier', reason: 'No GPS coordinates provided' }

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
