### PR TITLE
fix(raft): add log compaction and snapshotting to consensus-raft-go

### DIFF
--- a/services/consensus-raft-go/README.md
+++ b/services/consensus-raft-go/README.md
@@ -10,6 +10,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 - **Leader Election & Heartbeats**: Nodes start as `FOLLOWER`, campaign for leadership via `RequestVote` RPCs, and keep leadership with `AppendEntries` heartbeats and term bumps (Raft paper §5).
 - **Atomic Log Replication**: Appends transactional state transition entries into an append-only WAL log and replicates them to a quorum of followers (AppendEntries + `nextIndex`/`matchIndex` tracking) before advancing `CommitIndex`. `/commit` returns success only once the entry is replicated to a quorum and committed.
 - **Quorum-Aware Health**: `/api/v1/raft/status` reports `HEALTHY_CLUSTER` only when a leader has a *live* quorum — a majority of peers that have acknowledged a recent AppendEntries round; `NO_LEADER`, `ELECTION_IN_PROGRESS`, and `UNHEALTHY_CLUSTER` are reported otherwise. `matchIndex` is never seeded optimistically after an election: it is learned only from real AppendEntries acknowledgements (Raft §5.3).
+- **Log Compaction & Snapshots**: committed-and-applied entries are periodically folded into a state-machine snapshot (per-order last command + boundary term), the in-memory log is truncated, and the snapshot is persisted atomically (`RAFT_SNAPSHOT_PATH`). Heartbeats then send only the retained delta; a follower behind the snapshot boundary catches up via the `/api/v1/raft/snapshot` RPC instead of re-receiving the full log tail.
 
 ---
 
@@ -21,6 +22,7 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 | `/api/v1/raft/commit` | `POST` | Commits an order entry. The leader first admits the request only when it has evidence of a live quorum (a majority of followers that have acknowledged at least one AppendEntries round in the current term); otherwise it fails fast with `503` before touching its local log. The leader then appends the entry, replicates it to followers via `AppendEntries`, and advances `CommitIndex` only once a quorum acknowledges it — success is returned only after the entry is committed (and the updated commit index is propagated). Non-leaders return `409` with the current `leader_id`; without quorum it returns `503`. |
 | `/api/v1/raft/vote` | `POST` | Internal Raft `RequestVote` RPC used during elections. |
 | `/api/v1/raft/append` | `POST` | Internal Raft `AppendEntries` (heartbeat) RPC used by the leader. |
+| `/api/v1/raft/snapshot` | `POST` | Internal Raft `InstallSnapshot` RPC used to catch up followers that fell behind the retained log prefix. |
 
 ---
 
@@ -37,6 +39,8 @@ This directory contains the **Go Raft Distributed Consensus Engine** designed fo
 | `RAFT_ELECTION_TIMEOUT_MAX_MS` | `1200` | Upper bound of the randomized election timeout. |
 | `RAFT_API_KEY` | — | Shared service-to-service API key required on every endpoint. When unset, authenticated requests are rejected (`503`). |
 | `RAFT_ALLOWED_COMMANDS` | `CREATED,DISPATCHED,IN_TRANSIT,DELIVERED,COMPLETED,CANCELLED` | Comma-separated allow-list of order commands accepted by `/commit`. |
+| `RAFT_COMPACTION_THRESHOLD` | `1000` | Compact the log into a snapshot once this many committed entries have accumulated since the last snapshot. |
+| `RAFT_SNAPSHOT_PATH` | *(none — in-memory)* | File path for the compacted snapshot. When set, snapshots are persisted atomically on compaction and loaded on startup; when empty, snapshots live in memory only. Point it at a persistent volume in production. |
 
 ---
 

--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -159,6 +159,12 @@ type RaftNode struct {
 	// never accepts new entries without evidence of a reachable quorum.
 	liveAck            map[string]bool
 	httpClient         *http.Client
+
+	snapshotIndex       uint64
+	snapshotTerm        uint64
+	snapshotState       map[string]string
+	snapshotPath        string
+	compactionThreshold uint64
 }
 
 // rng is a source of randomness for election timeouts.
