### PR TITLE
fix: add request timeout to Snyk API calls

### DIFF
--- a/snyk/snyk.service.js
+++ b/snyk/snyk.service.js
@@ -7,6 +7,8 @@ import logger from '../backend/api/src/middleware/logger.js';
 
 const execAsync = promisify(exec);
 
+const REQUEST_TIMEOUT_MS = 15000;
+
 class SnykService {
     constructor() {
         this.snykToken = process.env.SNYK_TOKEN;
@@ -179,7 +181,8 @@ class SnykService {
                 {
                     headers: {
                         'Authorization': `token ${this.snykToken}`
-                    }
+                    },
+                    timeout: REQUEST_TIMEOUT_MS
                 }
             );
             
@@ -202,7 +205,8 @@ class SnykService {
                 {
                     headers: {
                         'Authorization': `token ${this.snykToken}`
-                    }
+                    },
+                    timeout: REQUEST_TIMEOUT_MS
                 }
             );
             
@@ -224,7 +228,8 @@ class SnykService {
                 {
                     headers: {
                         'Authorization': `token ${this.snykToken}`
-                    }
+                    },
+                    timeout: REQUEST_TIMEOUT_MS
                 }
             );
             


### PR DESCRIPTION
Fixes #10249

## Problem
\snyk/snyk.service.js\ makes three axios calls (\getVulnerabilities\, \createFixPR\, \getProjects\) with no \	imeout\, so a hanging Snyk API can block these requests indefinitely.

## Fix
Added a module-level \REQUEST_TIMEOUT_MS = 15000\ and set \	imeout\ on all three requests.

## Verification
- \
ode --check snyk/snyk.service.js\ passes.

## GSSOC'24