### PR TITLE
fix(safety): fail closed on zero sensor data in analyze_safety

### DIFF
--- a/backend/ml/routes/safety_routes.py
+++ b/backend/ml/routes/safety_routes.py
@@ -170,6 +170,38 @@ async def analyze_safety(
         if sensor_data is None:
             sensor_data = {}
         
+        # Check if any modality has actual data (fail closed on zero data)
+        has_vision = bool(vision_data)
+        has_audio = bool(audio_data)
+        has_sensor = bool(sensor_data)
+        
+        if not (has_vision or has_audio or has_sensor):
+            # No data from any modality - fail closed to UNKNOWN
+            return {
+                'success': True,
+                'data': {
+                    'fusion_risk': 0.0,
+                    'vision_risk': 0.0,
+                    'audio_risk': 0.0,
+                    'sensor_risk': 0.0,
+                    'alert_level': 'UNKNOWN',
+                    'alert_message': 'No sensor data available.',
+                    'components': {
+                        'vision': {},
+                        'audio': {},
+                        'sensors': {}
+                    },
+                    'actions': [
+                        '📊 Waiting for sensor data',
+                        '📡 Check device connectivity',
+                        '📝 No safety assessment possible without data'
+                    ],
+                    'timestamp': datetime.now().isoformat(),
+                    'data_available': False
+                },
+                'timestamp': datetime.now().isoformat()
+            }
+        
         # Fuse data
         result = sensor_fusion.fuse_data(vision_data, audio_data, sensor_data)
         


### PR DESCRIPTION
## Problem

`POST /safety/fusion/analyze` (`backend/ml/routes/safety_routes.py:157-185`) fails **open**: when there is no vision, audio, or sensor data at all, it reports `SAFE` / "Driver is safe." instead of an UNKNOWN/insufficient-data state.

The endpoint gets data from Redis (falling back to empty dicts) and passes them to `sensor_fusion.fuse_data()`, which computes `fused_risk = 0.0` and returns `SAFE`. This contradicts the hardened `get_safety_report` (sensor_fusion.py:180-196) which correctly returns `UNKNOWN` with `data_available: false` for the same situation.

## Fix

Added a data-availability check in `analyze_safety` before calling `fuse_data`. If all three modalities (vision, audio, sensor) are empty, the endpoint now returns `UNKNOWN` with `data_available: false` and appropriate actions — matching the behavior of `get_safety_report`:

```python
if not (has_vision or has_audio or has_sensor):
    return {
        'success': True,
        'data': {
            'fusion_risk': 0.0,
            'alert_level': 'UNKNOWN',
            'alert_message': 'No sensor data available.',
            'data_available': False,
            ...
        },
        ...
    }
```

## Files changed

- `backend/ml/routes/safety_routes.py`

## Testing

- `python -m py_compile backend/ml/routes/safety_routes.py` passes.
- The response shape mirrors `get_safety_report`'s UNKNOWN case.
- When any modality has data, the original `fuse_data` logic is used.

Closes #10781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fail-closed response when no vision, audio, or sensor data is available.
  * Reports the safety status as unknown with no detected risks and indicates that data is unavailable.
  * Provides clear waiting or connectivity guidance instead of attempting analysis without input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->