### PR TITLE
[Test] anomalyDetectionService.test.js: mock supabaseAdmin + fix stale table assertion, 3/23 fail → 23/23 pass

### DIFF
--- a/backend/api/test/unit/anomalyDetectionService.test.js
+++ b/backend/api/test/unit/anomalyDetectionService.test.js
@@ -30,8 +30,11 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: mockLogger,
 }));
 
+const mockSupabase = vi.hoisted(() => ({ from: vi.fn() }));
+
 vi.mock('../../src/config/db.js', () => ({
-  supabase: { from: vi.fn() },
+  supabase: mockSupabase,
+  supabaseAdmin: mockSupabase,
 }));
 
 import AnomalyDetectionService, { ANOMALY_THRESHOLDS, ANOMALY_SEVERITY } from '../../src/services/security/anomalyDetectionService.js';
@@ -197,7 +200,7 @@ describe('AnomalyDetectionService', () => {
       const avg = await service.getUserAverageWithdrawal('user-1', 'wallet-1');
 
       expect(avg).toBe(1500);
-      expect(supabase.from).toHaveBeenCalledWith('transactions');
+      expect(supabase.from).toHaveBeenCalledWith('wallet_transactions');
       expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
       expect(builder.limit).toHaveBeenCalledWith(1000);
     });


### PR DESCRIPTION
Closes #10559

Two independent defects in the test file:

1. **Mock omits `supabaseAdmin`.** The service queries through `(supabaseAdmin || supabase)`; the mock only exported `supabase`. Evaluating the undefined `supabaseAdmin` binding threw — but `getUserAverageWithdrawal`/`getUserWithdrawalStdDev` wrap their body in `try/catch` and silently return a fallback threshold value on any error. So instead of an obvious mock error, the tests got a plausible-looking wrong number back (`500` instead of `1500`, etc.).
2. **Stale `'transactions'` table assertion.** The service queries `'wallet_transactions'` — the only table that actually exists (per `docs/supabase_setup.sql` and every other caller). This was the bug in #9546, already fixed in source; the test just never caught up.

23/23 passing (was 3/23 failing).