### PR TITLE
fix : added error and close cache cleanup in requestCacheMiddleware

### DIFF
--- a/backend/api/src/middleware/requestCacheMiddleware.js
+++ b/backend/api/src/middleware/requestCacheMiddleware.js
@@ -4,10 +4,17 @@ import { RequestCache } from '../lib/requestCache.js';
 export function requestCacheMiddleware(req, res, next) {
   const store = { requestCache: new RequestCache() };
 
+  const clearCache = () => {
+    store.requestCache.clear();
+  };
+
   requestContext.run(store, () => {
-    res.once('finish', () => {
-      store.requestCache.clear();
-    });
+    // Clear on finish AND on error so a response that dies mid-stream (e.g.
+    // a socket error) cannot leak its request-scoped cache into the next
+    // request handled by the same process.
+    res.once('finish', clearCache);
+    res.once('error', clearCache);
+    res.once('close', clearCache);
     next();
   });
 }

--- a/backend/api/test/unit/requestCacheMiddleware.test.js
+++ b/backend/api/test/unit/requestCacheMiddleware.test.js
@@ -18,4 +18,16 @@ describe('requestCacheMiddleware', () => {
     expect(mockRes.once).toHaveBeenCalledWith('finish', expect.any(Function));
     expect(typeof finishCallback).toBe('function');
   });
+
+  it('also registers error and close listeners to clear the cache', () => {
+    const mockRes = { once: vi.fn() };
+    const mockNext = vi.fn();
+    const mockReq = {};
+
+    requestCacheMiddleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.once).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockRes.once).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(mockNext).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10842.

Summary of What Has Been Done:
Implemented the change requested in issue #10842: error and close cache cleanup in requestCacheMiddleware.

Changes Made:
- error and close cache cleanup in requestCacheMiddleware
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.