### PR TITLE
fix(webhook): make duplicate-delivery wallet reconcile best-effort to avoid poison DLQ messages (fixes #10673)

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -76,6 +76,23 @@ async function reconcileWalletLedger(order, txHash) {
   }
 }
 
+// Idempotent duplicate-delivery path: the order-level escrow_status effect
+// already happened on the first delivery, so a missing/errored wallet-ledger
+// reconcile must not throw here — otherwise the DLQ redelivers forever,
+// re-entering this same branch and failing identically each time (permanent
+// poison message). Log and swallow so the webhook can be acknowledged; a later
+// redelivery retries the (idempotent) reconcile again.
+async function tryReconcileWalletLedger(order, txHash) {
+  try {
+    await reconcileWalletLedger(order, txHash);
+  } catch (err) {
+    logger.warn(
+      { err: err.message, orderDisplayId: order.order_display_id, driverId: order.driver_id },
+      '[Webhook] Duplicate delivery: wallet ledger reconcile failed (best-effort) — order-level effect already applied, acknowledging delivery.'
+    );
+  }
+}
+
 async function getPolygonProvider() {
   const rpcUrl = process.env.POLYGON_RPC_URL;
   if (!rpcUrl) {
@@ -126,7 +143,7 @@ async function handlePaymentReleased(payload) {
   // the (idempotent) wallet ledger so a crash between the order update and the
   // wallet update is healed, then short-circuit without re-applying effects.
   if (order.escrow_status === 'released') {
-    await reconcileWalletLedger(order, payload.txHash || order.release_tx_hash);
+    await tryReconcileWalletLedger(order, payload.txHash || order.release_tx_hash);
     logger.info(`[Webhook] Order ${order.order_display_id} already released — duplicate delivery ignored.`);
     return;
   }
@@ -218,7 +235,7 @@ async function handleWithdrawalSettled(payload) {
       }
     }
     if (!isRefund) {
-      await reconcileWalletLedger(order, txHash);
+      await tryReconcileWalletLedger(order, txHash);
     }
     logger.info(`[Webhook] Order ${order.order_display_id} already ${targetStatus} — duplicate delivery ignored.`);
     return;


### PR DESCRIPTION
Fixes #10673

## Summary
`handlePaymentReleased` and `handleWithdrawalSettled` mark the order `escrow_status = 'released'`/`'refunded'` first, then call `reconcileWalletLedger`. If the matching `wallet_transactions` credit row is missing, `reconcileWalletLedger` throws (`...matched no credit transaction...`). On a **duplicate** delivery (order already in the terminal state) the duplicate branch calls the same throwing reconcile, so every DLQ redelivery hits the identical failing branch — a permanent poison message that can never succeed.

## Change
- Added `tryReconcileWalletLedger(order, txHash)` — runs the same idempotent reconcile but logs and swallows failures on the **duplicate-delivery** path only.
- `handlePaymentReleased` already-released branch and `handleWithdrawalSettled` already-terminal branch now use it.
- **First-delivery** reconcile calls still throw: a genuine reconcile failure on the first delivery stays visible to the DLQ retry loop.

## Behavior (verified with an isolated suite, 5/5 pass)
| Scenario | Before | After |
|---|---|---|
| Duplicate PaymentReleased, reconcile fails | ❌ throws → poison DLQ | ✅ acknowledged (`{received:true}`), warn logged |
| Duplicate WithdrawalReady, reconcile fails | ❌ throws → poison DLQ | ✅ acknowledged |
| Duplicate, reconcile succeeds | reconcile runs | unchanged — still reconciles |
| Duplicate: order-level effect not re-applied | ✓ | ✓ |
| First delivery, reconcile fails | ❌ throws (correct) | ❌ throws (correct) |

## Risk
- Duplicate-branch reconcile failure no longer surfaces as an exception. This is intentional: the order-level effect already committed on the first delivery, and the reconcile is idempotent so a later redelivery retries it. Only the already-terminal (duplicate) branch is softened; first-delivery failures remain loud.

## Note (pre-existing, out of scope)
`test/unit/escrowWebhookProcessor.test.js` and `escrowWebhookGuards.test.js` already fail on `main` because their `select` mock resolves immediately instead of chaining (`db.from(...).select(...).eq is not a function`), so none of the processor tests exercise the real code path. Not modified here to keep this PR focused on the source fix.
