### PR TITLE
security(api): secure KEDA metrics endpoints with auth, policy check, and rate limiting

### DIFF
--- a/backend/api/src/routes/kedaRoutes.js
+++ b/backend/api/src/routes/kedaRoutes.js
@@ -1,8 +1,15 @@
 import express from 'express';
 import kedaService from '../services/kedaService.js';
 import logger from '../middleware/logger.js';
+import { authenticate } from '../middleware/auth.js';
+import { requirePolicy } from '../middleware/requirePolicy.js';
+import { healthLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
+
+router.use(authenticate);
+router.use(healthLimiter);
+router.use(requirePolicy('admin:view-metrics'));
 
 router.get('/keda/metrics/requests', async (_req, res) => {
     try {

--- a/backend/api/test/unit/kedaRoutes.test.js
+++ b/backend/api/test/unit/kedaRoutes.test.js
@@ -28,6 +28,18 @@ vi.mock('../../src/services/kedaService.js', () => ({
   default: kedaServiceMock,
 }));
 
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  healthLimiter: (_req, _res, next) => next(),
+}));
+
 const { default: kedaRouter } = await import('../../src/routes/kedaRoutes.js');
 
 function makeApp() {


### PR DESCRIPTION
## Description
This PR resolves a security issue where KEDA metrics endpoints were publicly exposed without authentication, allowing access to internal cluster metrics.

To resolve this:
- Integrated `authenticate`, `requirePolicy('admin:view-metrics')`, and `healthLimiter` rate-limiting middleware in `kedaRoutes.js`.
- Updated unit tests in `kedaRoutes.test.js` to correctly mock/stub the new security middleware dependencies.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates
- [x] Security fix

## How Has This Been Tested?
- **Test Commands:** `pnpm run test test/unit/kedaRoutes.test.js` inside `backend/api`.
- **Test Steps / Prerequisites:** Setup test environments, stubbed authentication, ran route check scenarios.
- **Expected Result:** Routes are successfully secured and tests pass.

### Test Environment
- [ ] Local manual testing
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues
Closes #10706

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
