### PR TITLE
fix(api): strip service metadata from public /api/health/full response

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -296,6 +296,11 @@ const aggregator = createDefaultAggregator();
 router.get('/full', healthLimiter, async (req, res) => {
   try {
     const result = await aggregator.aggregate();
+    // Strip per-service metadata (broker hostnames, ports, pool counts, ML
+    // engine URL, chain ids) so the public surface exposes only status.
+    for (const service of Object.values(result.services || {})) {
+      delete service.metadata;
+    }
     // 200 = system operational (healthy or degraded with non-critical failures)
     // 503 = system not operational (critical services down)
     const httpStatus = result.status === 'unhealthy' ? 503 : 200;

--- a/backend/api/test/integration/healthAggregation.test.js
+++ b/backend/api/test/integration/healthAggregation.test.js
@@ -213,7 +213,7 @@ describe('GET /api/health/full (Centralized Health Aggregation)', () => {
     const res = await request(app).get('/api/health/full');
 
     expect(res.body.services.workers.status).toBe('healthy');
-    expect(res.body.services.workers.metadata.workerCount).toBe(3);
+    expect(res.body.services.workers.metadata).toBeUndefined();
   });
 
   it('reports degraded when a worker is not running', async () => {


### PR DESCRIPTION
## Problem

The unauthenticated `GET /api/health/full` endpoint discloses internal infrastructure details: Kafka brokers, Postgres pool counts, ports, and chainId are returned to any caller.

## Fix

The `/api/health/full` route now strips the `metadata` field from every `services.*` entry before responding, so internal broker/port/pool/chainId details are no longer exposed while statuses and summaries remain available.

Also updated `test/integration/healthAggregation.test.js`: the worker-health case now asserts `metadata` is `undefined` instead of asserting `workerCount === 3`.

## Files changed

- `backend/api/src/routes/healthRoutes.js`
- `backend/api/test/integration/healthAggregation.test.js`

## Testing

- `node --check` passed on the modified route.
- Health tests run locally; the 3 pre-existing failures (env/mock issues, also present on clean main) are unrelated to this change.

Closes #9894
