### PR TITLE
docs : added malware scanner documentation

### DIFF
--- a/docs/MALWARE_SCANNER.md
+++ b/docs/MALWARE_SCANNER.md
@@ -1,0 +1,65 @@
+# Malware Scanner
+
+## Overview
+
+The Truxify backend scans uploaded driver documents before they are stored or forwarded. The malware scanner (`lib/malwareScanner.js`) validates file content and, when configured, submits the payload to a ClamAV daemon.
+
+---
+
+## Location
+
+```
+backend/api/src/lib/malwareScanner.js
+```
+
+---
+
+## Content Validation
+
+Before any scan, the scanner rejects:
+
+- Executable or script extensions (`.exe`, `.bat`, `.ps1`, `.sh`, `.js`, ...).
+- Empty or non-buffer content.
+- Content whose magic bytes do not match an allowed type (JPEG, PNG, PDF).
+- **Payloads larger than the scan size limit** (default 10 MB, configurable via `MAX_SCAN_SIZE_BYTES`) — rejected before any byte reaches ClamAV.
+
+---
+
+## ClamAV Integration
+
+When `CLAMAV_HOST` is set, the buffer is streamed to the daemon:
+
+- `OK` — clean.
+- `FOUND` — malware detected; the upload is rejected.
+- Timeout or connection error — behavior depends on `CLAMAV_UNAVAILABLE_ACTION` (`pass` or `reject`, default: pass outside production, reject in production).
+- In production with no scanner configured, uploads are rejected.
+
+---
+
+## Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `CLAMAV_HOST` | Host:port of the ClamAV daemon (optional) |
+| `MAX_SCAN_SIZE_BYTES` | Maximum payload size forwarded to the scanner (default 10 MB) |
+| `CLAMAV_UNAVAILABLE_ACTION` | `pass` or `reject` when the scanner is unreachable |
+| `SCAN_TIMEOUT_MS` | Scanner response timeout (default 30 s) |
+| `NODE_ENV` | `production` enables fail-closed behavior |
+
+---
+
+## Why It Exists
+
+KYC documents arrive from mobile devices and can be renamed to look legitimate. Magic-byte validation defeats spoofing, and ClamAV catches actual malware that would otherwise be stored and served back to other users.
+
+---
+
+## Testing
+
+Automated tests verify:
+
+- Dangerous extensions are rejected.
+- Invalid content is rejected.
+- Oversized payloads are rejected before the scanner is contacted.
+- ClamAV clean / FOUND / timeout / error paths.
+- Fallback behavior when the scanner is unavailable.


### PR DESCRIPTION
Closes #10376.

Summary of What Has Been Done:
Added a documentation page for the malware scanner covering content validation, the ClamAV integration, the size guard, and configuration.

Changes Made:
- docs/MALWARE_SCANNER.md: new docs file

Impact it Made:
Documentation clarity for the document upload security layer.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.