### PR TITLE
fix: guard message.key logging so keyless messages do not crash

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -209,7 +209,7 @@ class KafkaConfig {
           }
           const parentContext = propagation.extract(context.active(), normalizedHeaders);
 
-          logger.debug(`📥 Message received: ${topic}`, { key: message.key.toString() });
+          logger.debug(`📥 Message received: ${topic}`, { key: message.key ? message.key.toString() : null });
 
           await context.with(parentContext, async () => {
             await messageHandler(topic, value, message);


### PR DESCRIPTION
Closes #10730

## What changed
`EachMessage` in `kafka.config.js` assumed every Kafka message carries a key and called `message.key.toString()` unconditionally. Keyless messages threw a TypeError, were never delivered to the topic handler, and were always routed to the dead-letter handler.

Now the key is only logged when present, so keyless messages reach their handler normally.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka message logging for messages without keys, preventing errors and recording the key as `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->