### PR TITLE
test: rewrite notificationService tests against real module API

### DIFF
--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { sendPushNotification, sendFcmNotification } from '../../src/services/notificationService.js';
+import crypto from 'crypto';
+import { sendPushNotification, sendFcmNotification, hashDeliveryOtp, verifyDeliveryOtpHash } from '../../src/services/notificationService.js';
 
 // notificationService reads supabaseAdmin and firebaseAdmin (not supabase),
 // and getUserFcmToken chains .select().eq().maybeSingle() — a mock lacking
@@ -102,6 +103,21 @@ describe('notificationService', () => {
       await expect(
         sendPushNotification('user-1', 'Title', 'Body', 'invalid_type')
       ).resolves.toBeDefined();
+    });
+  });
+
+  describe('delivery OTP hashing', () => {
+    it('round-trips a salted hash and rejects a wrong OTP', () => {
+      const { hash, salt } = hashDeliveryOtp('123456');
+      expect(hash).toMatch(/^[a-f0-9]{128}$/);
+      expect(verifyDeliveryOtpHash('123456', { otp_hash: hash, otp_salt: salt })).toBe(true);
+      expect(verifyDeliveryOtpHash('654321', { otp_hash: hash, otp_salt: salt })).toBe(false);
+    });
+
+    it('still verifies legacy unsalted SHA-256 hashes', () => {
+      const legacyHash = crypto.createHash('sha256').update('123456').digest('hex');
+      expect(verifyDeliveryOtpHash('123456', { otp_hash: legacyHash })).toBe(true);
+      expect(verifyDeliveryOtpHash('999999', { otp_hash: legacyHash })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
﻿Fixes #10242

## Status
The suite-loading half of this issue was already fixed by the merged PR #10094 (`d6e1d47f0`), which rewrote the tests to use the real named exports and removed the nonexistent default export / `DomainError` import. This PR was rebased on current `main` and now supplies the remaining piece of the issue's suggested fix: coverage for the OTP hashing helpers, which still had zero tests.

## Changes
- `backend/api/test/unit/notificationService.test.js`: added a `delivery OTP hashing` describe block on top of the existing (merged) suite:
  - `hashDeliveryOtp` / `verifyDeliveryOtpHash` round-trip (salted scrypt); wrong OTP is rejected.
  - Legacy unsalted SHA-256 hashes still verify; wrong OTP is rejected.

## Verification
- `npx vitest run test/unit/notificationService.test.js` ? 20/20 passed (18 existing + 2 new).
