### PR TITLE
fix(consensus-raft-go): reject duplicate and out-of-order order lifecycle commands

### DIFF
--- a/services/consensus-raft-go/README.md
+++ b/services/consensus-raft-go/README.md
@@ -48,6 +48,8 @@ Commit requests are validated before they touch the log:
 
 - `order_id` must be non-empty, at most 64 chars, and contain only `[A-Za-z0-9_-]`.
 - `command` must be in the allow-list (`CREATED`, `DISPATCHED`, `IN_TRANSIT`, `DELIVERED`, `COMPLETED`, `CANCELLED`), overridable via `RAFT_ALLOWED_COMMANDS` (comma-separated).
+- The command must follow the order's lifecycle state machine (replayed from the log): `CREATED` must be first, then `DISPATCHED` → `IN_TRANSIT` → `DELIVERED` → `COMPLETED`, with `CANCELLED` allowed from `CREATED`/`DISPATCHED`/`IN_TRANSIT`; `CANCELLED` and `COMPLETED` are terminal. Violations return `400`.
+- Re-submitting an identical `(order_id, command)` is idempotent: it returns the existing entry's `raft_index` instead of appending a duplicate.
 
 ---
 

--- a/services/consensus-raft-go/commit_validation_test.go
+++ b/services/consensus-raft-go/commit_validation_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// commitOrder posts an order lifecycle command to the node and returns the HTTP
+// status code and decoded payload.
+func commitOrder(t *testing.T, n *RaftNode, orderID, command string) (int, map[string]interface{}) {
+	t.Helper()
+	body := fmt.Sprintf(`{"order_id":%q,"command":%q}`, orderID, command)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/commit", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	n.HandleCommitOrder(w, req)
+	var payload map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&payload)
+	return w.Code, payload
+}
+
+// newTestLeader returns a single-node leader so every committed entry is
+// immediately committed locally (quorum of 1).
+func newTestLeader() *RaftNode {
+	n := NewRaftNode("node1", nil, nil)
+	n.mu.Lock()
+	n.Role = Leader
+	n.LeaderID = "node1"
+	n.CurrentTerm = 1
+	n.mu.Unlock()
+	return n
+}
+
+// TestCanTransition verifies the order state machine rules directly.
+func TestCanTransition(t *testing.T) {
+	cases := []struct {
+		from, to string
+		want     bool
+	}{
+		{"", "CREATED", true},
+		{"", "DISPATCHED", false},
+		{"", "CANCELLED", false},
+		{"CREATED", "CREATED", false},
+		{"CREATED", "DISPATCHED", true},
+		{"CREATED", "IN_TRANSIT", false},
+		{"CREATED", "CANCELLED", true},
+		{"CREATED", "COMPLETED", false},
+		{"CREATED", "DELIVERED", false},
+		{"DISPATCHED", "IN_TRANSIT", true},
+		{"DISPATCHED", "DELIVERED", false},
+		{"DISPATCHED", "CANCELLED", true},
+		{"DISPATCHED", "CREATED", false},
+		{"IN_TRANSIT", "DELIVERED", true},
+		{"IN_TRANSIT", "CANCELLED", true},
+		{"DELIVERED", "CANCELLED", false},
+		{"DELIVERED", "COMPLETED", true},
+		{"DELIVERED", "IN_TRANSIT", false},
+		{"COMPLETED", "CANCELLED", false},
+		{"COMPLETED", "COMPLETED", false},
+		{"CANCELLED", "COMPLETED", false},
+		{"CANCELLED", "CREATED", false},
+	}
+	for _, c := range cases {
+		if got := canTransition(c.from, c.to); got != c.want {
+			t.Errorf("canTransition(%q, %q) = %v, want %v", c.from, c.to, got, c.want)
+		}
+	}
+}
+
+// TestHandleCommitOrderRejectsInvalidTransitions verifies /commit rejects
+// commands that do not follow the order's lifecycle history.
+func TestHandleCommitOrderRejectsInvalidTransitions(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	n := newTestLeader()
+
+	// DISPATCHED before CREATED is invalid.
+	if code, _ := commitOrder(t, n, "ord-trans-1", "DISPATCHED"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for DISPATCHED before CREATED, got %d", code)
+	}
+
+	if code, _ := commitOrder(t, n, "ord-trans-1", "CREATED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for CREATED, got %d", code)
+	}
+
+	// DELIVERED before DISPATCHED is invalid (strict chain).
+	if code, _ := commitOrder(t, n, "ord-trans-1", "DELIVERED"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for DELIVERED before DISPATCHED, got %d", code)
+	}
+
+	if code, _ := commitOrder(t, n, "ord-trans-1", "DISPATCHED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for DISPATCHED, got %d", code)
+	}
+
+	if code, _ := commitOrder(t, n, "ord-trans-1", "IN_TRANSIT"); code != http.StatusOK {
+		t.Fatalf("expected 200 for IN_TRANSIT, got %d", code)
+	}
+
+	if code, _ := commitOrder(t, n, "ord-trans-1", "DELIVERED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for DELIVERED after IN_TRANSIT, got %d", code)
+	}
+
+	// CANCELLED from DELIVERED is invalid (only CREATED/DISPATCHED/IN_TRANSIT).
+	if code, _ := commitOrder(t, n, "ord-trans-1", "CANCELLED"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for CANCELLED after DELIVERED, got %d", code)
+	}
+
+	// Re-submitting the earlier DELIVERED is a duplicate, answered idempotently.
+	_, dup := commitOrder(t, n, "ord-trans-1", "DELIVERED")
+	if idx, ok := dup["raft_index"].(float64); !ok || idx != 4 {
+		t.Errorf("expected duplicate DELIVERED to report raft_index 4, got %v", dup["raft_index"])
+	}
+
+	n.mu.Lock()
+	logLen := len(n.Log)
+	n.mu.Unlock()
+	if logLen != 4 {
+		t.Errorf("expected log of 4 entries, got %d", logLen)
+	}
+}
+
+// TestHandleCommitOrderIdempotentDuplicate verifies the same (order_id,
+// command) submission returns the existing entry's index without appending.
+func TestHandleCommitOrderIdempotentDuplicate(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	n := newTestLeader()
+
+	code, first := commitOrder(t, n, "ord-dup-1", "CREATED")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 for first CREATED, got %d", code)
+	}
+	firstIndex := first["raft_index"].(float64)
+
+	// Re-submitting the identical command must not append a second entry.
+	code, second := commitOrder(t, n, "ord-dup-1", "CREATED")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 for duplicate CREATED, got %d", code)
+	}
+	secondIndex := second["raft_index"].(float64)
+	if secondIndex != firstIndex {
+		t.Errorf("expected duplicate to return raft_index %v, got %v", firstIndex, secondIndex)
+	}
+
+	n.mu.Lock()
+	logLen := len(n.Log)
+	n.mu.Unlock()
+	if logLen != 1 {
+		t.Errorf("expected log to stay at 1 entry for duplicate submission, got %d", logLen)
+	}
+}
+
+// TestHandleCommitOrderRejectsCommandAfterCompletion verifies a fully completed
+// order cannot be transitioned further.
+func TestHandleCommitOrderRejectsCommandAfterCompletion(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	n := newTestLeader()
+
+	for _, cmd := range []string{"CREATED", "DISPATCHED", "IN_TRANSIT", "DELIVERED", "COMPLETED"} {
+		if code, _ := commitOrder(t, n, "ord-complete-1", cmd); code != http.StatusOK {
+			t.Fatalf("expected 200 for %s, got %d", cmd, code)
+		}
+	}
+
+	// CANCELLED after COMPLETED is a fresh command rejected as terminal.
+	if code, _ := commitOrder(t, n, "ord-complete-1", "CANCELLED"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for CANCELLED after COMPLETED, got %d", code)
+	}
+	// A duplicate of an already-committed command stays idempotent.
+	_, dup := commitOrder(t, n, "ord-complete-1", "DELIVERED")
+	if idx, ok := dup["raft_index"].(float64); !ok || idx != 4 {
+		t.Errorf("expected duplicate DELIVERED to report raft_index 4, got %v", dup["raft_index"])
+	}
+
+	// Same for a cancelled order: a fresh command after CANCELLED is rejected.
+	n2 := newTestLeader()
+	for _, cmd := range []string{"CREATED", "DISPATCHED", "CANCELLED"} {
+		if code, _ := commitOrder(t, n2, "ord-cancel-1", cmd); code != http.StatusOK {
+			t.Fatalf("expected 200 for %s, got %d", cmd, code)
+		}
+	}
+	if code, _ := commitOrder(t, n2, "ord-cancel-1", "IN_TRANSIT"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for IN_TRANSIT after CANCELLED, got %d", code)
+	}
+}
+
+// TestHandleCommitOrderStateIsolation verifies the per-order state machine is
+// independent between orders.
+func TestHandleCommitOrderStateIsolation(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	n := newTestLeader()
+
+	if code, _ := commitOrder(t, n, "ord-a", "CREATED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-a CREATED, got %d", code)
+	}
+	if code, _ := commitOrder(t, n, "ord-b", "CREATED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-b CREATED, got %d", code)
+	}
+	// ord-a may move forward even though ord-b is still CREATED.
+	if code, _ := commitOrder(t, n, "ord-a", "DISPATCHED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-a DISPATCHED, got %d", code)
+	}
+	if code, _ := commitOrder(t, n, "ord-a", "IN_TRANSIT"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-a IN_TRANSIT, got %d", code)
+	}
+	if code, _ := commitOrder(t, n, "ord-a", "DELIVERED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-a DELIVERED, got %d", code)
+	}
+
+	// ord-b is still at CREATED: DISPATCHED is valid, DELIVERED is not (it
+	// requires IN_TRANSIT), proving the per-order machine stays isolated.
+	if code, _ := commitOrder(t, n, "ord-b", "DISPATCHED"); code != http.StatusOK {
+		t.Fatalf("expected 200 for ord-b DISPATCHED, got %d", code)
+	}
+	if code, _ := commitOrder(t, n, "ord-b", "DELIVERED"); code != http.StatusBadRequest {
+		t.Errorf("expected 400 for ord-b DELIVERED before IN_TRANSIT, got %d", code)
+	}
+}

