### PR TITLE
fix : added undefined header name guard in securityHeaderDuplicates

### DIFF
--- a/backend/api/src/middleware/securityHeaderDuplicates.js
+++ b/backend/api/src/middleware/securityHeaderDuplicates.js
@@ -17,6 +17,11 @@ export default function securityHeaderDuplicates(req, res, next) {
   const originalSetHeader = res.setHeader.bind(res);
 
   res.setHeader = (name, value) => {
+    // A proxy layer (e.g. nginx) can pass an undefined header name; guard so
+    // the monitor never throws on a malformed assignment.
+    if (name === undefined || name === null) {
+      return originalSetHeader(name, value);
+    }
     const header = String(name).toLowerCase();
 
     if (MONITORED_HEADERS.has(header)) {

--- a/backend/api/test/unit/securityHeaderDuplicatesUndefined.test.js
+++ b/backend/api/test/unit/securityHeaderDuplicatesUndefined.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+const { default: securityHeaderDuplicates } = await import('../../src/middleware/securityHeaderDuplicates.js');
+
+function makeMocks() {
+  const req = { method: 'GET', originalUrl: '/test' };
+  const res = {
+    _headers: {},
+    setHeader(name, value) {
+      if (name === undefined) return;
+      this._headers[String(name).toLowerCase()] = value;
+    },
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('securityHeaderDuplicates undefined-header guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  it('does not throw when setHeader is called with an undefined name', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    expect(() => res.setHeader(undefined, 'value')).not.toThrow();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when setHeader is called with a null name', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    expect(() => res.setHeader(null, 'value')).not.toThrow();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('still monitors valid headers after an undefined-name call', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaderDuplicates(req, res, next);
+    res.setHeader(undefined, 'ignored');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #10826.

Summary of What Has Been Done:
Implemented the change requested in issue #10826: undefined header name guard in securityHeaderDuplicates.

Changes Made:
- undefined header name guard in securityHeaderDuplicates
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.