### PR TITLE
test : added camelCase odometer alias tests in tripValidator

### DIFF
--- a/backend/api/test/unit/tripValidator.test.js
+++ b/backend/api/test/unit/tripValidator.test.js
@@ -98,4 +98,32 @@ describe('tripValidator Middleware', () => {
     tripValidator.validate(req, res, next);
     expect(res.status).toHaveBeenCalledWith(400);
   });
+
+  it('accepts the camelCase odometerKm alias', () => {
+    const req = {
+      params: { id: 'trip-1' },
+      body: { odometerKm: 120 },
+      headers: {},
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects a regression against the camelCase lastOdometerKm field', () => {
+    const req = {
+      params: { id: 'trip-1' },
+      body: { odometerKm: 100, lastOdometerKm: 110 },
+      headers: {},
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    tripValidator.validate(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #10916.

Summary of What Has Been Done:
Implemented the change requested in issue #10916: camelCase odometer alias tests in tripValidator.

Changes Made:
- camelCase odometer alias tests in tripValidator
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.