### PR TITLE
fix: serve cpp connections concurrently with timeouts and byte budgets

### DIFF
--- a/services/route-matrix-cpp/CMakeLists.txt
+++ b/services/route-matrix-cpp/CMakeLists.txt
@@ -4,4 +4,8 @@ project(TruxifyRouteMatrix CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(Threads REQUIRED)
+
 add_executable(route-matrix-cpp main.cpp)
+
+target_link_libraries(route-matrix-cpp PRIVATE Threads::Threads)

--- a/services/route-matrix-cpp/main.cpp
+++ b/services/route-matrix-cpp/main.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cctype>
 #include <cstring>
+#include <thread>
 
 #if defined(_WIN32)
 #include <winsock2.h>
@@ -19,11 +20,33 @@ typedef int socklen_t;
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <cerrno>
 #define SOCKET int
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1
 #define closesocket close
 #endif
+
+// Total request byte budget per connection. Oversized requests are answered
+// with 413 instead of being buffered, bounding memory per connection.
+const size_t MAX_REQUEST_BYTES = 64 * 1024;
+
+// Applies read/write idle timeouts so a slow or idle client cannot stall a
+// handler thread forever: recv returns after the timeout instead of blocking
+// indefinitely.
+void set_socket_timeouts(SOCKET client) {
+#if defined(_WIN32)
+    unsigned long timeout_ms = 30000;
+    setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+    setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+#else
+    timeval tv;
+    tv.tv_sec = 30;
+    tv.tv_usec = 0;
+    setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+#endif
+}
 
 // Point structure
 struct Location {
@@ -210,24 +233,33 @@ std::string build_response(const std::string& body, const std::string& status) {
 void handle_client(SOCKET client) {
     char buf[8192];
     std::string request;
+    bool too_large = false;
     for (;;) {
+        // SO_RCVTIMEO bounds how long recv blocks on an idle/slow client, so a
+        // single connection cannot stall this handler thread indefinitely.
         int n = recv(client, buf, sizeof(buf), 0);
-        if (n <= 0) break;
+        if (n <= 0) break; // closed, errored, or idle timeout elapsed
         request.append(buf, static_cast<size_t>(n));
+
+        if (request.size() > MAX_REQUEST_BYTES) {
+            too_large = true;
+            break;
+        }
 
         size_t header_end = request.find("\r\n\r\n");
         if (header_end != std::string::npos) {
             size_t content_length = parse_content_length(request);
             if (request.size() >= header_end + 4 + content_length) break;
         }
-        if (request.size() > 65536) break;
     }
 
     std::string method, path, body;
     parse_request(request, method, path, body);
 
     std::string response;
-    if (method == "GET" && path == "/health") {
+    if (too_large) {
+        response = build_response("{\"error\":\"request too large\"}", "413 Content Too Large");
+    } else if (method == "GET" && path == "/health") {
         response = build_response("{\"status\":\"ok\",\"service\":\"route-matrix-cpp\"}", "200 OK");
     } else if (method == "POST" && path == "/matrix") {
         std::vector<Location> locs = parse_locations(body);
@@ -289,7 +321,14 @@ int main() {
     for (;;) {
         SOCKET client = accept(listen_sock, nullptr, nullptr);
         if (client == INVALID_SOCKET) continue;
-        handle_client(client);
-        closesocket(client);
+
+        set_socket_timeouts(client);
+
+        // Handle each connection on its own thread so an idle or slow client
+        // can never block the accept loop (and thus the whole service).
+        std::thread([client]() {
+            handle_client(client);
+            closesocket(client);
+        }).detach();
     }
 }

--- a/services/vector-matcher-cpp/CMakeLists.txt
+++ b/services/vector-matcher-cpp/CMakeLists.txt
@@ -4,6 +4,8 @@ project(vector_matcher_cpp CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(Threads REQUIRED)
+
 include_directories(include)
 
 add_library(vector_matcher
@@ -15,3 +17,4 @@ add_executable(vector-matcher-cpp
 )
 
 target_compile_options(vector-matcher-cpp PRIVATE -O3)
+target_link_libraries(vector-matcher-cpp PRIVATE Threads::Threads)

--- a/services/vector-matcher-cpp/main.cpp
+++ b/services/vector-matcher-cpp/main.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cctype>
 #include <cstring>
+#include <thread>
 
 #if defined(_WIN32)
 #include <winsock2.h>
@@ -19,11 +20,33 @@ typedef int socklen_t;
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <cerrno>
 #define SOCKET int
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1
 #define closesocket close
 #endif
+
+// Total request byte budget per connection. Oversized requests are answered
+// with 413 instead of being buffered, bounding memory per connection.
+const size_t MAX_REQUEST_BYTES = 64 * 1024;
+
+// Applies read/write idle timeouts so a slow or idle client cannot stall a
+// handler thread forever: recv returns after the timeout instead of blocking
+// indefinitely.
+void set_socket_timeouts(SOCKET client) {
+#if defined(_WIN32)
+    unsigned long timeout_ms = 30000;
+    setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+    setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+#else
+    timeval tv;
+    tv.tv_sec = 30;
+    tv.tv_usec = 0;
+    setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+#endif
+}
 
 // Vector Embedding Matcher Structure (64-dimensional latent representation)
 constexpr int EMBEDDING_DIM = 64;
@@ -201,24 +224,33 @@ std::string build_response(const std::string& body, const std::string& status) {
 void handle_client(SOCKET client, const std::vector<DriverEmbedding>& driver_pool) {
     char buf[8192];
     std::string request;
+    bool too_large = false;
     for (;;) {
+        // SO_RCVTIMEO bounds how long recv blocks on an idle/slow client, so a
+        // single connection cannot stall this handler thread indefinitely.
         int n = recv(client, buf, sizeof(buf), 0);
-        if (n <= 0) break;
+        if (n <= 0) break; // closed, errored, or idle timeout elapsed
         request.append(buf, static_cast<size_t>(n));
+
+        if (request.size() > MAX_REQUEST_BYTES) {
+            too_large = true;
+            break;
+        }
 
         size_t header_end = request.find("\r\n\r\n");
         if (header_end != std::string::npos) {
             size_t content_length = parse_content_length(request);
             if (request.size() >= header_end + 4 + content_length) break;
         }
-        if (request.size() > 65536) break;
     }
 
     std::string method, path, body;
     parse_request(request, method, path, body);
 
     std::string response;
-    if (method == "GET" && path == "/health") {
+    if (too_large) {
+        response = build_response("{\"error\":\"request too large\"}", "413 Content Too Large");
+    } else if (method == "GET" && path == "/health") {
         response = build_response(
             "{\"status\":\"ok\",\"service\":\"vector-matcher-cpp\",\"pool_size\":" + std::to_string(driver_pool.size()) + "}",
             "200 OK");
@@ -306,7 +338,14 @@ int main() {
     for (;;) {
         SOCKET client = accept(listen_sock, nullptr, nullptr);
         if (client == INVALID_SOCKET) continue;
-        handle_client(client, driver_pool);
-        closesocket(client);
+
+        set_socket_timeouts(client);
+
+        // Handle each connection on its own thread so an idle or slow client
+        // can never block the accept loop (and thus the whole service).
+        std::thread([client, &driver_pool]() {
+            handle_client(client, driver_pool);
+            closesocket(client);
+        }).detach();
     }
 }


### PR DESCRIPTION
## Problem

Both `route-matrix-cpp` and `vector-matcher-cpp` accept and handle connections synchronously in a single thread. `handle_client` calls `recv` with no timeout and no `select`/`poll`/non-blocking mode, so a client that connects and never sends (or trickles bytes) blocks the whole service — including `/health` — indefinitely (slowloris).

## Fix

Both services (`route-matrix-cpp/main.cpp`, `vector-matcher-cpp/main.cpp`):
- `set_socket_timeouts` sets `SO_RCVTIMEO`/`SO_SNDTIMEO` (30 s) on each accepted socket (win32 + POSIX variants), so `recv` returns after the idle timeout instead of blocking forever.
- The accept loop spawns a detached `std::thread` per connection (`handle_client` + `closesocket`), so the accept loop never blocks on a slow client.
- `handle_client` enforces a total request byte budget (`MAX_REQUEST_BYTES` = 64 KiB): oversized requests get a single clean `413 Content Too Large` instead of being buffered.
- CMakeLists for both services link `Threads::Threads` for portable `std::thread` support.

## Files changed

- `services/route-matrix-cpp/main.cpp`
- `services/route-matrix-cpp/CMakeLists.txt`
- `services/vector-matcher-cpp/main.cpp`
- `services/vector-matcher-cpp/CMakeLists.txt`

## Testing

Manual review only — no C++ toolchain is available locally, so the binaries could not be built/run here. The change keeps the request parsing/response logic identical and only alters socket options, the accept loop, and the read loop's bound/timeout behavior.

Closes #10640
