### PR TITLE
fix(security): register admin:view-metrics policy for KEDA metric endpoints

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -108,6 +108,7 @@ const POLICIES = {
   'admin:view-dashboard':      { roles: [ROLES.ADMIN] },
   'admin:invalidate-cache':    { roles: [ROLES.ADMIN] },
   'admin:view-audit-logs':     { roles: [ROLES.ADMIN] },
+  'admin:view-metrics':        { roles: [ROLES.ADMIN] },
 
   'shard:view':                { roles: [ROLES.ADMIN] },
   'shard:query-orders':        { roles: [ROLES.ADMIN] },


### PR DESCRIPTION
## Problem

`backend/api/src/routes/kedaRoutes.js` applies `requirePolicy('admin:view-metrics')` to its router, but no such action exists in the `POLICIES` map in `backend/api/src/security/policyEngine.js`. As a result, `PolicyEngine.authorize()` threw `PolicyError(403, 'Unknown action: admin:view-metrics')` for every request — including admins — so all KEDA metric endpoints permanently returned 403 and the KEDA HTTP-add-on scalers could never receive a 200.

## Fix

- Added the missing `admin:view-metrics` policy to `POLICIES` in `backend/api/src/security/policyEngine.js`, restricted to the `admin` role, alongside the other `admin:*` policies.

## Files changed

- `backend/api/src/security/policyEngine.js`

## Testing

- `node --check backend/api/src/security/policyEngine.js` passes.
- The policy now resolves for admin users; `requirePolicy('admin:view-metrics')` on KEDA routes no longer throws `Unknown action`.

Closes #10949
