### PR TITLE
[Bug] recordDepositTx: underpaid deposits never get the DEPOSIT_AMOUNT_MISMATCH code

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -481,11 +481,6 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
     return { error: 'Transaction destination is not the Escrow contract' }
   }
 
-  // Critical Security Check: Verify tx.value (deposit amount)
-  if (expectedAmountWei && BigInt(tx.value) < BigInt(expectedAmountWei)) {
-    return { error: `Transaction value ${tx.value} wei is less than expected ${expectedAmountWei} wei` }
-  }
-
   let decoded
   try {
     decoded = escrowContract.interface.parseTransaction({ data: tx.data, value: tx.value })


### PR DESCRIPTION
Closes #10561

`recordDepositTx()` has two checks against the expected deposit amount:

1. An earlier guard (from #4701): `if (expectedAmountWei && tx.value < expectedAmountWei) return { error: '...' }` — no `code`.
2. A later exact-equality check (added afterward — its comment says *"Exact equality (not >=) rejects both under- and over-payments"*), returning `code: 'DEPOSIT_AMOUNT_MISMATCH'` for both directions.

Check 1 runs first and matches every case check 2's underpayment branch would also match, so that branch was dead code — underpaid deposits always got check 1's plain, uncoded error.

`deliveryVerificationService.js` branches on `releaseResult.code === "DEPOSIT_AMOUNT_MISMATCH"` to take a dedicated mismatch-recovery path (lines 581, 598). Underpayment never reached it — only overpayment did.

Removed the now-redundant earlier check; the later exact-equality check already covers both directions with the correct `code` and message, after the same `tx.to`/decode validation.

`test/unit/escrowSenderVerification.test.js` already asserts the exact-equality/coded behavior for underpayment (2 cases) — those now pass. 30/30 across the affected test files (`escrowSenderVerification`, `orderLifecycle.verifyDelivery`, `integration/escrow`).