### PR TITLE
fix(cugraph): redistribute dangling-node rank mass and guard empty graphs

### DIFF
--- a/services/gpu-graph-cugraph/src/driver_pagerank.cu
+++ b/services/gpu-graph-cugraph/src/driver_pagerank.cu
@@ -16,11 +16,17 @@ PageRankResult CudaPageRankSolver::computePageRank(
     }
 
     size_t numNodes = rowOffsets.size() - 1;
+    if (numNodes == 0) {
+        return { {}, 0, true };
+    }
+
     std::vector<float> ranks(numNodes, 1.0f / numNodes);
     
     // Simulating parallel GPU power iteration updates
     for (int iter = 0; iter < maxIterations; ++iter) {
         std::vector<float> nextRanks(numNodes, (1.0f - dampingFactor) / numNodes);
+
+        float danglingMass = 0.0f;
         
         for (size_t u = 0; u < numNodes; ++u) {
             int start = rowOffsets[u];
@@ -33,6 +39,17 @@ PageRankResult CudaPageRankSolver::computePageRank(
                     int v = colIndices[idx];
                     nextRanks[v] += dampingFactor * share;
                 }
+            } else {
+                danglingMass += ranks[u];
+            }
+        }
+
+        // Redistribute the rank mass of dangling nodes across all nodes so the
+        // total mass stays 1 and the result remains a valid rank distribution.
+        if (danglingMass > 0.0f) {
+            float danglingShare = (dampingFactor * danglingMass) / numNodes;
+            for (size_t v = 0; v < numNodes; ++v) {
+                nextRanks[v] += danglingShare;
             }
         }
 


### PR DESCRIPTION
## Problem

`CudaPageRankSolver::computePageRank` (`services/gpu-graph-cugraph/src/driver_pagerank.cu`):

1. **Drops dangling-node rank mass.** For nodes with `outDegree == 0` the rank `ranks[u]` is never redistributed, and `nextRanks` is seeded only with the teleport term `(1-d)/N`. Every iteration the total rank mass shrinks, so the returned ranks do not sum to 1 — an invalid PageRank distribution.
2. **Divides by zero on an empty graph.** If `rowOffsets.size() == 1` then `numNodes == 0` and `1.0f / numNodes` at both initialisation sites yields `inf`/`NaN`.

## Fix

- Added an early guard: if `rowOffsets.size() < 2` (i.e. `numNodes == 0`), return an empty result instead of dividing by zero.
- Accumulate the rank mass of all dangling nodes each iteration (`danglingMass`) and redistribute it evenly across every node:

```cpp
if (danglingMass > 0.0f) {
    float danglingShare = (dampingFactor * danglingMass) / numNodes;
    for (size_t v = 0; v < numNodes; ++v) {
        nextRanks[v] += danglingShare;
    }
}
```

This is the standard dangling-node redistribution for PageRank, preserving a total mass of 1 across iterations.

## Files changed

- `services/gpu-graph-cugraph/src/driver_pagerank.cu`

## Testing

No CUDA toolchain is available in this environment, so the fixed algorithm was verified with a faithful Python port of the exact loop logic:

- empty offset vector → `([], 0, true)` (no crash);
- single-row offset vector (`numNodes == 0`) → `([], 0, true)` (no division by zero);
- chain graph `0→1→2` with node 2 dangling → rank sum `1.0`, converged in 20 iterations;
- single dangling node → rank sum `1.0`;
- two-node cycle → rank sum `1.0`.

All checks passed (total rank mass preserved in every case).

Closes #10776