### PR TITLE
test : added alternate ADTS AAC sync pattern test

### DIFF
--- a/backend/api/test/unit/audioValidation.test.js
+++ b/backend/api/test/unit/audioValidation.test.js
@@ -76,6 +76,12 @@ describe('detectAudioMimeType', () => {
     expect(detectAudioMimeType(AAC_ADTS)).toBe('audio/aac');
   });
 
+  it('detects the alternate ADTS AAC sync pattern (0xFFF9)', () => {
+    // The second AAC signature covers the 0xFFF9 header variant.
+    const altAac = withHeader([0xff, 0xf9, 0x50, 0x80]);
+    expect(detectAudioMimeType(altAac)).toBe('audio/aac');
+  });
+
   it('rejects a RIFF container that is not WAVE', () => {
     const avi = Buffer.alloc(64);
     avi.write('RIFF', 0, 'ascii');


### PR DESCRIPTION
Closes #10906.

Summary of What Has Been Done:
Implemented the change requested in issue #10906: alternate ADTS AAC sync pattern test.

Changes Made:
- alternate ADTS AAC sync pattern test
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.