### PR TITLE
[BUG][backend][P2] errorHandler reads err.errors (zod v4 removed it) - any thrown ZodError becomes a TypeError inside the handler and returns 500 instead of 400

### DIFF
--- a/backend/api/src/middleware/errorHandler.js
+++ b/backend/api/src/middleware/errorHandler.js
@@ -35,11 +35,11 @@ export function errorHandler(err, req, res, next) {
 
   // Handle Zod validation errors
   if (err && err.name === 'ZodError') {
-    logger.warn({ requestId: req.requestId, errors: err.errors }, 'Zod validation failed');
+    logger.warn({ requestId: req.requestId, errors: err.issues }, 'Zod validation failed');
     return res.status(400).json({
       success: false,
       error: 'Validation failed',
-      details: err.errors.map(e => ({ field: e.path.join('.'), message: e.message })),
+      details: err.issues.map(e => ({ field: e.path.join('.'), message: e.message })),
     });
   }
 


### PR DESCRIPTION
## Problem

`errorHandler` reads the zod v4 error shape via `err.errors`, which was removed in zod v4 (`^4.4.3` installed). Any thrown `ZodError` makes `err.errors.map(...)` throw a `TypeError` inside the handler, masking the validation failure and returning `500 Critical Internal Server Error` instead of a `400` with field-level details.

## Fix

- Switched the `ZodError` branch to the v4 shape: `err.issues` for both the `logger.warn` context and the `details` mapping, matching `middleware/validate.js` and `routes/tripRoutes.js`.

## Files changed

- `backend/api/src/middleware/errorHandler.js`

## Testing

- `npx vitest run test/unit/errorHandler.test.js` — 3/3 pass.
- `npx eslint src/middleware/errorHandler.js` — clean.

Closes #10489
