### PR TITLE
fix : added clamped exponential backoff in osrm retries

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -20,6 +20,7 @@ const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
 const DEFAULT_TIMEOUT_MS = 1500;
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_BASE_DELAY_MS = 500;
+const MAX_RETRY_DELAY_MS = 10_000; // upper bound on a single backoff sleep
 const CACHE_TTL_SECONDS = 86400;
 const ROUTE_CACHE_TTL_SECONDS = 30;
 
@@ -39,6 +40,15 @@ export const validateCoordinates = (pickupLat, pickupLng, dropLat, dropLng) => {
 function parsePositiveNumber(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Exponential backoff delay for a retry attempt, clamped to MAX_RETRY_DELAY_MS
+ * so a misconfigured (very large) retry count or base delay cannot produce a
+ * multi-hour sleep in the request path.
+ */
+function retryDelayMs(baseDelayMs, attempt) {
+  return Math.min(baseDelayMs * Math.pow(2, attempt), MAX_RETRY_DELAY_MS);
 }
 
 function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
@@ -101,7 +111,7 @@ export async function getRouteEstimate(input = {}) {
         await response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message));
         if (response.status >= 500 && attempt < maxRetries - 1) {
           logger.warn({ status: response.status, attempt: attempt + 1, maxRetries }, 'Server error. Retrying...');
-          await new Promise(r => setTimeout(r, baseDelayMs * Math.pow(2, attempt)));
+          await new Promise(r => setTimeout(r, retryDelayMs(baseDelayMs, attempt)));
           continue;
         }
         return null;
@@ -133,7 +143,7 @@ export async function getRouteEstimate(input = {}) {
     } catch (err) {
       clearTimeout(timeout);
       if (attempt < maxRetries - 1) {
-        const delayMs = baseDelayMs * Math.pow(2, attempt);
+        const delayMs = retryDelayMs(baseDelayMs, attempt);
         if (err.code === 'EOPENBREAKER' || err.message?.includes('Breaker is open')) {
           logger.warn('[OSRM] Circuit is open. Falling back instantly.');
           return null; // Return null so caller knows to use straight-line fallback
@@ -276,6 +286,8 @@ export const __testing = {
   buildCacheKey,
   buildGeometryUrl,
   buildGeometryCacheKey,
+  retryDelayMs,
+  MAX_RETRY_DELAY_MS,
   DEFAULT_OSRM_BASE_URL,
   DEFAULT_TIMEOUT_MS,
 };

--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -23,7 +23,6 @@ import { getRouteEstimate, __testing } from '../../src/services/osrm.js';
 
 const { buildRouteUrl, buildCacheKey, DEFAULT_OSRM_BASE_URL, DEFAULT_TIMEOUT_MS } = __testing;
 
-
 describe('osrm - buildRouteUrl', () => {
   it('builds correct URL with coordinates', () => {
     const url = buildRouteUrl({
@@ -396,5 +395,21 @@ describe('osrm - getRouteEstimate edge cases', () => {
 
     // Redis get failed (invalid JSON), fetch was called as fallback
     expect(fetch).toHaveBeenCalled();
+  });
+});
+
+describe('osrm - retryDelayMs backoff clamp', () => {
+  const { retryDelayMs, MAX_RETRY_DELAY_MS } = __testing;
+
+  it('doubles the delay per attempt', () => {
+    expect(retryDelayMs(500, 0)).toBe(500);
+    expect(retryDelayMs(500, 1)).toBe(1000);
+    expect(retryDelayMs(500, 2)).toBe(2000);
+  });
+
+  it('clamps the delay at MAX_RETRY_DELAY_MS', () => {
+    expect(retryDelayMs(500, 10)).toBe(MAX_RETRY_DELAY_MS);
+    expect(retryDelayMs(10000, 3)).toBe(MAX_RETRY_DELAY_MS);
+    expect(MAX_RETRY_DELAY_MS).toBeLessThanOrEqual(10_000);
   });
 });


### PR DESCRIPTION
Closes #10863.

Summary of What Has Been Done:
Implemented the change requested in issue #10863: clamped exponential backoff in osrm retries.

Changes Made:
- clamped exponential backoff in osrm retries
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.