### PR TITLE
[BUG][backend] zkp_transactions table referenced by backend/zkp/zkp.service.js has no DDL in any migration or setup.sql

### DIFF
--- a/supabase/migrations/20260811060000_create_zkp_transactions_table.sql
+++ b/supabase/migrations/20260811060000_create_zkp_transactions_table.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- ZKP TRANSACTIONS TABLE
+-- ============================================================================
+-- The ZKP service (backend/zkp/zkp.service.js) persists processed and created
+-- private transactions into `zkp_transactions` and reads them back for replay
+-- checks and stats. No migration previously created this table, so every
+-- insert/select failed with `relation "zkp_transactions" does not exist`. This
+-- migration creates the table with columns matching the inserts, selects and
+-- nullifier lookups in zkp.service.js.
+--
+-- SECURITY MODEL:
+--   - Written by backend services using service_role credentials and never
+--     exposed directly to clients, so RLS allows service_role only.
+-- ============================================================================
+
+create table if not exists zkp_transactions (
+  tx_id      text primary key,            -- storeTransaction: data.txId || data.nullifier
+  nullifier  text,                        -- processPrivateTransaction: replay check
+  commitment text,
+  recipient  text,                        -- recipient address
+  amount     text,                        -- amount in the denomination sent to the contract
+  tx_hash    text,                        -- on-chain transaction hash
+  status     text not null default 'pending', -- 'pending' | 'created' | 'processed' | ...
+  created_at timestamptz not null default now()
+);
+
+-- Nullifier replay protection: the service checks for an existing row before
+-- processing, and the unique index makes double-spend impossible at the DB
+-- level. Multiple NULLs (created transactions carry no nullifier) are allowed.
+create unique index if not exists idx_zkp_transactions_nullifier
+  on zkp_transactions (nullifier);
+
+create index if not exists idx_zkp_transactions_status
+  on zkp_transactions (status);
+
+alter table zkp_transactions enable row level security;
+
+drop policy if exists "Service role full access on zkp_transactions"
+  on zkp_transactions;
+create policy "Service role full access on zkp_transactions"
+  on zkp_transactions
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table zkp_transactions from anon, authenticated;


### PR DESCRIPTION
## Problem

`backend/zkp/zkp.service.js` writes to a `zkp_transactions` table that has no migration, so the service fails (or the data is lost) because the table does not exist.

## Fix

Added `supabase/migrations/20260811060000_create_zkp_transactions_table.sql` creating `zkp_transactions` with the columns the service uses: `tx_id` (PK), `nullifier`, `commitment`, `recipient`, `amount`, `tx_hash`, `status` (default `pending`), `created_at`. Unique index on `nullifier`, index on `status`, service-role-only RLS, and explicit revoke from `anon`/`authenticated`.

## Files changed

- `supabase/migrations/20260811060000_create_zkp_transactions_table.sql`

## Testing

DDL matches the field names used in `zkp.service.js`; reviewed for column types and uniqueness constraints.

Closes #9956
