### PR TITLE
docs(schema): drop milestones and driver_milestones tables that no DDL creates

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # 📊 Truxify — Database Schema
 
-> **28 tables · 4 RPC functions · 28 foreign keys**
+> **26 tables · 4 RPC functions · 26 foreign keys**
 > Critical business entities now use physical referential integrity for core joins and audit trails.
 
 ---
@@ -287,24 +287,6 @@ erDiagram
         numeric hours_driven
     }
 
-    milestones {
-        uuid id PK
-        text title
-        text subtitle
-        int threshold
-        text metric
-        boolean is_active
-    }
-
-    driver_milestones {
-        uuid id PK
-        uuid driver_id
-        uuid milestone_id
-        boolean achieved
-        numeric progress
-        timestamptz achieved_at
-    }
-
     profiles ||--o| driver_details : "user_id"
     profiles ||--o| customer_stats : "user_id"
     profiles ||--o{ trucks : "driver_id"
@@ -339,10 +321,8 @@ erDiagram
     orders ||--o{ wallet_transactions : "order_display_id"
     trips ||--o{ wallet_transactions : "trip_display_id"
     profiles ||--o{ processed_batches : "user_id"
-    profiles ||--o{ earnings_daily : "driver_id"
-    profiles ||--o{ driver_milestones : "driver_id"
-    milestones ||--o{ driver_milestones : "milestone_id"
-```
+profiles ||--o{ earnings_daily : "driver_id"
+
 
 ---
 
@@ -395,8 +375,6 @@ graph LR
 
     subgraph ENGAGEMENT["⭐ Engagement Layer"]
         R[ratings]
-        M[milestones]
-        DM[driver_milestones]
         N[notifications]
         FAQ[faqs]
         ST[support_tickets]
@@ -491,13 +469,11 @@ graph LR
 |-------|---------|-------------|----------|
 | `processed_batches` | Offline sync / event idempotency tracking | `idempotency_key`, `user_id`, `event_count`, `processed_at` | `profiles.id` |
 
-### ⭐ Engagement Layer (6 tables)
+### ⭐ Engagement Layer (4 tables)
 
 | Table | Purpose | Key Columns | Links To |
 |-------|---------|-------------|----------|
 | `ratings` | Customer → driver reviews | `order_display_id`, `stars`, `comment` | `profiles.id`, `orders.order_display_id` |
-| `milestones` | Gamification achievement definitions | `title`, `threshold`, `metric` | — |
-| `driver_milestones` | Driver progress on milestones | `driver_id`, `milestone_id`, `achieved` | `profiles.id`, `milestones.id` |
 | `notifications` | In-app notification inbox | `user_id`, `title`, `notif_type`, `is_read` | `profiles.id` |
 | `faqs` | Help & support content | `app_type`, `question`, `answer` | — |
 | `support_tickets` | User support requests | `user_id`, `subject`, `category`, `status` | `profiles.id` |


### PR DESCRIPTION
## Problem

`docs/schema.md` documents `milestones` and `driver_milestones` tables that no DDL ever creates — fresh setups are missing them and `verify-db-schema` flags them on every run.

## Fix

Removed both tables from `docs/schema.md`:

- ER diagram mermaid blocks and relationship lines.
- Flow diagram nodes.
- Table Reference rows.

The header is now `**26 tables · 4 RPC functions · 26 foreign keys**` and the Engagement Layer section is `(4 tables)`.

## Files changed

- `docs/schema.md`

## Testing

Mermaid table block count verified as 26; no remaining references to `milestones` or `driver_milestones` in the file.

Closes #9916
