### PR TITLE
fix(api): project explicit allow-list for GET /api/orders/my/active

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -196,7 +196,9 @@ export class OrderLifecycleService {
       const activeStatuses = ['pending', 'active', 'truck_assigned', 'en_route_pickup', 'arrived_pickup', 'picked_up', 'in_transit', 'arriving'];
 
       const { data: orders, error } = await this.orderRepository.findOrdersByCustomer(
-        customerId, '*', activeStatuses, 'pickup_date', false
+        customerId,
+        'id, order_display_id, status, pickup_address, drop_address, pickup_date, pickup_lat, pickup_lng, drop_lat, drop_lng, eta, driver_id, truck_id, truck_number, total_amount, goods_type, weight_tonnes, length_ft, width_ft, height_ft, is_stackable, is_fragile, special_requirements, created_at, updated_at',
+        activeStatuses, 'pickup_date', false
       );
 
       if (error) throw new DomainError(500, { error: 'Failed to fetch active orders.', details: error.message });


### PR DESCRIPTION
## Problem

`GET /api/orders/my/active` returns complete `orders` rows (`select('*')`) for all of the caller's active orders, including sensitive financial/internal fields (`delivery_otp`, `upi_id`, `payment_method_id`, `blockchain_tx_hash`, escrow/refund state).

## Fix

`getActiveOrders` in `orderLifecycleService.js` now projects an explicit allow-list of columns instead of `*`:

`id, order_display_id, status, pickup_address, drop_address, pickup_date, pickup_lat, pickup_lng, drop_lat, drop_lng, eta, driver_id, truck_id, truck_number, total_amount, goods_type, weight_tonnes, length_ft, width_ft, height_ft, is_stackable, is_fragile, special_requirements, created_at, updated_at`

`sensitive` fields like `delivery_otp`/`upi_id` remain available only through the dedicated OTP/payment endpoints.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js`

## Testing

- `node --check` passed.
- Verified the customer app consumers (`home_screen.dart`, `orders_screen.dart`) only use allow-listed fields; the driver app and tests do not consume `getActiveOrders`.

Closes #9892
