### PR TITLE
fix: reject array x-correlation-id headers (#10836)

### DIFF
--- a/backend/api/src/middleware/correlationId.js
+++ b/backend/api/src/middleware/correlationId.js
@@ -9,10 +9,12 @@ const SAFE_CORRELATION_ID = /^[A-Za-z0-9_-]{1,64}$/;
 export function correlationIdMiddleware(req, res, next) {
   const headers = req?.headers || {};
   const header = headers['x-correlation-id'] || headers['X-Correlation-ID'];
-  const rawHeader = Array.isArray(header) ? header[0] : header;
+  // A repeated x-correlation-id header arrives as an array. The multi-value form
+  // is ambiguous and must not be trusted, so treat it as invalid and generate a
+  // fresh UUID rather than regex-testing any single entry.
   const correlationId =
-    typeof rawHeader === 'string' && SAFE_CORRELATION_ID.test(rawHeader.trim())
-      ? rawHeader.trim()
+    !Array.isArray(header) && typeof header === 'string' && SAFE_CORRELATION_ID.test(header.trim())
+      ? header.trim()
       : randomUUID();
 
   if (req) {

--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -81,13 +81,25 @@ describe('correlationIdMiddleware', () => {
     expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-ID', validUuid);
   });
 
-  it('handles array correlation ID headers safely by taking first entry', () => {
+  it('rejects array correlation ID headers and generates a fresh UUID', () => {
     const req = makeReq({ 'x-correlation-id': ['array-id-789', 'array-id-000'] });
     const res = makeRes();
     const next = vi.fn();
     correlationIdMiddleware(req, res, next);
-    expect(req.correlationId).toBe('array-id-789');
-    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-ID', 'array-id-789');
+    expect(req.correlationId).not.toBe('array-id-789');
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-ID', req.correlationId);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects uppercase array correlation ID headers and generates a fresh UUID', () => {
+    const req = makeReq({ 'X-Correlation-ID': ['array-id-200', 'array-id-300'] });
+    const res = makeRes();
+    const next = vi.fn();
+    correlationIdMiddleware(req, res, next);
+    expect(req.correlationId).not.toBe('array-id-200');
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it('handles uppercase X-Correlation-ID header name', () => {


### PR DESCRIPTION
﻿## Problem
A repeated `x-correlation-id` header reaches the middleware as an array. The previous implementation took `header[0]` and used it if it matched the safe-id regex, trusting one entry of an ambiguous multi-value form. This lets a client smuggle arbitrary values or bypass correlation-id validation by sending a duplicate header.

## Fix
In `backend/api/src/middleware/correlationId.js`, a header that arrives as an array (or is otherwise not a clean string) is now treated as invalid. Instead of selecting and reusing a single array entry, the middleware generates a fresh `randomUUID()` correlation id. The trusted string path is unaffected.

## Files changed
- `backend/api/src/middleware/correlationId.js`
- `backend/api/test/unit/correlationId.test.js`

## Testing
`npx vitest run test/unit/correlationId.test.js` — 9 tests pass, including new cases asserting array headers (both `x-correlation-id` and `X-Correlation-ID`) are rejected and replaced with a fresh UUID.

Closes #10836
