### PR TITLE
fix(device): remove duplicate errorResponse import to restore API boot

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -2,7 +2,6 @@ import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
-import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
## Problem

`deviceController.js` imports `errorResponse` twice (lines 3 and 5), causing a duplicate-identifier `SyntaxError` — the API cannot boot.

## Fix

Removed the duplicate `import { errorResponse }` line.

## Files changed

- `backend/api/src/controllers/deviceController.js`

## Testing

- `node --check` passed on the modified file.

Closes #9901
