### PR TITLE
fix: update orderNotificationService tests to match real module API

### DIFF
--- a/backend/api/test/unit/orderNotificationService.test.js
+++ b/backend/api/test/unit/orderNotificationService.test.js
@@ -1,10 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockNotificationDispatcher = vi.fn();
+const mockGetActiveDeliveryOtp = vi.fn();
+const mockStoreDeliveryOtp = vi.fn();
+const mockSendDeliveryOtpNotification = vi.fn();
 
-vi.mock('../../src/core/container.js', () => ({
-  notificationDispatcher: mockNotificationDispatcher,
+vi.mock('../../src/config/db.js', () => ({
+  redisClient: {
+    get: vi.fn().mockResolvedValue(null),
+    del: vi.fn(),
+    incr: vi.fn(),
+    expire: vi.fn(),
+    set: vi.fn(),
+  },
 }));
+
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendDeliveryOtpNotification: mockSendDeliveryOtpNotification,
+  storeDeliveryOtp: mockStoreDeliveryOtp,
+  getActiveDeliveryOtp: mockGetActiveDeliveryOtp,
+}));
+
+const mockOrderRepository = {
+  updateOrder: vi.fn(),
+};
 
 describe('orderNotificationService', () => {
   let orderNotificationService;
@@ -12,43 +30,58 @@ describe('orderNotificationService', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    orderNotificationService = (await import('../../src/services/order/orderNotificationService.js')).default;
+    const { OrderNotificationService } = await import('../../src/services/order/orderNotificationService.js');
+    orderNotificationService = new OrderNotificationService(mockOrderRepository);
   });
 
-  describe('sendOrderUpdate', () => {
-    it('dispatches notification with order update', async () => {
-      mockNotificationDispatcher.mockResolvedValue({ success: true });
-      await orderNotificationService.sendOrderUpdate('driver-1', 'order-1', 'Order started');
-      expect(mockNotificationDispatcher).toHaveBeenCalledWith(
-        'driver-1',
-        expect.stringContaining('order-1'),
-        expect.any(String),
-        expect.any(Object),
-      );
+  describe('sendOrderNotification', () => {
+    it('issues a fresh OTP and dispatches it', async () => {
+      mockGetActiveDeliveryOtp.mockResolvedValue(null);
+      mockStoreDeliveryOtp.mockResolvedValue(true);
+      mockSendDeliveryOtpNotification.mockResolvedValue({ success: true });
+
+      const result = await orderNotificationService.sendOrderNotification({
+        type: 'delivery_otp_in_transit',
+        orderId: 'order-1',
+        orderDisplayId: 'TRX-1',
+        customerId: 'cust-1',
+      });
+
+      expect(result.notified).toBe(true);
+      expect(result.otp).toMatch(/^\d{6}$/);
+      expect(mockStoreDeliveryOtp).toHaveBeenCalledWith('order-1', result.otp, expect.any(Number));
+      expect(mockSendDeliveryOtpNotification).toHaveBeenCalledWith('cust-1', 'TRX-1', result.otp);
+      expect(mockOrderRepository.updateOrder).not.toHaveBeenCalled();
     });
 
-    it('gracefully handles dispatcher failure', async () => {
-      mockNotificationDispatcher.mockRejectedValue(new Error('Dispatcher unavailable'));
-      // Should not throw
-      await expect(
-        orderNotificationService.sendOrderUpdate('driver-1', 'order-1', 'Update'),
-      ).resolves.not.toThrow();
-    });
-  });
+    it('does not regenerate while an active OTP exists', async () => {
+      mockGetActiveDeliveryOtp.mockResolvedValue({ otp: '111111' });
 
-  describe('sendBidReceived', () => {
-    it('dispatches bid received notification', async () => {
-      mockNotificationDispatcher.mockResolvedValue({ success: true });
-      await orderNotificationService.sendBidReceived('customer-1', 'bid-1', 15000);
-      expect(mockNotificationDispatcher).toHaveBeenCalled();
-    });
-  });
+      const result = await orderNotificationService.sendOrderNotification({
+        type: 'delivery_otp_in_transit',
+        orderId: 'order-1',
+        orderDisplayId: 'TRX-1',
+        customerId: 'cust-1',
+      });
 
-  describe('sendDeliveryConfirmed', () => {
-    it('dispatches delivery confirmed notification', async () => {
-      mockNotificationDispatcher.mockResolvedValue({ success: true });
-      await orderNotificationService.sendDeliveryConfirmed('customer-1', 'order-1');
-      expect(mockNotificationDispatcher).toHaveBeenCalled();
+      expect(result).toEqual({ otp: null, notified: false });
+      expect(mockStoreDeliveryOtp).not.toHaveBeenCalled();
+    });
+
+    it('handles a failed FCM dispatch without throwing', async () => {
+      mockGetActiveDeliveryOtp.mockResolvedValue(null);
+      mockStoreDeliveryOtp.mockResolvedValue(true);
+      mockSendDeliveryOtpNotification.mockResolvedValue({ success: false, fcm: { error: 'device offline' } });
+
+      const result = await orderNotificationService.sendOrderNotification({
+        type: 'delivery_otp_in_transit',
+        orderId: 'order-1',
+        orderDisplayId: 'TRX-1',
+        customerId: 'cust-1',
+      });
+
+      expect(result.notified).toBe(false);
+      expect(mockOrderRepository.updateOrder).toHaveBeenCalledWith('order-1', expect.objectContaining({ updated_at: expect.any(String) }));
     });
   });
 });


### PR DESCRIPTION
Fixes #10310

## Problem
\	est/unit/orderNotificationService.test.js\ imported a non-existent \.default\ export (the module exports \class OrderNotificationService\), failing all 4 tests. It also tested \sendOrderUpdate\/\sendBidReceived\/\sendDeliveryConfirmed\, none of which exist — the real method is \sendOrderNotification\ (OTP issuance for delivery).

## Fix
Rewrote the tests around \sendOrderNotification\ with mocks for \edisClient\, \storeDeliveryOtp\, \getActiveDeliveryOtp\, and \sendDeliveryOtpNotification\:
- issues a fresh OTP and dispatches it,
- refuses to regenerate while an active OTP exists,
- tolerates FCM dispatch failure (no throw) and still refreshes \updated_at\.

## Verification
- \
px vitest run test/unit/orderNotificationService.test.js\: 3/3 passing.

## GSSOC'24