### PR TITLE
fix : added control character stripping in malwareScanner extension extraction

### DIFF
--- a/backend/api/src/lib/malwareScanner.js
+++ b/backend/api/src/lib/malwareScanner.js
@@ -56,9 +56,13 @@ function detectMimeType(buffer) {
 
 function extractExtension(filename) {
   if (!filename || typeof filename !== 'string') return '';
-  const lastDot = filename.lastIndexOf('.');
-  if (lastDot === -1 || lastDot === filename.length - 1) return '';
-  return filename.slice(lastDot + 1).toLowerCase();
+  // Strip control characters so a filename like "file.\nexe" cannot smuggle
+  // a dangerous extension past the blocklist.
+  // eslint-disable-next-line no-control-regex
+  const clean = filename.replace(/[\x00-\x1f\x7f]/g, '');
+  const lastDot = clean.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === clean.length - 1) return '';
+  return clean.slice(lastDot + 1).toLowerCase();
 }
 
 function validateFileContent(buffer, filename) {

--- a/backend/api/test/unit/malwareScanner.test.js
+++ b/backend/api/test/unit/malwareScanner.test.js
@@ -154,6 +154,23 @@ describe('malwareScanner', () => {
       connectSpy.mockRestore();
     });
 
+    it('rejects a file with a dangerous extension before contacting ClamAV', async () => {
+      const connectSpy = vi.spyOn(net, 'createConnection');
+      const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      await expect(scanDocument(buf, 'malware.exe')).rejects.toThrow(/extension "\.exe" is not allowed/);
+      expect(connectSpy).not.toHaveBeenCalled();
+      connectSpy.mockRestore();
+    });
+
+    it('rejects a dangerous extension hidden behind a control character', async () => {
+      const connectSpy = vi.spyOn(net, 'createConnection');
+      const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      // "file.\nexe" — the newline is stripped before extension extraction.
+      await expect(scanDocument(buf, 'file.\nexe')).rejects.toThrow(/extension "\.exe" is not allowed/);
+      expect(connectSpy).not.toHaveBeenCalled();
+      connectSpy.mockRestore();
+    });
+
     it('accepts a buffer exactly at the scan size limit', async () => {
       const { socket, connectHandler } = createMockSocket({ response: 'stream: OK\0' });
       connectSpy = vi.spyOn(net, 'createConnection').mockImplementation(() => {


### PR DESCRIPTION
Closes #10869.

Summary of What Has Been Done:
Implemented the change requested in issue #10869: control character stripping in malwareScanner extension extraction.

Changes Made:
- control character stripping in malwareScanner extension extraction
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-name validation to reliably detect blocked extensions, including when hidden control characters are present.
  * Executable files are rejected before malware scanning begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->