### PR TITLE
fix(privacy): implement real secp256k1 LSAG ring signatures with verification

### DIFF
--- a/backend/privacy/ring_sig.js
+++ b/backend/privacy/ring_sig.js
@@ -1,36 +1,163 @@
-import { ethers } from 'ethers';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { keccak_256 } from '@noble/hashes/sha3';
+import { bytesToHex, hexToBytes, concatBytes, utf8ToBytes } from '@noble/hashes/utils';
+
+const G = secp256k1.ProjectivePoint.BASE;
+const N = secp256k1.CURVE.n;
+const P = secp256k1.CURVE.p;
+
+const strip0x = (hex) => (typeof hex === 'string' && hex.startsWith('0x') ? hex.slice(2) : hex);
+const toBigInt = (value) => {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (value instanceof Uint8Array) return BigInt('0x' + bytesToHex(value));
+  if (typeof value === 'string') return BigInt('0x' + strip0x(value));
+  throw new TypeError('Invalid scalar value');
+};
+const mod = (a, m) => ((a % m) + m) % m;
+const modPow = (base, exp, m) => {
+  let result = 1n;
+  let b = mod(base, m);
+  let e = exp;
+  while (e > 0n) {
+    if (e & 1n) result = (result * b) % m;
+    b = (b * b) % m;
+    e >>= 1n;
+  }
+  return result;
+};
+const sqrtModP = (a) => modPow(a, (P + 1n) / 4n, P);
+const pointFromHex = (hex) => secp256k1.ProjectivePoint.fromHex(strip0x(hex));
+
+const hashToPoint = (seedHex) => {
+  let counter = 0;
+  for (;;) {
+    const digest = keccak_256(concatBytes(hexToBytes(seedHex), hexToBytes(counter.toString(16).padStart(2, '0'))));
+    const x = BigInt('0x' + bytesToHex(digest)) % P;
+    const rhs = mod(x * x * x + 7n, P);
+    const y = sqrtModP(rhs);
+    if (mod(y * y, P) === rhs) {
+      return secp256k1.ProjectivePoint.fromAffine({ x, y });
+    }
+    counter += 1;
+  }
+};
+
+const hashHex = (...parts) =>
+  bytesToHex(keccak_256(concatBytes(...parts.map((part) => hexToBytes(strip0x(part))))));
 
 /**
  * Off-Chain Linkable Ring Signature (LSAG) Generator Utility
+ *
+ * Implements the Liu-Wei-Wong linkable spontaneous anonymous group signature
+ * over secp256k1. The challenge chain binds every `c`/`r` to the full ring, the
+ * message, and the signer's private key via the key image, so signatures are
+ * unforgeable and linkable (same signer + same ring => same key image).
  */
 export class RingSignatureService {
   generateRingKeyPair() {
-    const wallet = ethers.Wallet.createRandom();
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const publicKey = secp256k1.ProjectivePoint.fromPrivateKey(privateKey).toHex(true);
     return {
-      privateKey: wallet.privateKey,
-      publicKey: wallet.address,
+      privateKey: `0x${bytesToHex(privateKey)}`,
+      publicKey,
     };
   }
 
-  generateKeyImage(privateKey) {
-    const hash = ethers.keccak256(privateKey);
-    return ethers.keccak256(ethers.concat([hash, ethers.toUtf8Bytes('LSAG_KEY_IMAGE')]));
+  generateKeyImage(pubKeys, signerPrivateKey) {
+    const Hp = hashToPoint(pubKeys.map((k) => strip0x(k)).join(''));
+    return Hp.multiply(toBigInt(signerPrivateKey)).toHex(true);
+  }
+
+  hashMessage(message) {
+    return bytesToHex(keccak_256(utf8ToBytes(message)));
+  }
+
+  challenge(pubKeys, messageHash, pointA, pointB) {
+    return hashHex(pubKeys.map((k) => strip0x(k)).join(''), messageHash, pointA.toHex(true), pointB.toHex(true));
   }
 
   signRingMessage(message, pubKeys, signerPrivateKey) {
-    const keyImage = this.generateKeyImage(signerPrivateKey);
-    const messageHash = ethers.keccak256(ethers.toUtf8Bytes(message));
-    
-    const c = pubKeys.map((_, i) => ethers.keccak256(ethers.toUtf8Bytes(`c_${i}_${messageHash}`)));
-    const r = pubKeys.map((_, i) => ethers.keccak256(ethers.toUtf8Bytes(`r_${i}_${messageHash}`)));
+    const n = pubKeys.length;
+    if (n < 2) {
+      throw new Error('A ring signature requires at least two public keys');
+    }
+    const messageHash = this.hashMessage(message);
+    const ring = pubKeys.map((k) => pointFromHex(k));
+    const ringSeed = pubKeys.map((k) => strip0x(k)).join('');
+    const Hp = hashToPoint(ringSeed);
+    const x = toBigInt(signerPrivateKey);
+    const signerPoint = G.multiply(x);
+    const s = ring.findIndex((point) => point.equals(signerPoint));
+    if (s < 0) {
+      throw new Error('Signer private key does not match any public key in the ring');
+    }
+
+    const keyImage = Hp.multiply(x);
+
+    const u = toBigInt(secp256k1.utils.randomPrivateKey());
+    const uG = G.multiply(u);
+    const uHp = Hp.multiply(u);
+
+    const c = new Array(n);
+    const r = new Array(n);
+    c[(s + 1) % n] = this.challenge(pubKeys, messageHash, uG, uHp);
+
+    let i = (s + 1) % n;
+    while (i !== s) {
+      const ri = toBigInt(secp256k1.utils.randomPrivateKey());
+      const ci = BigInt('0x' + c[i]) % N;
+      r[i] = ri;
+      const Li = G.multiply(ri).add(ring[i].multiply(ci));
+      const Ri = Hp.multiply(ri).add(keyImage.multiply(ci));
+      const next = (i + 1) % n;
+      c[next] = this.challenge(pubKeys, messageHash, Li, Ri);
+      i = next;
+    }
+
+    const cs = BigInt('0x' + c[s]) % N;
+    r[s] = mod(u - cs * x, N);
 
     return {
       messageHash,
-      keyImage,
+      keyImage: keyImage.toHex(true),
       c,
-      r,
+      r: r.map((value) => value.toString(16).padStart(64, '0')),
       pubKeys,
     };
+  }
+
+  verifyRingSignature(message, pubKeys, signature) {
+    const n = pubKeys.length;
+    if (!signature || !Array.isArray(signature.c) || !Array.isArray(signature.r) ||
+        signature.c.length !== n || signature.r.length !== n || !signature.keyImage) {
+      return false;
+    }
+    let keyImagePoint;
+    try {
+      keyImagePoint = pointFromHex(signature.keyImage);
+    } catch {
+      return false;
+    }
+    const messageHash = this.hashMessage(message);
+    if (signature.messageHash && signature.messageHash !== messageHash) {
+      return false;
+    }
+    const ring = pubKeys.map((k) => pointFromHex(k));
+    const Hp = hashToPoint(pubKeys.map((k) => strip0x(k)).join(''));
+    try {
+      let c = signature.c[0];
+      for (let i = 0; i < n; i += 1) {
+        const ri = toBigInt(signature.r[i]);
+        const ci = BigInt('0x' + c) % N;
+        const Li = G.multiply(ri).add(ring[i].multiply(ci));
+        const Ri = Hp.multiply(ri).add(keyImagePoint.multiply(ci));
+        c = this.challenge(pubKeys, messageHash, Li, Ri);
+      }
+      return c === signature.c[0];
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/backend/privacy/test_ring_sig.js
+++ b/backend/privacy/test_ring_sig.js
@@ -6,13 +6,74 @@ console.log('Testing Ring Signature Service...');
 const kp1 = ringSignatureService.generateRingKeyPair();
 const kp2 = ringSignatureService.generateRingKeyPair();
 const kp3 = ringSignatureService.generateRingKeyPair();
+const attacker = ringSignatureService.generateRingKeyPair();
 
 const ring = [kp1.publicKey, kp2.publicKey, kp3.publicKey];
-const signature = ringSignatureService.signRingMessage('FREIGHT_COMMITMENT_100_TONS', ring, kp1.privateKey);
+const message = 'FREIGHT_COMMITMENT_100_TONS';
+const signature = ringSignatureService.signRingMessage(message, ring, kp1.privateKey);
 
 assert.strictEqual(signature.pubKeys.length, 3);
 assert.strictEqual(signature.c.length, 3);
 assert.strictEqual(signature.r.length, 3);
 assert.strictEqual(typeof signature.keyImage, 'string');
+
+assert.strictEqual(
+  ringSignatureService.verifyRingSignature(message, ring, signature),
+  true,
+  'valid signature by a ring member must verify'
+);
+
+assert.strictEqual(
+  ringSignatureService.verifyRingSignature('FREIGHT_COMMITMENT_999_TONS', ring, signature),
+  false,
+  'signature must fail for a different message'
+);
+
+assert.strictEqual(
+  ringSignatureService.verifyRingSignature(message, [kp1.publicKey, kp2.publicKey, attacker.publicKey], signature),
+  false,
+  'signature must fail when the ring is altered'
+);
+
+const forged = {
+  messageHash: ringSignatureService.hashMessage(message),
+  keyImage: ringSignatureService.generateKeyImage(ring, attacker.privateKey),
+  c: signature.c,
+  r: signature.r,
+};
+assert.strictEqual(
+  ringSignatureService.verifyRingSignature(message, ring, forged),
+  false,
+  'signature forged with a non-ring key image must fail'
+);
+
+const tampered = { ...signature, r: [...signature.r.slice(0, 1), '00'.repeat(32), ...signature.r.slice(2)] };
+assert.strictEqual(
+  ringSignatureService.verifyRingSignature(message, ring, tampered),
+  false,
+  'tampered r value must fail verification'
+);
+
+const signature2 = ringSignatureService.signRingMessage(message, ring, kp2.privateKey);
+assert.strictEqual(
+  signature.keyImage === signature2.keyImage,
+  false,
+  'key image must differ for different signers'
+);
+
+const signatureAgain = ringSignatureService.signRingMessage(message, ring, kp1.privateKey);
+assert.strictEqual(
+  signature.keyImage === signatureAgain.keyImage,
+  true,
+  'key image must be linkable across signatures by the same signer'
+);
+
+let signerNotInRingThrew = false;
+try {
+  ringSignatureService.signRingMessage(message, ring, attacker.privateKey);
+} catch (error) {
+  signerNotInRingThrew = error.message.includes('does not match');
+}
+assert.strictEqual(signerNotInRingThrew, true, 'signer not in ring must throw');
 
 console.log('✅ Ring Signature tests passed successfully.');


### PR DESCRIPTION
## Problem

`RingSignatureService.signRingMessage` produces "linkable ring signatures" whose `c` and `r` arrays depend only on the ring position `i` and `messageHash`:

```js
const c = pubKeys.map((_, i) => ethers.keccak256(ethers.toUtf8Bytes(`c_${i}_${messageHash}`)));
const r = pubKeys.map((_, i) => ethers.keccak256(ethers.toUtf8Bytes(`r_${i}_${messageHash}`)));
```

- `c`/`r` never incorporate the signer's private key or the ring members' public keys, so **anyone** can reproduce an identical signature for any message and any ring.
- The class exposes **no verification method** at all.
- `test_ring_sig.js` only asserted array lengths, so the defect passed CI.

## Fix

Implement a real Liu-Wei-Wong LSAG over secp256k1 using `@noble/curves` (already available as an ethers v6 dependency):

- `generateRingKeyPair()` now returns a real secp256k1 keypair (`privateKey` hex + compressed `publicKey` point).
- `generateKeyImage(pubKeys, signerPrivateKey)` computes the key image `I = x · H_p(L)` where `H_p(L)` is a deterministic hash-to-curve point of the full ring.
- `signRingMessage` performs the scalar challenge chain: pick `u`, set `c_{s+1} = H(L, m, u·G, u·H_p(L))`, then for every other ring index `i` pick random `r_i` and chain `c_{i+1} = H(L, m, r_i·G + c_i·y_i, r_i·H_p(L) + c_i·I)`, closing with `r_s = u − c_s·x_s mod n`.
- Added `verifyRingSignature(message, pubKeys, signature)`: recomputes the challenge chain and returns `true` only when `c_n == c_0`. It rejects mismatched message hashes, non-member key images, and malformed/tampered fields (returns `false` instead of throwing).

`test_ring_sig.js` now contains real positive and negative tests:
- valid signature verifies;
- wrong message fails;
- altered ring fails;
- forging with a non-ring key image fails;
- tampered `r` value fails;
- key images differ across signers but are identical for the same signer (linkability);
- signing with a key not in the ring throws.

## Files changed

- `backend/privacy/ring_sig.js`
- `backend/privacy/test_ring_sig.js`

## Testing

- `node backend/privacy/test_ring_sig.js` → `✅ Ring Signature tests passed successfully.`
- `node --check` passes on both files.

Closes #10775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced placeholder ring signatures with cryptographically verifiable LSAG signatures.
  * Added message hashing, challenge generation, key-image creation, and signature verification.
  * Added validation for ring membership, ring structure, altered messages, tampering, and forged signatures.

* **Bug Fixes**
  * Improved detection of invalid or manipulated ring signatures.
  * Prevented signing with keys that are not part of the selected ring.

* **Tests**
  * Expanded coverage for verification failures, key-image uniqueness, and signature linkability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->