### PR TITLE
[Test] sentry.test.js: declare Handlers key in @sentry/node mock

### DIFF
--- a/backend/api/test/unit/sentry.test.js
+++ b/backend/api/test/unit/sentry.test.js
@@ -26,6 +26,11 @@ vi.mock("../../src/middleware/logger.js", () => ({
 
 vi.mock("@sentry/node", async (real) => ({
   ...(await real()),
+  // The installed SDK version has no `Handlers` export (removed upstream);
+  // sentry.js probes it via optional chaining. Declaring the key here (even
+  // as undefined) keeps that access from throwing under vitest's mock
+  // strictness, so the fallback to expressErrorHandler() is actually exercised.
+  Handlers: undefined,
   init: vi.fn(),
   flush: vi.fn(),
   expressErrorHandler: () => vi.fn(),


### PR DESCRIPTION
Closes #10569

`sentryErrorHandler()` probes `Sentry.Handlers?.errorHandler` before falling back to `Sentry.expressErrorHandler()`. The installed `@sentry/node` has no `Handlers` export at all, so the test's `vi.mock("@sentry/node", async (real) => ({ ...(await real()), ... }))` never included that key — and vitest throws on any access to an undeclared mock export, even through optional chaining, crashing every test in the file.

Declared `Handlers: undefined` explicitly so the key is known and the fallback path is actually exercised.

13/17 passing (up from a file-wide crash). The remaining 4 failures are a separate, pre-existing mismatch between `shouldIgnoreError`'s boolean return and the test expecting a `'warn'`/`false` level string (plus disagreement on whether `ETIMEDOUT` should be filtered) — flagged in #10569 but left unfixed since it needs a design decision, not a mechanical correction.