### PR TITLE
fix(tracker): invalidate driver:active-order cache on trip transitions and re-verify cache hits

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -169,6 +169,7 @@ import {
 } from '../validation/requestSchemas.js';
 import { awardReputationPoints } from '../services/reputation.js';
 import { expireDeliveryOtps, sendPushNotification } from '../services/notificationService.js';
+import { invalidateDriverOrderCache } from '../sockets/tracker.js';
 import { DomainError } from '../services/order/domainError.js';
 import { predictDemand, predictPrice, matchEnRouteLoads } from '../services/ml.js';
 import { requireIdempotency } from '../middleware/idempotency.js';
@@ -739,6 +740,10 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
           details: acceptErr.message,
         });
       }
+      // Driver assignment confirmed — drop any stale cached mapping so the
+      // tracker resolves the newly assigned driver on the next ping
+      // (issue #10676).
+      await invalidateDriverOrderCache(pending.driver_id);
       sendPushNotification(
         pending.driver_id,
         'Bid Accepted!',

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -39,6 +39,7 @@ import {
   submitEscrowRefund,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
+import { invalidateDriverOrderCache } from '../sockets/tracker.js';
 import upiPaymentService from '../services/payment/UpiPaymentService.js';
 
 const router = express.Router();
@@ -399,6 +400,11 @@ router.post(
           });
         }
 
