### PR TITLE
fix(consensus-raft-go): persist currentTerm, votedFor, and log to an append-only WAL

### DIFF
--- a/services/consensus-raft-go/README.md
+++ b/services/consensus-raft-go/README.md
@@ -9,6 +9,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 - **Distributed State Machine**: Guarantees linearizable order state transitions (`CREATED` $\rightarrow$ `DISPATCHED` $\rightarrow$ `COMPLETED`) across multi-cloud regions.
 - **Leader Election & Heartbeats**: Nodes start as `FOLLOWER`, campaign for leadership via `RequestVote` RPCs, and keep leadership with `AppendEntries` heartbeats and term bumps (Raft paper §5).
 - **Atomic Log Replication**: Appends transactional state transition entries into an append-only WAL log and replicates them to a quorum of followers (AppendEntries + `nextIndex`/`matchIndex` tracking) before advancing `CommitIndex`. `/commit` returns success only once the entry is replicated to a quorum and committed.
+- **Durable State**: `currentTerm`, `votedFor`, and the log are persisted to an append-only state file (`RAFT_STATE_PATH`) and fsynced before any vote is granted or any entry is acknowledged as replicated, so a restart resumes exactly where the node left off instead of silently resetting consensus state (Raft §3.5).
 - **Quorum-Aware Health**: `/api/v1/raft/status` reports `HEALTHY_CLUSTER` only when a leader has a *live* quorum — a majority of peers that have acknowledged a recent AppendEntries round; `NO_LEADER`, `ELECTION_IN_PROGRESS`, and `UNHEALTHY_CLUSTER` are reported otherwise. `matchIndex` is never seeded optimistically after an election: it is learned only from real AppendEntries acknowledgements (Raft §5.3).
 
 ---
@@ -36,6 +37,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 | `RAFT_ELECTION_TIMEOUT_MIN_MS` | `500` | Lower bound of the randomized election timeout. |
 | `RAFT_ELECTION_TIMEOUT_MAX_MS` | `1200` | Upper bound of the randomized election timeout. |
 | `RAFT_API_KEY` | — | Shared service-to-service API key required on every endpoint. When unset, authenticated requests are rejected (`503`). |
+| `RAFT_STATE_PATH` | *(none — in-memory)* | File path for the append-only raft state WAL. When set, `currentTerm`, `votedFor`, and the log are persisted to and recovered from this file on startup (before the consensus loop starts); when empty, state stays in memory only. Point it at a persistent volume in production. |
 | `RAFT_ALLOWED_COMMANDS` | `CREATED,DISPATCHED,IN_TRANSIT,DELIVERED,COMPLETED,CANCELLED` | Comma-separated allow-list of order commands accepted by `/commit`. |
 
 ---

--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -159,6 +159,8 @@ type RaftNode struct {
 	// never accepts new entries without evidence of a reachable quorum.
 	liveAck            map[string]bool
 	httpClient         *http.Client
+	storePath          string
+	wal                *os.File
 }
 
 // rng is a source of randomness for election timeouts.
@@ -225,6 +227,11 @@ func (rn *RaftNode) stepDownLocked(term uint64) {
 		rn.Role = Follower
 	}
 	rn.lastLeaderSeen = time.Now()
+	// A higher term must be durable before any request in it is acknowledged;
+	// otherwise a restart would return to the stale lower term (Raft §3.5).
+	if err := rn.persistTermLocked(term, ""); err != nil {
+		log.Printf("⚠️ node [%s] failed to persist term %d: %v", rn.NodeID, term, err)
+	}
 }
 
 // startElection campaigns for leadership: bump term, vote for self, and
