### PR TITLE
fix : added defensive header size accounting and 431 test fixture fixes

### DIFF
--- a/backend/api/src/middleware/headerSizeMonitor.js
+++ b/backend/api/src/middleware/headerSizeMonitor.js
@@ -10,14 +10,17 @@ export default function headerSizeMonitor(req, res, next) {
   let totalSize = 0;
 
   for (const [name, value] of Object.entries(req.headers)) {
-    totalSize += Buffer.byteLength(name);
+    totalSize += Buffer.byteLength(String(name));
 
     if (Array.isArray(value)) {
       for (const item of value) {
-        totalSize += Buffer.byteLength(String(item));
+        if (item === undefined || item === null) continue;
+        // Stringify objects defensively; Buffer.byteLength on a non-string
+        // throws, and header values can be nested in exotic proxies.
+        totalSize += Buffer.byteLength(typeof item === 'string' ? item : JSON.stringify(item));
       }
-    } else if (value !== undefined) {
-      totalSize += Buffer.byteLength(String(value));
+    } else if (value !== undefined && value !== null) {
+      totalSize += Buffer.byteLength(typeof value === 'string' ? value : String(value));
     }
   }
 

--- a/backend/api/test/unit/headerSizeMonitor.test.js
+++ b/backend/api/test/unit/headerSizeMonitor.test.js
@@ -21,10 +21,15 @@ function makeReq(headers = {}) {
 }
 
 function makeRes() {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
   return {
     getHeader: vi.fn(),
     setHeader: vi.fn(),
     statusCode: 200,
+    status,
+    json,
+    _jsonMock: json,
     on: vi.fn(),
   };
 }
@@ -72,7 +77,8 @@ describe('headerSizeMonitor', () => {
       const res = makeRes();
       const next = vi.fn();
       headerSizeMonitor(req, res, next);
-      expect(next).toHaveBeenCalledOnce();
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(431);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'GET',
@@ -124,7 +130,8 @@ describe('headerSizeMonitor', () => {
       const res = makeRes();
       const next = vi.fn();
       headerSizeMonitor(req, res, next);
-      expect(next).toHaveBeenCalledOnce();
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(431);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           headerSize: expect.any(Number),
@@ -132,6 +139,27 @@ describe('headerSizeMonitor', () => {
         }),
         'Request headers exceed configured size threshold'
       );
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+      if (originalLimit !== undefined) process.env.HEADER_SIZE_LIMIT = originalLimit;
+      else delete process.env.HEADER_SIZE_LIMIT;
+    }
+  });
+
+  it('does not throw when array header items are non-string values', () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originalLimit = process.env.HEADER_SIZE_LIMIT;
+    process.env.NODE_ENV = 'development';
+    process.env.HEADER_SIZE_LIMIT = '5000';
+    try {
+      const req = makeReq({
+        'x-mixed': ['value', 42, { nested: true }, null, undefined],
+      });
+      const res = makeRes();
+      const next = vi.fn();
+      expect(() => headerSizeMonitor(req, res, next)).not.toThrow();
+      expect(next).toHaveBeenCalledOnce();
+      expect(logger.warn).not.toHaveBeenCalled();
     } finally {
       process.env.NODE_ENV = originalEnv;
       if (originalLimit !== undefined) process.env.HEADER_SIZE_LIMIT = originalLimit;


### PR DESCRIPTION
Closes #10830.

Summary of What Has Been Done:
Implemented the change requested in issue #10830: defensive header size accounting and 431 test fixture fixes.

Changes Made:
- defensive header size accounting and 431 test fixture fixes
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.