### PR TITLE
fix(istio): remove broken duplicate install block in install-istio.sh

### DIFF
--- a/k8s/istio/install-istio.sh
+++ b/k8s/istio/install-istio.sh
@@ -1,13 +1,4 @@
 ﻿#!/bin/bash
-echo "🚀 Installing Istio Service Mesh..."
-curl -L https://istio.io/downloadIstio | sh -
-cd istio-*
-export PATH=\C:\Users\bhakk\Truxify/bin:\
-istioctl install --set profile=demo -y
-kubectl label namespace default istio-injection=enabled
-kubectl get pods -n istio-system
-echo "✅ Istio installed successfully!"
-#!/bin/bash
 
 echo "🚀 Installing Istio Service Mesh..."
 


### PR DESCRIPTION
## Problem
`k8s/istio/install-istio.sh` contains a duplicated install script. The first block sets a broken PATH:
```sh
export PATH=\C:\Users\bhakk\Truxify/bin:\
```
This literal Windows path makes the script fail (`\C:\Users\bhakk\Truxify/bin` is not a valid directory in the CI/container), so `istioctl` can never be found and installation aborts.

## Fix
Removed the broken first block entirely, keeping the correct second block that adds the downloaded istioctl to PATH via `export PATH=$PWD/bin:$PATH`. The script now contains a single, valid install sequence.

## Files changed
- `k8s/istio/install-istio.sh`

## Testing
- Verified no `bhakk` or `Truxify/bin` literals remain in the file.
- Script still contains exactly one `#!/bin/bash` shebang and the full correct install flow (download → cd → PATH → install → label → verify).

Closes #10152
