### PR TITLE
fix(customer): stop logging full order and location payloads in live tracking

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -192,7 +192,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     );
 
     _trackingSubscription = _trackingWebSocket!.stream.listen((message) {
-      debugPrint('Tracking WebSocket message received: $message');
+      debugPrint('Tracking WebSocket message received');
       if (message is! String) return;
       try {
         if (message == 'pong') return;
@@ -218,7 +218,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
           }
         } else if (payload['event'] == 'milestone_update') {
           // Refresh timeline whenever the driver hits a new milestone.
-          debugPrint('[LiveTracking] Milestone update received: ${payload['data']}');
+          debugPrint('[LiveTracking] Milestone update received');
           _loadTimeline();
         } else if (payload['event'] == null && payload['error'] != null) {
           debugPrint('[LiveTracking] WS server error: ${payload['error']}');
@@ -285,8 +285,6 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
   Future<void> _loadOrder() async {
     try {
       final order = await _orderService.fetchOrderById(widget.orderId);
-
-      debugPrint('ORDER DATA = $order');
 
       if (!mounted) return;
 
@@ -375,7 +373,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     _supabaseRealtimeChannel!.onBroadcast(
       event: 'location',
       callback: (payload) {
-        debugPrint('Received Supabase Realtime location update: $payload');
+        debugPrint('Received Supabase Realtime location update');
         final lat = (payload['lat'] as num?)?.toDouble();
         final lng = (payload['lng'] as num?)?.toDouble();
         if (lat != null && lng != null && mounted) {
@@ -842,7 +840,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
             value: widget.orderId,
           ),
           callback: (payload) {
-            debugPrint('Realtime order update: ${payload.newRecord}');
+            debugPrint('Realtime order update received');
             _loadOrder();
             _loadTimeline();
           },


### PR DESCRIPTION
## Problem

The customer app logs full order objects and WebSocket/Supabase payloads via `debugPrint`, including sensitive PII and OTP/order data in release logs.

## Fix

Removed the PII-leaking `debugPrint` interpolations in `apps/customer/lib/screens/live_tracking_screen.dart`:
- Removed `ORDER DATA = $order` full-order logging.
- Removed `$message` / `$payload` / `${payload.newRecord}` interpolations from the WebSocket, milestone, and Supabase location + order-update logs.

## Files changed

- `apps/customer/lib/screens/live_tracking_screen.dart`

## Testing

- Simple string-edit removals only (Flutter not available locally); no logic changes.

Closes #9882
