### PR TITLE
fix: validate page and limit on order history routes

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1154,6 +1154,13 @@ router.get('/history', authenticate, userLimiter, requirePolicy('order:view-hist
   const page = cursor ? parseInt(cursor, 10) : (parseInt(req.query.page, 10) || 1);
   const limit = parseInt(req.query.limit, 10) || 20;
 
+  if (page < 1) {
+    return res.status(400).json({ error: 'Invalid page parameter. Must be a positive integer.' });
+  }
+  if (limit < 1 || limit > 100) {
+    return res.status(400).json({ error: 'Invalid limit parameter. Must be between 1 and 100.' });
+  }
+
   try {
     const result = await orderLifecycleService.getOrderHistory(req.user.id, page, limit);
     return res.json(result);
@@ -1187,6 +1194,13 @@ router.get('/my/history', authenticate, userLimiter, requirePolicy('order:view-h
 
   const page = cursor ? parseInt(cursor, 10) : (parseInt(req.query.page, 10) || 1);
   const limit = parseInt(req.query.limit, 10) || 20;
+
+  if (page < 1) {
+    return res.status(400).json({ error: 'Invalid page parameter. Must be a positive integer.' });
+  }
+  if (limit < 1 || limit > 100) {
+    return res.status(400).json({ error: 'Invalid limit parameter. Must be between 1 and 100.' });
+  }
 
   try {
     const result = await orderLifecycleService.getOrderHistory(req.user.id, page, limit);


### PR DESCRIPTION
Fixes #10248

## Problem
\GET /api/orders/history\ and \GET /api/orders/my/history\ parse \page\/\limit\ from the query string with no validation. Negative or absurd values (e.g. \page=-5\, \limit=999999999\) flow straight into \indOrdersWithCount\, which builds \.range(from, to)\ without clamping — negative offsets make PostgREST error and the route returns 500.

## Fix
Validate both params at the route layer, mirroring the existing \cursor\ validation above: reject \page < 1\ and \limit\ outside 1..100 (the app-wide max used by \uildPagination\) with 400 responses.

## Verification
- \
ode --check backend/api/src/routes/orderRoutes.js\ passes.
- Applied to both \/history\ and \/my/history\ handlers.
- Note: orderRoutes tests cannot load on main due to the unmerged duplicate \syncWeightSchema\ export (#10250) — pre-existing, unrelated.

## GSSOC'24