### PR TITLE
fix(sharding): fall back to SHARD_PASSWORD and only fail when SHARDING_ENABLED

### DIFF
--- a/backend/api/src/services/sharding/ShardManager.js
+++ b/backend/api/src/services/sharding/ShardManager.js
@@ -15,7 +15,7 @@ class ShardManager {
     const missingPasswords = [];
 
     // North Zone - Delhi, UP, Punjab, Haryana, Rajasthan
-    const northPassword = process.env.SHARD_PASSWORD_NORTH;
+    const northPassword = process.env.SHARD_PASSWORD_NORTH || process.env.SHARD_PASSWORD;
     if (!northPassword) missingPasswords.push('SHARD_PASSWORD_NORTH');
     this.shards.set('north', {
       name: 'north',
@@ -29,7 +29,7 @@ class ShardManager {
     });
 
     // South Zone - Tamil Nadu, Karnataka, Kerala, AP, Telangana
-    const southPassword = process.env.SHARD_PASSWORD_SOUTH;
+    const southPassword = process.env.SHARD_PASSWORD_SOUTH || process.env.SHARD_PASSWORD;
     if (!southPassword) missingPasswords.push('SHARD_PASSWORD_SOUTH');
     this.shards.set('south', {
       name: 'south',
@@ -43,7 +43,7 @@ class ShardManager {
     });
 
     // East Zone - WB, Bihar, Odisha, Jharkhand, NE States
-    const eastPassword = process.env.SHARD_PASSWORD_EAST;
+    const eastPassword = process.env.SHARD_PASSWORD_EAST || process.env.SHARD_PASSWORD;
     if (!eastPassword) missingPasswords.push('SHARD_PASSWORD_EAST');
     this.shards.set('east', {
       name: 'east',
@@ -57,7 +57,7 @@ class ShardManager {
     });
 
     // West Zone - Maharashtra, Gujarat, MP, Goa
-    const westPassword = process.env.SHARD_PASSWORD_WEST;
+    const westPassword = process.env.SHARD_PASSWORD_WEST || process.env.SHARD_PASSWORD;
     if (!westPassword) missingPasswords.push('SHARD_PASSWORD_WEST');
     this.shards.set('west', {
       name: 'west',
@@ -71,7 +71,13 @@ class ShardManager {
     });
 
     if (missingPasswords.length > 0) {
-      throw new Error(`Missing required shard password env vars: ${missingPasswords.join(', ')}`);
+      if (process.env.SHARDING_ENABLED === 'true') {
+        throw new Error(`Missing required shard password env vars: ${missingPasswords.join(', ')}`);
+      }
+      logger.warn(
+        `Sharding not enabled — missing shard password env vars: ${missingPasswords.join(', ')}. ` +
+        'Set SHARDING_ENABLED=true (with the SHARD_PASSWORD_* vars) to require shard credentials.'
+      );
     }
 
     // Initialize connection pools


### PR DESCRIPTION
## Problem

`ShardManager` runs `new ShardManager()` at module load and its constructor calls `initializeShards()`, which throws when `SHARD_PASSWORD_NORTH/SOUTH/EAST/WEST` are unset. `src/index.js` statically imports the singleton, so `npm start` crashes on any checkout that does not define all four env vars, and `.env.example` only documents the singular `SHARD_PASSWORD`.

## Fix

- Each directional password now falls back to `process.env.SHARD_PASSWORD`.
- The `missingPasswords` throw is guarded by `process.env.SHARDING_ENABLED === 'true'`; otherwise it logs a `logger.warn`, so sharding is effectively optional.

## Files changed

- `backend/api/src/services/sharding/ShardManager.js`

## Testing

Booting without any shard env vars no longer throws (the unit-test setup `backend/api/test/setup.js` sets none); deployments that enable `SHARDING_ENABLED=true` retain the hard failure mode when credentials are missing.

Closes #9918
