### PR TITLE
fix(eta): convert LSTM speed prediction to actual ETA seconds

### DIFF
--- a/backend/ml/routes/eta_routes.py
+++ b/backend/ml/routes/eta_routes.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 import numpy as np
 
-from services.traffic_pipeline import TrafficPipeline
+from services.traffic_pipeline import TrafficPipeline, eta_seconds_from_speed
 from app.execution import run_inference
 
 logger = logging.getLogger(__name__)
@@ -103,18 +103,35 @@ async def predict_eta(request: ETARequest, _auth=Depends(verify_api_key)):
 
             # TensorFlow LSTM inference is CPU-bound; run off the event loop so
             # an ETA request cannot stall other endpoints or /health.
-            eta_seconds = await run_inference(traffic_pipeline.predict_eta, features)
+            # The LSTM is trained on traffic_speed (m/s) (see train_model), so
+            # its raw output is a predicted speed, not a duration. Keep the
+            # dimension explicit and convert it to seconds below.
+            predicted_speed_mps = await run_inference(traffic_pipeline.predict_eta, features)
 
-            if eta_seconds:
-                return ETAResponse(
-                    order_id=request.order_id,
-                    eta_seconds=eta_seconds,
-                    eta_minutes=eta_seconds / 60,
-                    eta_string=str(timedelta(seconds=int(eta_seconds))),
-                    traffic_speed=traffic_data.traffic_speed,
-                    congestion_level=traffic_data.congestion_level,
-                    timestamp=utc_now.isoformat()
+            if predicted_speed_mps:
+                # Fetch the actual route distance (metres) from the routing
+                # engine, then convert predicted speed -> travel time.
+                osrm_data = await traffic_pipeline._fetch_osrm_data(
+                    {'lat': request.source_lat, 'lng': request.source_lng},
+                    {'lat': request.dest_lat, 'lng': request.dest_lng}
                 )
+                route_distance_m = float(osrm_data.get('distance') or 0)
+                eta_seconds = eta_seconds_from_speed(route_distance_m, predicted_speed_mps)
+                if eta_seconds is None:
+                    # No route distance available; fall back to the routing
+                    # engine's own duration estimate.
+                    eta_seconds = float(osrm_data.get('duration') or 0)
+
+                if eta_seconds > 0:
+                    return ETAResponse(
+                        order_id=request.order_id,
+                        eta_seconds=eta_seconds,
+                        eta_minutes=eta_seconds / 60,
+                        eta_string=str(timedelta(seconds=int(eta_seconds))),
+                        traffic_speed=traffic_data.traffic_speed,
+                        congestion_level=traffic_data.congestion_level,
+                        timestamp=utc_now.isoformat()
+                    )
 
         raise HTTPException(status_code=500, detail="ETA prediction failed")
 

--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -27,6 +27,21 @@ from functools import partial
 logger = logging.getLogger(__name__)
 Base = declarative_base()
 
+
+def eta_seconds_from_speed(route_distance_m: float, predicted_speed_mps: float) -> Optional[float]:
+    """Convert a predicted traffic speed (m/s) into a travel time (seconds).
+
+    The LSTM is trained on traffic_speed (m/s) (see train_model), so its raw
+    output is a speed, not a duration. eta_seconds = distance_m / speed_mps.
+    Returns None when either input is missing or non-positive so callers can
+    fall back to the routing engine's own duration estimate.
+    """
+    if not route_distance_m or route_distance_m <= 0:
+        return None
+    if not predicted_speed_mps or predicted_speed_mps <= 0:
+        return None
+    return route_distance_m / predicted_speed_mps
+
 class TrafficData(Base):
     __tablename__ = 'traffic_data'
     

--- a/backend/ml/tests/test_traffic_pipeline.py
+++ b/backend/ml/tests/test_traffic_pipeline.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 import os
 
-from services.traffic_pipeline import TrafficPipeline
+from services.traffic_pipeline import TrafficPipeline, eta_seconds_from_speed
 
 class TestTrafficPipeline:
     @patch("redis.Redis.from_url")
@@ -65,3 +65,33 @@ class TestEtaComputation:
         predicted_speed_kmh = 60.0
         eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
         assert 5900 < eta_seconds < 6100, f"Expected ~6000s, got {eta_seconds}"
+
+
+class TestEtaFromSpeedConversion:
+    """Regression tests for /eta/predict speed-to-duration conversion.
+
+    The LSTM predicts traffic speed in m/s (it is trained on traffic_speed,
+    see TrafficPipeline.train_model), but the endpoint used to label the raw
+    prediction as eta_seconds. eta_seconds = route_distance_m / speed_mps.
+    """
+
+    def test_20_mps_over_100_km_is_about_83_minutes(self):
+        """20 m/s over 100 km should be ~5000 s = ~83.3 minutes (not 0.33)."""
+        eta_seconds = eta_seconds_from_speed(100000.0, 20.0)
+        assert eta_seconds == pytest.approx(5000.0, abs=1.0)
+        assert eta_seconds / 60 == pytest.approx(83.3, abs=0.1)
+
+    def test_speed_dimension_is_mps_not_kmh(self):
+        """Distance (m) / speed (m/s) yields seconds; no 3.6 factor involved."""
+        # 10 km at 20 m/s = 10000 / 20 = 500 s. If speed were (wrongly) treated
+        # as km/h, dividing by 3.6 would give ~83.3 s and the trip would be
+        # reported as ~1.4 minutes instead of ~8.3 minutes.
+        assert eta_seconds_from_speed(10000.0, 20.0) == pytest.approx(500.0, abs=1.0)
+
+    def test_zero_or_missing_distance_returns_none(self):
+        assert eta_seconds_from_speed(0, 20.0) is None
+        assert eta_seconds_from_speed(None, 20.0) is None
+
+    def test_non_positive_speed_returns_none(self):
+        assert eta_seconds_from_speed(100000.0, 0) is None
+        assert eta_seconds_from_speed(100000.0, -5.0) is None


### PR DESCRIPTION
## Problem

`POST /eta/predict` (`backend/ml/routes/eta_routes.py:106-117`) labeled the LSTM output as `eta_seconds`, but the model is trained on `traffic_speed` (m/s) — see `train_model` and `_fetch_osrm_data` in `traffic_pipeline.py`. The endpoint returned the predicted *speed in m/s* (typically ~5-30) as if it were a duration in seconds, so `eta_string` read like `"15 seconds"` and `eta_minutes` was ~0.25 for a multi-hour trip. Every downstream consumer of `eta_seconds` inherited a dimensionally wrong value, off by orders of magnitude.

## Fix

- Renamed the raw model output variable to `predicted_speed_mps` so its dimension is explicit.
- Added `eta_seconds_from_speed(route_distance_m, predicted_speed_mps)` in `traffic_pipeline.py` — `eta_seconds = route_distance_m / predicted_speed_mps`.
- The endpoint now fetches the real route distance from OSRM and converts predicted speed → travel time; if no route distance is available it falls back to the routing engine's duration estimate.
- `eta_minutes` and `eta_string` are now derived from the converted duration, so a 20 m/s prediction over a 100 km route reports ~83.3 minutes instead of ~0.33.

## Files changed

- `backend/ml/routes/eta_routes.py` — rename variable, fetch route distance, convert speed→duration, fall back to OSRM duration.
- `backend/ml/services/traffic_pipeline.py` — new `eta_seconds_from_speed` helper.
- `backend/ml/tests/test_traffic_pipeline.py` — regression tests for the conversion (20 m/s over 100 km ≈ 83.3 min; m/s not km/h; zero/negative inputs return None).

## Testing

- `py -m pytest tests/test_traffic_pipeline.py -k EtaFromSpeed -v` → 4 passed.
- `py -m py_compile` on all three modified files → OK.
- Full suite not run: TensorFlow is not installed in the local environment (the LSTM model and `/eta/predict` end-to-end path require `tensorflow`/`keras`).

Closes #10641
