### PR TITLE
test : added non-object body passthrough in i18n error translation

### DIFF
--- a/backend/api/test/unit/i18n.test.js
+++ b/backend/api/test/unit/i18n.test.js
@@ -144,4 +144,15 @@ describe('i18n - errorTranslationInterceptor', () => {
     wrappedJson(body2);
     expect(body2.error).toBe('Translated');
   });
+
+  it('passes a non-object body through unchanged', () => {
+    mockReq.t = vi.fn();
+    capturedOriginalJson.mockReturnValue(mockRes);
+    errorTranslationInterceptor(mockReq, mockRes, mockNext);
+    const wrappedJson = mockRes.json;
+    const arr = ['a', 'b'];
+    wrappedJson(arr);
+    expect(arr).toEqual(['a', 'b']);
+    expect(mockReq.t).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10880.

Summary of What Has Been Done:
Implemented the change requested in issue #10880: non-object body passthrough in i18n error translation.

Changes Made:
- non-object body passthrough in i18n error translation
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.