### PR TITLE
fix: bind weight proofs to vehicle and reject replayed nonces

### DIFF
--- a/services/zkp-verifier-rust/src/verifier.rs
+++ b/services/zkp-verifier-rust/src/verifier.rs
@@ -1,25 +1,124 @@
-use crate::weight_proof::{canonical_payload, WeightProofOutput};
+use crate::weight_proof::{canonical_payload, now_seconds, WeightProofOutput};
 use ed25519_dalek::{Signature, VerifyingKey};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// Maximum allowed skew (seconds) between the device timestamp and the
 /// verifier clock. Proofs stamped further in the future (or further in the
 /// past) are rejected to keep the weight claim fresh.
-const MAX_TIMESTAMP_SKEW_SECS: u64 = 300;
+pub const MAX_TIMESTAMP_SKEW_SECS: u64 = 300;
+
+/// Upper bound on the replay cache so a flood of distinct nonces cannot grow
+/// memory without limit. The oldest entry is evicted when the cache is full.
+const MAX_CACHE_ENTRIES: usize = 100_000;
+
+/// Bounded, TTL-evicted replay cache keyed by proof nonce.
+///
+/// A captured weight proof carries a signed, unique nonce. Recording each
+/// nonce the first time it is accepted and rejecting it on any later attempt
+/// makes a captured proof usable exactly once within the skew window, so a
+/// captured signature cannot be replayed to clear multiple loads.
+pub struct ReplayCache {
+    seen: Mutex<HashMap<String, u64>>,
+}
+
+impl ReplayCache {
+    pub fn new() -> Self {
+        Self {
+            seen: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Records `nonce` as seen at `now`, pruning entries that are older than
+    /// the freshness window. Returns `false` (replay) if the nonce is already
+    /// recorded; `true` if it was freshly recorded.
+    pub fn record(&self, nonce: &str, now: u64) -> bool {
+        let cutoff = now.saturating_sub(MAX_TIMESTAMP_SKEW_SECS);
+        let mut seen = self.seen.lock().unwrap();
+        seen.retain(|_, first_seen| *first_seen >= cutoff);
+
+        if seen.contains_key(nonce) {
+            return false;
+        }
+
+        if seen.len() >= MAX_CACHE_ENTRIES {
+            if let Some(oldest) = seen
+                .iter()
+                .min_by_key(|(_, ts)| **ts)
+                .map(|(k, _)| k.clone())
+            {
+                seen.remove(&oldest);
+            }
+        }
+
+        seen.insert(nonce.to_string(), now);
+        true
+    }
+
+    /// Number of nonces currently tracked (used by tests).
+    pub fn len(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+
+    /// Persists the seen-nonce set so a restart does not reopen the freshness
+    /// window. Entries older than the skew window are dropped on save.
+    pub fn persist(&self, path: &str) -> std::io::Result<()> {
+        let cutoff = now_seconds().saturating_sub(MAX_TIMESTAMP_SKEW_SECS);
+        let seen = self.seen.lock().unwrap();
+        let entries: Vec<(String, u64)> = seen
+            .iter()
+            .filter(|(_, ts)| **ts >= cutoff)
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+        drop(seen);
+        let json = serde_json::to_string(&entries)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, json)
+    }
+
+    /// Loads a previously persisted seen-nonce set. A missing file yields an
+    /// empty cache; stale entries are pruned on the next `record`.
+    pub fn load(path: &str) -> Self {
+        let mut cache = Self::new();
+        if let Ok(json) = std::fs::read_to_string(path) {
+            if let Ok(entries) = serde_json::from_str::<Vec<(String, u64)>>(&json) {
+                if let Ok(mut seen) = cache.seen.lock() {
+                    for (nonce, ts) in entries {
+                        seen.insert(nonce, ts);
+                    }
+                }
+            }
+        }
+        cache
+    }
+}
+
+impl Default for ReplayCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 pub struct ZkWeightVerifier;
 
 impl ZkWeightVerifier {
     /// Independently enforces the weight limit and verifies the Ed25519
     /// signature over the canonical payload (weight + device limit + nonce +
-    /// timestamp), which only the weighing device's secret key can produce.
+    /// timestamp + vehicle/order binding), which only the weighing device's
+    /// secret key can produce.
     ///
     /// The prover's self-declared validity is never trusted: the claimed axle
     /// weight is re-checked against the verifier's own `max_allowed_limit`.
+    /// The proof must be bound to `required_binding` (the vehicle/order being
+    /// cleared) and its nonce must never have been accepted before, so a
+    /// captured proof cannot be replayed.
     pub fn verify_proof(
         proof: &WeightProofOutput,
         max_allowed_limit: u64,
         verifying_key: &VerifyingKey,
         now: u64,
+        replay_cache: &ReplayCache,
+        required_binding: &str,
     ) -> bool {
         // 1. Independent weight enforcement against the caller's limit.
         if proof.axle_weight_kg > max_allowed_limit {
@@ -35,16 +134,25 @@ impl ZkWeightVerifier {
             return false;
         }
 
-        // 3. Signature check over the exact canonical payload that was signed.
-        //    A tampered weight, limit, nonce, or timestamp breaks the binding.
+        // 3. The proof is bound to a vehicle/order: it must match the load
+        //    being cleared, so it cannot be reused across loads even with
+        //    distinct nonces.
+        if proof.vehicle_id != required_binding {
+            return false;
+        }
+
+        // 4. Signature check over the exact canonical payload that was signed.
+        //    A tampered weight, limit, nonce, timestamp, or vehicle_id breaks
+        //    the binding.
         let payload = canonical_payload(
             proof.axle_weight_kg,
             proof.max_legal_limit_kg,
             &proof.nonce,
             proof.timestamp,
+            &proof.vehicle_id,
         );
 
-        match hex::decode(&proof.signature_hex) {
+        let signature_ok = match hex::decode(&proof.signature_hex) {
             Ok(bytes) => match <[u8; 64]>::try_from(bytes.as_slice()) {
                 Ok(sig_bytes) => verifying_key
                     .verify_strict(&payload, &Signature::from_bytes(&sig_bytes))
@@ -52,6 +160,14 @@ impl ZkWeightVerifier {
                 Err(_) => false,
             },
             Err(_) => false,
+        };
+        if !signature_ok {
+            return false;
         }
+
+        // 5. Replay protection: only a cryptographically valid proof consumes
+        //    its nonce. A nonce seen before within the skew window is a replay
+        //    and is rejected here.
+        replay_cache.record(&proof.nonce, now)
     }
 }

--- a/services/zkp-verifier-rust/src/weight_proof.rs
+++ b/services/zkp-verifier-rust/src/weight_proof.rs
@@ -7,6 +7,7 @@ pub struct WeightProofInput {
     pub axle_weight_kg: u64,
     pub max_legal_limit_kg: u64,
     pub nonce: String,
+    pub vehicle_id: String,
 }
 
 /// A weight claim signed by the weighing device. There is intentionally NO
@@ -20,17 +21,20 @@ pub struct WeightProofOutput {
     pub nonce: String,
     pub timestamp: u64,
     pub signature_hex: String,
+    pub vehicle_id: String,
 }
 
-/// Canonically encodes the claim (weight, device limit, nonce, timestamp) so
-/// the signed commitment is unambiguous and the verifier can re-derive exactly
-/// the bytes that were signed. Length-prefixing the nonce prevents collisions
-/// between different field combinations.
+/// Canonically encodes the claim (weight, device limit, nonce, timestamp,
+/// vehicle/order binding) so the signed commitment is unambiguous and the
+/// verifier can re-derive exactly the bytes that were signed.
+/// Length-prefixing the nonce and vehicle_id prevents collisions between
+/// different field combinations.
 pub fn canonical_payload(
     axle_weight_kg: u64,
     max_legal_limit_kg: u64,
     nonce: &str,
     timestamp: u64,
+    vehicle_id: &str,
 ) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(b"truxify.zkp.weight.v1");
@@ -39,6 +43,8 @@ pub fn canonical_payload(
     out.extend_from_slice(&timestamp.to_be_bytes());
     out.extend_from_slice(&(nonce.len() as u64).to_be_bytes());
     out.extend_from_slice(nonce.as_bytes());
+    out.extend_from_slice(&(vehicle_id.len() as u64).to_be_bytes());
+    out.extend_from_slice(vehicle_id.as_bytes());
     out
 }
 
@@ -68,6 +74,7 @@ impl WeightProofGenerator {
             input.max_legal_limit_kg,
             &input.nonce,
             timestamp,
+            &input.vehicle_id,
         );
         let signature = signing_key.sign(&payload);
 
@@ -77,6 +84,7 @@ impl WeightProofGenerator {
             nonce: input.nonce.clone(),
             timestamp,
             signature_hex: hex::encode(signature.to_bytes()),
+            vehicle_id: input.vehicle_id.clone(),
         }
     }
 }

--- a/services/zkp-verifier-rust/tests/proof_test.rs
+++ b/services/zkp-verifier-rust/tests/proof_test.rs
@@ -1,6 +1,8 @@
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
-use truxify_zkp_verifier::verifier::ZkWeightVerifier;
-use truxify_zkp_verifier::weight_proof::{now_seconds, WeightProofGenerator, WeightProofInput};
+use truxify_zkp_verifier::verifier::{ReplayCache, ZkWeightVerifier};
+use truxify_zkp_verifier::weight_proof::{
+    now_seconds, WeightProofGenerator, WeightProofInput, WeightProofOutput,
+};
 
 /// Test-only signing key whose public half is used by the verifier in these
 /// tests. In production the secret key lives only with the weighing device.
@@ -8,6 +10,8 @@ const TEST_SIGNING_SEED: [u8; 32] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
 ];
+
+const TEST_VEHICLE_ID: &str = "vehicle_123";
 
 fn signing_key() -> SigningKey {
     SigningKey::from_bytes(&TEST_SIGNING_SEED)
@@ -22,7 +26,30 @@ fn input(axle_weight_kg: u64, max_legal_limit_kg: u64, nonce: &str) -> WeightPro
         axle_weight_kg,
         max_legal_limit_kg,
         nonce: nonce.to_string(),
+        vehicle_id: TEST_VEHICLE_ID.to_string(),
     }
+}
+
+fn verify_with(
+    proof: &WeightProofOutput,
+    max_allowed_limit: u64,
+    verifying_key: &VerifyingKey,
+    now: u64,
+    cache: &ReplayCache,
+    binding: &str,
+) -> bool {
+    ZkWeightVerifier::verify_proof(proof, max_allowed_limit, verifying_key, now, cache, binding)
+}
+
+fn verify_at(proof: &WeightProofOutput, now: u64) -> bool {
+    verify_with(
+        proof,
+        16200,
+        &verifying_key(),
+        now,
+        &ReplayCache::new(),
+        TEST_VEHICLE_ID,
+    )
 }
 
 #[test]
@@ -32,7 +59,7 @@ fn test_valid_weight_proof() {
         &signing_key(),
     );
 
-    assert!(ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+    assert!(verify_at(&proof, now_seconds()));
 }
 
 #[test]
@@ -45,7 +72,7 @@ fn test_overweight_proof_rejection() {
         &signing_key(),
     );
 
-    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+    assert!(!verify_at(&proof, now_seconds()));
 }
 
 #[test]
