### PR TITLE
fix: whitelist shipment details columns to prevent payment PII leak

### DIFF
--- a/backend/api/src/controllers/shipmentController.js
+++ b/backend/api/src/controllers/shipmentController.js
@@ -1,6 +1,45 @@
 import { createUserClient, supabase } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
+// Whitelist of order columns exposed to the shipment owner / assigned driver.
+// Never expose payment details (upi_id, payment_method_id), the delivery OTP
+// and its verification timestamps, blockchain tx hashes, escrow internals,
+// pending bid-acceptance context, or cancellation metadata.
+const SHIPMENT_COLUMNS = [
+  'id',
+  'order_display_id',
+  'customer_id',
+  'driver_id',
+  'truck_id',
+  'status',
+  'pickup_address',
+  'pickup_lat',
+  'pickup_lng',
+  'drop_address',
+  'drop_lat',
+  'drop_lng',
+  'pickup_date',
+  'pickup_time',
+  'goods_type',
+  'weight_tonnes',
+  'length_ft',
+  'width_ft',
+  'height_ft',
+  'is_stackable',
+  'is_fragile',
+  'special_requirements',
+  'base_freight',
+  'toll_estimate',
+  'platform_fee',
+  'total_amount',
+  'driver_name',
+  'driver_rating',
+  'truck_number',
+  'eta',
+  'created_at',
+  'updated_at',
+];
+
 export const getShipmentDetails = async (req, res) => {
   try {
     const shipmentId = req.query.shipmentId || req.params.shipmentId;
@@ -10,10 +49,12 @@ export const getShipmentDetails = async (req, res) => {
 
     const db = createUserClient(req.token) || supabase;
 
-    // Fetch the order (shipment) from the database
+    // Fetch the order (shipment) from the database, selecting only the safe
+    // allowlist instead of '*' so payment/OTP/escrow internals never reach
+    // the response.
     const { data: shipment, error } = await db
       .from('orders')
-      .select('*')
+      .select(SHIPMENT_COLUMNS.join(', '))
       .eq('id', shipmentId)
       .single();
 

--- a/backend/api/test/unit/controllers/shipmentController.test.js
+++ b/backend/api/test/unit/controllers/shipmentController.test.js
@@ -107,4 +107,41 @@ describe('shipmentController.getShipmentDetails', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(createUserClientMock).not.toHaveBeenCalled();
   });
+
+  it('selects only a safe allowlist and never payment/OTP/escrow internals', async () => {
+    const selectMock = vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn(async () => ({ data: { id: 'ship_1', customer_id: 'user_1', driver_id: null }, error: null })),
+      })),
+    }));
+    const client = { from: vi.fn(() => ({ select: selectMock })) };
+    createUserClientMock.mockReturnValue(client);
+
+    const req = {
+      query: {},
+      token: 'user-jwt',
+      params: { shipmentId: 'ship_1' },
+      user: { id: 'user_1' },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await getShipmentDetails(req, res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    const selected = selectMock.mock.calls[0][0];
+    expect(selected).not.toBe('*');
+    const columns = selected.split(',').map((c) => c.trim());
+
+    for (const sensitive of ['upi_id', 'payment_method_id', 'delivery_otp', 'blockchain_tx_hash', 'pending_bid_acceptance']) {
+      expect(columns).not.toContain(sensitive);
+    }
+    for (const prefix of ['escrow_', 'cancellation_', 'otp_']) {
+      expect(columns.some((c) => c.startsWith(prefix))).toBe(false);
+    }
+
+    expect(columns).toContain('total_amount');
+    expect(columns).toContain('status');
+    expect(columns).toContain('driver_id');
+    expect(columns).toContain('customer_id');
+  });
 });

--- a/backend/api/test/unit/shipmentController.test.js
+++ b/backend/api/test/unit/shipmentController.test.js
@@ -6,6 +6,7 @@ const { dbMock } = vi.hoisted(() => ({
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return dbMock.supabase; },
+  createUserClient: () => null,
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
## Problem

`GET /api/v1/shipment/details` (`shipmentController.js`) fetched the shipment with `select('*')` and returned the entire `orders` row to the authenticated owner / assigned driver. That response leaked sensitive internals: `upi_id`, `payment_method_id`, `delivery_otp` (plus `otp_verified`/`otp_generated_at`), `blockchain_tx_hash`, all `escrow_*` funding/refund state, `pending_bid_acceptance` context, and `cancellation_*` metadata.

## Fix

Replace the star select with an explicit allowlist of order columns that a shipment party legitimately needs (route pickup/drop, cargo/goods, pricing, status, driver snapshot, eta, timestamps). Any column added to `orders` in the future is excluded by default.

## Files changed

- `backend/api/src/controllers/shipmentController.js` — `SHIPMENT_COLUMNS` allowlist; `.select(SHIPMENT_COLUMNS.join(', '))`.
- `backend/api/test/unit/controllers/shipmentController.test.js` — new regression test asserting the select is a bounded allowlist that never contains `upi_id`, `payment_method_id`, `delivery_otp`, `blockchain_tx_hash`, `pending_bid_acceptance`, or any `escrow_`/`cancellation_`/`otp_` column.
- `backend/api/test/unit/shipmentController.test.js` — fixed a pre-existing stale failure: the test mocked only `supabase` while the controller has long used `createUserClient(req.token) || supabase`, so `createUserClient` resolved to `undefined` and every non-trivial case threw a TypeError → 500. Added `createUserClient: () => null` to the db mock.

## Testing

- `node --check` passes on the controller and tests.
- `npx vitest run test/unit/controllers/shipmentController.test.js test/unit/shipmentController.test.js` — **11 tests pass** (all ownership/404/403/500 cases plus the new allowlist regression test).

Closes #9826
