### PR TITLE
fix : added malformed Retry-After guard in reverseGeocode

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -51,7 +51,13 @@ export async function reverseGeocode(lat, lon) {
     // Handle rate-limiting with Retry-After support
     if (response.status === 429) {
       const retryAfter = response.headers.get('Retry-After');
-      const waitMs = retryAfter ? Math.min(parseInt(retryAfter, 10) * 1000, 60000) : 60000;
+      const parsedRetry = Number.parseInt(retryAfter, 10);
+      // Guard against a malformed Retry-After header: NaN would make the
+      // wait NaN and setTimeout fire immediately (no backoff at all).
+      const retrySeconds = Number.isFinite(parsedRetry) && parsedRetry > 0
+        ? parsedRetry
+        : 60;
+      const waitMs = Math.min(retrySeconds * 1000, 60000);
       logger.warn({ waitMs, lat: roundedLat, lon: roundedLon }, '[ReverseGeocode] Rate-limited, retrying after Retry-After delay');
       await new Promise((resolve) => setTimeout(resolve, waitMs));
       response = await fetch(url, {

--- a/backend/api/test/unit/reverseGeocode.test.js
+++ b/backend/api/test/unit/reverseGeocode.test.js
@@ -91,6 +91,27 @@ describe('reverseGeocode', () => {
     expect(result).toBeNull();
   });
 
+  it('retries after the Retry-After delay on a 429 response', async () => {
+    mockRedisGet.mockResolvedValue(null);
+    // First call: 429 with a 1-second Retry-After. Second call succeeds.
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: { get: () => '1' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          address: { road: 'MG Road', city: 'Mumbai' },
+        }),
+      });
+
+    const result = await reverseGeocode(19.076, 72.8777);
+    expect(result).toBe('MG Road, Mumbai');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('rounds coordinates to 3 decimal places for cache key', async () => {
     mockRedisGet.mockResolvedValue(null);
     mockFetch.mockResolvedValue({


### PR DESCRIPTION
Closes #10867.

Summary of What Has Been Done:
Implemented the change requested in issue #10867: malformed Retry-After guard in reverseGeocode.

Changes Made:
- malformed Retry-After guard in reverseGeocode
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.