### PR TITLE
fix: abe policy_builder evaluates all OR branches with proper precedence (#10815)

### DIFF
--- a/backend/abe/policy_builder.py
+++ b/backend/abe/policy_builder.py
@@ -1,3 +1,60 @@
+import re
+from typing import List, Set
+
+
+def _tokenize_policy(policy_str: str) -> List[str]:
+    """Tokenize a CP-ABE boolean policy into attributes, AND/OR and parens."""
+    if not isinstance(policy_str, str):
+        raise ValueError("Policy must be a string")
+    return [t for t in (p.strip() for p in re.split(r'(\(|\)|\bAND\b|\bOR\b)', policy_str)) if t]
+
+
+def _eval_or(tokens: List[str], pos: int, user_attributes: set):
+    left, pos = _eval_and(tokens, pos, user_attributes)
+    while pos < len(tokens) and tokens[pos] == 'OR':
+        right, pos = _eval_and(tokens, pos + 1, user_attributes)
+        left = left or right
+    return left, pos
+
+
+def _eval_and(tokens: List[str], pos: int, user_attributes: set):
+    left, pos = _eval_primary(tokens, pos, user_attributes)
+    while pos < len(tokens) and tokens[pos] == 'AND':
+        right, pos = _eval_primary(tokens, pos + 1, user_attributes)
+        left = left and right
+    return left, pos
+
+
+def _eval_primary(tokens: List[str], pos: int, user_attributes: set):
+    if pos >= len(tokens):
+        raise ValueError("Unexpected end of policy")
+    token = tokens[pos]
+    if token == '(':
+        value, pos = _eval_or(tokens, pos + 1, user_attributes)
+        if pos >= len(tokens) or tokens[pos] != ')':
+            raise ValueError("Mismatched parentheses")
+        return value, pos + 1
+    if token in ('AND', 'OR', ')'):
+        raise ValueError(f"Unexpected token: {token}")
+    return token in user_attributes, pos + 1
+
+
+def _evaluate(policy_str: str, user_attributes: set) -> bool:
+    """Evaluate a boolean policy string against the user's attribute set.
+
+    Uses a recursive-descent parser with proper AND/OR precedence and
+    parenthesis grouping. Fails closed: any policy the parser cannot fully
+    consume yields False rather than a permissive partial match.
+    """
+    tokens = _tokenize_policy(policy_str)
+    if not tokens:
+        return False
+    result, pos = _eval_or(tokens, 0, user_attributes)
+    if pos != len(tokens):
+        return False
+    return bool(result)
+
+
 class CpAbePolicyBuilder:
     """
     Builds Ciphertext-Policy Attribute-Based Encryption (CP-ABE) boolean policy strings from logistics attributes.
@@ -6,12 +63,16 @@ class CpAbePolicyBuilder:
         return f"(Role: {allowed_role} AND TripID: {trip_id}) OR Role: Admin"
 
     def evaluate_user_attributes(self, user_attributes: set, policy_str: str) -> bool:
-        """Evaluates whether user attribute set satisfies CP-ABE boolean expression."""
-        if "Role: Admin" in user_attributes:
-            return True
-        
-        # Check required role and trip ID match
-        parts = [p.strip(" ()") for p in policy_str.split("OR")[0].split("AND")]
-        return all(req_attr in user_attributes for req_attr in parts)
+        """Evaluates whether user attribute set satisfies CP-ABE boolean expression.
+
+        Parses the full policy with AND/OR precedence and parentheses, so every
+        OR alternative is considered. Fails closed on malformed or unparseable
+        policies.
+        """
+        try:
+            return _evaluate(policy_str, user_attributes)
+        except (ValueError, TypeError, IndexError):
+            return False
+
 
 policy_builder = CpAbePolicyBuilder()

--- a/backend/abe/test_abe.py
+++ b/backend/abe/test_abe.py
@@ -27,5 +27,44 @@ class TestCPABE(unittest.TestCase):
         with self.assertRaises(PermissionError):
             self.cipher.decrypt_document(enc["ciphertext_b64"], policy, wrong_attrs)
 
+
+class TestPolicyEvaluator(unittest.TestCase):
+    def setUp(self):
+        self.builder = CpAbePolicyBuilder()
+
+    def test_multi_or_second_branch_grants(self):
+        policy = "(Role: Driver AND TripID: TRIP_1001) OR Role: Admin"
+        self.assertTrue(self.builder.evaluate_user_attributes({"Role: Admin"}, policy))
+
+    def test_multi_or_first_branch_grants(self):
+        policy = "(Role: Driver AND TripID: TRIP_1001) OR Role: Admin"
+        self.assertTrue(
+            self.builder.evaluate_user_attributes({"Role: Driver", "TripID: TRIP_1001"}, policy)
+        )
+
+    def test_multi_or_denies_when_no_branch_satisfied(self):
+        policy = "(Role: Driver AND TripID: TRIP_1001) OR Role: Admin"
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Driver"}, policy))
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Manager", "TripID: TRIP_9999"}, policy))
+
+    def test_nested_parentheses_and_precedence(self):
+        policy = "(Role: Driver OR Role: Manager) AND (TripID: TRIP_1001 OR TripID: TRIP_2001)"
+        self.assertTrue(
+            self.builder.evaluate_user_attributes({"Role: Manager", "TripID: TRIP_2001"}, policy)
+        )
+        self.assertFalse(
+            self.builder.evaluate_user_attributes({"Role: Manager", "TripID: TRIP_9999"}, policy)
+        )
+
+    def test_fails_closed_on_malformed_policy(self):
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Admin"}, "(Role: Driver AND TripID: TRIP_1001"))
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Admin"}, "Role: Driver AND AND TripID: X"))
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Admin"}, "()"))
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Admin"}, ""))
+
+    def test_fails_closed_on_non_string_policy(self):
+        self.assertFalse(self.builder.evaluate_user_attributes({"Role: Admin"}, None))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem
`CpAbePolicyBuilder.evaluate_user_attributes` only evaluated the first `OR` branch of a policy. Multi-branch policies were mis-evaluated.

## Fix
- Implemented recursive-descent parser with proper AND/OR/parenthesis precedence.
- Evaluates all OR branches; fails closed on unparseable policy.
- Removed blanket `"Role: Admin"` shortcut.

## Files changed
- `backend/abe/policy_builder.py` (complete rewrite with `_evaluate`, `_tokenize_policy`, `_eval_or/and/primary`)
- `backend/abe/test_abe.py` (added `TestPolicyEvaluator` class with 6 tests)

## Testing
```
py -m unittest test_abe -v
```
→ 8 tests passing (2 original + 6 new policy evaluator)

Closes #10815