### PR TITLE
fix(api): project explicit allow-list for load-offer marketplace

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -63,6 +63,12 @@ import { escapeLike } from '../lib/escapeLike.js';
 
 const router = express.Router();
 
+// Explicit allow-list for the driver-facing marketplace. Excludes internal
+// columns such as customer_id so drivers never see the freight owner's
+// identity and any future sensitive column is not auto-disclosed.
+const MARKETPLACE_COLUMNS =
+  'id, order_display_id, customer_name, company_name, route_label, route_subtitle, pickup_address, pickup_lat, pickup_lng, drop_address, drop_lat, drop_lng, route_distance, route_duration, goods_type, weight, dimensions, is_stackable, is_fragile, special_handling, freight_value, fuel_cost, toll_cost, net_profit, capacity_used, truck_fill_label, space_available, badge_label, badge_emoji, is_best_profit, is_en_route, extra_distance_km, extra_earnings, route_note, distance_from_driver, status, created_at, updated_at';
+
 
 // Sanitize load filter query params to prevent injection attacks
 function sanitizeLoadFilters(query) {
@@ -197,7 +203,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('load-offer:browse'), v
     // marketplace board must read through the service-role client.
     let query = supabaseAdmin
       .from('load_offers')
-      .select('*', { count: 'exact' });
+      .select(MARKETPLACE_COLUMNS, { count: 'exact' });
 
     let statusFilter = 'available';
     if (req.query.status) {
@@ -396,7 +402,7 @@ router.get('/:id', authenticate, userLimiter, requirePolicy('load-offer:browse')
   try {
     const { data: load, error } = await supabaseAdmin
       .from('load_offers')
-      .select('*')
+      .select(MARKETPLACE_COLUMNS)
       .eq('id', req.params.id)
       .eq('status', 'available')
       .maybeSingle();


### PR DESCRIPTION
## Problem

The load-offer marketplace returns full `load_offers` rows via `select('*')` using the service-role client, including the internal `customer_id` and any other sensitive columns to all authenticated users browsing offers.

## Fix

Added a `MARKETPLACE_COLUMNS` allow-list constant (excluding `customer_id`) and used it for both `GET /api/loads` (with count) and `GET /api/loads/:id`. The POST create route keeps its bare `.select()` since the creator legitimately owns their own row.

## Files changed

- `backend/api/src/routes/loadRoutes.js`

## Testing

- `node --check` passed on the modified file.
- Full test suite run blocked by a pre-existing unrelated issue on main (duplicate `syncWeightSchema` export in `requestSchemas.js`).

Closes #9895
