### PR TITLE
fix(zkid): require authentication on all zkID routes

### DIFF
--- a/backend/zkid/routes.js
+++ b/backend/zkid/routes.js
@@ -1,11 +1,12 @@
 import express from 'express';
 import zkidService from './zkid.service.js';
 import logger from '../api/src/middleware/logger.js';
+import { authenticate } from '../api/src/middleware/auth.js';
 
 const router = express.Router();
 
 // Create identity
-router.post('/zkid/identity/create', async (req, res) => {
+router.post('/zkid/identity/create', authenticate, async (req, res) => {
     try {
         const { userAddress } = req.body;
         if (!userAddress) {
@@ -24,7 +25,7 @@ router.post('/zkid/identity/create', async (req, res) => {
 });
 
 // Issue credential
-router.post('/zkid/credential/issue', async (req, res) => {
+router.post('/zkid/credential/issue', authenticate, async (req, res) => {
     try {
         const { identityHash, credentialType, schemaHash } = req.body;
         if (!identityHash || !credentialType) {
@@ -43,7 +44,7 @@ router.post('/zkid/credential/issue', async (req, res) => {
 });
 
 // Verify credential
-router.get('/zkid/credential/verify/:credentialHash', async (req, res) => {
+router.get('/zkid/credential/verify/:credentialHash', authenticate, async (req, res) => {
     try {
         const { credentialHash } = req.params;
         const result = await zkidService.verifyCredential(credentialHash);
@@ -55,7 +56,7 @@ router.get('/zkid/credential/verify/:credentialHash', async (req, res) => {
 });
 
 // Revoke credential
-router.post('/zkid/credential/revoke', async (req, res) => {
+router.post('/zkid/credential/revoke', authenticate, async (req, res) => {
     try {
         const { credentialHash } = req.body;
         if (!credentialHash) {
@@ -74,7 +75,7 @@ router.post('/zkid/credential/revoke', async (req, res) => {
 });
 
 // Request verification
-router.post('/zkid/verification/request', async (req, res) => {
+router.post('/zkid/verification/request', authenticate, async (req, res) => {
     try {
         const { identityHash, credentialHash, proofData } = req.body;
         if (!identityHash || !credentialHash) {
@@ -93,7 +94,7 @@ router.post('/zkid/verification/request', async (req, res) => {
 });
 
 // Create selective disclosure
-router.post('/zkid/disclosure/create', async (req, res) => {
+router.post('/zkid/disclosure/create', authenticate, async (req, res) => {
     try {
         const { identityHash, disclosedAttributes, recipient } = req.body;
         if (!identityHash || !disclosedAttributes || !recipient) {
@@ -116,7 +117,7 @@ router.post('/zkid/disclosure/create', async (req, res) => {
 });
 
 // Revoke selective disclosure
-router.post('/zkid/disclosure/revoke', async (req, res) => {
+router.post('/zkid/disclosure/revoke', authenticate, async (req, res) => {
     try {
         const { disclosureId } = req.body;
         if (!disclosureId) {
@@ -135,7 +136,7 @@ router.post('/zkid/disclosure/revoke', async (req, res) => {
 });
 
 // Get identity
-router.get('/zkid/identity/:identityHash', async (req, res) => {
+router.get('/zkid/identity/:identityHash', authenticate, async (req, res) => {
     try {
         const { identityHash } = req.params;
         const identity = await zkidService.getIdentity(identityHash);
@@ -147,7 +148,7 @@ router.get('/zkid/identity/:identityHash', async (req, res) => {
 });
 
 // Get stats
-router.get('/zkid/stats', async (req, res) => {
+router.get('/zkid/stats', authenticate, async (req, res) => {
     try {
         const stats = await zkidService.getZKIDStats();
         res.json({ success: true, data: stats });


### PR DESCRIPTION
## Problem

The zkID router is mounted at `/api` with no authentication, exposing an identity-authority surface to anonymous callers: creating identities, issuing and revoking credentials, creating disclosures and verification requests, and reading identity records — all without any identity gate.

## Fix

- Added the `authenticate` middleware to every zkID route:
  - `POST /zkid/identity/create`
  - `POST /zkid/credential/issue`
  - `GET /zkid/credential/verify/:credentialHash`
  - `POST /zkid/credential/revoke`
  - `POST /zkid/verification/request`
  - `POST /zkid/disclosure/create`
  - `POST /zkid/disclosure/revoke`
  - `GET /zkid/identity/:identityHash`
  - `GET /zkid/stats`
- Auth is applied per-route so later-mounted public routers (e.g. webhooks) are unaffected.

## Files changed

- `backend/zkid/routes.js`

## Testing

- `node --check backend/zkid/routes.js` passes.
- Unauthenticated requests to any `/api/zkid/*` endpoint are now rejected by `authenticate` before reaching the handlers.

Closes #10958
