### PR TITLE
fix : added rate card numeric field validation in computeOrderPricing

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -135,6 +135,22 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
   if (!rateCard.handlingFee || rateCard.handlingFee < 0) {
     throw new RangeError(`handlingFee must be >= 0, got ${rateCard.handlingFee}`);
   }
+  // A caller-supplied rate card bypasses parsePositiveInt, so every numeric
+  // field must be validated here: a NaN/negative multiplier or percentage
+  // would otherwise silently zero out fees or flip the freight sign.
+  const numericFields = {
+    fragileMultiplier: { min: 0 },
+    stackableDiscount: { min: 0 },
+    tollPerKm: { min: 0 },
+    platformFeePct: { min: 0 },
+    fuelCostPct: { min: 0 },
+  };
+  for (const [field, { min }] of Object.entries(numericFields)) {
+    const value = rateCard[field];
+    if (!Number.isFinite(value) || value < min) {
+      throw new RangeError(`${field} must be a finite number >= ${min}, got ${value}`);
+    }
+  }
 
   const {
     pickupLat, pickupLng, dropLat, dropLng,

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -175,6 +175,17 @@ describe('Pricing Service Unit Tests', () => {
       expect(() => computeOrderPricing(input, weirdRateCard)).toThrow(RangeError);
     });
 
+    it('throws RangeError when a rate card numeric field is NaN', () => {
+      for (const field of ['tollPerKm', 'platformFeePct', 'fuelCostPct', 'stackableDiscount']) {
+        const bad = { ...mockRateCard, [field]: NaN };
+        expect(() => computeOrderPricing(defaultInput, bad)).toThrow(RangeError);
+      }
+    });
+
+    it('throws RangeError when a rate card numeric field is negative', () => {
+      const bad = { ...mockRateCard, tollPerKm: -1 };
+      expect(() => computeOrderPricing(defaultInput, bad)).toThrow(RangeError);
+    });
     it('returns 0 for NaN or negative tollFactor instead of propagating NaN', () => {
       const resNaN = computeOrderPricing({ ...defaultInput, tollFactor: NaN });
       expect(resNaN.tollEstimate).toBe(20000); // defaults to tollFactor = 1


### PR DESCRIPTION
Closes #10862.

Summary of What Has Been Done:
Implemented the change requested in issue #10862: rate card numeric field validation in computeOrderPricing.

Changes Made:
- rate card numeric field validation in computeOrderPricing
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.