### PR TITLE
fix(snn): require sustained eye closure for fatigue instead of loose 30% spike ratio

### DIFF
--- a/backend/ml/snn/fatigue_snn.py
+++ b/backend/ml/snn/fatigue_snn.py
@@ -5,9 +5,10 @@ class SpikingNeuralNetworkFatigueDetector:
     Spiking Neural Network (SNN) Fatigue Detector using Leaky Integrate-and-Fire (LIF) neuron model.
     Models event-driven temporal spikes to assess driver fatigue from eye-blink durations.
     """
-    def __init__(self, threshold: float = 1.0, decay_rate: float = 0.9):
+    def __init__(self, threshold: float = 1.0, decay_rate: float = 0.9, sustained_frames: int = 4):
         self.threshold = threshold
         self.decay = decay_rate
+        self.sustained_frames = sustained_frames
         self.membrane_potential = 0.0
 
     def process_spike_train(self, temporal_blinks: np.ndarray) -> dict:
@@ -16,11 +17,20 @@ class SpikingNeuralNetworkFatigueDetector:
         """
         spikes = []
         self.membrane_potential = 0.0
+        max_closed_run = 0
+        current_closed_run = 0
 
         for state in temporal_blinks:
             # Integrate incoming signal & apply decay dynamics
             self.membrane_potential = (self.membrane_potential * self.decay) + float(state)
-            
+
+            if int(state) == 1:
+                current_closed_run += 1
+                if current_closed_run > max_closed_run:
+                    max_closed_run = current_closed_run
+            else:
+                current_closed_run = 0
+
             if self.membrane_potential >= self.threshold:
                 spikes.append(1)
                 self.membrane_potential -= self.threshold # Reset potential
@@ -28,12 +38,17 @@ class SpikingNeuralNetworkFatigueDetector:
                 spikes.append(0)
 
         total_spikes = sum(spikes)
-        fatigue_detected = total_spikes > (len(temporal_blinks) * 0.3)
+        # Fatigue requires sustained eye closure, not short blinks. A run of
+        # only a few closed frames (a normal blink, ~0.1s) must not trip the
+        # detector, so use the longest sustained closed-eye duration instead
+        # of the loose total-spike ratio that fires on every blink.
+        fatigue_detected = max_closed_run >= self.sustained_frames
 
         return {
             "total_cycles": len(temporal_blinks),
             "generated_spikes_count": total_spikes,
             "final_membrane_potential": round(self.membrane_potential, 4),
+            "max_closed_run": max_closed_run,
             "fatigue_detected": fatigue_detected
         }
 

--- a/backend/ml/snn/test_snn.py
+++ b/backend/ml/snn/test_snn.py
@@ -21,5 +21,27 @@ class TestSnnFatigue(unittest.TestCase):
         
         self.assertFalse(res["fatigue_detected"])
 
+    def test_short_blink_not_fatigue(self):
+        # A short blink (3 consecutive closed frames ~= 0.1s) must not alarm
+        blink_inputs = np.array([1, 1, 1, 0])
+        res = self.detector.process_spike_train(blink_inputs)
+
+        self.assertFalse(res["fatigue_detected"])
+        self.assertLess(res["max_closed_run"], self.detector.sustained_frames)
+
+    def test_isolated_blinks_not_fatigue(self):
+        # Three isolated blinks across the window must not alarm either
+        blink_inputs = np.array([1, 0, 0, 1, 0, 0, 1, 0, 0])
+        res = self.detector.process_spike_train(blink_inputs)
+
+        self.assertFalse(res["fatigue_detected"])
+
+    def test_sustained_closure_alarms(self):
+        # Prolonged closure (sustained run) must alarm
+        blink_inputs = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        res = self.detector.process_spike_train(blink_inputs)
+
+        self.assertTrue(res["fatigue_detected"])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

`SpikingNeuralNetworkFatigueDetector` flags normal blink sequences as fatigue. With `threshold = 1.0` and `decay = 0.9`, every consecutive closed-eye frame immediately fires a spike, and the fatigue criterion was `total_spikes > 30%` of frames. A 3-frame blink `[1,1,1,0]` produced 3 spikes > `4 * 0.3 = 1.2` → `fatigue_detected = True`, and even three isolated blinks across 9 frames tripped it.

## Fix

Fatigue is now driven by sustained eye closure, not short blinks:

- Added a `sustained_frames` constructor option (default `4`). `fatigue_detected` is now `max_consecutive_closed_run >= sustained_frames` instead of the loose total-spike ratio.
- The LIF spike generation and the reported metrics (`total_cycles`, `generated_spikes_count`, `final_membrane_potential`) are unchanged.
- The result now also includes `max_closed_run` for observability.
- Added regression tests: a 3-frame blink and isolated blinks must not alarm; sustained closure still alarms.

## Files changed

- `backend/ml/snn/fatigue_snn.py`
- `backend/ml/snn/test_snn.py`

## Testing

```
python -m unittest test_snn -v
test_alert_normal_state ... ok
test_fatigue_alert_generation ... ok
test_isolated_blinks_not_fatigue ... ok
test_short_blink_not_fatigue ... ok
test_sustained_closure_alarms ... ok
Ran 5 tests in 0.000s
OK
```

Closes #10772
