### PR TITLE
fix(driverRoutes): apply validateBody(syncWeightSchema) once

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1619,7 +1619,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;


### PR DESCRIPTION
## Problem

`backend/api/src/routes/driverRoutes.js` applied `validateBody(syncWeightSchema)` twice on the same route (once at the start of the middleware chain and again right before the handler), causing a redundant validation pass on every sync-weight request.

## Fix

- Removed the duplicated `validateBody(syncWeightSchema)` from the start of the chain, keeping a single validation after `authenticate` / `requirePolicy` / `userLimiter` (matching the ordering used across the codebase).

## Files changed

- `backend/api/src/routes/driverRoutes.js`

## Testing

- `node --check backend/api/src/routes/driverRoutes.js` passes.
- The sync-weight route now runs `validateBody(syncWeightSchema)` exactly once.

Closes #10960
