### PR TITLE
fix: bound getActiveOrders read with pagination

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -195,7 +195,7 @@ export class OrderLifecycleService {
       const { data: orders, error } = await this.orderRepository.findOrdersByCustomer(
         customerId,
         'id, order_display_id, status, pickup_address, drop_address, pickup_date, pickup_lat, pickup_lng, drop_lat, drop_lng, eta, driver_id, truck_id, truck_number, total_amount, goods_type, weight_tonnes, length_ft, width_ft, height_ft, is_stackable, is_fragile, special_requirements, created_at, updated_at',
-        activeStatuses, 'pickup_date', false
+        activeStatuses, 'pickup_date', false, { limit: 100 }
       );
 
       if (error) throw new DomainError(500, { error: 'Failed to fetch active orders.', details: error.message });


### PR DESCRIPTION
﻿Fixes #10244

## Status
Rebased onto current `main` and resolved the merge conflict (upstream #10202 switched `getActiveOrders` to an explicit column allow-list, which is what clashed with this change).

## Change
- `backend/api/src/services/order/orderLifecycleService.js`: `getActiveOrders` now passes `{ limit: 100 }` (the app-wide max, enforced by `buildPagination`) to `findOrdersByCustomer`, so the read no longer relies on PostgREST's 1000-row server cap. Diff vs `main` is exactly +1/?1.

## Verification
- The changed line parses (vitest transform gets past it; the only parse error in the file is the pre-existing duplicate `newAmountWei` on `main`, introduced upstream by #8133 ? it also breaks `node --check`/ESLint for every PR right now and is unrelated to this change).
- `orderLifecycleService.test.js` 4 failures are pre-existing import failures from that same duplicate declaration.
