### PR TITLE
test : added retry backoff bounds coverage for notificationService

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -55,6 +55,10 @@ function calculateRetryBackoff(attempt) {
   return delay + Math.floor(Math.random() * 200);
 }
 
+// Exposed for unit tests; the bounds are verified so a misconfigured retry
+// count cannot produce an unbounded sleep.
+export const __testing = { calculateRetryBackoff, RETRY_MAX_DELAY };
+
 async function getUserFcmToken(userId) {
   if (!supabaseAdmin) return null;
   try {

--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -104,4 +104,22 @@ describe('notificationService', () => {
       ).resolves.toBeDefined();
     });
   });
+
+  describe('calculateRetryBackoff', () => {
+    it('grows the base delay exponentially per attempt', async () => {
+      const { __testing } = await import('../../src/services/notificationService.js');
+      const attempt0 = __testing.calculateRetryBackoff(0);
+      const attempt1 = __testing.calculateRetryBackoff(1);
+      const attempt2 = __testing.calculateRetryBackoff(2);
+      expect(attempt1).toBeGreaterThan(attempt0);
+      expect(attempt2).toBeGreaterThan(attempt1);
+    });
+
+    it('caps the delay at RETRY_MAX_DELAY plus jitter', async () => {
+      const { __testing } = await import('../../src/services/notificationService.js');
+      const delay = __testing.calculateRetryBackoff(10);
+      expect(delay).toBeLessThanOrEqual(__testing.RETRY_MAX_DELAY + 200);
+      expect(delay).toBeGreaterThanOrEqual(__testing.RETRY_MAX_DELAY);
+    });
+  });
 });


### PR DESCRIPTION
Closes #10896.

Summary of What Has Been Done:
Implemented the change requested in issue #10896: retry backoff bounds coverage for notificationService.

Changes Made:
- retry backoff bounds coverage for notificationService
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.