### PR TITLE
fix: start only consumer groups that are actually created

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -8,6 +8,7 @@ class OrderConsumer {
     this.handlers = new Map();
     this.initialized = false;
     this._eventBus = externalEventBus || null;
+    this.createdConsumerGroups = [];
   }
 
   setEventBus(eventBus) {
@@ -54,6 +55,13 @@ class OrderConsumer {
       TOPICS.PAYMENT_CONFIRMED,
       TOPICS.FRAUD_DETECTED,
     ]);
+
+    this.createdConsumerGroups = [
+      CONSUMER_GROUPS.ORDER_SERVICE,
+      CONSUMER_GROUPS.NOTIFICATION_SERVICE,
+      CONSUMER_GROUPS.ANALYTICS_SERVICE,
+      CONSUMER_GROUPS.FRAUD_SERVICE,
+    ];
 
     this.initialized = true;
     logger.info('✅ Kafka consumers initialized');
@@ -213,7 +221,10 @@ class OrderConsumer {
   async startAllConsumers() {
     await this.initialize();
 
-    const consumerGroups = Object.values(CONSUMER_GROUPS);
+    // Only start consumer groups that were actually created in initialize().
+    // CONSUMER_GROUPS also declares DRIVER/PAYMENT/ESCROW groups that are not
+    // wired up yet, and startConsuming() would fail on getConsumer() for them.
+    const consumerGroups = this.createdConsumerGroups;
     for (const groupId of consumerGroups) {
       try {
         await this.startConsuming(groupId);


### PR DESCRIPTION
Closes #10729

## What changed
`OrderConsumer.startAllConsumers()` was iterating all 7 entries of `CONSUMER_GROUPS`, but `initialize()` only creates 4 consumer groups (ORDER_SERVICE, NOTIFICATION_SERVICE, ANALYTICS_SERVICE, FRAUD_SERVICE). For the 3 uncreated groups (DRIVER_SERVICE, PAYMENT_SERVICE, ESCROW_SERVICE), `kafka.getConsumer(groupId)` throws "Consumer X not found", so those consumers were logged as failed and silently never started.

Now `initialize()` records the groups it actually creates in `createdConsumerGroups`, and `startAllConsumers()` iterates only those.

GSSOC
