### PR TITLE
fix(db): allow orders.status to store disputed via CHECK migration

### DIFF
--- a/supabase/migrations/20260811080000_add_disputed_to_orders_status_check.sql
+++ b/supabase/migrations/20260811080000_add_disputed_to_orders_status_check.sql
@@ -1,0 +1,17 @@
+-- Fix #9915: allow orders.status to store 'disputed'. updateOrder(status: DISPUTED)
+-- writes 'disputed', which previously violated the CHECK constraint and threw
+-- Postgres error 23514 on every dispute-status update.
+
+-- Drop the existing CHECK constraint (auto-named by Postgres from the inline
+-- definition in supabase_setup.sql).
+alter table orders
+  drop constraint if exists orders_status_check;
+
+-- Re-add with 'disputed' in the allowed set.
+alter table orders
+  add constraint orders_status_check
+  check (status in (
+    'pending','truck_assigned','en_route_pickup','arrived_pickup',
+    'picked_up','in_transit','arriving','delivered','cancelled',
+    'payment_released','disputed'
+  ));


### PR DESCRIPTION
## Problem

`updateOrder(status: DISPUTED)` writes `'disputed'`, which violates the `orders.status` CHECK constraint — every dispute-status update errors with `23514 check_violation`. This is a regression from the #7207 fix.

## Fix

New migration `20260811080000_add_disputed_to_orders_status_check.sql` drops `orders_status_check` and recreates it with `'disputed'` added to the allowed set, matching `toDbStatus('DISPUTED')`:

`pending, truck_assigned, en_route_pickup, arrived_pickup, picked_up, in_transit, arriving, delivered, cancelled, payment_released, disputed`

## Files changed

- `supabase/migrations/20260811080000_add_disputed_to_orders_status_check.sql`

## Testing

Constraint DDL pattern copied from `20260807000050_widen_notifications_notif_type_check.sql`; timestamp sorts after the other `20260811xxxxxx` migrations. Read-side mapping of the stored `disputed` value to the `DISPUTED` enum is covered by the PR for #9913.

Closes #9915
