### PR TITLE
test : added explicit prefix and duplicate registration tests for CacheNamespace

### DIFF
--- a/backend/api/test/unit/cacheNamespace.test.js
+++ b/backend/api/test/unit/cacheNamespace.test.js
@@ -162,6 +162,22 @@ describe('CacheNamespace', () => {
       expect(entry.prefix).toBe('my_namespace');
     });
 
+    it('uses an explicit prefix when provided', () => {
+      CacheNamespace.clear();
+      const entry = CacheNamespace.register('custom_ns', { prefix: 'cache:custom' });
+      expect(entry.prefix).toBe('cache:custom');
+      expect(CacheNamespace.get('custom_ns').prefix).toBe('cache:custom');
+    });
+
+    it('returns the same entry object on duplicate registration', () => {
+      CacheNamespace.clear();
+      const first = CacheNamespace.register('dup_ns', { prefix: 'p1' });
+      const second = CacheNamespace.register('dup_ns', { prefix: 'p2' });
+      expect(second).toBe(first);
+      // The original prefix is kept; the later options are ignored.
+      expect(second.prefix).toBe('p1');
+    });
+
     it('defaultTtl defaults to 900 when not provided', () => {
       CacheNamespace.clear();
       const entry = CacheNamespace.register('ttl_test');


### PR DESCRIPTION
Closes #10886.

Summary of What Has Been Done:
Implemented the change requested in issue #10886: explicit prefix and duplicate registration tests for CacheNamespace.

Changes Made:
- explicit prefix and duplicate registration tests for CacheNamespace
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.