### PR TITLE
fix(routes): disable IPv6 keyGenerator fallback validation for safeIpKeyGenerator limiters

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -19,6 +19,7 @@ const telemetryHistoryLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: safeIpKeyGenerator,
+  validate: { keyGeneratorIpFallback: false },
   store: createStore('rl:iot-telemetry-history:'),
   message: { error: 'Rate limit exceeded', retryAfter: 900 },
 });

--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -32,6 +32,7 @@ const publicLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: safeIpKeyGenerator,
+  validate: { keyGeneratorIpFallback: false },
   store: createStore('rl:public-track:'),
 });
 

--- a/backend/api/src/routes/roadConditionRoutes.js
+++ b/backend/api/src/routes/roadConditionRoutes.js
@@ -12,6 +12,7 @@ const roadConditionLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: safeIpKeyGenerator,
+  validate: { keyGeneratorIpFallback: false },
   store: createStore('rl:road-conditions:'),
 });
 

--- a/backend/api/src/routes/trackingRoutes.js
+++ b/backend/api/src/routes/trackingRoutes.js
@@ -19,6 +19,7 @@ const publicTrackingLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: safeIpKeyGenerator,
+  validate: { keyGeneratorIpFallback: false },
   store: createStore('rl:public-tracking:'),
 });
 


### PR DESCRIPTION
## Problem

Four route modules construct `express-rate-limit` limiters with the shared `safeIpKeyGenerator`, which reads `req.ip` without calling the library's `ipKeyGenerator` helper. `express-rate-limit` (pinned `^8.5.2`) rejects the configuration at module load and logs a hard `ValidationError: ERR_ERL_KEY_GEN_IPV6` stack trace on every boot for each affected route file.

## Fix

Added `validate: { keyGeneratorIpFallback: false }` to the limiters in:

- `backend/api/src/routes/iotRoutes.js`
- `backend/api/src/routes/roadConditionRoutes.js`
- `backend/api/src/routes/trackingRoutes.js`
- `backend/api/src/routes/publicTrackingRoutes.js`

This mirrors the flag already present on the shared limiter in `backend/api/src/middleware/rateLimiter.js`.

## Files changed

- `backend/api/src/routes/iotRoutes.js`
- `backend/api/src/routes/roadConditionRoutes.js`
- `backend/api/src/routes/trackingRoutes.js`
- `backend/api/src/routes/publicTrackingRoutes.js`

## Testing

Boot no longer emits `ERR_ERL_KEY_GEN_IPV6` for these limiters; `safeIpKeyGenerator` is left untouched so IPv6-to-/64 masking behaviour is preserved.

Closes #9921
