### PR TITLE
fix : removed duplicate syncWeightSchema export in requestSchemas

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -412,16 +412,3 @@ export const reportGripDataSchema = z.object({
   ).optional().default(0),
 }).strict();
 
-
-/**
- * Schema for POST /api/driver/weigh-stations/sync-weight
- */
-export const syncWeightSchema = z.object({
-  vehicleId: z.string().min(1, 'vehicleId is required'),
-  truckId: z.string().min(1, 'truckId is required'),
-  axles: z.array(z.object({
-    position: z.number().int().min(0),
-    pressure_psi: z.number().positive('pressure_psi must be a positive number'),
-  })).min(1, 'At least one axle is required'),
-  timestamp: z.string().datetime({ message: 'timestamp must be ISO 8601' }).optional(),
-});


### PR DESCRIPTION
Closes #10282.

Summary of What Has Been Done:
Removed the duplicated syncWeightSchema export from requestSchemas.js. The module now parses as valid ESM, so routes and tests importing it load correctly. Verified the schema suite (84 tests) passes and the module imports cleanly.

Changes Made:
- backend/api/src/validation/requestSchemas.js: removed the second, unused syncWeightSchema declaration

Impact it Made:
Fixes the ESM duplicate-export SyntaxError that broke all importers of requestSchemas; verified with `npx vitest run test/unit/requestSchemas.test.js test/unit/loadSchemas.test.js` (84/84 passed) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.