### PR TITLE
fix: outbox uses supabaseAdmin, surfaces write failures, enables RLS (#10817)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -2,6 +2,7 @@ import { getRequestCache } from '../lib/requestContext.js';
 import { executeWithRetry, isRetryable } from '../core/retry.js';
 import { measureExecution } from '../core/performanceMetrics.js';
 import { buildPagination } from '../utils/pagination.js';
+import logger from '../middleware/logger.js';
 
 export class OrderRepository {
   constructor(supabase) {
@@ -141,20 +142,29 @@ export class OrderRepository {
     .select('*')
     .single(), 'updateOrder');
 
-  // Write outbox event after successful mutation — best-effort, never throws.
+  // Write outbox event after successful mutation — the order itself already
+  // committed, so a failure here must not change the response, but it is
+  // logged at error level so a lost event is observable, never silent.
   if (!result.error && result.data && eventType) {
     const { outboxService } = await import('../services/outbox/outboxService.js');
-    await outboxService.writeEvent({
-      aggregateId: result.data.order_display_id || id,
-      aggregateType: 'order',
-      eventType,
-      payload: {
-        orderId: id,
-        orderDisplayId: result.data.order_display_id,
-        status: result.data.status,
-        updates,
-      },
-    });
+    try {
+      await outboxService.writeEvent({
+        aggregateId: result.data.order_display_id || id,
+        aggregateType: 'order',
+        eventType,
+        payload: {
+          orderId: id,
+          orderDisplayId: result.data.order_display_id,
+          status: result.data.status,
+          updates,
+        },
+      });
+    } catch (outboxErr) {
+      logger.error(
+        { err: outboxErr, orderId: id, eventType },
+        '[OrderRepository] Outbox write failed after successful order mutation'
+      );
+    }
   }
 
   return result;

--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../config/db.js';
+import { supabaseAdmin } from '../../config/db.js';
 import logger from '../../middleware/logger.js';
 import crypto from 'crypto';
 
@@ -6,11 +6,18 @@ import crypto from 'crypto';
  * Transactional Outbox Service
  * Inserts durable event records atomically with order mutations.
  * A separate relay picks them up and publishes to Kafka/event bus.
+ *
+ * SECURITY: every operation routes through the service-role admin client
+ * (supabaseAdmin). `outbox_events` is an internal table with RLS enabled and
+ * scoped to service_role only; the anon key can never read or write it.
  */
 export class OutboxService {
   /**
    * Write an outbox event. Call this AFTER a successful order DB write
    * within the same logical operation so the event is always durable.
+   *
+   * Failures are NOT swallowed: a failed insert throws so the caller can
+   * observe and alert instead of silently dropping the event.
    */
   async writeEvent({ aggregateId, aggregateType = 'order', eventType, payload }) {
     if (!aggregateId || !eventType) {
@@ -18,8 +25,12 @@ export class OutboxService {
       return null;
     }
 
+    if (!supabaseAdmin) {
+      throw new Error('[OutboxService] supabaseAdmin is not configured — cannot write outbox event');
+    }
+
     const eventId = crypto.randomUUID();
-    const { data, error } = await supabase
+    const { data, error } = await supabaseAdmin
       .from('outbox_events')
       .insert({
         id: eventId,
@@ -35,9 +46,11 @@ export class OutboxService {
       .single();
 
     if (error) {
-      // Best-effort: log but never throw — the order mutation already committed.
-      logger.error('[OutboxService] Failed to write outbox event:', error.message, { aggregateId, eventType });
-      return null;
+      // Surface to the caller: the order mutation may already have committed,
+      // so the caller decides how to alert. Never return a silent null.
+      throw new Error(
+        `[OutboxService] Failed to write outbox event for ${aggregateType}:${aggregateId} (${eventType}): ${error.message}`
+      );
     }
 
     logger.info('[OutboxService] Outbox event written:', { eventId, aggregateId, eventType });
@@ -48,7 +61,12 @@ export class OutboxService {
    * Fetch pending outbox events for the relay worker.
    */
   async fetchPendingEvents(limit = 50) {
-    const { data, error } = await supabase
+    if (!supabaseAdmin) {
+      logger.warn('[OutboxService] supabaseAdmin not configured — skipping fetchPendingEvents');
+      return [];
+    }
+
+    const { data, error } = await supabaseAdmin
       .from('outbox_events')
       .select('*')
       .eq('status', 'pending')
@@ -66,7 +84,12 @@ export class OutboxService {
    * Mark an event as published after successful Kafka delivery.
    */
   async markPublished(eventId) {
-    const { error } = await supabase
+    if (!supabaseAdmin) {
+      logger.warn('[OutboxService] supabaseAdmin not configured — skipping markPublished');
+      return;
+    }
+
+    const { error } = await supabaseAdmin
       .from('outbox_events')
       .update({ status: 'published', published_at: new Date().toISOString() })
       .eq('id', eventId);
@@ -85,11 +108,16 @@ export class OutboxService {
       return;
     }
 
+    if (!supabaseAdmin) {
+      logger.warn('[OutboxService] supabaseAdmin not configured — skipping markFailed');
+      return;
+    }
+
     // Fetch the current retry_count first so the increment is computed in
     // JavaScript rather than embedding a query builder as a column value
     // (supabase.rpc() returns a PostgREST builder, not a scalar — using it
     // inside .update() would write an invalid value).
-    const { data: event } = await supabase
+    const { data: event } = await supabaseAdmin
       .from('outbox_events')
       .select('retry_count')
       .eq('id', eventId)
@@ -97,7 +125,7 @@ export class OutboxService {
 
     const newRetryCount = (event?.retry_count ?? 0) + 1;
 
-    const { error } = await supabase
+    const { error } = await supabaseAdmin
       .from('outbox_events')
       .update({
         status: 'failed',
@@ -116,7 +144,12 @@ export class OutboxService {
    * Reset failed events back to pending for retry (up to maxRetries).
    */
   async requeueFailedEvents(maxRetries = 5) {
-    const { error } = await supabase
+    if (!supabaseAdmin) {
+      logger.warn('[OutboxService] supabaseAdmin not configured — skipping requeueFailedEvents');
+      return;
+    }
+
+    const { error } = await supabaseAdmin
       .from('outbox_events')
       .update({ status: 'pending' })
       .eq('status', 'failed')

--- a/backend/api/test/unit/outboxService.test.js
+++ b/backend/api/test/unit/outboxService.test.js
@@ -62,7 +62,7 @@ function buildSupabaseMock() {
 
 const mocks = buildSupabaseMock();
 vi.mock('../../src/config/db.js', () => ({
-  supabase: mocks.supabase,
+  supabaseAdmin: mocks.supabase,
 }));
 
 const { outboxService } = await import('../../src/services/outbox/outboxService.js');
@@ -75,7 +75,7 @@ describe('OutboxService', () => {
   });
 
   describe('writeEvent', () => {
-    it('writes a pending outbox event and returns its id', async () => {
+    it('writes a pending outbox event via supabaseAdmin and returns its id', async () => {
       mocks.chain.data = { id: 'evt-1' };
       const id = await outboxService.writeEvent({
         aggregateId: 'order-1',
@@ -101,14 +101,11 @@ describe('OutboxService', () => {
       expect(mocks.supabase.from).not.toHaveBeenCalled();
     });
 
-    it('returns null and logs when the insert errors', async () => {
+    it('throws when the insert errors so failures are observable', async () => {
       mocks.chain.error = { message: 'insert failed' };
-      const id = await outboxService.writeEvent({
-        aggregateId: 'order-1',
-        eventType: 'order.created',
-      });
-      expect(id).toBeNull();
-      expect(mockLogger.error).toHaveBeenCalled();
+      await expect(
+        outboxService.writeEvent({ aggregateId: 'order-1', eventType: 'order.created' })
+      ).rejects.toThrow(/insert failed/);
     });
   });
 

--- a/database/migrations/create_outbox_events_table.sql
+++ b/database/migrations/create_outbox_events_table.sql
@@ -12,6 +12,21 @@ CREATE TABLE IF NOT EXISTS outbox_events (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- SECURITY MODEL: outbox_events is an internal ledger written and read only by
+-- backend services using the service-role admin client (see
+-- backend/api/src/services/outbox/outboxService.js). Enable RLS and scope every
+-- operation to service_role so the shared anon key can never touch this table.
+ALTER TABLE outbox_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access on outbox_events" ON outbox_events;
+CREATE POLICY "Service role full access on outbox_events"
+  ON outbox_events
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+REVOKE ALL ON TABLE outbox_events FROM anon, authenticated;
+
 CREATE INDEX IF NOT EXISTS idx_outbox_events_status_created
   ON outbox_events (status, created_at)
   WHERE status = 'pending';


### PR DESCRIPTION
## Problem
`OutboxService` used the shared anon `supabase` client against `outbox_events` (no RLS). Every write path swallowed errors by returning `null`. If RLS were enabled, all outbox operations would silently fail and events would be lost.

## Fix
- All operations now route through `supabaseAdmin` (service-role client).
- `writeEvent` throws on DB error instead of returning `null` — failure is observable.
- `orderRepository.updateOrder` catches and logs outbox failures at error level (order response unaffected).
- Migration enables RLS on `outbox_events` with service-role-only policy: `FOR ALL TO service_role USING (true) WITH CHECK (true)`; revokes from `anon, authenticated`.

## Files changed
- `backend/api/src/services/outbox/outboxService.js` (import `supabaseAdmin`, throw on error)
- `backend/api/src/repositories/orderRepository.js` (import logger, catch+log outbox errors)
- `database/migrations/create_outbox_events_table.sql` (enable RLS, service-role policy, revoke anon/authenticated)
- `backend/api/test/unit/outboxService.test.js` (updated: expects throw on error, mocks `supabaseAdmin`)

## Testing
```
npx vitest run test/unit/outboxService.test.js test/unit/outboxRelayWorker.test.js test/unit/orderRepository.test.js test/unit/repositories/orderRepositoryStaleCancel.test.js
```
→ 13 + 8 = 21 tests passing

Closes #10817