### PR TITLE
docs(infra): document N8N_HOST and AWS backup vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,11 @@ SENTRY_DSN=
 N8N_ENCRYPTION_KEY=<generate-a-secure-random-key>
 N8N_USER_MANAGEMENT_JWT_SECRET=<generate-a-secure-random-key>
 
+# Public hostname n8n is reachable at (editor / webhook base URL).
+# docker-compose.prod.yml requires this value; the dev compose file defaults to
+# localhost when it is unset.
+N8N_HOST=localhost
+
 # Base URL of the backend Express API as reachable from the n8n container on
 # the internal Docker network (service name `api`, port 5000). Used by the
 # dispute-resolution workflow's HTTP nodes ({{$env.BACKEND_API_URL}}).
@@ -173,3 +178,15 @@ BACKEND_API_URL=http://api:5000
 # Dedicated database credentials for n8n. Provisioned at DB init time into the
 # `truxify_n8n` database owned by the `n8n` role (never the app `truxify` DB).
 N8N_DB_PASSWORD=<generate-a-secure-random-password>
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 10. BACKUP SERVICE (S3 object storage)
+# ──────────────────────────────────────────────────────────────────────────────
+# Credentials for the `backup` container, which uploads database dumps to S3.
+# docker-compose.yml requires AWS_S3_BUCKET to be set; AWS_ACCESS_KEY_ID and
+# AWS_SECRET_ACCESS_KEY may be left empty when the container runs with an IAM
+# instance profile instead.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=us-east-1
+AWS_S3_BUCKET=<your-s3-bucket-name>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
     ports:
       - "5678:5678"
     environment:
-      - N8N_HOST=localhost
+      - N8N_HOST=${N8N_HOST:-localhost}
       - N8N_PORT=5678
       - N8N_PROTOCOL=http
       - NODE_ENV=development


### PR DESCRIPTION
## Problem

`docker-compose.prod.yml` hard-requires `${N8N_HOST:?}` (line 241) and the `backup` service in `docker-compose.yml` hard-requires `${AWS_S3_BUCKET:?}` (plus shard/mongo credentials). None of `N8N_HOST`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, or `AWS_S3_BUCKET` appear in `.env.example`, so a fresh `cp .env.example .env && docker compose up` fails at `docker compose config` time before any container starts. The dev n8n service also hard-coded `N8N_HOST=localhost` instead of consuming the variable prod requires.

## Fix

- `.env.example`: added `N8N_HOST=localhost` to the n8n section and a new "BACKUP SERVICE (S3 object storage)" section documenting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` (default `us-east-1`), and `AWS_S3_BUCKET`, so a fresh environment satisfies every `:?`-required variable.
- `docker-compose.yml`: the n8n service now reads `N8N_HOST: ${N8N_HOST:-localhost}` instead of the literal `localhost`, so dev and prod agree on the same variable.

## Files changed

- `.env.example`
- `docker-compose.yml`

## Testing

- Both `docker-compose.yml` and `docker-compose.prod.yml` parse cleanly (`yaml.safe_load`).
- Every `:?`-required variable referenced by the dev/prod compose files (`N8N_HOST`, `AWS_S3_BUCKET`, plus the existing `SHARD_PASSWORD`/`MONGO_*`) is now present in `.env.example`.

Closes #10149
