### PR TITLE
fix(wasi): exact hostname allowlist to block SSRF substring bypass (#10630)

### DIFF
--- a/wasi/src/Cargo.toml
+++ b/wasi/src/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+url = "2.5"
 wasi = "0.11"
 
 [profile.release]

--- a/wasi/src/lib.rs
+++ b/wasi/src/lib.rs
@@ -215,6 +215,43 @@ mod tests {
         assert_eq!(resolve_lexically("./data/../data/x"), Some("data/x".to_string()));
         assert_eq!(resolve_lexically("../data/../../etc/hostname"), Some("../../etc/hostname".to_string()));
     }
+
+    #[test]
+    fn allows_exact_allowed_hosts() {
+        assert!(is_url_allowed("https://api.truxify.com/v1/routes").is_ok());
+        assert!(is_url_allowed("http://localhost:8080/ping").is_ok());
+        assert!(is_url_allowed("https://127.0.0.1/health").is_ok());
+    }
+
+    #[test]
+    fn rejects_substring_host_bypasses() {
+        assert!(is_url_allowed("https://api.truxify.com.evil.com/x").is_err());
+        assert!(is_url_allowed("https://127.0.0.1.evil.com/x").is_err());
+        assert!(is_url_allowed("https://evilapi.truxify.com/x").is_err());
+        assert!(is_url_allowed("https://localhost.evil.com/x").is_err());
+        assert!(is_url_allowed("https://notapi.truxify.com/x").is_err());
+    }
+
+    #[test]
+    fn rejects_non_allowed_hosts() {
+        assert!(is_url_allowed("https://example.com/x").is_err());
+        assert!(is_url_allowed("https://attacker.io/x").is_err());
+        assert!(is_url_allowed("https://truxify.com.evil.com/x").is_err());
+    }
+
+    #[test]
+    fn rejects_bad_schemes_and_malformed_urls() {
+        assert!(is_url_allowed("ftp://api.truxify.com/x").is_err());
+        assert!(is_url_allowed("file:///etc/passwd").is_err());
+        assert!(is_url_allowed("not-a-url").is_err());
+        assert!(is_url_allowed("").is_err());
+    }
+
+    #[test]
+    fn rejects_userinfo_smuggling() {
+        assert!(is_url_allowed("https://attacker.io@api.truxify.com/x").is_err());
+        assert!(is_url_allowed("https://user:pass@127.0.0.1/x").is_err());
+    }
 }
 
 // ============ Network System Calls ============
@@ -225,8 +262,8 @@ pub fn wasi_http_request(request: &str) -> Result<String, String> {
         .map_err(|e| format!("Failed to parse request: {}", e))?;
 
     // Capability-based security: only allow specific domains
-    if !is_url_allowed(&req.url) {
-        return Err("Access denied: domain not allowed".to_string());
+    if let Err(e) = is_url_allowed(&req.url) {
+        return Err(e);
     }
 
     // Make HTTP request using stdlib
@@ -261,20 +298,40 @@ pub fn wasi_sleep(ms: u64) {
     std::thread::sleep(std::time::Duration::from_millis(ms));
 }
 
-fn is_url_allowed(url: &str) -> bool {
-    // Capability-based security: only allow specific domains
-    let allowed_domains = vec![
+fn is_url_allowed(url: &str) -> Result<(), String> {
+    // Capability-based security: only allow specific domains.
+    // The URL is parsed and the *host* is compared exactly against the
+    // allowlist. A substring check (url.contains("api.truxify.com")) is
+    // bypassable with hosts like api.truxify.com.evil.com or
+    // 127.0.0.1.evil.com; exact hostname matching closes that SSRF hole.
+    let allowed_domains = [
         "api.truxify.com",
         "localhost",
         "127.0.0.1",
     ];
-    
-    for domain in allowed_domains {
-        if url.contains(domain) {
-            return true;
-        }
+
+    let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
+
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(format!("Access denied: URL scheme must be http or https"));
     }
-    false
+
+    // Credentials (userinfo) are never needed by the sandbox and could be used
+    // to smuggle an attacker-controlled host into the host part of the URL.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("Access denied: URL must not contain userinfo".to_string());
+    }
+
+    let host = match parsed.host_str() {
+        Some(h) => h.to_lowercase(),
+        None => return Err("Access denied: URL has no host".to_string()),
+    };
+
+    if allowed_domains.iter().any(|d| host == *d) {
+        Ok(())
+    } else {
+        Err(format!("Access denied: domain not allowed: {}", host))
+    }
 }
 
 // ============ Process System Calls ============


### PR DESCRIPTION
## Problem

is_url_allowed in the WASI sandbox (wasi/src/lib.rs) used substring matching (url.contains(domain)), which is bypassable with look-alike hosts such as pi.truxify.com.evil.com or 127.0.0.1.evil.com, enabling SSRF from inside the sandbox.

## Fix

- Parse the URL with the url crate and compare the exact hostname (host_str(), lowercased, port already stripped by URL parsing) against the allowlist.
- Reject non-http(s) schemes, URLs with userinfo (which can smuggle an attacker-controlled host), and URLs without a host.
- is_url_allowed now returns Result<(), String>; wasi_http_request returns the error instead of passing through on disallowed hosts.
- Added unit tests covering exact allowed hosts, substring bypass attempts, disallowed hosts, bad schemes, malformed URLs, and userinfo smuggling.

## Files changed

- wasi/src/lib.rs
- wasi/src/Cargo.toml

## Testing

- Added #[cfg(test)] unit tests for is_url_allowed covering the SSRF bypass cases (requires Rust toolchain to run; none available locally to execute them).

Closes #10630