### PR TITLE
test : added cvv pin and nested array redaction tests in scrubPii

### DIFF
--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -440,6 +440,26 @@ describe('scrubPii', () => {
     expect(scrubPii(input).card).toBe('my card is [REDACTED] and expires soon');
   });
 
+  it('redacts cvv and pin keys', () => {
+    const input = { cvv: '123', pin: '4321' };
+    expect(scrubPii(input)).toEqual({ cvv: '[REDACTED]', pin: '[REDACTED]' });
+  });
+
+  it('redacts secrets nested inside arrays of objects', () => {
+    const input = {
+      attempts: [
+        { apiKey: 'k1' },
+        { clientSecret: 's1' },
+      ],
+    };
+    expect(scrubPii(input)).toEqual({
+      attempts: [
+        { apiKey: '[REDACTED]' },
+        { clientSecret: '[REDACTED]' },
+      ],
+    });
+  });
+
   it('matches case-insensitively', () => {
     const input = { Password: 'x', API_KEY: 'y', 'Otp': 'z' };
     expect(scrubPii(input)).toEqual({


### PR DESCRIPTION
Closes #10913.

Summary of What Has Been Done:
Implemented the change requested in issue #10913: cvv pin and nested array redaction tests in scrubPii.

Changes Made:
- cvv pin and nested array redaction tests in scrubPii
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.