### PR TITLE
[Critical] `kyber_relayer.py` is not Kyber/ML-KEM at all — public key is derived from the secret seed, ciphertext is decryptable by anyone holding the public key

### DIFF
--- a/backend/pqc/kyber_relayer.py
+++ b/backend/pqc/kyber_relayer.py
@@ -1,5 +1,17 @@
-import os
-import hashlib
+"""
+Real ML-KEM-1024 (CRYSTALS-Kyber) key-encapsulation relayer service.
+
+Implemented on top of the standards-compliant ``mlkem`` package. Unlike the
+previous hash-based construction — where the public key was a pure function of
+the secret seed and the ciphertext XORed a keystream derived from the *public*
+key, so anyone holding the public key could decrypt the message and derive the
+shared secret — this module performs genuine ML-KEM-1024 key encapsulation:
+only the holder of the secret key can decapsulate the shared secret.
+"""
+
+from mlkem.ml_kem import ML_KEM
+from mlkem.parameter_set import ML_KEM_1024
+
 
 class Kyber1024Relayer:
     """
@@ -12,41 +24,23 @@ class Kyber1024Relayer:
         self.secret_key_len = 3168
         self.ciphertext_len = 1568
         self.shared_secret_len = 32
-
-    @staticmethod
-    def _expand(material: bytes, length: int) -> bytes:
-        """SHA3-512 expansion of ``material`` to exactly ``length`` bytes."""
-        out = b""
-        counter = 0
-        while len(out) < length:
-            out += hashlib.sha3_512(material + counter.to_bytes(4, 'big')).digest()
-            counter += 1
-        return out[:length]
+        self._kem = ML_KEM(ML_KEM_1024)
 
     def generate_keypair(self):
-        """Generates a Kyber1024 public/private keypair."""
-        seed = os.urandom(64)
-        # The seed is embedded at the front of the secret key so decapsulate can
-        # reconstruct the public key from the private key and recover the
-        # encapsulated secret.
-        sk = seed + self._expand(seed + b"KYBER_SK_TAG", self.secret_key_len - 64)
-        pk = self._expand(seed + b"KYBER_PK_TAG", self.public_key_len)
-        return pk, sk
+        """Generates an ML-KEM-1024 public/private keypair from a CSPRNG seed."""
+        return self._kem.key_gen()
 
     def encapsulate(self, public_key: bytes):
-        """Encapsulates a random 256-bit shared secret using the recipient's Kyber public key."""
+        """Encapsulates a random 256-bit shared secret using the recipient's Kyber public key.
+
+        Returns ``(ciphertext, shared_secret)``. The shared secret is only
+        recoverable by the holder of the corresponding secret key; a party
+        that knows only the public key and the ciphertext cannot derive it.
+        """
         if len(public_key) != self.public_key_len:
             raise ValueError(f"Invalid Kyber1024 public key length: {len(public_key)} bytes required.")
 
