### PR TITLE
[Test] bidAcceptanceService.test.js: mock findOrderById, not findOrderByIdOrDisplayId

### DIFF
--- a/backend/api/test/unit/bidAcceptanceService.test.js
+++ b/backend/api/test/unit/bidAcceptanceService.test.js
@@ -4,7 +4,7 @@ const mockAcquireLock = vi.fn();
 const mockReleaseLock = vi.fn();
 const mockFrom = vi.fn();
 const mockOrderRepository = {
-  findOrderByIdOrDisplayId: vi.fn(),
+  findOrderById: vi.fn(),
   updateOrderWithFilter: vi.fn(),
 };
 
@@ -38,7 +38,7 @@ describe('BidAcceptanceService', () => {
   describe('acceptBid', () => {
     it('rejects bid when order is already funded', async () => {
       mockAcquireLock.mockResolvedValue('lock-value');
-      mockOrderRepository.findOrderByIdOrDisplayId.mockResolvedValue({
+      mockOrderRepository.findOrderById.mockResolvedValue({
         id: 'order-1',
         escrow_status: 'funded',
         status: 'in_transit',
@@ -71,7 +71,7 @@ describe('BidAcceptanceService', () => {
 
     it('throws when order is in terminal state', async () => {
       mockAcquireLock.mockResolvedValue('lock-value');
-      mockOrderRepository.findOrderByIdOrDisplayId.mockResolvedValue({
+      mockOrderRepository.findOrderById.mockResolvedValue({
         id: 'order-1',
         escrow_status: 'pending',
         status: 'delivered',


### PR DESCRIPTION
Closes #10573

`BidAcceptanceService.acceptBid()` calls `this.orderRepository.findOrderById(...)`. The test's mock only defined `findOrderByIdOrDisplayId` — a distinct, real repository method the service doesn't call here. The missing method threw a plain `TypeError` ("findOrderById is not a function") instead of letting the service reach its intended `DomainError` for an already-funded order.

Renamed the mocked method to match. 3/3 passing.