### PR TITLE
fix : added salt format validation in otpHashing

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -15,9 +15,17 @@ export function hashOtp(otp, saltHex) {
   if (otp === null || otp === undefined || (typeof otp === 'string' && otp.trim() === '')) {
     throw new TypeError('OTP must be a non-empty value');
   }
-  const salt = saltHex || crypto.randomBytes(16).toString('hex');
+  let salt = saltHex;
+  if (salt === undefined || salt === null) {
+    salt = crypto.randomBytes(16).toString('hex');
+  } else if (typeof salt !== 'string' || !/^[a-f0-9]{32}$/i.test(salt)) {
+    // A supplied salt must be the hex encoding of exactly 16 bytes. Anything
+    // else would either make scrypt throw a cryptic error or (worse) silently
+    // weaken the KDF with a tiny salt.
+    throw new TypeError('saltHex must be a 32-character hex string (16 bytes)');
+  }
   const key = crypto.scryptSync(String(otp), salt, 64);
-  return { hash: key.toString('hex'), salt };
+  return { hash: key.toString('hex'), salt: salt.toLowerCase() };
 }
 
 /**
@@ -34,6 +42,11 @@ export function hashOtp(otp, saltHex) {
 export function verifyOtpHash(otp, otpRecord) {
   if (!otpRecord) return false;
   if (otpRecord.otp_salt) {
+    // A malformed stored salt must fail verification cleanly (false), not
+    // throw from scrypt.
+    if (typeof otpRecord.otp_salt !== 'string' || !/^[a-f0-9]{32}$/i.test(otpRecord.otp_salt)) {
+      return false;
+    }
     const { hash: submittedHash } = hashOtp(otp, otpRecord.otp_salt);
     const expected = String(otpRecord.otp_hash || '');
     if (!/^[a-f0-9]{128}$/.test(expected)) return false;

--- a/backend/api/test/unit/otpHashing.test.js
+++ b/backend/api/test/unit/otpHashing.test.js
@@ -119,6 +119,18 @@ describe('otpHashing', () => {
     it('throws TypeError when OTP is only whitespace', () => {
       expect(() => hashOtp('   ')).toThrow(TypeError);
     });
+
+    it('throws TypeError when the supplied salt is not 32-char hex', () => {
+      expect(() => hashOtp('123456', 'not-hex')).toThrow(TypeError);
+      expect(() => hashOtp('123456', 'abcd')).toThrow(TypeError);
+      expect(() => hashOtp('123456', 12345)).toThrow(TypeError);
+    });
+
+    it('accepts a valid 32-char uppercase hex salt and normalizes it', () => {
+      const { hash, salt } = hashOtp('123456', 'A'.repeat(32));
+      expect(salt).toBe('a'.repeat(32));
+      expect(hash).toMatch(/^[a-f0-9]{128}$/);
+    });
   });
 
 });


### PR DESCRIPTION
Closes #10857.

Summary of What Has Been Done:
Implemented the change requested in issue #10857: salt format validation in otpHashing.

Changes Made:
- salt format validation in otpHashing
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.