### PR TITLE
fix(atomic-swap): require authentication on all swap routes

### DIFF
--- a/backend/atomic-swap/routes.js
+++ b/backend/atomic-swap/routes.js
@@ -1,11 +1,12 @@
 import express from 'express';
 import swapService from './swap.service.js';
 import logger from '../api/src/middleware/logger.js';
+import { authenticate } from '../api/src/middleware/auth.js';
 
 const router = express.Router();
 
 // Create swap
-router.post('/swap/create', async (req, res) => {
+router.post('/swap/create', authenticate, async (req, res) => {
     try {
         const { counterparty, tokenAddress, amount, secret } = req.body;
         if (!counterparty || !amount) {
@@ -29,7 +30,7 @@ router.post('/swap/create', async (req, res) => {
 });
 
 // Execute swap
-router.post('/swap/execute', async (req, res) => {
+router.post('/swap/execute', authenticate, async (req, res) => {
     try {
         const { swapId, secret } = req.body;
         if (!swapId || !secret) {
@@ -48,7 +49,7 @@ router.post('/swap/execute', async (req, res) => {
 });
 
 // Refund swap
-router.post('/swap/refund', async (req, res) => {
+router.post('/swap/refund', authenticate, async (req, res) => {
     try {
         const { swapId } = req.body;
         if (!swapId) {
@@ -67,7 +68,7 @@ router.post('/swap/refund', async (req, res) => {
 });
 
 // Create cross-chain swap
-router.post('/swap/cross-chain/create', async (req, res) => {
+router.post('/swap/cross-chain/create', authenticate, async (req, res) => {
     try {
         const { destChainId, counterparty, tokenAddress, amount, secret } = req.body;
         if (!destChainId || !counterparty || !amount) {
@@ -92,7 +93,7 @@ router.post('/swap/cross-chain/create', async (req, res) => {
 });
 
 // Execute cross-chain swap
-router.post('/swap/cross-chain/execute', async (req, res) => {
+router.post('/swap/cross-chain/execute', authenticate, async (req, res) => {
     try {
         const { swapId, secret, proof } = req.body;
         if (!swapId || !secret || !proof) {
@@ -111,7 +112,7 @@ router.post('/swap/cross-chain/execute', async (req, res) => {
 });
 
 // Refund cross-chain swap
-router.post('/swap/cross-chain/refund', async (req, res) => {
+router.post('/swap/cross-chain/refund', authenticate, async (req, res) => {
     try {
         const { swapId } = req.body;
         if (!swapId) {
@@ -130,7 +131,7 @@ router.post('/swap/cross-chain/refund', async (req, res) => {
 });
 
 // Get stats
-router.get('/swap/stats', async (req, res) => {
+router.get('/swap/stats', authenticate, async (req, res) => {
     try {
         const stats = await swapService.getSwapStats();
         res.json({ success: true, data: stats });
@@ -141,7 +142,7 @@ router.get('/swap/stats', async (req, res) => {
 });
 
 // Get swap
-router.get('/swap/:swapId', async (req, res) => {
+router.get('/swap/:swapId', authenticate, async (req, res) => {
     try {
         const { swapId } = req.params;
         const swap = await swapService.getSwap(swapId);
@@ -153,7 +154,7 @@ router.get('/swap/:swapId', async (req, res) => {
 });
 
 // Get cross-chain swap
-router.get('/swap/cross-chain/:swapId', async (req, res) => {
+router.get('/swap/cross-chain/:swapId', authenticate, async (req, res) => {
     try {
         const { swapId } = req.params;
         const swap = await swapService.getCrossChainSwap(swapId);


### PR DESCRIPTION
## Problem

The atomic-swap router is mounted at `/api` with no authentication, exposing HTLC swap creation/execution/refund (including cross-chain variants) — a fund-moving surface operating on the platform's hot-wallet — to anonymous callers.

## Fix

- Added the `authenticate` middleware to every atomic-swap route:
  - `POST /swap/create`
  - `POST /swap/execute`
  - `POST /swap/refund`
  - `POST /swap/cross-chain/create`
  - `POST /swap/cross-chain/execute`
  - `POST /swap/cross-chain/refund`
  - `GET /swap/stats`
  - `GET /swap/:swapId`
  - `GET /swap/cross-chain/:swapId`
- Auth is applied per-route so later-mounted public routers (e.g. webhooks) are unaffected.

## Files changed

- `backend/atomic-swap/routes.js`

## Testing

- `node --check backend/atomic-swap/routes.js` passes.
- Unauthenticated requests to any `/api/swap/*` endpoint are now rejected by `authenticate` before reaching the handlers.

Closes #10956
