### PR TITLE
fix(dao): require authentication on all DAO routes

### DIFF
--- a/backend/dao/routes.js
+++ b/backend/dao/routes.js
@@ -1,11 +1,12 @@
 import express from 'express';
 import daoService from './dao.service.js';
 import logger from '../api/src/middleware/logger.js';
+import { authenticate } from '../api/src/middleware/auth.js';
 
 const router = express.Router();
 
 // Join DAO
-router.post('/dao/join', async (req, res) => {
+router.post('/dao/join', authenticate, async (req, res) => {
     try {
         const { userAddress } = req.body;
         if (!userAddress) {
@@ -24,7 +25,7 @@ router.post('/dao/join', async (req, res) => {
 });
 
 // Leave DAO
-router.post('/dao/leave', async (req, res) => {
+router.post('/dao/leave', authenticate, async (req, res) => {
     try {
         const { userAddress } = req.body;
         if (!userAddress) {
@@ -43,7 +44,7 @@ router.post('/dao/leave', async (req, res) => {
 });
 
 // Create proposal
-router.post('/dao/proposal/create', async (req, res) => {
+router.post('/dao/proposal/create', authenticate, async (req, res) => {
     try {
         const { title, description, callData, target, value, proposalType, proposer } = req.body;
         if (!title || !description) {
@@ -70,7 +71,7 @@ router.post('/dao/proposal/create', async (req, res) => {
 });
 
 // Cast vote
-router.post('/dao/vote/cast', async (req, res) => {
+router.post('/dao/vote/cast', authenticate, async (req, res) => {
     try {
         const { proposalId, votingPower, voterAddress } = req.body;
         if (!proposalId || !votingPower) {
@@ -89,7 +90,7 @@ router.post('/dao/vote/cast', async (req, res) => {
 });
 
 // Execute proposal
-router.post('/dao/proposal/execute', async (req, res) => {
+router.post('/dao/proposal/execute', authenticate, async (req, res) => {
     try {
         const { proposalId } = req.body;
         if (!proposalId) {
@@ -108,7 +109,7 @@ router.post('/dao/proposal/execute', async (req, res) => {
 });
 
 // Get proposal
-router.get('/dao/proposal/:proposalId', async (req, res) => {
+router.get('/dao/proposal/:proposalId', authenticate, async (req, res) => {
     try {
         const { proposalId } = req.params;
         const proposal = await daoService.getProposal(proposalId);
@@ -120,7 +121,7 @@ router.get('/dao/proposal/:proposalId', async (req, res) => {
 });
 
 // Get member
-router.get('/dao/member/:userAddress', async (req, res) => {
+router.get('/dao/member/:userAddress', authenticate, async (req, res) => {
     try {
         const { userAddress } = req.params;
         const member = await daoService.getMember(userAddress);
@@ -132,7 +133,7 @@ router.get('/dao/member/:userAddress', async (req, res) => {
 });
 
 // Get stats
-router.get('/dao/stats', async (req, res) => {
+router.get('/dao/stats', authenticate, async (req, res) => {
     try {
         const stats = await daoService.getDAOStats();
         res.json({ success: true, data: stats });


### PR DESCRIPTION
## Problem

The DAO router is mounted at `/api` with no authentication, exposing voting and proposal operations to anonymous callers: joining/leaving the DAO, creating proposals, casting votes, and executing proposals, plus proposal/member/stats reads — with no identity gate, so vote tallies and on-chain DAO actions could be manipulated anonymously.

## Fix

- Added the `authenticate` middleware to every DAO route:
  - `POST /dao/join`
  - `POST /dao/leave`
  - `POST /dao/proposal/create`
  - `POST /dao/vote/cast`
  - `POST /dao/proposal/execute`
  - `GET /dao/proposal/:proposalId`
  - `GET /dao/member/:userAddress`
  - `GET /dao/stats`
- Auth is applied per-route so later-mounted public routers (e.g. webhooks) are unaffected.

## Files changed

- `backend/dao/routes.js`

## Testing

- `node --check backend/dao/routes.js` passes.
- Unauthenticated requests to any `/api/dao/*` endpoint are now rejected by `authenticate` before reaching the handlers.

Closes #10957
