### PR TITLE
fix : added MAX_PAGE cap in buildPagination to prevent unsafe offsets

### DIFF
--- a/backend/api/src/utils/pagination.js
+++ b/backend/api/src/utils/pagination.js
@@ -4,6 +4,10 @@ const DEFAULTS = {
   maxLimit: 100,
 };
 
+// Cap the page number so `(page - 1) * limit` can never exceed
+// Number.MAX_SAFE_INTEGER, which would silently produce a broken offset.
+const MAX_PAGE = 1_000_000;
+
 function normalizeNumber(value) {
   if (Number.isFinite(value)) {
     return value;
@@ -17,7 +21,9 @@ function normalizeNumber(value) {
 export function buildPagination(params = {}) {
   const rawPage = normalizeNumber(params.page);
   const rawLimit = normalizeNumber(params.limit);
-  const page = Number.isFinite(rawPage) ? Math.max(1, Math.floor(rawPage)) : DEFAULTS.page;
+  const page = Number.isFinite(rawPage)
+    ? Math.min(Math.max(1, Math.floor(rawPage)), MAX_PAGE)
+    : DEFAULTS.page;
   const limit = Number.isFinite(rawLimit)
     ? Math.min(Math.max(1, Math.floor(rawLimit)), DEFAULTS.maxLimit)
     : DEFAULTS.limit;

--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -157,4 +157,11 @@ describe('pagination — NaN and edge case handling', () => {
     const result = buildPagination({ page: Infinity });
     expect(result.page).toBe(1);
   });
+
+  it('buildPagination caps a huge page number to MAX_PAGE', () => {
+    const result = buildPagination({ page: 1e12, limit: 100 });
+    expect(result.page).toBe(1000000);
+    expect(result.offset).toBe(99999900);
+    expect(Number.isSafeInteger(result.offset)).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #10838.

Summary of What Has Been Done:
Implemented the change requested in issue #10838: MAX_PAGE cap in buildPagination to prevent unsafe offsets.

Changes Made:
- MAX_PAGE cap in buildPagination to prevent unsafe offsets
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.