### PR TITLE
[BUG][ml][P2] fix: validate /transformer forecast horizon against the model's fixed pred_len and return the actual horizon

### DIFF
--- a/backend/ml/routes/transformer_routes.py
+++ b/backend/ml/routes/transformer_routes.py
@@ -32,9 +32,22 @@ class TrainRequest(BaseModel):
     epochs: int = 50
     batch_size: int = 32
 
+def _validate_horizon(request: ForecastRequest, pred_len: int) -> None:
+    """The transformer output head is sized for a fixed ``pred_len``; reject any
+    requested horizon that does not match so the response never lies about the
+    number of forecast points returned."""
+    if request.horizon != pred_len:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"horizon must equal the model's fixed prediction length ({pred_len})"
+            ),
+        )
+
 @router.post("/demand/forecast")
 async def forecast_demand(request: ForecastRequest):
     """Forecast demand using transformer"""
+    _validate_horizon(request, demand_model.transformer.pred_len)
     try:
         # Convert to tensor
         x = torch.tensor(request.data, dtype=torch.float32)
@@ -48,7 +61,7 @@ async def forecast_demand(request: ForecastRequest):
             'success': True,
             'data': {
                 'predictions': predictions.tolist(),
-                'horizon': request.horizon,
+                'horizon': demand_model.transformer.pred_len,
                 'type': 'demand'
             },
             'timestamp': datetime.now().isoformat()
@@ -62,6 +75,7 @@ async def forecast_demand(request: ForecastRequest):
 @router.post("/traffic/forecast")
 async def forecast_traffic(request: ForecastRequest):
     """Forecast traffic using transformer"""
+    _validate_horizon(request, traffic_model.transformer.pred_len)
     try:
         x = torch.tensor(request.data, dtype=torch.float32)
         if len(x.shape) == 2:
@@ -73,7 +87,7 @@ async def forecast_traffic(request: ForecastRequest):
             'success': True,
             'data': {
                 'predictions': predictions.tolist(),
-                'horizon': request.horizon,
+                'horizon': traffic_model.transformer.pred_len,
                 'type': 'traffic'
             },
             'timestamp': datetime.now().isoformat()
@@ -87,6 +101,7 @@ async def forecast_traffic(request: ForecastRequest):
 @router.post("/price/forecast")
 async def forecast_price(request: ForecastRequest):
     """Forecast price using transformer"""
+    _validate_horizon(request, price_model.transformer.pred_len)
     try:
         x = torch.tensor(request.data, dtype=torch.float32)
         if len(x.shape) == 2:
@@ -98,7 +113,7 @@ async def forecast_price(request: ForecastRequest):
             'success': True,
             'data': {
                 'predictions': predictions.tolist(),
-                'horizon': request.horizon,
+                'horizon': price_model.transformer.pred_len,
                 'type': 'price'
             },
             'timestamp': datetime.now().isoformat()

--- a/backend/ml/tests/test_transformers.py
+++ b/backend/ml/tests/test_transformers.py
@@ -1,9 +1,24 @@
 import pytest
 import torch
+from fastapi import HTTPException
 from transformers.model import TimeSeriesTransformer
+from routes.transformer_routes import (
+    ForecastRequest,
+    _validate_horizon,
+)
 
 class TestTimeSeriesTransformer:
     def test_transformer_init(self):
         model = TimeSeriesTransformer(seq_len=60, pred_len=12, d_model=64)
         assert model is not None
         assert hasattr(model, 'forward')
+
+
+class TestHorizonValidation:
+    def test_matching_horizon_passes(self):
+        _validate_horizon(ForecastRequest(data=[[1.0]], horizon=24), 24)
+
+    def test_mismatched_horizon_rejected(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_horizon(ForecastRequest(data=[[1.0]], horizon=48), 24)
+        assert exc_info.value.status_code == 422


### PR DESCRIPTION
## Problem

`POST /transformer/demand/forecast` accepts a `horizon` field but never passes it into the model — the transformer is built with a fixed `pred_len` (demand/price: 24, traffic: 12), so the forecast series always has that fixed length while the response echoes the client's requested `horizon`. Callers requesting `horizon=48` get 24 points but a response claiming 48.

## Fix

Since the output projection head is sized for a fixed `pred_len`, a request-level horizon is validated explicitly:

- A `_validate_horizon()` helper rejects any requested `horizon` that differs from the model's fixed prediction length with a clear `422` response.
- All three forecast endpoints (`/demand/forecast`, `/traffic/forecast`, `/price/forecast`) now call it before running inference.
- Each response reports the **actual** prediction length (`model.transformer.pred_len`) instead of echoing the client's request, so consumers never size charts/buffers from a value the model does not honor.

## Files changed

- `backend/ml/routes/transformer_routes.py` — added `_validate_horizon()`, wired it into all three forecast endpoints, and return the real `pred_len` in the response.
- `backend/ml/tests/test_transformers.py` — added `TestHorizonValidation` covering the matching-horizon pass case and the mismatched-horizon 422 case.

## Testing

- `pytest tests/test_transformers.py` — 3 passed.

Closes #10145
