### PR TITLE
fix: require auth + admin policy for WASM driver/load routes

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -134,6 +134,7 @@ const POLICIES = {
   'ebpf:manage':               { roles: [ROLES.ADMIN] },
   'snyk:manage':               { roles: [ROLES.ADMIN] },
   'wasi:manage':               { roles: [ROLES.ADMIN] },
+  'wasm:manage':               { roles: [ROLES.ADMIN] },
 };
 
 export class PolicyEngine {

--- a/backend/api/test/unit/wasmOtpRoutes.test.js
+++ b/backend/api/test/unit/wasmOtpRoutes.test.js
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+
+vi.mock('../../../../wasm/edge-runtime.js', () => ({
+  default: {
+    calculateRoute: vi.fn(async () => ({ estimated_price: 100 })),
+    processDrivers: vi.fn(async (drivers) => drivers),
+    optimizeLoads: vi.fn(async () => [0]),
+    calculateETA: vi.fn(async () => 42),
+    getFunctionStats: vi.fn(async () => ({ modulesLoaded: 0 })),
+  },
+}));
+
 import wasmRoutes from '../../../../wasm/routes.js';
 
 function buildApp() {
@@ -10,15 +21,84 @@ function buildApp() {
   return app;
 }
 
-describe('POST /api/wasm/otp (issue #6331)', () => {
-  it('cannot be used to validate an OTP with a client-controlled reference value', async () => {
+const ADMIN_HEADERS = { 'x-user-id': 'admin-1', 'x-user-role': 'admin' };
+const CUSTOMER_HEADERS = { 'x-user-id': 'customer-1', 'x-user-role': 'customer' };
+
+describe('wasm edge-runtime routes (issue #9825)', () => {
+  beforeEach(() => {
+    process.env.BYPASS_AUTH = 'true';
+    process.env.ENABLE_TEST_AUTH = 'true';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    delete process.env.BYPASS_AUTH;
+    delete process.env.ENABLE_TEST_AUTH;
+    delete process.env.NODE_ENV;
+  });
+
+  it('rejects anonymous requests with 401', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/wasm/drivers')
+      .send({ drivers: [] });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects authenticated non-admin roles with 403', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/wasm/route')
+      .set(CUSTOMER_HEADERS)
+      .send({ origin: 'A', destination: 'B' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows admins to call compute endpoints', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/wasm/eta')
+      .set(ADMIN_HEADERS)
+      .send({ distance: 100, speed: 40, trafficFactor: 0.1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toBe(42);
+  });
+
+  it('rejects oversized drivers arrays with 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/wasm/drivers')
+      .set(ADMIN_HEADERS)
+      .send({ drivers: Array(1001).fill({ speed: 60 }) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('too large');
+  });
+
+  it('rejects oversized loads arrays with 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/wasm/optimize')
+      .set(ADMIN_HEADERS)
+      .send({ loads: Array(1001).fill(10), capacity: 10000 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('too large');
+  });
+
+  it('does not expose a public OTP validation route (issue #6331)', async () => {
     const app = buildApp();
 
     // The route used to accept inputOTP + correctOTP from the request body
     // and return success whenever the two strings matched. It must no longer
-    // exist on the public API surface.
+    // exist on the API surface even for an authenticated admin.
     const res = await request(app)
       .post('/api/wasm/otp')
+      .set(ADMIN_HEADERS)
       .send({ inputOTP: '123456', correctOTP: '123456' });
 
     expect(res.status).toBe(404);

--- a/wasm/routes.js
+++ b/wasm/routes.js
@@ -1,8 +1,34 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import edgeRuntime from './edge-runtime.js';
 import logger from '../backend/api/src/middleware/logger.js';
+import { authenticate } from '../backend/api/src/middleware/auth.js';
+import { requirePolicy } from '../backend/api/src/middleware/requirePolicy.js';
 
 const router = express.Router();
+
+// The WASM edge runtime executes arbitrary compute per request — a fresh
+// worker thread per call (or synchronous fallback on the event loop when no
+// .wasm binary is deployed) — so it is isolated from the public API like the
+// sibling subsystem routers (ebpf/wasi/snyk): authenticated admin-only and
+// rate-limited.
+router.use(authenticate, requirePolicy('wasm:manage'));
+
+// Rate limiter for the compute endpoints
+const wasmActionLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 20,
+    message: { success: false, error: 'Too many requests' },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+router.use(wasmActionLimiter);
+
+// Bound attacker-sized bodies: each entry is processed on a worker thread or
+// synchronously on the event loop, so unbounded arrays enable CPU exhaustion.
+const MAX_DRIVERS = 1000;
+const MAX_LOADS = 1000;
 
 // Calculate route
 router.post('/wasm/route', async (req, res) => {
@@ -37,10 +63,16 @@ router.post('/wasm/route', async (req, res) => {
 router.post('/wasm/drivers', async (req, res) => {
     try {
         const { drivers } = req.body;
-        if (!drivers) {
+        if (!Array.isArray(drivers)) {
             return res.status(400).json({
                 success: false,
-                error: 'drivers required'
+                error: 'drivers must be an array'
+            });
+        }
+        if (drivers.length > MAX_DRIVERS) {
+            return res.status(400).json({
+                success: false,
+                error: `drivers array too large (max ${MAX_DRIVERS})`
             });
         }
         
@@ -60,10 +92,22 @@ router.post('/wasm/drivers', async (req, res) => {
 router.post('/wasm/optimize', async (req, res) => {
     try {
         const { loads, capacity } = req.body;
-        if (!loads || !capacity) {
+        if (!Array.isArray(loads)) {
+            return res.status(400).json({
+                success: false,
+                error: 'loads must be an array'
+            });
+        }
+        if (capacity === undefined || capacity === null) {
             return res.status(400).json({
                 success: false,
                 error: 'loads and capacity required'
+            });
+        }
+        if (loads.length > MAX_LOADS) {
+            return res.status(400).json({
+                success: false,
+                error: `loads array too large (max ${MAX_LOADS})`
             });
         }
         


### PR DESCRIPTION
## Problem

The WASM edge-runtime router (`wasm/routes.js`) exposes five endpoints with **no authentication, no policy check, and no rate limit**:

- `POST /api/wasm/route`
- `POST /api/wasm/drivers`
- `POST /api/wasm/optimize`
- `POST /api/wasm/eta`
- `GET /api/wasm/stats`

Mounted at `/api` (`backend/api/src/index.js`), every one is callable anonymously. Each request spawns a fresh `worker_threads.Worker` when a `.wasm` binary is deployed (or blocks the event loop synchronously in the fallback JS engine), so anonymous callers can run arbitrary compute and trivially exhaust CPU/memory with a handful of concurrent requests. `/wasm/drivers` also accepts an unbounded `drivers` array. All sibling subsystem routers (`ebpf`, `wasi`, `snyk`, `liquibase`) are admin-gated; this was the only exception.

## Fix

Match the sibling subsystem routers:

- `wasm/routes.js` — `router.use(authenticate, requirePolicy('wasm:manage'))` (same pattern as `wasi/routes.js` / `snyk/routes.js`), plus a 20 req/min rate limiter covering all endpoints.
- Body-size bounds: `/wasm/drivers` rejects non-array or >1000-entry `drivers`, `/wasm/optimize` rejects non-array or >1000-entry `loads` (and missing `capacity`) with a clear 400 — so attacker-sized bodies never reach the compute engine.
- `policyEngine.js` — registers `'wasm:manage'` as an admin-only action alongside `ebpf:manage` / `snyk:manage` / `wasi:manage` (unknown actions already fail closed with 403, but an unknown action would deny even admins).

## Files changed

- `wasm/routes.js`
- `backend/api/src/security/policyEngine.js`
- `backend/api/test/unit/wasmOtpRoutes.test.js`

## Testing

- `node --check` passes on all changed files.
- `npx vitest run test/unit/wasmOtpRoutes.test.js test/unit/policyEngine.test.js` — **74 tests pass**, including:
  - anonymous request → 401,
  - authenticated customer → 403 (`wasm:manage` is admin-only),
  - authenticated admin → 200 on a compute endpoint,
  - oversized `drivers` / `loads` arrays → 400,
  - the removed public OTP-validation route now returns 404 only for authenticated admins (the previous test asserted a 404 that is now short-circuited by auth).

Closes #9825


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protected WASM management endpoints for authenticated administrators.
  * Added rate limiting of 20 requests per minute.
  * Added validation for driver and load inputs, including array format and a maximum of 1,000 entries.
  * Valid zero-valued capacities are now accepted.

* **Bug Fixes**
  * Unauthorized and non-administrator requests are rejected.
  * Oversized or invalid inputs now return clear `400` responses.
  * Confirmed OTP functionality remains unavailable through the WASM routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->