@@ -238,6 +245,17 @@ func (rn *RaftNode) startElection() {
 	rn.LeaderID = ""
 	rn.electionStarted = time.Now()
 	rn.electionTimeout = rn.randomElectionTimeout()
+
+	// Persist the term and the self-vote before requesting votes: a node must
+	// never campaign in a term that is not durable (Raft §3.5).
+	if err := rn.persistTermLocked(term, rn.VotedFor); err != nil {
+		rn.Role = Follower
+		rn.VotedFor = ""
+		rn.CurrentTerm--
+		log.Printf("⚠️ node [%s] failed to persist election state for term %d: %v", rn.NodeID, term, err)
+		rn.mu.Unlock()
+		return
+	}
 
 	req := RequestVoteRequest{
 		Term:         rn.CurrentTerm,
@@ -603,9 +621,14 @@ func (rn *RaftNode) HandleVote(w http.ResponseWriter, r *http.Request) {
 	if req.Term == rn.CurrentTerm &&
 		(rn.VotedFor == "" || rn.VotedFor == req.CandidateID) &&
 		rn.isLogUpToDate(req.LastLogIndex, req.LastLogTerm) {
-		rn.VotedFor = req.CandidateID
-		rn.lastLeaderSeen = time.Now()
-		resp.VoteGranted = true
+		// Make the vote durable before acknowledging it (Raft §3.5).
+		if err := rn.persistTermLocked(rn.CurrentTerm, req.CandidateID); err != nil {
+			log.Printf("⚠️ node [%s] failed to persist vote for %s in term %d: %v", rn.NodeID, req.CandidateID, rn.CurrentTerm, err)
+		} else {
+			rn.VotedFor = req.CandidateID
+			rn.lastLeaderSeen = time.Now()
+			resp.VoteGranted = true
+		}
 	}
 
 	resp.Term = rn.CurrentTerm
@@ -694,18 +717,33 @@ func (rn *RaftNode) appendLogFromLeaderLocked(req AppendEntriesRequest) bool {
 			return false
 		}
 	}
+	origLen := len(rn.Log)
+	var appended []LogEntry
 	for i, e := range req.Entries {
 		idx := int(req.PrevLogIndex) + 1 + i
 		if idx <= len(rn.Log) {
 			if rn.Log[idx-1].Term != e.Term {
+				appended = req.Entries[i:]
 				rn.Log = rn.Log[:idx-1]
-				rn.Log = append(rn.Log, req.Entries[i:]...)
-				return true
+				rn.Log = append(rn.Log, appended...)
+				break
 			}
 		} else {
-			rn.Log = append(rn.Log, req.Entries[i:]...)
-			return true
+			appended = req.Entries[i:]
+			rn.Log = append(rn.Log, appended...)
+			break
 		}
+	}
+	if len(appended) == 0 {
+		return true
+	}
+	// Make the appended entries durable before acknowledging them; if that
+	// fails, roll the log back so we never acknowledge entries that are only
+	// volatile (Raft §3.5).
+	if err := rn.persistEntriesLocked(appended); err != nil {
+		rn.Log = rn.Log[:origLen]
+		log.Printf("⚠️ node [%s] failed to persist %d replicated entries: %v", rn.NodeID, len(appended), err)
+		return false
 	}
 	return true
 }
@@ -773,9 +811,18 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now(),
 	}
 
-	// Append to the local log first. CommitIndex is NOT advanced here: the entry
-	// must first be replicated to a quorum of followers (Raft §5.3).
+	// Append to the local log first and make the entry durable before
+	// replicating it: the leader must persist an entry before counting it
+	// (Raft §5.3). CommitIndex is NOT advanced here — the entry must first be
+	// replicated to a quorum of followers.
 	rn.Log = append(rn.Log, entry)
+	if err := rn.persistEntriesLocked([]LogEntry{entry}); err != nil {
+		rn.Log = rn.Log[:len(rn.Log)-1]
+		rn.mu.Unlock()
+		log.Printf("⚠️ node [%s] failed to persist entry at index %d: %v", rn.NodeID, entry.Index, err)
+		http.Error(w, "failed to persist entry", http.StatusInternalServerError)
+		return
+	}
 	rn.mu.Unlock()
 
 	// Replicate to followers and wait for a quorum acknowledgement before
@@ -894,6 +941,13 @@ func main() {
 	}
 
 	node := NewRaftNode(nodeID, peers, peerURLs)
+
+	if statePath := os.Getenv("RAFT_STATE_PATH"); statePath != "" {
+		if err := node.recoverFromWAL(statePath); err != nil {
+			log.Fatalf("Fatal consensus storage error: %v", err)
+		}
+		log.Printf("💾 node [%s] recovered raft state from %s (log length %d, term %d)", nodeID, statePath, len(node.Log), node.CurrentTerm)
+	}
 
 	http.HandleFunc("/api/v1/raft/status", node.HandleStatus)
 	http.HandleFunc("/api/v1/raft/commit", node.HandleCommitOrder)

