### PR TITLE
[Critical] Driver app calls `runApp` twice — first widget tree (with `TextScaleProvider` accessibility scaling) is immediately discarded

### DIFF
--- a/apps/driver/lib/main.dart
+++ b/apps/driver/lib/main.dart
@@ -10,10 +10,6 @@ import 'app.dart';
 import 'core/firebase_config.dart';
 import 'package:truxify_driver/config/env.dart';
 import 'providers/text_scale_provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'app.dart';
-import 'core/firebase_config.dart';
-import 'package:truxify_driver/config/env.dart';
 import 'providers/language_provider.dart';
 import 'services/background_sync_service.dart';
 
@@ -76,16 +72,16 @@ Future<void> main() async {
 
   // Wrap runApp in a guarded zone to capture uncaught async errors.
   runZonedGuarded(() {
+    final languageProvider = LanguageProvider();
     runApp(
       MultiProvider(
         providers: [
           ChangeNotifierProvider(create: (_) => TextScaleProvider()),
+          ChangeNotifierProvider.value(value: languageProvider),
         ],
-        child: const TruxifyApp(),
+        child: TruxifyApp(languageProvider: languageProvider),
       ),
     );
-    final languageProvider = LanguageProvider();
-    runApp(TruxifyApp(languageProvider: languageProvider));
   }, (error, stackTrace) {
     CrashReportingService.captureException(
       error,


### PR DESCRIPTION
## Problem

`apps/driver/lib/main.dart` called `runApp` inside a `ListenableBuilder` builder and also elsewhere, so `runApp` ran twice; `TruxifyApp` was constructed with the wrong provider shape and the language/text-scale providers were wired inconsistently with what `TruxifyApp` expects.

## Fix

`main.dart` now calls `runApp` exactly once inside `runZonedGuarded`, with `MultiProvider` providing `TextScaleProvider` and `LanguageProvider` (as a value), and passes `languageProvider:` into `TruxifyApp`. Duplicate imports removed.

## Files changed

- `apps/driver/lib/main.dart`

## Testing

Verified structurally against `TruxifyApp`'s constructor (`TruxifyUpgradeable`/`LanguageProviderScope` expectations). NOTE: no Dart/Flutter toolchain was available in this environment, so the change was not compiled.

Closes #9965
