### PR TITLE
fix(mev): construct wallet and escrow contract lazily so API can boot

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -23,9 +23,10 @@ export function toPreimageBytes32(secret) {
 
 class MEVService {
     constructor() {
-        this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
-        this.wallet = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider);
-        this.escrowAddress = process.env.MEV_ESCROW_ADDRESS;
+        this._provider = null;
+        this._wallet = null;
+        this._escrow = null;
+        this.escrowAddress = process.env.ESCROW_CONTRACT_ADDRESS || process.env.MEV_ESCROW_ADDRESS;
         
         this.escrowABI = [
             'function createProtectedDeposit(address payable driver, bytes32 secretHash) external payable returns (uint256)',
@@ -38,16 +39,42 @@ class MEVService {
             'event DepositRefunded(uint256 indexed depositId, address indexed shipper, uint256 amount)'
         ];
 
-        this.escrow = new ethers.Contract(
-            this.escrowAddress,
-            this.escrowABI,
-            this.wallet
-        );
-
         // Flashbots endpoint
         this.flashbotsEndpoint = process.env.FLASHBOTS_ENDPOINT || 'https://relay.flashbots.net';
         
         logger.info('✅ MEV Protection Service initialized');
+    }
+
+    get provider() {
+        if (!this._provider) {
+            this._provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
+        }
+        return this._provider;
+    }
+
+    get wallet() {
+        if (!this._wallet) {
+            const privateKey = process.env.RELAYER_WALLET_PRIVATE_KEY || process.env.PRIVATE_KEY;
+            if (!privateKey) {
+                throw new Error('RELAYER_WALLET_PRIVATE_KEY / PRIVATE_KEY environment variable is required for MEV operations');
+            }
+            this._wallet = new ethers.Wallet(privateKey, this.provider);
+        }
+        return this._wallet;
+    }
+
+    get escrow() {
+        if (!this._escrow) {
+            if (!this.escrowAddress) {
+                throw new Error('ESCROW_CONTRACT_ADDRESS / MEV_ESCROW_ADDRESS environment variable is required for MEV operations');
+            }
+            this._escrow = new ethers.Contract(
+                this.escrowAddress,
+                this.escrowABI,
+                this.wallet
+            );
+        }
+        return this._escrow;
     }
 
     // ============ Commitment Creation ============


### PR DESCRIPTION
## Problem

`backend/mev/mev.service.js` ends with `export default new MEVService()`, and its constructor built an `ethers.Wallet(process.env.PRIVATE_KEY, ...)` and an `ethers.Contract(process.env.MEV_ESCROW_ADDRESS, ...)` immediately at module import. When either env var was unset the import threw, and because `backend/api/src/index.js:86` imports `mevRoutes` at boot, the entire API crashed on startup. In Kubernetes neither `PRIVATE_KEY` nor `MEV_ESCROW_ADDRESS` is provisioned — the manifests only provide `RELAYER_WALLET_PRIVATE_KEY` and `ESCROW_CONTRACT_ADDRESS` — so production could never boot.

## Fix

- Refactored `MEVService` to construct the provider, wallet and escrow contract **lazily** via getters (`provider`, `wallet`, `escrow`), so importing the module no longer touches `PRIVATE_KEY` / `MEV_ESCROW_ADDRESS`. The getters fail closed with a clear error only when an on-chain MEV operation actually runs without the required config.
- Aligned the env var names with the already-provisioned k8s secrets: the wallet now reads `RELAYER_WALLET_PRIVATE_KEY || PRIVATE_KEY` and the escrow address reads `ESCROW_CONTRACT_ADDRESS || MEV_ESCROW_ADDRESS`. The production secrets that exist in `k8s/secrets.yaml` are therefore picked up without any manifest changes.

## Files changed

- `backend/mev/mev.service.js`

## Testing

- `node --check backend/mev/mev.service.js` passes.
- No `ethers.Wallet` / `ethers.Contract` construction happens at module scope or in the constructor; all construction sites are inside lazy getters, so importing the module (as `index.js` does at boot) no longer crashes when the env vars are unset.

Closes #10953
