### PR TITLE
fix : added empty pipeline result guard in redisRateLimiter

### DIFF
--- a/backend/api/src/middleware/redisRateLimiter.js
+++ b/backend/api/src/middleware/redisRateLimiter.js
@@ -53,7 +53,20 @@ export function redisRateLimiter({ routeKey, limit, windowMs, failClosed = false
       pipeline.zcard(key);
       const results = await pipeline.exec();
 
-      // Validate ZCARD result tuple [error, value].
+      // Validate ZCARD result tuple [error, value]. pipeline.exec() resolves
+      // to an array of [err, result] tuples; a null/empty result set means the
+      // pipeline failed wholesale and must not be read past.
+      if (!Array.isArray(results) || results.length < 2) {
+        if (failClosed) {
+          logger.error({ routeKey, err: 'empty pipeline result' }, '[RateLimiter] ZCARD failed — failing closed');
+          return res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable. Please try again shortly.',
+          });
+        }
+        logger.warn({ routeKey, err: 'empty pipeline result' }, '[RateLimiter] ZCARD failed — failing open');
+        return next();
+      }
       const zcardTuple = results[1];
       if (!zcardTuple || zcardTuple[0]) {
         if (failClosed) {

--- a/backend/api/test/unit/redisRateLimiterPipeline.test.js
+++ b/backend/api/test/unit/redisRateLimiterPipeline.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+describe('redisRateLimiter pipeline result handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeClient(execResult) {
+    const client = {
+      pipeline: vi.fn(() => ({
+        zremrangebyscore: vi.fn(),
+        zcard: vi.fn(),
+        exec: vi.fn().mockResolvedValue(execResult),
+        zadd: vi.fn(),
+        pexpire: vi.fn(),
+      })),
+      zrange: vi.fn(),
+    };
+    return client;
+  }
+
+  async function loadMiddleware(client) {
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({
+      redisClient: client,
+      supabase: null,
+      supabaseAdmin: null,
+      pgPool: null,
+      mongoDb: null,
+      firebaseAdmin: null,
+    }));
+    const { redisRateLimiter } = await import('../../src/middleware/redisRateLimiter.js');
+    return redisRateLimiter;
+  }
+
+  it('fails open when pipeline.exec resolves to a null result', async () => {
+    const client = makeClient(null);
+    const redisRateLimiter = await loadMiddleware(client);
+    const middleware = redisRateLimiter({ routeKey: 'test', limit: 10, windowMs: 60000, failClosed: false });
+    const req = { ip: '127.0.0.1' };
+    const res = { set: vi.fn(), status: vi.fn(() => ({ json: vi.fn() })) };
+    const next = vi.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it('fails closed with 503 when pipeline.exec resolves to a short array', async () => {
+    const client = makeClient([]);
+    const redisRateLimiter = await loadMiddleware(client);
+    const middleware = redisRateLimiter({ routeKey: 'test', limit: 10, windowMs: 60000, failClosed: true });
+    const req = { ip: '127.0.0.1' };
+    const json = vi.fn();
+    const res = { set: vi.fn(), status: vi.fn(() => ({ json })) };
+    const next = vi.fn();
+    await middleware(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false })
+    );
+  });
+
+  it('fails open with 429 when the count exceeds the limit', async () => {
+    const client = makeClient([[null, 1], [null, 10]]);
+    client.zrange.mockResolvedValue(['100', '2000']);
+    const redisRateLimiter = await loadMiddleware(client);
+    const middleware = redisRateLimiter({ routeKey: 'test', limit: 10, windowMs: 60000, failClosed: false });
+    const req = { ip: '127.0.0.1' };
+    const json = vi.fn();
+    const res = { set: vi.fn(), status: vi.fn(() => ({ json })) };
+    const next = vi.fn();
+    await middleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #10831.

Summary of What Has Been Done:
Implemented the change requested in issue #10831: empty pipeline result guard in redisRateLimiter.

Changes Made:
- empty pipeline result guard in redisRateLimiter
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unavailable or malformed rate-limiting data.
  - Requests now receive a service-unavailable response when configured to fail closed.
  - Rate limiting can safely bypass checks when configured to fail open, with a warning logged.
  - Requests exceeding configured limits continue to receive a too-many-requests response.

- **Tests**
  - Added coverage for missing, empty, and over-limit rate-limiting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->