+        // Driver assignment confirmed — drop any stale cached mapping so the
+        // tracker resolves the newly assigned driver on the next ping
+        // (issue #10676).
+        await invalidateDriverOrderCache(pending.driver_id);
+
         sendPushNotification(
           pending.driver_id,
           'Bid Accepted!',
@@ -415,6 +421,7 @@ router.post(
           { order_display_id: order.order_display_id, tx_hash }
         ).catch(err => logger.warn('[payments] Driver FCM push failed:', err.message));
       } else if (order.driver_id) {
+        await invalidateDriverOrderCache(order.driver_id);
         sendPushNotification(
           order.driver_id,
           '💰 Payment Locked',

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -3,6 +3,7 @@ import logger from '../middleware/logger.js';
 import { submitEscrowRefund, getEscrowBooking } from './escrow.js';
 import { acquireLock, releaseLock } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
+import { invalidateDriverOrderCache } from '../sockets/tracker.js';
 
 // Two-phase acceptance sweeper (#5724): orders that reached escrow_status
 // 'funding' but whose escrow deposit never lands within the funding TTL are
@@ -149,6 +150,11 @@ async function finalizeOrRevert(order, orderRepository) {
           return;
         }
 
+        // Driver assignment confirmed — drop any stale cached mapping so the
+        // tracker resolves the newly assigned driver on the next ping
+        // (issue #10676).
+        await invalidateDriverOrderCache(pending.driver_id);
+
         sendPushNotification(
           pending.driver_id,
           'Bid Accepted!',
@@ -238,6 +244,12 @@ async function finalizeOrRevert(order, orderRepository) {
     if (revertErr) {
       logger.error(`[escrow-funding] Failed to revert order ${order.order_display_id}: ${revertErr.message}`);
     } else {
+      // Driver released back to pool — drop any stale cached mapping so the
+      // tracker resolves the driver's next assignment (issue #10676).
+      const releasedDriverId = order.pending_bid_acceptance?.driver_id;
+      if (releasedDriverId) {
+        await invalidateDriverOrderCache(releasedDriverId);
+      }
       sendPushNotification(
         order.customer_id,
         'Bid Acceptance Expired',

--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -27,6 +27,7 @@ import {
 } from "../escrow.js";
 import logger from "../../middleware/logger.js";
 import { OrderTimelineService } from "./orderTimelineService.js";
+import { invalidateDriverOrderCache } from "../../sockets/tracker.js";
 
 const orderTimelineService = new OrderTimelineService({ supabase, logger });
 
@@ -773,6 +774,15 @@ export class DeliveryVerificationService {
             otpRecordId: otpRecord.id,
             orderId,
           });
+        }
+
+        // The trip is complete (payment_released) — drop the cached
+        // driver→order mapping so telemetry/geofence provenance and the
+        // tracker's cache-first lookup no longer report the driver on the
+        // finished order (issue #10676).
+        const tripDriverId = tripData?.driver_id || order.driver_id;
+        if (tripDriverId) {
+          await invalidateDriverOrderCache(tripDriverId);
         }
 
         // The trip is complete (payment_released) — kill any active public

--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1,6 +1,7 @@
 import { DomainError } from './domainError.js';
 import { DeliveryVerificationService } from './deliveryVerificationService.js';
 import { expireDeliveryOtps, sendPushNotification } from '../notificationService.js';
+import { invalidateDriverOrderCache } from '../../sockets/tracker.js';
 import { acquireLock, releaseLock } from '../../lib/redisLock.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
 import { supabaseAdmin } from '../../config/db.js';
@@ -691,6 +692,7 @@ export class OrderLifecycleService {
 
         if (currentOrder.status === 'cancelled' && (!requiresRefund || currentOrder.escrow_status === 'refunded')) {
           await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
+          await invalidateDriverOrderCache(currentOrder.driver_id);
           return {
             status: 200,
             body: {
@@ -792,6 +794,7 @@ export class OrderLifecycleService {
             await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
             await expireDeliveryOtps(currentOrder.id);
             await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
+            await invalidateDriverOrderCache(currentOrder.driver_id);
 
             return {
               status: 200,
@@ -814,6 +817,7 @@ export class OrderLifecycleService {
               escrow_refund_last_attempt_at: failedAt,
               updated_at: failedAt,
             });
+            await invalidateDriverOrderCache(currentOrder.driver_id);
 
             return {
               status: 202,
@@ -854,6 +858,7 @@ export class OrderLifecycleService {
         await this.orderTimelineService.insertCancelEvent(currentOrder.order_display_id);
         await expireDeliveryOtps(currentOrder.id);
         await this.revokeTrackingTokensForOrder(currentOrder.order_display_id);
+        await invalidateDriverOrderCache(currentOrder.driver_id);
 
         return {
           status: 200,

--- a/backend/api/src/services/order/orderMilestoneService.js
+++ b/backend/api/src/services/order/orderMilestoneService.js
@@ -20,7 +20,7 @@ import {
 import { escrowRelease, markEscrowBookingStarted, paisaToMaticWei, resolveExpectedDepositAmount } from '../escrow.js';
 import { DomainError } from './domainError.js';
 import { measureExecution } from '../../core/performanceMetrics.js';
-import { broadcastOrderMilestone } from '../../sockets/tracker.js';
+import { broadcastOrderMilestone, invalidateDriverOrderCache } from '../../sockets/tracker.js';
 
 export class OrderMilestoneService {
   constructor(args = {}) {
@@ -324,6 +324,13 @@ export class OrderMilestoneService {
 
       // Broadcast "Delivered" milestone to connected WebSocket clients
       broadcastOrderMilestone(order.order_display_id, 'Delivered', 'payment_released');
+
+      // Trip is complete — drop the cached driver→order mapping so the tracker
+      // no longer reports the driver on the finished order (issue #10676).
+      const completeDriverId = tripData?.driver_id || order.driver_id;
+      if (completeDriverId) {
+        await invalidateDriverOrderCache(completeDriverId);
+      }
 
       return {
         status: 200,

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -305,6 +305,13 @@ const WS_AUTH_TIMEOUT_MS = 10000;
 const DRIVER_ORDER_CACHE_TTL_SECONDS = 60;
 const DRIVER_ORDER_CACHE_KEY_PREFIX = 'driver:active-order:';
 
+// Orders in these statuses no longer keep a driver pinned to an active trip.
+// A cached `driver:active-order:` mapping for one of them is stale and must be
+// invalidated — otherwise mid-trip cache hits skip driver-assignment
+// re-verification and telemetry/geofence provenance keeps binding to the
+// previous trip (issue #10676).
+const TERMINAL_ORDER_STATUSES = new Set(['delivered', 'cancelled', 'payment_released']);
+
 /**
  * Retrieve the cached active order mapping for a driver.
  * Returns { orderId, orderDisplayId } or null on miss / error.
@@ -329,6 +336,7 @@ async function getCachedDriverOrder(driverId) {
 async function setCachedDriverOrder(driverId, orderId, orderDisplayId) {
   if (!driverId) return;
   if (!redisClient || !orderId) return;
+  if (!orderDisplayId) return;
   try {
     await redisClient.set(
       `${DRIVER_ORDER_CACHE_KEY_PREFIX}${driverId}`,
@@ -353,6 +361,7 @@ async function invalidateDriverOrderCache(driverId) {
     logger.error({ err, driverId }, 'Redis driver order cache invalidate error');
   }
 }
+export { invalidateDriverOrderCache };
 
 function getClientIp(request) {
   // Trust only the TCP peer address. The X-Forwarded-For header is
@@ -1055,15 +1064,39 @@ export async function handleLocationPing(ws, data, req) {
       // database.  This avoids repeated Supabase queries for the same
       // driver during an active trip.
       const cached = await getCachedDriverOrder(driver_id);
+      let cacheVerified = false;
       if (cached) {
-        orderUUID = cached.orderId;
-        orderDisplayId = cached.orderDisplayId;
-      } else {
+        // A cached mapping can outlive the trip (it is only invalidated on
+        // disconnect or an order transition), so re-verify it still points at
+        // the driver's current, non-terminal order before trusting it — a bare
+        // cache hit previously skipped driver-assignment re-verification
+        // entirely (issue #10676).
+        const { data: activeOrder } = await _orderRepository.findOrderByAnyId(
+          cached.orderId,
+          'id, order_display_id, driver_id, status'
+        );
+        if (
+          activeOrder
+          && activeOrder.driver_id === driver_id
+          && !TERMINAL_ORDER_STATUSES.has(activeOrder.status)
+        ) {
+          orderUUID = cached.orderId;
+          orderDisplayId = cached.orderDisplayId || activeOrder.order_display_id;
+          cacheVerified = true;
+        } else {
+          // Stale entry (delivered/cancelled/reassigned) — drop it so the
+          // authoritative lookup below resolves the current assignment.
+          await invalidateDriverOrderCache(driver_id);
+        }
+      }
+
+      if (!cacheVerified) {
         const idToLookup = orderUUID || orderDisplayId;
-        const { data: order } = await _orderRepository.findOrderByAnyId(idToLookup, 'id, order_display_id, driver_id');
+        const { data: order } = await _orderRepository.findOrderByAnyId(idToLookup, 'id, order_display_id, driver_id, status');
         if (order) {
           // Verify the authenticated driver is assigned to this order
           if (order.driver_id !== driver_id) {
+            await invalidateDriverOrderCache(driver_id);
             logger.warn({
               event: 'UNAUTHORIZED_ORDER_TRACKING',
               driverId: driver_id,
@@ -1078,7 +1111,18 @@ export async function handleLocationPing(ws, data, req) {
           }
           orderUUID = order.id;
           orderDisplayId = order.order_display_id;
-          await setCachedDriverOrder(driver_id, orderUUID, orderDisplayId);
+          if (TERMINAL_ORDER_STATUSES.has(order.status)) {
+            // Order has ended — drop any cached mapping and do not re-bind
+            // telemetry/geofence provenance to the finished order.
+            orderUUID = null;
+            orderDisplayId = null;
+            await invalidateDriverOrderCache(driver_id);
+          } else if (orderDisplayId) {
+            await setCachedDriverOrder(driver_id, orderUUID, orderDisplayId);
+          }
+        } else if (cached) {
+          // Cached order no longer exists — drop the stale mapping.
+          await invalidateDriverOrderCache(driver_id);
         }
       }
     } catch (err) {

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1935,12 +1935,19 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
       vi.resetModules();
     });
 
-    it('uses cached order mapping on cache hit, skipping DB query', async () => {
+    it('uses cached order mapping on cache hit after re-verifying it in DB', async () => {
       const redisGet = vi.fn().mockResolvedValue(
         JSON.stringify({ orderId: 'uuid-123', orderDisplayId: 'ORDER-789' })
       );
       const redisSet = vi.fn().mockResolvedValue('OK');
-      const supabaseFrom = vi.fn();
+      const repoFrom = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: { id: 'uuid-123', order_display_id: 'ORDER-789', driver_id: 'driver-cached', status: 'in_transit' },
+          error: null,
+        }),
+      });
       const mockChannel = { subscribe: vi.fn(), send: vi.fn().mockResolvedValue(undefined) };
 
       vi.doMock('../../src/config/db.js', () => ({
@@ -1948,21 +1955,12 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
         redisClient: { get: redisGet, set: redisSet, del: vi.fn(), publish: vi.fn().mockResolvedValue(0) },
         firebaseAdmin: null,
         supabaseAdmin: null,
-        supabase: { from: supabaseFrom, channel: vi.fn().mockReturnValue(mockChannel) },
+        supabase: { from: vi.fn(), channel: vi.fn().mockReturnValue(mockChannel) },
       }));
 
       const { OrderRepository: OR } = await import('../../src/repositories/orderRepository.js');
       const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
-      t.setOrderRepository(new OR({
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
-          maybeSingle: vi.fn().mockResolvedValue({
-            data: { id: 'uuid-123', order_display_id: 'ORDER-789', driver_id: 'driver-cached' },
-            error: null,
-          }),
-        }),
-      }));
+      t.setOrderRepository(new OR({ from: repoFrom }));
 
       const ws = { driverId: 'driver-cached', user: { id: 'driver-cached', role: 'driver' }, send: vi.fn() };
 
@@ -1975,6 +1973,8 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
 
       // Cache was checked
       expect(redisGet).toHaveBeenCalledWith('driver:active-order:driver-cached');
+      // Cached mapping was re-verified against the DB (issue #10676)
+      expect(repoFrom).toHaveBeenCalled();
       // No error sent
       expect(ws.send).not.toHaveBeenCalled();
     });
@@ -2118,16 +2118,29 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
         JSON.stringify({ orderId: 'uuid-auth', orderDisplayId: 'ORDER-AUTH' })
       );
       const redisSet = vi.fn().mockResolvedValue('OK');
+      const redisDel = vi.fn().mockResolvedValue(1);
 
       vi.doMock('../../src/config/db.js', () => ({
         mongoDb: null,
-        redisClient: { get: redisGet, set: redisSet, del: vi.fn(), publish: vi.fn().mockResolvedValue(0) },
+        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
         firebaseAdmin: null,
         supabaseAdmin: null,
         supabase: null,
       }));
 
-      const { handleLocationPing: hlp } = await import('../../src/sockets/tracker.js');
+      const { OrderRepository: OR } = await import('../../src/repositories/orderRepository.js');
+      const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+      t.setOrderRepository(new OR({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { id: 'uuid-auth', order_display_id: 'ORDER-AUTH', driver_id: 'driver-owner', status: 'in_transit' },
+            error: null,
+          }),
+        }),
+      }));
+
       const ws = { driverId: 'driver-unauth', user: { id: 'driver-unauth', role: 'driver' }, send: vi.fn() };
 
       await hlp(ws, {
@@ -2137,10 +2150,140 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
         longitude: 77.5,
       });
 
-      // Cache hit uses the cached values directly — no driver_id check on cache hit.
-      // This is intentional: the cache is only populated after a successful driver_id check,
-      // so if it's in the cache, the driver was previously authorized.
-      // Verify no error sent
+      // The cached mapping was re-verified and failed the driver_id check,
+      // so the ping is rejected and the stale cache entry is dropped
+      // (issue #10676).
+      expect(ws.send).toHaveBeenCalled();
+      expect(ws.send.mock.calls[0][0]).toContain('Not authorized');
+      expect(redisDel).toHaveBeenCalledWith('driver:active-order:driver-unauth');
+    });
+
+    it('invalidates a cached mapping whose order is terminal (delivered)', async () => {
+      const redisGet = vi.fn().mockResolvedValue(
+        JSON.stringify({ orderId: 'uuid-done', orderDisplayId: 'ORDER-DONE' })
+      );
+      const redisSet = vi.fn().mockResolvedValue('OK');
+      const redisDel = vi.fn().mockResolvedValue(1);
+
+      vi.doMock('../../src/config/db.js', () => ({
+        mongoDb: null,
+        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
+        firebaseAdmin: null,
+        supabaseAdmin: null,
+        supabase: null,
+      }));
+
+      const { OrderRepository: OR } = await import('../../src/repositories/orderRepository.js');
+      const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+      t.setOrderRepository(new OR({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { id: 'uuid-done', order_display_id: 'ORDER-DONE', driver_id: 'driver-terminal', status: 'payment_released' },
+            error: null,
+          }),
+        }),
+      }));
+
+      const ws = { driverId: 'driver-terminal', user: { id: 'driver-terminal', role: 'driver' }, send: vi.fn() };
+
+      await hlp(ws, {
+        driver_id: 'driver-terminal',
+        order_id: 'uuid-done',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+
+      // Stale terminal mapping dropped and never trusted as the active order
+      // (issue #10676).
+      expect(redisDel).toHaveBeenCalledWith('driver:active-order:driver-terminal');
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+
+    it('invalidates a cached mapping whose order no longer exists', async () => {
+      const redisGet = vi.fn().mockResolvedValue(
+        JSON.stringify({ orderId: 'uuid-gone', orderDisplayId: 'ORDER-GONE' })
+      );
+      const redisSet = vi.fn().mockResolvedValue('OK');
+      const redisDel = vi.fn().mockResolvedValue(1);
+
+      vi.doMock('../../src/config/db.js', () => ({
+        mongoDb: null,
+        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
+        firebaseAdmin: null,
+        supabaseAdmin: null,
+        supabase: null,
+      }));
+
+      const { OrderRepository: OR } = await import('../../src/repositories/orderRepository.js');
+      const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+      t.setOrderRepository(new OR({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }));
+
+      const ws = { driverId: 'driver-gone', user: { id: 'driver-gone', role: 'driver' }, send: vi.fn() };
+
+      await hlp(ws, {
+        driver_id: 'driver-gone',
+        order_id: 'uuid-gone',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+
+      // Stale mapping dropped (issue #10676).
+      expect(redisDel).toHaveBeenCalledWith('driver:active-order:driver-gone');
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+
+    it('does not re-cache a freshly resolved terminal order', async () => {
+      const redisGet = vi.fn().mockResolvedValue(null);
+      const redisSet = vi.fn().mockResolvedValue('OK');
+      const redisDel = vi.fn().mockResolvedValue(1);
+
+      vi.doMock('../../src/config/db.js', () => ({
+        mongoDb: null,
+        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
+        firebaseAdmin: null,
+        supabaseAdmin: null,
+        supabase: null,
+      }));
+
+      const { OrderRepository: OR } = await import('../../src/repositories/orderRepository.js');
+      const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+      t.setOrderRepository(new OR({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { id: 'uuid-fresh', order_display_id: 'ORDER-FRESH', driver_id: 'driver-fresh', status: 'cancelled' },
+            error: null,
+          }),
+        }),
+      }));
+
+      const ws = { driverId: 'driver-fresh', user: { id: 'driver-fresh', role: 'driver' }, send: vi.fn() };
+
+      await hlp(ws, {
+        driver_id: 'driver-fresh',
+        order_display_id: 'ORDER-FRESH',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+
+      // No fresh cache entry is written for a finished order; any pre-existing
+      // entry is dropped instead (issue #10676).
+      expect(redisSet).not.toHaveBeenCalledWith(
+        'driver:active-order:driver-fresh',
+        expect.any(String),
+        'EX',
+        expect.any(Number),
+      );
+      expect(redisDel).toHaveBeenCalledWith('driver:active-order:driver-fresh');
       expect(ws.send).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Problem

The Redis driver-to-order cache (`driver:active-order:<driverId>`) was only invalidated when the driver's socket disconnected. For the whole 60s TTL, a cache hit in `handleLocationPing` used the cached `orderId`/`orderDisplayId` directly and skipped driver-assignment re-verification. As a result:

- After a trip ended (delivered / payment_released / cancelled) the driver's entry stayed cached, so telemetry and geofence provenance kept binding to the previous trip's order.
- A driver reassigned mid-trip (or a stale entry from a released/reverted acceptance) could be served the old mapping.
- Orders that no longer exist left orphaned cache entries.

## Fix

- Re-verify a cached mapping against the database before trusting it: the cached order must still belong to the authenticated driver and must not be in a terminal status (`delivered`, `cancelled`, `payment_released`).
- Invalidate the cache at every trip transition point:
  - Delivery completion (`verify-delivery` / `confirm-otp` in `deliveryVerificationService.js`).
  - Milestone `Delivered` broadcast (`orderMilestoneService.js`).
  - Every `cancelOrder` success path in `orderLifecycleService.js` (including refund-pending/refund-failed reconciliations).
  - Driver (re)assignment via `accept_bid_tx` in `confirm-deposit`, payments lock, and the escrow funding heal path.
  - Pending-driver release when an escrow funding attempt is reverted.
- Never re-cache a terminal order, refuse to cache orders without a display id, and drop cached mappings whose order no longer exists.
- Added/updated unit tests in `tracker.test.js` covering re-verified cache hits, unauthorized/terminal/stale cache invalidation, and terminal fresh lookups.

## Files changed

- `backend/api/src/sockets/tracker.js`
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/src/routes/paymentRoutes.js`
- `backend/api/src/services/escrowFundingReconciliation.js`
- `backend/api/src/services/order/deliveryVerificationService.js`
- `backend/api/src/services/order/orderLifecycleService.js`
- `backend/api/src/services/order/orderMilestoneService.js`
- `backend/api/test/unit/tracker.test.js`

## Testing

- `npx vitest run test/unit/tracker.test.js` — all driver→order cache tests pass (9/9); the only remaining failures are 3 pre-existing `makeHandler is not defined` tests that also fail at `origin/main`.
- `node --check` passes on all modified source files except `orderRoutes.js` and `orderLifecycleService.js`, which contain pre-existing duplicate-identifier errors at HEAD unrelated to this change.

Closes #10676
