### PR TITLE
docs : added API response helpers documentation

### DIFF
--- a/docs/API_RESPONSE.md
+++ b/docs/API_RESPONSE.md
@@ -1,0 +1,62 @@
+# API Response Helpers
+
+## Overview
+
+The Truxify backend uses standard response helpers (`lib/apiResponse.js`) so every endpoint returns a consistent JSON envelope. This keeps client parsing simple and predictable.
+
+---
+
+## Location
+
+```
+backend/api/src/lib/apiResponse.js
+```
+
+---
+
+## Helpers
+
+### success(data, message, statusCode)
+
+```js
+success({ id: 1 }, 'Order created', 201);
+// { success: true, statusCode: 201, message: "Order created", data: { id: 1 } }
+```
+
+### error(message, statusCode, errors)
+
+```js
+error('Validation failed', 400, [{ field: 'phone', message: 'Invalid' }]);
+// { success: false, statusCode: 400, message: "Validation failed", errors: [...] }
+```
+
+The `errors` key is omitted when no error details are supplied.
+
+### paginated(data, page, limit, total, message)
+
+```js
+paginated(items, 1, 10, 42);
+// { success: true, statusCode: 200, message, data, pagination: { page, limit, total, totalPages, hasNextPage, hasPrevPage } }
+```
+
+The pagination envelope clamps non-positive/non-finite `limit` values so `totalPages` is always finite.
+
+---
+
+## Why It Exists
+
+Consistent envelopes mean:
+
+- Clients write one response parser instead of one per endpoint.
+- The `success` boolean gives an unambiguous success/failure signal.
+- Pagination metadata is standardized for list endpoints.
+
+---
+
+## Testing
+
+Automated tests verify:
+
+- Default and custom success/error shapes.
+- Error details inclusion/omission.
+- Pagination metadata, edge cases, and limit guards.


### PR DESCRIPTION
Closes #10405.

Summary of What Has Been Done:
Added a documentation page for the API response helpers covering the success/error/paginated envelopes and their guarantees.

Changes Made:
- docs/API_RESPONSE.md: new docs file

Impact it Made:
Documentation clarity for the standard response envelopes.

Note: Please assign this PR to the `tmdeveloper007` account.

This Pull Request is from GSSOC.