### PR TITLE
fix: load voice booking context via user-scoped client and column allowlist

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -60,7 +60,7 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
 
     const safeFilename = sanitizeUploadFilename(file.originalname, 'voice-query.wav');
 
-    const result = await processVoiceQuery(req.user.id, bookingId, file.buffer, safeFilename);
+    const result = await processVoiceQuery(req.user.id, bookingId, file.buffer, safeFilename, req.token);
     
     // Prefix the audio_url with host if relative path
     const protocol = req.headers['x-forwarded-proto'] || req.protocol;

--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -1,8 +1,10 @@
 import axios from 'axios';
 import crypto from 'crypto';
-import { supabase, supabaseAdmin } from '../config/db.js';
+import { supabase, supabaseAdmin, createUserClient } from '../config/db.js';
 const voiceDb = supabaseAdmin || supabase;
 import logger from '../middleware/logger.js';
+
+const ORDER_CONTEXT_COLUMNS = 'order_display_id, status, eta, escrow_status, pickup_address, drop_address';
 
 const MAX_CACHE_SIZE = 100;
 const CACHE_TTL_MS = 10 * 60 * 1000;
@@ -39,7 +41,7 @@ function cacheAudio(id, buffer, userId) {
   trimCache();
 }
 
-async function getBookingContext(bookingId, userId) {
+async function getBookingContext(bookingId, userId, token) {
   if (!userId) {
     return null;
   }
@@ -49,7 +51,8 @@ async function getBookingContext(bookingId, userId) {
 
   // Orders table is the real order model (there is no bookings table).
   try {
-    let orderQuery = voiceDb.from('orders').select('*');
+    const client = token ? createUserClient(token) : voiceDb;
+    let orderQuery = client.from('orders').select(ORDER_CONTEXT_COLUMNS);
     if (isUuid) {
       orderQuery = orderQuery.eq('id', bookingId);
     } else {
@@ -71,8 +74,8 @@ async function getBookingContext(bookingId, userId) {
   return null;
 }
 
-export async function processVoiceQuery(userId, bookingId, audioBuffer, filename) {
-  const bookingData = await getBookingContext(bookingId, userId);
+export async function processVoiceQuery(userId, bookingId, audioBuffer, filename, token) {
+  const bookingData = await getBookingContext(bookingId, userId, token);
   
   if (!process.env.OPENAI_API_KEY || !process.env.ELEVENLABS_API_KEY) {
     logger.warn('Missing OpenAI or ElevenLabs API keys. Using mock Voice AI pipeline.');

--- a/backend/api/test/unit/services/voiceService.test.js
+++ b/backend/api/test/unit/services/voiceService.test.js
@@ -6,11 +6,15 @@
  *   - getBookingContext with non-UUID bookingId uses order_display_id
  *   - getBookingContext returns null when supabase query returns null
  *   - getBookingContext returns null and logs warning on supabase error
+ *   - getBookingContext uses createUserClient(token) and a column allow-list
  *
  * Run with: npx vitest run test/unit/services/voiceService.test.js
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const ORDER_CONTEXT_COLUMNS = 'order_display_id, status, eta, escrow_status, pickup_address, drop_address';
+
+const mockSelect = vi.fn();
 const mockSupabaseFrom = vi.fn();
 const mockEq = vi.fn();
 const mockOr = vi.fn();
@@ -20,8 +24,12 @@ const mockSupabase = {
   from: mockSupabaseFrom,
 };
 
+const mockCreateUserClient = vi.fn();
+
 vi.mock('../../../src/config/db.js', () => ({
   supabase: mockSupabase,
+  supabaseAdmin: undefined,
+  createUserClient: mockCreateUserClient,
 }));
 
 vi.mock('../../../src/middleware/logger.js', () => ({
@@ -35,29 +43,36 @@ vi.mock('../../../src/middleware/logger.js', () => ({
 const { audioCache, __testing } = await import('../../../src/services/voiceService.js');
 const { getBookingContext, trimCache, cacheAudio, MAX_CACHE_SIZE, CACHE_TTL_MS } = __testing;
 
+function mockQueryChain() {
+  mockSupabaseFrom.mockReturnValue({
+    select: mockSelect.mockReturnValue({
+      eq: mockEq.mockReturnValue({
+        or: mockOr.mockReturnValue({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+    }),
+  });
+}
+
 describe('getBookingContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     audioCache.clear();
-    mockSupabaseFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: mockEq.mockReturnValue({
-          or: mockOr.mockReturnValue({
-            maybeSingle: mockMaybeSingle,
-          }),
-        }),
-      }),
-    });
+    mockCreateUserClient.mockReturnValue(mockSupabase);
+    mockQueryChain();
   });
 
   it('returns order when bookingId is a valid UUID and query succeeds', async () => {
     const mockOrder = { id: '550e8400-e29b-41d4-a716-446655440000', status: 'in_transit', eta: '2 hours' };
     mockMaybeSingle.mockResolvedValue({ data: mockOrder, error: null });
 
-    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1');
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1', 'token-1');
 
     expect(result).toEqual(mockOrder);
+    expect(mockCreateUserClient).toHaveBeenCalledWith('token-1');
     expect(mockSupabaseFrom).toHaveBeenCalledWith('orders');
+    expect(mockSelect).toHaveBeenCalledWith(ORDER_CONTEXT_COLUMNS);
     expect(mockEq).toHaveBeenCalledWith('id', '550e8400-e29b-41d4-a716-446655440000');
     expect(mockOr).toHaveBeenCalledWith('customer_id.eq.user-1,driver_id.eq.user-1');
   });
@@ -66,10 +81,11 @@ describe('getBookingContext', () => {
     const mockOrder = { id: '123e4567-e89b-12d3-a456-426614174000', order_display_id: '#FF20260101ABC123DEF456', status: 'delivered' };
     mockMaybeSingle.mockResolvedValue({ data: mockOrder, error: null });
 
-    const result = await getBookingContext('#FF20260101ABC123DEF456', 'driver-1');
+    const result = await getBookingContext('#FF20260101ABC123DEF456', 'driver-1', 'token-1');
 
     expect(result).toEqual(mockOrder);
     expect(mockSupabaseFrom).toHaveBeenCalledWith('orders');
+    expect(mockSelect).toHaveBeenCalledWith(ORDER_CONTEXT_COLUMNS);
     expect(mockEq).toHaveBeenCalledWith('order_display_id', '#FF20260101ABC123DEF456');
     expect(mockOr).toHaveBeenCalledWith('customer_id.eq.driver-1,driver_id.eq.driver-1');
   });
@@ -77,7 +93,7 @@ describe('getBookingContext', () => {
   it('returns null when supabase query returns null data', async () => {
     mockMaybeSingle.mockResolvedValue({ data: null, error: null });
 
-    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1');
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1', 'token-1');
 
     expect(result).toBeNull();
   });
@@ -87,12 +103,13 @@ describe('getBookingContext', () => {
 
     expect(result).toBeNull();
     expect(mockSupabaseFrom).not.toHaveBeenCalled();
+    expect(mockCreateUserClient).not.toHaveBeenCalled();
   });
 
   it('returns null when supabase query returns an error', async () => {
     mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'permission denied' } });
 
-    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1');
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1', 'token-1');
 
     expect(result).toBeNull();
   });
@@ -100,7 +117,7 @@ describe('getBookingContext', () => {
   it('returns null and logs warning when supabase query throws an error', async () => {
     mockMaybeSingle.mockRejectedValue(new Error('Connection refused'));
 
-    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1');
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1', 'token-1');
 
     expect(result).toBeNull();
   });
@@ -109,14 +126,37 @@ describe('getBookingContext', () => {
     const validUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
     mockMaybeSingle.mockResolvedValue({ data: { id: validUuid }, error: null });
 
-    await getBookingContext(validUuid, 'user-1');
+    await getBookingContext(validUuid, 'user-1', 'token-1');
     expect(mockEq).toHaveBeenCalledWith('id', validUuid);
 
     mockMaybeSingle.mockClear();
 
     const invalidUuid = 'not-a-uuid';
-    await getBookingContext(invalidUuid, 'user-1');
+    await getBookingContext(invalidUuid, 'user-1', 'token-1');
     expect(mockEq).toHaveBeenCalledWith('order_display_id', invalidUuid);
+  });
+
+  it('falls back to the shared client when no token is provided', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { id: '550e8400-e29b-41d4-a716-446655440000' }, error: null });
+
+    const result = await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1');
+
+    expect(result).not.toBeNull();
+    expect(mockCreateUserClient).not.toHaveBeenCalled();
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('orders');
+  });
+
+  it('never selects payment PII or delivery secrets', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { id: '550e8400-e29b-41d4-a716-446655440000' }, error: null });
+
+    await getBookingContext('550e8400-e29b-41d4-a716-446655440000', 'user-1', 'token-1');
+
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    const selectArg = mockSelect.mock.calls[0][0];
+    expect(selectArg).not.toContain('*');
+    for (const secret of ['upi_id', 'payment_method_id', 'delivery_otp', 'blockchain_tx_hash', 'escrow_booking_id']) {
+      expect(selectArg).not.toContain(secret);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem
`voiceService.getBookingContext()` always returned `null` in production: it used the shared anon-key `supabase` client with no user JWT, so PostgREST applied RLS as `anon` and the orders query is denied (orders expose no anon SELECT policy). Additionally, the `select('*')` would serialize the entire orders row — including `upi_id`, `payment_method_id`, `delivery_otp`, `blockchain_tx_hash`, and escrow internals — to OpenAI the moment the client is "fixed".

## Fix
- Pass `req.token` from the voice route (`/api/voice/query` is already behind `authenticate`) into `processVoiceQuery` → `getBookingContext`.
- `getBookingContext` now uses `createUserClient(token)` (user-scoped, RLS sees the caller) instead of the anon client, falling back to the shared client only when no token is present.
- Replaced `select('*')` with a column allowlist (`order_display_id, status, eta, escrow_status, pickup_address, drop_address`) so no payment PII or delivery secrets can reach OpenAI.

## Files changed
- backend/api/src/services/voiceService.js
- backend/api/src/routes/voiceRoutes.js
- backend/api/test/unit/services/voiceService.test.js

## Testing
- `npx vitest run test/unit/services/voiceService.test.js test/unit/voiceRoutes.test.js` → 21/21 pass.
- `npx vitest run test/integration/voiceAudioAccess.test.js` → 3/3 pass.
- Added tests asserting the token is passed to `createUserClient`, the allowlist is selected, and payment/delivery secret columns are never selected.

Closes #9829