--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -710,6 +710,18 @@ func (rn *RaftNode) appendLogFromLeaderLocked(req AppendEntriesRequest) bool {
 	return true
 }
 
+// writeCommitSuccess writes the success payload for a committed order entry.
+func (rn *RaftNode) writeCommitSuccess(w http.ResponseWriter, entry LogEntry) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"success":      true,
+		"raft_index":   entry.Index,
+		"term":         entry.Term,
+		"order_id":     entry.OrderID,
+		"committed_at": entry.Timestamp.Format(time.RFC3339),
+	})
+}
+
 // HandleCommitOrder accepts a committed order entry on the leader.
 func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -765,17 +777,43 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entry := LogEntry{
-		Index:     uint64(len(rn.Log) + 1),
-		Term:      rn.CurrentTerm,
-		Command:   req.Command,
-		OrderID:   req.OrderID,
-		Timestamp: time.Now(),
+	// Idempotency: an identical (order_id, command) already present in the log
+	// is never appended again. When it is already committed the retry is
+	// answered with the existing entry's index; when it is still pending
+	// replication the flow below simply waits for it to commit.
+	entryIndex := rn.findEntryLocked(req.OrderID, req.Command, uint64(len(rn.Log)))
+	if entryIndex == 0 {
+		// State-transition validation: the command must follow the order's
+		// recorded lifecycle history.
+		last := rn.orderStatesLocked(uint64(len(rn.Log)))[req.OrderID]
+		if !canTransition(last, req.Command) {
+			rn.mu.Unlock()
+			http.Error(w, "invalid state transition for order", http.StatusBadRequest)
+			return
+		}
+
+		entry := LogEntry{
+			Index:     uint64(len(rn.Log) + 1),
+			Term:      rn.CurrentTerm,
+			Command:   req.Command,
+			OrderID:   req.OrderID,
+			Timestamp: time.Now(),
+		}
+
+		// Append to the local log first. CommitIndex is NOT advanced here: the
+		// entry must first be replicated to a quorum of followers (Raft §5.3).
+		rn.Log = append(rn.Log, entry)
+		entryIndex = entry.Index
 	}
 
-	// Append to the local log first. CommitIndex is NOT advanced here: the entry
-	// must first be replicated to a quorum of followers (Raft §5.3).
-	rn.Log = append(rn.Log, entry)
+	if entryIndex <= rn.CommitIndex {
+		// Already committed in a previous round — answer the retry idempotently.
+		e := rn.Log[entryIndex-1]
+		rn.mu.Unlock()
+		rn.writeCommitSuccess(w, e)
+		return
+	}
+
 	rn.mu.Unlock()
 
 	// Replicate to followers and wait for a quorum acknowledgement before
@@ -794,7 +832,8 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	committed := rn.CommitIndex >= entry.Index
+	committed := rn.CommitIndex >= entryIndex
+	entry := rn.Log[entryIndex-1]
 	rn.mu.Unlock()
 
 	if !committed {
@@ -815,7 +854,7 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success":    false,
 			"error":      "entry not yet committed to a quorum of followers",
-			"raft_index": entry.Index,
+			"raft_index": entryIndex,
 		})
 		return
 	}
