### PR TITLE
fix: never leave a dirty node unprocessed when layout throws

### DIFF
--- a/backend/layout/LayoutEngine.js
+++ b/backend/layout/LayoutEngine.js
@@ -80,10 +80,20 @@ class LayoutEngine {
                 for (const nodeId of this.dirtyNodes) {
                     const node = this.root ? this.root.findNodeById(nodeId) : null;
                     if (node) {
-                        await node.measure();
-                        await node.render();
-                        this.metrics.totalMeasures++;
-                        this.metrics.totalRenders++;
+                        try {
+                            await node.measure();
+                            await node.render();
+                            this.metrics.totalMeasures++;
+                            this.metrics.totalRenders++;
+                        } catch (err) {
+                            // A throwing measure()/render() must not leave the
+                            // node stuck in dirtyNodes forever, otherwise the
+                            // layout loop re-processes it on every tick and the
+                            // engine can never settle. Log and drop the dirty
+                            // marker so the node is retried only if it dirties
+                            // itself again.
+                            logger.error(`[LayoutEngine] Failed to layout node ${nodeId}:`, err.message);
+                        }
                     }
                     this.removeDirtyNode(nodeId);
                 }


### PR DESCRIPTION
Closes #10734

## What changed
If `node.measure()` or `node.render()` threw, the exception escaped the layout loop: no remaining dirty nodes were processed, and the throwing node's dirty marker was never removed. The engine re-ran on the next dirty event, hit the same node, threw again, and the node stayed dirty forever — the engine could never settle.

`measure()`/`render()` are now wrapped in a per-node try/catch, and `removeDirtyNode(nodeId)` always runs. A failing node is dropped from the dirty set and is only re-laid out if it dirties itself again.

GSSOC
