### PR TITLE
fix: add valid api keys to env example

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -113,3 +113,10 @@ ESCROW_RECONCILIATION_INTERVAL_MS=60000
 #   "reject" (default) — deny all uploads (fail-closed, recommended for production)
 #   "pass"            — allow uploads without scanning (development only)
 # CLAMAV_UNAVAILABLE_ACTION=reject
+
+# ── Internal API Keys ──────────────────────
+# Comma-separated list of API keys accepted by the requireApiKey middleware
+# for internal/automation endpoints (e.g. n8n document-integrity workflow,
+# circuit-breaker automation under /api/internal/*).
+# Replace with real, securely generated keys before deploying.
+VALID_API_KEYS=changeme-replace-in-production


### PR DESCRIPTION
## Description

Added `VALID_API_KEYS` to `.env.example` so API key-protected internal endpoints can be configured in development and reference deployments.

## Changes Made

- Added `VALID_API_KEYS` with a development placeholder value.
- Documented its purpose for internal and automation endpoints.
- Added a reminder to replace the placeholder with a secure key before production deployment.

## Impact

- Allows `requireApiKey`-protected endpoints to be configured correctly.
- Supports development and reference deployments.
- No production secrets were added.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/10510