### PR TITLE
test : added nested undefined removal and falsy passthrough in responseSanitizer

### DIFF
--- a/backend/api/test/unit/responseSanitizer.test.js
+++ b/backend/api/test/unit/responseSanitizer.test.js
@@ -81,4 +81,28 @@ describe('responseSanitizer', () => {
 
     expect(res._data).toBe('hello');
   });
+
+  it('removes undefined values from nested objects', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json({ user: { id: 'u1', deleted: undefined, profile: { name: 'A', temp: undefined } } });
+
+    expect(res._data).toEqual({ user: { id: 'u1', profile: { name: 'A' } } });
+  });
+
+  it('passes falsy primitives through unchanged', () => {
+    const req = {};
+    const res = makeResMock();
+    const next = vi.fn();
+
+    responseSanitizer(req, res, next);
+    res.json(0);
+    expect(res._data).toBe(0);
+
+    res.json(false);
+    expect(res._data).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #10921.

Summary of What Has Been Done:
Implemented the change requested in issue #10921: nested undefined removal and falsy passthrough in responseSanitizer.

Changes Made:
- nested undefined removal and falsy passthrough in responseSanitizer
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.