### PR TITLE
fix(ebpf): LRU-hash rate map, atomic counter, fail-closed saturation, TCP/WebSocket coverage (#10632)

### DIFF
--- a/ebpf/loader.py
+++ b/ebpf/loader.py
@@ -3,7 +3,9 @@ import subprocess
 import json
 import redis
 import logging
-from typing import Dict, List, Any
+import struct
+import threading
+from typing import Dict, List, Any, Optional
 from datetime import datetime
 import time
 
@@ -17,6 +19,8 @@ class eBPFLoader:
         self.programs_dir = os.path.dirname(__file__) + "/programs"
         self.loaded_programs = []
         self.stats = {}
+        self._pruner_thread = None
+        self._pruner_stop = threading.Event()
         
         logger.info("✅ eBPF Loader initialized")
     
@@ -103,6 +107,82 @@ class eBPFLoader:
         # In production: read from BPF maps
         
         return stats
+    
+    def _extract_last_time_ns(self, value: Any) -> Optional[int]:
+        """Extract last_time_ns from a telemetry_rate_map entry value.
+        With BTF the value is a dict; without it the value is a raw little-
+        endian byte array where last_time_ns (u64) sits at offset 4 after the
+        leading __u32 lock field."""
+        if isinstance(value, dict):
+            return value.get("last_time_ns")
+        if isinstance(value, list):
+            try:
+                raw = bytes(value)
+                if len(raw) < 12:
+                    return None
+                return struct.unpack_from("<Q", raw, 4)[0]
+            except (struct.error, TypeError):
+                return None
+        return None
+    
+    def prune_rate_limit_entries(self, idle_window_seconds: int = 60) -> int:
+        """Delete telemetry_rate_map entries idle past the rate-limit window.
+        Called periodically so the per-IP map never fills with stale sources
+        (LRU_HASH bounds memory as a backstop, this keeps it healthy in
+        normal operation). Returns the number of entries pruned."""
+        if idle_window_seconds <= 0:
+            raise ValueError("idle_window_seconds must be positive")
+        idle_ns = idle_window_seconds * 1_000_000_000
+        now_ns = time.time_ns()
+        pruned = 0
+        try:
+            dump = subprocess.run(
+                ["sudo", "bpftool", "map", "dump", "name", "telemetry_rate_map"],
+                check=True, capture_output=True, text=True
+            )
+            for entry in json.loads(dump.stdout):
+                key = entry.get("key")
+                last_time_ns = self._extract_last_time_ns(entry.get("value"))
+                if key is None or last_time_ns is None:
+                    continue
+                if now_ns - last_time_ns <= idle_ns:
+                    continue
+                key_hex = bytes(key).hex()
+                subprocess.run(
+                    ["sudo", "bpftool", "map", "delete", "name", "telemetry_rate_map",
+                     "key", key_hex],
+                    check=True, capture_output=True, text=True
+                )
+                pruned += 1
+        except Exception as e:
+            logger.warning(f"Rate-limit map prune failed: {e}")
+        return pruned
+    
+    def start_rate_limit_pruner(self, interval_seconds: int = 60, idle_window_seconds: int = 60):
+        """Start a periodic userspace sweep of telemetry_rate_map. Entries idle
+        past idle_window_seconds are deleted every interval_seconds."""
+        if self._pruner_thread and self._pruner_thread.is_alive():
+            return
+        self._pruner_stop.clear()
+        self._pruner_thread = threading.Thread(
+            target=self._rate_limit_pruner_loop,
+            args=(interval_seconds, idle_window_seconds),
+            daemon=True
+        )
+        self._pruner_thread.start()
+        logger.info("✅ Rate-limit map pruner started")
+    
+    def stop_rate_limit_pruner(self):
+        """Stop the periodic telemetry_rate_map sweep."""
+        self._pruner_stop.set()
+        if self._pruner_thread:
+            self._pruner_thread.join(timeout=5)
+            self._pruner_thread = None
+        logger.info("✅ Rate-limit map pruner stopped")
+    
+    def _rate_limit_pruner_loop(self, interval_seconds: int, idle_window_seconds: int):
+        while not self._pruner_stop.wait(interval_seconds):
+            self.prune_rate_limit_entries(idle_window_seconds)
     
     def load_all_programs(self) -> Dict:
         """Load all eBPF programs"""

--- a/ebpf/telemetry_filter.c
+++ b/ebpf/telemetry_filter.c
@@ -15,13 +15,18 @@
 #define MAX_PACKETS_PER_SEC 10             // Max 10 telemetry pings per sec per IP
 
 struct rate_limit_entry {
+    __u32 lock;
     __u64 last_time_ns;
     __u32 packet_count;
 };
 
-// BPF Map: Per-IP Telemetry Rate Limiting
+// BPF Map: Per-IP Telemetry Rate Limiting.
+// BPF_MAP_TYPE_LRU_HASH bounds memory and evicts idle entries automatically,
+// so a flood of spoofed source IPs can no longer permanently fill the map.
+// A periodic userspace sweep (loader.py) additionally deletes entries that
+// are idle past the window so the map stays healthy in normal operation.
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, MAX_TRACKERS);
     __type(key, __u32); // IPv4 Address
     __type(value, struct rate_limit_entry);
