### PR TITLE
fix: delegate zkSTARKVerifier to ISTARKVerifier and require non-empty proof (#10797)

### DIFF
--- a/blockchain/contracts/MockSTARKVerifier.sol
+++ b/blockchain/contracts/MockSTARKVerifier.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockSTARKVerifier {
+    // Test double: accepts only a proof whose hash matches the known-good
+    // value; every arbitrary proof is rejected.
+    function verifyProof(
+        uint256,
+        uint256[] calldata,
+        bytes calldata proof
+    ) external pure returns (bool) {
+        return keccak256(proof) == keccak256("accepted-proof");
+    }
+}

--- a/blockchain/contracts/zkSTARKVerifier.sol
+++ b/blockchain/contracts/zkSTARKVerifier.sol
@@ -1,26 +1,35 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
+
+interface ISTARKVerifier {
+    function verifyProof(
+        uint256 programHash,
+        uint256[] calldata publicInputs,
+        bytes calldata proof
+    ) external view returns (bool);
+}
 
 contract zkSTARKVerifier {
-    // Simplified zk-STARK verifier
-    // In production: use actual STARK verification
+    // Real STARK verification (e.g. a Cairo/FRI verifier or a precompiled
+    // verifier) is delegated to the immutable `verifier`. Without a genuine
+    // verifier the result is always false/reverting, never a blind accept.
+    ISTARKVerifier public immutable verifier;
 
-    function verifyProof(
-        bytes calldata proof,
-        bytes calldata publicInputs
-    ) external pure returns (bool) {
-        // Reject empty and all-zero proofs instead of accepting every proof
-        if (!_hasNonZeroByte(proof) || !_hasNonZeroByte(publicInputs)) {
-            return false;
-        }
-        // Placeholder verification
-        return true;
+    constructor(address _verifier) {
+        require(_verifier != address(0), "Invalid verifier");
+        verifier = ISTARKVerifier(_verifier);
     }
 
-    function _hasNonZeroByte(bytes calldata data) internal pure returns (bool) {
-        for (uint i = 0; i < data.length; i++) {
-            if (data[i] != 0) return true;
-        }
-        return false;
+    function verifyProof(bytes calldata proof, bytes calldata publicInputs)
+        external
+        view
+        returns (bool)
+    {
+        require(proof.length > 0, "Proof is empty");
+        // Decode the public inputs (program hash + inputs) and run the real
+        // verification, reverting on any mismatch.
+        (uint256 programHash, uint256[] memory pi) =
+            abi.decode(publicInputs, (uint256, uint256[]));
+        return verifier.verifyProof(programHash, pi, proof);
     }
 }

--- a/blockchain/test/zkVerifier.test.js
+++ b/blockchain/test/zkVerifier.test.js
@@ -85,14 +85,25 @@ describe("ZK proof verification", function () {
     );
   });
 
-  it("rejects zero/empty proofs in zkSTARKVerifier", async function () {
-    const zkSTARKVerifier = await (await ethers.getContractFactory("zkSTARKVerifier")).deploy();
+  it("rejects arbitrary proof bytes in zkSTARKVerifier (issue #10797)", async function () {
+    const mock = await (await ethers.getContractFactory("MockSTARKVerifier")).deploy();
+    await mock.waitForDeployment();
+    const zkSTARKVerifier = await (await ethers.getContractFactory("zkSTARKVerifier")).deploy(await mock.getAddress());
     await zkSTARKVerifier.waitForDeployment();
 
-    assert.equal(await zkSTARKVerifier.verifyProof("0x", "0x1234"), false);
-    assert.equal(await zkSTARKVerifier.verifyProof("0x1234", "0x"), false);
-    assert.equal(await zkSTARKVerifier.verifyProof("0x0000", "0x0000"), false);
-    assert.equal(await zkSTARKVerifier.verifyProof("0x1234", "0x5678"), true);
+    const publicInputs = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "uint256[]"],
+      [123n, [1n, 2n]]
+    );
+
+    // Arbitrary proof bytes must NOT verify.
+    assert.equal(await zkSTARKVerifier.verifyProof("0x1234", publicInputs), false);
+
+    // Empty proofs are rejected outright.
+    await assertRejectsWith(
+      zkSTARKVerifier.verifyProof("0x", publicInputs),
+      "Proof is empty"
+    );
   });
 
   it("rejects zero proofs in KYCVerifier.verifyKYC", async function () {
@@ -111,9 +122,12 @@ describe("ZK proof verification", function () {
     await kycVerifier.waitForDeployment();
     const [admin, user] = await ethers.getSigners();
 
+    // Bind the proof to the user (as KYCVerifier requires), but use a
+    // fabricated on-curve proof that must still fail verification.
+    const boundInput = [BigInt(user.address), 1n];
     const verified = await kycVerifier
       .connect(admin)
-      .verifyKYC.staticCall([1, 2], [[1, 2], [1, 2]], [1, 2], [1, 1], user.address);
+      .verifyKYC.staticCall([1, 2], [[1, 2], [1, 2]], [1, 2], boundInput, user.address);
     assert.equal(verified, false);
     assert.equal(await kycVerifier.isVerified(user.address), false);
   });


### PR DESCRIPTION
## Problem
`zkSTARKVerifier` did not delegate to an immutable `ISTARKVerifier` interface and did not validate proof structure (empty proofs accepted).

## Fix
- `zkSTARKVerifier` now delegates to immutable `ISTARKVerifier`, decodes `publicInputs` as `(programHash, uint256[] pi)`.
- Requires `proof.length > 0`; reverts otherwise.
- Added `MockSTARKVerifier.sol`; fixed KYCVerifier test to bind `input[0]=user.address`; 10 tests pass.

## Files changed
- `blockchain/contracts/zkSTARKVerifier.sol`
- `blockchain/contracts/MockSTARKVerifier.sol` (added)
- `blockchain/test/zkVerifier.test.js`

## Testing
```
npx hardhat test test/zkVerifier.test.js
```
→ 10 passing

Closes #10797