### PR TITLE
[Critical] Driver app `app.dart` build method is a botched merge of two return statements — Dart compile error, driver app cannot build

### DIFF
--- a/apps/driver/lib/app.dart
+++ b/apps/driver/lib/app.dart
@@ -58,40 +58,6 @@ class _TruxifyAppState extends State<TruxifyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return TruxifyScope(
-      controller: _controller,
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        builder: (context, child) {
-          final isLargeText = context.watch<TextScaleProvider>().isLargeText;
-          Widget existingChild = child!;
-          return MediaQuery(
-            data: MediaQuery.of(context).copyWith(
-              textScaler: isLargeText
-                  ? const TextScaler.linear(1.25)
-                  : const TextScaler.linear(1.0),
-            ),
-            child: existingChild,
-          );
-        },
-        onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-        theme: TruxifyTheme.light(),
-        darkTheme: TruxifyTheme.dark(),
-        themeMode: _controller.themeMode,
-        locale: _controller.locale,
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        supportedLocales: const [
-          Locale('en', ''),
-          Locale('hi', ''),
-          Locale('ta', ''),
-          Locale('kn', ''),
-          Locale('mr', ''),
-        ],
     return LanguageProviderScope(
       provider: _languageProvider,
       child: TruxifyScope(
@@ -100,98 +66,113 @@ class _TruxifyAppState extends State<TruxifyApp> {
           listenable: _languageProvider,
           builder: (context, _) {
             return MaterialApp(
-            debugShowCheckedModeBanner: false,
-            onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-            theme: TruxifyTheme.light(),
-            darkTheme: TruxifyTheme.dark(),
-            themeMode: _controller.themeMode,
-            locale: _languageProvider.currentLocale,
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-            supportedLocales: const [
-              Locale('en'),
-              Locale('hi'),
-              Locale('ta'),
-            ],
-        initialRoute: AppRoutes.splash,
-        onGenerateRoute: (settings) {
-          switch (settings.name) {
-            case AppRoutes.splash:
-              return truxifyPageRoute(
-                (context) => const SplashScreen(),
-              );
+              debugShowCheckedModeBanner: false,
+              builder: (context, child) {
+                final isLargeText = context.watch<TextScaleProvider>().isLargeText;
+                Widget existingChild = child!;
+                return MediaQuery(
+                  data: MediaQuery.of(context).copyWith(
+                    textScaler: isLargeText
+                        ? const TextScaler.linear(1.25)
+                        : const TextScaler.linear(1.0),
+                  ),
+                  child: existingChild,
+                );
+              },
+              onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+              theme: TruxifyTheme.light(),
+              darkTheme: TruxifyTheme.dark(),
+              themeMode: _controller.themeMode,
+              locale: _languageProvider.currentLocale,
+              localizationsDelegates: const [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [
+                Locale('en', ''),
+                Locale('hi', ''),
+                Locale('ta', ''),
+                Locale('kn', ''),
+                Locale('mr', ''),
+              ],
+              initialRoute: AppRoutes.splash,
+              onGenerateRoute: (settings) {
+                switch (settings.name) {
+                  case AppRoutes.splash:
+                    return truxifyPageRoute(
+                      (context) => const SplashScreen(),
+                    );
 
-            case AppRoutes.login:
-              return truxifyPageRoute(
-                (context) => const LoginScreen(),
-              );
+                  case AppRoutes.login:
+                    return truxifyPageRoute(
+                      (context) => const LoginScreen(),
+                    );
 
-            case AppRoutes.otp:
-              final args = settings.arguments as Map<String, String>? ?? {};
-              return truxifyPageRoute(
-                (context) => OtpScreen(
-                  phone: args['phone'] ?? '',
-                  verificationId: args['verificationId'] ?? '',
-                  countryCode: args['countryCode'] ?? '+91',
-                ),
-              );
+                  case AppRoutes.otp:
+                    final args = settings.arguments as Map<String, String>? ?? {};
+                    return truxifyPageRoute(
+                      (context) => OtpScreen(
+                        phone: args['phone'] ?? '',
+                        verificationId: args['verificationId'] ?? '',
+                        countryCode: args['countryCode'] ?? '+91',
+                      ),
+                    );
 
-            case AppRoutes.shell:
-              return truxifyPageRoute(
-                (context) => const ShellScreen(),
-              );
+                  case AppRoutes.shell:
+                    return truxifyPageRoute(
+                      (context) => const ShellScreen(),
+                    );
 
-            case AppRoutes.documents:
-              return truxifyPageRoute(
-                (context) => const DocumentsScreen(),
-              );
+                  case AppRoutes.documents:
+                    return truxifyPageRoute(
+                      (context) => const DocumentsScreen(),
+                    );
 
-            case AppRoutes.loadDetail:
-              final load = settings.arguments as LoadOffer?;
-              if (load == null) return null;
+                  case AppRoutes.loadDetail:
+                    final load = settings.arguments as LoadOffer?;
+                    if (load == null) return null;
 
-              return truxifyPageRoute(
-                (context) => LoadDetailScreen(load: load),
-              );
+                    return truxifyPageRoute(
+                      (context) => LoadDetailScreen(load: load),
+                    );
 
-            case AppRoutes.loadPointDetail:
-              final point = settings.arguments as RouteMapPoint?;
-              if (point == null) return null;
+                  case AppRoutes.loadPointDetail:
+                    final point = settings.arguments as RouteMapPoint?;
+                    if (point == null) return null;
 
-              return truxifyPageRoute(
-                (context) => LoadPointDetailScreen(point: point),
-              );
+                    return truxifyPageRoute(
+                      (context) => LoadPointDetailScreen(point: point),
+                    );
 
-            case AppRoutes.destinationPicker:
-              final args = settings.arguments as DestinationPickerArgs?;
+                  case AppRoutes.destinationPicker:
+                    final args = settings.arguments as DestinationPickerArgs?;
 
-              return truxifyPageRoute(
-                (context) => DestinationPickerScreen(
-                  title: args?.title ?? 'Select Destination',
-                  initialQuery: args?.initialQuery,
-                  initialPoint: args?.initialPoint,
-                ),
-              );
+                    return truxifyPageRoute(
+                      (context) => DestinationPickerScreen(
+                        title: args?.title ?? 'Select Destination',
+                        initialQuery: args?.initialQuery,
+                        initialPoint: args?.initialPoint,
+                      ),
+                    );
 
-            case AppRoutes.pastTrips:
-              return truxifyPageRoute(
-                (context) => const PastTripsScreen(),
-              );
+                  case AppRoutes.pastTrips:
+                    return truxifyPageRoute(
+                      (context) => const PastTripsScreen(),
+                    );
 
-            default:
-              return truxifyPageRoute(
-                (context) => const SplashScreen(),
-              );
-          }
-        },
-        navigatorObservers: const [],
-      );
-    },
-    ),
+                  default:
+                    return truxifyPageRoute(
+                      (context) => const SplashScreen(),
+                    );
+                }
+              },
+              navigatorObservers: const [],
+            );
+          },
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Problem

`apps/driver/lib/app.dart` had two `return` statements in `TruxifyApp.build` — one for `isLargeText` and one for the normal path — with an early unconditional `return MaterialApp(...)` at the top of the method. The build returned `MaterialApp` twice and dropped the `onGenerateRoute` cases and locale support from one branch, and the method could not compile as written.

## Fix

Merged both paths into one coherent return: `LanguageProviderScope` -> `TruxifyScope` -> `ListenableBuilder` -> `MaterialApp`, combining the `TextScaler` builder (1.25 / 1.0 via `TextScaleProvider.isLargeText`), the full `supportedLocales` list (en, hi, ta, kn, mr), `initialRoute`, and all `onGenerateRoute` cases. Braces/parens balanced.

## Files changed

- `apps/driver/lib/app.dart`

## Testing

Verified brace/paren balance programmatically. NOTE: no Dart/Flutter toolchain was available in this environment, so the change was not compiled.

Closes #9955
