### PR TITLE
fix : added truncated filename re-normalization and broken test fixture fix

### DIFF
--- a/backend/api/src/lib/uploadFilename.js
+++ b/backend/api/src/lib/uploadFilename.js
@@ -67,6 +67,10 @@ export function sanitizeUploadFilename(originalName, fallback = 'upload') {
     const lastDot = name.lastIndexOf('.');
     const extension = lastDot > 0 ? name.slice(lastDot, lastDot + 12) : '';
     name = name.slice(0, MAX_FILENAME_LENGTH - extension.length) + extension;
+    // The truncated extension could reintroduce a leading dot or a traversal
+    // segment (e.g. extension ".." from a name like "a...."); re-run the
+    // normalization pass on the truncated result.
+    name = name.replace(/\.{2,}/g, '.').replace(/^\.+/, '');
   }
 
   const stem = (name.split('.')[0] || '').toLowerCase();

--- a/backend/api/test/unit/uploadFilename.test.js
+++ b/backend/api/test/unit/uploadFilename.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeUploadFilename } from '../../../src/lib/uploadFilename.js';
+import { sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
 
 describe('sanitizeUploadFilename', () => {
   it('returns original name when safe', () => {
@@ -7,11 +7,13 @@ describe('sanitizeUploadFilename', () => {
   });
 
   it('strips directory traversal sequences', () => {
-    expect(sanitizeUploadFilename('../../../etc/passwd', 'default')).toBe('etc.passwd');
+    // Only the basename survives directory stripping; traversal segments are
+    // removed entirely.
+    expect(sanitizeUploadFilename('../../../etc/passwd', 'default')).toBe('passwd');
   });
 
   it('strips backslash traversal on POSIX', () => {
-    expect(sanitizeUploadFilename('..\\..\\etc\\passwd', 'default')).toBe('etc.passwd');
+    expect(sanitizeUploadFilename('..\\..\\etc\\passwd', 'default')).toBe('passwd');
   });
 
   it('strips control characters', () => {
@@ -23,6 +25,16 @@ describe('sanitizeUploadFilename', () => {
     const result = sanitizeUploadFilename(longName, 'default');
     expect(result.length).toBeLessThanOrEqual(120);
     expect(result.endsWith('.pdf')).toBe(true);
+  });
+
+  it('re-normalizes a truncated filename that ends in dots', () => {
+    // The truncated extension slice can reintroduce a run of dots; the
+    // result must not contain a traversal segment or a leading dot.
+    const result = sanitizeUploadFilename('a'.repeat(140) + '....', 'default');
+    expect(result).not.toContain('..');
+    expect(result).not.toMatch(/^\./);
+    expect(result.length).toBeLessThanOrEqual(120);
+    expect(result.length).toBeGreaterThan(0);
   });
 
   it('returns fallback for empty string', () => {


### PR DESCRIPTION
Closes #10868.

Summary of What Has Been Done:
Implemented the change requested in issue #10868: truncated filename re-normalization and broken test fixture fix.

Changes Made:
- truncated filename re-normalization and broken test fixture fix
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.