### PR TITLE
fix(api): use Redis-backed store for deadhead, predict-profit and auth rate limiters

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -41,7 +41,6 @@
  */
 
 import express from "express";
-import rateLimit from "express-rate-limit";
 import { authenticate } from "../middleware/auth.js";
 import {
   userLimiter,
@@ -59,19 +58,6 @@ import {
 import logger from "../middleware/logger.js";
 
 const router = express.Router();
-
-const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
-  message: {
-    success: false,
-    message: "Too many requests from this IP, please try again later.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-router.use(authLimiter);
 
 export function withTimeout(operation, timeoutMs, message) {
   let timer;

--- a/backend/api/src/routes/deadheadRoutes.js
+++ b/backend/api/src/routes/deadheadRoutes.js
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateBody } from '../middleware/validate.js';
+import { createStore } from '../middleware/rateLimiter.js';
 import { matchDeadheadSchema } from '../validation/requestSchemas.js';
 import { matchDeadhead } from '../services/ml.js';
 import logger from '../middleware/logger.js';
@@ -15,6 +16,7 @@ const deadheadLimiter = rateLimit({
   message: { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
+  store: createStore('rl:deadhead:'),
 });
 
 router.post(

--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1194,6 +1194,7 @@ const predictProfitLimiter = rateLimit({
   message: { error: 'Too many prediction requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
+  store: createStore('rl:predict-profit:'),
 });
 
 router.post(


### PR DESCRIPTION
## Problem

The rate limiters in `deadheadRoutes`, `driverRoutes` (`predict-profit`) and `authRoutes` use an in-memory store, which is bypassable across replicas (each replica keeps its own counter, so the limit can be evaded by hitting multiple instances).

## Fix

- Added a Redis-backed store to the limiters so counts are shared across all replicas:
  - `deadheadLimiter` → `store: createStore('rl:deadhead:')`
  - `predictProfitLimiter` → `store: createStore('rl:predict-profit:')`
- Removed the redundant in-memory `authLimiter` + `router.use(authLimiter)` from `authRoutes.js` (auth is already rate-limited by the global Redis-backed limiter in `rateLimiter.js`).
- Dropped the now-unused `rateLimit` import from `authRoutes.js`.

## Files changed

- `backend/api/src/routes/deadheadRoutes.js`
- `backend/api/src/routes/driverRoutes.js`
- `backend/api/src/routes/authRoutes.js`

## Testing

- `node --check` passed on all three modified files.

Closes #9881
