### PR TITLE
test : added malformed traceparent handling in TraceContext message extraction

### DIFF
--- a/backend/api/test/unit/TraceContext.test.js
+++ b/backend/api/test/unit/TraceContext.test.js
@@ -181,6 +181,13 @@ describe('TraceContext', () => {
     it('tolerates being called with no message at all', () => {
       expect(trace.getSpanContext(TraceContext.extractFromMessage())).toBeUndefined();
     });
+
+    it('ignores a malformed traceparent in message headers', () => {
+      const ctx = TraceContext.extractFromMessage({
+        headers: { traceparent: 'not-a-valid-traceparent' },
+      });
+      expect(trace.getSpanContext(ctx)).toBeUndefined();
+    });
   });
 
   describe('serialize() / deserialize()', () => {


### PR DESCRIPTION
Closes #10889.

Summary of What Has Been Done:
Implemented the change requested in issue #10889: malformed traceparent handling in TraceContext message extraction.

Changes Made:
- malformed traceparent handling in TraceContext message extraction
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.