### PR TITLE
fix(fraud): match criticalEndpoints to actual /api/v1/trips mount (#10501)

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -8,11 +8,14 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
   try {
     const userId = req.user?.id;
 
+    // These must match the actual mount paths in index.js. Trips are mounted
+    // at /api/v1/trips (with authenticate + this middleware); the bare
+    // /api/trips mount has no auth/middleware, so matching it would be moot.
+    // See issue #10501.
     const criticalEndpoints = [
       '/api/orders',
       '/api/payments',
-      '/api/escrow',
-      '/api/trips'
+      '/api/v1/trips'
     ];
 
     const isCritical = criticalEndpoints.some(endpoint => req.originalUrl.startsWith(endpoint));

--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -68,6 +68,25 @@ describe('fraudMiddleware', () => {
       await fraudDetectionMiddleware(req, res, next);
       expect(res.status).toHaveBeenCalledWith(503);
     });
+
+    // #10501: trips are mounted at /api/v1/trips in index.js, so the fraud
+    // middleware's criticalEndpoints entry must match that path (not the
+    // auth-less /api/trips mount). A v1 trip request must be treated as
+    // critical and run real-time risk scoring.
+    it('treats /api/v1/trips requests as critical (runs risk scoring)', async () => {
+      const { req, res, next } = makeReqRes({ originalUrl: '/api/v1/trips/123' });
+      await fraudDetectionMiddleware(req, res, next);
+      expect(fraudMock.getRealTimeRisk).toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('blocks high-risk /api/v1/trips requests', async () => {
+      fraudMock.getRealTimeRisk.mockResolvedValue({ riskScore: 0.95, riskLevel: 'HIGH' });
+      const { req, res, next } = makeReqRes({ originalUrl: '/api/v1/trips' });
+      await fraudDetectionMiddleware(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
   });
 
   describe('networkAnalysisMiddleware', () => {


### PR DESCRIPTION
## What

Fixes #10501

`fraudDetectionMiddleware` (`backend/api/src/middleware/fraudMiddleware.js`) lists the critical endpoints that trigger real-time risk review/blocking:

```js
const criticalEndpoints = [
  '/api/orders',
  '/api/payments',
  '/api/escrow',
  '/api/trips'
];
const isCritical = criticalEndpoints.some(endpoint => req.originalUrl.startsWith(endpoint));
```

Two problems:

1. **Trips are mounted at `/api/v1/trips`** in `src/index.js:475` (the mount that carries `authenticate` + `fraudDetectionMiddleware`):
   ```js
   app.use('/api/v1/trips', authenticate, fraudDetectionMiddleware, networkAnalysisMiddleware, tripRoutes);
   ```
   A request to `/api/v1/trips/...` does **not** start with `/api/trips`, so `isCritical` is `false`. The fraud middleware runs (it's mounted), but the critical-endpoint branch — `getRealTimeRisk(...)`, review-queue flagging, the high-risk `403` block, and `req.riskScore`/`req.riskLevel` population — is skipped for every trip request. Trip endpoints are the highest-value fraud surface and are currently unprotected.
   (There is a bare `app.use('/api/trips', tripRoutes)` at `index.js:476`, but it has **no auth and no fraud middleware**, so matching it would be moot — the middleware never executes there.)
2. **`/api/escrow` has no mount** anywhere in `index.js` (only escrow *services* are imported), so it's a dead entry.

## Fix

Align `criticalEndpoints` with the real, fraud-protected mount paths:

```js
const criticalEndpoints = [
  '/api/orders',
  '/api/payments',
  '/api/v1/trips'
];
```

- `/api/trips` → `/api/v1/trips` so the critical branch runs for the mount that actually carries this middleware.
- Drop `/api/escrow` (no mount; never matched).

`/api/orders` (`index.js:486`) and `/api/payments` (`index.js:487`) are already correct and untouched.

## Verification

Added two cases to `backend/api/test/unit/fraudMiddleware.test.js` (vitest, mocks `FraudDetectionService` + `logger`):
- `treats /api/v1/trips requests as critical (runs risk scoring)` — `/api/v1/trips/123` now calls `getRealTimeRisk` and proceeds.
- `blocks high-risk /api/v1/trips requests` — high-risk trip request returns `403` and does not call `next()`.

Both tests **fail on unpatched `main`** (2 failed → `getRealTimeRisk` never called / `403` never returned) and **pass with this fix** (9/9). The pre-existing 7 tests still pass unchanged.

```
RUN  v4.1.10
 ✓ test/unit/fraudMiddleware.test.js (9 tests)
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Impact

- Trip endpoints under `/api/v1/trips` now run real-time fraud scoring: high-risk trip requests are blocked (`403`), suspicious activity is queued for review, and `req.riskScore`/`req.riskLevel` are populated for downstream use.
- Removing the dead `/api/escrow` entry has no behavioural effect (it never matched).
- No new dependencies; no changes to other surfaces.

## Files changed

- `backend/api/src/middleware/fraudMiddleware.js` — fix `criticalEndpoints` (1 entry changed, 1 dead entry removed) + a comment linking the entry to the `index.js` mount.
- `backend/api/test/unit/fraudMiddleware.test.js` — two regression cases for `/api/v1/trips`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fraud protection for trip requests to correctly apply real-time risk checks.
  * High-risk trip requests are now blocked with an appropriate access-denied response.
  * Corrected fraud monitoring coverage for order, payment, and trip endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->