### PR TITLE
fix(graphql): resolve profiles.id before assigning driver to order

### DIFF
--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -166,10 +166,23 @@ const resolvers = {
                 throw new Error('Dispatcher role required');
             }
 
+            // orders.driver_id is a uuid FK to profiles(id), but the Driver.id
+            // exposed by the `drivers` view is the numeric driver_details.id.
+            // Resolve the driver's profile UUID before writing the assignment.
+            const { data: driver, error: driverError } = await supabase
+                .from('drivers')
+                .select('user_id')
+                .eq('id', driverId)
+                .single();
+
+            if (driverError || !driver?.user_id) {
+                throw new Error(`Driver ${driverId} not found`);
+            }
+
             const { data, error } = await supabase
                 .from('orders')
                 .update({
-                    driver_id: driverId,
+                    driver_id: driver.user_id,
                     status: 'truck_assigned',
                     updated_at: new Date().toISOString()
                 })
@@ -178,7 +191,7 @@ const resolvers = {
                 .single();
             
             if (error) throw error;
-            return data;
+            return { id: data.id, driver: { id: driverId } };
         },
         updateDriverLocation: async (_, { id, location }, { user }) => {
             const currentUser = requireUser(user);


### PR DESCRIPTION
## Problem

The GraphQL `assignDriver` mutation writes the client-supplied `Driver.id` straight into `orders.driver_id`. The `drivers` view used as the `Driver` source exposes `driver_details.id` (numeric) as the driver identity, but `orders.driver_id` is a `uuid` column with a foreign key to `profiles(id)`. The numeric `driver_details.id` is neither a UUID nor a `profiles.id`, so every assignment fails with `23503`/`22P02`. The mutation also returned the raw snake_case row, which mismatches the GraphQL shape.

## Fix

`backend/graphql/services/driver.service.js` — `assignDriver` now:

1. Resolves the driver's profile UUID by selecting `user_id` from the `drivers` view (which joins `driver_details.user_id` to `profiles.id`) filtered by the numeric `driverId`. Throws `Driver <id> not found` if the driver does not exist.
2. Writes that profile UUID into `orders.driver_id`, satisfying the FK.
3. Returns a GraphQL-shaped `Order { id, driver { id } }` entity reference instead of the raw row.

The `orders.driver_id` FK is now always written with a value that matches `profiles(id)`.

## Files changed

- `backend/graphql/services/driver.service.js`

## Testing

- `node --check backend/graphql/services/driver.service.js` — syntax OK.
- Logic verified against the schema: `supabase/migrations/20260805000020_create_drivers_view.sql` exposes `dd.user_id` as `user_id` (joined to `profiles.id`), and `orders.driver_id` is a `uuid REFERENCES profiles(id)` per the issue evidence. The pre-change path wrote the numeric view `id` into that FK; the new path writes the resolved profile UUID and returns `{ id, driver: { id } }` per the subgraph's `Order` extension.

Closes #10148
