### PR TITLE
fix: atomic retry_count increment and cap dead-letter replay

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -3,6 +3,8 @@ import processedEventRepository from '../repositories/processedEvent.repository.
 import deadLetterRepository from '../repositories/deadLetter.repository.js';
 import logger from '../../api/src/middleware/logger.js';
 
+const MAX_REPLAY_ATTEMPTS = 3;
+
 class OrderConsumer {
   constructor({ eventBus: externalEventBus } = {}) {
     this.handlers = new Map();
@@ -188,7 +190,12 @@ class OrderConsumer {
         parsedMessage = JSON.parse(serialized);
       } catch (error) {
         logger.error(`Replay failed for dead letter ${entry.id} (${entry.topic}): message is not valid JSON:`, error);
-        await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        if ((entry.retry_count ?? 0) >= MAX_REPLAY_ATTEMPTS) {
+          await deadLetterRepository.markStatus(entry.id, 'failed');
+          logger.error(`Dead letter ${entry.id} (${entry.topic}) marked failed after ${entry.retry_count ?? 0} retries`);
+        } else {
+          await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        }
         results.failed += 1;
         continue;
       }
@@ -201,7 +208,16 @@ class OrderConsumer {
         results.succeeded += 1;
       } catch (error) {
         logger.error(`Replay failed for dead letter ${entry.id} (${entry.topic}):`, error);
-        await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        // Cap replay attempts so a poison message is not retried forever.
+        // After the cap the dead letter is marked failed and no longer
+        // picked up by listPending(), otherwise each replay cycles the same
+        // failing entry back into the pending queue indefinitely.
+        if ((entry.retry_count ?? 0) >= MAX_REPLAY_ATTEMPTS) {
+          await deadLetterRepository.markStatus(entry.id, 'failed');
+          logger.error(`Dead letter ${entry.id} (${entry.topic}) marked failed after ${entry.retry_count ?? 0} retries`);
+        } else {
+          await deadLetterRepository.markStatus(entry.id, 'pending', { incrementRetry: true });
+        }
         results.failed += 1;
       }
     }

--- a/backend/kafka/repositories/deadLetter.repository.js
+++ b/backend/kafka/repositories/deadLetter.repository.js
@@ -51,14 +51,12 @@ class DeadLetterRepository {
         replayed_at: status === 'replayed' ? new Date().toISOString() : null,
       };
 
+      // Atomic increment: never read-then-write. A SELECT followed by an
+      // UPDATE lets two concurrent replays read the same retry_count and
+      // both write retry_count + 1, losing an attempt. PostgREST applies
+      // { inc: 1 } as a single UPDATE ... SET retry_count = retry_count + 1.
       if (incrementRetry) {
-        const { data: current, error: fetchError } = await supabaseAdmin
-          .from('kafka_dead_letters')
-          .select('retry_count')
-          .eq('id', id)
-          .single();
-        if (fetchError) throw fetchError;
-        update.retry_count = (current?.retry_count || 0) + 1;
+        update.retry_count = { inc: 1 };
       }
 
       const { error } = await supabaseAdmin


### PR DESCRIPTION
Closes #10738

## What changed
**Atomic `retry_count` increment** — `deadLetterRepository.markStatus()` did a read-then-write (SELECT `retry_count`, then UPDATE `+1`). Two concurrent replays could both read the same value and both write `retry_count + 1`, losing one attempt. It now uses PostgREST's `{ retry_count: { inc: 1 } }`, which Postgres applies as a single atomic `UPDATE ... SET retry_count = retry_count + 1`.

**Capped replay** — `replayDeadLetters()` re-marked every failed entry as `pending` with an incremented `retry_count` and no limit, so a poison message (including one whose payload is not valid JSON) was retried forever and each replay cycled the same entry back into the pending queue. Entries now stay `pending` until `MAX_REPLAY_ATTEMPTS` (3), after which they are marked `failed` and drop out of `listPending()`.

GSSOC
