### PR TITLE
[Critical] Event-sourcing `checkSnapshot` uses the in-memory event cache — snapshots are taken at stale versions across instances

### DIFF
--- a/backend/eventsourcing/event-sourcing-core.js
+++ b/backend/eventsourcing/event-sourcing-core.js
@@ -441,23 +441,44 @@ export class EventStoreCore {
    * Snapshot policy: snapshot when the aggregate has grown by
    * `snapshotThreshold` events since its last snapshot. Never snapshot every
    * event, and never delete the underlying event history.
+   *
+   * The trigger and the snapshot state are based on DB-authoritative data:
+   * `getLatestVersion` bypasses the in-memory event cache, and the state is
+   * rebuilt from freshly-fetched rows. This keeps snapshots consistent across
+   * instances whose caches have not yet seen writes committed by another
+   * instance.
    */
   async checkSnapshot(aggregateId) {
-    const events = await this.getEventStream(aggregateId);
-    if (!events || events.length === 0) {
-      return;
+    const latestVersion = await this.getLatestVersion(aggregateId);
+    if (latestVersion === null || latestVersion <= 0) {
+      return false;
     }
-    const latestVersion = Math.max(...events.map((e) => Number(e.version) || 0));
+
     const snapshot = await this.getSnapshot(aggregateId);
     const snapshotVersion = snapshot ? Number(snapshot.version) : 0;
 
-    if (latestVersion - snapshotVersion >= this.snapshotThreshold) {
-      const state = await this.getAggregateState(aggregateId);
-      await this.takeSnapshot(aggregateId, state, latestVersion);
-      this.logger.info?.(`Snapshot taken for ${aggregateId} at version ${latestVersion}`);
-      return true;
+    if (latestVersion - snapshotVersion < this.snapshotThreshold) {
+      return false;
     }
-    return false;
+
+    // Rebuild the snapshot state from freshly-fetched rows so it includes
+    // events committed by other instances, and refresh the cache so this
+    // instance's reads stay consistent with the database afterwards.
+    const rawRows = await this.db.fetchEventStream(aggregateId);
+    const events = (rawRows || [])
+      .map(normalizeEventRow)
+      .filter(Boolean)
+      .sort((a, b) => Number(a.version) - Number(b.version));
+    this.eventStreams.set(aggregateId, events);
+
+    const state = await this.rebuildFromRows(aggregateId, rawRows);
+    if (!state) {
+      return false;
+    }
+
+    await this.takeSnapshot(aggregateId, state, latestVersion);
+    this.logger.info?.(`Snapshot taken for ${aggregateId} at version ${latestVersion}`);
+    return true;
   }
 }
 

--- a/backend/eventsourcing/test/event-sourcing-core.test.js
+++ b/backend/eventsourcing/test/event-sourcing-core.test.js
@@ -388,6 +388,46 @@ describe('EventStoreCore — snapshots', () => {
     assert.equal(state.reason, 'user request');
     assert.equal(state.version, 13);
   });
+
+  test('two instances: instance B snapshots at the DB version including instance A events despite a stale warm cache', async () => {
+    const db = new InMemoryDb();
+    const instanceA = createCore({ db, threshold: 5 });
+    const instanceB = createCore({ db, threshold: 5 });
+    const orderId = 'order_two_instances';
+
+    // Instance A appends events; instance B warms its cache at version 4.
+    await appendChain(instanceA, orderId, [
+      { type: 'ORDER_CREATED', payload: { customerId: 'c', amount: 1, pickup: 'p', dropoff: 'd' } },
+      { type: 'ORDER_UPDATED', payload: { amount: 2 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 3 } },
+      { type: 'ORDER_UPDATED', payload: { amount: 4 } },
+    ]);
+    assert.equal((await instanceB.getAggregateState(orderId)).version, 4);
+
+    // Instance A commits one more event past the threshold; instance B's
+    // in-memory cache has not seen it and stays stale.
+    await appendChain(instanceA, orderId, [
+      { type: 'ORDER_UPDATED', payload: { amount: 5, fromInstance: 'A' } },
+    ]);
+    assert.equal((await instanceB.getAggregateState(orderId)).version, 4);
+
+    // checkSnapshot must use the DB-authoritative version (5), not the cached
+    // stream, and rebuild the snapshot state from fresh rows.
+    assert.equal(await instanceB.checkSnapshot(orderId), true);
+
+    const snapshot = await instanceB.getSnapshot(orderId);
+    assert.equal(snapshot.version, 5);
+    assert.equal(snapshot.state.amount, 5);
+    assert.equal(snapshot.state.fromInstance, 'A');
+
+    // The snapshot check refreshed instance B's cache too.
+    assert.equal((await instanceB.getAggregateState(orderId)).version, 5);
+
+    // The snapshot is persisted, so instance A sees the same authoritative
+    // snapshot after clearing its cache.
+    instanceA.clearCache(orderId);
+    assert.equal((await instanceA.getSnapshot(orderId)).version, 5);
+  });
 });
 
 describe('EventStoreCore — optimistic concurrency', () => {


### PR DESCRIPTION
## Problem

`checkSnapshot` computed the "latest" version from `getEventStream`, which returns the in-memory `eventStreams` cache when present. In a multi-instance deployment a warm-but-stale instance could fail to snapshot, or snapshot stale state at a stale version. After restart/failover, aggregates could replay from a stale snapshot and silently drop events, corrupting the read model.

## Fix

`checkSnapshot` now computes the trigger version from `getLatestVersion` (which deliberately bypasses the cache and is DB-authoritative), rebuilds the snapshot state from freshly-fetched rows via `rebuildFromRows`, and refreshes the in-memory cache so subsequent reads stay consistent with the database.

## Files changed

- `backend/eventsourcing/event-sourcing-core.js`
- `backend/eventsourcing/test/event-sourcing-core.test.js`

## Testing

Added an integration test simulating two instances: instance B's warm cache is stale behind instance A's writes, and `checkSnapshot` on instance B must snapshot at the DB version including A's events. Full suite passes (`node --test`, 30 tests).

Closes #9964
