### PR TITLE
fix : added strict finite coordinate validation in reverseGeocode

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -18,9 +18,14 @@ function getTimeoutMs() {
  * @returns {Promise<string|null>} Formatted location string or null if failed
  */
 export async function reverseGeocode(lat, lon) {
-  if (lat == null || lon == null || Number.isNaN(Number(lat)) || Number.isNaN(Number(lon))) return null;
+  if (lat == null || lon == null) return null;
   const numLat = Number(lat);
   const numLon = Number(lon);
+  // Reject NaN/Infinity and hex-like strings ('0x10' -> 16) that Number()
+  // would otherwise coerce into a bogus coordinate.
+  if (!Number.isFinite(numLat) || !Number.isFinite(numLon)) return null;
+  if (typeof lat === 'string' && !/^-?\d*\.?\d+$/.test(lat.trim())) return null;
+  if (typeof lon === 'string' && !/^-?\d*\.?\d+$/.test(lon.trim())) return null;
   if (numLat < -90 || numLat > 90 || numLon < -180 || numLon > 180) return null;
 
   // Round coordinates to ~100m precision (3 decimal places) to maximize cache hits

--- a/backend/api/test/unit/reverseGeocode.test.js
+++ b/backend/api/test/unit/reverseGeocode.test.js
@@ -56,6 +56,16 @@ describe('reverseGeocode', () => {
     expect(await reverseGeocode(23.0, -185.0)).toBeNull();
   });
 
+  it('returns null for Infinity coordinates', async () => {
+    expect(await reverseGeocode(Infinity, 72.5)).toBeNull();
+    expect(await reverseGeocode(23.0, -Infinity)).toBeNull();
+  });
+
+  it('returns null for hex-like string coordinates', async () => {
+    expect(await reverseGeocode('0x10', '72.5')).toBeNull();
+    expect(await reverseGeocode('23.0', '0x1A')).toBeNull();
+  });
+
   it('returns cached value from Redis when available', async () => {
     mockRedisGet.mockResolvedValue('MG Road, Mumbai');
     const result = await reverseGeocode(19.076, 72.8777);


### PR DESCRIPTION
Closes #10866.

Summary of What Has Been Done:
Implemented the change requested in issue #10866: strict finite coordinate validation in reverseGeocode.

Changes Made:
- strict finite coordinate validation in reverseGeocode
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.