### PR TITLE
fix : added nested array flattening in hppProtection

### DIFF
--- a/backend/api/src/middleware/hppProtection.js
+++ b/backend/api/src/middleware/hppProtection.js
@@ -8,8 +8,14 @@ export default function hppProtection(req, res, next) {
       duplicateParams.push(key);
 
       // Preserve backward compatibility by consistently selecting
-      // the first value.
-      req.query[key] = value[0];
+      // the first value. A nested array (e.g. `?a=1&a=2&a=3` parsed as
+      // `[['1','2'],'3']` by some middleware) is flattened so the query
+      // value can never remain an array after this middleware runs.
+      let first = value[0];
+      while (Array.isArray(first)) {
+        first = first[0];
+      }
+      req.query[key] = first;
     }
   }
 

--- a/backend/api/test/unit/hppProtection.test.js
+++ b/backend/api/test/unit/hppProtection.test.js
@@ -96,4 +96,17 @@ describe('hppProtection', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(logger.warn).not.toHaveBeenCalled();
   });
+
+  it('flattens a nested array query value to a single scalar', () => {
+    const req = makeReq({ page: [['2', '3'], '4'] });
+    const res = makeRes();
+    const next = vi.fn();
+    hppProtection(req, res, next);
+    expect(req.query.page).toBe('2');
+    expect(Array.isArray(req.query.page)).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ duplicateParams: ['page'] }),
+      'Potential HTTP Parameter Pollution detected'
+    );
+  });
 });


### PR DESCRIPTION
Closes #10834.

Summary of What Has Been Done:
Implemented the change requested in issue #10834: nested array flattening in hppProtection.

Changes Made:
- nested array flattening in hppProtection
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.