### PR TITLE
fix: update orderLifecycleService tests to match real module API

### DIFF
--- a/backend/api/test/unit/orderLifecycleService.test.js
+++ b/backend/api/test/unit/orderLifecycleService.test.js
@@ -1,13 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockOrderRepository = {
-  findOrderById: vi.fn(),
-  updateOrderWithFilter: vi.fn(),
+  findOrdersByCustomer: vi.fn(),
+  findOrdersWithCount: vi.fn(),
+  findProfilesByIds: vi.fn(),
 };
-
-vi.mock('../../src/core/container.js', () => ({
-  orderRepository: mockOrderRepository,
-}));
 
 describe('orderLifecycleService', () => {
   let orderLifecycleService;
@@ -15,38 +12,59 @@ describe('orderLifecycleService', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    orderLifecycleService = (await import('../../src/services/order/orderLifecycleService.js')).default;
-  });
-
-  describe('startOrder', () => {
-    it('starts an order in pending state', async () => {
-      const order = { id: 'order-1', status: 'pending', escrow_status: 'pending' };
-      mockOrderRepository.findOrderById.mockResolvedValue(order);
-      mockOrderRepository.updateOrderWithFilter.mockResolvedValue({ error: null });
-
-      const result = await orderLifecycleService.startOrder('order-1', 'driver-1');
-      expect(mockOrderRepository.updateOrderWithFilter).toHaveBeenCalled();
-    });
-
-    it('throws when order not found', async () => {
-      mockOrderRepository.findOrderById.mockResolvedValue(null);
-      await expect(orderLifecycleService.startOrder('order-nonexistent', 'driver-1')).rejects.toThrow();
+    const { OrderLifecycleService } = await import('../../src/services/order/orderLifecycleService.js');
+    orderLifecycleService = new OrderLifecycleService({
+      orderRepository: mockOrderRepository,
+      orderTimelineService: {},
+      bidAcceptanceService: {},
+      deliveryVerificationService: {},
+      trackingTokenService: null,
     });
   });
 
-  describe('completeOrder', () => {
-    it('completes an order in_transit', async () => {
-      const order = { id: 'order-1', status: 'in_transit', escrow_status: 'funded' };
-      mockOrderRepository.findOrderById.mockResolvedValue(order);
-      mockOrderRepository.updateOrderWithFilter.mockResolvedValue({ error: null });
+  describe('getActiveOrders', () => {
+    it('returns active orders enriched with driver names', async () => {
+      mockOrderRepository.findOrdersByCustomer.mockResolvedValue({
+        data: [{ id: 'order-1', driver_id: 'driver-1' }],
+        error: null,
+      });
+      mockOrderRepository.findProfilesByIds.mockResolvedValue({
+        data: [{ id: 'driver-1', full_name: 'Ravi Kumar' }],
+      });
 
-      await expect(orderLifecycleService.completeOrder('order-1')).resolves.not.toThrow();
+      const result = await orderLifecycleService.getActiveOrders('cust-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].driver_name).toBe('Ravi Kumar');
+      expect(mockOrderRepository.findOrdersByCustomer).toHaveBeenCalledWith(
+        'cust-1', '*', expect.any(Array), 'pickup_date', false,
+      );
     });
 
-    it('throws when trying to complete delivered order', async () => {
-      const order = { id: 'order-1', status: 'delivered' };
-      mockOrderRepository.findOrderById.mockResolvedValue(order);
-      await expect(orderLifecycleService.completeOrder('order-1')).rejects.toThrow();
+    it('throws when the query fails', async () => {
+      mockOrderRepository.findOrdersByCustomer.mockResolvedValue({ data: null, error: { message: 'DB down' } });
+      await expect(orderLifecycleService.getActiveOrders('cust-1')).rejects.toThrow();
+    });
+  });
+
+  describe('getOrderHistory', () => {
+    it('returns paginated history', async () => {
+      mockOrderRepository.findOrdersWithCount.mockResolvedValue({
+        data: [{ id: 'order-1' }],
+        error: null,
+        count: 1,
+      });
+
+      const result = await orderLifecycleService.getOrderHistory('cust-1', 1, 10);
+
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(result.history).toHaveLength(1);
+    });
+
+    it('throws when the history query fails', async () => {
+      mockOrderRepository.findOrdersWithCount.mockResolvedValue({ data: null, error: { message: 'DB down' }, count: 0 });
+      await expect(orderLifecycleService.getOrderHistory('cust-1', 1, 10)).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
Fixes #10312

## Problem
\	est/unit/orderLifecycleService.test.js\ imported a non-existent \.default\ export (\OrderLifecycleService\ is a named class) and tested \startOrder\/\completeOrder\ methods that do not exist, failing all 4 tests.

## Fix
Rewrote the tests against the real API: construct \OrderLifecycleService\ with a mocked \orderRepository\ and cover the read paths \getActiveOrders\ (enrichment of driver names, error) and \getOrderHistory\ (pagination totals, error).

## Verification
- \
px vitest run test/unit/orderLifecycleService.test.js\: 4/4 passing.

## GSSOC'24