### PR TITLE
fix(security): resolve on-chain key ownership transfer parameter mismatch error 

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -200,7 +200,6 @@ class KeyRotationService {
         const tx = await oldWallet.sendTransaction({
           to: this.escrowContract.target,
           data: this.escrowContract.interface.encodeFunctionData('transferKeyOwnership', [
-            newAddress,
             newWalletAddress,  // public address only — never the private key
             Date.now(),
           ]),
@@ -218,8 +217,6 @@ class KeyRotationService {
           const { error: insertError } = await supabaseAdmin
             .from('key_ownership_transfers')
             .insert([{
-              old_wallet_address: walletAddress,
-              new_wallet_address: newAddress,
               old_wallet_address: oldWallet.address,   // public address only
               new_wallet_address: newWalletAddress,     // public address only
               wallet_address: walletAddress,

--- a/backend/api/test/unit/security/keyRotationService.test.js
+++ b/backend/api/test/unit/security/keyRotationService.test.js
@@ -36,8 +36,9 @@ vi.mock('../../../src/config/db.js', () => {
     }))
   }));
   return {
-    default: { supabase: { from } },
+    default: { supabase: { from }, supabaseAdmin: { from } },
     supabase: { from },
+    supabaseAdmin: { from },
   };
 });
 


### PR DESCRIPTION
## Description
This Pull Request resolves a critical parameter mismatch error during on-chain key transfer in the security key rotation service (`keyRotationService.js`) under GSSoC.
### Key Changes
1. **Removed Parameter Overlap:** The `transferKeyOwnership` method of the escrow smart contract expects exactly two parameters (`newKeyAddress` and `nonce`). The Javascript code was previously passing three parameters (`newAddress`, `newWalletAddress`, and `Date.now()`). This has been corrected to only pass the two expected parameters.
2. **Audit payload cleanup:** Removed the duplicate and redundant property declarations (`old_wallet_address` and `new_wallet_address`) in the Supabase audit logs insertion payload.
3. **Test Mock Update:** Added the missing `supabaseAdmin` export to the mocked `db.js` file in `keyRotationService.test.js` to ensure the unit tests run and pass without throwing mock export errors.
## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
## How Has This Been Tested?
- **Test Commands:**
  Run the key rotation unit tests:
  ```bash
  npx vitest run test/unit/security/keyRotationService.test.js
Test Steps / Prerequisites:
Navigate to the backend/api/ directory.
Run the test command above.
Expected Result: All 15 tests pass successfully, confirming that the on-chain transfer payload structure matches the contract ABI constraints and that the rotation logs are correctly recorded without throwing any errors.
Test Environment
 Unit / Integration tests (npm test, flutter test, etc.)
Related Issues
Fixes #11139 

PR Checklist
 My code follows the code style guidelines of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have updated corresponding documentation if applicable.
 My changes generate no new warnings or console errors.