### PR TITLE
test : added logger and forecast time coverage in WeatherService

### DIFF
--- a/backend/api/test/unit/weatherService.test.js
+++ b/backend/api/test/unit/weatherService.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { WeatherService } from '../../src/services/weatherService.js';
 
 describe('WeatherService', () => {
@@ -48,6 +49,26 @@ describe('WeatherService', () => {
     it('treats string numeric latitude correctly', async () => {
       const result = await service.getWeatherForecast('50', 0);
       expect(result.temperature_c).toBe(-5);
+      expect(result.condition).toBe('snow');
+    });
+
+    it('returns an ISO-8601 forecast time', async () => {
+      const result = await service.getWeatherForecast(19.07, 72.87);
+      expect(new Date(result.forecast_time).toISOString()).toBe(result.forecast_time);
+    });
+
+    it('invokes the injected logger with the coordinates', async () => {
+      const debug = vi.fn();
+      const svc = new WeatherService({ logger: { debug } });
+      await svc.getWeatherForecast(19.07, 72.87);
+      expect(debug).toHaveBeenCalledWith(
+        '[WeatherService] Fetching forecast for lat: 19.07, lng: 72.87'
+      );
+    });
+
+    it('works without an injected logger', async () => {
+      const svc = new WeatherService({});
+      const result = await svc.getWeatherForecast(45, 10);
       expect(result.condition).toBe('snow');
     });
   });


### PR DESCRIPTION
Closes #10900.

Summary of What Has Been Done:
Implemented the change requested in issue #10900: logger and forecast time coverage in WeatherService.

Changes Made:
- logger and forecast time coverage in WeatherService
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.