### PR TITLE
fix : fail closed instead of XOR CP-ABE with zero confidentiality

### DIFF
--- a/backend/abe/abe_cipher.py
+++ b/backend/abe/abe_cipher.py
@@ -1,26 +1,26 @@
-import base64
-import hashlib
-from policy_builder import policy_builder
-
 class CpAbeCipherEngine:
     """
     Ciphertext-Policy Attribute-Based Encryption (CP-ABE) Engine for logistics documents.
+
+    This engine is intentionally disabled. The previous implementation was a
+    repeating-key XOR cipher whose keystream was derived from the public policy
+    string, giving zero confidentiality. No real pairing-based CP-ABE scheme is
+    available in this project, so rather than ship broken crypto the engine
+    fails closed: any call to encrypt or decrypt raises instead of producing a
+    ciphertext that offers no protection.
     """
     def encrypt_document(self, plaintext_bytes: bytes, policy_str: str) -> dict:
-        key = hashlib.sha256(policy_str.encode()).digest()
-        encrypted = bytes([b ^ key[i % len(key)] for i, b in enumerate(plaintext_bytes)])
-        return {
-            "policy": policy_str,
-            "ciphertext_b64": base64.b64encode(encrypted).decode('utf-8')
-        }
+        raise NotImplementedError(
+            "CP-ABE encryption is not available: the previous XOR-based cipher "
+            "offered no confidentiality and has been disabled. Integrate a real "
+            "pairing-based CP-ABE scheme before enabling this engine."
+        )
 
     def decrypt_document(self, ciphertext_b64: str, policy_str: str, user_attributes: set) -> bytes:
-        if not policy_builder.evaluate_user_attributes(user_attributes, policy_str):
-            raise PermissionError("CP-ABE Policy Evaluation Failed: User attributes do not satisfy ciphertext access policy.")
-
-        encrypted = base64.b64decode(ciphertext_b64)
-        key = hashlib.sha256(policy_str.encode()).digest()
-        decrypted = bytes([b ^ key[i % len(key)] for i, b in enumerate(encrypted)])
-        return decrypted
+        raise NotImplementedError(
+            "CP-ABE decryption is not available: the previous XOR-based cipher "
+            "offered no confidentiality and has been disabled. Integrate a real "
+            "pairing-based CP-ABE scheme before enabling this engine."
+        )
 
 abe_cipher = CpAbeCipherEngine()

--- a/backend/abe/test_abe.py
+++ b/backend/abe/test_abe.py
@@ -7,25 +7,19 @@ class TestCPABE(unittest.TestCase):
         self.cipher = CpAbeCipherEngine()
         self.builder = CpAbePolicyBuilder()
 
-    def test_authorized_decryption(self):
+    def test_encryption_fails_closed(self):
         policy = self.builder.build_trip_document_policy(trip_id="TRIP_1001", allowed_role="Driver")
         doc_data = b"CONFIDENTIAL_BILL_OF_LADING"
 
-        enc = self.cipher.encrypt_document(doc_data, policy)
+        with self.assertRaises(NotImplementedError):
+            self.cipher.encrypt_document(doc_data, policy)
+
+    def test_decryption_fails_closed(self):
+        policy = self.builder.build_trip_document_policy(trip_id="TRIP_1001", allowed_role="Driver")
         driver_attrs = {"Role: Driver", "TripID: TRIP_1001"}
 
-        decrypted = self.cipher.decrypt_document(enc["ciphertext_b64"], policy, driver_attrs)
-        self.assertEqual(decrypted, doc_data)
-
-    def test_unauthorized_decryption_rejection(self):
-        policy = self.builder.build_trip_document_policy(trip_id="TRIP_1001", allowed_role="Driver")
-        doc_data = b"CONFIDENTIAL_BILL_OF_LADING"
-
-        enc = self.cipher.encrypt_document(doc_data, policy)
-        wrong_attrs = {"Role: Driver", "TripID: TRIP_9999"}  # Wrong trip ID
-
-        with self.assertRaises(PermissionError):
-            self.cipher.decrypt_document(enc["ciphertext_b64"], policy, wrong_attrs)
+        with self.assertRaises(NotImplementedError):
+            self.cipher.decrypt_document("dGVzdA==", policy, driver_attrs)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
﻿## Problem

CpAbeCipherEngine.encrypt_document is a repeating-key XOR cipher whose keystream is derived from sha256(policy_str). The policy is stored inside the returned dict, so anyone holding the ciphertext (who receives the policy in the same payload) can derive the key and decrypt. Decryption never involves attribute-authority credentials, master keys, or user keys - the PermissionError gate is the only control and it is trivially bypassed. Confidentiality is zero.

## Fix

No pairing-based CP-ABE library is available in this project (requirements.txt only ships cryptography/pycryptodome), so per the issue's suggested option the scheme is removed and the engine now fails closed: encrypt_document and decrypt_document raise NotImplementedError with guidance to integrate a real ABE scheme, instead of silently producing or accepting zero-confidentiality ciphertext.

## Files changed

- backend/abe/abe_cipher.py
- backend/abe/test_abe.py

## Testing

- Replaced the two encryption tests with fail-closed tests asserting encrypt_document and decrypt_document raise NotImplementedError.
- py -m unittest test_abe -v -- 2/2 pass.

Closes #10819
