### PR TITLE
test : added custom prefix version subkey combination in CacheKeyBuilder

### DIFF
--- a/backend/api/test/unit/cacheKeyBuilder.test.js
+++ b/backend/api/test/unit/cacheKeyBuilder.test.js
@@ -78,6 +78,12 @@ describe('CacheKeyBuilder', () => {
       expect(key).toBe('order:v2:order-42:items');
     });
 
+    it('combines custom prefix, version, and subKey', async () => {
+      CacheNamespace.register('custom', { prefix: 'c:v2' });
+      const key = await CacheKeyBuilder.buildVersioned('custom', 'entity-1', 'sub', 5);
+      expect(key).toBe('c:v2:v5:entity-1:sub');
+    });
+
     it('defaults to v1 for unknown namespace', async () => {
       const key = await CacheKeyBuilder.buildVersioned('unknown', 'id-1');
       expect(key).toBe('unknown:v1:id-1');


### PR DESCRIPTION
Closes #10887.

Summary of What Has Been Done:
Implemented the change requested in issue #10887: custom prefix version subkey combination in CacheKeyBuilder.

Changes Made:
- custom prefix version subkey combination in CacheKeyBuilder
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.