@@ -189,16 +195,18 @@ func NewRaftNode(id string, peers []string, peerURLs []string) *RaftNode {
 		matchIndex:         make(map[string]uint64),
 		liveAck:            make(map[string]bool),
 		httpClient:         &http.Client{Timeout: 500 * time.Millisecond},
+		snapshotState:       make(map[string]string),
+		compactionThreshold: uint64(envInt("RAFT_COMPACTION_THRESHOLD", 1000)),
 	}
 }
 
 func (rn *RaftNode) lastLogIndex() uint64 {
-	return uint64(len(rn.Log))
+	return rn.snapshotIndex + uint64(len(rn.Log))
 }
 
 func (rn *RaftNode) lastLogTerm() uint64 {
 	if len(rn.Log) == 0 {
-		return 0
+		return rn.snapshotTerm
 	}
 	return rn.Log[len(rn.Log)-1].Term
 }
@@ -356,6 +364,28 @@ func (rn *RaftNode) callAppend(peerURL string, req AppendEntriesRequest) (Append
 	return resp, err
 }
 
+// callSnapshot sends an InstallSnapshot RPC to a peer.
+func (rn *RaftNode) callSnapshot(peerURL string, req InstallSnapshotRequest) (InstallSnapshotResponse, error) {
+	var resp InstallSnapshotResponse
+	body, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+	reqHTTP, err := http.NewRequest(http.MethodPost, peerURL+"/api/v1/raft/snapshot", bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	reqHTTP.Header.Set("Content-Type", "application/json")
+	reqHTTP.Header.Set("X-API-Key", string(raftAPIKey))
+	res, err := rn.httpClient.Do(reqHTTP)
+	if err != nil {
+		return resp, err
+	}
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	return resp, err
+}
+
 // sendHeartbeats replicates the leader's log to followers and advances
 // CommitIndex once a quorum acknowledges the replicated entries. Each heartbeat
 // sends AppendEntries with the entries a follower is still missing (based on
@@ -370,19 +400,34 @@ func (rn *RaftNode) sendHeartbeats() {
 	term := rn.CurrentTerm
 
 	type peerState struct {
-		url     string
-		request AppendEntriesRequest
+		url      string
+		request  AppendEntriesRequest
+		snapshot *InstallSnapshotRequest
 	}
 	states := make([]peerState, 0, len(rn.PeerURLs))
 	for _, url := range rn.PeerURLs {
 		next := rn.nextIndex[url]
 		if next == 0 {
-			next = 1
+			next = rn.snapshotIndex + 1
+		}
+		if next <= rn.snapshotIndex {
+			// The follower is behind the retained log prefix: send it the
+			// snapshot instead of re-sending the full (possibly unbounded)
+			// entry tail.
+			snap := &InstallSnapshotRequest{
+				Term:          term,
+				LeaderID:      rn.NodeID,
+				SnapshotIndex: rn.snapshotIndex,
+				SnapshotTerm:  rn.snapshotTerm,
+				State:         rn.snapshotState,
+			}
+			states = append(states, peerState{url: url, snapshot: snap})
+			continue
 		}
 		prevLogIndex := next - 1
-		prevLogTerm := uint64(0)
-		if prevLogIndex > 0 && prevLogIndex <= uint64(len(rn.Log)) {
-			prevLogTerm = rn.Log[prevLogIndex-1].Term
+		prevLogTerm := rn.snapshotTerm
+		if prevLogIndex > rn.snapshotIndex {
+			prevLogTerm = rn.Log[prevLogIndex-rn.snapshotIndex-1].Term
 		}
 		req := AppendEntriesRequest{
 			Term:         term,
@@ -391,18 +436,20 @@ func (rn *RaftNode) sendHeartbeats() {
 			PrevLogTerm:  prevLogTerm,
 			LeaderCommit: rn.CommitIndex,
 		}
-		if next <= uint64(len(rn.Log)) {
-			req.Entries = append(req.Entries, rn.Log[next-1:]...)
+		if next <= rn.lastLogIndex() {
+			req.Entries = append(req.Entries, rn.Log[next-rn.snapshotIndex-1:]...)
 		}
 		states = append(states, peerState{url: url, request: req})
 	}
 	rn.mu.Unlock()
 
 	type result struct {
-		url     string
-		request AppendEntriesRequest
-		resp    AppendEntriesResponse
-		err     error
+		url      string
+		request  AppendEntriesRequest
+		snapshot *InstallSnapshotRequest
+		resp     AppendEntriesResponse
+		snapResp InstallSnapshotResponse
+		err      error
 	}
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -410,13 +457,20 @@ func (rn *RaftNode) sendHeartbeats() {
 
 	for _, st := range states {
 		wg.Add(1)
-		go func(url string, req AppendEntriesRequest) {
+		go func(url string, req AppendEntriesRequest, snap *InstallSnapshotRequest) {
 			defer wg.Done()
+			if snap != nil {
+				resp, err := rn.callSnapshot(url, *snap)
+				mu.Lock()
+				results = append(results, result{url: url, snapshot: snap, snapResp: resp, err: err})
+				mu.Unlock()
+				return
+			}
 			resp, err := rn.callAppend(url, req)
 			mu.Lock()
 			results = append(results, result{url: url, request: req, resp: resp, err: err})
 			mu.Unlock()
-		}(st.url, st.request)
+		}(st.url, st.request, st.snapshot)
 	}
 	wg.Wait()
 
@@ -429,6 +483,21 @@ func (rn *RaftNode) sendHeartbeats() {
 
 	for _, res := range results {
 		if res.err != nil {
+			continue
+		}
+		if res.snapshot != nil {
+			if res.snapResp.Term > rn.CurrentTerm {
+				rn.stepDownLocked(res.snapResp.Term)
+				return
+			}
+			if res.snapResp.Success {
+				if res.snapshot.SnapshotIndex > rn.matchIndex[res.url] {
+					rn.matchIndex[res.url] = res.snapshot.SnapshotIndex
+				}
+				if next := res.snapshot.SnapshotIndex + 1; next > rn.nextIndex[res.url] {
+					rn.nextIndex[res.url] = next
+				}
+			}
 			continue
 		}
 		if res.resp.Term > rn.CurrentTerm {
@@ -458,6 +527,7 @@ func (rn *RaftNode) sendHeartbeats() {
 	}
 
 	rn.advanceCommitIndexLocked()
+	rn.maybeSnapshotLocked()
 }
 
 // advanceCommitIndexLocked advances CommitIndex to the highest index replicated
@@ -467,8 +537,13 @@ func (rn *RaftNode) sendHeartbeats() {
 // (Raft §5.4.2).
 func (rn *RaftNode) advanceCommitIndexLocked() {
 	last := rn.lastLogIndex()
-	for n := rn.CommitIndex + 1; n <= last; n++ {
-		if rn.Log[n-1].Term != rn.CurrentTerm {
+	// Indices at or below the snapshot boundary are compacted away.
+	start := rn.CommitIndex + 1
+	if start < rn.snapshotIndex+1 {
+		start = rn.snapshotIndex + 1
+	}
+	for n := start; n <= last; n++ {
+		if rn.logTermAtLocked(n) != rn.CurrentTerm {
 			continue
 		}
 		acked := 1 // the leader's own log always matches
@@ -566,17 +641,18 @@ func (rn *RaftNode) HandleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"node_id":      rn.NodeID,
-		"role":         rn.Role,
-		"term":         rn.CurrentTerm,
-		"voted_for":    rn.VotedFor,
-		"leader_id":    rn.LeaderID,
-		"commit_index": rn.CommitIndex,
-		"log_length":   len(rn.Log),
-		"peers":        rn.Peers,
-		"quorum":       rn.quorum(),
-		"status":       rn.clusterStatusLocked(),
-		"timestamp":    time.Now().Format(time.RFC3339),
+		"node_id":        rn.NodeID,
+		"role":           rn.Role,
+		"term":           rn.CurrentTerm,
+		"voted_for":      rn.VotedFor,
+		"leader_id":      rn.LeaderID,
+		"commit_index":   rn.CommitIndex,
+		"log_length":     len(rn.Log),
+		"snapshot_index": rn.snapshotIndex,
+		"peers":          rn.Peers,
+		"quorum":         rn.quorum(),
+		"status":         rn.clusterStatusLocked(),
+		"timestamp":      time.Now().Format(time.RFC3339),
 	})
 }
 
@@ -658,7 +734,7 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 
 		if rn.appendLogFromLeaderLocked(req) {
 			if req.LeaderCommit > rn.CommitIndex {
-				last := uint64(len(rn.Log))
+				last := rn.lastLogIndex()
 				if req.LeaderCommit < last {
 					last = req.LeaderCommit
 				}
@@ -672,6 +748,7 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 			if rn.CommitIndex > rn.LastApplied {
 				rn.LastApplied = rn.CommitIndex
 			}
+			rn.maybeSnapshotLocked()
 			resp.Success = true
 		}
 	}
@@ -685,17 +762,24 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 // appendLogFromLeaderLocked appends replicated entries after checking log
 // consistency with the previous entry.
 func (rn *RaftNode) appendLogFromLeaderLocked(req AppendEntriesRequest) bool {
-	if req.PrevLogIndex > uint64(len(rn.Log)) {
+	if req.PrevLogIndex < rn.snapshotIndex {
 		return false
 	}
-	if req.PrevLogIndex > 0 {
-		prev := rn.Log[req.PrevLogIndex-1]
+	if req.PrevLogIndex == rn.snapshotIndex {
+		if req.PrevLogTerm != rn.snapshotTerm {
+			return false
+		}
+	} else {
+		prev := rn.Log[req.PrevLogIndex-rn.snapshotIndex-1]
 		if prev.Term != req.PrevLogTerm {
 			return false
 		}
 	}
 	for i, e := range req.Entries {
-		idx := int(req.PrevLogIndex) + 1 + i
+		if e.Index <= rn.snapshotIndex {
+			continue
+		}
+		idx := int(e.Index - rn.snapshotIndex)
 		if idx <= len(rn.Log) {
 			if rn.Log[idx-1].Term != e.Term {
 				rn.Log = rn.Log[:idx-1]
@@ -895,10 +979,18 @@ func main() {
 
 	node := NewRaftNode(nodeID, peers, peerURLs)
 
+	if snapPath := os.Getenv("RAFT_SNAPSHOT_PATH"); snapPath != "" {
+		if err := node.loadSnapshot(snapPath); err != nil {
+			log.Fatalf("Fatal snapshot storage error: %v", err)
+		}
+		log.Printf("💽 node [%s] loaded snapshot from %s (index %d, term %d)", nodeID, snapPath, node.snapshotIndex, node.snapshotTerm)
+	}
+
 	http.HandleFunc("/api/v1/raft/status", node.HandleStatus)
 	http.HandleFunc("/api/v1/raft/commit", node.HandleCommitOrder)
 	http.HandleFunc("/api/v1/raft/vote", node.HandleVote)
 	http.HandleFunc("/api/v1/raft/append", node.HandleAppend)
+	http.HandleFunc("/api/v1/raft/snapshot", node.HandleSnapshot)
 
 	log.Printf("🌐 Go Raft Distributed Consensus Node [%s] starting on port %s...", nodeID, port)
 	go node.run()

--- a/services/consensus-raft-go/snapshot.go
+++ b/services/consensus-raft-go/snapshot.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// RaftSnapshot is the compacted state-machine snapshot: the last recorded
+// command per order as of Index, together with the term of the last included
+// entry. It lets a follower that falls behind the retained log prefix catch up
+// without re-receiving the whole history.
+type RaftSnapshot struct {
+	Index uint64            `json:"index"`
+	Term  uint64            `json:"term"`
+	State map[string]string `json:"state"`
+}
+
+// InstallSnapshotRequest is the Raft InstallSnapshot RPC payload.
+type InstallSnapshotRequest struct {
+	Term          uint64            `json:"term"`
+	LeaderID      string            `json:"leader_id"`
+	SnapshotIndex uint64            `json:"snapshot_index"`
+	SnapshotTerm  uint64            `json:"snapshot_term"`
+	State         map[string]string `json:"state"`
+}
+
+// InstallSnapshotResponse is the Raft InstallSnapshot RPC result.
+type InstallSnapshotResponse struct {
+	Term    uint64 `json:"term"`
+	Success bool   `json:"success"`
+}
+
+// logTermAtLocked returns the term of the entry at the given log index,
+// consulting the snapshot boundary when the index is compacted away.
+func (rn *RaftNode) logTermAtLocked(index uint64) uint64 {
+	if index <= rn.snapshotIndex {
+		return rn.snapshotTerm
+	}
+	return rn.Log[index-rn.snapshotIndex-1].Term
+}
+
+// maybeSnapshotLocked folds committed-and-applied entries into a snapshot,
+// truncates the log, and persists the snapshot when a snapshot path is
+// configured. It must be called with rn.mu held.
+func (rn *RaftNode) maybeSnapshotLocked() {
+	if rn.CommitIndex < rn.snapshotIndex+rn.compactionThreshold {
+		return
+	}
+	state := make(map[string]string, len(rn.snapshotState))
+	for k, v := range rn.snapshotState {
+		state[k] = v
+	}
+	cut := 0
+	for cut < len(rn.Log) && rn.Log[cut].Index <= rn.CommitIndex {
+		state[rn.Log[cut].OrderID] = rn.Log[cut].Command
+		cut++
+	}
+	// Capture the term of the last folded entry before the boundary moves.
+	snapshotTerm := rn.logTermAtLocked(rn.CommitIndex)
+	rn.snapshotIndex = rn.CommitIndex
+	rn.snapshotTerm = snapshotTerm
+	rn.snapshotState = state
+	rn.Log = rn.Log[cut:]
+	if rn.snapshotPath != "" {
+		if err := rn.persistSnapshotLocked(RaftSnapshot{Index: rn.snapshotIndex, Term: rn.snapshotTerm, State: state}); err != nil {
+			log.Printf("⚠️ node [%s] failed to persist snapshot at index %d: %v", rn.NodeID, rn.snapshotIndex, err)
+		}
+	}
+	log.Printf("💽 node [%s] compacted log into snapshot at index %d (term %d), retained %d entries", rn.NodeID, rn.snapshotIndex, rn.snapshotTerm, len(rn.Log))
+}
+
+// persistSnapshotLocked writes the snapshot atomically (temp file + rename).
+func (rn *RaftNode) persistSnapshotLocked(snap RaftSnapshot) error {
+	if rn.snapshotPath == "" {
+		return nil
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return err
+	}
+	tmp := rn.snapshotPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, rn.snapshotPath)
+}
+
+// loadSnapshot reads a previously persisted snapshot so recovery is bounded by
+// the snapshot plus the small retained log delta. A missing file is not an
+// error (first boot). It must be called before run() starts.
+func (rn *RaftNode) loadSnapshot(path string) error {
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+	rn.snapshotPath = path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var snap RaftSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return err
+	}
+	rn.snapshotIndex = snap.Index
+	rn.snapshotTerm = snap.Term
+	rn.snapshotState = snap.State
+	if rn.snapshotState == nil {
+		rn.snapshotState = make(map[string]string)
+	}
+	return nil
+}
+
+// HandleSnapshot implements the Raft InstallSnapshot RPC for followers that
+// fell behind the leader's retained log prefix.
+func (rn *RaftNode) HandleSnapshot(w http.ResponseWriter, r *http.Request) {
+	if !requireAuth(w, r) {
+		return
+	}
+
+	var req InstallSnapshotRequest
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+
+	rn.mu.Lock()
+	defer rn.mu.Unlock()
+
+	resp := InstallSnapshotResponse{Term: rn.CurrentTerm, Success: false}
+
+	if req.Term > rn.CurrentTerm {
+		rn.stepDownLocked(req.Term)
+	}
+
+	if req.Term == rn.CurrentTerm {
+		rn.Role = Follower
+		rn.LeaderID = req.LeaderID
+		if rn.VotedFor == "" || rn.VotedFor == req.LeaderID {
+			rn.VotedFor = req.LeaderID
+		}
+		rn.lastLeaderSeen = time.Now()
+
+		if req.SnapshotIndex >= rn.snapshotIndex {
+			if req.SnapshotIndex > rn.snapshotIndex {
+				state := make(map[string]string, len(req.State))
+				for k, v := range req.State {
+					state[k] = v
+				}
+				cut := 0
+				for cut < len(rn.Log) && rn.Log[cut].Index <= req.SnapshotIndex {
+					cut++
+				}
+				rn.Log = rn.Log[cut:]
+				rn.snapshotIndex = req.SnapshotIndex
+				rn.snapshotTerm = req.SnapshotTerm
+				rn.snapshotState = state
+				if rn.CommitIndex < req.SnapshotIndex {
+					rn.CommitIndex = req.SnapshotIndex
+					rn.LastApplied = req.SnapshotIndex
+				}
+				if rn.snapshotPath != "" {
+					if err := rn.persistSnapshotLocked(RaftSnapshot{Index: req.SnapshotIndex, Term: req.SnapshotTerm, State: state}); err != nil {
+						log.Printf("⚠️ node [%s] failed to persist received snapshot at index %d: %v", rn.NodeID, req.SnapshotIndex, err)
+					}
+				}
+			}
+			resp.Success = true
+		}
+	}
+
+	resp.Term = rn.CurrentTerm
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/services/consensus-raft-go/snapshot_test.go
+++ b/services/consensus-raft-go/snapshot_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// raftHandlersWithSnapshot wires all Raft HTTP routes including the snapshot RPC.
+func raftHandlersWithSnapshot(n *RaftNode) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/raft/status", n.HandleStatus)
+	mux.HandleFunc("/api/v1/raft/commit", n.HandleCommitOrder)
+	mux.HandleFunc("/api/v1/raft/vote", n.HandleVote)
+	mux.HandleFunc("/api/v1/raft/append", n.HandleAppend)
+	mux.HandleFunc("/api/v1/raft/snapshot", n.HandleSnapshot)
+	return mux
+}
+
+// TestCompactionTruncatesAppliedLog verifies committed-and-applied entries are
+// folded into a snapshot and the in-memory log is truncated.
+func TestCompactionTruncatesAppliedLog(t *testing.T) {
+	node := NewRaftNode("node1", nil, nil)
+	node.compactionThreshold = 2
+	now := time.Now()
+	node.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+		{Index: 3, Term: 1, Command: "IN_TRANSIT", OrderID: "ord-1", Timestamp: now},
+		{Index: 4, Term: 1, Command: "DELIVERED", OrderID: "ord-1", Timestamp: now},
+		{Index: 5, Term: 1, Command: "COMPLETED", OrderID: "ord-1", Timestamp: now},
+	}
+	node.CommitIndex = 5
+
+	node.mu.Lock()
+	node.maybeSnapshotLocked()
+	node.mu.Unlock()
+
+	if node.snapshotIndex != 5 || node.snapshotTerm != 1 {
+		t.Errorf("expected snapshot at index 5 term 1, got index %d term %d", node.snapshotIndex, node.snapshotTerm)
+	}
+	if len(node.Log) != 0 {
+		t.Errorf("expected log truncated to 0 entries, got %d", len(node.Log))
+	}
+	if node.lastLogIndex() != 5 {
+		t.Errorf("expected lastLogIndex 5, got %d", node.lastLogIndex())
+	}
+	if node.snapshotState["ord-1"] != "COMPLETED" {
+		t.Errorf("expected snapshot state COMPLETED, got %q", node.snapshotState["ord-1"])
+	}
+}
+
+// TestAdvanceCommitIndexAfterSnapshot verifies commit accounting continues
+// correctly past the snapshot boundary.
+func TestAdvanceCommitIndexAfterSnapshot(t *testing.T) {
+	node := NewRaftNode("node1", nil, nil)
+	node.Role = Leader
+	node.CurrentTerm = 2
+	node.snapshotIndex = 5
+	node.snapshotTerm = 1
+	node.snapshotState = map[string]string{"ord-1": "DELIVERED"}
+	node.Log = []LogEntry{
+		{Index: 6, Term: 2, Command: "COMPLETED", OrderID: "ord-1", Timestamp: time.Now()},
+	}
+	node.CommitIndex = 5
+
+	node.mu.Lock()
+	node.advanceCommitIndexLocked()
+	node.mu.Unlock()
+
+	if node.CommitIndex != 6 {
+		t.Errorf("expected commit_index 6 after snapshot, got %d", node.CommitIndex)
+	}
+	if node.LastApplied != 6 {
+		t.Errorf("expected last_applied 6, got %d", node.LastApplied)
+	}
+}
+
+// TestSnapshotTransferToLaggingFollower verifies a follower that fell behind the
+// retained log prefix catches up via the InstallSnapshot RPC.
+func TestSnapshotTransferToLaggingFollower(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	follower := NewRaftNode("node2", []string{"node1"}, nil)
+	now := time.Now()
+	follower.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: now},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: now},
+	}
+	server := httptest.NewServer(raftHandlersWithSnapshot(follower))
+	defer server.Close()
+
+	leader := NewRaftNode("node1", []string{"node2"}, []string{server.URL})
+	leader.snapshotIndex = 5
+	leader.snapshotTerm = 1
+	leader.snapshotState = map[string]string{"ord-1": "DELIVERED"}
+	leader.Log = []LogEntry{
+		{Index: 6, Term: 1, Command: "COMPLETED", OrderID: "ord-1", Timestamp: now},
+	}
+	leader.mu.Lock()
+	leader.Role = Leader
+	leader.LeaderID = "node1"
+	leader.CurrentTerm = 1
+	leader.nextIndex = map[string]uint64{server.URL: 1}
+	leader.matchIndex = map[string]uint64{server.URL: 0}
+	leader.mu.Unlock()
+
+	leader.sendHeartbeats()
+
+	follower.mu.Lock()
+	snapIdx := follower.snapshotIndex
+	snapTerm := follower.snapshotTerm
+	state := follower.snapshotState["ord-1"]
+	logLen := len(follower.Log)
+	follower.mu.Unlock()
+
+	if snapIdx != 5 || snapTerm != 1 {
+		t.Errorf("expected follower snapshot index 5 term 1, got %d/%d", snapIdx, snapTerm)
+	}
+	if state != "DELIVERED" {
+		t.Errorf("expected follower snapshot state DELIVERED, got %q", state)
+	}
+	if logLen != 0 {
+		t.Errorf("expected follower log truncated to 0 entries, got %d", logLen)
+	}
+
+	leader.mu.Lock()
+	match := leader.matchIndex[server.URL]
+	next := leader.nextIndex[server.URL]
+	leader.mu.Unlock()
+	if match != 5 {
+		t.Errorf("expected leader matchIndex 5 after snapshot ack, got %d", match)
+	}
+	if next != 6 {
+		t.Errorf("expected leader nextIndex 6 after snapshot ack, got %d", next)
+	}
+}
+
+// TestLeaderSendsDeltaNotFullLogAfterSnapshot verifies a follower that is up to
+// date with the snapshot boundary receives only the retained delta, not the
+// compacted prefix.
+func TestLeaderSendsDeltaNotFullLogAfterSnapshot(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	now := time.Now()
+	var mu sync.Mutex
+	var captured *AppendEntriesRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/raft/append" {
+			var req AppendEntriesRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			mu.Lock()
+			captured = &req
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(AppendEntriesResponse{Term: 1, Success: true})
+		}
+	}))
+	defer server.Close()
+
+	leader := NewRaftNode("node1", []string{"node2"}, []string{server.URL})
+	leader.snapshotIndex = 5
+	leader.snapshotTerm = 1
+	leader.snapshotState = map[string]string{"ord-1": "DELIVERED"}
+	leader.Log = []LogEntry{
+		{Index: 6, Term: 1, Command: "COMPLETED", OrderID: "ord-1", Timestamp: now},
+		{Index: 7, Term: 1, Command: "ARCHIVED", OrderID: "ord-1", Timestamp: now},
+	}
+	leader.mu.Lock()
+	leader.Role = Leader
+	leader.LeaderID = "node1"
+	leader.CurrentTerm = 1
+	leader.nextIndex = map[string]uint64{server.URL: 6}
+	leader.matchIndex = map[string]uint64{server.URL: 5}
+	leader.mu.Unlock()
+
+	leader.sendHeartbeats()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if captured == nil {
+		t.Fatal("expected an AppendEntries request to the follower")
+	}
+	if len(captured.Entries) != 2 {
+		t.Fatalf("expected only 2 delta entries, got %d", len(captured.Entries))
+	}
+	if captured.Entries[0].Index != 6 || captured.Entries[1].Index != 7 {
+		t.Errorf("expected delta entries 6 and 7, got %d and %d", captured.Entries[0].Index, captured.Entries[1].Index)
+	}
+	if captured.PrevLogIndex != 5 || captured.PrevLogTerm != 1 {
+		t.Errorf("expected PrevLogIndex 5 / PrevLogTerm 1 (snapshot boundary), got %d / %d", captured.PrevLogIndex, captured.PrevLogTerm)
+	}
+}
+
+// TestSnapshotPersistenceRoundTrip verifies a persisted snapshot is recovered on
+// startup so restart recovery is bounded by snapshot + retained delta.
+func TestSnapshotPersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+
+	n1 := NewRaftNode("node1", nil, nil)
+	n1.mu.Lock()
+	n1.snapshotPath = path
+	if err := n1.persistSnapshotLocked(RaftSnapshot{Index: 5, Term: 1, State: map[string]string{"ord-1": "COMPLETED"}}); err != nil {
+		t.Fatalf("persist snapshot: %v", err)
+	}
+	n1.mu.Unlock()
+
+	n2 := NewRaftNode("node1", nil, nil)
+	if err := n2.loadSnapshot(path); err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	n2.mu.Lock()
+	defer n2.mu.Unlock()
+	if n2.snapshotIndex != 5 || n2.snapshotTerm != 1 {
+		t.Errorf("expected snapshot index 5 term 1, got %d/%d", n2.snapshotIndex, n2.snapshotTerm)
+	}
+	if n2.snapshotState["ord-1"] != "COMPLETED" {
+		t.Errorf("expected recovered state COMPLETED, got %q", n2.snapshotState["ord-1"])
+	}
+}
+
+// TestHandleSnapshotAppliesState verifies the InstallSnapshot RPC applies the
+// compacted state, truncates the log, and advances CommitIndex.
+func TestHandleSnapshotAppliesState(t *testing.T) {
+	bypassAuth = true
+	defer func() { bypassAuth = false }()
+
+	follower := NewRaftNode("node2", nil, nil)
+	follower.Log = []LogEntry{
+		{Index: 1, Term: 1, Command: "CREATED", OrderID: "ord-1", Timestamp: time.Now()},
+		{Index: 2, Term: 1, Command: "DISPATCHED", OrderID: "ord-1", Timestamp: time.Now()},
+	}
+	body := `{"term":1,"leader_id":"node1","snapshot_index":5,"snapshot_term":1,"state":{"ord-1":"DELIVERED"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/raft/snapshot", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	follower.HandleSnapshot(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp InstallSnapshotResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatal("expected snapshot accepted")
+	}
+	follower.mu.Lock()
+	defer follower.mu.Unlock()
+	if follower.snapshotIndex != 5 {
+		t.Errorf("expected snapshot index 5, got %d", follower.snapshotIndex)
+	}
+	if follower.snapshotState["ord-1"] != "DELIVERED" {
+		t.Errorf("expected state DELIVERED, got %q", follower.snapshotState["ord-1"])
+	}
+	if len(follower.Log) != 0 {
+		t.Errorf("expected follower log truncated, got %d entries", len(follower.Log))
+	}
+	if follower.CommitIndex != 5 {
+		t.Errorf("expected follower commit_index 5, got %d", follower.CommitIndex)
+	}
+}


### PR DESCRIPTION
## Problem

The Raft log grows without bound: every committed entry stays in memory for the lifetime of the node. Long-running deployments accumulate memory, and a freshly started or partitioned follower that misses many entries must replay the full history before it can catch up — slow joins and large transient memory spikes.

## Fix

Add log compaction with snapshotting to the consensus-raft-go node:

- **Compaction threshold** — after advancing `CommitIndex`, applied entries with `Index <= CommitIndex` are folded into an in-memory snapshot (`snapshotState`) and truncated from the log. Configurable via `RAFT_COMPACTION_THRESHOLD` (default `1000`).
- **Term tracking across the boundary** — `lastLogIndex()` = `snapshotIndex + len(Log)` and `lastLogTerm()`/`logTermAtLocked(index)` resolve indexes at or below `snapshotIndex` against the snapshot's term, so AppendEntries consensus and the leader commit gate stay correct across the boundary.
- **Snapshot transfer (InstallSnapshot RPC)** — `sendHeartbeats` sends a full `InstallSnapshotRequest` to peers whose `nextIndex <= snapshotIndex` instead of an empty AppendEntries. Followers apply the snapshot via the new `/api/v1/raft/snapshot` handler, and the leader updates `matchIndex`/`nextIndex` accordingly.
- **Durable snapshots (optional)** — when `RAFT_SNAPSHOT_PATH` is set, snapshots are persisted atomically (temp file + rename) and loaded on startup before `run()`.
- **Status visibility** — `HandleStatus` now reports `snapshot_index`.

The snapshot handler and persistence are env-gated, so the node's default behavior is unchanged when the new variables are unset.

## Files changed

- `services/consensus-raft-go/main.go` — snapshot fields, compaction in `maybeSnapshotLocked`/`advanceCommitIndexLocked`, rewritten `sendHeartbeats` with InstallSnapshot support, `HandleSnapshot` route registration, `snapshot_index` in status.
- `services/consensus-raft-go/snapshot.go` — new: `RaftSnapshot`, `InstallSnapshotRequest/Response`, `logTermAtLocked`, `maybeSnapshotLocked`, `persistSnapshotLocked` (atomic), `loadSnapshot`, `HandleSnapshot`, `callSnapshot`.
- `services/consensus-raft-go/snapshot_test.go` — new: 6 tests covering compaction truncation, commit accounting across the boundary, snapshot transfer to a lagging follower, delta-not-full-log sends, persistence round-trip, and HandleSnapshot application.
- `services/consensus-raft-go/README.md` — document `RAFT_COMPACTION_THRESHOLD`, `RAFT_SNAPSHOT_PATH`, and the `/api/v1/raft/snapshot` endpoint.

## Testing

- `go test ./...` in `services/consensus-raft-go` (Go 1.21.13): all tests pass except the pre-existing `TestHandleCommitOrderRejectsOversizedBody`, which also fails at HEAD (oversized non-JSON body is rejected with 400 at JSON-decode before the 413 size cap).
- `go vet ./...` clean.

Closes #10681
