### PR TITLE
fix(kafka): use aggregate/order id as publishBatch message key

### DIFF
--- a/backend/kafka/config/kafka.config.js
+++ b/backend/kafka/config/kafka.config.js
@@ -186,7 +186,6 @@ class KafkaConfig {
         messages: [
           {
             key: key || event.aggregateId || event.orderId || event.order_id || null,
-            key: key || event.eventId || event.orderId,
             value: JSON.stringify({
               ...event,
               timestamp: event.timestamp || new Date().toISOString(),


### PR DESCRIPTION
## Problem

`publishBatch` in `backend/kafka/config/kafka.config.js` had a duplicate `key` assignment in the message builder. The first assignment (`key || event.aggregateId || event.orderId || event.order_id`) was immediately overwritten by the second (`key || event.eventId || event.orderId`), so every batched message used the event id as the Kafka message key instead of the aggregate/order id. This breaks consumer partitioning (messages for the same order can land in different partitions) and consumer correlation, and contradicts the documented behaviour in `publishEvent`.

## Fix

- Removed the duplicate `key` assignment so the message key is always the aggregate/order id (`key || event.aggregateId || event.orderId || event.order_id`), matching `publishEvent`.

## Files changed

- `backend/kafka/config/kafka.config.js`

## Testing

- `node --check backend/kafka/config/kafka.config.js` passes.
- `publishBatch` now produces the same key resolution used by `publishEvent`.

Closes #11179
