### PR TITLE
fix: fhe-ai aggregate deserializes updates and fails closed on errors (#10805)

### DIFF
--- a/backend/fhe-ai/fhe_model.py
+++ b/backend/fhe-ai/fhe_model.py
@@ -331,20 +331,24 @@ class FHEService:
             return {'success': False, 'error': str(e)}
     
     def secure_aggregation(self, encrypted_updates: List[ts.ckks_vector]) -> ts.ckks_vector:
-        """Secure aggregation of encrypted updates"""
-        try:
-            # Sum all encrypted updates
-            aggregated = encrypted_updates[0]
-            for update in encrypted_updates[1:]:
-                aggregated = aggregated + update
-            
-            # Average
-            aggregated = aggregated / len(encrypted_updates)
-            
-            return aggregated
-        except Exception as e:
-            logger.error(f"Secure aggregation failed: {e}")
-            return None
+        """Secure aggregation of encrypted updates.
+
+        Fails closed: raises on empty input or any failed merge instead of
+        returning None, so callers can never mistake a failed aggregation for
+        a successful one.
+        """
+        if not encrypted_updates:
+            raise ValueError("Secure aggregation requires at least one encrypted update")
+
+        # Sum all encrypted updates
+        aggregated = encrypted_updates[0]
+        for update in encrypted_updates[1:]:
+            aggregated = aggregated + update
+
+        # Average
+        aggregated = aggregated / len(encrypted_updates)
+
+        return aggregated
     
     def get_stats(self) -> Dict:
         """Get FHE-AI statistics"""

--- a/backend/fhe-ai/routes.py
+++ b/backend/fhe-ai/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Optional, List, Dict, Any
 import numpy as np
+import tenseal as ts
 import json
 from datetime import datetime
 import logging
@@ -86,20 +87,40 @@ async def encrypt_model():
 
 @router.post("/aggregate")
 async def secure_aggregation(encrypted_updates: List[str]):
-    """Secure aggregation of encrypted updates"""
+    """Secure aggregation of encrypted updates.
+
+    Deserializes each update and merges them under CKKS. Fails closed: an
+    empty/undeserializable payload or a failed aggregation is an explicit
+    error, never a fabricated 'aggregated: true'.
+    """
     try:
-        # In production: deserialize encrypted updates
+        if not encrypted_updates:
+            raise HTTPException(status_code=400, detail="No encrypted updates provided")
+
         updates = []
         for update in encrypted_updates:
-            # Placeholder
-            updates.append(None)
-        
+            if not isinstance(update, str) or not update:
+                raise HTTPException(status_code=400, detail="Invalid encrypted update payload")
+            try:
+                raw = bytes.fromhex(update)
+                updates.append(ts.ckks_vector_from(fhe_service.context, raw))
+            except (ValueError, TypeError) as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Could not deserialize encrypted update: {e}",
+                )
+
         result = fhe_service.secure_aggregation(updates)
+        if result is None:
+            raise HTTPException(status_code=500, detail="Secure aggregation failed")
+
         return {
             'success': True,
             'data': {'aggregated': True},
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Aggregation failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Problem
`POST /aggregate` in `fhe-ai` always reported `aggregated: true` but discarded updates (returned `None`) and never ran aggregation.

## Fix
- `/aggregate` deserializes hex updates via `ts.ckks_vector_from(fhe_service.context, bytes.fromhex(update))`.
- Returns 400 on empty/invalid updates; 500 if `secure_aggregation` returns `None`.
- `secure_aggregation` now raises `ValueError` on empty list or failed merge (removed swallow-and-return-None).

## Files changed
- `backend/fhe-ai/routes.py`
- `backend/fhe-ai/fhe_model.py`

## Testing
```
py -m py_compile backend/fhe-ai/routes.py backend/fhe-ai/fhe_model.py
```
→ compiles OK (CI will run with tenseal)

Closes #10805