### PR TITLE
fix(safety): fuse real sensor data, stop synthesizing random inputs

### DIFF
--- a/backend/ml/multimodal/sensor_fusion.py
+++ b/backend/ml/multimodal/sensor_fusion.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Any
 import redis
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -159,30 +158,51 @@ class SensorFusion:
         return min(risk, 1.0)
     
     def get_safety_report(self) -> Dict:
-        """Get latest safety report"""
+        """Get latest safety report.
+
+        Sensor state is read from Redis keys populated by real device
+        ingestion (e.g. ``sensor:latest``, mirroring ``vision:latest`` /
+        ``audio:latest``). Sensor inputs are never synthesized: when no real
+        sensor frame is available the report is ``UNKNOWN`` with
+        ``data_available: false`` instead of inventing values.
+        """
         # Get latest data from all modalities
         vision_data = self.redis.get('vision:latest')
         audio_data = self.redis.get('audio:latest')
-        
+        sensor_data = self.redis.get('sensor:latest')
+
         vision = json.loads(vision_data) if vision_data else {}
         audio = json.loads(audio_data) if audio_data else {}
-        
-        # Simulate sensor data (in production: read from IoT devices)
-        sensor = {
-            'speed': np.random.uniform(40, 90),
-            'acceleration': np.random.uniform(-8, 8),
-            'steering_angle': np.random.uniform(-45, 45),
-            'seatbelt': np.random.choice([True, False], p=[0.95, 0.05]),
-            'timestamp': datetime.now().isoformat()
-        }
-        
+        sensor = json.loads(sensor_data) if sensor_data else {}
+
+        # No real sensor frame (and no vision/audio either): report an
+        # explicit UNKNOWN state rather than fabricating sensor inputs.
+        if not sensor and not vision and not audio:
+            return {
+                'fusion_risk': 0.0,
+                'vision_risk': 0.0,
+                'audio_risk': 0.0,
+                'sensor_risk': 0.0,
+                'alert_level': 'UNKNOWN',
+                'alert_message': 'No sensor data available.',
+                'components': {
+                    'vision': {},
+                    'audio': {},
+                    'sensors': {}
+                },
+                'actions': self._generate_actions({'alert_level': 'UNKNOWN'}),
+                'timestamp': datetime.now().isoformat(),
+                'data_available': False
+            }
+
         # Fuse data
         result = self.fuse_data(vision, audio, sensor)
-        
+
         # Generate actions
         actions = self._generate_actions(result)
         result['actions'] = actions
-        
+        result['data_available'] = True
+
         return result
     
     def _generate_actions(self, report: Dict) -> List[str]:
@@ -203,6 +223,12 @@ class SensorFusion:
                 '📊 Monitor driver closely',
                 '🔄 Suggest rest stop',
                 '📝 Log incident for review'
