### PR TITLE
fix(api): add express-validator dependency to unblock API boot

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -40,6 +40,7 @@
     "ethers": "6.17.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
+    "express-validator": "^7.3.2",
     "firebase-admin": "^14.1.0",
     "helmet": "^8.2.0",
     "i18next": "^26.3.4",


### PR DESCRIPTION
## Problem

`escortWalletRoutes.js`/`escortWalletController.js` import `express-validator`, which is not declared in any `package.json` — the API crashes at boot with `ERR_MODULE_NOT_FOUND`.

## Fix

Added `"express-validator": "^7.3.2"` to `backend/api/package.json` dependencies so the module resolves at boot.

## Files changed

- `backend/api/package.json`

## Testing

- Module now resolves; API boots past the escort-wallet imports.

Closes #9897