-        # Random message encapsulated for the recipient
-        message = os.urandom(self.shared_secret_len)
-        shared_secret = hashlib.sha3_512(public_key + message).digest()[:self.shared_secret_len]
-        # Encrypt the message under a key derived from the public key; only the
-        # holder of the secret key (who can reconstruct the public key) can
-        # recover it.
-        enc_key = hashlib.sha3_512(public_key).digest()
-        ct_blob = bytes(a ^ b for a, b in zip(message, enc_key[:self.shared_secret_len]))
-        ciphertext = (ct_blob * ((self.ciphertext_len + self.shared_secret_len - 1) // self.shared_secret_len))[:self.ciphertext_len]
+        shared_secret, ciphertext = self._kem.encaps(public_key)
         return ciphertext, shared_secret
 
     def decapsulate(self, ciphertext: bytes, secret_key: bytes):
@@ -56,14 +50,7 @@ class Kyber1024Relayer:
         if len(secret_key) != self.secret_key_len:
             raise ValueError(f"Invalid secret key length: {len(secret_key)} bytes required.")
 
-        # Reconstruct the public key from the seed embedded in the secret key
-        seed = secret_key[:64]
-        public_key = self._expand(seed + b"KYBER_PK_TAG", self.public_key_len)
+        return self._kem.decaps(secret_key, ciphertext)
 
-        # Recover the encapsulated message and re-derive the shared secret
-        enc_key = hashlib.sha3_512(public_key).digest()
-        ct_blob = ciphertext[:self.shared_secret_len]
-        message = bytes(a ^ b for a, b in zip(ct_blob, enc_key[:self.shared_secret_len]))
-        return hashlib.sha3_512(public_key + message).digest()[:self.shared_secret_len]
 
 relayer_service = Kyber1024Relayer()

--- a/backend/pqc/requirements.txt
+++ b/backend/pqc/requirements.txt
@@ -1,2 +1,3 @@
 cryptography>=42.0.0
+mlkem>=1.1.0
 pycryptodome>=3.20.0

--- a/backend/pqc/test_kyber.py
+++ b/backend/pqc/test_kyber.py
@@ -1,4 +1,6 @@
 import unittest
+import hashlib
+
 from kyber_relayer import Kyber1024Relayer
 
 class TestKyber1024Relayer(unittest.TestCase):
@@ -19,6 +21,44 @@ class TestKyber1024Relayer(unittest.TestCase):
         ss2 = self.relayer.decapsulate(ct, sk)
         self.assertEqual(len(ss2), 32)
         self.assertEqual(ss1, ss2)
+
+    def test_shared_secret_not_derivable_from_public_key_alone(self):
+        pk, sk = self.relayer.generate_keypair()
+        ct, ss = self.relayer.encapsulate(pk)
+
+        # The old construction derived the encryption key and the shared
+        # secret purely from the public key. With real ML-KEM-1024 those
+        # derivations must not reproduce the shared secret.
+        self.assertNotEqual(ss, hashlib.sha3_512(pk).digest()[:32])
+        self.assertNotEqual(ss, hashlib.sha3_512(pk + ct).digest()[:32])
+        self.assertNotEqual(ss, hashlib.sha3_512(ct).digest()[:32])
+
+    def test_old_xor_ciphertext_attack_no_longer_recovers_shared_secret(self):
+        pk, sk = self.relayer.generate_keypair()
+        ct, ss = self.relayer.encapsulate(pk)
+
+        # Previous scheme: message = ct_blob XOR SHA3-512(pk), then
+        # shared_secret = SHA3-512(pk + message). A holder of only the public
+        # key could perform this. It must fail against real ML-KEM ciphertext.
+        recovered = bytes(a ^ b for a, b in zip(ct[:32], hashlib.sha3_512(pk).digest()[:32]))
+        recovered_secret = hashlib.sha3_512(pk + recovered).digest()[:32]
+        self.assertNotEqual(recovered_secret, ss)
+
+    def test_decapsulation_with_wrong_secret_key_does_not_reveal_shared_secret(self):
+        pk, sk = self.relayer.generate_keypair()
+        ct, ss = self.relayer.encapsulate(pk)
+
+        # A party holding a different keypair must not be able to recover the
+        # shared secret from the same ciphertext.
+        pk_other, sk_other = self.relayer.generate_keypair()
+        wrong_ss = self.relayer.decapsulate(ct, sk_other)
+        self.assertNotEqual(wrong_ss, ss)
+
+    def test_invalid_lengths_raise(self):
+        with self.assertRaises(ValueError):
+            self.relayer.encapsulate(b"too-short")
+        with self.assertRaises(ValueError):
+            self.relayer.decapsulate(b"bad", b"bad")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

`Kyber1024Relayer` in `backend/pqc/kyber_relayer.py` was not Kyber/ML-KEM at all. The public key was a pure SHA3 expansion of the secret seed, and the ciphertext XORed a keystream derived from the public key itself — so anyone holding the public key could decrypt the message and derive the shared secret. The encapsulation provided zero confidentiality.

## Fix

Replaced the ad-hoc hash construction with real, standards-compliant ML-KEM-1024 via the `mlkem` package (`ML_KEM(ML_KEM_1024)`): keypair generation from the CSPRNG, `encapsulate` returning a ciphertext only the secret-key holder can decapsulate, and no shared secret derivable from the public key + ciphertext. The existing public API (`generate_keypair` / `encapsulate` / `decapsulate`) and key lengths (pk 1568, sk 3168, ct 1568, ss 32) are preserved. Added `mlkem` to `requirements.txt`.

## Files changed

- `backend/pqc/kyber_relayer.py`
- `backend/pqc/test_kyber.py`
- `backend/pqc/requirements.txt`

## Testing

All 6 tests pass (`py -m unittest test_kyber`): keypair lengths, roundtrip decapsulation, and new attack-resistance tests proving a public-key-only party cannot derive the shared secret (old pk-derived XOR recovery fails, wrong secret key cannot decapsulate).

Closes #9963
