### PR TITLE
fix: digital-twin optimize/routes validates assets, derives from history, reports missing (#10812)

### DIFF
--- a/backend/digital-twin/routes.py
+++ b/backend/digital-twin/routes.py
@@ -212,11 +212,23 @@ async def optimize_routes(asset_ids: List[str]):
     try:
         result = optimizer.optimize_routes(asset_ids)
         
+        if not result.get('success'):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    'message': 'Route optimization incomplete',
+                    'missing_assets': result.get('missing_assets', []),
+                    'insufficient_data_assets': result.get('insufficient_data_assets', [])
+                }
+            )
+        
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Optimize routes failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/digital-twin/twin_model.py
+++ b/backend/digital-twin/twin_model.py
@@ -6,8 +6,19 @@ import logging
 import json
 from dataclasses import dataclass, field
 import random
+from math import radians, cos, sin, atan2, sqrt
 
 logger = logging.getLogger(__name__)
+
+
+def haversine_km(a: Dict, b: Dict) -> float:
+    """Great-circle distance in kilometres between two lat/lng points."""
+    lat1, lng1 = radians(a['lat']), radians(a['lng'])
+    lat2, lng2 = radians(b['lat']), radians(b['lng'])
+    dlat = lat2 - lat1
+    dlng = lng2 - lng1
+    h = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlng / 2) ** 2
+    return 6371.0 * 2 * atan2(sqrt(h), sqrt(1 - h))
 
 @dataclass
 class LogisticsAsset:
@@ -325,31 +336,68 @@ class DigitalTwinOptimizer:
         logger.info("✅ Digital Twin Optimizer initialized")
     
     def optimize_routes(self, asset_ids: List[str]) -> Dict:
-        """Optimize routes for assets"""
+        """Optimize routes for assets.
+
+        Derives the next stop, distance and ETA from the asset's real event
+        history (most recent event location as target, observed average speed).
+        Fails closed: missing assets are reported instead of silently skipped,
+        and assets without enough history are flagged as insufficient_data.
+        """
         routes = {}
+        missing_assets = []
+        insufficient_assets = []
         
         for asset_id in asset_ids:
             asset = self.twin.assets.get(asset_id)
             if not asset:
+                missing_assets.append(asset_id)
+                continue
+            
+            events = self.twin.get_events(asset_id, 100)
+            
+            if len(events) < 2:
+                insufficient_assets.append(asset_id)
                 continue
             
             current_location = asset.location
+            next_stop = events[0]['location']
+            distance = haversine_km(current_location, next_stop)
+            
+            # Average speed from consecutive event locations (newest first)
+            speeds = []
+            for prev, cur in zip(events, events[1:]):
+                prev_ts = datetime.fromisoformat(prev['timestamp'])
+                cur_ts = datetime.fromisoformat(cur['timestamp'])
+                elapsed_hours = (prev_ts - cur_ts).total_seconds() / 3600
+                travelled_km = haversine_km(prev['location'], cur['location'])
+                if elapsed_hours > 0:
+                    speeds.append(travelled_km / elapsed_hours)
+            
+            speeds = [s for s in speeds if s > 0]
+            if not speeds:
+                insufficient_assets.append(asset_id)
+                continue
+            
+            avg_speed = sum(speeds) / len(speeds)
+            estimated_time_minutes = (distance / avg_speed) * 60 if avg_speed > 0 else 0.0
             
             optimized_route = {
                 'asset_id': asset_id,
                 'current_location': current_location,
-                'next_stop': {
-                    'lat': current_location['lat'] + random.uniform(-0.5, 0.5),
-                    'lng': current_location['lng'] + random.uniform(-0.5, 0.5)
-                },
-                'estimated_time': random.uniform(30, 180),
-                'distance': random.uniform(10, 100)
+                'next_stop': next_stop,
+                'estimated_time': round(estimated_time_minutes, 2),
+                'distance': round(distance, 2),
+                'average_speed': round(avg_speed, 2),
+                'source': 'event_history'
             }
             
             routes[asset_id] = optimized_route
         
         return {
+            'success': not missing_assets and not insufficient_assets,
             'routes': routes,
+            'missing_assets': missing_assets,
+            'insufficient_data_assets': insufficient_assets,
             'optimization_time': datetime.now().isoformat()
         }
     


### PR DESCRIPTION
## Problem
`POST /digital-twin/optimize/routes` fabricated next stop/ETA/distance from `random.uniform`. Silently skipped missing assets.

## Fix
- `DigitalTwinOptimizer.optimize_routes` validates all `asset_ids`, reports `missing_assets` and `insufficient_data_assets` instead of skipping.
- Derives next stop from latest event location, distance via haversine, ETA from observed average speed.
- `/optimize/routes` returns 400 with missing/insufficient assets when validation fails.

## Files changed
- `backend/digital-twin/twin_model.py` (rewrote `optimize_routes`)
- `backend/digital-twin/routes.py` (propagates failures as 400)

## Testing
```
py -m pytest test_twin.py -q
```
→ 1 passing + manual sanity: missing asset → reported; no-data → insufficient_data; with-data → event_history route

Closes #10812