### PR TITLE
test : added unsafe inbound request id rejection tests

### DIFF
--- a/backend/api/test/unit/requestId.test.js
+++ b/backend/api/test/unit/requestId.test.js
@@ -57,6 +57,24 @@ describe('requestIdMiddleware', () => {
     requestIdMiddleware(req2, makeRes(), vi.fn());
     expect(req1.requestId).not.toBe(req2.requestId);
   });
+
+  it('ignores an inbound id with unsafe characters', () => {
+    const req = makeReq({ headers: { 'x-request-id': 'bad id with spaces!' } });
+    const res = makeRes();
+    requestIdMiddleware(req, res, vi.fn());
+    expect(req.requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('ignores an inbound id that exceeds the length limit', () => {
+    const req = makeReq({ headers: { 'x-request-id': 'a'.repeat(65) } });
+    const res = makeRes();
+    requestIdMiddleware(req, res, vi.fn());
+    expect(req.requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
 });
 
 describe('requestLogger', () => {


### PR DESCRIPTION
Closes #10881.

Summary of What Has Been Done:
Implemented the change requested in issue #10881: unsafe inbound request id rejection tests.

Changes Made:
- unsafe inbound request id rejection tests
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.