### PR TITLE
fix(eventsourcing): correct gapSize assertion in divergence test (fixes #10675)

### DIFF
--- a/backend/eventsourcing/test_divergence.js
+++ b/backend/eventsourcing/test_divergence.js
@@ -23,6 +23,6 @@ assert.strictEqual(res5.isDivergent, true);
 
 const logs = divergenceDetector.getDivergenceLogs();
 assert.strictEqual(logs.length, 1);
-assert.strictEqual(logs[0].gapSize, 3);
+assert.strictEqual(logs[0].gapSize, 2);
 
 console.log('✅ Divergence Detector tests passed successfully.');


### PR DESCRIPTION
Under GSSOC
Fixes #10675

## Summary
`backend/eventsourcing/test_divergence.js` asserted `logs[0].gapSize === 3` for a sequence of frames `1, 2, 5`. The frames skip only `3` and `4`, so the divergence detector correctly reports a gap size of `2` (`5 - 2 - 1 = 2`). The assertion was wrong; the detector is right.

## Change
- `assert.strictEqual(logs[0].gapSize, 3)` → `2`

## Verification
```
node test_divergence.js
✅ Divergence Detector tests passed successfully.
```
Also confirmed the detector log itself reports the gap for `DRV_TEST_999` (`expected 3, got 5` is the detector's message for the *next expected* frame, not the gap size).

## Risk
- Test-only change; no production behavior touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated divergence detection test expectations to reflect the correct skipped-frame gap size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->