### PR TITLE
fix(order): remove duplicate newAmountWei declaration in changeDrop

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -579,7 +579,6 @@ export class OrderLifecycleService {
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
         const newAmountWei = paisaToMaticWei(pricing.totalAmount);
-        const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {
           drop_address,


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/orderLifecycleService.js`, the `changeDrop` function has a duplicate `const newAmountWei` declaration at lines 581-582:

```js
const newAmountWei = paisaToMaticWei(pricing.totalAmount);
const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
```

The second declaration shadows the first and causes "Identifier 'newAmountWei' has already been declared" in strict mode. Additionally, `paisaToMaticWei` already returns a `bigint` (see `backend/api/src/services/escrow.js`), so the `BigInt()` wrapper is redundant.

## Fix

- Removed the duplicate line 582.
- The single assignment `const newAmountWei = paisaToMaticWei(pricing.totalAmount);` is correct since the function returns bigint, and `.toString()` on line 592 works properly.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js`

## Testing

- `node --check backend/api/src/services/order/orderLifecycleService.js` passes.
- No more duplicate const declaration; syntax error resolved.

Closes #11181