### PR TITLE
fix : added TTL clamping in setCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -250,6 +250,11 @@ export async function setCachedProfile(
 ) {
   const redisClient = getRedisClient();
   if (!redisClient || !firebaseUid || !profile) return;
+  // Clamp the TTL the same way the Supabase setters do: a non-positive TTL
+  // would immediately expire the key, and an unbounded TTL could pin a
+  // stale (e.g. deactivated) profile in cache for a very long time.
+  if (!Number.isFinite(Number(ttlSeconds)) || ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       firebaseProfileKey(firebaseUid),

--- a/backend/api/test/unit/profileCacheTtl.test.js
+++ b/backend/api/test/unit/profileCacheTtl.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+describe('setCachedProfile TTL clamping', () => {
+  let redisMock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMock = { get: vi.fn(), set: vi.fn(), del: vi.fn() };
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({ redisClient: redisMock }));
+  });
+
+  async function load() {
+    return import('../../src/lib/profileCache.js');
+  }
+
+  it('clamps a TTL below 1 second up to 1', async () => {
+    const { setCachedProfile } = await load();
+    await setCachedProfile('fb-1', { id: 'p1' }, 0);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      expect.stringContaining('fb-1'),
+      expect.any(String),
+      'EX',
+      1,
+    );
+  });
+
+  it('clamps a TTL above 86400 down to 86400', async () => {
+    const { setCachedProfile } = await load();
+    await setCachedProfile('fb-1', { id: 'p1' }, 999999);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      expect.stringContaining('fb-1'),
+      expect.any(String),
+      'EX',
+      86400,
+    );
+  });
+
+  it('clamps a non-finite TTL to 1', async () => {
+    const { setCachedProfile } = await load();
+    await setCachedProfile('fb-1', { id: 'p1' }, NaN);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      expect.stringContaining('fb-1'),
+      expect.any(String),
+      'EX',
+      1,
+    );
+  });
+
+  it('keeps a valid TTL unchanged', async () => {
+    const { setCachedProfile } = await load();
+    await setCachedProfile('fb-1', { id: 'p1' }, 120);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      expect.stringContaining('fb-1'),
+      expect.any(String),
+      'EX',
+      120,
+    );
+  });
+});


### PR DESCRIPTION
Closes #10854.

Summary of What Has Been Done:
Implemented the change requested in issue #10854: TTL clamping in setCachedProfile.

Changes Made:
- TTL clamping in setCachedProfile
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.