### PR TITLE
[Critical] TruxifyUpgradeable emergency upgrade path bypasses the implementation allowlist

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -226,6 +226,10 @@ contract TruxifyUpgradeable is
         uint256 requestTimestamp = emergencyUpgradeRequests[newImplementation];
         if (requestTimestamp != 0) {
             require(
+                approvedImplementations[newImplementation],
+                "Implementation not approved"
+            );
+            require(
                 block.timestamp >= requestTimestamp + EMERGENCY_UPGRADE_TIMELOCK,
                 "Emergency timelock not yet elapsed"
             );
@@ -460,6 +464,10 @@ function disputeEscrow(uint256 escrowId) external onlyRole(DEFAULT_ADMIN_ROLE) n
     {
         require(newImplementation != address(0), "Invalid implementation");
         require(bytes(reason).length > 0, "Reason required");
+        require(
+            approvedImplementations[newImplementation],
+            "Implementation not approved"
+        );
         require(
             emergencyUpgradeRequests[newImplementation] == 0,
             "Emergency upgrade already requested for this implementation"

--- a/blockchain/test/TruxifyUpgradeable.emergencyAllowlist.test.cjs
+++ b/blockchain/test/TruxifyUpgradeable.emergencyAllowlist.test.cjs
@@ -1,0 +1,117 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+const ONE_DAY = 86_400;
+
+async function expectRevert(promise, expectedMessage) {
+  try {
+    await promise;
+    expect.fail("Expected transaction to revert");
+  } catch (error) {
+    const reason =
+      error.reason ??
+      error.info?.error?.message ??
+      error.shortMessage ??
+      error.message ??
+      "";
+    if (!reason.toLowerCase().includes(expectedMessage.toLowerCase())) {
+      const fullMsg = JSON.stringify(error).toLowerCase();
+      if (!fullMsg.includes(expectedMessage.toLowerCase())) {
+        expect.fail(
+          `Expected revert reason to include "${expectedMessage}", got: "${reason}"`
+        );
+      }
+    }
+  }
+}
+
+describe("TruxifyUpgradeable emergency upgrade allowlist", function () {
+  let truxify, v2Implementation;
+  let owner, upgrader, voter;
+
+  beforeEach(async function () {
+    [owner, upgrader, voter] = await ethers.getSigners();
+
+    const TruxifyUpgradeable = await ethers.getContractFactory(
+      "TruxifyUpgradeable"
+    );
+    const implementation = await TruxifyUpgradeable.deploy();
+    await implementation.waitForDeployment();
+
+    v2Implementation = await TruxifyUpgradeable.deploy();
+    await v2Implementation.waitForDeployment();
+
+    const UUPSProxy = await ethers.getContractFactory("UUPSProxy");
+    const initializeData =
+      implementation.interface.encodeFunctionData("initialize");
+    const proxy = await UUPSProxy.deploy(
+      await implementation.getAddress(),
+      initializeData
+    );
+    await proxy.waitForDeployment();
+
+    truxify = await ethers.getContractAt(
+      "TruxifyUpgradeable",
+      await proxy.getAddress()
+    );
+
+    await truxify.grantUpgraderRole(upgrader.address);
+    await truxify.setApprovedImplementation(
+      await v2Implementation.getAddress(),
+      true
+    );
+  });
+
+  it("rejects an emergency upgrade request for a non-allowlisted implementation", async function () {
+    const nonApproved = voter.address;
+    await expectRevert(
+      truxify.connect(upgrader).requestEmergencyUpgrade(
+        nonApproved,
+        "Critical security fix"
+      ),
+      "Implementation not approved"
+    );
+
+    const requestTimestamp = await truxify.emergencyUpgradeRequests(
+      nonApproved
+    );
+    expect(requestTimestamp).to.equal(0n);
+  });
+
+  it("allows requesting and executing an emergency upgrade for an allowlisted implementation", async function () {
+    const v2Address = await v2Implementation.getAddress();
+
+    await truxify.connect(upgrader).requestEmergencyUpgrade(
+      v2Address,
+      "Critical security fix"
+    );
+    expect(await truxify.emergencyUpgradeRequests(v2Address)).to.not.equal(0n);
+
+    await time.increase(2 * ONE_DAY + 1);
+
+    await truxify.connect(upgrader).upgradeToAndCall(v2Address, "0x");
+
+    expect(await truxify.getUpgradeCount()).to.equal(1n);
+    expect(await truxify.emergencyUpgradeRequests(v2Address)).to.equal(0n);
+  });
+
+  it("blocks an emergency upgrade whose allowlist entry was revoked during the timelock", async function () {
+    const v2Address = await v2Implementation.getAddress();
+
+    await truxify.connect(upgrader).requestEmergencyUpgrade(
+      v2Address,
+      "Critical security fix"
+    );
+
+    // The admin revokes the allowlist entry while the timelock runs.
+    await truxify.setApprovedImplementation(v2Address, false);
+
+    await time.increase(2 * ONE_DAY + 1);
+
+    await expectRevert(
+      truxify.connect(upgrader).upgradeToAndCall(v2Address, "0x"),
+      "Implementation not approved"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The emergency upgrade path in `blockchain/contracts/TruxifyUpgradeable.sol` bypassed the `approvedImplementations` allowlist that gates the DAO path: `requestEmergencyUpgrade` only required UPGRADER_ROLE and a non-zero address, so an upgrader could schedule an emergency upgrade to arbitrary attacker-chosen bytecode and execute it after the timelock.

## Fix

`requestEmergencyUpgrade` now rejects targets that are not in the allowlist immediately ("Implementation not approved") and writes no request timestamp. `upgradeToAndCall` re-verifies the allowlist at execution time, so revoking an implementation during the timelock also blocks the emergency upgrade.

## Files changed

- `blockchain/contracts/TruxifyUpgradeable.sol`
- `blockchain/test/TruxifyUpgradeable.emergencyAllowlist.test.cjs` (new)

## Testing

Added a self-contained test suite (the pre-existing `UUPSProxy.test.cjs` cannot run as-is — its `beforeEach` deploys `DAOToken` with 3 constructor args while `DAOToken` takes none) covering: non-allowlisted request reverts and writes no timestamp, allowlisted request + timelock upgrade succeeds, and an allowlist entry revoked during the timelock blocks execution. All 3 pass via a temporary hardhat test config (removed before commit).

Closes #9959
