### PR TITLE
fix: cap HTTP request bodies at 1 MiB with 413 rejection

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"log"
 	"math/rand"
 	"net/http"
@@ -72,6 +73,27 @@ func requireAuth(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
+	return true
+}
+
+// maxRequestBodyBytes caps request bodies decoded by this service (1 MiB) so
+// an oversized or streamed body cannot be buffered into memory.
+const maxRequestBodyBytes = 1 << 20
+
+// decodeJSONBody decodes r.Body into v with a 1 MiB cap. It writes a 413 and
+// returns false when the body exceeds the cap; the net/http server drains and
+// closes the connection afterwards so it is not left in an unsafe state.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, v interface{}) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, "Invalid payload", http.StatusBadRequest)
+		return false
+	}
 	return true
 }
 
@@ -559,8 +581,7 @@ func (rn *RaftNode) HandleVote(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req RequestVoteRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid payload", http.StatusBadRequest)
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 
@@ -604,8 +625,7 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req AppendEntriesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid payload", http.StatusBadRequest)
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 
@@ -700,8 +720,7 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		Command string `json:"command"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid payload", http.StatusBadRequest)
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 

--- a/services/consensus-raft-go/main_test.go
+++ b/services/consensus-raft-go/main_test.go
@@ -440,3 +440,40 @@ func TestHandleVoteResetsElectionTimer(t *testing.T) {
 	}
 }
 
+// TestHandleCommitOrderRejectsOversizedBody verifies the service returns 413
+// for a body larger than the 1 MiB cap instead of buffering it into memory.
+func TestHandleCommitOrderRejectsOversizedBody(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	node := NewRaftNode("node1", []string{"node2"}, nil)
+
+	big := strings.Repeat("a", maxRequestBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/commit", strings.NewReader(big))
+	w := httptest.NewRecorder()
+
+	node.HandleCommitOrder(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for oversized body, got %d", w.Code)
+	}
+}
+
+// TestHandleCommitOrderAcceptsBodyWithinLimit verifies a body at the cap
+// boundary is still decoded (malformed payload → 400, not 413).
+func TestHandleCommitOrderAcceptsBodyWithinLimit(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	node := NewRaftNode("node1", []string{"node2"}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/commit", strings.NewReader("{not-json"))
+	w := httptest.NewRecorder()
+
+	node.HandleCommitOrder(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed in-limit body, got %d", w.Code)
+	}
+}
+

--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -92,6 +93,27 @@ var operatorRoles = map[string]bool{
 	"admin":      true,
 	"operator":   true,
 	"dispatcher": true,
+}
+
+// maxRequestBodyBytes caps request bodies decoded by this service (1 MiB) so
+// an oversized or streamed body cannot be buffered into memory.
+const maxRequestBodyBytes = 1 << 20
+
+// decodeJSONBody decodes r.Body into v with a 1 MiB cap. It writes a 413 and
+// returns false when the body exceeds the cap; the net/http server drains and
+// closes the connection afterwards so it is not left in an unsafe state.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, v interface{}) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, "Invalid payload", http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 // Calculate Haversine distance in meters between two lat/lng points
@@ -490,8 +512,7 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var ping TelemetryPing
-	if err := json.NewDecoder(r.Body).Decode(&ping); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid telemetry payload: %v", err), http.StatusBadRequest)
+	if !decodeJSONBody(w, r, &ping) {
 		return
 	}
 
@@ -546,8 +567,7 @@ func handleGeofence(w http.ResponseWriter, r *http.Request) {
 		RadiusM   float64 `json:"radius_meters"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 

--- a/services/telemetry-ingestion/main_test.go
+++ b/services/telemetry-ingestion/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -104,4 +107,41 @@ func TestSweepDriversPrunesStaleGeofenceEntries(t *testing.T) {
 	geofenceRateLimit.Delete("geo-stale")
 	geofenceRateLimit.Delete("geo-fresh")
 	atomic.AddUint64(&geofenceRateTracked, ^uint64(0))
+}
+
+// TestHandlePingRejectsOversizedBody verifies the service returns 413 for a
+// body larger than the 1 MiB cap instead of buffering it into memory.
+func TestHandlePingRejectsOversizedBody(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	big := strings.Repeat("a", maxRequestBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/ping", strings.NewReader(big))
+	req.Header.Set("X-Driver-ID", "driver-test")
+	w := httptest.NewRecorder()
+
+	handlePing(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for oversized body, got %d", w.Code)
+	}
+}
+
+// TestHandlePingAcceptsBodyWithinLimit verifies a body at the cap boundary is
+// still processed normally (reaching validation, not rejected as too large).
+func TestHandlePingAcceptsBodyWithinLimit(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	// The decoder errors on malformed JSON, but not with a MaxBytesError: the
+	// response must be 400 (payload validation), not 413.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry/ping", strings.NewReader("{not-json"))
+	req.Header.Set("X-Driver-ID", "driver-test")
+	w := httptest.NewRecorder()
+
+	handlePing(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed in-limit body, got %d", w.Code)
+	}
 }

--- a/services/zkp-verifier-rust/src/main.rs
+++ b/services/zkp-verifier-rust/src/main.rs
@@ -9,6 +9,11 @@ use tokio::net::{TcpListener, TcpStream};
 /// Address the verification microservice listens on (matches `EXPOSE 8087`).
 const BIND_ADDR: &str = "0.0.0.0:8087";
 
+/// Upper bound on the HTTP request body accepted by the verifier (1 MiB).
+/// Bodies larger than this, and streamed bodies that claim a huge
+/// `Content-Length`, are rejected with 413 before they can exhaust memory.
+const MAX_BODY: usize = 1024 * 1024;
+
 /// Dev-only Ed25519 verifying public key (hex-encoded).
 ///
 /// A verification key is public material: it is safe to ship inside the
@@ -128,6 +133,39 @@ fn parse_content_length(head: &str) -> usize {
     0
 }
 
+/// True when the declared `Content-Length` exceeds the accepted body cap.
+fn body_exceeds_limit(content_length: usize) -> bool {
+    content_length > MAX_BODY
+}
+
+/// Reads and discards up to `max` remaining body bytes so leftover request
+/// data does not poison the connection before we respond. Bounded so a peer
+/// that declares a huge `Content-Length` cannot force us to read it all.
+async fn drain_remaining(stream: &mut TcpStream, max: usize) {
+    let mut chunk = [0u8; 4096];
+    let mut drained = 0usize;
+    while drained < max {
+        let n = match stream.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        drained += n;
+    }
+}
+
+/// Writes a `413 Content Too Large` response after draining the connection.
+async fn respond_payload_too_large(stream: &mut TcpStream) {
+    drain_remaining(stream, MAX_BODY).await;
+    let _ = stream
+        .write_all(&http_response(
+            "413 Content Too Large",
+            "{\"error\":\"request body too large\"}",
+        ))
+        .await;
+    let _ = stream.flush().await;
+}
+
 /// Builds a minimal HTTP/1.1 JSON response with `Connection: close`.
 fn http_response(status_line: &str, body: &str) -> Vec<u8> {
     let body = body.as_bytes();
@@ -191,20 +229,44 @@ async fn handle_connection(mut stream: TcpStream) {
     let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
     let content_length = parse_content_length(&head);
 
-    // Read the remaining body bytes.
-    while buf.len() < header_end + content_length {
+    // Reject oversized bodies up front (413): the declared length comes from
+    // an unauthenticated client, so it must be capped before we buffer a byte.
+    if body_exceeds_limit(content_length) {
+        respond_payload_too_large(&mut stream).await;
+        return;
+    }
+
+    // Read the remaining body bytes, stopping as soon as the cap is reached so
+    // a peer that lies about `Content-Length` cannot force unbounded buffering.
+    while buf.len() < header_end + content_length && buf.len() < header_end + MAX_BODY {
         let n = match stream.read(&mut chunk).await {
-            Ok(0) => return,
+            Ok(0) => break,
             Ok(n) => n,
             Err(_) => return,
         };
         buf.extend_from_slice(&chunk[..n]);
     }
 
+    // The body exceeded the cap despite a small declared length (streamed):
+    // reject with 413 after draining the connection.
+    if buf.len() >= header_end + MAX_BODY && buf.len() < header_end + content_length {
+        respond_payload_too_large(&mut stream).await;
+        return;
+    }
+
     let (method, path) = parse_request_line(&head);
     let body =
         String::from_utf8_lossy(&buf[header_end..header_end + content_length]).to_string();
     let (status, payload) = route(&method, &path, &body);
+
+    // Drain any unread body bytes before responding so the connection can be
+    // closed/reused safely without leftover request data. Chunk reads may have
+    // overshot the declared length, hence the saturating subtraction.
+    drain_remaining(
+        &mut stream,
+        (header_end + content_length).saturating_sub(buf.len()),
+    )
+    .await;
 
     let _ = stream.write_all(&http_response(status, &payload)).await;
     let _ = stream.flush().await;
@@ -371,6 +433,29 @@ mod tests {
     fn unknown_route_returns_404() {
         let (status, _) = route("GET", "/nope", "");
         assert_eq!(status, "404 Not Found");
+    }
+
+    #[test]
+    fn parse_content_length_reads_header() {
+        let head = "POST /verify HTTP/1.1\r\nHost: x\r\nContent-Length: 42\r\n\r\n";
+        assert_eq!(parse_content_length(head), 42);
+    }
+
+    #[test]
+    fn parse_content_length_defaults_to_zero() {
+        assert_eq!(parse_content_length("GET /health HTTP/1.1\r\n\r\n"), 0);
+    }
+
+    #[test]
+    fn oversized_content_length_is_rejected() {
+        let head = "POST /verify HTTP/1.1\r\nContent-Length: 4294967296\r\n\r\n";
+        assert!(body_exceeds_limit(parse_content_length(head)));
+    }
+
+    #[test]
+    fn body_within_limit_is_accepted() {
+        let head = format!("POST /verify HTTP/1.1\r\nContent-Length: {MAX_BODY}\r\n\r\n");
+        assert!(!body_exceeds_limit(parse_content_length(&head)));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`services/zkp-verifier-rust/src/main.rs` reads the HTTP request body with no upper bound: `Content-Length` comes straight from the unauthenticated client and the read loop appends chunks until the declared length is reached, so a client sending `Content-Length: 4294967296` forces unbounded memory allocation (OOM/DoS). The Go services use the same unbounded `json.NewDecoder(r.Body).Decode(...)` pattern.

## Fix

Rust (`main.rs`):
- Added `const MAX_BODY: usize = 1 MiB`.
- Any `Content-Length` above `MAX_BODY` is rejected up front with `413 Content Too Large`.
- The body read loop stops appending once `buf.len() >= header_end + MAX_BODY`, so a lying/streamed peer cannot force unbounded buffering.
- `drain_remaining` reads and discards leftover body bytes (bounded to `MAX_BODY`) before responding so the connection is not left poisoned.
- Unit tests: `parse_content_length` parsing, oversized `Content-Length` rejected, in-limit accepted.

Go (`consensus-raft-go/main.go`, `telemetry-ingestion/main.go`):
- Added a shared `decodeJSONBody` helper that wraps `r.Body` in `http.MaxBytesReader` (1 MiB cap) and returns `413 StatusRequestEntityTooLarge` on `*http.MaxBytesError`; the net/http server drains and closes the connection afterwards.
- Applied to all `json.NewDecoder(r.Body)` request paths: `HandleVote`, `HandleAppend`, `HandleCommitOrder`, `handlePing`, `handleGeofence`.
- Added httptest coverage: oversized body → 413, in-limit malformed body → 400 (not 413).

## Files changed

- `services/zkp-verifier-rust/src/main.rs`
- `services/consensus-raft-go/main.go`
- `services/consensus-raft-go/main_test.go`
- `services/telemetry-ingestion/main.go`
- `services/telemetry-ingestion/main_test.go`

## Testing

- Rust: new unit tests for `parse_content_length` and the cap boundary (no Rust toolchain locally, so `cargo test` could not be run here).
- Go: new `TestHandleCommitOrderRejectsOversizedBody` / `TestHandleCommitOrderAcceptsBodyWithinLimit` (consensus) and `TestHandlePingRejectsOversizedBody` / `TestHandlePingAcceptsBodyWithinLimit` (telemetry). No Go toolchain locally, so `go test` could not be run here.

Closes #10636
