### PR TITLE
[Test] maintenancePhotoRoutes.test.js: mock createUserClient, 11/13 fail → 13/13 pass

### DIFF
--- a/backend/api/test/integration/maintenancePhotoRoutes.test.js
+++ b/backend/api/test/integration/maintenancePhotoRoutes.test.js
@@ -5,8 +5,23 @@ import express from 'express';
 const { createSupabaseMock } = await vi.importActual('../helpers/supabaseMock.js');
 const m = createSupabaseMock();
 
+// The controller calls createUserClient(req.token) unconditionally (the
+// append_maintenance_photos RPC is SECURITY DEFINER and needs the caller's
+// JWT), so the mock must provide it or every request 500s before reaching
+// any route logic.
+const userClientRpc = vi.fn(async (fnName, args) => {
+  if (fnName === 'append_maintenance_photos') {
+    const ticket = m.store.truck_maintenance_tickets.find((t) => t.id === args.p_ticket_id);
+    if (ticket) {
+      ticket.photo_urls = [...(ticket.photo_urls || []), ...args.p_new_paths];
+    }
+  }
+  return { data: null, error: null };
+});
+
 vi.mock('../../src/config/db.js', () => ({
   supabase: m.supabase,
+  createUserClient: () => ({ rpc: userClientRpc }),
   firebaseAdmin: null,
   redisClient: null,
   mongoDb: null,


### PR DESCRIPTION
Closes #10555

`uploadMaintenancePhotos` calls `createUserClient(req.token)` unconditionally right after the auth check (the `append_maintenance_photos` RPC is `SECURITY DEFINER` and needs the caller's JWT). The test's `config/db.js` mock never exported `createUserClient`, so that call threw immediately and every request 500'd before any real route logic — file presence, ticket lookup, ownership, MIME validation, malware scan — ever ran.

Added `createUserClient` to the mock, backed by an `rpc()` that appends uploaded paths to the matching ticket in the shared in-memory store for `append_maintenance_photos`, so the "updates the ticket record with photo URLs" assertion reflects real behavior rather than a no-op.

11/13 failing → 13/13 passing.