### PR TITLE
fix(delivery): add order_display_id filter to geofence telemetry query

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -420,15 +420,25 @@ export class DeliveryVerificationService {
 
     // Ownership + provenance: only telemetry for THIS driver on THIS order.
     // driver_id is stamped server-side from the authenticated connection.
+    // order_display_id is cross-verified to prevent stale telemetry from a
+    // previous order for the same driver being used to satisfy the geofence.
     const latestTelemetry = await mongoDb
       .collection("telemetry")
-      .find({ driver_id: order.driver_id, order_id: order.id })
+      .find({
+        driver_id: order.driver_id,
+        order_id: order.id,
+        order_display_id: order.order_display_id,
+      })
       .sort({ server_received_at: -1 })
       .limit(1)
       .toArray();
 
     const telemetry = latestTelemetry?.[0];
-    if (!telemetry || telemetry.driver_id !== order.driver_id) {
+    if (
+      !telemetry ||
+      telemetry.driver_id !== order.driver_id ||
+      telemetry.order_display_id !== order.order_display_id
+    ) {
       throw new DomainError(409, {
         error: "Location is not available for this driver on this order.",
       });


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/deliveryVerificationService.js`, the `assertDriverAtDropoff` method queries MongoDB for the latest telemetry point but only filters by `driver_id` and `order_id`. It does not verify that the telemetry point's `order_display_id` matches the order's `order_display_id`.

If an order is cancelled and a new order is created, the driver's telemetry from the old order could potentially be used to satisfy the geofence check for the new order.

## Fix

- Add `order_display_id` to the telemetry query filter in `assertDriverAtDropoff`
- Also verify the `order_display_id` in the returned telemetry matches the order's `order_display_id` before proceeding

## Files changed

- `backend/api/src/services/order/deliveryVerificationService.js`

## Testing

- `node --check backend/api/src/services/order/deliveryVerificationService.js` passes.
- Telemetry query now filters by `order_display_id` and verifies the returned telemetry matches.

Closes #11185