### PR TITLE
[Test] healthAggregation.test.js: mock supabaseAdmin, 3/9 fail → 9/9 pass

### DIFF
--- a/backend/api/test/integration/healthAggregation.test.js
+++ b/backend/api/test/integration/healthAggregation.test.js
@@ -10,6 +10,9 @@ let mockPgPool = null;
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return mockSupabase; },
+  // supabaseHealth probes through supabaseAdmin (falling back to supabase)
+  // since the anon client can't read `profiles` post revoke_anon_privileges.
+  get supabaseAdmin() { return mockSupabase; },
   get mongoDb() { return mockMongoDb; },
   get redisClient() { return mockRedisClient; },
   get firebaseAdmin() { return mockFirebaseAdmin; },


### PR DESCRIPTION
Closes #10557

`supabaseHealth` probes through `supabaseAdmin || supabase` — the anon client can't read `profiles` after `revoke_anon_privileges.sql`, so it deliberately prefers the service-role client. The test's `config/db.js` mock never exported `supabaseAdmin`, so destructuring it threw on every call, making the (critical) supabase check always report `unhealthy` — and since it's critical, `/api/health/full` always returned 503, even in the "all services healthy" test case.

Added `supabaseAdmin` to the mock, pointing at the same double as `supabase`, so `mockSupabase = null` still correctly exercises the unhealthy path.

3/9 failing → 9/9 passing.