### PR TITLE
fix(sgx): never report fabricated quote as hardware-verified attestation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,19 @@ RELAYER_WALLET_PRIVATE_KEY=0xabcdef1234567890abcdef1234567890abcdef1234567890abc
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# 6.5 INTEL SGX (Remote Attestation)
+# ──────────────────────────────────────────────────────────────────────────────
+# Controls how backend/sgx/attestation.js performs enclave attestation.
+#   - none  (default) — attestation is disabled and the service fails closed;
+#                       no fabricated quote is ever reported as verified.
+#   - mock            — explicit opt-in simulated quote for local development;
+#                       results are labelled hardwareBacked:false / verified:false.
+#   - <provider>      — a real provider (e.g. dcap, azure) must be integrated
+#                       before it is used; until then the service fails closed.
+ENCLAVE_ATTESTATION=none
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # 7. MAPS & ROUTING APIs (Routing calculations, Map tiles, Geocoding backups)
 # ──────────────────────────────────────────────────────────────────────────────
 # OpenRouteService or Google Maps API key (for calculating distances and duration)

--- a/backend/api/test/unit/sgxAttestation.test.js
+++ b/backend/api/test/unit/sgxAttestation.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SgxAttestationService, sgxAttestationService } from '../../../sgx/attestation.js';
+
+const DOC = Buffer.from('{"document":"drivers-license"}').toString('base64');
+
+function createService(mode) {
+  vi.stubEnv('ENCLAVE_ATTESTATION', mode);
+  return new SgxAttestationService();
+}
+
+describe('SgxAttestationService', () => {
+  beforeEach(() => {
+    delete process.env.ENCLAVE_ATTESTATION;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('fails closed when attestation is not enabled (default)', async () => {
+    const service = createService('none');
+    const result = await service.verifyDriverDocumentInEnclave(DOC);
+
+    expect(result.success).toBe(false);
+    expect(result.verified).toBe(false);
+    expect(result.attestationQuote).toBeNull();
+    expect(result.reason).toMatch(/not enabled/i);
+    expect(result.docHash).toBeTruthy();
+  });
+
+  it('returns verified:false even in explicit mock mode', async () => {
+    const service = createService('mock');
+    const result = await service.verifyDriverDocumentInEnclave(DOC);
+
+    expect(result.success).toBe(true);
+    expect(result.verified).toBe(false);
+    expect(result.hardwareBacked).toBe(false);
+    expect(result.attestationProvider).toBe('mock');
+    expect(result.attestationQuote).toMatch(/^SGX_QUOTE_V3_MOCK_/);
+  });
+
+  it('fails closed when a real provider is requested but not integrated', async () => {
+    const service = createService('dcap');
+    const result = await service.verifyDriverDocumentInEnclave(DOC);
+
+    expect(result.success).toBe(false);
+    expect(result.verified).toBe(false);
+    expect(result.attestationQuote).toBeNull();
+    expect(result.reason).toMatch(/not integrated/i);
+  });
+
+  it('never returns verified:true for a fabricated quote', async () => {
+    const service = createService('mock');
+    const result = await service.verifyDriverDocumentInEnclave(DOC);
+    expect(result.verified).toBe(false);
+  });
+
+  it('exposes the configured provider and enabled flag', () => {
+    expect(createService('mock').enabled).toBe(true);
+    expect(createService('mock').provider).toBe('mock');
+    expect(createService('none').enabled).toBe(false);
+    expect(createService('none').provider).toBeNull();
+  });
+
+  it('exports a singleton service instance', () => {
+    expect(sgxAttestationService).toBeInstanceOf(SgxAttestationService);
+  });
+});

--- a/backend/sgx/attestation.js
+++ b/backend/sgx/attestation.js
@@ -2,20 +2,92 @@ import crypto from 'crypto';
 
 /**
  * Intel SGX Remote Attestation Node.js Bridge
+ *
+ * Attestation is gated behind ENCLAVE_ATTESTATION so that a fabricated quote is
+ * never presented as a hardware-verified result:
+ *
+ *   - `none`  (default)  — no attestation is performed and the service fails
+ *                          closed. This is the only safe default until a real
+ *                          attestation provider (Intel SGX DCAP, Azure
+ *                          attestation, RA-TLS verifier) is integrated.
+ *   - `mock`  (opt-in)   — produces a simulated quote for local development.
+ *                          The result is explicitly labelled
+ *                          `attestationProvider: 'mock'` /
+ *                          `hardwareBacked: false` and `verified` stays
+ *                          `false`, so no consumer can mistake it for real
+ *                          hardware attestation.
+ *   - anything else      — a real provider was requested but none is wired up;
+ *                          fail closed with an explicit reason.
  */
 export class SgxAttestationService {
+  constructor() {
+    this.mode = (process.env.ENCLAVE_ATTESTATION || 'none').toLowerCase();
+  }
+
+  get enabled() {
+    return this.mode !== 'none';
+  }
+
+  get provider() {
+    if (this.mode === 'mock') return 'mock';
+    if (this.mode !== 'none') return this.mode;
+    return null;
+  }
+
   async verifyDriverDocumentInEnclave(documentBase64) {
-    console.log('[SGX Enclave] Loading isolated execution enclave memory...');
-    
     const docHash = crypto.createHash('sha256').update(documentBase64).digest('hex');
-    const mockQuote = `SGX_QUOTE_V3_VALIDATED_HASH_${documentBase64.length}_${docHash.slice(0, 16)}`;
 
-    // Verify attestation quote signature
-    const isAttestationValid = mockQuote.startsWith('SGX_QUOTE_V3');
+    if (this.mode === 'none') {
+      console.warn(
+        '[SGX Enclave] Attestation disabled (ENCLAVE_ATTESTATION=none). ' +
+        'No enclave-backed attestation was performed.'
+      );
+      return {
+        success: false,
+        verified: false,
+        reason:
+          'SGX attestation is not enabled. Set ENCLAVE_ATTESTATION to a real ' +
+          'attestation provider before relying on enclave-backed results.',
+        attestationQuote: null,
+        attestationProvider: null,
+        hardwareBacked: false,
+        docHash,
+        timestamp: Date.now(),
+      };
+    }
 
+    if (this.mode === 'mock') {
+      console.warn(
+        '[SGX Enclave] Running in mock mode (ENCLAVE_ATTESTATION=mock). ' +
+        'Results are NOT hardware-verified.'
+      );
+      const mockQuote = `SGX_QUOTE_V3_MOCK_${documentBase64.length}_${docHash.slice(0, 16)}`;
+      return {
+        success: true,
+        verified: false,
+        attestationQuote: mockQuote,
+        attestationProvider: 'mock',
+        hardwareBacked: false,
+        docHash,
+        timestamp: Date.now(),
+      };
+    }
+
+    // A real provider was requested but no verification implementation is wired
+    // up yet. Fail closed instead of fabricating a "valid" quote.
+    console.warn(
+      `[SGX Enclave] Attestation provider '${this.mode}' is not integrated. ` +
+      'Failing closed — no attestation was performed.'
+    );
     return {
-      success: isAttestationValid,
-      attestationQuote: mockQuote,
+      success: false,
+      verified: false,
+      reason:
+        `SGX attestation provider '${this.mode}' is configured but not ` +
+        'integrated. No enclave-backed attestation was performed.',
+      attestationQuote: null,
+      attestationProvider: this.mode,
+      hardwareBacked: false,
       docHash,
       timestamp: Date.now(),
     };


### PR DESCRIPTION
## Problem

`backend/sgx/attestation.js` built a quote that starts with `SGX_QUOTE_V3` and then "verified" it by checking the same hardcoded prefix — a tautology that always returned `success: true`, i.e. a self-fabricated quote reported as hardware-verified attestation.

## Fix

- Gated attestation behind `ENCLAVE_ATTESTATION`:
  - `none` (default) — fails closed, never returns verified.
  - `mock` — explicit opt-in; results are labelled `verified: false`, `hardwareBacked: false`, `attestationProvider: 'mock'`.
  - any requested-but-unintegrated real provider — fails closed (`not integrated`).
- No code path can return `verified: true` from a fabricated quote.
- Added `enabled`/`provider` getters and documented the env var in `.env.example` (section 6.5).
- Added `backend/api/test/unit/sgxAttestation.test.js` covering default/mock/unknown modes.

## Files changed

- `backend/sgx/attestation.js`
- `.env.example`
- `backend/api/test/unit/sgxAttestation.test.js` (new)

## Testing

- `npx vitest run test/unit/sgxAttestation.test.js`: 6/6 passing.
- `node --check backend/sgx/attestation.js` passes.

Closes #10181
