### PR TITLE
fix: do not coerce stored snapshot_version 0 to the default schema version

### DIFF
--- a/backend/eventsourcing/event-sourcing-core.js
+++ b/backend/eventsourcing/event-sourcing-core.js
@@ -381,15 +381,22 @@ export class EventStoreCore {
     }
     if (row.snapshot_version !== undefined && row.snapshot_version !== null) {
       const schemaVersion = Number(row.snapshot_version);
-      if (Number.isNaN(schemaVersion) || schemaVersion > this.snapshotSchemaVersion) {
+      if (!Number.isInteger(schemaVersion) || schemaVersion < 0 || schemaVersion > this.snapshotSchemaVersion) {
         return null;
       }
     }
+    // Preserve the stored schema version exactly. The old `Number(...) || default`
+    // idiom coerced a stored snapshot_version of 0 into the default schema
+    // version, silently mislabeling v0 snapshots as the current schema version.
+    const storedSchemaVersion =
+      row.snapshot_version !== undefined && row.snapshot_version !== null
+        ? Number(row.snapshot_version)
+        : this.snapshotSchemaVersion;
     return {
       aggregateId: row.aggregate_id ?? row.aggregateId,
       version,
       state: row.state,
-      snapshotVersion: Number(row.snapshot_version) || this.snapshotSchemaVersion,
+      snapshotVersion: storedSchemaVersion,
       createdAt: row.created_at ?? row.timestamp,
     };
   }


### PR DESCRIPTION
Closes #10737

## What changed
`_validateSnapshot()` materialized the schema version with `Number(row.snapshot_version) || this.snapshotSchemaVersion`. Since `0` is falsy, a stored `snapshot_version` of `0` was silently coerced to the current default schema version — mislabeling v0 snapshots and skipping the migration that should have run.

Now the stored value is preserved exactly (validated as an integer ≥ 0), and the default schema version is only applied when `snapshot_version` is absent/null. The existing corrupt-snapshot tests (`snapshot_version: 999`, `snapshot_version: 'abc'`) still fall back to full event replay.

GSSOC
