### PR TITLE
fix : added array x-api-key header handling in requireApiKey

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,8 +8,11 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
-  
+  const rawApiKey = req.headers['x-api-key'] || req.query.api_key;
+  // A repeated `x-api-key` header arrives as an array; only a single string
+  // value is meaningful for credential comparison.
+  const apiKey = Array.isArray(rawApiKey) ? rawApiKey[0] : rawApiKey;
+
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);
 

--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -166,4 +166,15 @@ describe('requireApiKey', () => {
 
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it('uses the first value when x-api-key header is repeated as an array', () => {
+    const { req, res, next } = createMocks({
+      req: { headers: { 'x-api-key': ['test-key-1', 'other-key'] } },
+    });
+
+    requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10824.

Summary of What Has Been Done:
Implemented the change requested in issue #10824: array x-api-key header handling in requireApiKey.

Changes Made:
- array x-api-key header handling in requireApiKey
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.