### PR TITLE
fix(tracing): fall back to global no-op tracer when provider init fails

### DIFF
--- a/backend/api/src/tracing/tracing.js
+++ b/backend/api/src/tracing/tracing.js
@@ -90,7 +90,7 @@ class Tracing {
         if (!this.isInitialized) {
             this.initialize();
         }
-        return this.provider.getTracer(name);
+        return this.provider ? this.provider.getTracer(name) : trace.getTracer(name);
     }
 
     createSpan(name, options = {}) {


### PR DESCRIPTION
## Problem

`tracing.js` `getTracer()` calls `initialize()` when `!this.isInitialized`, then unconditionally dereferences `this.provider.getTracer(name)`. `initialize()` swallows errors and leaves `provider = null` when OpenTelemetry setup fails, so every `getTracer()` call — and therefore every `EventBus.publish()` — crashes with `TypeError: Cannot read properties of null (reading 'getTracer')`. 15 unit tests fail on clean main for this single root cause.

## Fix

`getTracer()` now falls back to the global no-op tracer when the provider is unavailable:

```js
return this.provider ? this.provider.getTracer(name) : trace.getTracer(name);
```

## Files changed

- `backend/api/src/tracing/tracing.js`

## Testing

Publish paths no longer throw when tracing initialization fails; implementation matches the issue's expected behaviour (fall back to `@opentelemetry/api` global tracer).

Closes #9919
