### PR TITLE
fix(orderRoutes): remove duplicate getEscrowBookingId import so API can boot

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -186,7 +186,6 @@ import {
   recordDepositTx,
   confirmEscrowRefund,
 } from '../core/container.js';
-import { getEscrowBookingId, resolveExpectedDepositAmount, paisaToMaticWei } from '../services/escrow.js';
 import { getEscrowBookingId, resolveExpectedDepositAmount, paisaToMaticWei, submitEscrowRefund } from '../services/escrow.js';
 
 import { getRouteEstimate, getRouteGeometry, buildStraightLineGeometry } from '../services/osrm.js';
@@ -204,7 +203,6 @@ const getOrderResource = async (req) => {
 router.post('/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
   const { id } = req.params;
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
-  const { id } = req.params;
 
   const lat = parseFloat(driver_lat);
   const lng = parseFloat(driver_lng);
@@ -213,10 +211,6 @@ router.post('/:id/geofence-confirm', authenticate, requireRole(['driver']), asyn
     return res.status(400).json({ error: 'Invalid driver_lat or driver_lng' });
   }
 
-  const geofenceRadiusM = geofence_radius_m !== undefined ? parseFloat(geofence_radius_m) : undefined;
-  if (geofenceRadiusM !== undefined && (!Number.isFinite(geofenceRadiusM) || geofenceRadiusM <= 0)) {
-    return res.status(400).json({ error: 'Invalid geofence_radius_m' });
-  if (!id || !id.trim()) {
   if (!req.params.id || !req.params.id.trim()) {
     return res.status(400).json({ error: 'Invalid order id' });
   }


### PR DESCRIPTION
## Problem

`backend/api/src/routes/orderRoutes.js` declares a duplicate named import of `getEscrowBookingId` (lines 189-190), so the module fails to parse and the entire API cannot boot. `backend/api/src/index.js:47` imports `orderRoutes`, so ESM evaluation aborts the whole server startup.

## Fix

- Removed the duplicate `getEscrowBookingId` import, keeping a single declaration that also includes `submitEscrowRefund` (which was only present on the duplicate line and is used at line 694).
- While verifying the fix, `node --check` surfaced additional pre-existing duplicate declarations in the same file that also blocked parsing: a duplicate `const { id } = req.params` in the `/:id/geofence-confirm` handler and mangled merge-leftover lines (interleaved duplicate `geofenceRadiusM` validation blocks). These were removed so the file actually parses and the API can boot.

## Files changed

- `backend/api/src/routes/orderRoutes.js`

## Testing

- `node --check backend/api/src/routes/orderRoutes.js` now passes (previously failed with `SyntaxError: Identifier 'getEscrowBookingId' has already been declared`).

Closes #10947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geofence confirmation validation for more reliable handling of order IDs and optional radius values.
  * Added support for submitting escrow refunds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->