@@ -57,11 +84,13 @@ fn test_forged_proof_rejected() {
     );
     let attacker_key = SigningKey::from_bytes(&[0xaa; 32]);
 
-    assert!(!ZkWeightVerifier::verify_proof(
+    assert!(!verify_with(
         &proof,
         16200,
         &attacker_key.verifying_key(),
         now_seconds(),
+        &ReplayCache::new(),
+        TEST_VEHICLE_ID,
     ));
 }
 
@@ -75,7 +104,7 @@ fn test_tampered_weight_rejected() {
     );
     proof.axle_weight_kg = 14001;
 
-    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now_seconds()));
+    assert!(!verify_at(&proof, now_seconds()));
 }
 
 #[test]
@@ -88,7 +117,7 @@ fn test_future_timestamp_rejected() {
     );
     let now = now_seconds();
 
-    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now + 1_000_000));
+    assert!(!verify_at(&proof, now + 1_000_000));
 }
 
 #[test]
@@ -99,5 +128,168 @@ fn test_stale_timestamp_rejected() {
     );
     let now = now_seconds();
 
-    assert!(!ZkWeightVerifier::verify_proof(&proof, 16200, &verifying_key(), now - 1_000_000));
+    assert!(!verify_at(&proof, now - 1_000_000));
+}
+
+#[test]
+fn test_proof_replayed_within_window_rejected() {
+    // A proof captured at the weigh gate must be usable exactly once: the same
+    // nonce replayed within the 300s skew window must be rejected.
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_replay_001"),
+        &signing_key(),
+    );
+    let cache = ReplayCache::new();
+    let now = now_seconds();
+
+    // First use: accepted, nonce recorded.
+    assert!(verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+
+    // Replay within the skew window (same and later timestamps): rejected.
+    assert!(!verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+    assert!(!verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now + 60,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+}
+
+#[test]
+fn test_fresh_nonce_accepted_after_replay() {
+    // Distinct nonces are distinct proofs: after a replay rejection, a fresh
+    // nonce for the same vehicle is still accepted.
+    let cache = ReplayCache::new();
+    let now = now_seconds();
+
+    let proof1 = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_fresh_001"),
+        &signing_key(),
+    );
+    let proof2 = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_fresh_002"),
+        &signing_key(),
+    );
+
+    assert!(verify_with(
+        &proof1,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+    assert!(!verify_with(
+        &proof1,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+    assert!(verify_with(
+        &proof2,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+}
+
+#[test]
+fn test_proof_bound_to_vehicle_binding() {
+    // A proof signed for one vehicle/order must not clear a different load,
+    // even though the nonce and signature are both valid.
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_vehicle_001"),
+        &signing_key(),
+    );
+    let cache = ReplayCache::new();
+    let now = now_seconds();
+
+    assert!(!verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        "vehicle_999",
+    ));
+    assert!(verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+}
+
+#[test]
+fn test_tampered_binding_rejected() {
+    // Re-targeting a signed proof at another vehicle must invalidate it: the
+    // vehicle_id is part of the signed canonical payload.
+    let mut proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_vehicle_002"),
+        &signing_key(),
+    );
+    proof.vehicle_id = "vehicle_999".to_string();
+
+    assert!(!verify_at(&proof, now_seconds()));
+}
+
+#[test]
+fn test_replay_cache_survives_restart() {
+    // Persisting the seen-nonce set closes the window that a restart would
+    // otherwise reopen: a proof replayed after a reload is still rejected.
+    let cache = ReplayCache::new();
+    let now = now_seconds();
+    let path = std::env::temp_dir().join("truxify_zkp_replay_cache_test.json");
+    let path_str = path.to_string_lossy().to_string();
+    let _ = std::fs::remove_file(&path_str);
+
+    let proof = WeightProofGenerator::generate_proof(
+        &input(14000, 16200, "nonce_persist_001"),
+        &signing_key(),
+    );
+    assert!(verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &cache,
+        TEST_VEHICLE_ID,
+    ));
+    cache
+        .persist(&path_str)
+        .expect("replay cache should persist");
+
+    let restored = ReplayCache::load(&path_str);
+    assert!(!verify_with(
+        &proof,
+        16200,
+        &verifying_key(),
+        now,
+        &restored,
+        TEST_VEHICLE_ID,
+    ));
+
+    let _ = std::fs::remove_file(&path_str);
 }


### PR DESCRIPTION
## Problem

`verifier.rs` enforces only timestamp-skew checks (`MAX_TIMESTAMP_SKEW_SECS = 300`). The proof nonce is part of the signed `canonical_payload`, but the verifier never records accepted nonces and never binds the payload to a vehicle/order. A captured weight proof is therefore replayable for every truck within the 300s window (issue #10635).

## Fix

- Added a bounded, TTL-evicted `ReplayCache` in `verifier.rs`, keyed by nonce and pruned on every `record` to the skew window; the cache is size-capped (`MAX_CACHE_ENTRIES`) and persisted/restored across restarts (`persist`/`load` as JSON).
- `verify_proof` now:
  1. enforces the verifier's own `max_allowed_limit` independently,
  2. enforces the timestamp-skew window,
  3. requires `proof.vehicle_id == required_binding` so a proof cannot clear a different load,
  4. verifies the Ed25519 signature over the canonical payload (which now also binds `vehicle_id`),
  5. records the nonce and rejects any nonce already seen within the skew window (replay).
- `weight_proof.rs`: `WeightProofInput`/`WeightProofOutput` carry `vehicle_id`; `canonical_payload` length-prefixes the vehicle/order binding so it is signed.

## Files changed

- `services/zkp-verifier-rust/src/verifier.rs`
- `services/zkp-verifier-rust/src/weight_proof.rs`
- `services/zkp-verifier-rust/tests/proof_test.rs`

## Testing

Added integration tests in `tests/proof_test.rs`:
- replay within the skew window (same and later timestamps) is rejected,
- a fresh nonce is still accepted after a replay rejection,
- a proof bound to one vehicle is rejected for another (`vehicle_id` binding),
- tampering with `vehicle_id` after signing invalidates the proof,
- the replay cache survives a restart (`persist` + `load`),
- existing valid/overweight/forged/tampered/future/stale tests updated for the new signature.

Note: no Rust toolchain is available in the local environment, so `cargo test` could not be run here.

Closes #10635