--- a/services/consensus-raft-go/store.go
+++ b/services/consensus-raft-go/store.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// raftRecordType identifies a record in the append-only WAL.
+type raftRecordType string
+
+const (
+	// recordTerm persists a currentTerm change together with the vote cast in
+	// that term ("" when no vote has been cast yet).
+	recordTerm raftRecordType = "term"
+	// recordEntry persists a single log entry.
+	recordEntry raftRecordType = "entry"
+)
+
+// raftWALRecord is a single JSON line in the append-only state file.
+type raftWALRecord struct {
+	Type     raftRecordType `json:"type"`
+	Term     uint64         `json:"term,omitempty"`
+	VotedFor *string        `json:"voted_for,omitempty"`
+	Entry    *LogEntry      `json:"entry,omitempty"`
+}
+
+// recoverFromWAL opens (creating if needed) the append-only state file at path,
+// replays the persisted currentTerm, votedFor, and log, and wires subsequent
+// mutations to the same file. It must run before run() starts so the node never
+// campaigns or votes with a term lower than the persisted one (Raft §3.5).
+func (rn *RaftNode) recoverFromWAL(path string) error {
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+
+	rn.Log = make([]LogEntry, 0, len(rn.Log))
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		raw := scanner.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		var rec raftWALRecord
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			file.Close()
+			return fmt.Errorf("raft state file %s: invalid record on line %d: %w", path, line, err)
+		}
+		switch rec.Type {
+		case recordTerm:
+			rn.CurrentTerm = rec.Term
+			if rec.VotedFor != nil {
+				rn.VotedFor = *rec.VotedFor
+			} else {
+				rn.VotedFor = ""
+			}
+		case recordEntry:
+			if rec.Entry == nil || rec.Entry.Index == 0 {
+				file.Close()
+				return fmt.Errorf("raft state file %s: invalid entry record on line %d", path, line)
+			}
+			idx := int(rec.Entry.Index)
+			// Later records overwrite earlier ones at the same index (log
+			// conflict resolution in appendLogFromLeaderLocked), so a stale
+			// entry followed by a replacement must not both survive replay.
+			if idx <= len(rn.Log) {
+				rn.Log = rn.Log[:idx-1]
+			}
+			rn.Log = append(rn.Log, *rec.Entry)
+		default:
+			file.Close()
+			return fmt.Errorf("raft state file %s: unknown record type %q on line %d", path, rec.Type, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		file.Close()
+		return err
+	}
+
+	rn.wal = file
+	rn.storePath = path
+	return nil
+}
+
+// Close flushes and releases the raft state file. It is safe to call on a node
+// whose persistence is disabled.
+func (rn *RaftNode) Close() error {
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+	if rn.wal == nil {
+		return nil
+	}
+	err := rn.wal.Close()
+	rn.wal = nil
+	return err
+}
+
+// persistTermLocked durably records the current term and the vote decision made
+// in it. It must be called with rn.mu held, before any acknowledgment that
+// depends on the new term (Raft §3.5).
+func (rn *RaftNode) persistTermLocked(term uint64, votedFor string) error {
+	if rn.wal == nil {
+		return nil
+	}
+	v := votedFor
+	return rn.appendWALLocked(raftWALRecord{Type: recordTerm, Term: term, VotedFor: &v})
+}
+
+// persistEntriesLocked durably appends log entries to the state file. It must
+// be called with rn.mu held, before an entry is acknowledged as replicated.
+func (rn *RaftNode) persistEntriesLocked(entries []LogEntry) error {
+	if rn.wal == nil {
+		return nil
+	}
+	for i := range entries {
+		e := entries[i]
+		if err := rn.appendWALLocked(raftWALRecord{Type: recordEntry, Entry: &e}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appendWALLocked writes one JSON record and fsyncs it so the write is durable
+// before the caller returns any acknowledgment.
+func (rn *RaftNode) appendWALLocked(rec raftWALRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if _, err := rn.wal.Write(data); err != nil {
+		return err
+	}
+	return rn.wal.Sync()
+}

--- a/services/consensus-raft-go/store_test.go
+++ b/services/consensus-raft-go/store_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDurableStateSurvivesRestart verifies that a freshly recovered node resumes
+// the exact currentTerm, votedFor, and log that were persisted before it went
+// down.
+func TestDurableStateSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "raft.log")
+
+	n1 := NewRaftNode("node1", []string{"node2"}, nil)
+	if err := n1.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer n1.Close()
+	n1.mu.Lock()
+	n1.CurrentTerm = 3
+	n1.VotedFor = "node2"
+	if err := n1.persistTermLocked(3, "node2"); err != nil {
+		t.Fatalf("persist term/vote: %v", err)
+	}
+	now := time.Now()
+	if err := n1.persistEntriesLocked([]LogEntry{
+		{Index: 1, Term: 3, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 3, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+	}); err != nil {
+		t.Fatalf("persist entries: %v", err)
+	}
+	n1.mu.Unlock()
+
+	// Simulate a restart: a fresh node recovers from the same file.
+	n2 := NewRaftNode("node1", []string{"node2"}, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover after restart: %v", err)
+	}
+	defer n2.Close()
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if n2.CurrentTerm != 3 {
+		t.Errorf("expected recovered term 3, got %d", n2.CurrentTerm)
+	}
+	if n2.VotedFor != "node2" {
+		t.Errorf("expected recovered voted_for node2, got %q", n2.VotedFor)
+	}
+	if len(n2.Log) != 2 || n2.Log[0].OrderID != "ord-1" || n2.Log[1].Index != 2 {
+		t.Errorf("expected recovered log of 2 entries, got %+v", n2.Log)
+	}
+}
+
+// TestRecoverFromWALReconcilesOverwrittenEntries verifies that replay applies
+// later log records at the same index as overwrites, matching the conflict
+// resolution used when appending entries from a leader.
+func TestRecoverFromWALReconcilesOverwrittenEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "raft.log")
+	now := time.Now()
+
+	n := NewRaftNode("node1", nil, nil)
+	if err := n.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	n.mu.Lock()
+	if err := n.persistEntriesLocked([]LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+		{Index: 3, Term: 1, Command: "IN_TRANSIT", OrderID: "ord-1", Timestamp: now},
+	}); err != nil {
+		t.Fatalf("persist entries: %v", err)
+	}
+	// The leader later overwrites index 2 with a conflicting term, sending its
+	// own version of the whole tail (entries 2 and 3).
+	if err := n.persistEntriesLocked([]LogEntry{
+		{Index: 2, Term: 2, Command: "CANCELLED", OrderID: "ord-1", Timestamp: now},
+		{Index: 3, Term: 2, Command: "DELIVERED", OrderID: "ord-1", Timestamp: now},
+	}); err != nil {
+		t.Fatalf("persist overwrite: %v", err)
+	}
+	n.mu.Unlock()
+	defer n.Close()
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	defer n2.Close()
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if len(n2.Log) != 3 {
+		t.Fatalf("expected 3 entries after replay, got %d", len(n2.Log))
+	}
+	if n2.Log[1].Term != 2 || n2.Log[1].Command != "CANCELLED" {
+		t.Errorf("expected index 2 to reflect the overwrite, got %+v", n2.Log[1])
+	}
+	if n2.Log[2].Term != 2 || n2.Log[2].Command != "DELIVERED" {
+		t.Errorf("expected index 3 to reflect the leader tail, got %+v", n2.Log[2])
+	}
+}
+
+// TestStartElectionPersistsTermAndVote verifies a candidate durably records its
+// term and self-vote before requesting votes.
+func TestStartElectionPersistsTermAndVote(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "raft.log")
+	n := NewRaftNode("node1", nil, nil)
+	if err := n.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer n.Close()
+	n.startElection()
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	defer n2.Close()
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if n2.CurrentTerm != 1 {
+		t.Errorf("expected recovered term 1, got %d", n2.CurrentTerm)
+	}
+	if n2.VotedFor != "node1" {
+		t.Errorf("expected recovered self-vote for node1, got %q", n2.VotedFor)
+	}
+}
+
+// TestHandleVotePersistsVoteBeforeAck verifies that granting a vote makes the
+// decision durable before the 200 response is sent.
+func TestHandleVotePersistsVoteBeforeAck(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	path := filepath.Join(t.TempDir(), "raft.log")
+	n := NewRaftNode("node1", []string{"node2"}, nil)
+	if err := n.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer n.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/vote", strings.NewReader(`{"term":1,"candidate_id":"node2","last_log_index":0,"last_log_term":0}`))
+	w := httptest.NewRecorder()
+	n.HandleVote(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp RequestVoteResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.VoteGranted {
+		t.Fatal("expected vote to be granted")
+	}
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	defer n2.Close()
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if n2.VotedFor != "node2" {
+		t.Errorf("expected recovered vote for node2, got %q", n2.VotedFor)
+	}
+}
+
+// TestRecoveredNodeRejectsStaleTermVote verifies a restarted node never votes in
+// a term lower than the persisted one.
+func TestRecoveredNodeRejectsStaleTermVote(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	path := filepath.Join(t.TempDir(), "raft.log")
+	n := NewRaftNode("node1", nil, nil)
+	if err := n.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer n.Close()
+	n.mu.Lock()
+	n.CurrentTerm = 5
+	if err := n.persistTermLocked(5, ""); err != nil {
+		t.Fatalf("persist term: %v", err)
+	}
+	n.mu.Unlock()
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	defer n2.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/vote", strings.NewReader(`{"term":4,"candidate_id":"node2","last_log_index":0,"last_log_term":0}`))
+	w := httptest.NewRecorder()
+	n2.HandleVote(w, req)
+
+	var resp RequestVoteResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.VoteGranted {
+		t.Error("expected stale-term vote to be rejected")
+	}
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if n2.CurrentTerm != 5 {
+		t.Errorf("expected term to remain 5, got %d", n2.CurrentTerm)
+	}
+	if n2.VotedFor != "" {
+		t.Errorf("expected no vote to be recorded, got %q", n2.VotedFor)
+	}
+}
+
+// TestHandleCommitOrderPersistsEntryBeforeAck verifies the leader makes a new
+// entry durable before returning success to the client.
+func TestHandleCommitOrderPersistsEntryBeforeAck(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	path := filepath.Join(t.TempDir(), "raft.log")
+	n := NewRaftNode("node1", nil, nil)
+	if err := n.recoverFromWAL(path); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer n.Close()
+	n.mu.Lock()
+	n.Role = Leader
+	n.LeaderID = "node1"
+	n.CurrentTerm = 1
+	n.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/commit", strings.NewReader(`{"order_id":"ord-dur-1","command":"CREATED"}`))
+	w := httptest.NewRecorder()
+	n.HandleCommitOrder(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from single-node leader, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.recoverFromWAL(path); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	defer n2.Close()
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if len(n2.Log) != 1 || n2.Log[0].OrderID != "ord-dur-1" || n2.Log[0].Command != "CREATED" {
+		t.Errorf("expected the committed entry to survive restart, got %+v", n2.Log)
+	}
+	if n2.Log[0].Term != 1 || n2.Log[0].Index != 1 {
+		t.Errorf("expected entry term 1 index 1, got term %d index %d", n2.Log[0].Term, n2.Log[0].Index)
+	}
+}


### PR DESCRIPTION
## Problem

`services/consensus-raft-go/main.go` keeps all Raft state — `Log`, `CurrentTerm`, and `VotedFor` — only in memory. A restart wipes the committed log, resets the term to 0, and clears the vote, so a restarted node can grant votes in stale lower terms or be elected with an empty log and re-accept order commands that contradict the previously committed history (Raft §3.5 durability requirement).

## Fix

Added an append-only WAL (`services/consensus-raft-go/store.go`) that persists `currentTerm`, `votedFor`, and every log entry, fsynced **before** any acknowledgment:

- `recoverFromWAL(path)` — opened in `main()` before `run()` starts; replays term, vote, and log so a node never campaigns or votes with a term lower than the persisted one. Replay applies later records at the same index as overwrites, mirroring the conflict resolution in `appendLogFromLeaderLocked`.
- `persistTermLocked` — called from `stepDownLocked` (higher term), `startElection` (term + self-vote before requesting votes), and `HandleVote` (vote made durable before it is granted).
- `persistEntriesLocked` — called from `HandleCommitOrder` (leader persists its entry before replicating, §5.3) and `appendLogFromLeaderLocked` (entries made durable before the AppendEntries success is returned; on failure the in-memory log is rolled back and a failure response is sent).
- Enabled via the new `RAFT_STATE_PATH` env var; when unset the node keeps the previous in-memory behavior.

`CommitIndex`/`LastApplied` intentionally stay volatile (re-derived from the leader's `LeaderCommit` on restart, standard Raft §5.3) since applying entries has no external side effects in this service.

## Files changed

- `services/consensus-raft-go/main.go` — struct fields, durability hooks in `stepDownLocked`/`startElection`/`HandleVote`/`appendLogFromLeaderLocked`/`HandleCommitOrder`, WAL recovery in `main()`.
- `services/consensus-raft-go/store.go` — new append-only WAL (record types, recovery/replay, fsynced persist helpers, `Close`).
- `services/consensus-raft-go/store_test.go` — new tests.
- `services/consensus-raft-go/README.md` — documents `RAFT_STATE_PATH`.

## Testing

`go vet ./...` clean; `go test ./...` passes all tests except the pre-existing `TestHandleCommitOrderRejectsOversizedBody`, which also fails on an untouched checkout at `origin/main` (it sends a non-JSON body that fails decode as 400 before the size cap can be exceeded).

New tests added:

- `TestDurableStateSurvivesRestart` — recovered node resumes exact term, vote, and log.
- `TestRecoverFromWALReconcilesOverwrittenEntries` — replay handles log-conflict overwrites.
- `TestStartElectionPersistsTermAndVote` — term + self-vote durable before RequestVote.
- `TestHandleVotePersistsVoteBeforeAck` — granted vote survives restart.
- `TestRecoveredNodeRejectsStaleTermVote` — restarted node never votes in a term below the persisted one.
- `TestHandleCommitOrderPersistsEntryBeforeAck` — leader entry durable before success is returned.

Closes #10679
