### PR TITLE
[Critical] `submitAnonymousRating` accepts caller-chosen nullifier and unverified proof — driver ratings can be spammed/inflated/tanked at will

### DIFF
--- a/blockchain/contracts/MockZKPrivacyVerifier.sol
+++ b/blockchain/contracts/MockZKPrivacyVerifier.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/// @notice Test-only verifier matching ZKPrivacy's IVerifier interface. It
+///         accepts a proof only when every public input equals the expected
+///         input recorded by the test, so both the valid and the forged paths
+///         can be exercised without a real Groth16 proof. Never used in
+///         production deployments.
+contract MockZKPrivacyVerifier {
+    bool public shouldVerify;
+    uint256[] private expectedInput;
+
+    function setShouldVerify(bool _shouldVerify) external {
+        shouldVerify = _shouldVerify;
+    }
+
+    function setExpectedInput(uint[] calldata _input) external {
+        expectedInput = _input;
+    }
+
+    function verifyProof(
+        uint[2] memory,
+        uint[2][2] memory,
+        uint[2] memory,
+        uint[] memory input
+    ) external view returns (bool) {
+        if (!shouldVerify) return false;
+        if (input.length != expectedInput.length) return false;
+        for (uint256 i = 0; i < input.length; i++) {
+            if (input[i] != expectedInput[i]) return false;
+        }
+        return true;
+    }
+}

