### PR TITLE
fix(supabase): exclude failed withdrawals from withdraw_funds_tx daily cap

### DIFF
--- a/supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql
+++ b/supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql
@@ -1,0 +1,103 @@
+-- =============================================================================
+-- Migration: withdraw_funds_tx daily cap must exclude failed withdrawals
+-- (Issue #10677)
+-- =============================================================================
+-- Problem:
+--   20260805120001_fix_rpc_ownership_checks.sql rewrote withdraw_funds_tx to
+--   use the get_profile_id() ownership check but, in doing so, dropped the
+--   `status <> 'failed'` exclusion (added by #6298/#6271) from the daily-cap
+--   query. The cap now sums every withdrawal for the UTC day regardless of
+--   outcome. A payout that is later failed by fail_withdrawal_tx restores its
+--   amount to wallet_confirmed, yet the failed transaction still consumes the
+--   driver's ₹1,00,000 daily cap and can permanently block legitimate
+--   withdrawals that never left the wallet.
+--
+-- Fix:
+--   Redefine withdraw_funds_tx to exclude failed withdrawals from the
+--   per-driver per-day cap sum, restoring the pre-regression behaviour while
+--   keeping the get_profile_id() ownership guard, the positive-amount guard
+--   and the row-lock serialization of the cap decision.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION withdraw_funds_tx(
+  p_driver_id   UUID,
+  p_amount      INT
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_confirmed  INT;
+  v_pending    INT;
+  v_day_total  INT;
+  v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
+BEGIN
+  -- Verify the caller IS the driver. get_profile_id() maps the Firebase JWT
+  -- sub to profiles.id, which is what p_driver_id/req.user.id actually store
+  -- (auth.uid() is the Firebase UID and would never match). Null-safe: an
+  -- unauthenticated caller (auth.uid() IS NULL) must also be rejected, not
+  -- just skipped.
+  IF auth.uid() IS NULL OR get_profile_id() <> p_driver_id THEN
+    RAISE EXCEPTION 'Unauthorized: you can only withdraw your own funds';
+  END IF;
+
+  -- Reject non-positive amounts: a negative p_amount would otherwise mint
+  -- wallet_confirmed via wallet_confirmed = v_confirmed - p_amount.
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'Withdrawal amount must be a positive whole number of paisa';
+  END IF;
+
+  -- Lock the wallet row first so the daily cap decision and the balance
+  -- movement are serialized: two concurrent withdrawals from the same driver
+  -- cannot both read the same v_day_total and both pass the cap check.
+  SELECT wallet_confirmed, wallet_pending
+    INTO v_confirmed, v_pending
+    FROM driver_details
+   WHERE user_id = p_driver_id
+     FOR UPDATE;
+
+  -- Enforce the per-driver per-day withdrawal cap under the row lock.
+  -- Only count withdrawals that actually left the wallet: failed withdrawals
+  -- have their amount restored to wallet_confirmed by fail_withdrawal_tx and
+  -- must not consume the cap (restores the #6298/#6271 exclusion that
+  -- 20260805120001_fix_rpc_ownership_checks.sql dropped).
+  SELECT COALESCE(SUM(amount), 0)
+    INTO v_day_total
+    FROM wallet_transactions
+   WHERE driver_id  = p_driver_id
+     AND txn_type   = 'withdrawal'
+     AND status    <> 'failed'
+     AND created_at >= date_trunc('day', now());
+
+  IF v_day_total + p_amount > v_daily_cap THEN
+    RAISE EXCEPTION 'Daily withdrawal cap exceeded: % of % used',
+      v_day_total + p_amount, v_daily_cap;
+  END IF;
+
+  IF v_confirmed IS NULL OR v_confirmed < p_amount THEN
+    RAISE EXCEPTION 'Insufficient balance: available %, requested %',
+      COALESCE(v_confirmed, 0), p_amount;
+  END IF;
+
+  -- Move funds from confirmed → pending.
+  UPDATE driver_details
+     SET wallet_confirmed = v_confirmed - p_amount,
+         wallet_pending   = v_pending   + p_amount,
+         updated_at       = now()
+   WHERE user_id = p_driver_id;
+
+  -- Log the withdrawal transaction.
+  INSERT INTO wallet_transactions
+    (driver_id, amount, txn_type, status, description)
+  VALUES
+    (p_driver_id, p_amount, 'withdrawal', 'pending',
+     'Withdrawal to registered bank account');
+END;
+$$;
+
+-- Function creation grants EXECUTE to PUBLIC by default (callable with the
+-- public anon key). Revoke it and allow only authenticated sessions so the
+-- ownership guard above is the only gate for real users.
+REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) TO authenticated;


### PR DESCRIPTION
## Problem

`20260805120001_fix_rpc_ownership_checks.sql` rewrote `withdraw_funds_tx` to use the `get_profile_id()` ownership check but, in doing so, dropped the `status <> 'failed'` exclusion from the daily-cap query that was originally added in #6298/#6271.

The cap query now sums every `withdrawal` transaction for the UTC day regardless of outcome. When a payout is later failed by `fail_withdrawal_tx`, the amount is restored to `wallet_confirmed`, yet the failed transaction still consumes the driver's ₹1,00,000 daily cap. Repeated failed payouts can permanently block legitimate withdrawals that never actually left the wallet.

## Fix

Add a new migration that redefines `withdraw_funds_tx` to exclude failed withdrawals from the per-driver per-day cap sum, restoring the pre-regression behavior while preserving:

- the `get_profile_id()` ownership guard (caller must be the driver),
- the positive-amount guard,
- the row-lock serialization of the cap decision with the balance movement.

## Files changed

- `supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql`

## Testing

- The new migration mirrors the current `withdraw_funds_tx` definition from `20260805120001_fix_rpc_ownership_checks.sql` with only the `status <> 'failed'` filter restored; `fail_withdrawal_tx` (which restores funds to `wallet_confirmed`) confirms the exclusion matches wallet semantics.
- Migration version prefix `20260812120000` verified unique (uniqueness is enforced in CI per #9823).
- No API change required — `driverRoutes.js` calls `withdraw_funds_tx` with the same signature.

Closes #10677


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed withdrawal processing to exclude failed transactions from daily withdrawal limits.
  * Added validation to prevent unauthorized, invalid, or overdrawn withdrawals.
  * Improved withdrawal consistency by locking wallet updates and enforcing serialized daily-limit checks.
  * Withdrawals now correctly move funds to pending status and record the transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->