### PR TITLE
fix : added MulterError message sanitization and default code in errorHandler

### DIFF
--- a/backend/api/src/middleware/errorHandler.js
+++ b/backend/api/src/middleware/errorHandler.js
@@ -26,10 +26,14 @@ export function errorHandler(err, req, res, next) {
 
   if (err && err.name === 'MulterError') {
     const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+    // Multer error messages can embed the offending field name from the
+    // request; strip control characters so a hostile filename cannot inject
+    // into the JSON response body.
+    const message = String(err.message || 'Upload failed').replace(/[\x00-\x1f\x7f]/g, '');
     return res.status(status).json({
       success: false,
-      error: `File upload error: ${err.message}`,
-      code: err.code
+      error: `File upload error: ${message}`,
+      code: err.code || 'UPLOAD_ERROR'
     });
   }
 

--- a/backend/api/test/unit/errorHandler.test.js
+++ b/backend/api/test/unit/errorHandler.test.js
@@ -45,4 +45,32 @@ describe('errorHandler Middleware', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Unauthorized access' });
   });
+
+  it('sanitizes control characters from MulterError messages', () => {
+    const err = { name: 'MulterError', code: 'LIMIT_UNEXPECTED_FILE', message: 'Unexpected field "file\x1b]0;evil\x07"' };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    const next = vi.fn();
+
+    errorHandler(err, mockReq, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.error).not.toMatch(/[\x00-\x1f\x7f]/);
+    expect(body.code).toBe('LIMIT_UNEXPECTED_FILE');
+  });
+
+  it('provides a default code for MulterError without a code', () => {
+    const err = { name: 'MulterError', message: 'File upload error' };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    const next = vi.fn();
+
+    errorHandler(err, mockReq, res, next);
+    const body = res.json.mock.calls[0][0];
+    expect(body.code).toBe('UPLOAD_ERROR');
+  });
 });


### PR DESCRIPTION
Closes #10846.

Summary of What Has Been Done:
Implemented the change requested in issue #10846: MulterError message sanitization and default code in errorHandler.

Changes Made:
- MulterError message sanitization and default code in errorHandler
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.