### PR TITLE
[Bug] telemetry-ingestion: wire pruneGeofenceRateEntries into the periodic sweep

### DIFF
--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -470,6 +470,11 @@ func sweepDrivers() {
 		e.mu.Unlock()
 		return true
 	})
+
+	// geofenceRateLimit has no TTL-based cleanup of its own — without this,
+	// it only ever shrinks via evictGeofenceOverflow's oldest-first hard-cap
+	// eviction once it hits maxRateTracked entries.
+	pruneGeofenceRateEntries()
 }
 
 // Handle Single Telemetry Ping

--- a/services/telemetry-ingestion/main_test.go
+++ b/services/telemetry-ingestion/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -75,4 +76,32 @@ func TestSweepDriversEvictsStaleRetainsFresh(t *testing.T) {
 	activeDrivers.Delete("fresh-driver")
 	pingRateLimit.Delete("stale-ping")
 	pingRateLimit.Delete("fresh-ping")
+}
+
+func TestSweepDriversPrunesStaleGeofenceEntries(t *testing.T) {
+	now := time.Now()
+
+	staleEntry := &rateEntry{driverID: "geo-stale", stamps: []time.Time{now.Add(-2 * time.Second)}}
+	freshEntry := &rateEntry{driverID: "geo-fresh", stamps: []time.Time{now}}
+	geofenceRateLimit.Store("geo-stale", staleEntry)
+	geofenceRateLimit.Store("geo-fresh", freshEntry)
+	atomic.AddUint64(&geofenceRateTracked, 2)
+
+	before := atomic.LoadUint64(&geofenceRateTracked)
+
+	sweepDrivers()
+
+	if _, ok := geofenceRateLimit.Load("geo-stale"); ok {
+		t.Error("expected stale geofence rate-limit entry (all stamps older than 1s) to be pruned")
+	}
+	if _, ok := geofenceRateLimit.Load("geo-fresh"); !ok {
+		t.Error("expected fresh geofence rate-limit entry to be retained")
+	}
+	if after := atomic.LoadUint64(&geofenceRateTracked); after != before-1 {
+		t.Errorf("expected geofenceRateTracked to decrement by 1 (from %d), got %d", before, after)
+	}
+
+	geofenceRateLimit.Delete("geo-stale")
+	geofenceRateLimit.Delete("geo-fresh")
+	atomic.AddUint64(&geofenceRateTracked, ^uint64(0))
 }


### PR DESCRIPTION
Closes #10579

`pruneGeofenceRateEntries()` has existed since 4441c999 (its locking was refined in the #6882 TOCTOU fix, PR #7155) but is never called anywhere in the codebase. `sweepDrivers()` — run periodically by the ticker in `main()` — only cleans up `activeDrivers` and `pingRateLimit`; `geofenceRateLimit` was left with no TTL-based cleanup at all, unlike its ping-rate-limit counterpart.

In practice this means the geofence rate-limit map only ever shrinks via `evictGeofenceOverflow`'s crude oldest-insertion-order eviction once it hits `maxRateTracked` (default 100,000) entries, rather than continuously pruning genuinely stale entries the way `pingRateLimit` does.

Fix: call `pruneGeofenceRateEntries()` from `sweepDrivers()`. Added `TestSweepDriversPrunesStaleGeofenceEntries` verifying stale entries are pruned (and `geofenceRateTracked` decremented), fresh entries retained.

`go test ./...` and `go vet ./...` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup of expired geofence rate-limit entries.
  * Prevented empty, outdated rate-limit windows from accumulating over time.
  * Preserved active geofence rate-limit entries while removing stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->