### PR TITLE
test: guard top-level undefined header value (#10837)

### DIFF
--- a/backend/api/test/unit/headerSizeMonitor.test.js
+++ b/backend/api/test/unit/headerSizeMonitor.test.js
@@ -165,4 +165,22 @@ describe('headerSizeMonitor', () => {
       else delete process.env.HEADER_SIZE_LIMIT;
     }
   });
+
+  it('does not throw when a header value is a top-level undefined', () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originalLimit = process.env.HEADER_SIZE_LIMIT;
+    process.env.NODE_ENV = 'development';
+    process.env.HEADER_SIZE_LIMIT = '5000';
+    try {
+      const req = makeReq({ 'x-undefined': undefined, 'x-ok': 'value' });
+      const res = makeRes();
+      const next = vi.fn();
+      expect(() => headerSizeMonitor(req, res, next)).not.toThrow();
+      expect(next).toHaveBeenCalledOnce();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+      if (originalLimit !== undefined) process.env.HEADER_SIZE_LIMIT = originalLimit;
+      else delete process.env.HEADER_SIZE_LIMIT;
+    }
+  });
 });


### PR DESCRIPTION
﻿## Problem
`headerSizeMonitor` computes `Buffer.byteLength(value)` for each header value. When a header arrives with a top-level `undefined` value (e.g. `req.headers` containing `{ 'x-undefined': undefined }`), `Buffer.byteLength(undefined)` throws, breaking the middleware and the request pipeline.

## Fix
The guard in `backend/api/src/middleware/headerSizeMonitor.js` already skips values that are `undefined` or `null` (and coerces non-string names with `String(name)`). This regression test formally covers the top-level `undefined` case to ensure the middleware never throws. No source change was required because the fix is already present — this PR pins the behavior with a test and closes #10837.

## Files changed
- `backend/api/test/unit/headerSizeMonitor.test.js`

## Testing
`npx vitest run test/unit/headerSizeMonitor.test.js` — 7 tests pass, including the new top-level `undefined` header regression test. Also confirms existing coverage for array items containing `undefined`/non-string values.

Closes #10837
