### PR TITLE
fix: keep orderId as key fallback in publishBatch

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -174,7 +174,7 @@ class KafkaConfig {
         topic,
         messages: [
           {
-            key: key || event.eventId,
+            key: key || event.eventId || event.orderId,
             value: JSON.stringify({
               ...event,
               timestamp: event.timestamp || new Date().toISOString(),


### PR DESCRIPTION
Closes #10731

## What changed
`publishEvent` falls back to `event.orderId` when no key is provided, but `publishBatch` only used `event.eventId`. Batched order events published without an explicit key got a random `eventId` key, which broke per-order partition ordering. Added the `event.orderId` fallback to match `publishEvent`.

GSSOC
