### PR TITLE
[Test] services/voiceService.test.js: mock supabaseAdmin so the suite loads

### DIFF
--- a/backend/api/test/unit/services/voiceService.test.js
+++ b/backend/api/test/unit/services/voiceService.test.js
@@ -22,6 +22,7 @@ const mockSupabase = {
 
 vi.mock('../../../src/config/db.js', () => ({
   supabase: mockSupabase,
+  supabaseAdmin: mockSupabase,
 }));
 
 vi.mock('../../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
Closes #10567

`voiceService.js` resolves its db client at module scope: `const voiceDb = supabaseAdmin || supabase`. The test's `config/db.js` mock only exported `supabase`, so destructuring `supabaseAdmin` threw at import time — the whole suite failed to load (0 tests ran) rather than any individual test failing.

Added `supabaseAdmin` to the mock, pointing at the same double as `supabase`. 13/13 passing.