### PR TITLE
test : added direct TLS HSTS coverage in securityHeaders

### DIFF
--- a/backend/api/test/unit/securityHeaders.test.js
+++ b/backend/api/test/unit/securityHeaders.test.js
@@ -55,6 +55,23 @@ describe('securityHeaders', () => {
     );
   });
 
+  it('sends HSTS for a direct secure (TLS) request', () => {
+    const headers = {};
+    const req = { secure: true, headers: {} };
+    const res = {
+      getHeader(name) {
+        return headers[String(name).toLowerCase()];
+      },
+      setHeader(name, value) {
+        headers[String(name).toLowerCase()] = value;
+      },
+    };
+    securityHeaders(req, res, () => {});
+    expect(headers['strict-transport-security']).toBe(
+      'max-age=31536000; includeSubDomains'
+    );
+  });
+
   it('preserves headers an earlier layer already set', async () => {
     const res = await request(
       createApp({


### PR DESCRIPTION
Closes #10875.

Summary of What Has Been Done:
Implemented the change requested in issue #10875: direct TLS HSTS coverage in securityHeaders.

Changes Made:
- direct TLS HSTS coverage in securityHeaders
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.