### PR TITLE
fix: make revokeAllForOrder throw on DB error

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -777,10 +777,18 @@ export class DeliveryVerificationService {
 
         // The trip is complete (payment_released) — kill any active public
         // tracking tokens so a shared link can no longer broadcast the driver's
-        // live location. Best-effort: revokeAllForOrder never throws.
-        await this.trackingTokenService?.revokeAllForOrder(
-          order.order_display_id,
-        );
+        // live location. Best-effort: token revocation failure must not break
+        // the delivery-complete flow, so swallow the throw here.
+        try {
+          await this.trackingTokenService?.revokeAllForOrder(
+            order.order_display_id,
+          );
+        } catch (error) {
+          logger.error(
+            `[verify-delivery] Failed to revoke tracking tokens for order ${order.order_display_id}:`,
+            error,
+          );
+        }
 
         // --- Fire FCM push to driver: "Payment Released ✓" ---
         const resolvedDriverIdForPush = tripData?.driver_id || order.driver_id;

--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -99,6 +99,7 @@ export class TrackingTokenService {
 
     if (error) {
       this._logger.error({ error, orderDisplayId }, 'Failed to revoke tracking tokens for order');
+      throw new Error('Failed to revoke tracking tokens for order');
     }
   }
 


### PR DESCRIPTION
Closes #10735

## What changed
`revokeAllForOrder()` only logged the DB error and returned, unlike `revokeToken()` which throws. A silent failure left public tracking tokens active after the trip completed, so a shared tracking link kept broadcasting the driver's live location.

Now throws `Error('Failed to revoke tracking tokens for order')` on DB error, matching `revokeToken`. The one best-effort caller that relied on "never throws" (`deliveryVerificationService`) now wraps the call in try/catch so the delivery-complete flow is not broken by a revocation failure.

GSSOC
