### PR TITLE
[Test] verificationService.test.js: fix statuses to match ACTIVE_DELIVERY_STATUSES from #9537

### DIFF
--- a/backend/api/test/unit/services/verificationService.test.js
+++ b/backend/api/test/unit/services/verificationService.test.js
@@ -84,11 +84,11 @@ describe('VerificationService', () => {
       expect(result.error).toBe('Order not found');
     });
 
-    it('returns full verification result for a valid delivered order', async () => {
+    it('returns full verification result for an in-progress delivery the oracle confirms', async () => {
       const order = {
         id: VALID_ORDER_ID,
         order_display_id: 'ORD-001',
-        status: 'payment_released',
+        status: 'in_transit',
         customer_id: 'customer-1',
         driver_id: VALID_DRIVER_ID,
         truck_id: VALID_TRUCK_ID,
@@ -121,10 +121,10 @@ describe('VerificationService', () => {
       expect(result.timestamp).toBeDefined();
     });
 
-    it('marks deliveryVerified as false when order status is not delivered', async () => {
+    it('marks deliveryVerified as false once the order has reached a terminal status', async () => {
       const order = {
         id: VALID_ORDER_ID,
-        status: 'in_transit',
+        status: 'payment_released',
         driver_id: VALID_DRIVER_ID,
         truck_id: VALID_TRUCK_ID,
         blockchain_tx_hash: null,


### PR DESCRIPTION
Closes #10565

`VerificationService.verifyOrder()` gates `deliveryVerified` on `ACTIVE_DELIVERY_STATUSES` (`picked_up`, `in_transit`, `arriving`), deliberately excluding terminal statuses — per the source comment, this was the fix for #9537: `confirmDelivery` runs before the order reaches `delivered`/`payment_released`, so requiring a terminal status would make `deliveryVerified` unreachable.

Two tests still used the pre-fix semantics: the "valid" case used `status: 'payment_released'` (terminal, so always `false`) expecting `true`, and the "false" case used `status: 'in_transit'` (active, so always `true` given the default confirming oracle mock) expecting `false` — both always failed.

Swapped the statuses so each test exercises the case it claims to, and renamed the second test to describe the actual invariant (terminal status, not "not delivered"). 15/15 passing.