### PR TITLE
fix: use authenticated client for offline GPS reads and sync

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -414,7 +414,11 @@ class WebRTCSignalingServer {
       logger.warn(`[WebRTC] Unauthorized offline GPS data access attempt for peer ${peerId}`);
       return [];
     }
-    const { data } = await supabase
+    const peer = this.peers.get(peerId);
+    // Use an authenticated Supabase client for GPS data reads (RLS requires authenticated role)
+    const userClient = peer?.token ? createUserClient(peer.token) : null;
+    const gpsClient = userClient || supabase;
+    const { data } = await gpsClient
       .from('gps_offline_data')
       .select('*')
       .eq('peerId', peerId)
@@ -430,7 +434,11 @@ class WebRTCSignalingServer {
       return;
     }
     // Mark data as synced for this peer
-    await supabase
+    const peer = this.peers.get(peerId);
+    // Use an authenticated Supabase client for GPS data updates (RLS requires authenticated role)
+    const userClient = peer?.token ? createUserClient(peer.token) : null;
+    const gpsClient = userClient || supabase;
+    await gpsClient
       .from('gps_offline_data')
       .update({ synced: true })
       .eq('peerId', peerId)


### PR DESCRIPTION
Fixes #10245

## Problem
\getOfflineGPSData\ and \syncOfflineData\ in \WebRTCSignalingServer.js\ read and update \gps_offline_data\ via the anonymous \supabase\ client. Under RLS, the anon role has no access to this table, so offline GPS data can never be retrieved or marked synced — only the insert path (line ~247) had been migrated to an authenticated client via \createUserClient(peer.token)\.

## Fix
Mirrored the existing authenticated-client pattern from the insert path: both methods now build \createUserClient(peer.token)\ from the peer in the in-memory map (falling back to \supabase\ exactly like the insert path) before hitting \gps_offline_data\.

## Verification
- \
ode --check backend/api/src/services/webrtc/WebRTCSignalingServer.js\ passes.
- \
px vitest run test/unit/WebRTCSignalingServer.test.js\ → 61/61 passed.

## GSSOC'24