### PR TITLE
fix : guarded paginated() against non-positive limit values

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -26,19 +26,25 @@ export function error(message = 'An error occurred', statusCode = 500, errors = 
 }
 
 export function paginated(data = [], page = 1, limit = 10, total = 0, message = 'Success') {
-  const totalPages = Math.ceil(total / limit) || 0;
+  // Guard against a non-positive or non-finite limit so the pagination
+  // envelope never contains Infinity (e.g. limit=0 would otherwise make
+  // totalPages = Math.ceil(total/0) = Infinity).
+  const safeLimit = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : 1;
+  const safePage = Number.isFinite(Number(page)) ? Number(page) : 1;
+  const safeTotal = Number.isFinite(Number(total)) ? Number(total) : 0;
+  const totalPages = Math.ceil(safeTotal / safeLimit) || 0;
   return {
     success: true,
     statusCode: 200,
     message,
     data,
     pagination: {
-      page: Number(page),
-      limit: Number(limit),
-      total: Number(total),
+      page: safePage,
+      limit: safeLimit,
+      total: safeTotal,
       totalPages,
-      hasNextPage: Number(page) < totalPages,
-      hasPrevPage: Number(page) > 1,
+      hasNextPage: safePage < totalPages,
+      hasPrevPage: safePage > 1,
     },
   };
 }

--- a/backend/api/test/unit/apiResponse.test.js
+++ b/backend/api/test/unit/apiResponse.test.js
@@ -114,6 +114,25 @@ describe('apiResponse helpers', () => {
 
 
 describe('paginated edge cases', () => {
+  it('handles a zero limit without producing Infinity', () => {
+    const result = paginated([], 1, 0, 10);
+    expect(result.pagination.limit).toBe(1);
+    expect(result.pagination.totalPages).toBe(10);
+    expect(Number.isFinite(result.pagination.totalPages)).toBe(true);
+  });
+
+  it('handles a negative limit without producing Infinity', () => {
+    const result = paginated([], 1, -5, 10);
+    expect(result.pagination.limit).toBe(1);
+    expect(result.pagination.totalPages).toBe(10);
+  });
+
+  it('handles a non-finite limit gracefully', () => {
+    const result = paginated([], 1, NaN, 10);
+    expect(result.pagination.limit).toBe(1);
+    expect(result.pagination.totalPages).toBe(10);
+  });
+
   it('handles page 0 gracefully', () => {
     const result = paginated([{ id: 1 }], 0, 10, 1);
     expect(result.pagination.page).toBe(0);


### PR DESCRIPTION
Closes #10303.

Summary of What Has Been Done:
Added a guard in paginated() that clamps non-positive or non-finite limit values to a positive finite fallback, so the pagination envelope never contains Infinity. Added three regression tests.

Changes Made:
- backend/api/src/lib/apiResponse.js: safeLimit clamp in paginated()
- backend/api/test/unit/apiResponse.test.js: 3 new tests (zero/negative/NaN limit)

Impact it Made:
Prevents Infinity from leaking into pagination metadata; verified with `npx vitest run test/unit/apiResponse.test.js` (3 new tests pass, pre-existing failure count unchanged) and eslint clean.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.