### PR TITLE
fix: use service-role client in FuelAdvisorService

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -96,7 +96,7 @@ import { FuelAdvisorService } from '../services/fuelAdvisorService.js';
 import { WeatherService } from '../services/weatherService.js';
 
 const weatherService = new WeatherService({ logger });
-const fuelAdvisorService = new FuelAdvisorService({ supabase, weatherService, logger });
+const fuelAdvisorService = new FuelAdvisorService({ supabase: supabaseAdmin, weatherService, logger });
 
 const DEFAULT_TRUCK_TYPES = ['Open Body', 'Closed Body', 'Container', 'Refrigerated'];
 


### PR DESCRIPTION
Fixes #10247

## Problem
\FuelAdvisorService\ (instantiated in \	ruckRoutes.js\) reads \orders\, \	rips\, and \	rip_events\ to compute the engine-load fuel recommendation, but is constructed with the anonymous \supabase\ client. Under RLS the anon role cannot read those tables, so \GET /trucks/:id/fuel-recommendation\ always computes from empty data (or errors server-side).

## Fix
Construct the service with the already-imported service-role \supabaseAdmin\ client. Route-level authorization is unaffected — the handler still enforces truck ownership for driver roles before calling the service.

## Verification
- \
ode --check backend/api/src/routes/truckRoutes.js\ passes.

## GSSOC'24