### PR TITLE
fix: prevent voice language detection from failing open

### DIFF
--- a/backend/voice/services/voice_ai_service.py
+++ b/backend/voice/services/voice_ai_service.py
@@ -70,6 +70,14 @@ class VoiceAIService:
         }
         
         logger.info(f"✅ Voice AI Service initialized with {len(self.languages)} languages")
+
+    def _confidence_from_result(self, result: Dict) -> Optional[float]:
+        segments = result.get('segments') or []
+        avg_logprobs = [s['avg_logprob'] for s in segments if 'avg_logprob' in s]
+        if not avg_logprobs:
+            return None
+        mean_logprob = sum(avg_logprobs) / len(avg_logprobs)
+        return max(0.0, min(1.0, 1.0 + mean_logprob))
     
     async def detect_language(self, audio_data: bytes) -> Dict:
         """Detect language from speech with dialect recognition"""
@@ -86,7 +94,7 @@ class VoiceAIService:
             
             detected_lang = result.get('language', 'hi')
             text = result.get('text', '')
-            confidence = result.get('confidence', 0.7)
+            confidence = self._confidence_from_result(result)
             
             # Fine-tune dialect detection
             dialect = self._detect_dialect(text, detected_lang)
@@ -104,6 +112,7 @@ class VoiceAIService:
             )
             
             return {
+                'success': True,
                 'language_code': detected_lang,
                 'language_name': self.languages.get(detected_lang, {}).get('name', 'Unknown'),
                 'dialect': dialect,
@@ -115,12 +124,13 @@ class VoiceAIService:
         except Exception as e:
             logger.error(f"Language detection failed: {e}")
             return {
-                'language_code': 'hi',
-                'language_name': 'Hindi',
-                'dialect': 'hindi',
-                'confidence': 0.5,
+                'success': False,
+                'language_code': None,
+                'language_name': None,
+                'dialect': None,
+                'confidence': None,
                 'text': '',
-                'is_supported': True,
+                'is_supported': False,
                 'error': str(e)
             }
     
@@ -178,7 +188,7 @@ class VoiceAIService:
             )
             
             text = result.get('text', '')
-            confidence = result.get('confidence', 0.7)
+            confidence = self._confidence_from_result(result)
             
             # Adapt text for dialect
             adapted_text = self._adapt_dialect(text, dialect)
@@ -293,6 +303,12 @@ class VoiceAIService:
         try:
             # 1. Detect language
             detection = await self.detect_language(audio_data)
+            if not detection.get('success'):
+                return {
+                    'success': False,
+                    'error': detection.get('error', 'language detection failed'),
+                    'timestamp': datetime.now().isoformat()
+                }
             
             # 2. Transcribe speech
             transcription = await self.transcribe_speech(


### PR DESCRIPTION
## Summary

Fixes the voice language detection flow to prevent it from failing open when an exception occurs.

Previously, a language detection failure returned a fabricated successful Hindi result, which could allow downstream voice processing to continue with invalid detection data.

## Changes

- Added explicit `success: false` handling when language detection fails.
- Removed fabricated Hindi fallback values on exceptions.
- Returns `None` for language and confidence fields when detection fails.
- Sets `is_supported: false` for failed detections.
- Stops `process_voice_command` when language detection is unsuccessful.
- Removed the hardcoded confidence fallback value.
- Added confidence calculation based on Whisper segment `avg_logprob` values when available.

## Impact

This prevents failed language detection from being treated as a valid Hindi detection and ensures downstream voice processing does not continue after a detection error.

The confidence value is also no longer always set to a hardcoded default and is instead derived from available model output.

## Testing

- [x] Verified successful language detection still works.
- [x] Verified exceptions return `success: false`.
- [x] Verified failed detection stops downstream voice processing.
- [x] Verified hardcoded confidence fallbacks were removed.

Closes https://github.com/KanishJebaMathewM/Truxify/issues/10930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved confidence reporting for voice transcription and language detection.
  - Language detection failures now return clear unsupported results instead of incorrectly defaulting to Hindi.
  - Voice commands stop gracefully and provide an error when the spoken language cannot be detected.
  - Successful language detection responses now explicitly indicate success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->