### PR TITLE
fix : added declared MIME type normalization in documentValidation

### DIFF
--- a/backend/api/src/lib/documentValidation.js
+++ b/backend/api/src/lib/documentValidation.js
@@ -60,7 +60,14 @@ export function validateDocumentBuffer(buffer, declaredMimeType) {
     );
   }
 
-  if (declaredMimeType && detected !== declaredMimeType) {
+  // Normalize the declared type: MIME types are case-insensitive, and an
+  // empty/whitespace-only declared type is treated as absent rather than a
+  // mismatch.
+  const declared =
+    typeof declaredMimeType === 'string'
+      ? declaredMimeType.trim().toLowerCase()
+      : '';
+  if (declared && detected !== declared) {
     throw new DocumentValidationError(
       `File content (${detected}) does not match declared type (${declaredMimeType}).`
     );

--- a/backend/api/test/unit/documentValidation.test.js
+++ b/backend/api/test/unit/documentValidation.test.js
@@ -69,4 +69,14 @@ describe('validateDocumentBuffer', () => {
   it('accepts content when no declared type is provided, based on content alone', () => {
     expect(validateDocumentBuffer(PDF_BYTES, undefined)).toBe('application/pdf');
   });
+
+  it('treats an empty-string declared type as absent', () => {
+    expect(validateDocumentBuffer(PDF_BYTES, '')).toBe('application/pdf');
+    expect(validateDocumentBuffer(PDF_BYTES, '   ')).toBe('application/pdf');
+  });
+
+  it('compares the declared type case-insensitively', () => {
+    expect(validateDocumentBuffer(JPEG_BYTES, 'IMAGE/JPEG')).toBe('image/jpeg');
+    expect(validateDocumentBuffer(PNG_BYTES, 'Image/PNG')).toBe('image/png');
+  });
 });


### PR DESCRIPTION
Closes #10871.

Summary of What Has Been Done:
Implemented the change requested in issue #10871: declared MIME type normalization in documentValidation.

Changes Made:
- declared MIME type normalization in documentValidation
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.