### PR TITLE
fix : added square bracket wildcard escaping in escapeLike

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -1,8 +1,14 @@
 export function escapeLike(value) {
   if (value == null) return value;
   if (typeof value !== 'string') return value;
+  if (value === '') return value;
+  // Backslash must be escaped first so the escapes applied after it are not
+  // themselves unescaped by the database. `[`/`]` are wildcard brackets in
+  // some LIKE dialects (e.g. MySQL default), so escape them too.
   return value
     .replace(/\\/g, '\\\\')
     .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_');
+    .replace(/_/g, '\\_')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]');
 }

--- a/backend/api/test/unit/escapeLike.test.js
+++ b/backend/api/test/unit/escapeLike.test.js
@@ -42,4 +42,12 @@ describe('escapeLike', () => {
     const result = escapeLike('test');
     expect(typeof result).toBe('string');
   });
+
+  it('escapes square bracket wildcards', () => {
+    expect(escapeLike('a[b]c')).toBe('a\\[b\\]c');
+  });
+
+  it('escapes mixed wildcards including brackets in one pass', () => {
+    expect(escapeLike('50%_[x]')).toBe('50\\%\\_\\[x\\]');
+  });
 });


### PR DESCRIPTION
Closes #10856.

Summary of What Has Been Done:
Implemented the change requested in issue #10856: square bracket wildcard escaping in escapeLike.

Changes Made:
- square bracket wildcard escaping in escapeLike
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.