### PR TITLE
fix(verification): derive digilocker verify subject from authenticated user (IDOR)

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -165,10 +165,10 @@ router.post('/digilocker/token', digilockerLimiter, authenticate, async (req, re
 
 router.post('/digilocker/verify', digilockerLimiter, authenticate, async (req, res) => {
   try {
-    const { accessToken, userId: bodyUserId } = req.body;
-    const userId = req.user?.id || bodyUserId;
+    const { accessToken } = req.body;
+    const userId = req.user?.id;
     if (!userId) {
-      return res.status(400).json({ success: false, error: 'User ID is required' });
+      return res.status(401).json({ success: false, error: 'Not authenticated: req.user is missing.' });
     }
     if (!accessToken) {
       return res.status(400).json({ success: false, error: 'Access token is required' });


### PR DESCRIPTION
## Problem

`backend/api/src/routes/verificationRoutes.js` used a client-supplied `bodyUserId` as a fallback when resolving the DigiLocker verification subject:

```js
const userId = req.user?.id || bodyUserId;
```

When `req.user` was absent (or the fallback won), an unauthenticated or spoofed request could pass `bodyUserId` to target any user's verification flow — an IDOR on `POST /api/verify/digilocker/verify`.

## Fix

- Removed the `|| bodyUserId` fallback entirely.
- The subject is now always derived from the authenticated principal via `req.user.id`.
- When the authenticated identity is missing, the request is rejected with HTTP 401 (`Not authenticated: req.user is missing.`) instead of trusting a client-supplied user id.

## Files changed

- `backend/api/src/routes/verificationRoutes.js`

## Testing

- `node --check backend/api/src/routes/verificationRoutes.js` passes.
- A request without an authenticated `req.user` can no longer supply `bodyUserId` to select the verification subject; the handler now rejects it.

Closes #10959
