### PR TITLE
fix(eta): remove bogus km/h to m/s conversion in realtime ETA

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -305,19 +305,21 @@ class TrafficPipeline:
                     datetime.now().weekday()
                 ]])
                 
-                # Predict traffic speed (km/h) with the LSTM.
-                predicted_speed_kmh = self.predict_eta(features)
+                # The LSTM predicts traffic speed in m/s (it is trained on
+                # traffic_speed, see _fetch_osrm_data and train_model), so its
+                # output is a speed, not a duration. Convert the predicted
+                # speed into an ETA in seconds using the route distance so the
+                # value is meaningful as a travel time.
+                predicted_speed_mps = self.predict_eta(features)
 
-                if predicted_speed_kmh is not None:
-                    # The model predicts speed, not duration. Convert the
-                    # predicted speed into an ETA in seconds using the route
-                    # distance so the value is meaningful as a travel time.
+                if predicted_speed_mps is not None:
                     osrm_data = await self._fetch_osrm_data(current_location, destination)
                     route_distance_m = float(osrm_data.get('distance') or 0)
-                    if route_distance_m > 0 and predicted_speed_kmh > 0:
-                        # Convert speed from km/h to m/s, then divide distance_m by speed_mps to get seconds.
-                        # Incorrect: (route_distance_m / 1000.0) / (speed_kmh / 3.6) mixes km with m/s, off by 1000x.
-                        eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
+                    if route_distance_m > 0 and predicted_speed_mps > 0:
+                        # Distance (m) / speed (m/s) yields seconds. The speed
+                        # is already m/s — do NOT divide by 3.6 as if it were
+                        # km/h, that inflated the ETA by 3.6x.
+                        eta_seconds = route_distance_m / predicted_speed_mps
                     else:
                         # Fall back to the routing engine's duration estimate.
                         eta_seconds = float(osrm_data.get('duration') or 0)

--- a/backend/ml/tests/test_traffic_pipeline.py
+++ b/backend/ml/tests/test_traffic_pipeline.py
@@ -25,43 +25,41 @@ class TestTrafficPipeline:
 class TestEtaComputation:
     """Tests for the ETA computation formula in update_eta_realtime.
 
-    The bug was: eta_seconds = (route_distance_m / 1000.0) / (speed_kmh / 3.6)
-    This mixes km (from dividing m by 1000) with m/s (from dividing km/h by 3.6),
-    producing a result 1000x too small.
+    The LSTM predicts traffic speed in m/s (it is trained on traffic_speed,
+    see _fetch_osrm_data: speed = distance / duration). The correct conversion
+    to a travel time is: eta_seconds = route_distance_m / predicted_speed_mps.
 
-    Correct formula: eta_seconds = route_distance_m / (speed_kmh / 3.6)
-    This converts speed to m/s first, then divides distance_m by speed_mps to get seconds.
+    Regression (issue 10642): the code divided the m/s prediction by 3.6 as if
+    it were km/h, inflating every real-time ETA by 3.6x.
     """
 
-    def test_eta_formula_returns_correct_seconds(self):
-        """10 km at 40 km/h should be ~900 seconds (15 minutes)."""
-        route_distance_m = 10000  # 10 km in metres
-        predicted_speed_kmh = 40.0
-        # Correct formula: distance_m / (speed_kmh / 3.6) = 10000 / 11.111 = 900
-        eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
-        assert 890 < eta_seconds < 910, f"Expected ~900s, got {eta_seconds}"
+    def test_20_mps_over_100_km_is_about_83_minutes(self):
+        """20 m/s over 100 km should be ~5000 s = ~83.3 minutes."""
+        route_distance_m = 100000  # 100 km
+        predicted_speed_mps = 20.0
+        eta_seconds = route_distance_m / predicted_speed_mps
+        assert eta_seconds == pytest.approx(5000.0, abs=1.0)
+        assert eta_seconds / 60 == pytest.approx(83.3, abs=0.1)
 
