### PR TITLE
fix(escrow): use weiWithinTolerance when comparing funding booking amount

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,6 +1,6 @@
 import { redisClient, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
-import { submitEscrowRefund, getEscrowBooking } from './escrow.js';
+import { submitEscrowRefund, getEscrowBooking, weiWithinTolerance } from './escrow.js';
 import { acquireLock, renewLock, releaseLock } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
 
@@ -45,13 +45,16 @@ async function finalizeOrRevert(order, orderRepository) {
     const bookingFunded = booking && bookingAmount != null && bookingAmount > 0n;
 
     // An on-chain booking only counts as "the deposit landed" if it is funded
-    // with EXACTLY the authoritative amount recorded for the order. A booking
-    // funded with any other amount must never finalize the acceptance — the
-    // order is reverted and the deposit refunded instead.
+    // with the authoritative amount recorded for the order, within the same
+    // tolerance the rest of the escrow pipeline uses (1 gwei default). Sub-gwei
+    // deviations from blockchain mechanics (gas refunds, priority fees) must
+    // not reject a legitimate deposit; a booking funded with any other amount
+    // must never finalize the acceptance — the order is reverted and the
+    // deposit refunded instead.
     let mismatchReason = null;
     if (bookingFunded && order.escrow_amount_wei != null) {
       const expectedWei = BigInt(order.escrow_amount_wei);
-      if (bookingAmount !== expectedWei) {
+      if (!weiWithinTolerance(bookingAmount, expectedWei)) {
         mismatchReason = `booking amount ${bookingAmount} wei does not match expected ${expectedWei} wei`;
         logger.error(`[escrow-funding] Order ${order.order_display_id} ${mismatchReason} — reverting instead of healing.`);
       }

--- a/backend/api/test/unit/escrowFundingReconciliation.test.js
+++ b/backend/api/test/unit/escrowFundingReconciliation.test.js
@@ -34,18 +34,23 @@ vi.mock('../../src/config/db.js', () => ({
   supabaseAdmin: {},
 }));
 
-vi.mock('../../src/services/escrow.js', () => ({
-  escrowRefund: vi.fn(),
-  getEscrowBooking: vi.fn(),
-}));
+vi.mock('../../src/services/escrow.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    submitEscrowRefund: vi.fn(),
+    getEscrowBooking: vi.fn(),
+  };
+});
 
 vi.mock('../../src/lib/redisLock.js', () => ({
   acquireLock: vi.fn(),
+  renewLock: vi.fn(),
   releaseLock: vi.fn(),
 }));
 
 vi.mock('../../src/services/notificationService.js', () => ({
-  sendPushNotification: vi.fn(),
+  sendPushNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock the order repository
@@ -121,6 +126,102 @@ describe('escrowFundingReconciliation', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         '[escrow-funding] Failed to load stale funding orders:',
         'DB error'
+      );
+    });
+
+    it('heals a funded booking whose on-chain amount differs from expected within tolerance', async () => {
+      mockRedisClient.set.mockResolvedValue('locked');
+
+      const order = {
+        id: 'order-tol-ok',
+        order_display_id: 'DIS-TOL-OK',
+        status: 'accepted',
+        escrow_status: 'funding',
+        escrow_booking_id: 'booking-1',
+        escrow_amount_wei: '1000000000000000000',
+        escrow_funding_attempts: 0,
+        escrow_funding_last_attempt_at: null,
+        customer_id: 'cust-1',
+        pending_bid_acceptance: {
+          bid_id: 'bid-1',
+          load_id: 'load-1',
+          driver_id: 'driver-1',
+          truck_id: 'truck-1',
+          driver_name: 'Driver',
+          driver_rating: 4.5,
+          truck_number: 'KA-01-1234',
+          bid_amount: 5000,
+          order_display_id: 'DIS-TOL-OK',
+          version: 1,
+        },
+      };
+      mockOrderRepository.findStaleFundingOrders.mockResolvedValueOnce({ data: [order], error: null });
+      mockOrderRepository.executeRpc.mockResolvedValueOnce({ error: null });
+      mockOrderRepository.updateOrderWithFilter.mockResolvedValueOnce({ error: null });
+
+      const { acquireLock, releaseLock } = await import('../../src/lib/redisLock.js');
+      acquireLock.mockResolvedValueOnce('lock-value');
+      releaseLock.mockResolvedValueOnce(undefined);
+
+      const { getEscrowBooking } = await import('../../src/services/escrow.js');
+      // 500 wei above expected — sub-gwei, must be treated as landed.
+      getEscrowBooking.mockResolvedValueOnce({ paid: true, amount: 1000000000000000500n });
+
+      await reconcileStaleFunding(mockOrderRepository);
+
+      expect(mockOrderRepository.executeRpc).toHaveBeenCalledWith(
+        'accept_bid_tx',
+        expect.objectContaining({ p_order_id: 'order-tol-ok' }),
+        expect.anything()
+      );
+      expect(mockOrderRepository.updateOrderWithFilter).toHaveBeenCalledWith(
+        order.id,
+        expect.objectContaining({ escrow_funding_attempts: 0, escrow_funding_error: null }),
+        expect.anything(),
+        'id'
+      );
+    });
+
+    it('reverts a funded booking whose on-chain amount differs beyond tolerance', async () => {
+      mockRedisClient.set.mockResolvedValue('locked');
+
+      const order = {
+        id: 'order-tol-bad',
+        order_display_id: 'DIS-TOL-BAD',
+        status: 'accepted',
+        escrow_status: 'funding',
+        escrow_booking_id: 'booking-1',
+        escrow_amount_wei: '1000000000000000000',
+        escrow_funding_attempts: 0,
+        escrow_funding_last_attempt_at: null,
+        customer_id: 'cust-1',
+        pending_bid_acceptance: null,
+      };
+      mockOrderRepository.findStaleFundingOrders.mockResolvedValueOnce({ data: [order], error: null });
+      mockOrderRepository.updateOrderWithFilter.mockResolvedValueOnce({ error: null });
+
+      const { acquireLock, releaseLock } = await import('../../src/lib/redisLock.js');
+      acquireLock.mockResolvedValueOnce('lock-value');
+      releaseLock.mockResolvedValueOnce(undefined);
+
+      const { getEscrowBooking, submitEscrowRefund } = await import('../../src/services/escrow.js');
+      // 2 gwei above expected — exceeds the 1 gwei tolerance.
+      getEscrowBooking.mockResolvedValueOnce({ paid: true, amount: 1000000002000000000n });
+      submitEscrowRefund.mockResolvedValueOnce({
+        txHash: '0xrefund',
+        waitForConfirmation: vi.fn().mockResolvedValueOnce({ blockNumber: 42 }),
+      });
+
+      await reconcileStaleFunding(mockOrderRepository);
+
+      expect(mockOrderRepository.updateOrderWithFilter).toHaveBeenCalledWith(
+        order.id,
+        expect.objectContaining({
+          escrow_status: 'pending',
+          escrow_funding_error: expect.stringContaining('ESCROW_AMOUNT_MISMATCH'),
+        }),
+        expect.anything(),
+        'id'
       );
     });
 


### PR DESCRIPTION
## Problem

In `backend/api/src/services/escrowFundingReconciliation.js`, `finalizeOrRevert` compared the on-chain booking amount with the order's `escrow_amount_wei` using exact equality:

```javascript
if (bookingAmount !== expectedWei) {
```

Sub-gwei differences from blockchain mechanics (gas refunds, priority fees, MEV) caused legitimate customer deposits to be rejected, reverting valid orders.

## Fix

- Use the existing `weiWithinTolerance` helper (default 1 gwei tolerance) from `escrow.js`, consistent with the rest of the escrow pipeline.
- Checked `escrowReleaseReconciliation.js` for similar comparisons — it only checks `booking.paid === true` (a boolean), so no change is needed there.
- Updated the test mock for `escrow.js` to spread the real module (so `weiWithinTolerance` is available) and added two focused tests:
  - a booking within tolerance (500 wei above expected) is treated as landed and heals the acceptance;
  - a booking beyond tolerance (2 gwei above expected) is reverted with `ESCROW_AMOUNT_MISMATCH`.

## Files changed

- `backend/api/src/services/escrowFundingReconciliation.js`
- `backend/api/test/unit/escrowFundingReconciliation.test.js`

## Testing

- `node --check backend/api/src/services/escrowFundingReconciliation.js` passes.
- `npx vitest run test/unit/escrowFundingReconciliation.test.js` — 10 pass including the two new tolerance tests.
- Two pre-existing test failures remain (`refunds cancelled funded orders only after submit and confirmation`, `marks refund_failed when cancelled order refund is not submitted`) — they fail identically on `origin/main` because they assert `updateOrder` while the code calls `updateOrderWithFilter` and the mock returns `undefined`. Unrelated to this change.

Closes #11189