### PR TITLE
test : added unsafe and over-length correlation id fallback tests

### DIFF
--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -80,4 +80,24 @@ describe('correlationIdMiddleware', () => {
     expect(req.correlationId).toBe(validUuid);
     expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-ID', validUuid);
   });
+
+  it('falls back to a random UUID for an unsafe header value', () => {
+    const req = makeReq({ 'x-correlation-id': 'bad id with spaces and !!!' });
+    const res = makeRes();
+    const next = vi.fn();
+    correlationIdMiddleware(req, res, next);
+    expect(req.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('falls back to a random UUID for an over-length header value', () => {
+    const req = makeReq({ 'x-correlation-id': 'a'.repeat(65) });
+    const res = makeRes();
+    const next = vi.fn();
+    correlationIdMiddleware(req, res, next);
+    expect(req.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
 });


### PR DESCRIPTION
Closes #10915.

Summary of What Has Been Done:
Implemented the change requested in issue #10915: unsafe and over-length correlation id fallback tests.

Changes Made:
- unsafe and over-length correlation id fallback tests
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.