### PR TITLE
fix(tracking): mirror revoked/expired status (410) on /route endpoint (#10503)

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -7,6 +7,9 @@ import logger from '../middleware/logger.js';
 import { validateParams } from '../middleware/validate.js';
 import { createStore, safeIpKeyGenerator } from '../middleware/rateLimiter.js';
 import { publicTrackingTokenSchema } from '../validation/requestSchemas.js';
+import {
+  trackingTokenInvalidResponse,
+} from '../utils/trackingTokenStatus.js';
 
 const router = express.Router();
 
@@ -48,13 +51,7 @@ router.get(
       }
 
       if (!validation.valid) {
-        const statusMessages = {
-          not_found: { status: 404, message: 'Tracking link not found or invalid' },
-          revoked: { status: 410, message: 'This tracking link has been revoked' },
-          expired: { status: 410, message: 'This tracking link has expired' },
-        };
-
-        const { status, message } = statusMessages[validation.reason] || statusMessages.not_found;
+        const { status, message } = trackingTokenInvalidResponse(validation);
         return res.status(status).json({ error: message });
       }
 
@@ -138,7 +135,8 @@ router.get(
       }
 
       if (!validation.valid) {
-        return res.status(404).json({ error: 'Tracking link not found or invalid' });
+        const { status, message } = trackingTokenInvalidResponse(validation);
+        return res.status(status).json({ error: message });
       }
 
       const { orderDisplayId } = validation;

--- a/backend/api/src/utils/trackingTokenStatus.js
+++ b/backend/api/src/utils/trackingTokenStatus.js
@@ -1,0 +1,17 @@
+// Maps an invalid tracking-token `validation` result (from
+// TrackingTokenService.validateToken) to a consistent HTTP status + message
+// across both public tracking endpoints. `revoked`/`expired` → 410 (gone,
+// client should request a fresh link); `not_found` (and any unmapped reason)
+// → 404. See issue #10503.
+export const TRACKING_TOKEN_STATUS_MESSAGES = {
+  not_found: { status: 404, message: 'Tracking link not found or invalid' },
+  revoked: { status: 410, message: 'This tracking link has been revoked' },
+  expired: { status: 410, message: 'This tracking link has expired' },
+};
+
+export function trackingTokenInvalidResponse(validation) {
+  const { status, message } =
+    TRACKING_TOKEN_STATUS_MESSAGES[validation.reason] ||
+    TRACKING_TOKEN_STATUS_MESSAGES.not_found;
+  return { status, message };
+}

--- a/backend/api/test/integration/publicTracking.test.js
+++ b/backend/api/test/integration/publicTracking.test.js
@@ -315,6 +315,35 @@ describe('Tracking Routes', () => {
       expect(res.status).toBe(422);
       expect(res.body.error).toBe('Route coordinates are not available for this order');
     });
+
+    // #10503: the /route endpoint must mirror the main tracking endpoint's
+    // status mapping for invalid tokens (410 for revoked/expired, 404 for
+    // not_found) instead of returning 404 for every invalid state.
+    it('should return 410 for a revoked token (mirrors main endpoint)', async () => {
+      const shareRes = await request(app)
+        .post('/api/orders/%23FF20241205/share-tracking')
+        .set('x-user-id', 'customer-uuid-123')
+        .send({});
+
+      await request(app)
+        .post('/api/orders/%23FF20241205/share-tracking/revoke')
+        .set('x-user-id', 'customer-uuid-123')
+        .send({});
+
+      const res = await request(app)
+        .get(`/api/public/tracking/${shareRes.body.token}/route`);
+
+      expect(res.status).toBe(410);
+      expect(res.body.error).toBe('This tracking link has been revoked');
+    });
+
+    it('should return 404 for an unknown token (mirrors main endpoint)', async () => {
+      const res = await request(app)
+        .get('/api/public/tracking/invalid-token-abc123/route');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tracking link not found or invalid');
+    });
   });
 
   describe('Security: No auth required for public endpoint', () => {

--- a/backend/api/test/unit/trackingTokenStatus.test.js
+++ b/backend/api/test/unit/trackingTokenStatus.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+// #10503: the /route endpoint must mirror the main tracking endpoint's status
+// mapping for invalid tokens. This is a pure unit test of the shared helper
+// (no HTTP layer) so it runs independently of the integration suite, whose
+// route module currently cannot be imported on main due to an unrelated
+// pre-existing duplicate-export parse error in requestSchemas.js (#10082).
+
+import {
+  trackingTokenInvalidResponse,
+  TRACKING_TOKEN_STATUS_MESSAGES,
+} from '../../src/utils/trackingTokenStatus.js';
+
+describe('trackingTokenInvalidResponse', () => {
+  it('maps revoked → 410', () => {
+    const { status, message } = trackingTokenInvalidResponse({
+      valid: false,
+      reason: 'revoked',
+    });
+    expect(status).toBe(410);
+    expect(message).toBe('This tracking link has been revoked');
+  });
+
+  it('maps expired → 410', () => {
+    const { status, message } = trackingTokenInvalidResponse({
+      valid: false,
+      reason: 'expired',
+    });
+    expect(status).toBe(410);
+    expect(message).toBe('This tracking link has expired');
+  });
+
+  it('maps not_found → 404', () => {
+    const { status, message } = trackingTokenInvalidResponse({
+      valid: false,
+      reason: 'not_found',
+    });
+    expect(status).toBe(404);
+    expect(message).toBe('Tracking link not found or invalid');
+  });
+
+  it('falls back to 404 for an unmapped reason', () => {
+    const { status, message } = trackingTokenInvalidResponse({
+      valid: false,
+      reason: 'something_unexpected',
+    });
+    expect(status).toBe(404);
+    expect(message).toBe('Tracking link not found or invalid');
+  });
+
+  it('falls back to 404 when reason is missing', () => {
+    const { status, message } = trackingTokenInvalidResponse({ valid: false });
+    expect(status).toBe(404);
+    expect(message).toBe('Tracking link not found or invalid');
+  });
+
+  it('never returns 404 for revoked or expired (the #10503 regression)', () => {
+    for (const reason of ['revoked', 'expired']) {
+      const { status } = trackingTokenInvalidResponse({
+        valid: false,
+        reason,
+      });
+      expect(status).toBe(410);
+    }
+  });
+
+  it('exposes the message map for the three known states', () => {
+    expect(Object.keys(TRACKING_TOKEN_STATUS_MESSAGES).sort()).toEqual(
+      ['expired', 'not_found', 'revoked'],
+    );
+    expect(TRACKING_TOKEN_STATUS_MESSAGES.revoked.status).toBe(410);
+    expect(TRACKING_TOKEN_STATUS_MESSAGES.expired.status).toBe(410);
+    expect(TRACKING_TOKEN_STATUS_MESSAGES.not_found.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What

Fixes #10503

The two public tracking endpoints handle invalid tokens inconsistently:

- `GET /tracking/:token` (`publicTrackingRoutes.js`) maps `revoked`/`expired` → **410** and `not_found` → **404** via an inline `statusMessages` table.
- `GET /tracking/:token/route` treated **every** invalid state identically:
  ```js
  if (!validation.valid) {
    return res.status(404).json({ error: 'Tracking link not found or invalid' });
  }
  ```

So the same revoked/expired token yields `410` on the main endpoint but `404` on the route endpoint. Clients that key UI off the status code cannot distinguish "this link was revoked/expired — re-request a fresh link" from "no such link — you may have mistyped the URL", and the route endpoint contradicts its sibling's own documented contract.

## Fix

Hoist the status mapping into a small shared module — `backend/api/src/utils/trackingTokenStatus.js` — and use it from **both** handlers:

```js
export const TRACKING_TOKEN_STATUS_MESSAGES = {
  not_found: { status: 404, message: 'Tracking link not found or invalid' },
  revoked:   { status: 410, message: 'This tracking link has been revoked' },
  expired:   { status: 410, message: 'This tracking link has expired' },
};

export function trackingTokenInvalidResponse(validation) {
  const { status, message } =
    TRACKING_TOKEN_STATUS_MESSAGES[validation.reason] ||
    TRACKING_TOKEN_STATUS_MESSAGES.not_found;
  return { status, message };
}
```

The first handler's inline table is removed in favour of the shared helper (no behaviour change — same map, same fallback), and the `/route` handler now calls the same helper instead of hard-coding `404`. Both endpoints now agree: `revoked`/`expired` → `410`, `not_found` (and any unmapped reason) → `404`.

## Verification

New unit test `backend/api/test/unit/trackingTokenStatus.test.js` (vitest, 7 tests, passes):
- `revoked` → `410` + correct message
- `expired` → `410` + correct message
- `not_found` → `404` + correct message
- unmapped reason → `404` fallback
- missing reason → `404` fallback
- explicit regression guard: `revoked`/`expired` never return `404` (the #10503 bug)
- the message map exposes exactly the three known states with the right statuses

```
RUN  v4.1.10
 ✓ test/unit/trackingTokenStatus.test.js (7 tests)
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Two integration cases were also added to `backend/api/test/integration/publicTracking.test.js` for the `/route` endpoint (revoked → `410`, unknown token → `404`). **Note:** the integration suite currently cannot be loaded on `main` due to an unrelated, pre-existing parse error — `src/validation/requestSchemas.js` declares `export const syncWeightSchema` twice (lines 257 and 419), which Rolldown rejects (`Duplicated export 'syncWeightSchema'`). That is tracked separately by issues #10082 / open PR #10093 and is **not caused by this change**; I verified the failure is identical on clean `upstream/main`. The shared helper was deliberately extracted into its own module so its behaviour can be unit-tested independently of that pre-existing breakage. Once #10093 lands, the two integration cases here will exercise the same mapping end-to-end.

## Impact

- `GET /tracking/:token/route` now returns `410` for revoked/expired tokens, consistent with `GET /tracking/:token`. Clients can reliably distinguish "link expired/revoked" from "link not found".
- The duplicated inline status table is removed; there is now a single source of truth for tracking-token status mapping.
- No new dependencies.

## Files changed

- `backend/api/src/utils/trackingTokenStatus.js` — new shared status-map + helper.
- `backend/api/src/routes/publicTrackingRoutes.js` — import the helper; both handlers use it; inline duplicate table removed.
- `backend/api/test/unit/trackingTokenStatus.test.js` — new, 7 unit cases (passes on `main`).
- `backend/api/test/integration/publicTracking.test.js` — two `/route` regression cases (revoked → 410, unknown → 404).

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._