### PR TITLE
fix : remove headerSizeMonitor production skip and return 431 (#10602)

### DIFF
--- a/backend/api/src/middleware/headerSizeMonitor.js
+++ b/backend/api/src/middleware/headerSizeMonitor.js
@@ -3,10 +3,6 @@ import logger from './logger.js';
 const DEFAULT_LIMIT = 8192; // 8 KB
 
 export default function headerSizeMonitor(req, res, next) {
-  if (process.env.NODE_ENV === 'production') {
-    return next();
-  }
-
   const rawLimit = process.env.HEADER_SIZE_LIMIT;
   const parsedLimit = Number(rawLimit);
   const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_LIMIT;
@@ -35,6 +31,10 @@ export default function headerSizeMonitor(req, res, next) {
       },
       'Request headers exceed configured size threshold'
     );
+    return res.status(431).json({
+      success: false,
+      error: 'Request header fields too large',
+    });
   }
 
   next();


### PR DESCRIPTION
## Summary
Fixes the `headerSizeMonitor` middleware:

- **#10602**: Removes the production environment skip that bypassed header size checking entirely
- Adds HTTP 431 (Request Header Fields Too Large) response when header size exceeds limit

## Files Changed
- `backend/api/src/middleware/headerSizeMonitor.js`

---

**GSSOC-2026**