@@ -824,17 +863,7 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	// before the client observes success.
 	rn.sendHeartbeats()
 
-	rn.mu.Lock()
-	defer rn.mu.Unlock()
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"success":      true,
-		"raft_index":   entry.Index,
-		"term":         entry.Term,
-		"order_id":     entry.OrderID,
-		"committed_at": entry.Timestamp.Format(time.RFC3339),
-	})
+	rn.writeCommitSuccess(w, entry)
 }
 
 func envInt(key string, def int) int {

--- a/services/consensus-raft-go/state_machine.go
+++ b/services/consensus-raft-go/state_machine.go
@@ -1,0 +1,56 @@
+package main
+
+// orderTransitions defines the per-order lifecycle state machine: the commands
+// that may follow each recorded command. The lifecycle is a strict chain
+// (CREATED -> DISPATCHED -> IN_TRANSIT -> DELIVERED -> COMPLETED) with
+// CANCELLED branching off the active states; CANCELLED and COMPLETED are
+// terminal.
+var orderTransitions = map[string]map[string]bool{
+	"CREATED":    {"DISPATCHED": true, "CANCELLED": true},
+	"DISPATCHED": {"IN_TRANSIT": true, "CANCELLED": true},
+	"IN_TRANSIT": {"DELIVERED": true, "CANCELLED": true},
+	"DELIVERED":  {"COMPLETED": true},
+	"COMPLETED":  {},
+	"CANCELLED":  {},
+}
+
+// canTransition reports whether `to` may follow `from` in an order's lifecycle.
+// from == "" means the order has no recorded state yet. Commands outside the
+// standard ordering (custom RAFT_ALLOWED_COMMANDS entries) are allowed to move
+// forward only when the previous state is not terminal and `to` is not CREATED.
+func canTransition(from, to string) bool {
+	if from == "" {
+		return to == "CREATED"
+	}
+	if _, known := orderTransitions[from]; !known {
+		return to != "CREATED"
+	}
+	return orderTransitions[from][to]
+}
+
+// orderStatesLocked replays the log up to limit and returns the last recorded
+// command for each order (the per-order state machine).
+func (rn *RaftNode) orderStatesLocked(limit uint64) map[string]string {
+	if limit > uint64(len(rn.Log)) {
+		limit = uint64(len(rn.Log))
+	}
+	states := make(map[string]string)
+	for i := 0; i < int(limit); i++ {
+		states[rn.Log[i].OrderID] = rn.Log[i].Command
+	}
+	return states
+}
+
+// findEntryLocked returns the index (1-based) of the first entry in the log up
+// to limit matching the order id and command, or 0 when there is none.
+func (rn *RaftNode) findEntryLocked(orderID, command string, limit uint64) uint64 {
+	if limit > uint64(len(rn.Log)) {
+		limit = uint64(len(rn.Log))
+	}
+	for i := 0; i < int(limit); i++ {
+		if rn.Log[i].OrderID == orderID && rn.Log[i].Command == command {
+			return rn.Log[i].Index
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## Problem

`HandleCommitOrder` validates only that `order_id` is well-formed and that `command` is in the allow-list. The same `(order_id, command)` can be committed repeatedly (a failed replication leaves the entry appended to the leader's log, so a client retry after the 503 appends a second identical entry), and arbitrary orderings are accepted — `DELIVERED` before `DISPATCHED`, `CANCELLED` after `COMPLETED`, `CREATED` twice — because there is no per-order state machine anywhere in the handler or apply path.

## Fix

`HandleCommitOrder` now enforces both a lifecycle state machine and idempotency:

- **Idempotency/dedup**: `findEntryLocked` looks up `(order_id, command)` in the log. A duplicate is never appended again — if it is already committed the retry returns `200` with the existing entry's `raft_index`; if it is still pending replication the flow waits for that entry to commit instead of appending a copy.
- **State-transition validation**: `canTransition` enforces the strict lifecycle chain `CREATED` → `DISPATCHED` → `IN_TRANSIT` → `DELIVERED` → `COMPLETED`, with `CANCELLED` allowed from `CREATED`/`DISPATCHED`/`IN_TRANSIT` and both `CANCELLED`/`COMPLETED` terminal. The order's current state is rebuilt by replaying the log (`orderStatesLocked`). Violations return `400` before anything touches the log. Commands outside the standard ordering (custom `RAFT_ALLOWED_COMMANDS`) are allowed forward moves as long as the order is not terminal.

## Files changed

- `services/consensus-raft-go/main.go` — dedup + transition check in `HandleCommitOrder`; extracted `writeCommitSuccess`.
- `services/consensus-raft-go/state_machine.go` — `orderTransitions`/`canTransition`, `orderStatesLocked`, `findEntryLocked`.
- `services/consensus-raft-go/commit_validation_test.go` — new tests.
- `services/consensus-raft-go/README.md` — documents the validation rules.

## Testing

`go vet ./...` clean; `go test ./...` passes all tests except the pre-existing `TestHandleCommitOrderRejectsOversizedBody`, which also fails on an untouched checkout at `origin/main` (it sends a non-JSON body that fails decode as 400 before the size cap can be exceeded).

New tests:

- `TestCanTransition` — full transition table.
- `TestHandleCommitOrderRejectsInvalidTransitions` — `DISPATCHED` before `CREATED`, `DELIVERED` before `DISPATCHED`, `CANCELLED` after `DELIVERED` all rejected; duplicate re-submission stays idempotent with no extra log entry.
- `TestHandleCommitOrderIdempotentDuplicate` — re-submitted command returns the existing `raft_index`; log length stays 1.
- `TestHandleCommitOrderRejectsCommandAfterCompletion` — `CANCELLED` after `COMPLETED` and `IN_TRANSIT` after `CANCELLED` rejected; committed duplicates remain idempotent.
- `TestHandleCommitOrderStateIsolation` — per-order state machine is independent between orders.

Closes #10680
