### PR TITLE
[Test] Fix stale BigInt(...) wrapper assertion in changeDrop.escrowRebalance.test.js

### DIFF
--- a/backend/api/test/changeDrop.escrowRebalance.test.js
+++ b/backend/api/test/changeDrop.escrowRebalance.test.js
@@ -186,7 +186,8 @@ describe('RPC/route persist escrow_amount_wei (issue #5825)', () => {
       src.indexOf('// ============================================================================\n// 16.'),
     );
     expect(changeDropSection).toContain('escrow_amount_wei: newAmountWei.toString()');
+    // paisaToMaticWei already returns a bigint, so the route no longer wraps
+    // it in an extra BigInt(...) call.
     expect(changeDropSection).toContain('paisaToMaticWei(pricing.totalAmount)');
-    expect(changeDropSection).toContain('BigInt(paisaToMaticWei(pricing.totalAmount))');
   });
 });


### PR DESCRIPTION
Closes #10553

`paisaToMaticWei()` already returns a `bigint` (see its JSDoc), so the change-drop route calls it directly with no extra `BigInt(...)` wrap. The test asserted that wrapper existed in the source, which is stale — it fails on current `main`.

Dropped the redundant assertion; the preceding `toContain('paisaToMaticWei(pricing.totalAmount)')` already covers the real invariant this test guards (issue #5825: escrow_amount_wei rebalancing on change-drop). 5/5 passing.