### PR TITLE
fix : added strict field allowlist validation to isValidCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -102,19 +102,31 @@ function getRedisClient() {
  * @param {string} firebaseUid - The expected Firebase UID.
  * @param {object|null} cachedProfile - The cached profile to validate.
  *   Must have: isActive (boolean), uid (string matching firebaseUid), id (string),
- *   role (string). Optional: fullName (string|null), phone (string|null).
+ *   role (string). Optional: fullName (string|null), phone (string|null), updatedAt (string|null).
  * @returns {boolean} True if the cached profile shape is valid, false otherwise.
  */
 export function isValidCachedProfile(firebaseUid, cachedProfile) {
-  if (typeof firebaseUid !== "string" || !firebaseUid.trim()) {
+  if (typeof firebaseUid !== 'string' || !firebaseUid.trim()) {
     return false;
   }
   if (
     !cachedProfile ||
-    typeof cachedProfile !== "object" ||
+    typeof cachedProfile !== 'object' ||
     Array.isArray(cachedProfile)
   ) {
     return false;
+  }
+
+  // Reject objects with unexpected fields to enforce strict schema
+  const ALLOWED_FIELDS = new Set([
+    'isActive', 'uid', 'id', 'role',
+    'fullName', 'phone', 'updatedAt',
+  ]);
+  const profileKeys = Object.keys(cachedProfile);
+  for (const key of profileKeys) {
+    if (!ALLOWED_FIELDS.has(key)) {
+      return false;
+    }
   }
   if (typeof cachedProfile.isActive !== "boolean") {
     return false;


### PR DESCRIPTION
Closes #10651.

Summary of What Has Been Done:
Added a strict field allowlist check to the `isValidCachedProfile` function. Previously, cached profile objects with unexpected extra fields would silently pass validation. Now, only profiles containing the expected fields (isActive, uid, id, role, fullName, phone, updatedAt) are accepted.

Changes Made:
- backend/api/src/lib/profileCache.js: Added ALLOWED_FIELDS Set and Object.keys() iteration to reject profiles with unexpected fields. Also updated JSDoc to include updatedAt as an optional field.

Impact it Made:
- Prevents type errors from unexpected fields on cached profile objects
- Makes the profile caching layer more robust against data schema drift
- Verified ESLint passes on changed file

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).