### PR TITLE
fix : added strict decimal-only coercion in sanitizePrice

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -18,6 +18,11 @@
 import logger from '../middleware/logger.js';
 
 export function sanitizePrice(value) {
+  // Reject empty/whitespace strings and hex-like strings ('0x10' -> 16) that
+  // Number() would coerce; only decimal numbers are meaningful for prices.
+  if (typeof value === 'string' && (value.trim() === '' || !/^-?\d*\.?\d+$/.test(value.trim()))) {
+    return 0;
+  }
   const num = Number(value);
   return Number.isFinite(num) && num >= 0 ? Math.round(num) : 0;
 }

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -34,6 +34,16 @@ describe('Pricing Service Unit Tests', () => {
       expect(sanitizePrice(undefined)).toBe(0);
       expect(sanitizePrice('invalid')).toBe(0);
     });
+
+    it('rejects hex-like strings that Number() would coerce', () => {
+      expect(sanitizePrice('0x10')).toBe(0);
+      expect(sanitizePrice('0b101')).toBe(0);
+    });
+
+    it('rejects empty and whitespace-only strings', () => {
+      expect(sanitizePrice('')).toBe(0);
+      expect(sanitizePrice('   ')).toBe(0);
+    });
   });
 
   describe('haversineKm', () => {


### PR DESCRIPTION
Closes #10860.

Summary of What Has Been Done:
Implemented the change requested in issue #10860: strict decimal-only coercion in sanitizePrice.

Changes Made:
- strict decimal-only coercion in sanitizePrice
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.