### PR TITLE
fix: remove duplicate errorResponse import in deviceController.js

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -2,7 +2,6 @@ import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
-import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
Fixes #10238

## Problem
The API server cannot boot: \ackend/api/src/controllers/deviceController.js\ imports \errorResponse\ twice (lines 3 and 5), causing \SyntaxError: Identifier 'errorResponse' has already been declared\ at module load time. \deviceRoutes.js\ imports from this controller, so the whole API fails at startup. Verified with \
ode --check\.

## Fix
Removed the duplicate \import { errorResponse }\ statement, keeping the single import.

## Verification
- \
ode --check backend/api/src/controllers/deviceController.js\ passes.
- Full unit suite unaffected (284 pre-existing failures on clean main are unrelated; no device tests broken).

## GSSOC'24