### PR TITLE
fix(k8s): provision WIM_SIGNING_SECRET so api-deployment can boot

### DIFF
--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -15,6 +15,7 @@ data:
   SUPABASE_SERVICE_ROLE_KEY: <base64-encoded-supabase-service-role-key>
   WEBHOOK_SECRET: <base64-encoded-webhook-secret>
   JWT_SECRET: <base64-encoded-jwt-secret>
+  WIM_SIGNING_SECRET: <base64-encoded-wim-signing-secret-at-least-32-chars>
   SHARD_PASSWORD_NORTH: <base64-encoded-shard-password-north>
   SHARD_PASSWORD_SOUTH: <base64-encoded-shard-password-south>
   SHARD_PASSWORD_EAST: <base64-encoded-shard-password-east>


### PR DESCRIPTION
## Problem

The WIM signed-bypass feature requires `WIM_SIGNING_SECRET` at API startup (`backend/api/src/index.js:253` calls `validateWimConfig()`, and `backend/api/src/config/wim.js` fails closed when the secret is missing or shorter than 32 chars). The Kubernetes manifests never provisioned the key, so the production `api-deployment` container exited during boot validation and the API could not start.

## Fix

- Added `WIM_SIGNING_SECRET` to `k8s/secrets.yaml` (placeholder base64 entry, matching the other secret keys in the file).
- `k8s/deployements/api-deployement.yaml` already injects every key from the `truxify-secrets` Secret via `envFrom: secretRef: truxify-secrets`, so the new key is automatically available to the API container; no deployment edit was required.

## Files changed

- `k8s/secrets.yaml`

## Testing

- YAML structure verified; the added key follows the exact format of the existing secret entries.
- The deployment's `envFrom secretRef` guarantees `WIM_SIGNING_SECRET` is present in the container env, satisfying `validateWimConfig()`'s fail-closed requirement.

Closes #10948
