### PR TITLE
fix(mev): implement submitFlashbotsBundle on MEVService

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import axios from 'axios';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
+import { getMevRelayer } from './flashbots_relayer.js';
 
 /**
  * Derives the exact 32-byte preimage that is revealed on-chain.
@@ -190,6 +191,26 @@ class MEVService {
             signedTxs.push(signedTx);
         }
         return signedTxs;
+    }
+
+    async submitFlashbotsBundle(escrowId, transactions) {
+        try {
+            const relayer = getMevRelayer();
+            const targetBlock = (await this.provider.getBlockNumber()) + 1;
+            const result = await relayer.sendPrivateBundle({
+                signedBundle: transactions,
+                targetBlock
+            });
+            await this.storeBundle({
+                escrowId,
+                bundleId: result.bundleHash,
+                blockNumber: result.targetBlock
+            });
+            return result;
+        } catch (error) {
+            logger.error('Flashbots bundle submission failed:', error);
+            throw error;
+        }
     }
 
     // ============ MEV Protection Level ============


### PR DESCRIPTION
## Problem

`backend/mev/routes.js` calls `mevService.submitFlashbotsBundle(escrowId, transactions)` on `POST /mev/flashbots/:escrowId`, but the `MEVService` class in `backend/mev/mev.service.js` defined no such method. Every request to this endpoint threw `TypeError: mevService.submitFlashbotsBundle is not a function` (HTTP 500), so the Flashbots bundle-submission feature advertised by the relayer integration was not callable.

## Fix

- Implemented `submitFlashbotsBundle(escrowId, transactions)` on `MEVService`:
  - Resolves the Flashbots relayer via `getMevRelayer()` from `backend/mev/flashbots_relayer.js`.
  - Computes the next target block from the provider.
  - Submits the client-supplied signed transactions through `sendPrivateBundle`.
  - Persists the submission via the existing `storeBundle` (`flashbots_bundles` table) using the returned `bundleHash` / `targetBlock`.
- Added the `getMevRelayer` import.

## Files changed

- `backend/mev/mev.service.js`

## Testing

- `node --check backend/mev/mev.service.js` passes.
- `POST /api/mev/flashbots/:escrowId` no longer throws `TypeError`; the endpoint now reaches a defined method that submits the bundle and records it in `flashbots_bundles`.

Closes #10952
