### PR TITLE
fix(test): don't require anon REVOKE for exempt public reference tables (fixes #10644)

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -53,6 +53,16 @@ const MAIN_RLS_TABLES = ALL_TABLES.filter(
   (t) => !['user_devices', 'driver_documents', 'webhook_failures', 'tracking_tokens', 'behavioral_profiles', 'fraud_risk_scores', 'fraud_review_queue'].includes(t)
 );
 
+// Tables that revoke_anon_privileges.sql intentionally exempts: their RLS
+// policies grant SELECT to anon so GET /api/v1/vehicle-types and
+// GET /api/v1/regions work for unauthenticated clients. They must still be
+// covered by the "enables RLS" checks (hence staying in ALL_TABLES) but must
+// not be required to appear in the revoke migration.
+const ANON_REVOKE_EXEMPT_TABLES = ['vehicle_types', 'regions'];
+const ANON_REVOKE_TABLES = ALL_TABLES.filter(
+  (t) => !ANON_REVOKE_EXEMPT_TABLES.includes(t)
+);
+
 describe('RLS Migration (20240101000000_rls.sql)', () => {
   let rlsContent;
 
@@ -180,8 +190,13 @@ describe('Revoke anon privileges (revoke_anon_privileges.sql)', () => {
     revokeContent = await fs.readFile(revokePath, 'utf8');
   });
 
-  it.each(ALL_TABLES)('revokes anon privileges on table: %s', (table) => {
+  it.each(ANON_REVOKE_TABLES)('revokes anon privileges on table: %s', (table) => {
     expect(revokeContent).toContain(`REVOKE ALL ON TABLE public.${table} FROM anon`);
+  });
+
+  it.each(ANON_REVOKE_EXEMPT_TABLES)('pins the documented anon exemption for public reference table: %s', (table) => {
+    expect(revokeContent).not.toContain(`REVOKE ALL ON TABLE public.${table} FROM anon`);
+    expect(revokeContent).toMatch(/intentionally public reference tables/);
   });
 });
 


### PR DESCRIPTION
Fixes #10644

## Summary
`test/unit/rlsSecurity.test.js` failed 2/148: the `it.each(ALL_TABLES)` "revokes anon privileges on table: %s" suite asserted that `revoke_anon_privileges.sql` contains `REVOKE ALL ON TABLE public.<table> FROM anon` for **every** table, but that migration intentionally exempts `vehicle_types` and `regions` — public reference tables whose RLS policies grant SELECT to `anon`+`authenticated` so `GET /api/v1/vehicle-types` and `GET /api/v1/regions` work for unauthenticated clients.

## Change
- Introduced `ANON_REVOKE_EXEMPT_TABLES = ['vehicle_types', 'regions']` and `ANON_REVOKE_TABLES = ALL_TABLES.filter(...)`. Both tables **stay** in `ALL_TABLES`, so the "enables RLS on table" checks still cover them.
- The revoke `it.each` now iterates `ANON_REVOKE_TABLES` only.
- Added a regression test per exempt table asserting the migration contains **no** `REVOKE ALL ON TABLE public.vehicle_types/regions FROM anon` and that the documented exemption comment is present, pinning the intent so a future "fix" can't silently break the public endpoints.

## Verification
```
✓ test/unit/rlsSecurity.test.js (148 tests) — all pass
```

## Risk
- A future contributor adding `REVOKE ALL ... FROM anon` for these two tables will now get a failing test (guarded by the regression), protecting `GET /api/v1/vehicle-types` and `GET /api/v1/regions`.
