### PR TITLE
fix(tracker): proactive cleanup of circuit breaker map for inactive drivers

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -155,12 +155,12 @@ const consecutiveDropCount = new Map();
 // DRIVER STATE TTL & LAZY CLEANUP
 // =====================================================================
 const TRACKER_DRIVER_STATE_TTL_MS = parseInt(process.env.TRACKER_DRIVER_STATE_TTL_MS, 10) || 900000; // default 15 min
-const DRIVER_STATE_SWEEP_THRESHOLD = 50;
-const DRIVER_STATE_SWEEP_INTERVAL_MS = 60000;
+const DRIVER_STATE_SWEEP_INTERVAL_MS = parseInt(process.env.DRIVER_STATE_SWEEP_INTERVAL_MS, 10) || 300000; // default 5 min
 let lastDriverStateSweep = 0;
 
 function sweepStaleDriverState(now) {
-  if (consecutiveDropCount.size < DRIVER_STATE_SWEEP_THRESHOLD) return;
+  // Clean up stale driver state periodically regardless of Map size to
+  // prevent unbounded memory growth from drivers who stop sending telemetry.
   if (now - lastDriverStateSweep < DRIVER_STATE_SWEEP_INTERVAL_MS) return;
   lastDriverStateSweep = now;
   for (const [driverId, entry] of consecutiveDropCount) {


### PR DESCRIPTION
## Problem

In `backend/api/src/sockets/tracker.js`, the `consecutiveDropCount` Map tracks out-of-order telemetry drops per driver for the circuit breaker. The `sweepStaleDriverState` function only cleaned up when the Map size exceeded `DRIVER_STATE_SWEEP_THRESHOLD` (50), so:

1. The Map was never cleaned up for drivers who stop sending telemetry but haven't hit the drop threshold
2. If fewer than 50 drivers ever have drops, the Map grows unboundedly
3. Memory leak in long-running processes

## Fix

- Removed the `DRIVER_STATE_SWEEP_THRESHOLD` (50) gate that prevented cleanup when the Map was small
- Changed the sweep interval from 60s to 5 min (configurable via `DRIVER_STATE_SWEEP_INTERVAL_MS`) so cleanup runs on a periodic interval regardless of Map size
- Stale entries are now cleaned whenever the sweep interval elapses, independent of how many drivers have entries

## Files changed

- `backend/api/src/sockets/tracker.js`

## Testing

- `node --check backend/api/src/sockets/tracker.js` passes.
- `sweepStaleDriverState` now runs on a periodic interval regardless of Map size, so `consecutiveDropCount` can no longer grow unboundedly.

Closes #11186