### PR TITLE
fix : added reject zero-distance routes in getRouteEstimate

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -109,7 +109,10 @@ export async function getRouteEstimate(input = {}) {
 
       const payload = await response.json();
       const route = Array.isArray(payload?.routes) ? payload.routes[0] : null;
-      if (!route || !Number.isFinite(route.distance) || route.distance < 0) {
+      // A zero distance means the API returned no real path (identical
+      // coordinates or an empty route); treat it as invalid so callers fall
+      // back to straight-line geometry instead of caching a useless estimate.
+      if (!route || !Number.isFinite(route.distance) || route.distance <= 0) {
         clearTimeout(timeout);
         return null;
       }

--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -154,6 +154,19 @@ describe('osrm - getRouteEstimate', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null when route distance is zero', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ routes: [{ distance: 0, duration: 0 }] }),
+    });
+
+    const result = await getRouteEstimate({
+      pickupLat: 12.9, pickupLng: 77.5, dropLat: 13.0, dropLng: 80.2,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it('returns distanceKm and durationSeconds on valid response', async () => {
     fetch.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
Closes #10864.

Summary of What Has Been Done:
Implemented the change requested in issue #10864: reject zero-distance routes in getRouteEstimate.

Changes Made:
- reject zero-distance routes in getRouteEstimate
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.