### PR TITLE
test : added redisLock error path and TTL passthrough tests

### DIFF
--- a/backend/api/test/unit/redisLockSemantics.test.js
+++ b/backend/api/test/unit/redisLockSemantics.test.js
@@ -93,4 +93,27 @@ describe('redisLock acquire/renew/release semantics', () => {
 
     expect(await renewLock('res', 'other', 30000)).toBe(false);
   });
+
+  it('releaseLock returns false on a Lua script error', async () => {
+    const redis = { eval: vi.fn().mockRejectedValue(new Error('redis down')) };
+    const { releaseLock } = await loadRedisLock(redis);
+
+    expect(await releaseLock('res', 'token-1')).toBe(false);
+  });
+
+  it('acquireLock passes a custom TTL to SET NX PX', async () => {
+    const redis = { set: vi.fn().mockResolvedValue('OK') };
+    const { acquireLock } = await loadRedisLock(redis);
+
+    await acquireLock('res', 45000);
+    expect(redis.set).toHaveBeenCalledWith('res', expect.any(String), 'PX', 45000, 'NX');
+  });
+
+  it('releaseLock treats a falsy token as a no-op without calling eval', async () => {
+    const redis = { eval: vi.fn() };
+    const { releaseLock } = await loadRedisLock(redis);
+
+    expect(await releaseLock('res', undefined)).toBe(false);
+    expect(redis.eval).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10909.

Summary of What Has Been Done:
Implemented the change requested in issue #10909: redisLock error path and TTL passthrough tests.

Changes Made:
- redisLock error path and TTL passthrough tests
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.