### PR TITLE
ci(k8s): publish api and ml images to GHCR and point manifests at them

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,75 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - "backend/api/**"
+      - "backend/ml/**"
+      - ".github/workflows/docker-build.yml"
+
+concurrency:
+  group: truxify-docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  api:
+    name: Build and push API image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/api
+          target: production
+          push: true
+          tags: |
+            ghcr.io/kanishjebamathewm/truxify-api:latest
+            ghcr.io/kanishjebamathewm/truxify-api:canary
+            ghcr.io/kanishjebamathewm/truxify-api:${{ github.sha }}
+
+  ml:
+    name: Build and push ML image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ML
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/ml
+          push: true
+          tags: |
+            ghcr.io/kanishjebamathewm/truxify-ml:latest
+            ghcr.io/kanishjebamathewm/truxify-ml:${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     build:
       context: ./backend/api
       target: development
+    image: ghcr.io/kanishjebamathewm/truxify-api
     container_name: truxify-api
     env_file:
       - .env
@@ -84,6 +85,7 @@ services:
   ml-engine:
     build:
       context: ./backend/ml
+    image: ghcr.io/kanishjebamathewm/truxify-ml
     container_name: truxify-ml-engine
     env_file:
       - .env

--- a/k8s/argo-rollouts/auto-rollback.yaml
+++ b/k8s/argo-rollouts/auto-rollback.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
   strategy:
     canary:
       steps:

--- a/k8s/argo-rollouts/blue-green.yaml
+++ b/k8s/argo-rollouts/blue-green.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
         ports:
         - containerPort: 5000
   strategy:

--- a/k8s/argo-rollouts/ml-analysis.yaml
+++ b/k8s/argo-rollouts/ml-analysis.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: ml-engine
-        image: truxify/ml:latest
+        image: ghcr.io/kanishjebamathewm/truxify-ml:latest
         ports:
         - containerPort: 8000
   strategy:

--- a/k8s/argo-rollouts/rollout.yaml
+++ b/k8s/argo-rollouts/rollout.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
         ports:
         - containerPort: 5000
         env:

--- a/k8s/argocd/auto-rollback.yaml
+++ b/k8s/argocd/auto-rollback.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
   strategy:
     canary:
       steps:

--- a/k8s/argocd/blue-green.yaml
+++ b/k8s/argocd/blue-green.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
         ports:
         - containerPort: 5000
   strategy:

--- a/k8s/argocd/progressive-delivery.yaml
+++ b/k8s/argocd/progressive-delivery.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
         ports:
         - containerPort: 5000
         resources:

--- a/k8s/deployements/api-deployement.yaml
+++ b/k8s/deployements/api-deployement.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: api-service-account
       containers:
       - name: api
-        image: truxify/api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 5000

--- a/k8s/deployements/ml-deployements.yaml
+++ b/k8s/deployements/ml-deployements.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: ml-engine
-        image: truxify/ml:latest
+        image: ghcr.io/kanishjebamathewm/truxify-ml:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8000

--- a/k8s/fluxcd/image-automation.yaml
+++ b/k8s/fluxcd/image-automation.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  image: truxify/api
+  image: ghcr.io/kanishjebamathewm/truxify-api
   secretRef:
-    name: docker-hub
+    name: ghcr
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy

--- a/k8s/istio/canary-deployement.yaml
+++ b/k8s/istio/canary-deployement.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:canary
+        image: ghcr.io/kanishjebamathewm/truxify-api:canary
         ports:
         - containerPort: 5000
         env:

--- a/k8s/istio/canary-deployment.yaml
+++ b/k8s/istio/canary-deployment.yaml
@@ -20,6 +20,6 @@ spec:
     spec:
       containers:
       - name: api
-        image: truxify/api:canary
+        image: ghcr.io/kanishjebamathewm/truxify-api:canary
         ports:
         - containerPort: 5000


### PR DESCRIPTION
## Problem

Every Kubernetes workload manifest pins `truxify/api:latest`, `truxify/api:canary`, or `truxify/ml:latest`, but no Dockerfile tags any image with those names and no CI workflow builds or pushes them. The compose API/ML services had `build:` contexts but no `image:` name. Clusters therefore pull images that no registry publishes, so `api`, `ml`, canary, Argo Rollouts, Argo CD, and FluxCD reconcile loops can never become ready.

## Fix

- Added `.github/workflows/docker-build.yml` — on pushes to `main` and `v*` tags (when `backend/api/**` or `backend/ml/**` change) it builds and pushes:
  - `ghcr.io/kanishjebamathewm/truxify-api` (Dockerfile `production` target) tagged `latest`, `canary`, and the commit SHA
  - `ghcr.io/kanishjebamathewm/truxify-ml` tagged `latest` and the commit SHA
  - Uses `GITHUB_TOKEN` (`packages: write`) against GHCR.
- `docker-compose.yml`: `api` and `ml-engine` services now declare explicit `image: ghcr.io/kanishjebamathewm/truxify-api` / `ghcr.io/kanishjebamathewm/truxify-ml` so builds tag a real registry target (local dev still builds from the `build:` context).
- Repointed all 12 k8s manifests to the GHCR registry: deployments (`api`, `ml`), istio canaries (`:canary`), Argo Rollouts (`rollout.yaml`, `auto-rollback.yaml`, `blue-green.yaml`, `ml-analysis.yaml`), Argo CD (`auto-rollback.yaml`, `blue-green.yaml`, `progressive-delivery.yaml`), and the FluxCD `ImageRepository` (`ghcr.io/kanishjebamathewm/truxify-api`, secret ref renamed `docker-hub` → `ghcr`).

## Files changed

- `.github/workflows/docker-build.yml` (new)
- `docker-compose.yml`
- `k8s/deployements/api-deployement.yaml`
- `k8s/deployements/ml-deployements.yaml`
- `k8s/istio/canary-deployement.yaml`
- `k8s/istio/canary-deployment.yaml`
- `k8s/argo-rollouts/rollout.yaml`
- `k8s/argo-rollouts/auto-rollback.yaml`
- `k8s/argo-rollouts/blue-green.yaml`
- `k8s/argo-rollouts/ml-analysis.yaml`
- `k8s/argocd/auto-rollback.yaml`
- `k8s/argocd/blue-green.yaml`
- `k8s/argocd/progressive-delivery.yaml`
- `k8s/fluxcd/image-automation.yaml`

## Testing

- All modified YAML (every `k8s/**/*.yaml`, `docker-compose.yml`, and the new workflow) parses cleanly.
- No `truxify/*` image reference remains anywhere under `k8s/`; every workload now points at `ghcr.io/kanishjebamathewm/truxify-*`.
- The API Dockerfile `production` target exists (used by the workflow) and the ML Dockerfile builds to the `truxify-ml` name.

Note: the FluxCD `ImageRepository` secret ref changed from `docker-hub` to `ghcr` — the cluster needs a `flux-system/ghcr` pull secret to read the tag list.

Closes #10150
