### PR TITLE
[BUG][ml][P1] fix: ensure CPU-bound inference runs exactly once per request on demand/packing/deadhead/mid-trip endpoints

### DIFF
--- a/backend/ml/tests/test_endpoints.py
+++ b/backend/ml/tests/test_endpoints.py
@@ -167,3 +167,108 @@ def test_predict_demand_invalid_fields():
     }
     response = client.post("/predict/demand", json=payload)
     assert response.status_code == 422
+
+
+def test_cpu_bound_inference_runs_once_per_request(monkeypatch):
+    """Regression guard for #10144: demand/packing/deadhead/mid-trip must run
+    the CPU-bound scorer exactly once — never twice via a second
+    asyncio.to_thread call that discards the run_inference result."""
+    import main as main_module
+
+    calls = []
+
+    async def fake_run_inference(func, *args, **kwargs):
+        calls.append(func.__name__)
+        if func is main_module.predict_demand:
+            return 10.0
+        if func is main_module.optimise_packing:
+            return {
+                "packing_arrangement": [],
+                "unpacked_packages": [],
+                "stop_sequence": [0],
+                "utilization_pct": 50.0,
+            }
+        return {"recommendations": []}
+
+    async def fail_to_thread(*args, **kwargs):
+        raise AssertionError(
+            "asyncio.to_thread must not be called by endpoint inference"
+        )
+
+    monkeypatch.setattr(main_module, "run_inference", fake_run_inference)
+    monkeypatch.setattr(main_module.asyncio, "to_thread", fail_to_thread)
+
+    demand_payload = _auth_payload()
+    response = client.post("/predict/demand", json=demand_payload)
+    assert response.status_code == 200
+    assert calls == ["predict_demand"]
+    calls.clear()
+
+    packing_payload = {
+        "packages": [{"length": 1.0, "width": 1.0, "height": 1.0, "weight": 5.0}],
+        "truck": {"length": 10.0, "width": 5.0, "height": 5.0, "max_weight": 1000.0},
+        "delivery_addresses": [{"lat": 19.07, "lng": 72.87}],
+    }
+    response = client.post("/optimise/packing", json=packing_payload)
+    assert response.status_code == 200
+    assert calls == ["optimise_packing"]
+    calls.clear()
+
+    deadhead_payload = {
+        "driver_destination": {"lat": 19.07, "lng": 72.87},
+        "truck_specs": {
+            "max_weight_kg": 10000.0,
+            "max_length_m": 20.0,
+            "max_width_m": 8.0,
+            "max_height_m": 8.0,
+        },
+        "arrival_time": "2026-08-11T10:00:00Z",
+        "available_loads": [
+            {
+                "load_id": "L1",
+                "origin_lat": 19.0,
+                "origin_lng": 72.0,
+                "dest_lat": 20.0,
+                "dest_lng": 73.0,
+                "weight_kg": 5000.0,
+                "length_m": 10.0,
+                "width_m": 5.0,
+                "height_m": 5.0,
+                "pickup_deadline": "2026-08-11T10:00:00Z",
+                "payment_inr": 10000.0,
+            }
+        ],
+    }
+    response = client.post("/match/deadhead", json=deadhead_payload)
+    assert response.status_code == 200
+    assert calls == ["find_return_loads"]
+    calls.clear()
+
+    mid_trip_payload = {
+        "current_location": {"lat": 19.07, "lng": 72.87},
+        "remaining_route": [{"lat": 19.0, "lng": 72.0}],
+        "available_capacity": {
+            "weight_kg": 5000.0,
+            "length_m": 10.0,
+            "width_m": 5.0,
+            "height_m": 5.0,
+        },
+        "nearby_loads": [
+            {
+                "load_id": "L1",
+                "pickup_lat": 19.0,
+                "pickup_lng": 72.0,
+                "dropoff_lat": 20.0,
+                "dropoff_lng": 73.0,
+                "weight_kg": 5000.0,
+                "length_m": 10.0,
+                "width_m": 5.0,
+                "height_m": 5.0,
+                "payment_inr": 10000.0,
+                "pickup_deadline": "2026-08-11T10:00:00Z",
+            }
+        ],
+    }
+    response = client.post("/optimise/mid-trip", json=mid_trip_payload)
+    assert response.status_code == 200
+    assert calls == ["find_mid_trip_loads"]


### PR DESCRIPTION
## Problem

Issue #10144 reports that the demand, packing, deadhead, and mid-trip endpoints each run the CPU-bound scorer twice per request (once via `run_inference` and again via a second `asyncio.to_thread` call that discards the first result), doubling ML latency and inference-worker saturation.

## Fix

On current HEAD the duplicate `asyncio.to_thread` calls have already been removed (merged in #8720), and each of the four endpoints now runs inference exactly once through the bounded `run_inference` helper. This PR locks that behavior in with a regression test that exercises all four endpoints and asserts:

- the scorer is invoked exactly once per request, and
- `asyncio.to_thread` is never called by these endpoints (a second call now fails the test).

## Files changed

- `backend/ml/tests/test_endpoints.py` — added `test_cpu_bound_inference_runs_once_per_request`.

## Testing

- `pytest tests/test_endpoints.py::test_cpu_bound_inference_runs_once_per_request` — passes.
- Full `tests/test_endpoints.py` suite — only pre-existing `test_health` environment-related failure (model set mismatch), unrelated to this change.

Closes #10144
