### PR TITLE
fix: run authenticate before multer on KYC upload route

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -202,7 +202,7 @@ const upload = multer({
   },
 });
 
-router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
+router.post('/kyc/upload', authenticate, kycUploadLimiter, upload.single('image'), async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {


### PR DESCRIPTION
Fixes #10239

## Problem
\POST /api/verification/kyc/upload\ runs \upload.single('image')\ before \uthenticate\, so unauthenticated callers can force the server to buffer large multipart uploads (up to the 8 MB multer limit) in memory before the request is rejected.

## Fix
Reordered the middleware chain to \uthenticate, kycUploadLimiter, upload.single('image')\, consistent with every other upload route in the codebase (e.g. \maintenancePhotoRoutes.js\).

## Verification
- \
ode --check backend/api/src/routes/verificationRoutes.js\ passes.
- Behavior for authenticated users is unchanged.
- Note: \erificationRoutes.test.js\/kycUploadSecurity.test.js currently fail to load on main due to the unmerged duplicate \syncWeightSchema\ export in requestSchemas.js (#10250) — pre-existing, unrelated.

## GSSOC'24