### PR TITLE
test : added AppError default status and ValidationError custom message tests

### DIFF
--- a/backend/api/test/unit/errors.test.js
+++ b/backend/api/test/unit/errors.test.js
@@ -15,6 +15,25 @@ describe('errors', () => {
       expect(err.name).toBe('AppError')
       expect(err).toBeInstanceOf(Error)
     })
+
+    it('leaves statusCode undefined when not provided', () => {
+      const err = new AppError('plain')
+      expect(err.statusCode).toBeUndefined()
+    })
+  })
+
+  describe('ValidationError', () => {
+    it('defaults to 400', () => {
+      const err = new ValidationError()
+      expect(err.statusCode).toBe(400)
+      expect(err.message).toBe('Validation Error')
+    })
+
+    it('accepts a custom message while keeping the 400 status', () => {
+      const err = new ValidationError('Bad payload')
+      expect(err.message).toBe('Bad payload')
+      expect(err.statusCode).toBe(400)
+    })
   })
 
   describe('NotFoundError', () => {
@@ -29,14 +48,6 @@ describe('errors', () => {
       const err = new NotFoundError('No such order')
       expect(err.message).toBe('No such order')
       expect(err.statusCode).toBe(404)
-    })
-  })
-
-  describe('ValidationError', () => {
-    it('defaults to 400', () => {
-      const err = new ValidationError()
-      expect(err.statusCode).toBe(400)
-      expect(err.message).toBe('Validation Error')
     })
   })
 


### PR DESCRIPTION
Closes #10923.

Summary of What Has Been Done:
Implemented the change requested in issue #10923: AppError default status and ValidationError custom message tests.

Changes Made:
- AppError default status and ValidationError custom message tests
- Added or extended unit tests in backend/api/test/unit/

Impact it Made:
- Small, isolated backend improvement with unit tests passing locally.

This pull request is made as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.