### PR TITLE
test : added fix for bidAcceptanceService.test.js wrong mock method name

### DIFF
--- a/backend/api/test/unit/bidAcceptanceService.test.js
+++ b/backend/api/test/unit/bidAcceptanceService.test.js
@@ -4,7 +4,7 @@ const mockAcquireLock = vi.fn();
 const mockReleaseLock = vi.fn();
 const mockFrom = vi.fn();
 const mockOrderRepository = {
-  findOrderByIdOrDisplayId: vi.fn(),
+  findOrderById: vi.fn(),
   updateOrderWithFilter: vi.fn(),
 };
 
@@ -38,7 +38,7 @@ describe('BidAcceptanceService', () => {
   describe('acceptBid', () => {
     it('rejects bid when order is already funded', async () => {
       mockAcquireLock.mockResolvedValue('lock-value');
-      mockOrderRepository.findOrderByIdOrDisplayId.mockResolvedValue({
+      mockOrderRepository.findOrderById.mockResolvedValue({
         id: 'order-1',
         escrow_status: 'funded',
         status: 'in_transit',
@@ -71,7 +71,7 @@ describe('BidAcceptanceService', () => {
 
     it('throws when order is in terminal state', async () => {
       mockAcquireLock.mockResolvedValue('lock-value');
-      mockOrderRepository.findOrderByIdOrDisplayId.mockResolvedValue({
+      mockOrderRepository.findOrderById.mockResolvedValue({
         id: 'order-1',
         escrow_status: 'pending',
         status: 'delivered',


### PR DESCRIPTION
Closes #10593.

Summary of What Has Been Done:
Renamed the mock key from findOrderByIdOrDisplayId to findOrderById in bidAcceptanceService.test.js to match what BidAcceptanceService.acceptBid() actually calls. Updated the two test assertions that reference the mock accordingly. All 3 tests now pass.

Changes Made:
- backend/api/test/unit/bidAcceptanceService.test.js: Renamed findOrderByIdOrDisplayId to findOrderById in the mockOrderRepository object and both test assertions that reference it.

Impact it Made:
- bidAcceptanceService.test.js: 3/3 tests pass (was failing due to TypeError from calling undefined findOrderById)

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC.