### PR TITLE
test : added empty object and array details tests in formatError

### DIFF
--- a/backend/api/test/unit/errorFormatter.test.js
+++ b/backend/api/test/unit/errorFormatter.test.js
@@ -34,4 +34,14 @@ describe('formatError', () => {
     const err = formatError(400, 'Invalid', null)
     expect(err.error.details).toBeUndefined()
   })
+
+  it('includes details when they are an empty object', () => {
+    const err = formatError(400, 'Invalid', {})
+    expect(err.error.details).toEqual({})
+  })
+
+  it('preserves non-object details such as arrays', () => {
+    const err = formatError(400, 'Invalid', ['a', 'b'])
+    expect(err.error.details).toEqual(['a', 'b'])
+  })
 })


### PR DESCRIPTION
Closes #10922.

Summary of What Has Been Done:
Implemented the change requested in issue #10922: empty object and array details tests in formatError.

Changes Made:
- empty object and array details tests in formatError
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.