### PR TITLE
test : added mixed scalar and array query param handling in hppProtection

### DIFF
--- a/backend/api/test/unit/hppProtection.test.js
+++ b/backend/api/test/unit/hppProtection.test.js
@@ -96,4 +96,20 @@ describe('hppProtection', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(logger.warn).not.toHaveBeenCalled();
   });
+
+  it('handles a mix of scalar and array params in one request', () => {
+    const req = makeReq({ page: '1', ids: ['a', 'b'], limit: '10' });
+    const res = makeRes();
+    const next = vi.fn();
+    hppProtection(req, res, next);
+    expect(req.query.page).toBe('1');
+    expect(req.query.limit).toBe('10');
+    expect(req.query.ids).toBe('a');
+    expect(Array.isArray(req.query.ids)).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ duplicateParams: ['ids'] }),
+      'Potential HTTP Parameter Pollution detected'
+    );
+    expect(next).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
Closes #10879.

Summary of What Has Been Done:
Implemented the change requested in issue #10879: mixed scalar and array query param handling in hppProtection.

Changes Made:
- mixed scalar and array query param handling in hppProtection
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.