### PR TITLE
fix : added phone number redaction in audit log scrubPii

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -179,7 +179,13 @@ export function scrubPii(value, path = '') {
   if (typeof value === 'string') {
     // Redact 16-digit card numbers that may be embedded in strings.
     const CARD_NUMBER_PATTERN = /\b\d{4}[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}\b/g;
-    return value.replace(CARD_NUMBER_PATTERN, '[REDACTED]');
+    let scrubbed = value.replace(CARD_NUMBER_PATTERN, '[REDACTED]');
+    // Redact full 10-digit Indian mobile numbers (starting 6-9) that may be
+    // embedded in log/metadata strings. Partial numbers (e.g. last 4 digits
+    // shown in UIs) are left alone.
+    const PHONE_PATTERN = /\b[6-9]\d{9}\b/g;
+    scrubbed = scrubbed.replace(PHONE_PATTERN, '[REDACTED]');
+    return scrubbed;
   }
 
   return value;

--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -440,6 +440,16 @@ describe('scrubPii', () => {
     expect(scrubPii(input).card).toBe('my card is [REDACTED] and expires soon');
   });
 
+  it('redacts full 10-digit phone numbers embedded in strings', () => {
+    const input = { note: 'contact 9876543210 for delivery updates' };
+    expect(scrubPii(input).note).toBe('contact [REDACTED] for delivery updates');
+  });
+
+  it('leaves partial phone numbers untouched', () => {
+    const input = { note: 'last four digits are 3210' };
+    expect(scrubPii(input).note).toBe('last four digits are 3210');
+  });
+
   it('matches case-insensitively', () => {
     const input = { Password: 'x', API_KEY: 'y', 'Otp': 'z' };
     expect(scrubPii(input)).toEqual({


### PR DESCRIPTION
Closes #10844.

Summary of What Has Been Done:
Implemented the change requested in issue #10844: phone number redaction in audit log scrubPii.

Changes Made:
- phone number redaction in audit log scrubPii
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.