### PR TITLE
fix: validate vehicle capacity and compute capacity-bounded route distances

### DIFF
--- a/services/gpu-routing-cuda/CMakeLists.txt
+++ b/services/gpu-routing-cuda/CMakeLists.txt
@@ -9,3 +9,12 @@ include_directories(include)
 add_library(gpu_vrp
     src/cuda_vrp.cu
 )
+
+enable_testing()
+
+add_executable(gpu_vrp_tests
+    src/cuda_vrp_tests.cu
+)
+target_link_libraries(gpu_vrp_tests PRIVATE gpu_vrp)
+
+add_test(NAME gpu_vrp_tests COMMAND gpu_vrp_tests)

--- a/services/gpu-routing-cuda/src/cuda_vrp.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp.cu
@@ -1,36 +1,54 @@
 #include "../include/cuda_vrp.cuh"
+#include <algorithm>
 #include <cmath>
 #include <numeric>
 
 namespace TruxifyCuda {
+
+namespace {
+// Euclidean distance between two locations.
+float distance(const Location& a, const Location& b) {
+    float dx = b.x - a.x;
+    float dy = b.y - a.y;
+    return std::sqrt(dx * dx + dy * dy);
+}
+} // namespace
 
 VrpSolution CudaVrpSolver::solveParallelVRP(
     const Location& depot,
     const std::vector<Location>& stops,
     size_t vehicleCapacity
 ) {
+    // vehicleCapacity == 0 is degenerate caller input: the ceil division
+    // below would underflow/wrap and divide by zero, crashing the process.
+    // Reject it up front instead.
+    if (vehicleCapacity == 0) {
+        return { 0.0f, 0, false };
+    }
+
     if (stops.empty()) {
         return { 0.0f, 0, true };
     }
 
-    float distance = 0.0f;
-    Location prev = depot;
-
-    for (const auto& stop : stops) {
-        float dx = stop.x - prev.x;
-        float dy = stop.y - prev.y;
-        distance += std::sqrt(dx * dx + dy * dy);
-        prev = stop;
-    }
-
-    // Return to depot
-    float dx = depot.x - prev.x;
-    float dy = depot.y - prev.y;
-    distance += std::sqrt(dx * dx + dy * dy);
-
     size_t routesNeeded = (stops.size() + vehicleCapacity - 1) / vehicleCapacity;
 
-    return { distance, routesNeeded, true };
+    // Partition the stops into capacity-bounded route sequences. Each route
+    // leaves from the depot, visits at most `vehicleCapacity` stops, and
+    // returns to the depot, so the returned distance is the actual sum of the
+    // per-route tour distances reported by `routesNeeded`.
+    float totalDistance = 0.0f;
+    for (size_t routeStart = 0; routeStart < stops.size(); routeStart += vehicleCapacity) {
+        size_t routeEnd = std::min(routeStart + vehicleCapacity, stops.size());
+
+        Location prev = depot;
+        for (size_t i = routeStart; i < routeEnd; ++i) {
+            totalDistance += distance(prev, stops[i]);
+            prev = stops[i];
+        }
+        totalDistance += distance(prev, depot);
+    }
+
+    return { totalDistance, routesNeeded, true };
 }
 
 } // namespace TruxifyCuda

