### PR TITLE
test : added content type and extension rejection tests in malwareScanner

### DIFF
--- a/backend/api/test/unit/malwareScanner.test.js
+++ b/backend/api/test/unit/malwareScanner.test.js
@@ -184,5 +184,22 @@ describe('malwareScanner', () => {
       delete process.env.MAX_SCAN_SIZE_BYTES;
       connectSpy.mockRestore();
     });
+
+    it('rejects a buffer whose content is not an allowed document type', async () => {
+      const connectSpy = vi.spyOn(net, 'createConnection');
+      // ZIP magic bytes are not JPEG/PNG/PDF.
+      const zip = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]);
+      await expect(scanDocument(zip, 'archive.zip')).rejects.toThrow(/content type/);
+      expect(connectSpy).not.toHaveBeenCalled();
+      connectSpy.mockRestore();
+    });
+
+    it('rejects a dangerous extension even with valid JPEG content', async () => {
+      const connectSpy = vi.spyOn(net, 'createConnection');
+      const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      await expect(scanDocument(jpeg, 'photo.exe')).rejects.toThrow(/extension "\.exe" is not allowed/);
+      expect(connectSpy).not.toHaveBeenCalled();
+      connectSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
Closes #10908.

Summary of What Has Been Done:
Implemented the change requested in issue #10908: content type and extension rejection tests in malwareScanner.

Changes Made:
- content type and extension rejection tests in malwareScanner
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.