### PR TITLE
fix : added trimmed case-insensitive localhost origin matching in cors

### DIFF
--- a/backend/api/src/middleware/cors.js
+++ b/backend/api/src/middleware/cors.js
@@ -31,8 +31,11 @@ export const corsMiddleware = cors({
     if (allowedOrigins.includes(cleanOrigin)) return callback(null, true);
 
     if (process.env.NODE_ENV !== "production") {
-      const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(
-        origin,
+      // The localhost regex runs on the trimmed origin so a trailing space
+      // cannot bypass the check, and the hostname is matched
+      // case-insensitively ("LOCALHOST" is still localhost).
+      const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/i.test(
+        cleanOrigin,
       );
       if (isLocalhost) return callback(null, true);
     }

--- a/backend/api/test/unit/cors.test.js
+++ b/backend/api/test/unit/cors.test.js
@@ -47,4 +47,14 @@ describe('corsMiddleware', () => {
     const { nextCalled } = await invoke(null)
     expect(nextCalled).toBe(true)
   })
+
+  it('allows localhost when the origin has surrounding whitespace', async () => {
+    const { res } = await invoke('  http://localhost:8080  ')
+    expect(res.getHeader('access-control-allow-origin')).toBeTruthy()
+  })
+
+  it('allows localhost with a case-variant hostname', async () => {
+    const { res } = await invoke('http://LOCALHOST:8080')
+    expect(res.getHeader('access-control-allow-origin')).toBe('http://LOCALHOST:8080')
+  })
 })


### PR DESCRIPTION
Closes #10829.

Summary of What Has Been Done:
Implemented the change requested in issue #10829: trimmed case-insensitive localhost origin matching in cors.

Changes Made:
- trimmed case-insensitive localhost origin matching in cors
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.