### PR TITLE
[Bug] vector-matcher-cpp: parse_query_vector scans past ']' and swallows trailing numeric fields

### DIFF
--- a/services/vector-matcher-cpp/main.cpp
+++ b/services/vector-matcher-cpp/main.cpp
@@ -114,8 +114,13 @@ std::vector<float> parse_query_vector(const std::string& body) {
     if (pos == std::string::npos) return vec;
     pos++;
     while (pos < body.size()) {
+        // Stop the skip-scan at ']' — without this check it treats the
+        // closing bracket as just another non-digit character and keeps
+        // scanning past it, picking up any later numeric field in the body
+        // (e.g. "k": 5) as an extra vector element.
         while (pos < body.size() &&
-               !(std::isdigit(static_cast<unsigned char>(body[pos])) || body[pos] == '-')) {
+               !(std::isdigit(static_cast<unsigned char>(body[pos])) || body[pos] == '-') &&
+               body[pos] != ']') {
             pos++;
         }
         if (pos >= body.size() || body[pos] == ']') break;


### PR DESCRIPTION
Closes #10582

`parse_query_vector()`'s digit-skip loop treats `]` as just another non-digit character and scans right past it — the `body[pos] == ']'` end-of-array check immediately after can therefore never be true when reached (the loop's only exit conditions are end-of-string or landing on a digit/`-`). Once past the bracket, the scanner keeps consuming the body and picks up the next numeric literal — most naturally the `"k"` field that follows `"query"` in a normal request payload — as an extra vector element.

Repro:
```cpp
std::string body = R"({"query": [0.1, 0.2, 0.3], "k": 5})";
auto vec = parse_query_vector(body);
// vec == {0.1, 0.2, 0.3, 5} — 4 elements, not 3
```

Since `/search` requires exactly `EMBEDDING_DIM` (64) elements, any client sending a well-formed 64-element query followed by `k` in the same body gets a spurious 65-element parse and a 400 rejection.

Fix: add `body[pos] != ']'` to the skip-loop condition so scanning actually halts at the bracket.

Verified via a standalone extraction of the function against 4 cases (trailing `k` field / bug repro, `k` before `query`, negative numbers, truncated array with no `]`) — all pass. `g++ -std=c++17 -Wall -Wextra -c main.cpp` compiles clean (no CMake available in this sandbox, verified via direct g++ compilation).