### PR TITLE
[Test] redisLock.test.js: fix import depth and stale return-null assertion

### DIFF
--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the db module before importing redisLock
-vi.mock('../../config/db.js', () => ({
+vi.mock('../../src/config/db.js', () => ({
   redisClient: null,
 }));
 
@@ -10,14 +10,13 @@ describe('redisLock', () => {
     vi.clearAllMocks();
   });
 
-  it('acquireLock returns null when redisClient is null', async () => {
-    const { acquireLock } = await import('../../lib/redisLock.js');
-    const result = await acquireLock('test-resource', 5000);
-    expect(result).toBeNull();
+  it('acquireLock throws (fails closed) when redisClient is null', async () => {
+    const { acquireLock, LockAcquisitionError } = await import('../../src/lib/redisLock.js');
+    await expect(acquireLock('test-resource', 5000)).rejects.toBeInstanceOf(LockAcquisitionError);
   });
 
   it('releaseLock does not throw when redisClient is null', async () => {
-    const { releaseLock } = await import('../../lib/redisLock.js');
+    const { releaseLock } = await import('../../src/lib/redisLock.js');
     await expect(releaseLock('non-existent-lock')).resolves.not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #10563

Two independent defects:

1. **Wrong import depth.** From `test/unit/`, both `vi.mock('../../config/db.js', ...)` and the dynamic `import('../../lib/redisLock.js')` are one level too shallow — missing `src/`. Since the `vi.mock` target path never matched what `redisLock.js` actually imports, the mock silently never applied, and the dynamic import 404'd.
2. **Stale assertion.** `acquireLock()`'s documented contract is fail-closed — it throws `LockAcquisitionError` when `redisClient` is null, not return `null`. The test still asserted the old return-null behavior.

Fixed both import paths and updated the assertion to expect the documented throw. 2/2 passing.