### PR TITLE
fix(zkp): remove double-0x prefix from generateSTARKProof output

### DIFF
--- a/backend/zkp/zkp.service.js
+++ b/backend/zkp/zkp.service.js
@@ -140,8 +140,8 @@ class ZKPService {
 
             return {
                 success: true,
-                proof: `0x${ethers.hexlify(proof)}`,
-                publicInputs: `0x${ethers.hexlify(publicInputs)}`,
+                proof: ethers.hexlify(proof),
+                publicInputs: ethers.hexlify(publicInputs),
                 timestamp: new Date().toISOString()
             };
         } catch (error) {


### PR DESCRIPTION
## Problem

`ZKPService.generateSTARKProof` returns `proof` and `publicInputs` with a doubled `0x` prefix (`0x0x...`). The method does:

```js
const proof = ethers.randomBytes(64);
const publicInputs = ethers.randomBytes(32);
return {
    proof: `0x${ethers.hexlify(proof)}`,          // hexlify already returns "0x..."
    publicInputs: `0x${ethers.hexlify(publicInputs)}`,
    ...
};
```

`ethers.hexlify(Uint8Array)` returns a `0x`-prefixed hex string, so the template literal produces `0x0x...`. When `verifySTARK` passes these strings into `this.zkp.verifySTARK(proof, publicInputs)`, ethers' ABI encoder rejects the string (`invalid BytesLike value`) and the call throws. The STARK generate→verify round trip always 500s.

## Fix

Remove the redundant `0x` template literal prefix; use `ethers.hexlify()` directly since it already returns a single `0x`-prefixed hex string.

```js
proof: ethers.hexlify(proof),
publicInputs: ethers.hexlify(publicInputs),
```

## Files changed

- `backend/zkp/zkp.service.js`

## Testing

- `node --check backend/zkp/zkp.service.js` passes.
- Verified `ethers.hexlify(ethers.randomBytes(64))` returns single `0x`-prefixed hex (no double prefix).
- The fix restores valid `BytesLike` strings for the contract call.

Closes #10774