### PR TITLE
fix: fhe train_encrypted raises NotImplementedError instead of constant loss (#10807)

### DIFF
--- a/backend/fhe-ai/fhe_model.py
+++ b/backend/fhe-ai/fhe_model.py
@@ -181,30 +181,18 @@ class FHETrainer:
         return self.model
     
     def train_encrypted(self, X: np.ndarray, y: np.ndarray, epochs: int = 10) -> Dict:
-        """Train model on encrypted data"""
-        if self.model is None:
-            raise ValueError("Model not created")
-        
-        # Encrypt input
-        X_enc = self.model.encrypt_input(X)
-        
-        # Simple training (simulated)
-        losses = []
-        for epoch in range(epochs):
-            # Forward pass (encrypted)
-            y_pred = self.model.forward(X_enc)
-            
-            # Loss (simulated)
-            loss = 0.5
-            losses.append(loss)
-            
-            if (epoch + 1) % 5 == 0:
-                logger.info(f"Epoch {epoch+1}/{epochs}: Loss = {loss:.4f}")
-        
-        return {
-            'losses': losses,
-            'final_loss': losses[-1] if losses else None
-        }
+        """Train model on encrypted data.
+
+        Real encrypted gradient descent is not implemented, and the previous
+        stub returned a constant 0.5 loss every epoch without updating any
+        weights. Fail closed: refuse to report fabricated training progress
+        instead of pretending learning occurred.
+        """
+        raise NotImplementedError(
+            "Encrypted training is not implemented; refusing to return "
+            "a fabricated loss curve. Train a model on plaintext data "
+            "and encrypt the resulting weights."
+        )
     
     def predict_encrypted(self, X: np.ndarray) -> np.ndarray:
         """Make predictions on encrypted data"""

--- a/backend/fhe-ai/routes.py
+++ b/backend/fhe-ai/routes.py
@@ -46,11 +46,15 @@ async def train_model(request: TrainRequest):
         y = np.array(request.labels)
         
         result = fhe_service.train(X, y, request.epochs)
+        if not result.get('success'):
+            raise HTTPException(status_code=500, detail=result.get('error', 'Training failed'))
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Training failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Problem
`train_encrypted` simulated a constant loss of 0.5 instead of failing closed. Route `/model/train` didn't check success.

## Fix
- `train_encrypted` raises `NotImplementedError` (removed constant 0.5).
- `/model/train` propagates `success:false` → 500.

## Files changed
- `backend/fhe-ai/fhe_model.py`
- `backend/fhe-ai/routes.py`

## Testing
```
py -m py_compile backend/fhe-ai/fhe_model.py backend/fhe-ai/routes.py
```
→ compiles OK

Closes #10807