### PR TITLE
test : added fix for escrowRebalance.test.js stale BigInt wrapper assertion

### DIFF
--- a/backend/api/test/changeDrop.escrowRebalance.test.js
+++ b/backend/api/test/changeDrop.escrowRebalance.test.js
@@ -187,6 +187,5 @@ describe('RPC/route persist escrow_amount_wei (issue #5825)', () => {
     );
     expect(changeDropSection).toContain('escrow_amount_wei: newAmountWei.toString()');
     expect(changeDropSection).toContain('paisaToMaticWei(pricing.totalAmount)');
-    expect(changeDropSection).toContain('BigInt(paisaToMaticWei(pricing.totalAmount))');
   });
 });


### PR DESCRIPTION
Closes #10594.

Summary of What Has Been Done:
Removed the stale assertion that checked for 'BigInt(paisaToMaticWei(pricing.totalAmount))' in the change-drop route handler. The source (orderRoutes.js line 497) calls paisaToMaticWei() directly without a BigInt() wrapper since paisaToMaticWei already returns a bigint per its JSDoc. The preceding assertion toContain('paisaToMaticWei(pricing.totalAmount)') already covers the invariant. All 5 tests now pass.

Changes Made:
- backend/api/test/changeDrop.escrowRebalance.test.js: Removed the stale toContain('BigInt(paisaToMaticWei(pricing.totalAmount))') assertion.

Impact it Made:
- changeDrop.escrowRebalance.test.js: 5/5 tests pass (was failing on this assertion)

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC.