### PR TITLE
fix(graphql): make driver BUSY status representable end-to-end

### DIFF
--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -108,7 +108,9 @@ const resolvers = {
             let query = supabase.from('drivers').select('*');
             
             if (available !== undefined) {
-                query = query.eq('status', available ? 'AVAILABLE' : 'BUSY');
+                query = available
+                    ? query.eq('status', 'AVAILABLE')
+                    : query.neq('status', 'AVAILABLE');
             }
             
             if (location) {
@@ -144,6 +146,7 @@ const resolvers = {
                 .from('drivers')
                 .update({
                     status: input.status,
+                    availability: input.availability,
                     current_location: input.currentLocation,
                     truck_type: input.truckType || undefined,
                     truck_number: input.truckNumber || undefined,

--- a/supabase/migrations/20260811090000_add_driver_busy_status.sql
+++ b/supabase/migrations/20260811090000_add_driver_busy_status.sql
@@ -1,0 +1,100 @@
+-- Migration: add driver busy state to driver_details and expose it via the
+-- drivers view so the GraphQL DriverStatus.BUSY enum is representable end-to-end.
+-- Backs backend/graphql/services/driver.service.js which reads/writes the
+-- `drivers` view created by 20260805000020_create_drivers_view.sql.
+
+-- 1. Persist busy state on driver_details (existing rows default to available).
+ALTER TABLE driver_details
+  ADD COLUMN IF NOT EXISTS is_busy boolean NOT NULL DEFAULT false;
+
+-- 2. Redefine the drivers view: status now emits BUSY, and availability /
+--    is_busy are exposed as writable columns so updateDriver can set them.
+CREATE OR REPLACE VIEW drivers AS
+SELECT
+  dd.id                 AS id,
+  dd.user_id            AS user_id,
+  p.full_name           AS name,
+  p.phone               AS phone,
+  t.truck_type          AS truck_type,
+  t.number_plate        AS truck_number,
+  CASE
+    WHEN dd.is_online AND dd.is_busy THEN 'BUSY'
+    WHEN dd.is_online THEN 'AVAILABLE'
+    ELSE 'OFFLINE'
+  END                   AS status,
+  dd.is_online          AS availability,
+  dd.is_busy            AS is_busy,
+  jsonb_build_object(
+    'lat', dl.latitude,
+    'lng', dl.longitude,
+    'address', COALESCE(dl.accuracy::text, '')
+  )                     AS current_location,
+  dd.rating             AS rating,
+  dd.total_trips        AS trips_completed,
+  dd.updated_at         AS updated_at
+FROM driver_details dd
+JOIN profiles p       ON p.id = dd.user_id
+LEFT JOIN trucks t    ON t.id = dd.truck_id
+LEFT JOIN LATERAL (
+  SELECT *
+  FROM driver_locations
+  WHERE driver_id = dd.user_id AND is_active = true
+  ORDER BY id DESC
+  LIMIT 1
+) dl ON true;
+
+-- 3. Teach the INSTEAD OF UPDATE trigger how to persist status, availability
+--    and is_busy back to driver_details.
+CREATE OR REPLACE FUNCTION sync_drivers_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    UPDATE driver_details
+       SET is_online = (NEW.status IN ('AVAILABLE', 'BUSY')),
+           is_busy   = (NEW.status = 'BUSY')
+     WHERE id = NEW.id;
+  END IF;
+
+  IF NEW.availability IS DISTINCT FROM OLD.availability THEN
+    UPDATE driver_details
+       SET is_online = NEW.availability
+     WHERE id = NEW.id;
+  END IF;
+
+  IF NEW.is_busy IS DISTINCT FROM OLD.is_busy THEN
+    UPDATE driver_details
+       SET is_busy = NEW.is_busy
+     WHERE id = NEW.id;
+  END IF;
+
+  IF NEW.truck_type IS DISTINCT FROM OLD.truck_type
+     OR NEW.truck_number IS DISTINCT FROM OLD.truck_number THEN
+    UPDATE trucks t
+       SET truck_type   = COALESCE(NEW.truck_type, t.truck_type),
+           number_plate = COALESCE(NEW.truck_number, t.number_plate)
+     WHERE t.driver_id = NEW.user_id;
+  END IF;
+
+  IF NEW.current_location IS DISTINCT FROM OLD.current_location THEN
+    UPDATE driver_locations
+       SET is_active = false
+     WHERE driver_id = NEW.user_id AND is_active = true;
+
+    INSERT INTO driver_locations (driver_id, latitude, longitude, accuracy, is_active)
+    VALUES (
+      NEW.user_id,
+      (NEW.current_location ->> 'lat')::numeric(10, 8),
+      (NEW.current_location ->> 'lng')::numeric(11, 8),
+      NULL,
+      true
+    );
+  END IF;
+
+  UPDATE driver_details SET updated_at = now() WHERE id = NEW.id;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Problem

GraphQL `DriverStatus.BUSY` is unrepresentable end-to-end: the `drivers` view only ever emits `AVAILABLE`/`OFFLINE`, so `BUSY` never appears in the status column. `drivers(available: false)` filters `eq('status', 'BUSY')` and always returns an empty list, `updateDriver({ status: BUSY })` is silently coerced to `OFFLINE` by the INSTEAD OF UPDATE trigger, and the `availability: Boolean` input is declared but never read.

## Fix

- New migration `20260811090000_add_driver_busy_status.sql`:
  - Adds `driver_details.is_busy boolean not null default false` to persist busy state.
  - Redefines the `drivers` view so `status` emits `BUSY` when a driver is online and busy, and exposes writable `availability` and `is_busy` columns.
  - Extends `sync_drivers_update()` to persist `status` to `is_online` + `is_busy`, `availability` to `is_online`, and `is_busy` to `is_busy`.
- `drivers(available: false)` now filters `neq('status', 'AVAILABLE')`, returning busy and offline drivers.
- `updateDriver` passes `input.availability` to the view so the input takes effect.

## Files changed

- `supabase/migrations/20260811090000_add_driver_busy_status.sql`
- `backend/graphql/services/driver.service.js`

## Testing

Migration is idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE VIEW`/`FUNCTION`); status/availability round-trips are pure SQL trigger logic reviewed against the view definition. The GraphQL subgraph has no unit test harness; behavior verified by inspection against the issue's evidence.

Closes #9905
