### PR TITLE
fix : errorHandler reads err.errors but zod v4 uses err.issues (#10608)

### DIFF
--- a/backend/api/src/middleware/errorHandler.js
+++ b/backend/api/src/middleware/errorHandler.js
@@ -35,11 +35,11 @@ export function errorHandler(err, req, res, next) {
 
   // Handle Zod validation errors
   if (err && err.name === 'ZodError') {
-    logger.warn({ requestId: req.requestId, errors: err.errors }, 'Zod validation failed');
+    logger.warn({ requestId: req.requestId, errors: err.issues }, 'Zod validation failed');
     return res.status(400).json({
       success: false,
       error: 'Validation failed',
-      details: err.errors.map(e => ({ field: e.path.join('.'), message: e.message })),
+      details: err.issues.map(e => ({ field: e.path.join('.'), message: e.message })),
     });
   }
 


### PR DESCRIPTION
## Summary
Fixes the error handler middleware:

- **#10608**: Updates ZodError handling from `err.errors` to `err.issues` for Zod v4 compatibility

## Files Changed
- `backend/api/src/middleware/errorHandler.js`

---

**GSSOC-2026**