### PR TITLE
fix(mev): require authentication on all MEV routes and derive userId server-side

### DIFF
--- a/backend/mev/routes.js
+++ b/backend/mev/routes.js
@@ -1,20 +1,47 @@
 import express from 'express';
+import { z } from 'zod';
 import mevService from './mev.service.js';
 import logger from '../api/src/middleware/logger.js';
+import { authenticate } from '../api/src/middleware/auth.js';
+import { validateBody, validateParams } from '../api/src/middleware/validate.js';
 
 const router = express.Router();
 
+const createCommitmentSchema = z.object({
+    secret: z.string().min(1, 'secret is required')
+});
+
+const createEscrowSchema = z.object({
+    driver: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'driver must be a valid Ethereum address'),
+    amount: z.union([z.string(), z.number()]).refine(
+        (value) => {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) && parsed > 0;
+        },
+        { message: 'amount must be a positive finite number' }
+    ),
+    secret: z.string().min(1, 'secret is required')
+});
+
+const releaseEscrowSchema = z.object({
+    secret: z.string().min(1, 'secret is required'),
+    proof: z.string().optional()
+});
+
+const submitFlashbotsSchema = z.object({
+    transactions: z.array(z.unknown()).min(1, 'transactions must be a non-empty array')
+});
+
+const escrowIdParamsSchema = z.object({
+    escrowId: z.string().min(1, 'escrowId is required')
+});
+
 // Create commitment
-router.post('/mev/commitment', async (req, res) => {
+router.post('/mev/commitment', authenticate, validateBody(createCommitmentSchema), async (req, res) => {
     try {
-        const { secret, userId } = req.body;
-        if (!secret) {
-            return res.status(400).json({
-                success: false,
-                error: 'secret required'
-            });
-        }
-        
+        const { secret } = req.body;
+        const userId = req.user.id;
+
         const result = await mevService.createCommitment(secret, userId);
         res.json({ success: true, data: result });
     } catch (error) {
@@ -24,16 +51,11 @@ router.post('/mev/commitment', async (req, res) => {
 });
 
 // Create MEV protected escrow
-router.post('/mev/escrow', async (req, res) => {
+router.post('/mev/escrow', authenticate, validateBody(createEscrowSchema), async (req, res) => {
     try {
-        const { driver, amount, secret, userId } = req.body;
-        if (!driver || !amount || !secret) {
-            return res.status(400).json({
-                success: false,
-                error: 'driver, amount, and secret required'
-            });
-        }
-        
+        const { driver, amount, secret } = req.body;
+        const userId = req.user.id;
+
         const result = await mevService.createEscrow(driver, amount, secret, userId);
         res.json({ success: true, data: result });
     } catch (error) {
@@ -43,17 +65,11 @@ router.post('/mev/escrow', async (req, res) => {
 });
 
 // Release escrow
-router.post('/mev/release/:escrowId', async (req, res) => {
+router.post('/mev/release/:escrowId', authenticate, validateParams(escrowIdParamsSchema), validateBody(releaseEscrowSchema), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const { secret, proof } = req.body;
-        if (!secret) {
-            return res.status(400).json({
-                success: false,
-                error: 'secret required'
-            });
-        }
-        
+
         const result = await mevService.releaseEscrow(escrowId, secret, proof);
         res.json({ success: true, data: result });
     } catch (error) {
@@ -63,17 +79,11 @@ router.post('/mev/release/:escrowId', async (req, res) => {
 });
 
 // Submit Flashbots bundle
-router.post('/mev/flashbots/:escrowId', async (req, res) => {
+router.post('/mev/flashbots/:escrowId', authenticate, validateParams(escrowIdParamsSchema), validateBody(submitFlashbotsSchema), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const { transactions } = req.body;
-        if (!transactions) {
-            return res.status(400).json({
-                success: false,
-                error: 'transactions required'
-            });
-        }
-        
+
         const result = await mevService.submitFlashbotsBundle(escrowId, transactions);
         res.json({ success: true, data: result });
     } catch (error) {
@@ -83,7 +93,7 @@ router.post('/mev/flashbots/:escrowId', async (req, res) => {
 });
 
 // Get MEV protection level
-router.get('/mev/protection/:escrowId', async (req, res) => {
+router.get('/mev/protection/:escrowId', authenticate, validateParams(escrowIdParamsSchema), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const result = await mevService.getMEVProtectionLevel(escrowId);
@@ -95,7 +105,7 @@ router.get('/mev/protection/:escrowId', async (req, res) => {
 });
 
 // Get escrow details
-router.get('/mev/escrow/:escrowId', async (req, res) => {
+router.get('/mev/escrow/:escrowId', authenticate, validateParams(escrowIdParamsSchema), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const result = await mevService.getEscrowDetails(escrowId);
@@ -107,7 +117,7 @@ router.get('/mev/escrow/:escrowId', async (req, res) => {
 });
 
 // Get MEV stats
-router.get('/mev/stats', async (req, res) => {
+router.get('/mev/stats', authenticate, async (req, res) => {
     try {
         const stats = await mevService.getMEVStats();
         res.json({ success: true, data: stats });


### PR DESCRIPTION
## Problem

The MEV router is mounted at `/api` with no authentication middleware, and its handlers fund on-chain deposits from the platform's own wallet using fully client-controlled parameters. Any anonymous caller could drain the MEV relayer/escrow wallet via `POST /api/mev/escrow` (attacker-chosen `driver` and `amount`) and release the funds with `POST /api/mev/release/:escrowId` using the attacker-supplied `secret`. Callers also controlled `userId`, so commitment records could be attributed to arbitrary users.

## Fix

- Added `authenticate` to every MEV route (`commitment`, `escrow`, `release`, `flashbots`, `protection`, `escrow details`, `stats`) so no MEV operation is reachable anonymously.
- Removed the client-supplied `userId` from the request body; the acting user is now derived server-side from `req.user.id`.
- Added `validateBody` / `validateParams` Zod schemas to every route: Ethereum-address validation for `driver`, positive finite `amount`, required `secret`, non-empty `transactions`, and required `escrowId`.
- Replaced inline manual validation with the schema middleware so the routes reject invalid or non-finite payloads with HTTP 400 before any on-chain funding can occur.

## Files changed

- `backend/mev/routes.js`

## Testing

- `node --check backend/mev/routes.js` passes.
- Unauthenticated requests to any `/api/mev/*` endpoint are now rejected by `authenticate` before reaching the handlers.
- Requests with missing/invalid `driver`, `amount`, `secret`, `transactions`, or `escrowId` are rejected by the validation middleware.

Closes #10950
