### PR TITLE
fix : added non-object payload guard in getCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -218,8 +218,16 @@ export async function getCachedProfile(firebaseUid) {
   try {
     const raw = await redisClient.get(firebaseProfileKey(firebaseUid));
     if (raw) {
+      const parsed = JSON.parse(raw);
+      // A corrupted payload that parses to a non-object (e.g. "42", "null",
+      // "some string") must not be treated as a valid cached profile.
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        cacheMisses++;
+        await redisClient.del(firebaseProfileKey(firebaseUid)).catch(() => {});
+        return null;
+      }
       cacheHits++;
-      return JSON.parse(raw);
+      return parsed;
     }
     cacheMisses++;
     return null;

--- a/backend/api/test/unit/profileCacheParse.test.js
+++ b/backend/api/test/unit/profileCacheParse.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+describe('getCachedProfile payload validation', () => {
+  let redisMock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMock = { get: vi.fn(), set: vi.fn(), del: vi.fn() };
+    vi.resetModules();
+    vi.doMock('../../src/config/db.js', () => ({ redisClient: redisMock }));
+  });
+
+  async function load() {
+    return import('../../src/lib/profileCache.js');
+  }
+
+  it('returns the parsed profile for a valid JSON object payload', async () => {
+    const { getCachedProfile } = await load();
+    redisMock.get.mockResolvedValue(JSON.stringify({ id: 'p1', role: 'driver' }));
+    const result = await getCachedProfile('fb-1');
+    expect(result).toEqual({ id: 'p1', role: 'driver' });
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  it('treats a numeric JSON payload as a miss and deletes the corrupt key', async () => {
+    const { getCachedProfile } = await load();
+    redisMock.get.mockResolvedValue('42');
+    const result = await getCachedProfile('fb-1');
+    expect(result).toBeNull();
+    expect(redisMock.del).toHaveBeenCalledWith(expect.stringContaining('fb-1'));
+  });
+
+  it('treats a string JSON payload as a miss and deletes the corrupt key', async () => {
+    const { getCachedProfile } = await load();
+    redisMock.get.mockResolvedValue(JSON.stringify('not-an-object'));
+    const result = await getCachedProfile('fb-1');
+    expect(result).toBeNull();
+    expect(redisMock.del).toHaveBeenCalled();
+  });
+
+  it('treats a JSON array payload as a miss', async () => {
+    const { getCachedProfile } = await load();
+    redisMock.get.mockResolvedValue(JSON.stringify([{ id: 'p1' }]));
+    const result = await getCachedProfile('fb-1');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #10855.

Summary of What Has Been Done:
Implemented the change requested in issue #10855: non-object payload guard in getCachedProfile.

Changes Made:
- non-object payload guard in getCachedProfile
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.