### PR TITLE
[P0] zkEVM `executeBatch` reverts every batch — nonce is marked used before `_applyTx` re-checks it

### DIFF
--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -131,9 +131,10 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             require(_verifySignature(txHashForSig, signature, from), "Invalid signature");
 
             processedTxHashes[txHash] = true;
-            usedNonces[from][nonce] = true;
 
             // Same per-tx signature/nonce/balance checks as the single-tx path.
+            // _applyTx marks the nonce used; do not mark it before the call or
+            // _applyTx's own "Nonce already used" check reverts every batch.
             _applyTx(from, to, value, data, nonce, gasPrice, gasLimit, signature);
             txHashes[i] = txHash;
         }


### PR DESCRIPTION
## Problem

`executeBatch` in `blockchain/contracts/zkEVM.sol` marked `usedNonces[from][nonce] = true` before delegating to `_applyTx`, and `_applyTx` itself re-checked the same nonce. Every batch transaction therefore reverted at the nonce check inside `_applyTx`, making `executeBatch` unusable.

## Fix

Removed the premature `usedNonces[from][nonce] = true` so `_applyTx`'s own nonce bookkeeping owns the check and every transaction in a batch can execute.

## Files changed

- `blockchain/contracts/zkEVM.sol`

## Testing

Ran all 8 tests in `blockchain/contracts/zkEVM.test.js` against a temporary hardhat config — all pass. Temp config and generated lockfiles were removed before committing.

Closes #9957
