### PR TITLE
fix: remove duplicate syncWeightSchema export in requestSchemas.js

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -254,14 +254,6 @@ export const updateDocumentStatusSchema = z.object({
   rejection_reason: z.string().optional()
 });
 
-export const syncWeightSchema = z.object({
-  truck_id: z.string().min(1, "Truck ID is required"),
-  axles: z.array(z.object({
-    position: z.string().min(1, "Axle position is required"),
-    pressure_psi: coerceNumber(z.number().positive("Pressure must be positive"))
-  })).min(1, "At least one axle reading is required")
-}).strict();
-
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
 // e.g. MH12AB1234 or DL01C1234
 const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;


### PR DESCRIPTION
Fixes #10250

## Problem
The API server cannot boot: \ackend/api/src/validation/requestSchemas.js\ exports \syncWeightSchema\ twice (lines 257 and 419), causing \SyntaxError: Identifier 'syncWeightSchema' has already been declared\ at module load time. Verified with \
ode --check\.

## Fix
Removed the stale duplicate definition (older \	ruck_id\-shaped schema) and kept the documented schema used by \POST /api/driver/weigh-stations/sync-weight\ in \driverRoutes.js\.

## Verification
- \
ode --check backend/api/src/validation/requestSchemas.js\ passes.
- \
px vitest run test/unit/requestSchemas.test.js test/unit/loadSchemas.test.js test/unit/profileSchema.test.js\ → 3 files, 91 tests passed.

## GSSOC'24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weight synchronization validation with clearer vehicle and truck identifiers.
  * Added validation for numeric axle positions and positive pressure readings.
  * Added optional ISO 8601 timestamp support for synchronization requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->