@@ -43,20 +48,21 @@ int xdp_telemetry_filter(struct xdp_md *ctx) {
     if ((void *)(ip + 1) > data_end)
         return XDP_PASS;
 
-    // Filter UDP / telemetry traffic
-    if (ip->protocol == IPPROTO_UDP) {
-        struct udphdr *udp = (void *)(ip + 1);
-        if ((void *)(udp + 1) > data_end)
-            return XDP_PASS;
-
+    // Filter UDP and TCP/WebSocket telemetry traffic
+    if (ip->protocol == IPPROTO_UDP || ip->protocol == IPPROTO_TCP) {
         __u32 src_ip = ip->saddr;
         __u64 now = bpf_ktime_get_ns();
 
         struct rate_limit_entry *entry = bpf_map_lookup_elem(&telemetry_rate_map, &src_ip);
         if (entry) {
+            // Guard the read-modify-write on the shared map value so
+            // concurrent packets on different CPUs cannot both pass the
+            // >= MAX_PACKETS_PER_SEC check.
+            bpf_spin_lock(&entry->lock);
             if (now - entry->last_time_ns < RATE_LIMIT_WINDOW_NS) {
                 if (entry->packet_count >= MAX_PACKETS_PER_SEC) {
                     // Rate limit exceeded: Drop packet at XDP layer
+                    bpf_spin_unlock(&entry->lock);
                     return XDP_DROP;
                 }
                 entry->packet_count++;
@@ -65,12 +71,18 @@ int xdp_telemetry_filter(struct xdp_md *ctx) {
                 entry->last_time_ns = now;
                 entry->packet_count = 1;
             }
+            bpf_spin_unlock(&entry->lock);
         } else {
             struct rate_limit_entry new_entry = {
+                .lock = 0,
                 .last_time_ns = now,
                 .packet_count = 1
             };
-            bpf_map_update_elem(&telemetry_rate_map, &src_ip, &new_entry, BPF_ANY);
+            // Fail closed: if the map is saturated and this source cannot be
+            // tracked, drop rather than silently leaving it unlimited.
+            if (bpf_map_update_elem(&telemetry_rate_map, &src_ip, &new_entry, BPF_ANY) != 0) {
+                return XDP_DROP;
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The XDP telemetry rate-limiter (`ebpf/telemetry_filter.c`) had four defects:

1. **Entries are never pruned** — nothing ever deleted per-IP entries, so after 10,000 distinct source IPs the map was permanently full.
2. **Fails open at saturation** — `bpf_map_update_elem(..., BPF_ANY)` returns `-E2BIG` on a full hash map, and the return value was discarded, so every *new* source IP silently bypassed the rate limit (attacker fills the map once, then defeats the filter forever).
3. **Non-atomic counter** — `entry->packet_count++` is a shared read-modify-write; concurrent packets across CPUs can both pass the `>= MAX_PACKETS_PER_SEC` check.
4. **Scope mismatch** — the header claims to cover "telemetry UDP/WebSocket" but only `IPPROTO_UDP` was counted, so TCP/WebSocket telemetry was never limited.

## Fix

- Switched `telemetry_rate_map` to `BPF_MAP_TYPE_LRU_HASH` so the kernel bounds memory and evicts idle entries instead of permanently saturating.
- Checked the `bpf_map_update_elem` return value and fail closed (XDP_DROP) when a source cannot be tracked.
- Guarded the counter update with `bpf_spin_lock`/`bpf_spin_unlock` around the shared map value.
- Parsed the L4 protocol and applied the same per-IP bucket to TCP/WebSocket traffic as well as UDP.
- Added a periodic userspace sweep in `ebpf/loader.py` (`prune_rate_limit_entries` + `start_rate_limit_pruner`/`stop_rate_limit_pruner`) that deletes entries idle past the window, keeping the map healthy in normal operation.

## Files changed

- `ebpf/telemetry_filter.c`
- `ebpf/loader.py`

## Testing

- `ebpf/loader.py` verified with `python -m py_compile`.
- The eBPF C program cannot be compiled on this machine (needs clang bpf target / Linux headers); changes follow the kernel's documented LRU_HASH, spinlock and map-update semantics.

Closes #10632
