### PR TITLE
fix(scripts): drop RPC functions with no DDL or callers from required list

### DIFF
--- a/backend/api/scripts/verify-db-schema.js
+++ b/backend/api/scripts/verify-db-schema.js
@@ -12,9 +12,6 @@ const REQUIRED_RPC_FUNCTIONS = [
   'submit_rating_tx',
   'cancel_order_tx',
   'cancel_stale_order_tx',
-  'release_escrow_tx',
-  'refund_escrow_tx',
-  'update_trip_status_tx',
 ];
 
 const REQUIRED_INDEXES = [


### PR DESCRIPTION
## Problem

`verify-db-schema.js` `REQUIRED_RPC_FUNCTIONS` lists `release_escrow_tx`, `refund_escrow_tx` and `update_trip_status_tx`, none of which have any DDL (`create function`) or any callers. The RPC check can never pass on a healthy DB.

## Fix

Removed the three phantom functions from `REQUIRED_RPC_FUNCTIONS` after verifying they are absent from all `*.sql` DDL and all callers.

## Files changed

- `backend/api/scripts/verify-db-schema.js`

## Testing

Grep across `docs/` and `supabase/migrations/` confirms no DDL or callers reference the three functions.

Closes #9912
