### PR TITLE
fix : added request id in fraud review queue entries

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -46,10 +46,11 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
       });
 
       if (risk && risk.riskScore > RISK_REVIEW_THRESHOLD) {
-        // Flag for review
+        // Flag for review. The reason carries the request id so review
+        // entries can be traced back to a specific request in the logs.
         await fraudDetection.addToReviewQueue(
           userId,
-          `Suspicious activity on ${req.path}`,
+          `Suspicious activity on ${req.path} (requestId: ${req.requestId || req.id || 'unknown'})`,
           risk.riskScore
         );
 
@@ -70,7 +71,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
 
     next();
   } catch (error) {
-    logger.error('Fraud middleware error — failing closed:', error);
+    logger.error({ requestId: req.requestId, err: error }, 'Fraud middleware error — failing closed');
     return res.status(503).json({
       error: 'Fraud detection service is temporarily unavailable. Please retry.',
     });

--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -87,6 +87,18 @@ describe('fraudMiddleware', () => {
       expect(res.status).toHaveBeenCalledWith(403);
       expect(next).not.toHaveBeenCalled();
     });
+
+    it('includes the request id in the review queue reason', async () => {
+      fraudMock.getRealTimeRisk.mockResolvedValue({ riskScore: 0.8, riskLevel: 'HIGH' });
+      const { req, res, next } = makeReqRes({ requestId: 'fraud-req-42' });
+      await fraudDetectionMiddleware(req, res, next);
+      expect(fraudMock.addToReviewQueue).toHaveBeenCalledWith(
+        'u1',
+        expect.stringContaining('fraud-req-42'),
+        0.8
+      );
+      expect(next).toHaveBeenCalled();
+    });
   });
 
   describe('networkAnalysisMiddleware', () => {


### PR DESCRIPTION
Closes #10848.

Summary of What Has Been Done:
Implemented the change requested in issue #10848: request id in fraud review queue entries.

Changes Made:
- request id in fraud review queue entries
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.