### PR TITLE
fix(did): persist is_active, add deactivation path, aggregate stats counts

### DIFF
--- a/backend/did/did.service.js
+++ b/backend/did/did.service.js
@@ -296,8 +296,37 @@ class DIDService {
     async storeDID(data) {
         const { error } = await (supabaseAdmin || supabase)
             .from('dids')
-            .insert([{ did: data.did, owner: data.owner, public_key: data.publicKey, created_at: new Date().toISOString() }]);
+            .insert([{
+                did: data.did,
+                owner: data.owner,
+                public_key: data.publicKey,
+                is_active: true,
+                created_at: new Date().toISOString()
+            }]);
         if (error) throw error;
+    }
+
+    async updateDIDStatus(did, isActive) {
+        const { error } = await (supabaseAdmin || supabase)
+            .from('dids')
+            .update({ is_active: isActive, updated_at: new Date().toISOString() })
+            .eq('did', did);
+        if (error) throw error;
+    }
+
+    async deactivateDID(did) {
+        try {
+            const tx = await this.didRegistry.deactivateDID(did);
+            await tx.wait();
+
+            await this.updateDIDStatus(did, false);
+
+            logger.info(`✅ DID deactivated: ${did}`);
+            return { success: true, did };
+        } catch (error) {
+            logger.error('DID deactivation failed:', error);
+            throw error;
+        }
     }
 
     async storeCredential(data) {
@@ -325,21 +354,27 @@ class DIDService {
     }
 
     async getDIDStats() {
-        const { data: dids, error: didsErr } = await (supabaseAdmin || supabase).from('dids').select('*').order('created_at', { ascending: false }).limit(100);
-        const { data: credentials, error: credsErr } = await (supabaseAdmin || supabase).from('credentials').select('*').order('issued_at', { ascending: false }).limit(100);
+        const client = supabaseAdmin || supabase;
 
-        if (didsErr || credsErr) {
-            logger.error('Failed to fetch DID stats', { didsErr, credsErr });
+        const [totalDids, activeDids, totalCreds, revokedCreds] = await Promise.all([
+            client.from('dids').select('id', { count: 'exact', head: true }),
+            client.from('dids').select('id', { count: 'exact', head: true }).eq('is_active', true),
+            client.from('credentials').select('id', { count: 'exact', head: true }),
+            client.from('credentials').select('id', { count: 'exact', head: true }).eq('revoked', true)
+        ]);
+
+        const errors = [totalDids, activeDids, totalCreds, revokedCreds]
+            .filter((result) => result.error)
+            .map((result) => result.error);
+        if (errors.length > 0) {
+            logger.error('Failed to fetch DID stats', errors);
         }
 
-        const safeDids = dids || [];
-        const safeCreds = credentials || [];
-
         return {
-            totalDIDs: safeDids.length,
-            activeDIDs: safeDids.filter(d => d.is_active !== false).length,
-            totalCredentials: safeCreds.length,
-            revokedCredentials: safeCreds.filter(c => c.revoked === true).length
+            totalDIDs: totalDids.error ? 0 : (totalDids.count ?? 0),
+            activeDIDs: activeDids.error ? 0 : (activeDids.count ?? 0),
+            totalCredentials: totalCreds.error ? 0 : (totalCreds.count ?? 0),
+            revokedCredentials: revokedCreds.error ? 0 : (revokedCreds.count ?? 0)
         };
     }
 }


### PR DESCRIPTION
## Problem

`DIDService.getDIDStats` (`backend/did/did.service.js`):

1. **`is_active` never written** — `storeDID` inserts no `is_active` value and no JS path updates it (the `deactivateDID` ABI entry was never called). Since `undefined !== false` is `true`, every row counts as active, so `activeDIDs === totalDIDs` always and deactivations are invisible.
2. **Total capped at 100** — the stats query fetched `.limit(100)` rows and reported `rows.length` as `totalDIDs`, silently undercounting whenever more than 100 DIDs exist.

## Fix

- `storeDID` now persists `is_active: true` on insert.
- Added `updateDIDStatus(did, isActive)` to flip `is_active` (and `updated_at`) in the `dids` table.
- Added a real deactivation path `deactivateDID(did)` that calls the on-chain `DIDRegistry.deactivateDID` and then marks the row inactive.
- `getDIDStats` now computes all four numbers with exact aggregate count queries (`select('id', { count: 'exact', head: true })`, the same pattern already used throughout this repo, e.g. `zkp.service.js`):
  - `totalDIDs` — count of all `dids` rows;
  - `activeDIDs` — count where `is_active = true`;
  - `totalCredentials` — count of all `credentials` rows;
  - `revokedCredentials` — count where `revoked = true`.

The returned object keeps the exact same keys as before, so `/did/stats` consumers are unaffected.

## Files changed

- `backend/did/did.service.js`

## Testing

- `node --check backend/did/did.service.js` passes.
- Return shape of `getDIDStats` unchanged (`totalDIDs`, `activeDIDs`, `totalCredentials`, `revokedCredentials`).
- Count queries follow the repo's existing `{ count: 'exact', head: true }` convention and have no `limit(100)` truncation.

Closes #10779