### PR TITLE
fix : resolve HSTS max-age from SECURE_HSTS_MAX_AGE env with bounded fallback

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -5,6 +5,21 @@
  * existing Content-Security-Policy configuration.
  */
 
+const DEFAULT_HSTS_MAX_AGE = 31536000; // 1 year, the previously hardcoded value
+const MIN_HSTS_MAX_AGE = 60; // 1 minute — never allow a weaker bound
+const MAX_HSTS_MAX_AGE = 63072000; // 2 years
+
+// Resolve the Strict-Transport-Security max-age from SECURE_HSTS_MAX_AGE with
+// a bounded fallback so deployments can tune it without accidentally weakening
+// the value to 0, a negative number, or an unbounded one.
+function resolveHstsMaxAge() {
+  const raw = Number(process.env.SECURE_HSTS_MAX_AGE);
+  if (Number.isFinite(raw) && raw >= MIN_HSTS_MAX_AGE && raw <= MAX_HSTS_MAX_AGE) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_HSTS_MAX_AGE;
+}
+
 export default function securityHeaders(req, res, next) {
   // Prevent MIME-type sniffing
   if (!res.getHeader('X-Content-Type-Options')) {
@@ -24,7 +39,10 @@ export default function securityHeaders(req, res, next) {
   // Enforce HTTPS for sensitive headers
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
     if (!res.getHeader('Strict-Transport-Security')) {
-      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+      res.setHeader(
+        'Strict-Transport-Security',
+        `max-age=${resolveHstsMaxAge()}; includeSubDomains`
+      );
     }
   }
 

--- a/backend/api/test/unit/securityHeaders.test.js
+++ b/backend/api/test/unit/securityHeaders.test.js
@@ -55,6 +55,57 @@ describe('securityHeaders', () => {
     );
   });
 
+  it('uses SECURE_HSTS_MAX_AGE when configured', async () => {
+    const original = process.env.SECURE_HSTS_MAX_AGE;
+    process.env.SECURE_HSTS_MAX_AGE = '3600';
+    try {
+      const res = await request(createApp())
+        .get('/test')
+        .set('x-forwarded-proto', 'https');
+
+      expect(res.headers['strict-transport-security']).toBe(
+        'max-age=3600; includeSubDomains'
+      );
+    } finally {
+      if (original === undefined) delete process.env.SECURE_HSTS_MAX_AGE;
+      else process.env.SECURE_HSTS_MAX_AGE = original;
+    }
+  });
+
+  it('falls back to the default max-age for an invalid SECURE_HSTS_MAX_AGE', async () => {
+    const original = process.env.SECURE_HSTS_MAX_AGE;
+    process.env.SECURE_HSTS_MAX_AGE = 'not-a-number';
+    try {
+      const res = await request(createApp())
+        .get('/test')
+        .set('x-forwarded-proto', 'https');
+
+      expect(res.headers['strict-transport-security']).toBe(
+        'max-age=31536000; includeSubDomains'
+      );
+    } finally {
+      if (original === undefined) delete process.env.SECURE_HSTS_MAX_AGE;
+      else process.env.SECURE_HSTS_MAX_AGE = original;
+    }
+  });
+
+  it('falls back to the default max-age for weakening values like 0', async () => {
+    const original = process.env.SECURE_HSTS_MAX_AGE;
+    process.env.SECURE_HSTS_MAX_AGE = '0';
+    try {
+      const res = await request(createApp())
+        .get('/test')
+        .set('x-forwarded-proto', 'https');
+
+      expect(res.headers['strict-transport-security']).toBe(
+        'max-age=31536000; includeSubDomains'
+      );
+    } finally {
+      if (original === undefined) delete process.env.SECURE_HSTS_MAX_AGE;
+      else process.env.SECURE_HSTS_MAX_AGE = original;
+    }
+  });
+
   it('preserves headers an earlier layer already set', async () => {
     const res = await request(
       createApp({


### PR DESCRIPTION
﻿## Problem

The Strict-Transport-Security header max-age is hardcoded to 31536000 in securityHeaders, so deployments cannot tune the HSTS lifetime, and any future config-driven value could accidentally weaken it to 0, negative, or unbounded.

## Fix

Add resolveHstsMaxAge() which reads SECURE_HSTS_MAX_AGE and returns the value only when it is a finite number within the bounded range [60, 63072000] seconds, flooring fractions; otherwise it falls back to the previous default 31536000 (1 year), so HSTS can never be weakened to an unsafe value.

## Files changed

- backend/api/src/middleware/securityHeaders.js

## Testing

- 3 new unit tests in backend/api/test/unit/securityHeaders.test.js: configured value honored; invalid value falls back; weakening value 0 falls back.
- npx vitest run test/unit/securityHeaders.test.js — 10/10 pass.

Closes #10827