--- a/services/gpu-routing-cuda/src/cuda_vrp_tests.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp_tests.cu
@@ -1,0 +1,87 @@
+#include "cuda_vrp.cuh"
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using TruxifyCuda::Location;
+using TruxifyCuda::VrpSolution;
+
+static int failures = 0;
+
+static void check(bool cond, const char* what) {
+    if (!cond) {
+        std::printf("FAIL: %s\n", what);
+        failures++;
+    }
+}
+
+static float approx(float a, float b) {
+    return std::fabs(a - b) < 1e-4f;
+}
+
+int main() {
+    const Location depot{0.0f, 0.0f};
+    const std::vector<Location> stops = {
+        {1.0f, 0.0f},
+        {2.0f, 0.0f},
+        {3.0f, 0.0f},
+    };
+
+    // vehicleCapacity == 0 must be rejected without crashing (no division by
+    // zero / underflow).
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 0);
+        check(!s.isValid, "capacity 0 rejected as invalid");
+        check(s.routeCount == 0, "capacity 0 reports zero routes");
+        check(s.totalDistance == 0.0f, "capacity 0 reports zero distance");
+    }
+
+    // Empty stops remain valid with zero work.
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, {}, 5);
+        check(s.isValid, "empty stops is valid");
+        check(s.routeCount == 0 && s.totalDistance == 0.0f, "empty stops has zero routes/distance");
+    }
+
+    // capacity >= stops.size(): one out-and-back tour visiting every stop,
+    // 0->1->2->3->0 = 1+1+1+3 = 6.
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 3);
+        check(s.isValid, "single-route solution is valid");
+        check(s.routeCount == 1, "capacity >= n reports one route");
+        check(approx(s.totalDistance, 6.0f), "single-route distance matches tour");
+    }
+
+    // capacity == 1: each stop is its own depot out-and-back route;
+    // (1+1) + (2+2) + (3+3) = 12.
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 1);
+        check(s.isValid, "capacity 1 solution is valid");
+        check(s.routeCount == 3, "capacity 1 reports one route per stop");
+        check(approx(s.totalDistance, 12.0f), "capacity 1 distance sums per-route tours");
+    }
+
+    // capacity == 2: routes [1,2] and [3];
+    // (0->1->2->0) + (0->3->0) = (1+1+2) + (3+3) = 10.
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 2);
+        check(s.isValid, "capacity 2 solution is valid");
+        check(s.routeCount == 2, "capacity 2 reports ceil(3/2) = 2 routes");
+        check(approx(s.totalDistance, 10.0f), "capacity 2 distance sums both route tours");
+    }
+
+    // Consistency: the reported distance must equal the sum of the reported
+    // capacity-bounded routes (never a single unbounded tour when routes > 1).
+    {
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 2);
+        check(s.routeCount == 2, "consistency test: two routes reported");
+        check(!approx(s.totalDistance, 6.0f), "consistency: distance differs from single tour");
+    }
+
+    if (failures == 0) {
+        std::printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    std::printf("%d TEST(S) FAILED\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Problem

`CudaVrpSolver::solveParallelVRP` has two correctness bugs:
1. `vehicleCapacity == 0` makes `(vehicleCapacity - 1)` underflow, then the division by zero raises `SIGFPE`/UB — a crash from unvalidated caller input.
2. `totalDistance` was computed as a single depot out-and-back tour visiting every stop, while `routesNeeded` claims `ceil(n / capacity)` capacity-bounded routes — the distance never matched the reported routes for `capacity < stops.size()`.

## Fix

`services/gpu-routing-cuda/src/cuda_vrp.cu`:
- Validates `vehicleCapacity == 0` at entry and returns `{ 0.0f, 0, isValid = false }` instead of dividing by zero.
- Computes `routesNeeded` only after validation.
- Partitions `stops` into capacity-bounded route sequences (at most `vehicleCapacity` stops per route); each route tours out from the depot and returns to it, and the per-route tour distances are summed into `totalDistance` — so the returned distance now matches the reported `routeCount`.

## Files changed

- `services/gpu-routing-cuda/src/cuda_vrp.cu`
- `services/gpu-routing-cuda/src/cuda_vrp_tests.cu` (new)
- `services/gpu-routing-cuda/CMakeLists.txt` (test target + `ctest` registration)

## Testing

Added a self-contained `gpu_vrp_tests` executable wired into CMake/ctest covering:
- `vehicleCapacity == 0` → rejected (`isValid == false`), no crash;
- empty stops → valid with zero routes/distance;
- `capacity >= stops.size()` → one route, distance equals the full out-and-back tour;
- `capacity == 1` → one route per stop, distance equals the sum of per-route depot tours;
- `capacity == 2` (with 3 collinear stops) → 2 routes and distance = sum of both route tours, explicitly different from the old single-tour value.

Note: no CUDA/host C++ toolchain is available locally, so the tests could not be executed here.

Closes #10637
