### PR TITLE
fix : added case-insensitive cookie attribute matching in cookieSecurityValidator

### DIFF
--- a/backend/api/src/middleware/cookieSecurityValidator.js
+++ b/backend/api/src/middleware/cookieSecurityValidator.js
@@ -20,8 +20,11 @@ function validateCookies(req, value) {
 
   for (const cookie of cookies) {
     const cookieValue = String(cookie);
+    // Attribute names are case-insensitive per RFC 6265 (e.g. `httponly`
+    // is equivalent to `HttpOnly`), so match on the lowercased cookie.
+    const lowerCookie = cookieValue.toLowerCase();
     const missingAttributes = RECOMMENDED_ATTRIBUTES.filter(
-      (attribute) => !cookieValue.includes(attribute)
+      (attribute) => !lowerCookie.includes(attribute.toLowerCase())
     );
 
     if (missingAttributes.length === 0) continue;

--- a/backend/api/test/unit/cookieSecurityValidator.test.js
+++ b/backend/api/test/unit/cookieSecurityValidator.test.js
@@ -95,5 +95,11 @@ describe('cookieSecurityValidator', () => {
       // First cookie missing HttpOnly and Secure, second missing HttpOnly, SameSite, Secure
       expect(mockLogger.warn).toHaveBeenCalledTimes(2);
     });
+
+    it('does not warn when attributes use lowercase names', () => {
+      applyValidator();
+      res.setHeader('set-cookie', 'session=abc123; httponly; samesite=strict; path=/; secure');
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Closes #10843.

Summary of What Has Been Done:
Implemented the change requested in issue #10843: case-insensitive cookie attribute matching in cookieSecurityValidator.

Changes Made:
- case-insensitive cookie attribute matching in cookieSecurityValidator
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.