### PR TITLE
fix(delivery): call complete_trip_tx on stuck escrow retry path to credit wallet

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -766,6 +766,41 @@ export class DeliveryVerificationService {
           logger.info(
             `[verify-delivery] Retry for stuck escrow for order ${orderId} by driver ${driverId} — release confirmed (tx_hash=${releaseTxHash || "alreadyReleased"}).`,
           );
+
+          // The order is already `payment_released` (that is what defines a
+          // stuck-escrow retry), but `complete_trip_tx` may never have run —
+          // e.g. the original call failed after the on-chain release landed —
+          // leaving the driver's wallet uncredited. Call `complete_trip_tx`
+          // (service_role, no OTP) now: it is idempotent on
+          // `status = 'payment_released'`, so an already-finalized order
+          // short-circuits without double-crediting the wallet, while a
+          // never-finalized order gets its wallet credited exactly once
+          // (issue #11188).
+          const retryRpcResult = await this.orderRepository.executeRpc(
+            "complete_trip_tx",
+            {
+              p_order_id: orderId,
+              p_otp_id: null,
+              p_release_tx_hash: releaseTxHash,
+            },
+            supabaseAdmin,
+          );
+          if (retryRpcResult.error) {
+            logger.error(
+              "[verify-delivery] complete_trip_tx failed on stuck-escrow retry for order",
+              orderId,
+              ":",
+              retryRpcResult.error.message,
+            );
+            throw new DomainError(503, {
+              error:
+                "Failed to finalize trip and credit wallet. Please retry.",
+              details: retryRpcResult.error.message,
+              retryable: true,
+            });
+          }
+          tripData = retryRpcResult.data;
+
           // The verified OTP is consumed on the retry path too so it cannot be
           // replayed by a later attempt. It is only consumed after the release
           // is confirmed, so a failed release leaves the OTP intact for the

--- a/backend/api/test/unit/deliveryVerificationGeofence.test.js
+++ b/backend/api/test/unit/deliveryVerificationGeofence.test.js
@@ -475,7 +475,18 @@ describe("DeliveryVerificationService.verifyDelivery geofence gating", () => {
       otp: "123456",
     });
     expect(escrowReleaseFn).toHaveBeenCalledWith("ORD-GEO", 600000000000000000n);
-    expect(repo.executeRpc).not.toHaveBeenCalled();
+    // The retry path skips the geofence check but must still finalize the trip
+    // and credit the wallet via complete_trip_tx (service_role, no OTP) so a
+    // driver is not left unpaid when the original RPC never ran (issue #11188).
+    expect(repo.executeRpc).toHaveBeenCalledWith(
+      "complete_trip_tx",
+      expect.objectContaining({
+        p_order_id: "order-geo-1",
+        p_otp_id: null,
+        p_release_tx_hash: "0xrelease",
+      }),
+      null,
+    );
     expect(repo.updateOrder).toHaveBeenCalled();
     expect(result.escrowUpdateFailed).toBe(false);
   });


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/deliveryVerificationService.js`, the `verifyDelivery` method's stuck-escrow retry path (order `status === 'payment_released'` but `escrow_status` still `funded`/`release_failed`) skipped the entire RPC section:

```javascript
if (!isRetryForStuckEscrow) {
  // ... guard check, complete_trip_tx RPC, status verification, OTP consumption
} else {
  // Only OTP consumption, NO RPC call
  await this.completeDeliveryOtp({ otpRecordId: otpRecord.id, orderId });
}
```

The `complete_trip_tx` RPC — which credits the driver's wallet and finalizes the trip — never runs on the retry path. If the original `complete_trip_tx` never ran successfully (e.g. a failure after the on-chain release landed), the driver is never paid.

## Fix

- On the stuck-escrow retry path, after confirming the on-chain release, call `complete_trip_tx` via the service-role client (`supabaseAdmin`) with `p_otp_id: null` — the same pattern the release reconciliation worker uses.
- `complete_trip_tx` is idempotent on `status = 'payment_released'` (short-circuits and returns), so an already-finalized order is a safe no-op with no double wallet credit, while a never-finalized order gets its wallet credited exactly once.
- If the RPC errors, fail closed with a retryable 503 instead of reporting success while the driver remains unpaid.
- Updated the geofence unit test to assert `complete_trip_tx` is invoked on the retry path instead of asserting it is never called.

## Files changed

- `backend/api/src/services/order/deliveryVerificationService.js`
- `backend/api/test/unit/deliveryVerificationGeofence.test.js`

## Testing

- `npx vitest run test/unit/deliveryVerificationGeofence.test.js test/deliveryVerification.releaseOrder.test.js` — 30 tests pass.
- `node --check backend/api/src/services/order/deliveryVerificationService.js` passes.
- Note: `test/contracts/delivery.contract.test.js` fails to load on this branch because `origin/main`'s `src/middleware/auth.js` has a pre-existing duplicate `const userClient` declaration (fixed in PR #11292). Unrelated to this change.

Closes #11188