### PR TITLE
fix: update driver-location syntax test for two-arg requirePolicy

### DIFF
--- a/backend/api/test/unit/orderRoutesDriverLocationSyntax.test.js
+++ b/backend/api/test/unit/orderRoutesDriverLocationSyntax.test.js
@@ -66,7 +66,7 @@ describe('orderRoutes.js driver-location route syntax (issue #6662)', () => {
     const { call } = driverLocationCall(source);
 
     for (const piece of [
-      "requirePolicy('order:view-driver-location')",
+      "requirePolicy('order:view-driver-location', async (req) => {",
       'validateParams(paramIdSchema)',
       "async (req, res) =>",
     ]) {


### PR DESCRIPTION
Fixes #10313

## Problem
\	est/unit/orderRoutesDriverLocationSyntax.test.js\ (issue #6662 regression gate) still asserted the old one-arg form \equirePolicy('order:view-driver-location')\. The route at \orderRoutes.js:863\ now passes a resource callback — \equirePolicy('order:view-driver-location', async (req) => {...})\ — so the third test failed with \missing middleware/handler\.

## Fix
Updated the expected middleware chain to the two-arg \equirePolicy\ form. The guard's intent (route must be a single balanced \outer.get\ with the middleware inside it) is preserved.

## Verification
- \
px vitest run test/unit/orderRoutesDriverLocationSyntax.test.js\: 3/3 passing.

## GSSOC'24