### PR TITLE
fix: fhe _encrypted_linear raises NotImplementedError, routes propagate failures (#10806)

### DIFF
--- a/backend/fhe-ai/fhe_model.py
+++ b/backend/fhe-ai/fhe_model.py
@@ -108,11 +108,18 @@ class FHEModel:
         return x
     
     def _encrypted_linear(self, x: ts.ckks_vector, weights: ts.ckks_vector, bias: ts.ckks_vector) -> ts.ckks_vector:
-        """Encrypted linear layer"""
-        # In production: use FHE matrix multiplication
-        # For now, multiply by a scalar (simplified)
-        result = x * 0.5  # Simulated linear transformation
-        return result
+        """Encrypted linear layer.
+
+        Real encrypted matrix multiplication over CKKS is not implemented, and
+        the previous `x * 0.5` stub ignored the layer's weights and bias.
+        Fail closed: refuse to return fabricated predictions instead of
+        pretending the learned parameters participated in the computation.
+        """
+        raise NotImplementedError(
+            "Encrypted linear layer is not implemented; refusing to return "
+            "predictions that ignore the model weights. Train and serve a "
+            "model whose parameters are actually used."
+        )
     
     def _encrypted_relu(self, x: ts.ckks_vector) -> ts.ckks_vector:
         """Encrypted ReLU (approximated using degree-2 least-squares polynomial)

--- a/backend/fhe-ai/routes.py
+++ b/backend/fhe-ai/routes.py
@@ -29,11 +29,15 @@ async def create_model(architecture: ModelArchitecture):
     """Create encrypted model"""
     try:
         result = fhe_service.create_model(architecture.layers)
+        if not result.get('success'):
+            raise HTTPException(status_code=500, detail=result.get('error', 'Model creation failed'))
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Model creation failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -46,11 +50,15 @@ async def train_model(request: TrainRequest):
         y = np.array(request.labels)
         
         result = fhe_service.train(X, y, request.epochs)
+        if not result.get('success'):
+            raise HTTPException(status_code=500, detail=result.get('error', 'Training failed'))
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Training failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -61,11 +69,15 @@ async def predict(request: PredictRequest):
     try:
         X = np.array(request.data)
         result = fhe_service.predict(X)
+        if not result.get('success'):
+            raise HTTPException(status_code=500, detail=result.get('error', 'Prediction failed'))
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Prediction failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -75,11 +87,15 @@ async def encrypt_model():
     """Encrypt model weights"""
     try:
         result = fhe_service.encrypt_model_weights()
+        if not result.get('success'):
+            raise HTTPException(status_code=500, detail=result.get('error', 'Encryption failed'))
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Encryption failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/fhe-ai/test_fhe_model.py
+++ b/backend/fhe-ai/test_fhe_model.py
@@ -113,32 +113,20 @@ class TestEncryptedReLU(unittest.TestCase):
 
         self.assertTrue(np.all(np.isfinite(decrypted)))
 
-    def test_model_pre_activation_range_within_domain(self):
-        """9. Empirical validation: Representative inputs produce pre-ReLU activations within [-2, 2]."""
+    def test_model_linear_layer_fails_closed(self):
+        """9. The encrypted linear layer must fail closed rather than return
+        fabricated outputs that ignore the learned weights and bias."""
         model = FHEModel(self.context)
         model.add_linear(4, 4)
         model.encrypt()
 
-        # Deterministic collection of 5 representative 4D normalized inputs
-        representative_inputs = np.array([
-            [1.0, -1.0, 0.5, -0.5],
-            [0.8, 0.9, -0.7, -0.6],
-            [-1.0, -1.0, 1.0, 1.0],
-            [0.0, 0.0, 0.0, 0.0],
-            [0.5, -0.5, 0.25, -0.25]
-        ])
-
-        for sample in representative_inputs:
-            x_enc = model.encrypt_input(sample)
-            pre_relu_enc = model._encrypted_linear(x_enc, model.weights[0], model.biases[0])
-            pre_relu_dec = model.decrypt_output(pre_relu_enc)
-
-            # Assert pre-activation values fall within [-2, 2] operating range
-            self.assertTrue(np.all(pre_relu_dec >= -2.0))
-            self.assertTrue(np.all(pre_relu_dec <= 2.0))
+        x_enc = model.encrypt_input(np.array([1.0, -1.0, 0.5, -0.5]))
+        with self.assertRaises(NotImplementedError):
+            model._encrypted_linear(x_enc, model.weights[0], model.biases[0])
 
     def test_full_encrypted_model_forward_path(self):
-        """10. Full encrypted model forward pass completes end-to-end without plaintext fallback."""
+        """10. Forward passes through a linear layer fail closed: the endpoint
+        must not return predictions that ignore the model's parameters."""
         architecture = [
             {'type': 'linear', 'in': 4, 'out': 4},
             {'type': 'relu'},
@@ -149,11 +137,8 @@ class TestEncryptedReLU(unittest.TestCase):
         X = np.array([[1.0, -1.0, 0.5, -0.5]])
         pred_res = self.service.predict(X)
 
-        self.assertTrue(pred_res['success'])
-        self.assertEqual(len(pred_res['predictions']), 4)
-        for val in pred_res['predictions']:
-            self.assertIsInstance(val, float)
-            self.assertFalse(np.isnan(val))
+        self.assertFalse(pred_res['success'])
+        self.assertIn('linear layer is not implemented', pred_res['error'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem
`_encrypted_linear` in `fhe_model.py` ignored weights/bias and returned `x * 0.5`. Routes never checked success flags.

## Fix
- `_encrypted_linear` raises `NotImplementedError` instead of stub.
- Routes `/model/create|train|predict|encrypt` propagate `success:false` → 500.
- `test_fhe_model.py` updated with fail-closed assertions.

## Files changed
- `backend/fhe-ai/fhe_model.py`
- `backend/fhe-ai/routes.py`
- `backend/fhe-ai/test_fhe_model.py`

## Testing
```
py -m py_compile backend/fhe-ai/fhe_model.py backend/fhe-ai/routes.py
```
→ compiles OK

Closes #10806