### PR TITLE
docs : added JSDoc comments to formatValidationIssues function

### DIFF
--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -1,5 +1,22 @@
 import logger from './logger.js';
 
+/**
+ * Format a Zod validation error into a flat array of field+message objects
+ * suitable for returning as an HTTP 400 body.
+ *
+ * @param {object} error - A Zod error object with an `issues` array.
+ *   Each issue has at least { path: string[], message: string }.
+ * @returns {Array<{field: string, message: string}>} Formatted issues with
+ *   `field` set to the dot-joined path or "body" if empty, and
+ *   `message` set to the issue message.
+ *
+ * @example
+ * // Given a Zod error for missing "email" in the request body:
+ * const formatted = formatValidationIssues(error);
+ * // => [{ field: "body.email", message: "Required" }]
+ *
+ * @since 1.0.0
+ */
 export function formatValidationIssues(error) {
   return error.issues.map((issue) => ({
     field: issue.path.length > 0 ? issue.path.join(".") : "body",


### PR DESCRIPTION
Closes #10120.

Summary of What Has Been Done:
Added comprehensive JSDoc comments to the formatValidationIssues function in backend/api/src/middleware/validate.js documenting its input contract (Zod error with issues array), output contract (flat array of {field, message}), and includes an @example usage.

Changes Made:
- backend/api/src/middleware/validate.js: added JSDoc @param, @returns, @example, @since tags

Impact it Made:
- Improves IDE autocomplete for developers using this utility
- Documents the Zod-error-to-field-message transformation contract
- Enables better onboarding for new contributors

Note: Please assign this PR to the tmdeveloper007 account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).
