### PR TITLE
fix(kafka): wire telemetry producer/consumer to real kafkajs client and compacted topic

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -31,6 +31,7 @@ export const TOPICS = {
   FRAUD_DETECTED: 'fraud.detected',
   ETA_UPDATED: 'eta.updated',
   LOCATION_UPDATED: 'location.updated',
+  TELEMETRY_DRIVER_COMPACTED: 'telemetry.driver.compacted',
 };
 
 export const CONSUMER_GROUPS = {
@@ -84,11 +85,13 @@ class KafkaConfig {
       topic,
       numPartitions: 3,
       replicationFactor: 1,
-      configEntries: [
-        { name: 'retention.ms', value: '604800000' }, // 7 days
-        { name: 'cleanup.policy', value: 'delete' },
-        { name: 'delete.retention.ms', value: '604800000' },
-      ],
+      configEntries: topic === TOPICS.TELEMETRY_DRIVER_COMPACTED
+        ? [{ name: 'cleanup.policy', value: 'compact' }]
+        : [
+            { name: 'retention.ms', value: '604800000' }, // 7 days
+            { name: 'cleanup.policy', value: 'delete' },
+            { name: 'delete.retention.ms', value: '604800000' },
+          ],
     }));
     
     await admin.createTopics({

--- a/backend/kafka/consumer.js
+++ b/backend/kafka/consumer.js
@@ -1,15 +1,52 @@
 /**
  * Kafka Log-Compacted Topic Telemetry Consumer Group
  */
+import kafkaConfig, { TOPICS } from './config/kafka.config.js';
+import logger from '../api/src/middleware/logger.js';
+
 export class KafkaTelemetryConsumer {
   constructor(groupId = 'truxify-telemetry-group') {
     this.groupId = groupId;
-    this.topic = 'telemetry.driver.compacted';
+    this.topic = TOPICS.TELEMETRY_DRIVER_COMPACTED;
+    this.consumer = null;
   }
 
   async startListening(onMessageCallback) {
-    console.log(`[Kafka Consumer] Joining consumer group ${this.groupId} listening to topic ${this.topic}...`);
-    // Simulated event processing loop
+    if (typeof onMessageCallback !== 'function') {
+      throw new Error('onMessageCallback is required to consume telemetry events');
+    }
+
+    const consumer = await kafkaConfig.createConsumer(this.groupId, [this.topic]);
+    this.consumer = consumer;
+
+    await consumer.run({
+      eachMessage: async ({ topic, partition, message }) => {
+        const key = message.key ? message.key.toString() : null;
+        let value = null;
+        try {
+          value = JSON.parse(message.value.toString());
+        } catch {
+          value = message.value.toString();
+        }
+
+        await onMessageCallback(value, {
+          key,
+          partition,
+          topic,
+          timestamp: Number(message.timestamp),
+        });
+      },
+    });
+
+    logger.info(`[Kafka Consumer] Listening to ${this.topic} in group ${this.groupId}`);
+    return consumer;
+  }
+
+  async stopListening() {
+    if (this.consumer) {
+      await this.consumer.disconnect();
+      this.consumer = null;
+    }
   }
 }
 

--- a/backend/kafka/producer.js
+++ b/backend/kafka/producer.js
@@ -1,24 +1,49 @@
 /**
  * Kafka Key-Based Telemetry Event Producer
  */
+import kafkaConfig, { TOPICS } from './config/kafka.config.js';
+import logger from '../api/src/middleware/logger.js';
+
 export class KafkaTelemetryProducer {
   constructor(broker = 'localhost:9092') {
     this.broker = broker;
-    this.topic = 'telemetry.driver.compacted';
+    this.topic = TOPICS.TELEMETRY_DRIVER_COMPACTED;
   }
 
   async sendTelemetryEvent(driverId, telemetryPayload) {
-    const message = {
-      key: driverId, // Kafka partition key enforcing log compaction
-      value: JSON.stringify(telemetryPayload),
-      timestamp: Date.now().toString(),
-    };
+    if (!driverId) {
+      throw new Error('driverId is required to publish a telemetry event');
+    }
 
-    console.log(`[Kafka Producer] Publishing compacted state for key ${driverId} to topic ${this.topic}...`);
+    const producer = await kafkaConfig.getProducer();
+
+    const records = await producer.send({
+      topic: this.topic,
+      messages: [
+        {
+          key: String(driverId), // Kafka partition key enforcing log compaction
+          value: JSON.stringify(telemetryPayload),
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    if (!records || records.length === 0) {
+      throw new Error('Kafka producer returned no record metadata for the published message');
+    }
+
+    const { partition, offset, errorCode } = records[0];
+    if (errorCode) {
+      throw new Error(`Kafka producer reported error code ${errorCode} for topic ${this.topic}`);
+    }
+
+    logger.info(`[Kafka Producer] Published compacted state for key ${driverId} to ${this.topic} (partition ${partition}, offset ${offset})`);
+
     return {
       success: true,
-      partition: 0,
-      offset: 1042,
+      topic: this.topic,
+      partition,
+      offset,
     };
   }
 }


### PR DESCRIPTION
## Problem

`KafkaTelemetryProducer` / `KafkaTelemetryConsumer` (`backend/kafka/producer.js`, `consumer.js`) were no-op stubs:

- `sendTelemetryEvent` returned a fabricated `{ success: true, partition: 0, offset: 1042 }` without ever contacting Kafka.
- `startListening` did nothing — no subscribe, no poll, no message delivery.

Callers checking the returned `success`/`offset` believed events were durably written when nothing happened, silently dropping the log-compacted driver-telemetry pipeline.

## Fix

Wire both classes to the real kafkajs client in `backend/kafka/config/kafka.config.js`:

- `producer.js`: `sendTelemetryEvent` validates `driverId`, obtains the real producer via `kafkaConfig.getProducer()`, and calls `producer.send()` on `telemetry.driver.compacted`. It returns the **real** `partition`/`offset` from the broker's `RecordMetadata`, and **throws** on missing driver id, empty metadata, or a broker error code.
- `consumer.js`: `startListening` creates a real consumer group via `kafkaConfig.createConsumer(this.groupId, [this.topic])` and runs `consumer.run({ eachMessage })`, invoking the callback with the parsed payload plus `key`/`partition`/`topic`/`timestamp` metadata. It throws when no callback is provided, and adds `stopListening()` to disconnect.
- `config/kafka.config.js`: added `TOPICS.TELEMETRY_DRIVER_COMPACTED = 'telemetry.driver.compacted'` and made `createTopics()` create that topic with `cleanup.policy: compact` (the other topics keep the `delete` policy).

## Files changed

- `backend/kafka/producer.js`
- `backend/kafka/consumer.js`
- `backend/kafka/config/kafka.config.js`

## Testing

Installed `kafkajs@2.2.4` (a declared dependency of `backend/kafka/package.json`) and ran a functional test with a mocked broker config:

- `sendTelemetryEvent` publishes with `key = driverId`, JSON value, and topic `telemetry.driver.compacted`; returns real `{ partition: 2, offset: '1043' }`;
- throws without `driverId`;
- throws on broker `errorCode`;
- throws when no `RecordMetadata` is returned;
- consumer subscribes to the compacted topic in the configured group;
- `eachMessage` delivers the parsed payload and correct `key`/`partition`/`timestamp` to the callback;
- throws without a callback;
- `stopListening()` disconnects.

All checks passed. (`node --check` also passes on all three files.)

Closes #10780