### PR TITLE
fix(mev): implement releaseEscrowPrivate via Flashbots relayer

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import axios from 'axios';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
+import { getMevRelayer } from './flashbots_relayer.js';
 
 /**
  * Derives the exact 32-byte preimage that is revealed on-chain.
@@ -190,6 +191,30 @@ class MEVService {
             signedTxs.push(signedTx);
         }
         return signedTxs;
+    }
+
+    async releaseEscrowPrivate(escrowId, preimage) {
+        try {
+            const relayer = getMevRelayer();
+            const targetBlock = (await this.provider.getBlockNumber()) + 1;
+            const bundle = await relayer.assemblePrivateBundle(
+                this.escrowAddress,
+                this.escrowABI,
+                'releaseDepositPrivate',
+                [escrowId, preimage],
+                targetBlock
+            );
+            const result = await relayer.sendPrivateBundle(bundle);
+            return {
+                success: true,
+                txHash: result.bundleHash,
+                bundleHash: result.bundleHash,
+                targetBlock: result.targetBlock
+            };
+        } catch (error) {
+            logger.error('Private bundle release failed:', error);
+            throw error;
+        }
     }
 
     // ============ MEV Protection Level ============


### PR DESCRIPTION
## Problem

`backend/mev/mev.service.js` calls `this.releaseEscrowPrivate(escrowId, preimage)` in the `MEV_PRIVATE_RELAY === 'true'` branch, but no such method existed on the `MEVService` class. Every private-relay release threw `TypeError: this.releaseEscrowPrivate is not a function`, so escrows could never be released through the private path (funds stayed locked on-chain).

## Fix

- Implemented `releaseEscrowPrivate(escrowId, preimage)` on `MEVService`, wiring in the existing `FlashbotsRelayerService` from `backend/mev/flashbots_relayer.js` (via `getMevRelayer()`):
  - Resolves the next target block from the provider.
  - Assembles a private bundle calling `releaseDepositPrivate(escrowId, preimage)` on the escrow contract.
  - Submits it with `sendPrivateBundle` and returns `{ success, txHash, bundleHash, targetBlock }` so the existing `updateEscrowStatus(escrowId, 'released', result.txHash)` call works.
- Added the `getMevRelayer` import. `flashbots_relayer.js` is importable without a relayer key, so importing the service module is safe; the relayer is only constructed lazily when the private-relay path actually runs.

## Files changed

- `backend/mev/mev.service.js`

## Testing

- `node --check backend/mev/mev.service.js` passes.
- With `MEV_PRIVATE_RELAY=true`, `releaseEscrow()` now reaches a defined method instead of throwing `TypeError`.

Closes #10951
