### PR TITLE
test : added whitespace-padded api key rejection test

### DIFF
--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -166,4 +166,15 @@ describe('requireApiKey', () => {
 
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it('rejects a whitespace-padded key that is not in the allow list', () => {
+    const { req, res, next } = createMocks({
+      req: { headers: { 'x-api-key': '  test-key-1  ' } },
+    });
+
+    requireApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10874.

Summary of What Has Been Done:
Implemented the change requested in issue #10874: whitespace-padded api key rejection test.

Changes Made:
- whitespace-padded api key rejection test
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.