### PR TITLE
fix(maintenance): align photo multer allowlist with controller

### DIFF
--- a/backend/api/src/routes/maintenancePhotoRoutes.js
+++ b/backend/api/src/routes/maintenancePhotoRoutes.js
@@ -4,15 +4,16 @@ import { uploadMaintenancePhotos } from '../controllers/maintenancePhotoControll
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
-import { ALLOWED_DOCUMENT_MIME_TYPES } from '../lib/documentValidation.js';
 
 const router = express.Router();
 
-// Photos only — the controller re-checks the actual bytes, but rejecting on
-// the declared type here avoids buffering 8MB of non-image content first.
-const ALLOWED_PHOTO_MIME_TYPES = ALLOWED_DOCUMENT_MIME_TYPES.filter(
-  (mime) => mime.startsWith('image/')
-);
+// Photos only — must match the controller's ALLOWED_PHOTO_MIME_TYPES exactly.
+// Rejecting on the declared type here avoids buffering 8MB of a file that is
+// guaranteed to be rejected (422) after upload.
+const ALLOWED_PHOTO_MIME_TYPES = Object.freeze([
+  'image/jpeg',
+  'image/png',
+]);
 
 const upload = multer({
   storage: multer.memoryStorage(),


### PR DESCRIPTION
## Problem

`backend/api/src/routes/maintenancePhotoRoutes.js` built the multer declared-type allowlist by deriving it from `ALLOWED_DOCUMENT_MIME_TYPES` via `mime.startsWith('image/')`. Any image type added to the shared document list (e.g. `image/webp`, `image/heic`) is automatically accepted by the route-level `fileFilter`, while the controller only accepts JPEG/PNG and rejects everything else with a 422 — after multer has already buffered up to 8MB per file. The two allowlists were derived from different sources and could diverge, causing up to 24MB of guaranteed-to-be-rejected content to be buffered per request.

## Fix

- Replaced the derived route-level allowlist with an explicit `ALLOWED_PHOTO_MIME_TYPES` (`image/jpeg`, `image/png`) that exactly matches the controller's list.
- Removed the now-unused `ALLOWED_DOCUMENT_MIME_TYPES` import.
- Non-accepted declared types are now rejected by `fileFilter` before any buffering.

## Files changed

- `backend/api/src/routes/maintenancePhotoRoutes.js`

## Testing

- `node --check backend/api/src/routes/maintenancePhotoRoutes.js` passes.
- The route-level `fileFilter` and the controller now accept exactly the same declared types (JPEG/PNG), so non-photo declared types are rejected before multer buffers the file.

Closes #10961
