### PR TITLE
fix: use service-role client for reputation failure logging

### DIFF
--- a/backend/api/src/subscribers/reputationSubscriber.js
+++ b/backend/api/src/subscribers/reputationSubscriber.js
@@ -1,7 +1,7 @@
 import { eventBus } from '../core/events/index.js';
 import { awardReputationPoints } from '../services/reputation.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
-import { supabase } from '../config/db.js';
+import { supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { ContextPropagator } from '../core/telemetry/ContextPropagator.js';
 import spanFactory from '../core/telemetry/SpanFactory.js';
@@ -38,7 +38,7 @@ eventBus.subscribe('rating:submitted', async (payload) => {
         
         // Attempt to log failure in DB for retry worker
         try {
-          const orderRepository = new OrderRepository(supabase);
+          const orderRepository = new OrderRepository(supabaseAdmin);
           await orderRepository.insertReputationFailure({
             driver_wallet: driverWallet,
             stars,


### PR DESCRIPTION
Fixes #10246

## Problem
When an on-chain reputation update fails, \eputationSubscriber.js\ logs the failure by constructing \
ew OrderRepository(supabase)\ with the anonymous client. The \eputation_failures\ table is not readable/writable by the anon role under RLS, so the retry-worker record is never persisted.

## Fix
Use the service-role \supabaseAdmin\ client instead, matching the pattern already used by other background writers (\uditLogService.js\, \documentExpiryService.js\). Background subscribers have no user session, so \supabaseAdmin\ is the correct client here.

## Verification
- \
ode --check backend/api/src/subscribers/reputationSubscriber.js\ passes.

## GSSOC'24