### PR TITLE
[BUG][backend][test] core/auth unit tests fail 11/11 — authorizationError/permission/role tests were written against a different API than the source exposes

### DIFF
--- a/backend/api/test/unit/core/auth/authorizationError.test.js
+++ b/backend/api/test/unit/core/auth/authorizationError.test.js
@@ -2,30 +2,50 @@ import { describe, it, expect } from 'vitest';
 import { AuthorizationError } from '../../../../src/core/auth/AuthorizationError.js';
 
 describe('AuthorizationError', () => {
-  it('should create an error with a message', () => {
-    const error = new AuthorizationError('Not authorized');
+  it('should create an error with a status and message', () => {
+    const error = new AuthorizationError(403, 'Not authorized');
     expect(error).toBeInstanceOf(Error);
     expect(error).toBeInstanceOf(AuthorizationError);
     expect(error.message).toBe('Not authorized');
+    expect(error.status).toBe(403);
   });
 
   it('should have AuthorizationError as name', () => {
-    const error = new AuthorizationError('Forbidden');
+    const error = new AuthorizationError(403, 'Forbidden');
     expect(error.name).toBe('AuthorizationError');
   });
 
-  it('should have the code property set when provided', () => {
-    const error = new AuthorizationError('Access denied', 'ERR_ACCESS_DENIED');
-    expect(error.code).toBe('ERR_ACCESS_DENIED');
+  it('should use the error code when provided', () => {
+    const error = new AuthorizationError(403, 'Access denied', 'ROLE_NOT_ALLOWED');
+    expect(error.errorCode).toBe('ROLE_NOT_ALLOWED');
   });
 
-  it('should default code to undefined when not provided', () => {
-    const error = new AuthorizationError('No access');
-    expect(error.code).toBeUndefined();
+  it('should infer UNAUTHENTICATED for a 401 status', () => {
+    const error = new AuthorizationError(401, 'Not authenticated');
+    expect(error.errorCode).toBe('UNAUTHENTICATED');
+  });
+
+  it('should infer FORBIDDEN for a 403 status', () => {
+    const error = new AuthorizationError(403, 'Forbidden');
+    expect(error.errorCode).toBe('FORBIDDEN');
+  });
+
+  it('should default to AUTHORIZATION_ERROR for other statuses', () => {
+    const error = new AuthorizationError(500, 'Unexpected');
+    expect(error.errorCode).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('should serialize via toJSON', () => {
+    const error = new AuthorizationError(403, 'Forbidden', 'FORBIDDEN');
+    expect(error.toJSON()).toEqual({
+      error: 'Forbidden',
+      errorCode: 'FORBIDDEN',
+      status: 403,
+    });
   });
 
   it('should capture a stack trace', () => {
-    const error = new AuthorizationError('Stack trace test');
+    const error = new AuthorizationError(403, 'Stack trace test');
     expect(error.stack).toBeDefined();
     expect(error.stack).toContain('AuthorizationError');
   });

--- a/backend/api/test/unit/core/auth/permission.test.js
+++ b/backend/api/test/unit/core/auth/permission.test.js
@@ -2,32 +2,80 @@ import { describe, it, expect } from 'vitest';
 import { Permission } from '../../../../src/core/auth/Permission.js';
 
 describe('Permission', () => {
-  it('should create a permission with a resource and action', () => {
-    const perm = new Permission('orders', 'create');
-    expect(perm.resource).toBe('orders');
-    expect(perm.action).toBe('create');
+  it('should create a permission with an action', () => {
+    const perm = new Permission({ action: 'orders:create' });
+    expect(perm.action).toBe('orders:create');
   });
 
-  it('should generate a string representation', () => {
-    const perm = new Permission('drivers', 'read');
-    expect(perm.toString()).toBe('drivers:read');
+  it('should store the allowed roles from the options object', () => {
+    const perm = new Permission({ action: 'orders:create', roles: ['driver', 'admin'] });
+    expect(perm.roles).toEqual(['driver', 'admin']);
   });
 
-  it('should be equal to another permission with the same resource and action', () => {
-    const perm1 = new Permission('orders', 'update');
-    const perm2 = new Permission('orders', 'update');
-    expect(perm1.equals(perm2)).toBe(true);
+  it('should default roles to empty when not provided', () => {
+    const perm = new Permission({ action: 'orders:create' });
+    expect(perm.roles).toEqual([]);
   });
 
-  it('should not be equal to a permission with different resource', () => {
-    const perm1 = new Permission('orders', 'delete');
-    const perm2 = new Permission('drivers', 'delete');
-    expect(perm1.equals(perm2)).toBe(false);
+  it('should freeze the roles array', () => {
+    const perm = new Permission({ action: 'orders:create', roles: ['driver'] });
+    expect(Object.isFrozen(perm.roles)).toBe(true);
   });
 
-  it('should handle wildcard action', () => {
-    const perm = new Permission('orders', '*');
-    expect(perm.action).toBe('*');
-    expect(perm.toString()).toBe('orders:*');
+  it('should store the description and ownership check', () => {
+    const ownership = () => true;
+    const perm = new Permission({ action: 'orders:create', ownership, description: 'Create an order' });
+    expect(perm.description).toBe('Create an order');
+    expect(perm.ownership).toBe(ownership);
+  });
+
+  it('should allow any authenticated role when no roles are listed', () => {
+    const perm = new Permission({ action: 'orders:create' });
+    expect(perm.isRoleAllowed('driver')).toBe(true);
+    expect(perm.isRoleAllowed('customer')).toBe(true);
+  });
+
+  it('should allow only the roles in the allow-list', () => {
+    const perm = new Permission({ action: 'orders:create', roles: ['driver'] });
+    expect(perm.isRoleAllowed('driver')).toBe(true);
+    expect(perm.isRoleAllowed('customer')).toBe(false);
+  });
+
+  it('should reject a missing role', () => {
+    const perm = new Permission({ action: 'orders:create' });
+    expect(perm.isRoleAllowed(null)).toBe(false);
+    expect(perm.isRoleAllowed(undefined)).toBe(false);
+  });
+
+  it('should deny when the ownership check returns false', () => {
+    const perm = new Permission({ action: 'orders:read', ownership: () => false });
+    expect(perm.checkOwnership({ id: 'u1' }, { owner_id: 'u2' })).toBe(false);
+  });
+
+  it('should allow when the ownership check returns true', () => {
+    const perm = new Permission({
+      action: 'orders:read',
+      ownership: (user, resource) => user.id === resource.owner_id,
+    });
+    expect(perm.checkOwnership({ id: 'u1' }, { owner_id: 'u1' })).toBe(true);
+  });
+
+  it('should allow access when no ownership check is defined', () => {
+    const perm = new Permission({ action: 'orders:read' });
+    expect(perm.checkOwnership({ id: 'u1' }, { owner_id: 'u2' })).toBe(true);
+  });
+
+  it('should throw when the action is missing', () => {
+    expect(() => new Permission({})).toThrow('Permission requires a non-empty action string.');
+  });
+
+  it('should serialize via toJSON', () => {
+    const perm = new Permission({ action: 'orders:create', roles: ['driver'], description: 'Create an order' });
+    expect(perm.toJSON()).toEqual({
+      action: 'orders:create',
+      roles: ['driver'],
+      hasOwnershipCheck: false,
+      description: 'Create an order',
+    });
   });
 });

--- a/backend/api/test/unit/core/auth/role.test.js
+++ b/backend/api/test/unit/core/auth/role.test.js
@@ -1,30 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { Role } from '../../../../src/core/auth/Role.js';
-import { Permission } from '../../../../src/core/auth/Permission.js';
+import { ROLES, isValidRole, allRoles } from '../../../../src/core/auth/Role.js';
 
 describe('Role', () => {
-  it('should create a role with a name', () => {
-    const role = new Role('admin');
-    expect(role.name).toBe('admin');
+  it('should define the application roles', () => {
+    expect(ROLES).toEqual({ CUSTOMER: 'customer', DRIVER: 'driver', ADMIN: 'admin' });
   });
 
-  it('should add permissions to the role', () => {
-    const role = new Role('editor');
-    const perm = new Permission('articles', 'write');
-    role.addPermission(perm);
-    expect(role.hasPermission(perm)).toBe(true);
+  it('should recognise valid roles', () => {
+    expect(isValidRole('customer')).toBe(true);
+    expect(isValidRole('driver')).toBe(true);
+    expect(isValidRole('admin')).toBe(true);
   });
 
-  it('should check if role has a permission', () => {
-    const role = new Role('viewer');
-    role.addPermission(new Permission('orders', 'read'));
-    expect(role.hasPermission(new Permission('orders', 'read'))).toBe(true);
-    expect(role.hasPermission(new Permission('orders', 'write'))).toBe(false);
+  it('should reject unknown roles', () => {
+    expect(isValidRole('editor')).toBe(false);
+    expect(isValidRole('')).toBe(false);
   });
 
-  it('should support wildcard permissions', () => {
-    const role = new Role('superuser');
-    role.addPermission(new Permission('*', '*'));
-    expect(role.hasPermission(new Permission('anything', 'any_action'))).toBe(true);
+  it('should reject non-string input', () => {
+    expect(isValidRole(null)).toBe(false);
+    expect(isValidRole(undefined)).toBe(false);
+    expect(isValidRole(123)).toBe(false);
+  });
+
+  it('should return all valid roles', () => {
+    expect(allRoles()).toEqual(['customer', 'driver', 'admin']);
   });
 });


### PR DESCRIPTION
## Problem

`core/auth` unit tests fail 11/11. The `authorizationError`/`permission`/`role` tests were written against a different API than the source exposes (constructor signature, error-code inference, and role/permission helpers).

## Fix

- `authorizationError.test.js`: align with `AuthorizationError(status, message, errorCode?)` — assert `status`, `errorCode` inference (401 → `UNAUTHENTICATED`, 403 → `FORBIDDEN`, other → `AUTHORIZATION_ERROR`), `toJSON()`, and stack capture.
- `permission.test.js` / `role.test.js`: rewrite assertions to match the actual helper APIs the source exports.

## Files changed

- `backend/api/test/unit/core/auth/authorizationError.test.js`
- `backend/api/test/unit/core/auth/permission.test.js`
- `backend/api/test/unit/core/auth/role.test.js`

## Testing

- `npx vitest run test/unit/core/auth` — all tests pass.
- `npx eslint backend/api/test/unit/core/auth` — clean.

Closes #10480
