### PR TITLE
[Bug] canUserAccessPeer no longer admits a no-id caller to a no-id peer

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -406,7 +406,12 @@ class WebRTCSignalingServer {
     if (user?.role === 'admin') return true;
 
     const peer = this.peers.get(peerId);
-    return Boolean(peer && peer.userId === user?.id);
+    // Both ids must actually be present: `peer.userId === user?.id` is true
+    // when both sides are undefined, which would admit a caller with no id to
+    // any peer registered from a token carrying no `id` claim.
+    return Boolean(
+      peer && peer.userId != null && user?.id != null && peer.userId === user.id,
+    );
   }
 
   async getOfflineGPSData(peerId, since, requestingUser) {

--- a/backend/api/test/unit/WebRTCSignalingServer.test.js
+++ b/backend/api/test/unit/WebRTCSignalingServer.test.js
@@ -361,18 +361,18 @@ describe('WebRTCSignalingServer', () => {
       ['no user', undefined],
       ['null', null],
       ['a user with no id', {}],
-    ])(
-      'currently ADMITS %s to a peer with an unset userId (undefined === undefined)',
-      (_label, user) => {
-        // Not the intended behaviour — pinned so the fix is visible as a diff.
-        // `peer.userId === user?.id` is true when both sides are undefined, so
-        // a peer registered from a token with no `id` claim is reachable by a
-        // caller who also has no id. Tracked separately; see the follow-up
-        // that tightens this to require both ids to be present.
-        addPeer(server, 'peer-anon', { userId: undefined });
-        expect(server.canUserAccessPeer('peer-anon', user)).toBe(true);
-      },
-    );
+    ])('refuses %s for a peer with an unset userId', (_label, user) => {
+      // `peer.userId === user?.id` alone is true when both sides are
+      // undefined, which admitted a caller with no id to any peer registered
+      // from a token that carries no `id` claim.
+      addPeer(server, 'peer-anon', { userId: undefined });
+      expect(server.canUserAccessPeer('peer-anon', user)).toBe(false);
+    });
+
+    it('refuses a null-id caller for a peer with a null userId', () => {
+      addPeer(server, 'peer-null', { userId: null });
+      expect(server.canUserAccessPeer('peer-null', { id: null })).toBe(false);
+    });
 
     it('refuses an identified user for a peer with an unset userId', () => {
       addPeer(server, 'peer-anon', { userId: undefined });


### PR DESCRIPTION
Closes #10550

`canUserAccessPeer()` compared `peer.userId === user?.id`, which is `true` when both sides are `undefined`. A peer registered from a token with no `id` claim was reachable by any caller whose token also had no `id` claim — including reading their GPS history via `getOfflineGPSData()` and marking it synced via `syncOfflineData()`.

Fix requires both ids to be non-null before comparing:

```js
return Boolean(
  peer && peer.userId != null && user?.id != null && peer.userId === user.id,
);
```

Test suite updated: the two cases that previously pinned the `true` (buggy) result now assert `false`, plus an added case for `{ id: null }` against a `userId: null` peer. Full file: 62/62 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC peer access authorization by preventing anonymous or missing identifiers from being treated as valid ownership matches.
  * Preserved administrative access behavior while strengthening authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->