### PR TITLE
test : added originInstanceId round-trip preservation in CacheEvent

### DIFF
--- a/backend/api/test/unit/cacheEvent.test.js
+++ b/backend/api/test/unit/cacheEvent.test.js
@@ -149,6 +149,17 @@ describe('CacheEvent', () => {
       expect(parsed.namespace).toBe(original.namespace);
       expect(parsed.entityId).toBe(original.entityId);
     });
+
+    it('preserves the originInstanceId through a round-trip', () => {
+      const original = createCacheEvent(CacheEventType.INVALIDATE_KEY, {
+        namespace: 'profile',
+        key: 'profile:user-1',
+        originInstanceId: 'instance-abc',
+      });
+      const json = serializeCacheEvent(original);
+      const parsed = JSON.parse(json);
+      expect(parsed.originInstanceId).toBe('instance-abc');
+    });
   });
 
   describe('deserializeCacheEvent', () => {


### PR DESCRIPTION
Closes #10888.

Summary of What Has Been Done:
Implemented the change requested in issue #10888: originInstanceId round-trip preservation in CacheEvent.

Changes Made:
- originInstanceId round-trip preservation in CacheEvent
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.