### PR TITLE
fix : added configurable bounded HSTS max-age in securityHeaders

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -5,6 +5,21 @@
  * existing Content-Security-Policy configuration.
  */
 
+/**
+ * Default HSTS max-age (seconds). The value is overridable via
+ * SECURE_HSTS_MAX_AGE with a hard floor of 1 day so a deployment cannot
+ * accidentally weaken the header to a near-zero value.
+ */
+const DEFAULT_HSTS_MAX_AGE = 31536000; // 1 year
+const MIN_HSTS_MAX_AGE = 86400; // 1 day
+
+function resolveHstsMaxAge() {
+  const raw = Number(process.env.SECURE_HSTS_MAX_AGE);
+  return Number.isFinite(raw) && raw >= MIN_HSTS_MAX_AGE
+    ? Math.floor(raw)
+    : DEFAULT_HSTS_MAX_AGE;
+}
+
 export default function securityHeaders(req, res, next) {
   // Prevent MIME-type sniffing
   if (!res.getHeader('X-Content-Type-Options')) {
@@ -24,7 +39,7 @@ export default function securityHeaders(req, res, next) {
   // Enforce HTTPS for sensitive headers
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
     if (!res.getHeader('Strict-Transport-Security')) {
-      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', `max-age=${resolveHstsMaxAge()}; includeSubDomains`);
     }
   }
 

--- a/backend/api/test/unit/securityHeadersHsts.test.js
+++ b/backend/api/test/unit/securityHeadersHsts.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { default: securityHeaders } = await import('../../src/middleware/securityHeaders.js');
+
+function makeMocks(overrides = {}) {
+  const headers = {};
+  const req = {
+    secure: true,
+    headers: {},
+    ...overrides,
+  };
+  const res = {
+    _headers: headers,
+    getHeader(name) {
+      return headers[String(name).toLowerCase()];
+    },
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+    },
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('securityHeaders HSTS max-age', () => {
+  beforeEach(() => {
+    delete process.env.SECURE_HSTS_MAX_AGE;
+  });
+
+  afterEach(() => {
+    delete process.env.SECURE_HSTS_MAX_AGE;
+  });
+
+  it('sets the default HSTS max-age when no env override is present', () => {
+    const { req, res, next } = makeMocks();
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  it('uses SECURE_HSTS_MAX_AGE when set to a valid value', () => {
+    process.env.SECURE_HSTS_MAX_AGE = '172800';
+    const { req, res, next } = makeMocks();
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBe('max-age=172800; includeSubDomains');
+  });
+
+  it('falls back to the default when the override is below the minimum floor', () => {
+    process.env.SECURE_HSTS_MAX_AGE = '60';
+    const { req, res, next } = makeMocks();
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  it('falls back to the default when the override is not a finite number', () => {
+    process.env.SECURE_HSTS_MAX_AGE = 'abc';
+    const { req, res, next } = makeMocks();
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  it('does not emit HSTS for plain HTTP requests', () => {
+    const { req, res, next } = makeMocks({ secure: false });
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #10827.

Summary of What Has Been Done:
Implemented the change requested in issue #10827: configurable bounded HSTS max-age in securityHeaders.

Changes Made:
- configurable bounded HSTS max-age in securityHeaders
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.