### PR TITLE
fix(zkid): lazy-init wallet so module import no longer crashes when PRIVATE_KEY is unset

### DIFF
--- a/backend/zkid/zkid.service.js
+++ b/backend/zkid/zkid.service.js
@@ -8,7 +8,7 @@ import { zkDidVerifier } from './did_verifier.js';
 class ZKIDService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
-        this.wallet = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider);
+        this._wallet = null;
         this.zkidAddress = process.env.ZKID_CONTRACT_ADDRESS;
 
         // ABI mirrors the deployed ZKIdentity.sol surface only. The contract
@@ -22,12 +22,32 @@ class ZKIDService {
             'function revokedCredentials(bytes32 credentialHash) external view returns (bool)'
         ];
 
-        this.zkid = new ethers.Contract(this.zkidAddress, this.zkidABI, this.wallet);
-
         // Generate identity secret
         this.identitySecret = crypto.randomBytes(32);
 
         logger.info('✅ ZK-ID Service initialized');
+    }
+
+    // The wallet and contract are created lazily so importing this module
+    // never crashes when PRIVATE_KEY is unset. Callers that actually sign or
+    // read on-chain state get a clear validation error instead.
+    getWallet() {
+        if (this._wallet) return this._wallet;
+
+        const privateKey = process.env.PRIVATE_KEY;
+        if (!privateKey || !privateKey.trim()) {
+            throw new Error('PRIVATE_KEY environment variable is required to use the ZK-ID service');
+        }
+
+        this._wallet = new ethers.Wallet(privateKey.trim(), this.provider);
+        return this._wallet;
+    }
+
+    getZkidContract() {
+        if (this._zkid) return this._zkid;
+
+        this._zkid = new ethers.Contract(this.zkidAddress, this.zkidABI, this.getWallet());
+        return this._zkid;
     }
 
     // ============ Identity Management ============
@@ -43,7 +63,7 @@ class ZKIDService {
             // the identity hash as the credential merkle root.
             const didURI = zkDidVerifier.createDidUri(userAddress);
 
-            const tx = await this.zkid.registerDID(didURI, identityHash, {
+            const tx = await this.getZkidContract().registerDID(didURI, identityHash, {
                 gasLimit: 200000
             });
             const receipt = await tx.wait();
@@ -100,7 +120,7 @@ class ZKIDService {
 
     async revokeCredential(credentialHash) {
         try {
-            const tx = await this.zkid.revokeCredential(credentialHash, {
+            const tx = await this.getZkidContract().revokeCredential(credentialHash, {
                 gasLimit: 100000
             });
             const receipt = await tx.wait();
@@ -123,7 +143,7 @@ class ZKIDService {
         try {
             // On-chain revocation check against the real contract getter, plus
             // the issued credential record persisted by issueCredential.
-            const isRevoked = await this.zkid.revokedCredentials(credentialHash);
+            const isRevoked = await this.getZkidContract().revokedCredentials(credentialHash);
 
             const { data: credentialRow } = await supabase
                 .from('zkid_credentials')
@@ -143,7 +163,7 @@ class ZKIDService {
                         issuedAt: credentialRow.issued_at,
                         expiresAt: null,
                         revoked: Boolean(credentialRow.revoked),
-                        issuer: this.wallet.address
+                        issuer: this.getWallet().address
                     }
                     : null,
                 timestamp: new Date().toISOString()
@@ -176,7 +196,7 @@ class ZKIDService {
 
             let verified = false;
             if (identity?.user_address) {
-                verified = await this.zkid.verifyZkProof(
+                verified = await this.getZkidContract().verifyZkProof(
                     identity.user_address,
                     proofHash,
                     nullifierHash
@@ -271,7 +291,7 @@ class ZKIDService {
             // the owning address is known.
             let didDocument = null;
             if (identityRow?.user_address) {
-                const doc = await this.zkid.didRegistry(identityRow.user_address);
+                const doc = await this.getZkidContract().didRegistry(identityRow.user_address);
                 didDocument = {
                     didURI: doc[0],
                     credentialMerkleRoot: doc[1],
@@ -311,7 +331,7 @@ class ZKIDService {
                 issuedAt: credentialRow.issued_at,
                 expiresAt: null,
                 revoked: Boolean(credentialRow.revoked),
-                issuer: this.wallet.address
+                issuer: this.getWallet().address
             };
         } catch (error) {
             logger.error('Credential fetch failed:', error);


### PR DESCRIPTION
## Problem

`backend/zkid/zkid.service.js` crashes at import time when `PRIVATE_KEY` is unset or invalid. The module instantiates `ZKIDService` (and an `ethers.Wallet`) at module scope (lines 10-11 and the `export default new ZKIDService()` at line 421), so importing the module throws `invalid private key` and the whole process fails to boot. Tests and tooling cannot even import the module without a signing key.

## Fix

Defer wallet (and contract) creation until actually used:

- The constructor no longer creates the wallet or contract; it only records configuration and the ABI.
- Added `getWallet()` — lazily builds `ethers.Wallet` from `process.env.PRIVATE_KEY` on first use, caching it. If the variable is unset/blank it throws a clear, actionable error (`PRIVATE_KEY environment variable is required to use the ZK-ID service`) instead of an obscure ethers error at import time.
- Added `getZkidContract()` — lazily creates the contract with the wallet.
- All `this.wallet` / `this.zkid` usages now go through the lazy getters.

Importing the module no longer requires `PRIVATE_KEY`; only callers that actually sign or read on-chain state need it.

## Files changed

- `backend/zkid/zkid.service.js`

## Testing

- `node --check backend/zkid/zkid.service.js` passes.
- Verified via node REPL:
  - Without `PRIVATE_KEY` set: `import('./zkid.service.js')` succeeds (no crash); `getWallet()` throws `PRIVATE_KEY environment variable is required to use the ZK-ID service`.
  - With a valid `PRIVATE_KEY`: `getWallet()` returns a working wallet and the wallet instance is cached across calls.

Closes #10771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The service can now start without a private key configured.
  * Blockchain wallet and contract access is initialized only when needed.
  * Credential issuance and selective disclosure continue to work without requiring blockchain access.
  * Clear validation is provided when blockchain operations require a missing private key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->