### PR TITLE
test : added trip serialisation coverage in earningsSummaryService

### DIFF
--- a/backend/api/test/unit/earningsSummaryService.test.js
+++ b/backend/api/test/unit/earningsSummaryService.test.js
@@ -39,6 +39,37 @@ describe('earningsSummaryService', () => {
       expect(result.brokerSavingsAmount).toBe(3500); // 35% of 10000
       expect(result.brokerSavingsPercent).toBe(35);
     });
+
+    it('serialises each trip into the response shape', () => {
+      const trips = [
+        {
+          trip_display_id: 'T-1',
+          trip_date: '2026-08-10',
+          distance: '420 km',
+          total_earnings: '10000',
+          fuel_deducted: '2000',
+        },
+      ];
+      const result = buildEarningsSummary(trips, 'weekly', 'driver-1');
+      expect(result.trips).toEqual([
+        {
+          id: 'T-1',
+          date: '2026-08-10',
+          distance: '420 km',
+          gross: 10000,
+          deductions: 2000,
+          net: 8000,
+        },
+      ]);
+    });
+
+    it('coerces null earnings to zero in the trip serialisation', () => {
+      const trips = [
+        { trip_display_id: 'T-2', total_earnings: null, fuel_deducted: null },
+      ];
+      const result = buildEarningsSummary(trips, 'monthly', 'driver-1');
+      expect(result.trips[0]).toMatchObject({ gross: 0, deductions: 0, net: 0 });
+    });
   });
 
   describe('getPeriodStart', () => {


### PR DESCRIPTION
Closes #10894.

Summary of What Has Been Done:
Implemented the change requested in issue #10894: trip serialisation coverage in earningsSummaryService.

Changes Made:
- trip serialisation coverage in earningsSummaryService
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.