### PR TITLE
fix: register geofence-confirm under /:id on orders router

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -200,7 +200,8 @@ const getOrderResource = async (req) => {
 };
 
 
-router.post('/api/deliveries/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
+router.post('/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
+  const { id } = req.params;
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);

--- a/backend/api/test/unit/orderRoutesGeofence.test.js
+++ b/backend/api/test/unit/orderRoutesGeofence.test.js
@@ -38,9 +38,9 @@ app.use((req, res, next) => {
   req.user = { id: 'driver-1' };
   next();
 });
-app.use(orderRoutes);
+app.use('/api/orders', orderRoutes);
 
-describe('POST /api/deliveries/:id/geofence-confirm validation', () => {
+describe('POST /api/orders/:id/geofence-confirm validation', () => {
   beforeEach(() => {
     orderValidationService.findOrderByIdOrDisplayId.mockReset();
     orderLifecycleService.deliveryVerification.geofenceAutoConfirm.mockReset();
@@ -51,7 +51,7 @@ describe('POST /api/deliveries/:id/geofence-confirm validation', () => {
     orderLifecycleService.deliveryVerification.geofenceAutoConfirm.mockResolvedValue({ success: true });
 
     const res = await request(app)
-      .post('/api/deliveries/123/geofence-confirm')
+      .post('/api/orders/123/geofence-confirm')
       .send({ driver_lat: 12.9716, driver_lng: 77.5946, geofence_radius_m: 100 });
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -66,7 +66,7 @@ describe('POST /api/deliveries/:id/geofence-confirm validation', () => {
 
   it('should reject NaN geofence_radius_m with 400', async () => {
     const res = await request(app)
-      .post('/api/deliveries/123/geofence-confirm')
+      .post('/api/orders/123/geofence-confirm')
       .send({ driver_lat: 12.9716, driver_lng: 77.5946, geofence_radius_m: 'invalid' });
     expect(res.status).toBe(400);
     expect(res.body.error).toBeDefined();
@@ -74,7 +74,7 @@ describe('POST /api/deliveries/:id/geofence-confirm validation', () => {
 
   it('should reject non-positive geofence_radius_m with 400', async () => {
     const res = await request(app)
-      .post('/api/deliveries/123/geofence-confirm')
+      .post('/api/orders/123/geofence-confirm')
       .send({ driver_lat: 12.9716, driver_lng: 77.5946, geofence_radius_m: -50 });
     expect(res.status).toBe(400);
     expect(res.body.error).toBeDefined();


### PR DESCRIPTION
## Problem
The driver app calls `POST /api/orders/:id/geofence-confirm`, but the handler was registered at `router.post('/api/deliveries/:id/geofence-confirm', ...)`. Since `orderRoutes` is mounted at `/api/orders` (backend/api/src/index.js:484), the real registered path became `/api/orders/api/deliveries/:id/geofence-confirm`, so geofence auto-confirm always 404s and `DeliveryVerificationService.geofenceAutoConfirm` is unreachable.

## Fix
Register the handler as `router.post('/:id/geofence-confirm', ...)` on the orders router so it resolves to `POST /api/orders/:id/geofence-confirm`, matching the driver app call site (apps/driver/lib/screens/delivery_otp_screen.dart:215). Also destructure `id` from `req.params` — the handler previously referenced an undeclared `id`, which would throw a ReferenceError once the route became reachable.

## Files changed
- backend/api/src/routes/orderRoutes.js
- backend/api/test/unit/orderRoutesGeofence.test.js

## Testing
- Updated `orderRoutesGeofence.test.js` to mount the router at `/api/orders` (matching production) and hit `POST /api/orders/:id/geofence-confirm`.
- `npx vitest run test/unit/orderRoutesGeofence.test.js test/unit/deliveryVerificationGeofence.test.js` → 21/21 pass.

Closes #9828
