### PR TITLE
fix : added treat ZodError from validateQuery as a client 400 instead of 500

### DIFF
--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -111,6 +111,19 @@ export function validateQuery(schema) {
       });
       return next();
     } catch (err) {
+      // Zod throws on malformed/oversized input (e.g. transform failures).
+      // Treat those as client errors with the same envelope as a failed
+      // safeParse rather than surfacing an internal 500.
+      if (err && (err.name === 'ZodError' || err.issues)) {
+        logger.warn(
+          { event: 'VALIDATION_ERROR', type: 'query', requestId: req.requestId || req.id, details: formatValidationIssues(err) },
+          'Query validation failed',
+        );
+        return res.status(400).json({
+          error: "Validation failed",
+          details: formatValidationIssues(err),
+        });
+      }
       return res.status(500).json({
         error: "Internal query validation error",
         details: err.message,

--- a/backend/api/test/unit/validate.test.js
+++ b/backend/api/test/unit/validate.test.js
@@ -187,6 +187,27 @@ describe('validateQuery middleware', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-
+  it('returns 400 instead of 500 when the schema throws a ZodError', () => {
+    // A schema whose transform throws (e.g. a value that cannot be coerced)
+    // must surface as a client error, not an internal server error.
+    const throwingSchema = {
+      safeParse: () => {
+        const err = new Error('Malformed value');
+        err.name = 'ZodError';
+        err.issues = [{ path: ['page'], message: 'Malformed value' }];
+        throw err;
+      },
+    };
+    const req = { query: { page: 'huge-value' } };
+    const res = makeRes();
+    const next = makeNext();
+    validateQuery(throwingSchema)(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Validation failed',
+      details: [{ field: 'page', message: 'Malformed value' }],
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
 
 });


### PR DESCRIPTION
Closes #10823.

Summary of What Has Been Done:
Implemented the change requested in issue #10823: treat ZodError from validateQuery as a client 400 instead of 500.

Changes Made:
- treat ZodError from validateQuery as a client 400 instead of 500
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.