### PR TITLE
fix: align ml-engine volume mount to /app/models_storage and make MODEL_STORAGE_DIR env-configurable (#10143)

### DIFF
--- a/backend/ml/app/models/base.py
+++ b/backend/ml/app/models/base.py
@@ -8,8 +8,10 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
-MODEL_STORAGE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "models_storage")
-
+MODEL_STORAGE_DIR = os.environ.get(
+    "MODEL_STORAGE_DIR",
+    os.path.join(os.path.dirname(__file__), "..", "..", "models_storage"),
+)
 _model_locks: dict[str, asyncio.Lock] = {}
 
 def _get_lock(model_name: str) -> asyncio.Lock:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,10 +84,11 @@ services:
     environment:
       ML_API_KEY: ${ML_API_KEY:?ML_API_KEY is required}
       ENVIRONMENT: production
+      MODEL_STORAGE_DIR: /app/models_storage
     volumes:
       # Remove dev code mount — code is baked into the production image
-      # Persist trained models across restarts
-      - ml_models_data:/app/models
+      # Persist trained models across restarts — must match MODEL_STORAGE_DIR in base.py
+      - ml_models_data:/app/models_storage
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Description
MODEL_STORAGE_DIR in base.py resolved to /app/models_storage (a path derived from the file location) while docker-compose.prod.yml mounted the ml_models_data named volume at /app/models. These two paths never overlapped, so every save_model() call wrote into unmounted container-local storage. On every container restart the trained models were silently lost and load_model() found nothing — causing /predict/price and all other prediction endpoints to permanently return 503 "model unavailable" in production regardless of how many training runs succeeded. The dev compose masked the bug because it bind-mounts the entire ./backend/ml directory as /app, so models_storage/ on the host was always accessible. Fixed by changing the docker-compose.prod.yml volume mount from /app/models to /app/models_storage so it aligns with the actual write path. Also made MODEL_STORAGE_DIR env-configurable via os.environ.get("MODEL_STORAGE_DIR", ...) so k8s deployments can point it at a PVC mount path via a ConfigMap env var without touching source code. Added MODEL_STORAGE_DIR: /app/models_storage to the ml-engine environment block in docker-compose.prod.yml to make the path explicit and auditable.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [x] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** docker compose -f docker-compose.prod.yml up --build ml-engine
- **Test Steps:** Build and start ml-engine in prod mode. POST /train/demand. Restart the container. POST /predict/demand. Verify the model loads and returns a prediction instead of 503. Verify docker exec truxify-ml-engine ls /app/models_storage shows the trained model files. Verify the named volume truxify_ml_models is non-empty after training.
- **Expected Result:** Trained models survive container restarts. /predict endpoints return real predictions after a single training run. /app/models_storage is mounted to the named volume and models persist across restarts.

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [x] Tested via Docker Compose

## Related Issues
Closes #10143

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.