-    def test_eta_formula_100x_too_small_before_fix(self):
-        """Verify the old (incorrect) formula was off by exactly 1000x."""
-        route_distance_m = 10000
-        predicted_speed_kmh = 40.0
-        # Incorrect: (route_distance_m / 1000.0) / (speed_kmh / 3.6)
-        incorrect_eta = (route_distance_m / 1000.0) / (predicted_speed_kmh / 3.6)
-        correct_eta = route_distance_m / (predicted_speed_kmh / 3.6)
-        assert incorrect_eta == correct_eta / 1000, (
-            "Old formula should be exactly 1000x smaller than correct formula"
-        )
+    def test_buggy_kmh_conversion_inflates_eta_by_3_6x(self):
+        """Dividing the m/s speed by 3.6 (as if km/h) inflates ETA by 3.6x."""
+        route_distance_m = 100000
+        predicted_speed_mps = 20.0
+        buggy_eta_seconds = route_distance_m / (predicted_speed_mps / 3.6)
+        correct_eta_seconds = route_distance_m / predicted_speed_mps
+        assert buggy_eta_seconds == correct_eta_seconds * 3.6
+        assert buggy_eta_seconds / 60 == pytest.approx(300.0, abs=1.0)
 
     def test_eta_zero_distance_returns_zero(self):
         """Zero distance should give zero ETA regardless of speed."""
         route_distance_m = 0
-        predicted_speed_kmh = 40.0
-        eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
+        predicted_speed_mps = 20.0
+        eta_seconds = route_distance_m / predicted_speed_mps
         assert eta_seconds == 0.0
 
     def test_eta_reasonable_range_for_real_trip(self):
-        """100 km at 60 km/h should be ~6000 seconds (100 minutes)."""
+        """100 km at ~16.67 m/s (60 km/h) should be ~6000 seconds."""
         route_distance_m = 100000  # 100 km
-        predicted_speed_kmh = 60.0
-        eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)
+        predicted_speed_mps = 16.67
+        eta_seconds = route_distance_m / predicted_speed_mps
         assert 5900 < eta_seconds < 6100, f"Expected ~6000s, got {eta_seconds}"


### PR DESCRIPTION
## Problem

`update_eta_realtime` (`backend/ml/services/traffic_pipeline.py:288-323`, called by `POST /eta/update/{order_id}`) inflated every real-time ETA by 3.6×. The LSTM is trained on `traffic_speed` in **m/s** (`_fetch_osrm_data` computes `speed = distance / duration` in m/s), but the code treated the prediction as km/h and divided it by 3.6: `eta_seconds = route_distance_m / (predicted_speed_kmh / 3.6)`. The inflated value was written to Redis (`eta:order:{id}`) and consumed as the live trip ETA, so the driver/app showed ~3.6× the real arrival time.

## Fix

- Removed the bogus `/ 3.6` — the prediction is already m/s, so the correct conversion is `eta_seconds = route_distance_m / predicted_speed_mps`.
- Renamed `predicted_speed_kmh` → `predicted_speed_mps` so the unit is documented and cannot silently drift.
- Updated the unit tests that previously codified the km/h assumption to assert m/s semantics (20 m/s over 100 km ≈ 83.3 minutes, and the 3.6× inflation the bug produced ≈ 300 minutes).

## Files changed

- `backend/ml/services/traffic_pipeline.py` — drop `/ 3.6`, rename variable to `predicted_speed_mps`.
- `backend/ml/tests/test_traffic_pipeline.py` — regression tests for the m/s formula and the 3.6× inflation.

## Testing

- `py -m pytest tests/test_traffic_pipeline.py -k EtaComputation -v` → 4 passed.
- `py -m py_compile` on both modified files → OK.
- Full suite not run: TensorFlow is not installed locally (the `/eta/update` end-to-end path requires `tensorflow`/`keras` and a running Redis/OSRM).

Closes #10642
