### PR TITLE
fix : added strict decimal-only coercion in sanitizePrice with tests

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -18,6 +18,11 @@
 import logger from '../middleware/logger.js';
 
 export function sanitizePrice(value) {
+  // Reject hex/exponent strings that Number() would otherwise coerce
+  // ('0x10' -> 16, '1e3' -> 1000); only decimal strings are prices.
+  if (typeof value === 'string' && !/^-?\d*\.?\d+$/.test(value.trim())) {
+    return 0;
+  }
   const num = Number(value);
   return Number.isFinite(num) && num >= 0 ? Math.round(num) : 0;
 }

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -239,5 +239,12 @@ describe('Pricing Service Unit Tests', () => {
       expect(() => convertKmToMiles(-5)).toThrow(RangeError);
       expect(() => convertKmToMiles(-100)).toThrow(RangeError);
     });
+
+    it('rejects hex and exponent strings in sanitizePrice', () => {
+      // Number() would coerce these to 16 and 1000 respectively; the strict
+      // decimal guard must reject them.
+      expect(sanitizePrice('0x10')).toBe(0);
+      expect(sanitizePrice('1e3')).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Closes #10901.

Summary of What Has Been Done:
Implemented the change requested in issue #10901: strict decimal-only coercion in sanitizePrice with tests.

Changes Made:
- strict decimal-only coercion in sanitizePrice with tests
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.