### PR TITLE
fix(blockchain): watch real TruxifyEscrow events in BlockchainMonitor

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - "backend/api/**"
+      - "blockchain/**"
       - ".github/workflows/backend-ci.yml"
   push:
     branches:
       - main
     paths:
       - "backend/api/**"
+      - "blockchain/**"
       - ".github/workflows/backend-ci.yml"
 
 concurrency:
@@ -35,6 +37,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Verify monitored blockchain events exist in contract sources
+        run: node backend/api/scripts/check-blockchain-events.js
 
       - name: Install dependencies
         working-directory: backend/api

--- a/backend/api/scripts/check-blockchain-events.js
+++ b/backend/api/scripts/check-blockchain-events.js
@@ -1,0 +1,51 @@
+/**
+ * Verifies that every event watched by the blockchain monitor is declared or
+ * emitted by at least one Solidity contract under blockchain/contracts/.
+ *
+ * Run from the repo root:  node backend/api/scripts/check-blockchain-events.js
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..', '..', '..');
+
+const monitorPath = resolve(repoRoot, 'backend/api/src/services/blockchain/blockchainMonitor.js');
+const monitorSource = readFileSync(monitorPath, 'utf8');
+
+const watchedNames = [...monitorSource.matchAll(/event\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g)].map((m) => m[1]);
+
+function collectSolFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...collectSolFiles(full));
+    } else if (full.endsWith('.sol')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const contractsDir = resolve(repoRoot, 'blockchain/contracts');
+const contractSources = collectSolFiles(contractsDir).map((file) => readFileSync(file, 'utf8'));
+
+const missing = watchedNames.filter(
+  (name) => !contractSources.some((source) => new RegExp(`\\b${name}\\b`).test(source)),
+);
+
+if (missing.length > 0) {
+  console.error(
+    '[check-blockchain-events] The monitor watches events that no contract in blockchain/contracts/ declares or emits:',
+  );
+  for (const name of missing) {
+    console.error(`  - ${name}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `[check-blockchain-events] OK: ${watchedNames.length} watched events all exist in blockchain/contracts/.`,
+);

--- a/backend/api/src/routes/blockchainMonitoringRoutes.js
+++ b/backend/api/src/routes/blockchainMonitoringRoutes.js
@@ -72,7 +72,7 @@ router.post('/alerts/:alertId/resolve', authenticate, requireRole(['admin', 'sup
 
 /**
  * Get monitoring events with filtering
- * GET /api/blockchain/events?type=PAYMENT_RECEIVED&severity=CRITICAL&limit=50
+ * GET /api/blockchain/events?type=BOOKING_DISPUTED&severity=CRITICAL&limit=50
  */
 router.get('/events', authenticate, requireRole(['admin', 'support']), async (req, res) => {
   try {
@@ -86,12 +86,17 @@ router.get('/events', authenticate, requireRole(['admin', 'support']), async (re
 
     // Validate event type if provided
     const validTypes = [
-      'PAYMENT_RECEIVED',
-      'INSURANCE_CLAIM_APPROVED',
-      'INSURANCE_CLAIM_REJECTED',
-      'GEOFENCE_BREACH',
-      'BALANCE_UPDATE_FAILED',
-      'SMART_CONTRACT_REVERT',
+      'BOOKING_CREATED',
+      'PAYMENT_RELEASED',
+      'BOOKING_CANCELLED',
+      'BOOKING_STARTED',
+      'CANCELLATION_PENALTY_APPLIED',
+      'BOOKING_DISPUTED',
+      'DISPUTE_RESOLVED',
+      'WITHDRAWAL_READY',
+      'WITHDRAWN',
+      'EMERGENCY_RECOVERED',
+      'RELAYER_UPDATED',
     ];
     if (type && !validTypes.includes(type)) {
       return res.status(400).json({ error: 'Invalid event type' });

--- a/backend/api/src/services/blockchain/alertRouter.js
+++ b/backend/api/src/services/blockchain/alertRouter.js
@@ -174,12 +174,17 @@ class AlertRouter {
 
   getTypeEmoji(type) {
     const emojis = {
-      PAYMENT_RECEIVED: '💰',
-      INSURANCE_CLAIM_APPROVED: '✅',
-      INSURANCE_CLAIM_REJECTED: '❌',
-      GEOFENCE_BREACH: '⚠️',
-      BALANCE_UPDATE_FAILED: '🚨',
-      SMART_CONTRACT_REVERT: '💥',
+      BOOKING_CREATED: '📋',
+      PAYMENT_RELEASED: '💰',
+      BOOKING_CANCELLED: '↩️',
+      BOOKING_STARTED: '🚚',
+      CANCELLATION_PENALTY_APPLIED: '⚖️',
+      BOOKING_DISPUTED: '⚠️',
+      DISPUTE_RESOLVED: '✅',
+      WITHDRAWAL_READY: '🏦',
+      WITHDRAWN: '💵',
+      EMERGENCY_RECOVERED: '🚨',
+      RELAYER_UPDATED: '🔄',
     };
     return emojis[type] || '📢';
   }

--- a/backend/api/src/services/blockchain/blockchainMonitor.js
+++ b/backend/api/src/services/blockchain/blockchainMonitor.js
@@ -4,20 +4,30 @@ import * as Sentry from '@sentry/node';
 import { supabase, supabaseAdmin } from '../../config/db.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 
-const PAYMENT_RECEIVED_EVENT = 'PaymentReceived(address indexed driver, uint256 amount, uint256 timestamp)';
-const INSURANCE_CLAIM_APPROVED_EVENT = 'InsuranceClaimApproved(uint256 indexed claimId, uint256 amount)';
-const INSURANCE_CLAIM_REJECTED_EVENT = 'InsuranceClaimRejected(uint256 indexed claimId, string reason)';
-const GEOFENCE_BREACH_EVENT = 'GeofenceBreach(uint256 indexed shipmentId, address driver)';
-const BALANCE_UPDATE_FAILED_EVENT = 'BalanceUpdateFailed(address indexed wallet, string reason)';
-const SMART_CONTRACT_REVERT_EVENT = 'SmartContractRevert(bytes indexed txHash, string reason)';
+const BOOKING_CREATED_EVENT = 'event BookingCreated(uint256 indexed bookingId, address indexed customer, address indexed driver, uint256 amount)';
+const PAYMENT_RELEASED_EVENT = 'event PaymentReleased(uint256 indexed bookingId, address indexed driver, uint256 amount)';
+const BOOKING_CANCELLED_EVENT = 'event BookingCancelled(uint256 indexed bookingId, address indexed customer, uint256 refundAmount)';
+const BOOKING_STARTED_EVENT = 'event BookingStarted(uint256 indexed bookingId, address indexed driver, uint256 amount)';
+const CANCELLATION_PENALTY_APPLIED_EVENT = 'event CancellationPenaltyApplied(uint256 indexed bookingId, address indexed driver, uint256 driverAmount, address customer, uint256 refundAmount)';
+const BOOKING_DISPUTED_EVENT = 'event BookingDisputed(uint256 indexed bookingId, address indexed raisedBy)';
+const DISPUTE_RESOLVED_EVENT = 'event DisputeResolved(uint256 indexed bookingId, address indexed driver, uint256 driverAmount, address indexed customer, uint256 refundAmount)';
+const WITHDRAWAL_READY_EVENT = 'event WithdrawalReady(uint256 indexed bookingId, address indexed recipient, uint256 amount)';
+const WITHDRAWN_EVENT = 'event Withdrawn(address indexed recipient, uint256 amount)';
+const EMERGENCY_RECOVERED_EVENT = 'event EmergencyRecovered(address indexed recipient, uint256 amount)';
+const RELAYER_UPDATED_EVENT = 'event RelayerUpdated(address indexed newRelayer)';
 
 const ESCROW_ABI = [
-  'event PaymentReceived(address indexed driver, uint256 amount, uint256 timestamp)',
-  'event InsuranceClaimApproved(uint256 indexed claimId, uint256 amount)',
-  'event InsuranceClaimRejected(uint256 indexed claimId, string reason)',
-  'event GeofenceBreach(uint256 indexed shipmentId, address driver)',
-  'event BalanceUpdateFailed(address indexed wallet, string reason)',
-  'event SmartContractRevert(bytes indexed txHash, string reason)',
+  BOOKING_CREATED_EVENT,
+  PAYMENT_RELEASED_EVENT,
+  BOOKING_CANCELLED_EVENT,
+  BOOKING_STARTED_EVENT,
+  CANCELLATION_PENALTY_APPLIED_EVENT,
+  BOOKING_DISPUTED_EVENT,
+  DISPUTE_RESOLVED_EVENT,
+  WITHDRAWAL_READY_EVENT,
+  WITHDRAWN_EVENT,
+  EMERGENCY_RECOVERED_EVENT,
+  RELAYER_UPDATED_EVENT,
 ];
 
 class BlockchainMonitor {
@@ -85,12 +95,17 @@ class BlockchainMonitor {
 
   setupEventHandlers() {
     this.eventHandlers = {
-      'PaymentReceived': this.handlePaymentReceived.bind(this),
-      'InsuranceClaimApproved': this.handleInsuranceClaimApproved.bind(this),
-      'InsuranceClaimRejected': this.handleInsuranceClaimRejected.bind(this),
-      'GeofenceBreach': this.handleGeofenceBreach.bind(this),
-      'BalanceUpdateFailed': this.handleBalanceUpdateFailed.bind(this),
-      'SmartContractRevert': this.handleSmartContractRevert.bind(this),
+      'BookingCreated': this.handleBookingCreated.bind(this),
+      'PaymentReleased': this.handlePaymentReleased.bind(this),
+      'BookingCancelled': this.handleBookingCancelled.bind(this),
+      'BookingStarted': this.handleBookingStarted.bind(this),
+      'CancellationPenaltyApplied': this.handleCancellationPenaltyApplied.bind(this),
+      'BookingDisputed': this.handleBookingDisputed.bind(this),
+      'DisputeResolved': this.handleDisputeResolved.bind(this),
+      'WithdrawalReady': this.handleWithdrawalReady.bind(this),
+      'Withdrawn': this.handleWithdrawn.bind(this),
+      'EmergencyRecovered': this.handleEmergencyRecovered.bind(this),
+      'RelayerUpdated': this.handleRelayerUpdated.bind(this),
     };
   }
 
@@ -151,15 +166,33 @@ class BlockchainMonitor {
     }
   }
 
-  async handlePaymentReceived(args, log) {
-    const [driver, amount, timestamp] = args;
+  async handleBookingCreated(args, log) {
+    const [bookingId, customer, driver, amount] = args;
 
     const alert = {
-      type: 'PAYMENT_RECEIVED',
-      severity: 'MEDIUM',
+      type: 'BOOKING_CREATED',
+      severity: 'LOW',
+      bookingId: bookingId.toString(),
+      customer,
       driver,
       amount: amount.toString(),
-      timestamp: parseInt(timestamp),
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
+  }
+
+  async handlePaymentReleased(args, log) {
+    const [bookingId, driver, amount] = args;
+
+    const alert = {
+      type: 'PAYMENT_RELEASED',
+      severity: 'MEDIUM',
+      bookingId: bookingId.toString(),
+      driver,
+      amount: amount.toString(),
       txHash: log.transactionHash,
       blockNumber: log.blockNumber,
     };
@@ -169,13 +202,31 @@ class BlockchainMonitor {
     this.metricsService?.recordPaymentEvent('success');
   }
 
-  async handleInsuranceClaimApproved(args, log) {
-    const [claimId, amount] = args;
+  async handleBookingCancelled(args, log) {
+    const [bookingId, customer, refundAmount] = args;
 
     const alert = {
-      type: 'INSURANCE_CLAIM_APPROVED',
+      type: 'BOOKING_CANCELLED',
       severity: 'MEDIUM',
-      claimId: claimId.toString(),
+      bookingId: bookingId.toString(),
+      customer,
+      refundAmount: refundAmount.toString(),
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
+  }
+
+  async handleBookingStarted(args, log) {
+    const [bookingId, driver, amount] = args;
+
+    const alert = {
+      type: 'BOOKING_STARTED',
+      severity: 'LOW',
+      bookingId: bookingId.toString(),
+      driver,
       amount: amount.toString(),
       txHash: log.transactionHash,
       blockNumber: log.blockNumber,
@@ -183,83 +234,129 @@ class BlockchainMonitor {
 
     await this.storeEvent(alert);
     await this.alertRouter?.route(alert);
-    this.metricsService?.recordInsuranceEvent('approved');
   }
 
-  async handleInsuranceClaimRejected(args, log) {
-    const [claimId, reason] = args;
+  async handleCancellationPenaltyApplied(args, log) {
+    const [bookingId, driver, driverAmount, customer, refundAmount] = args;
 
     const alert = {
-      type: 'INSURANCE_CLAIM_REJECTED',
-      severity: 'HIGH',
-      claimId: claimId.toString(),
-      reason,
-      txHash: log.transactionHash,
-      blockNumber: log.blockNumber,
-    };
-
-    await this.storeEvent(alert);
-    await this.alertRouter?.route(alert);
-    this.metricsService?.recordInsuranceEvent('rejected');
-
-    if (alert.severity === 'HIGH' || alert.severity === 'CRITICAL') {
-      await this.escalationHandler?.escalate(alert);
-    }
-  }
-
-  async handleGeofenceBreach(args, log) {
-    const [shipmentId, driver] = args;
-
-    const alert = {
-      type: 'GEOFENCE_BREACH',
-      severity: 'HIGH',
-      shipmentId: shipmentId.toString(),
+      type: 'CANCELLATION_PENALTY_APPLIED',
+      severity: 'MEDIUM',
+      bookingId: bookingId.toString(),
       driver,
+      driverAmount: driverAmount.toString(),
+      customer,
+      refundAmount: refundAmount.toString(),
       txHash: log.transactionHash,
       blockNumber: log.blockNumber,
     };
 
     await this.storeEvent(alert);
     await this.alertRouter?.route(alert);
-    this.metricsService?.recordGeofenceBreach();
-    await this.escalationHandler?.escalate(alert);
   }
 
-  async handleBalanceUpdateFailed(args, log) {
-    const [wallet, reason] = args;
+  async handleBookingDisputed(args, log) {
+    const [bookingId, raisedBy] = args;
 
     const alert = {
-      type: 'BALANCE_UPDATE_FAILED',
-      severity: 'CRITICAL',
-      wallet,
-      reason,
+      type: 'BOOKING_DISPUTED',
+      severity: 'HIGH',
+      bookingId: bookingId.toString(),
+      raisedBy,
       txHash: log.transactionHash,
       blockNumber: log.blockNumber,
-      timestamp: new Date().toISOString(),
     };
 
     await this.storeEvent(alert);
     await this.alertRouter?.route(alert);
-    this.metricsService?.recordBalanceUpdateFailure();
     await this.escalationHandler?.escalate(alert);
   }
 
-  async handleSmartContractRevert(args, log) {
-    const [txHash, reason] = args;
+  async handleDisputeResolved(args, log) {
+    const [bookingId, driver, driverAmount, customer, refundAmount] = args;
 
     const alert = {
-      type: 'SMART_CONTRACT_REVERT',
-      severity: 'CRITICAL',
-      txHash: '0x' + txHash.slice(2).padEnd(64, '0'),
-      reason,
+      type: 'DISPUTE_RESOLVED',
+      severity: 'MEDIUM',
+      bookingId: bookingId.toString(),
+      driver,
+      driverAmount: driverAmount.toString(),
+      customer,
+      refundAmount: refundAmount.toString(),
+      txHash: log.transactionHash,
       blockNumber: log.blockNumber,
-      timestamp: new Date().toISOString(),
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
+    this.metricsService?.recordPaymentEvent('success');
+  }
+
+  async handleWithdrawalReady(args, log) {
+    const [bookingId, recipient, amount] = args;
+
+    const alert = {
+      type: 'WITHDRAWAL_READY',
+      severity: 'MEDIUM',
+      bookingId: bookingId.toString(),
+      recipient,
+      amount: amount.toString(),
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
+  }
+
+  async handleWithdrawn(args, log) {
+    const [recipient, amount] = args;
+
+    const alert = {
+      type: 'WITHDRAWN',
+      severity: 'MEDIUM',
+      recipient,
+      amount: amount.toString(),
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
+    this.metricsService?.recordPaymentEvent('success');
+  }
+
+  async handleEmergencyRecovered(args, log) {
+    const [recipient, amount] = args;
+
+    const alert = {
+      type: 'EMERGENCY_RECOVERED',
+      severity: 'CRITICAL',
+      recipient,
+      amount: amount.toString(),
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
     };
 
     await this.storeEvent(alert);
     await this.alertRouter?.route(alert);
     this.metricsService?.recordContractRevert();
     await this.escalationHandler?.escalate(alert);
+  }
+
+  async handleRelayerUpdated(args, log) {
+    const [newRelayer] = args;
+
+    const alert = {
+      type: 'RELAYER_UPDATED',
+      severity: 'MEDIUM',
+      newRelayer,
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    await this.storeEvent(alert);
+    await this.alertRouter?.route(alert);
   }
 
   async storeEvent(alert) {

--- a/backend/api/test/unit/blockchainMonitorGuard.test.js
+++ b/backend/api/test/unit/blockchainMonitorGuard.test.js
@@ -35,7 +35,7 @@ describe('BlockchainMonitor', () => {
 
   it('wires event handlers for all supported event names', () => {
     monitor.setupEventHandlers();
-    const expected = ['PaymentReceived', 'InsuranceClaimApproved', 'InsuranceClaimRejected', 'GeofenceBreach', 'BalanceUpdateFailed', 'SmartContractRevert'];
+    const expected = ['BookingCreated', 'PaymentReleased', 'BookingCancelled', 'BookingStarted', 'CancellationPenaltyApplied', 'BookingDisputed', 'DisputeResolved', 'WithdrawalReady', 'Withdrawn', 'EmergencyRecovered', 'RelayerUpdated'];
     for (const name of expected) {
       expect(typeof monitor.eventHandlers[name]).toBe('function');
     }

--- a/backend/api/test/unit/blockchainMonitoringRoutes.test.js
+++ b/backend/api/test/unit/blockchainMonitoringRoutes.test.js
@@ -106,12 +106,12 @@ describe('blockchainMonitoringRoutes', () => {
 
   it('GET /api/blockchain/events queries blockchain_monitoring_events through the attached supabase client', async () => {
     const res = await request(buildApp({ blockchainMetrics: metrics, escalationHandler, supabase }))
-      .get('/api/blockchain/events?type=PAYMENT_RECEIVED&severity=CRITICAL&limit=10');
+      .get('/api/blockchain/events?type=BOOKING_DISPUTED&severity=CRITICAL&limit=10');
 
     expect(res.status).toBe(200);
     expect(supabase.from).toHaveBeenCalledWith('blockchain_monitoring_events');
     expect(supabase.calls).toEqual([
-      { column: 'type', value: 'PAYMENT_RECEIVED' },
+      { column: 'type', value: 'BOOKING_DISPUTED' },
       { column: 'severity', value: 'CRITICAL' },
     ]);
     expect(res.body.count).toBe(0);

--- a/backend/api/test/unit/services/blockchainMonitoring.test.js
+++ b/backend/api/test/unit/services/blockchainMonitoring.test.js
@@ -27,10 +27,10 @@ describe('Blockchain Monitoring Suite', () => {
 
     it('routes CRITICAL alerts to Slack, Email, and SMS', async () => {
       const alert = {
-        type: 'SMART_CONTRACT_REVERT',
+        type: 'EMERGENCY_RECOVERED',
         severity: SEVERITY_LEVELS.CRITICAL,
-        reason: 'Out of gas',
-        txHash: '0x123',
+        recipient: '0xRecipient',
+        amount: '1000',
       };
 
       await router.route(alert);
@@ -42,10 +42,10 @@ describe('Blockchain Monitoring Suite', () => {
 
     it('routes HIGH alerts to Slack and Email', async () => {
       const alert = {
-        type: 'GEOFENCE_BREACH',
+        type: 'BOOKING_DISPUTED',
         severity: SEVERITY_LEVELS.HIGH,
-        shipmentId: '101',
-        driver: '0xDriver',
+        bookingId: '101',
+        raisedBy: '0xCustomer',
       };
 
       await router.route(alert);
@@ -57,7 +57,7 @@ describe('Blockchain Monitoring Suite', () => {
 
     it('routes MEDIUM alerts to Slack only', async () => {
       const alert = {
-        type: 'PAYMENT_RECEIVED',
+        type: 'PAYMENT_RELEASED',
         severity: SEVERITY_LEVELS.MEDIUM,
         amount: '1000',
       };
@@ -81,9 +81,10 @@ describe('Blockchain Monitoring Suite', () => {
 
     it('starts tracking and resolves alert', async () => {
       const alert = {
-        type: 'BALANCE_UPDATE_FAILED',
-        severity: 'CRITICAL',
-        wallet: '0xWallet',
+        type: 'BOOKING_DISPUTED',
+        severity: 'HIGH',
+        bookingId: '42',
+        raisedBy: '0xCustomer',
       };
 
       await escalation.escalate(alert);
@@ -100,9 +101,10 @@ describe('Blockchain Monitoring Suite', () => {
 
     it('performs escalation steps correctly', async () => {
       const alert = {
-        type: 'SMART_CONTRACT_REVERT',
+        type: 'EMERGENCY_RECOVERED',
         severity: 'CRITICAL',
-        txHash: '0x456',
+        recipient: '0xRecipient',
+        amount: '1000',
       };
 
       await escalation.escalate(alert);
@@ -164,30 +166,44 @@ describe('Blockchain Monitoring Suite', () => {
       });
     });
 
-    it('handles payment received event', async () => {
-      const args = ['0xDriver', 1000n, 1700000000n];
+    it('handles payment released event', async () => {
+      const args = [42n, '0xDriver', 1000n];
       const log = { transactionHash: '0xTx', blockNumber: 12345 };
 
-      await monitor.handlePaymentReceived(args, log);
+      await monitor.handlePaymentReleased(args, log);
 
       expect(mockAlertRouter.route).toHaveBeenCalledWith(expect.objectContaining({
-        type: 'PAYMENT_RECEIVED',
+        type: 'PAYMENT_RELEASED',
         severity: 'MEDIUM',
         driver: '0xDriver',
       }));
       expect(mockMetrics.recordPaymentEvent).toHaveBeenCalledWith('success');
     });
 
-    it('handles smart contract revert event', async () => {
-      const args = ['0x1234567890abcdef', 'Out of gas'];
-      const log = { blockNumber: 12346 };
+    it('handles booking disputed event with escalation', async () => {
+      const args = [7n, '0xCustomer'];
+      const log = { transactionHash: '0xTx', blockNumber: 12346 };
 
-      await monitor.handleSmartContractRevert(args, log);
+      await monitor.handleBookingDisputed(args, log);
 
       expect(mockAlertRouter.route).toHaveBeenCalledWith(expect.objectContaining({
-        type: 'SMART_CONTRACT_REVERT',
+        type: 'BOOKING_DISPUTED',
+        severity: 'HIGH',
+        bookingId: '7',
+      }));
+      expect(mockEscalation.escalate).toHaveBeenCalled();
+    });
+
+    it('handles emergency recovered event', async () => {
+      const args = ['0xAdmin', 500n];
+      const log = { transactionHash: '0xTx', blockNumber: 12347 };
+
+      await monitor.handleEmergencyRecovered(args, log);
+
+      expect(mockAlertRouter.route).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'EMERGENCY_RECOVERED',
         severity: 'CRITICAL',
-        reason: 'Out of gas',
+        recipient: '0xAdmin',
       }));
       expect(mockEscalation.escalate).toHaveBeenCalled();
       expect(mockMetrics.recordContractRevert).toHaveBeenCalled();

--- a/docs/blockchain-monitoring-setup.md
+++ b/docs/blockchain-monitoring-setup.md
@@ -177,7 +177,7 @@ const metrics = await supabase
 
 ### Manual Testing
 
-1. Trigger a PaymentReceived event from contract
+1. Trigger a PaymentReleased event from contract
 2. Verify Slack notification appears
 3. Monitor escalation if alert not acknowledged
 
@@ -185,18 +185,17 @@ const metrics = await supabase
 
 ```javascript
 describe('BlockchainMonitor', () => {
-  test('should detect PaymentReceived events', async () => {
+  test('should detect PaymentReleased events', async () => {
     const monitor = new BlockchainMonitor({ /* deps */ });
     await monitor.initialize();
     await monitor.startListening();
     
     // Simulate event
     const alert = {
-      type: 'PAYMENT_RECEIVED',
+      type: 'PAYMENT_RELEASED',
       severity: 'MEDIUM',
       driver: '0x...',
       amount: '1000',
-      timestamp: Date.now(),
     };
     
     // Verify routing


### PR DESCRIPTION
## Problem

`BlockchainMonitor` watches six event signatures that no Truxify contract emits (`PaymentReceived`, `InsuranceClaimApproved`, `InsuranceClaimRejected`, `GeofenceBreach`, `BalanceUpdateFailed`, `SmartContractRevert`) and its `ESCROW_ABI` contains exactly those six events. The actual `TruxifyEscrow.sol` emits a completely different set (`BookingCreated`, `PaymentReleased`, `BookingCancelled`, `BookingStarted`, `CancellationPenaltyApplied`, `BookingDisputed`, `DisputeResolved`, `WithdrawalReady`, `Withdrawn`, `EmergencyRecovered`, `RelayerUpdated`). Because the monitor filters logs by signatures that never occur, every handler is dead code and the escrow lifecycle — payment releases, disputes, withdrawals — is never observed by the backend.

## Fix

- `backend/api/src/services/blockchain/blockchainMonitor.js`: replaced the six fictional event signature constants and the `ESCROW_ABI` with the real `TruxifyEscrow` event set, rewired `setupEventHandlers`, and replaced the six dead handlers with eleven handlers for the actual lifecycle events (routing, storing, metrics, and escalation where severity warrants it).
- `backend/api/src/routes/blockchainMonitoringRoutes.js`: updated the `GET /api/blockchain/events` type whitelist to the real event types.
- `backend/api/src/services/blockchain/alertRouter.js`: updated the alert-type emoji map to the real event types.
- Added `backend/api/scripts/check-blockchain-events.js` and wired it into `backend-ci.yml` (also triggered on `blockchain/**` changes) so any future rename on either side fails CI instead of silently blinding the monitor again.
- Updated the affected unit tests and `docs/blockchain-monitoring-setup.md` examples to the real event vocabulary.

## Files changed

- `.github/workflows/backend-ci.yml`
- `backend/api/scripts/check-blockchain-events.js`
- `backend/api/src/routes/blockchainMonitoringRoutes.js`
- `backend/api/src/services/blockchain/alertRouter.js`
- `backend/api/src/services/blockchain/blockchainMonitor.js`
- `backend/api/test/unit/blockchainMonitorGuard.test.js`
- `backend/api/test/unit/blockchainMonitoringRoutes.test.js`
- `backend/api/test/unit/services/blockchainMonitoring.test.js`
- `docs/blockchain-monitoring-setup.md`

## Testing

- `npx vitest run test/unit/blockchainMonitorGuard.test.js test/unit/blockchainMonitoringRoutes.test.js test/unit/services/blockchainMonitoring.test.js` — 20/20 pass.
- Verified with ethers that every `ESCROW_ABI` event topic hash matches the canonical signature in `TruxifyEscrow.sol` (all 11 match).
- Round-trip parsed a real `DisputeResolved` log through `new ethers.Interface(ESCROW_ABI)` — argument names/order correct.
- `node backend/api/scripts/check-blockchain-events.js` passes (11 watched events all exist in `blockchain/contracts/`).

Closes #10147
