### PR TITLE
fix : compute digital-twin utilization and efficiency as 0-1 metrics

### DIFF
--- a/backend/digital-twin/test_twin_model.py
+++ b/backend/digital-twin/test_twin_model.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import datetime, timedelta
+
+from twin_model import DigitalTwin, LogisticsEvent, SimulationEngine
+
+
+class TestSimulationMetrics(unittest.TestCase):
+    def setUp(self):
+        self.engine = SimulationEngine(DigitalTwin())
+        self.base = datetime(2026, 1, 1, 12, 0, 0)
+
+    def _event(self, event_type, timestamp, asset_id="TRUCK_1"):
+        return LogisticsEvent(
+            id=f"{event_type}_{int(timestamp.timestamp())}",
+            type=event_type,
+            timestamp=timestamp,
+            asset_id=asset_id,
+            location={"lat": 25.0, "lng": 75.0},
+        )
+
+    def test_utilization_is_zero_to_one_fraction(self):
+        # One asset busy for the full 60s window -> utilization 1.0
+        events = [
+            self._event("pickup", self.base),
+            self._event("dropoff", self.base + timedelta(seconds=60)),
+        ]
+        metrics = self.engine._calculate_metrics(events, {})
+        self.assertAlmostEqual(metrics["utilization"], 1.0, places=4)
+
+    def test_utilization_scales_down_with_idle_time(self):
+        # Two assets, each busy 10s within a 110s window -> utilization ~0.09
+        events = [
+            self._event("pickup", self.base, "TRUCK_1"),
+            self._event("dropoff", self.base + timedelta(seconds=10), "TRUCK_1"),
+            self._event("pickup", self.base + timedelta(seconds=100), "TRUCK_2"),
+            self._event("dropoff", self.base + timedelta(seconds=110), "TRUCK_2"),
+        ]
+        metrics = self.engine._calculate_metrics(events, {})
+        self.assertGreaterEqual(metrics["utilization"], 0.0)
+        self.assertLessEqual(metrics["utilization"], 1.0)
+        self.assertAlmostEqual(metrics["utilization"], 20.0 / 220.0, places=4)
+
+    def test_utilization_bounds_for_short_window(self):
+        # Single instantaneous event has no measurable window -> 0.0
+        metrics = self.engine._calculate_metrics([self._event("pickup", self.base)], {})
+        self.assertEqual(metrics["utilization"], 0.0)
+
+    def test_utilization_zero_for_no_events(self):
+        metrics = self.engine._calculate_metrics([], {})
+        self.assertEqual(metrics["utilization"], 0.0)
+        self.assertEqual(metrics["efficiency"], 0.0)
+
+    def test_efficiency_reflects_delays(self):
+        # 3 events, 1 delay -> efficiency 2/3
+        events = [
+            self._event("pickup", self.base),
+            self._event("delay", self.base + timedelta(seconds=10)),
+            self._event("dropoff", self.base + timedelta(seconds=20)),
+        ]
+        metrics = self.engine._calculate_metrics(events, {})
+        self.assertAlmostEqual(metrics["efficiency"], 2.0 / 3.0, places=4)
+
+    def test_efficiency_is_perfect_without_delays(self):
+        events = [
+            self._event("pickup", self.base),
+            self._event("dropoff", self.base + timedelta(seconds=10)),
+        ]
+        metrics = self.engine._calculate_metrics(events, {})
+        self.assertEqual(metrics["efficiency"], 1.0)
+
+    def test_recommendations_fire_on_low_utilization(self):
+        metrics = {"utilization": 0.1, "efficiency": 0.9, "event_types": {}}
+        recs = self.engine._generate_recommendations(metrics)
+        self.assertIn("Increase asset utilization by optimizing routes", recs)
+
+    def test_recommendations_fire_on_low_efficiency(self):
+        metrics = {"utilization": 0.9, "efficiency": 0.4, "event_types": {}}
+        recs = self.engine._generate_recommendations(metrics)
+        self.assertIn("Improve operational efficiency by reducing delays", recs)
+
+    def test_recommendations_smooth_when_metrics_healthy(self):
+        metrics = {"utilization": 0.9, "efficiency": 0.9, "event_types": {}}
+        recs = self.engine._generate_recommendations(metrics)
+        self.assertEqual(recs, ["Current operations are running smoothly"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/digital-twin/twin_model.py
+++ b/backend/digital-twin/twin_model.py
@@ -214,11 +214,30 @@ class SimulationEngine:
             metrics['event_types'][event.type] = metrics['event_types'].get(event.type, 0) + 1
         
         if events:
-            total_time = (events[-1].timestamp - events[0].timestamp).total_seconds()
-            if total_time > 0:
-                metrics['utilization'] = len(events) / (total_time / 60)
-        
-        metrics['efficiency'] = min(1.0, len(events) / 100)
+            total_window = (events[-1].timestamp - events[0].timestamp).total_seconds()
+            if total_window > 0 and metrics['unique_assets'] > 0:
+                # Active asset-time: each asset counts as active from its first
+                # to its last event in the window. Utilization is the fraction
+                # of available asset-time (window * unique assets) actually used.
+                spans: Dict[str, List] = {}
+                for event in events:
+                    spans.setdefault(event.asset_id, []).append(event.timestamp)
+
+                active_seconds = sum(
+                    (max(ts) - min(ts)).total_seconds() for ts in spans.values()
+                )
+                available_seconds = total_window * metrics['unique_assets']
+                metrics['utilization'] = (
+                    min(1.0, active_seconds / available_seconds)
+                    if available_seconds > 0
+                    else 0.0
+                )
+
+            # Efficiency: the fraction of events that completed on time
+            # (i.e., without a delay), rather than raw event volume.
+            delay_events = metrics['event_types'].get('delay', 0)
+            on_time_events = len(events) - delay_events
+            metrics['efficiency'] = on_time_events / len(events)
         
         return metrics
     


### PR DESCRIPTION
﻿## Problem

SimulationEngine._calculate_metrics computes utilization as events-per-minute (len(events) / elapsed_minutes), an unbounded ratio, but compares it against a 0-0.5 threshold and treats it as a 0-1 fraction. efficiency is min(1.0, len(events)/100), which scores perfect efficiency at 100 events regardless of delays. The derived recommendations are therefore unit-inconsistent and misleading.

## Fix

- utilization is now the fraction of available asset-time actually used: active asset-time (each asset busy from its first to its last event in the window) divided by window duration x unique assets, clamped to [0,1].
- efficiency is now the fraction of events that completed on time: (total_events - delay_events) / total_events.
- Thresholds already expressed in 0-1 units (utilization < 0.5, efficiency < 0.7) now operate on consistent 0-1 metrics.

## Files changed

- backend/digital-twin/twin_model.py
- backend/digital-twin/test_twin_model.py (new)

## Testing

- 9 new unittest cases in test_twin_model.py covering 0-1 utilization bounds, delay-based efficiency, and recommendation thresholds; existing test_twin.py still passes.
- py -m unittest test_twin_model test_twin -v -- 10/10 pass.

Closes #10818
