### PR TITLE
fix : added invalid clock fallback in generateOrderDisplayId

### DIFF
--- a/backend/api/src/lib/orderDisplayId.js
+++ b/backend/api/src/lib/orderDisplayId.js
@@ -27,7 +27,15 @@ export const ORDER_DISPLAY_ID_MAX_RETRIES = 5;
  */
 export function generateOrderDisplayId() {
   const now = new Date();
-  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  let dateStr;
+  try {
+    dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  } catch (err) {
+    // An invalid Date (e.g. a system clock that produced an out-of-range
+    // value) makes toISOString throw; fall back to the Unix epoch day so the
+    // id format stays stable and unique per day.
+    dateStr = '19700101';
+  }
   const random = Array.from(
     { length: DISPLAY_ID_RANDOM_LENGTH },
     () => DISPLAY_ID_RANDOM_ALPHABET[crypto.randomInt(DISPLAY_ID_RANDOM_ALPHABET.length)],

--- a/backend/api/test/unit/lib/orderDisplayId.test.js
+++ b/backend/api/test/unit/lib/orderDisplayId.test.js
@@ -47,4 +47,20 @@ describe('orderDisplayId — generateOrderDisplayId', () => {
     expect(ORDER_DISPLAY_ID_MAX_RETRIES).toBeGreaterThanOrEqual(1)
     expect(Number.isInteger(ORDER_DISPLAY_ID_MAX_RETRIES)).toBe(true)
   })
+
+  it('falls back to the epoch date when the system clock is invalid', () => {
+    const RealDate = globalThis.Date
+    class BrokenDate extends RealDate {
+      toISOString() {
+        throw new RangeError('Invalid time value')
+      }
+    }
+    globalThis.Date = BrokenDate
+    try {
+      const id = generateOrderDisplayId()
+      expect(id).toMatch(/^#FF19700101[A-Z0-9]{12}$/)
+    } finally {
+      globalThis.Date = RealDate
+    }
+  })
 })


### PR DESCRIPTION
Closes #10858.

Summary of What Has Been Done:
Implemented the change requested in issue #10858: invalid clock fallback in generateOrderDisplayId.

Changes Made:
- invalid clock fallback in generateOrderDisplayId
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.