### PR TITLE
fix : added requestId in cacheControlVerifier warning payload

### DIFF
--- a/backend/api/src/middleware/cacheControlVerifier.js
+++ b/backend/api/src/middleware/cacheControlVerifier.js
@@ -41,6 +41,7 @@ export default function cacheControlVerifier(req, res, next) {
     if (warnings.length > 0) {
       logger.warn(
         {
+          requestId: req.requestId || req.id,
           method: req.method,
           path: req.originalUrl,
           missingHeaders: warnings,

--- a/backend/api/test/unit/cacheControlVerifier.test.js
+++ b/backend/api/test/unit/cacheControlVerifier.test.js
@@ -82,6 +82,7 @@ describe('cacheControlVerifier', () => {
       emitFinish(res);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
+          requestId: 'req-456',
           method: 'GET',
           path: '/api/test',
           missingHeaders: expect.arrayContaining(['Cache-Control']),


### PR DESCRIPTION
Closes #10833.

Summary of What Has Been Done:
Implemented the change requested in issue #10833: requestId in cacheControlVerifier warning payload.

Changes Made:
- requestId in cacheControlVerifier warning payload
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.