### PR TITLE
test : added band ratio and confidence bounds in predictionValidator

### DIFF
--- a/backend/api/test/unit/predictionValidator.test.js
+++ b/backend/api/test/unit/predictionValidator.test.js
@@ -145,6 +145,32 @@ describe('validatePricePrediction', () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe(RejectionReason.INVALID_MIN_PRICE);
   });
+
+  it('rejects max_price beyond the 3x band ratio', () => {
+    const result = validatePricePrediction({
+      estimated_price: 2000,
+      currency: 'INR',
+      max_price: 7000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe(RejectionReason.INVALID_MAX_PRICE);
+  });
+
+  it('accepts max_price within the 3x band ratio', () => {
+    const result = validatePricePrediction({
+      estimated_price: 2000,
+      currency: 'INR',
+      max_price: 5000,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects confidence outside 0..1', () => {
+    const below = validatePricePrediction({ estimated_price: 1500, currency: 'INR', confidence: -0.1 });
+    const above = validatePricePrediction({ estimated_price: 1500, currency: 'INR', confidence: 1.1 });
+    expect(below.reason).toBe(RejectionReason.INVALID_CONFIDENCE);
+    expect(above.reason).toBe(RejectionReason.INVALID_CONFIDENCE);
+  });
 });
 
 describe('convertToPaisa', () => {


### PR DESCRIPTION
Closes #10903.

Summary of What Has Been Done:
Implemented the change requested in issue #10903: band ratio and confidence bounds in predictionValidator.

Changes Made:
- band ratio and confidence bounds in predictionValidator
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.