### PR TITLE
fix: update orderTimelineService tests to match real module API

### DIFF
--- a/backend/api/test/unit/orderTimelineService.test.js
+++ b/backend/api/test/unit/orderTimelineService.test.js
@@ -1,18 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockFrom = vi.fn();
 const mockOrderRepository = {
-  addTimelineEvent: vi.fn(),
-  getOrderTimeline: vi.fn(),
+  getTimeline: vi.fn(),
+  updateTimelineMilestone: vi.fn(),
+  createTimeline: vi.fn(),
 };
-
-vi.mock('../../src/config/db.js', () => ({
-  supabase: { from: mockFrom },
-}));
-
-vi.mock('../../src/core/container.js', () => ({
-  orderRepository: mockOrderRepository,
-}));
 
 describe('orderTimelineService', () => {
   let orderTimelineService;
@@ -20,47 +12,47 @@ describe('orderTimelineService', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    orderTimelineService = (await import('../../src/services/order/orderTimelineService.js')).default;
-  });
-
-  describe('addTimelineEvent', () => {
-    it('adds a timeline event with actor info', async () => {
-      const event = { id: 'e1', order_id: 'order-1', type: 'status_change', created_at: new Date().toISOString() };
-      mockOrderRepository.addTimelineEvent.mockResolvedValue(event);
-
-      const result = await orderTimelineService.addTimelineEvent('order-1', {
-        type: 'status_change',
-        actor: 'driver-1',
-        description: 'Order started',
-      });
-      expect(mockOrderRepository.addTimelineEvent).toHaveBeenCalled();
-    });
-
-    it('throws when database insert fails', async () => {
-      mockOrderRepository.addTimelineEvent.mockRejectedValue(new Error('DB insert failed'));
-      await expect(
-        orderTimelineService.addTimelineEvent('order-1', { type: 'status_change' }),
-      ).rejects.toThrow('DB insert failed');
-    });
+    const { OrderTimelineService } = await import('../../src/services/order/orderTimelineService.js');
+    orderTimelineService = new OrderTimelineService(mockOrderRepository);
   });
 
   describe('getOrderTimeline', () => {
-    it('returns events in chronological order', async () => {
-      const events = [
-        { id: 'e1', created_at: '2026-08-01T10:00:00Z', type: 'created' },
-        { id: 'e2', created_at: '2026-08-01T11:00:00Z', type: 'status_change' },
-      ];
-      mockOrderRepository.getOrderTimeline.mockResolvedValue(events);
+    it('returns events for an order', async () => {
+      mockOrderRepository.getTimeline.mockResolvedValue({
+        data: [{ id: 'e1', milestone: 'Order Placed' }],
+        error: null,
+      });
 
       const result = await orderTimelineService.getOrderTimeline('order-1');
-      expect(result).toHaveLength(2);
-      expect(result[0].created_at).toBeLessThan(result[1].created_at);
+      expect(result).toHaveLength(1);
+      expect(mockOrderRepository.getTimeline).toHaveBeenCalledWith('order-1');
     });
 
     it('returns empty array when no events', async () => {
-      mockOrderRepository.getOrderTimeline.mockResolvedValue([]);
+      mockOrderRepository.getTimeline.mockResolvedValue({ data: [], error: null });
       const result = await orderTimelineService.getOrderTimeline('order-1');
       expect(result).toEqual([]);
+    });
+
+    it('throws when the timeline query fails', async () => {
+      mockOrderRepository.getTimeline.mockResolvedValue({ data: null, error: { message: 'DB down' } });
+      await expect(orderTimelineService.getOrderTimeline('order-1')).rejects.toThrow();
+    });
+  });
+
+  describe('completeMilestone', () => {
+    it('marks a milestone completed', async () => {
+      mockOrderRepository.updateTimelineMilestone.mockResolvedValue({ error: null });
+
+      await expect(orderTimelineService.completeMilestone('order-1', 'In Transit')).resolves.not.toThrow();
+      expect(mockOrderRepository.updateTimelineMilestone).toHaveBeenCalledWith(
+        'order-1', 'In Transit', expect.objectContaining({ completed: true }),
+      );
+    });
+
+    it('throws when the milestone update fails', async () => {
+      mockOrderRepository.updateTimelineMilestone.mockResolvedValue({ error: { message: 'DB down' } });
+      await expect(orderTimelineService.completeMilestone('order-1', 'In Transit')).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
Fixes #10309

## Problem
\	est/unit/orderTimelineService.test.js\ imported a non-existent \.default\ export from \orderTimelineService.js\ (the module only exports \class OrderTimelineService\), so all 4 tests failed with \Cannot read properties of undefined\. It also exercised \ddTimelineEvent\, a method that no longer exists on the class.

## Fix
Rewrote the tests against the real API: named-import \OrderTimelineService\, construct with a mocked repository, and cover \getOrderTimeline\ (events, empty, error) and \completeMilestone\ (success, error).

## Verification
- \
px vitest run test/unit/orderTimelineService.test.js\: 5/5 passing.

## GSSOC'24