### PR TITLE
fix : invoke wasi.start() before WASI export calls in executeFunction

### DIFF
--- a/wasi/wasi-runtime.js
+++ b/wasi/wasi-runtime.js
@@ -121,11 +121,12 @@ class WASIRuntime {
                 throw new Error('Instance timeout');
             }
             
+            // Start WASI runtime before invoking any exports — WASI must be
+            // initialized before the WASM module can safely use stdin/stdout/stderr
+            wasi.start(instance);
+            
             // Execute function
             const result = instance.exports[functionName](...args);
-            
-            // Handle WASI
-            wasi.start(instance);
             
             return result;
             


### PR DESCRIPTION
Closes #10658.

Summary of What Has Been Done:
Fixed the WASI runtime execution order in executeFunction. WASI.start() must be called before invoking any WASI export functions, as WASI needs to initialize stdin/stdout/stderr before the module can safely execute. Previously the runtime called instance.exports[functionName](...) BEFORE wasi.start(instance), meaning the WASI sandbox was never properly initialized.

Changes Made:
- wasi/wasi-runtime.js: Moved wasi.start(instance) call to before the exports invocation in executeFunction

Impact it Made:
- Ensures WASI sandbox security boundaries are properly enforced
- Prevents bypass of WASM execution sandboxing
- Makes the edge runtime actually secure as designed

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).