### PR TITLE
fix: abe _check_multi_authority_attributes evaluates policy against issued attributes (#10814)

### DIFF
--- a/backend/abe/abe_core.py
+++ b/backend/abe/abe_core.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import base64
 import os
+import re
 from typing import Dict, List, Tuple, Any, Optional
 from dataclasses import dataclass
 import numpy as np
@@ -21,6 +22,71 @@ def _derive_attribute_mask(attributes: List[str]) -> bytes:
         attr_hash = hashlib.sha256(attr.encode()).digest()
         combined = hashlib.sha256(combined + attr_hash).digest()
     return combined
+
+def _extract_policy_attributes(policy: str) -> List[str]:
+    """Extract attribute tokens from a CP-ABE boolean policy expression.
+
+    Operates on the attribute tokens that carry a 'Label: value' form. The
+    extraction is conservative: if an attribute cannot be recognised it is
+    skipped, and callers that depend on a fully verified policy will fail
+    closed rather than grant access.
+    """
+    if not policy or not isinstance(policy, str):
+        return []
+
+    normalized = policy.replace('(', ' ').replace(')', ' ')
+    parts = re.split(r'\s+(?:AND|OR)\s+', normalized)
+    return [p.strip() for p in parts if p.strip() and ':' in p]
+
+
+def _tokenize_policy(policy: str) -> List[str]:
+    """Tokenize a CP-ABE boolean policy into attributes, AND/OR and parens."""
+    return [t for t in (p.strip() for p in re.split(r'(\(|\)|\bAND\b|\bOR\b)', policy)) if t]
+
+
+def _eval_policy_or(tokens: List[str], pos: int, attrs: set):
+    left, pos = _eval_policy_and(tokens, pos, attrs)
+    while pos < len(tokens) and tokens[pos] == 'OR':
+        right, pos = _eval_policy_and(tokens, pos + 1, attrs)
+        left = left or right
+    return left, pos
+
+
+def _eval_policy_and(tokens: List[str], pos: int, attrs: set):
+    left, pos = _eval_policy_primary(tokens, pos, attrs)
+    while pos < len(tokens) and tokens[pos] == 'AND':
+        right, pos = _eval_policy_primary(tokens, pos + 1, attrs)
+        left = left and right
+    return left, pos
+
+
+def _eval_policy_primary(tokens: List[str], pos: int, attrs: set):
+    if pos >= len(tokens):
+        raise ValueError('Unexpected end of policy')
+    token = tokens[pos]
+    if token == '(':
+        value, pos = _eval_policy_or(tokens, pos + 1, attrs)
+        if pos >= len(tokens) or tokens[pos] != ')':
+            raise ValueError('Mismatched parentheses')
+        return value, pos + 1
+    if token in ('AND', 'OR', ')'):
+        raise ValueError(f'Unexpected token: {token}')
+    return token in attrs, pos + 1
+
+
+def _evaluate_policy(policy: str, attrs: set) -> bool:
+    """Evaluate a CP-ABE boolean policy against an attribute set.
+
+    Fails closed: returns False for any malformed or unparseable policy.
+    """
+    try:
+        tokens = _tokenize_policy(policy)
+        if not tokens:
+            return False
+        result, pos = _eval_policy_or(tokens, 0, attrs)
+        return bool(result) and pos == len(tokens)
+    except (ValueError, IndexError, TypeError):
+        return False
 
 @dataclass
 class Attribute:
@@ -429,6 +495,29 @@ class DecentralizedABE:
         return bytes([k ^ m for k, m in zip(key_bytes, mask)])
     
     def _check_multi_authority_attributes(self, user_attributes: Dict, policy: str) -> bool:
-        """Check if user has required attributes from all authorities"""
-        # In production: implement proper policy checking
-        return True
+        """Check if user has required attributes from all authorities.
+
+        Evaluates the boolean policy expression against every attribute issued
+        to the user across all authorities. Fails closed: returns False for an
+        empty or malformed policy, for a user with no issued attributes, or for
+        any policy branch the user does not satisfy.
+        """
+        if not user_attributes:
+            return False
+
+        # Collect every attribute issued to this user across all authorities
+        issued = set()
+        for attr in user_attributes.values():
+            if isinstance(attr, dict):
+                if 'attribute' in attr:
+                    issued.add(attr['attribute'])
+                if 'attributes' in attr:
+                    for a in attr['attributes']:
+                        issued.add(a)
+            elif isinstance(attr, (list, tuple, set)):
+                for a in attr:
+                    issued.add(a)
+            elif attr is not None:
+                issued.add(attr)
+
+        return _evaluate_policy(policy, issued)

--- a/backend/abe/test_abe.py
+++ b/backend/abe/test_abe.py
@@ -1,6 +1,8 @@
 import unittest
 from abe_cipher import CpAbeCipherEngine
 from policy_builder import CpAbePolicyBuilder
+from abe_core import DecentralizedABE, AccessPolicy
+
 
 class TestCPABE(unittest.TestCase):
     def setUp(self):
@@ -26,6 +28,55 @@ class TestCPABE(unittest.TestCase):
 
         with self.assertRaises(PermissionError):
             self.cipher.decrypt_document(enc["ciphertext_b64"], policy, wrong_attrs)
+
+
+class TestMultiAuthority(unittest.TestCase):
+    def setUp(self):
+        self.dabe = DecentralizedABE()
+        self.dabe.add_authority('auth-1', 'public-key-1')
+        self.policy = "(Role: Driver AND TripID: TRIP_1001) OR Role: Admin"
+
+    def _issued_attrs(self, *attrs):
+        return {"auth-1": {"attributes": list(attrs)}}
+
+    def test_grants_user_with_all_required_attributes(self):
+        user = self._issued_attrs("Role: Driver", "TripID: TRIP_1001")
+        self.assertTrue(self.dabe._check_multi_authority_attributes(user, self.policy))
+
+    def test_grants_admin_via_second_branch(self):
+        user = self._issued_attrs("Role: Admin")
+        self.assertTrue(self.dabe._check_multi_authority_attributes(user, self.policy))
+
+    def test_denies_user_missing_a_required_attribute(self):
+        user = self._issued_attrs("Role: Driver", "TripID: TRIP_9999")
+        self.assertFalse(self.dabe._check_multi_authority_attributes(user, self.policy))
+
+    def test_fails_closed_on_empty_attributes(self):
+        self.assertFalse(self.dabe._check_multi_authority_attributes({}, self.policy))
+        self.assertFalse(self.dabe._check_multi_authority_attributes(None, self.policy))
+
+    def test_fails_closed_on_malformed_policy(self):
+        user = self._issued_attrs("Role: Driver", "TripID: TRIP_1001")
+        self.assertFalse(self.dabe._check_multi_authority_attributes(user, None))
+        self.assertFalse(self.dabe._check_multi_authority_attributes(user, ""))
+
+    def test_decrypt_fails_closed_for_unauthorized_user(self):
+        enc = self.dabe.encrypt(
+            "secret",
+            AccessPolicy(expression=self.policy, attributes=["Role: Driver", "TripID: TRIP_1001", "Role: Admin"]),
+            authorities=["auth-1"],
+        )
+        self.assertTrue(enc["success"])
+
+        unauthorized = self._issued_attrs("Role: Driver")
+        result = self.dabe.decrypt(enc, unauthorized)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Insufficient attributes")
+
+        authorized = self._issued_attrs("Role: Driver", "TripID: TRIP_1001")
+        result = self.dabe.decrypt(enc, authorized)
+        self.assertTrue(result["success"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem
`_check_multi_authority_attributes` in `DecentralizedABE` was hardcoded `return True`. Multi-authority access control always granted. The XOR mask depended only on authority names, not user attributes.

## Fix
- Implemented full boolean policy evaluation (AND/OR/parens) against issued attributes collected across all authorities.
- `_check_multi_authority_attributes` returns `False` for malformed policy, empty attributes, or unmet requirements.
- Decrypt fails closed via `ValueError("Insufficient attributes")`.

## Files changed
- `backend/abe/abe_core.py` (added `_evaluate_policy`, `_tokenize_policy`, `_eval_policy_or/and/primary`, rewrote `_check_multi_authority_attributes`)
- `backend/abe/test_abe.py` (added `TestMultiAuthority` class with 6 tests)

## Testing
```
py -m unittest test_abe -v
```
→ 8 tests passing (2 original + 6 new multi-authority)

Closes #10814