### PR TITLE
fix(delivery): add order_display_id filter to geofence telemetry query

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -420,9 +420,16 @@ export class DeliveryVerificationService {
 
     // Ownership + provenance: only telemetry for THIS driver on THIS order.
     // driver_id is stamped server-side from the authenticated connection.
+    // Also filter by order_display_id to prevent stale telemetry from a
+    // previous order with the same driver from satisfying the geofence check
+    // (issue #11185).
     const latestTelemetry = await mongoDb
       .collection("telemetry")
-      .find({ driver_id: order.driver_id, order_id: order.id })
+      .find({
+        driver_id: order.driver_id,
+        order_id: order.id,
+        order_display_id: order.order_display_id,
+      })
       .sort({ server_received_at: -1 })
       .limit(1)
       .toArray();


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/deliveryVerificationService.js`, the `assertDriverAtDropoff` method (called by `geofenceAutoConfirm`) queries MongoDB for the latest telemetry point using only `driver_id` and `order_id`. If an order is cancelled and a new order is created with the same driver, the driver's telemetry from the old order (which had a different `order_display_id`) could be used to satisfy the geofence check for the new order.

## Fix

Added `order_display_id` to the telemetry query filter to ensure the location point belongs to the current order, not a previous order with the same driver:

```js
.find({
  driver_id: order.driver_id,
  order_id: order.id,
  order_display_id: order.order_display_id,  // Added this
})
```

## Files changed

- `backend/api/src/services/order/deliveryVerificationService.js`

## Testing

- `node --check backend/api/src/services/order/deliveryVerificationService.js` passes.
- Telemetry query now filters by `order_display_id` in addition to `driver_id` and `order_id`.

Closes #11185