### PR TITLE
fix : added non-negative durationMs clamp in requestLogger

### DIFF
--- a/backend/api/src/middleware/requestId.js
+++ b/backend/api/src/middleware/requestId.js
@@ -41,7 +41,9 @@ export function requestLogger(req, res, next) {
   req.log = reqLogger;
 
   res.on('finish', () => {
-    const durationMs = Date.now() - start;
+    // Clamp so a premature finish event (or a clock that moved backwards)
+    // cannot produce a negative duration in logs and dashboards.
+    const durationMs = Math.max(0, Date.now() - start);
     const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
     reqLogger[level]({
       requestId: req.requestId,

--- a/backend/api/test/unit/requestId.test.js
+++ b/backend/api/test/unit/requestId.test.js
@@ -105,4 +105,14 @@ describe('requestLogger', () => {
       expect.objectContaining({ durationMs: expect.any(Number) })
     );
   });
+
+  it('never logs a negative durationMs', () => {
+    const req = { requestId: 'test-id', method: 'GET', originalUrl: '/api/health' };
+    const res = makeRes(200);
+    requestLogger(req, res, vi.fn());
+    // Force a "finish" that fires instantly; the clamped duration must be >= 0.
+    res.emit('finish');
+    const payload = logger.info.mock.calls[0][0];
+    expect(payload.durationMs).toBeGreaterThanOrEqual(0);
+  });
 });


### PR DESCRIPTION
Closes #10835.

Summary of What Has Been Done:
Implemented the change requested in issue #10835: non-negative durationMs clamp in requestLogger.

Changes Made:
- non-negative durationMs clamp in requestLogger
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.