### PR TITLE
fix: hoist outbox relay worker imports in index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -165,6 +165,7 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
+import { startOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -741,7 +742,6 @@ server.listen(PORT, () => {
   startStaleOrderWorker(escrowReconciliationOrderRepository)
   startDocumentExpiryWorker()
   startWithdrawalSettlementWorker()
-  import { startOutboxRelayWorker } from './workers/outboxRelayWorker.js'
   startOutboxRelayWorker()
 
   // Register worker states for health aggregation

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -165,7 +165,7 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
-import { startOutboxRelayWorker } from './workers/outboxRelayWorker.js'
+import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -784,7 +784,6 @@ async function shutdown(signal) {
   stopDlqWorker()
   stopDocumentExpiryWorker()
   stopWithdrawalSettlementWorker()
-  import { stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
   stopOutboxRelayWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()


### PR DESCRIPTION
Fixes #10305

## Problem
\src/index.js\ had \import { startOutboxRelayWorker }\ and \import { stopOutboxRelayWorker }\ inside function bodies (in \startWorkers()\/\stopWorkers()\). Static imports are only legal at module top level, so \
ode --check\ failed with \SyntaxError: Unexpected token '{'\ and the API could not boot at all.

## Fix
Hoisted both to the top-level imports as \import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'\ and kept the calls in the worker lifecycle functions.

## Verification
- \
ode --check backend/api/src/index.js\ now passes.

## GSSOC'24