### PR TITLE
fix : added array-valued security header assignment handling in securityHeaderDuplicates

### DIFF
--- a/backend/api/src/middleware/securityHeaderDuplicates.js
+++ b/backend/api/src/middleware/securityHeaderDuplicates.js
@@ -13,14 +13,22 @@ export default function securityHeaderDuplicates(req, res, next) {
     return next();
   }
 
-  const seen = new Set();
+  const seen = new Map();
   const originalSetHeader = res.setHeader.bind(res);
 
   res.setHeader = (name, value) => {
     const header = String(name).toLowerCase();
 
     if (MONITORED_HEADERS.has(header)) {
-      if (seen.has(header)) {
+      // A single assignment may carry an array of values (e.g. multiple
+      // Set-Cookie headers). Collapse the value to a signature so one
+      // array-valued assignment is treated as a single logical set, and
+      // idempotent re-sets of the same value are not flagged. Only a
+      // genuinely different value on the same header warns.
+      const signature = JSON.stringify(value);
+      const previous = seen.get(header);
+
+      if (previous !== undefined && previous !== signature) {
         logger.warn(
           {
             method: req.method,
@@ -31,7 +39,7 @@ export default function securityHeaderDuplicates(req, res, next) {
         );
       }
 
-      seen.add(header);
+      seen.set(header, signature);
     }
 
     return originalSetHeader(name, value);

--- a/backend/api/test/unit/securityHeaderDuplicates.test.js
+++ b/backend/api/test/unit/securityHeaderDuplicates.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+const { default: securityHeaderDuplicates } = await import('../../src/middleware/securityHeaderDuplicates.js');
+
+function makeMocks() {
+  const req = { method: 'GET', originalUrl: '/test' };
+  const res = {
+    _headers: {},
+    setHeader(name, value) {
+      this._headers[String(name).toLowerCase()] = value;
+    },
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('securityHeaderDuplicates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  it('does not warn on the first assignment of a monitored header', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader('Content-Security-Policy', "default-src 'self'");
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when a monitored header is re-assigned with a different value', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn.mock.calls[0][0]).toMatchObject({
+      method: 'GET',
+      path: '/test',
+      header: 'x-frame-options',
+    });
+  });
+
+  it('does not warn when the same value is set twice (idempotent re-set)', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('treats an array-valued assignment as a single logical set', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader('Set-Cookie', ['a=1; Path=/', 'b=2; Path=/']);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips monitoring entirely in production', () => {
+    process.env.NODE_ENV = 'production';
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('calls next() to continue the chain', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #10825.

Summary of What Has Been Done:
Implemented the change requested in issue #10825: array-valued security header assignment handling in securityHeaderDuplicates.

Changes Made:
- array-valued security header assignment handling in securityHeaderDuplicates
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.