### PR TITLE
test : added MPEG frame sync boundary tests for audioValidation

### DIFF
--- a/backend/api/test/unit/audioValidation.test.js
+++ b/backend/api/test/unit/audioValidation.test.js
@@ -107,6 +107,13 @@ describe('detectAudioMimeType', () => {
     // ISO box length present but truncated before "ftyp".
     expect(detectAudioMimeType(Buffer.from([0x00, 0x00, 0x00, 0x20, 0x66]))).toBeNull();
   });
+
+  it('requires two bytes for an MPEG frame sync', () => {
+    // A single 0xFF byte is not long enough for the frame-sync check.
+    expect(detectAudioMimeType(Buffer.from([0xff]))).toBeNull();
+    // 0xFF followed by a byte without the 11-bit sync pattern is not MPEG.
+    expect(detectAudioMimeType(Buffer.from([0xff, 0x10]))).toBeNull();
+  });
 });
 
 describe('validateAudioBuffer', () => {


### PR DESCRIPTION
Closes #10872.

Summary of What Has Been Done:
Implemented the change requested in issue #10872: MPEG frame sync boundary tests for audioValidation.

Changes Made:
- MPEG frame sync boundary tests for audioValidation
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.