+            ]
+        elif report['alert_level'] == 'UNKNOWN':
+            actions = [
+                '📊 Waiting for sensor data',
+                '📡 Check device connectivity',
+                '📝 No safety assessment possible without data'
             ]
         else:
             actions = [

--- a/backend/ml/tests/test_multimodal.py
+++ b/backend/ml/tests/test_multimodal.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -9,3 +10,84 @@ class TestMultimodal:
         engine = SensorFusion()
         assert engine is not None
         assert hasattr(engine, 'weights')
+
+
+def _make_fusion(redis_get_result=None):
+    """Build a SensorFusion backed by a fake Redis with a stubbed get()."""
+    fake_redis = MagicMock()
+    fake_redis.get.return_value = redis_get_result
+    with patch("redis.Redis.from_url", return_value=fake_redis):
+        return SensorFusion(), fake_redis
+
+
+class TestFuseDataDeterministic:
+    """fuse_data must be deterministic given real, fixed sensor payloads."""
+
+    def test_safe_sensor_payload_returns_safe(self):
+        engine, _ = _make_fusion()
+        sensor = {
+            'speed': 60.0,
+            'acceleration': 2.0,
+            'steering_angle': 10.0,
+            'seatbelt': True,
+        }
+        report = engine.fuse_data({}, {}, sensor)
+        assert report['sensor_risk'] == 0.0
+        assert report['alert_level'] == 'SAFE'
+
+    def test_risky_sensor_payload_returns_critical(self):
+        engine, _ = _make_fusion()
+        sensor = {
+            'speed': 95.0,        # > 80 -> +0.2
+            'acceleration': 7.0,  # |a| > 5 -> +0.2
+            'steering_angle': 40.0,  # |angle| > 30 -> +0.1
+            'seatbelt': False,    # -> +0.3
+        }
+        report = engine.fuse_data({}, {}, sensor)
+        assert report['sensor_risk'] == pytest.approx(0.8)
+        # sensor weight is 0.2, so fused = 0.8 * 0.2 = 0.16 -> SAFE without
+        # vision/audio. With matching vision/audio risk it crosses CRITICAL.
+        assert report['fusion_risk'] == pytest.approx(0.16)
+
+    def test_risky_sensor_plus_vision_audio_raises_level(self):
+        engine, _ = _make_fusion()
+        vision = {'drowsiness': {'status': 'DROWSY'}, 'distraction': {'status': 'DISTRACTED'}}
+        audio = {'emergency': {'is_emergency': True}}
+        sensor = {
+            'speed': 95.0,
+            'acceleration': 7.0,
+            'steering_angle': 40.0,
+            'seatbelt': False,
+        }
+        report = engine.fuse_data(vision, audio, sensor)
+        assert report['sensor_risk'] == pytest.approx(0.8)
+        # vision 0.7*0.5 + audio 0.4*0.3 + sensor 0.8*0.2 = 0.63 -> WARNING.
+        # Deterministic: the same payload always yields the same level.
+        assert report['fusion_risk'] == pytest.approx(0.63)
+        assert report['alert_level'] == 'WARNING'
+
+
+class TestGetSafetyReportNoSynthesis:
+    """get_safety_report must never fabricate sensor inputs."""
+
+    def test_no_data_returns_unknown(self):
+        engine, _ = _make_fusion(redis_get_result=None)
+        report = engine.get_safety_report()
+        assert report['alert_level'] == 'UNKNOWN'
+        assert report['data_available'] is False
+        assert report['fusion_risk'] == 0.0
+
+    def test_uses_real_sensor_frame_from_redis(self):
+        sensor = {
+            'speed': 60.0,
+            'acceleration': 2.0,
+            'steering_angle': 10.0,
+            'seatbelt': True,
+        }
+        engine, _ = _make_fusion(redis_get_result=json.dumps(sensor))
+        report = engine.get_safety_report()
+        assert report['data_available'] is True
+        assert report['components']['sensors']['speed'] == 60.0
+        assert report['alert_level'] in ('SAFE', 'WARNING', 'CRITICAL')
+        # No random synthesis: components reflect exactly the stored frame.
+        assert report['components']['sensors'] == sensor


### PR DESCRIPTION
## Problem

`get_safety_report` (`backend/ml/multimodal/sensor_fusion.py:170-177`, exposed via `GET /safety/fusion/report`) fabricated its sensor input with `np.random.uniform`/`np.random.choice` calls. A single random draw could score 0.8 and, combined with vision/audio risk, exceed the CRITICAL threshold — producing emergency actions (alarm, contact emergency services) for drivers who were fine, and missing real incidents. Alert levels were decided by randomness, not the driver's actual state.

## Fix

- Removed the random-data path from `get_safety_report`.
- Sensor state is now read from the Redis key `sensor:latest` (mirroring the existing `vision:latest` / `audio:latest` pattern used by the real vision/audio monitors), so reports fuse the latest telemetry frame from real device ingestion.
- When no real sensor/vision/audio data is available, the report returns `alert_level: 'UNKNOWN'` with `data_available: false` (and 0.0 risks) instead of inventing inputs.
- Added a dedicated `UNKNOWN` action list so operators see a "waiting for sensor data / check connectivity" state rather than a false-safe message.
- Dropped the now-unused `numpy` import.

## Files changed

- `backend/ml/multimodal/sensor_fusion.py` — real Redis-backed sensor reads, UNKNOWN state when no data, removed random synthesis.
- `backend/ml/tests/test_multimodal.py` — deterministic `fuse_data` tests (safe payload → SAFE, risky payload → exact risk values, fusion with vision/audio → WARNING) and no-synthesis tests (`UNKNOWN`/`data_available: false` when Redis empty, exact stored frame echoed when present).

## Testing

- `py -m pytest tests/test_multimodal.py -v` → 6 passed.
- `py -m py_compile` on both modified files → OK.
- Full suite not run locally (TensorFlow/MediaPipe absent); new tests are self-contained with a mocked Redis.

Closes #10643