--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -79,18 +79,34 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
     function submitAnonymousRating(
         address _driver,
         uint8 _stars,
-        bytes32 _nullifierHash,
-        bytes32 _zkProof
-    ) external {
+        bytes32 _tripId,
+        Proof calldata proof
+    ) external nonReentrant whenNotPaused {
+        require(_driver != address(0), "Invalid driver");
         require(_stars >= 1 && _stars <= 5, "Invalid rating stars (1-5)");
-        require(!usedNullifiers[_nullifierHash], "Nullifier already used for trip rating");
-        require(_zkProof != bytes32(0), "Invalid ZK proof");
+        require(_tripId != bytes32(0), "Invalid trip id");
+        require(verifier != address(0), "Verifier not set");
 
-        usedNullifiers[_nullifierHash] = true;
+        // Derive the nullifier from the trip and the rater so it cannot be
+        // freely chosen and each rater can rate a given trip at most once.
+        bytes32 nullifierHash = keccak256(abi.encodePacked(_tripId, msg.sender));
+        require(!usedNullifiers[nullifierHash], "Nullifier already used for trip rating");
+
+        // Bind the proof's public inputs to this exact rating: nullifier,
+        // driver and stars must all be committed inside the proof.
+        require(proof.input.length >= 3, "Invalid proof public inputs length");
+        require(proof.input[0] == uint256(nullifierHash), "Nullifier mismatch in proof input");
+        require(proof.input[1] == uint256(uint160(_driver)), "Driver mismatch in proof input");
+        require(proof.input[2] == uint256(_stars), "Stars mismatch in proof input");
+
+        bool isValid = IVerifier(verifier).verifyProof(proof.a, proof.b, proof.c, proof.input);
+        require(isValid, "Invalid ZK proof");
+
+        usedNullifiers[nullifierHash] = true;
         driverRatings[_driver].totalStars += _stars;
         driverRatings[_driver].totalRatings += 1;
 
-        emit RatingSubmitted(_driver, _stars, _nullifierHash);
+        emit RatingSubmitted(_driver, _stars, nullifierHash);
     }
 
     function getDriverAverageRating(address _driver) external view returns (uint256 averageScaled) {

--- a/blockchain/test/ZKPrivacy.anonymousRating.test.cjs
+++ b/blockchain/test/ZKPrivacy.anonymousRating.test.cjs
@@ -1,0 +1,181 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+function deriveNullifier(tripId, rater) {
+  return ethers.keccak256(
+    ethers.solidityPacked(["bytes32", "address"], [tripId, rater])
+  );
+}
+
+function proofWithInput(input) {
+  return {
+    a: [1n, 2n],
+    b: [
+      [3n, 4n],
+      [5n, 6n],
+    ],
+    c: [7n, 8n],
+    input,
+  };
+}
+
+async function expectRevert(promise, expectedMessage) {
+  try {
+    await promise;
+    expect.fail("Expected transaction to revert");
+  } catch (error) {
+    const reason =
+      error.reason ??
+      error.info?.error?.message ??
+      error.shortMessage ??
+      error.message ??
+      "";
+    if (!reason.toLowerCase().includes(expectedMessage.toLowerCase())) {
+      const fullMsg = JSON.stringify(error).toLowerCase();
+      if (!fullMsg.includes(expectedMessage.toLowerCase())) {
+        expect.fail(
+          `Expected revert reason to include "${expectedMessage}", got: "${reason}"`
+        );
+      }
+    }
+  }
+}
+
+describe("ZKPrivacy submitAnonymousRating", function () {
+  let zkPrivacy, verifier;
+  let driver, rater, otherRater;
+  const tripId = ethers.id("trip-0001");
+
+  beforeEach(async function () {
+    [driver, rater, otherRater] = await ethers.getSigners();
+
+    const MockVerifier = await ethers.getContractFactory(
+      "MockZKPrivacyVerifier"
+    );
+    verifier = await MockVerifier.deploy();
+    await verifier.waitForDeployment();
+
+    const ZKPrivacy = await ethers.getContractFactory("ZKPrivacy");
+    zkPrivacy = await ZKPrivacy.deploy(await verifier.getAddress());
+    await zkPrivacy.waitForDeployment();
+  });
+
+  it("accepts a rating whose proof verifies and binds nullifier, driver and stars", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const input = [
+      BigInt(nullifier),
+      BigInt(driver.address),
+      5n,
+    ];
+    await verifier.setShouldVerify(true);
+    await verifier.setExpectedInput(input);
+
+    await zkPrivacy
+      .connect(rater)
+      .submitAnonymousRating(driver.address, 5, tripId, proofWithInput(input));
+
+    expect(await zkPrivacy.usedNullifiers(nullifier)).to.equal(true);
+    expect(await zkPrivacy.getDriverAverageRating(driver.address)).to.equal(500n);
+  });
+
+  it("derives a distinct nullifier per rater for the same trip", async function () {
+    const raterNullifier = deriveNullifier(tripId, rater.address);
+    const otherNullifier = deriveNullifier(tripId, otherRater.address);
+    expect(raterNullifier).to.not.equal(otherNullifier);
+
+    for (const [who, nullifier] of [
+      [rater, raterNullifier],
+      [otherRater, otherNullifier],
+    ]) {
+      const input = [BigInt(nullifier), BigInt(driver.address), 4n];
+      await verifier.setShouldVerify(true);
+      await verifier.setExpectedInput(input);
+      await zkPrivacy
+        .connect(who)
+        .submitAnonymousRating(driver.address, 4, tripId, proofWithInput(input));
+    }
+
+    expect(await zkPrivacy.getDriverAverageRating(driver.address)).to.equal(400n);
+  });
+
+  it("rejects a forged proof that fails verification", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const input = [BigInt(nullifier), BigInt(driver.address), 5n];
+    await verifier.setShouldVerify(false);
+    await verifier.setExpectedInput(input);
+
+    await expectRevert(
+      zkPrivacy
+        .connect(rater)
+        .submitAnonymousRating(driver.address, 5, tripId, proofWithInput(input)),
+      "Invalid ZK proof"
+    );
+
+    expect(await zkPrivacy.getDriverAverageRating(driver.address)).to.equal(0n);
+    expect(await zkPrivacy.usedNullifiers(nullifier)).to.equal(false);
+  });
+
+  it("rejects a proof whose public inputs do not match the rating parameters", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const correctInput = [BigInt(nullifier), BigInt(driver.address), 5n];
+
+    // The verifier would accept this input, but it does not commit to the
+    // derived nullifier, so the contract must fail closed.
+    const mismatchedInput = [BigInt(ethers.id("attacker-nullifier")), BigInt(driver.address), 5n];
+    await verifier.setShouldVerify(true);
+    await verifier.setExpectedInput(mismatchedInput);
+
+    await expectRevert(
+      zkPrivacy
+        .connect(rater)
+        .submitAnonymousRating(driver.address, 5, tripId, proofWithInput(mismatchedInput)),
+      "Nullifier mismatch in proof input"
+    );
+  });
+
+  it("rejects a proof with missing public inputs", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const input = [BigInt(nullifier), BigInt(driver.address), 5n];
+    await verifier.setShouldVerify(true);
+    await verifier.setExpectedInput(input);
+
+    await expectRevert(
+      zkPrivacy
+        .connect(rater)
+        .submitAnonymousRating(driver.address, 5, tripId, proofWithInput([])),
+      "Invalid proof public inputs length"
+    );
+  });
+
+  it("rejects a duplicate nullifier for the same trip and rater", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const input = [BigInt(nullifier), BigInt(driver.address), 5n];
+    await verifier.setShouldVerify(true);
+    await verifier.setExpectedInput(input);
+
+    await zkPrivacy
+      .connect(rater)
+      .submitAnonymousRating(driver.address, 5, tripId, proofWithInput(input));
+
+    await expectRevert(
+      zkPrivacy
+        .connect(rater)
+        .submitAnonymousRating(driver.address, 5, tripId, proofWithInput(input)),
+      "Nullifier already used for trip rating"
+    );
+  });
+
+  it("rejects ratings outside the valid star range", async function () {
+    const nullifier = deriveNullifier(tripId, rater.address);
+    const input = [BigInt(nullifier), BigInt(driver.address), 0n];
+    await verifier.setShouldVerify(true);
+    await verifier.setExpectedInput(input);
+
+    await expectRevert(
+      zkPrivacy
+        .connect(rater)
+        .submitAnonymousRating(driver.address, 0, tripId, proofWithInput(input)),
+      "Invalid rating stars (1-5)"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`submitAnonymousRating` in `blockchain/contracts/ZKPrivacy.sol` accepted a caller-chosen `_nullifierHash` and a `_zkProof` that was only checked to be non-zero. Anyone could mint unlimited fresh nullifiers and rate any driver arbitrarily, inflating or tanking `getDriverAverageRating` at zero cost with no on-chain trip evidence.

## Fix

The nullifier is now derived from the trip and the rater (`keccak256(tripId, msg.sender)`) instead of being caller-supplied. The proof must be verified by the contract's `IVerifier`, with public inputs that commit to the derived nullifier, the driver, and the stars. The nullifier is marked used only after the proof passes, giving one rating per trip per rater.

## Files changed

- `blockchain/contracts/ZKPrivacy.sol`
- `blockchain/contracts/MockZKPrivacyVerifier.sol` (new test helper, mirrors `MockZkEVMVerifier`)
- `blockchain/test/ZKPrivacy.anonymousRating.test.cjs` (new)

## Testing

Added 7 tests: valid proof flow succeeds, distinct nullifiers per rater, forged proof rejected, proof with mismatched public inputs rejected, truncated inputs rejected, duplicate nullifier rejected, and out-of-range stars rejected — all pass via a temporary hardhat test config (removed before commit).

Closes #9961
