### PR TITLE
fix : handle array x-api-key header in requireApiKey middleware

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,7 +8,10 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const rawApiKey = req.headers['x-api-key'] || req.query.api_key;
+  // A repeated x-api-key header arrives as an array; coerce to a single
+  // string (first occurrence) before comparing against the valid keys.
+  const apiKey = Array.isArray(rawApiKey) ? rawApiKey[0] : rawApiKey;
   
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);

--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -166,4 +166,26 @@ describe('requireApiKey', () => {
 
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it('returns 401 when repeated x-api-key header is an array of invalid keys', () => {
+    const { req, res, next } = createMocks({
+      req: { headers: { 'x-api-key': ['bad-key-1', 'bad-key-2'] } },
+    });
+
+    requireApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid key when repeated x-api-key header is an array', () => {
+    const { req, res, next } = createMocks({
+      req: { headers: { 'x-api-key': ['test-key-1', 'test-key-2'] } },
+    });
+
+    requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

`req.headers['x-api-key']` can be an array when the header is sent more than once. Comparing that array directly against `validKeys` rejects even a valid key, so the backend-to-backend auth gate can fail spuriously.

## Fix

Coerce a repeated `x-api-key` header array to a single string (first occurrence) before comparing against `VALID_API_KEYS`. A non-array value is passed through unchanged.

## Files changed

- `backend/api/src/middleware/apiKey.js`
- `backend/api/test/unit/apiKey.test.js`

## Testing

`npx vitest run test/unit/apiKey.test.js` — 11 tests pass, including new cases for an invalid array header (401) and a valid first element in an array header (calls `next()`).

Closes #10824
