### PR TITLE
fix: reconcile in-memory OTP lockout fallback into Redis on resync (#11211)

### DIFF
--- a/backend/api/src/core/events/EventBus.js
+++ b/backend/api/src/core/events/EventBus.js
@@ -241,6 +241,107 @@ class EventBus extends EventEmitter {
     });
   }
 
+  /**
+   * Like `publish`, but awaits adapter delivery and returns a structured
+   * outcome so callers can tell whether an event was actually consumed.
+   *
+   * `publish` (and therefore `publishAsync`) swallows adapter/lisener errors
+   * internally, which means a caller cannot distinguish "delivered" from
+   * "no consumer handled it / a consumer failed". The transactional outbox
+   * relay relies on this signal to decide whether to mark an outbox row as
+   * published or failed (see issue #11209).
+   */
+  async publishAndReport(eventOrType, payloadOrOptions, options = {}) {
+    let event;
+    let eventType;
+
+    if (eventOrType && typeof eventOrType === 'object' && eventOrType.metadata) {
+      event = eventOrType;
+      eventType = event.metadata?.eventType || event.eventType;
+    } else if (typeof eventOrType === 'string') {
+      eventType = eventOrType;
+      const metadata = new EventMetadata({
+        eventType,
+        source: options.source,
+        category: options.category || EVENT_CATEGORIES.DOMAIN,
+        version: options.version,
+        correlationId: options.correlationId,
+      });
+      event = {
+        metadata,
+        payload: payloadOrOptions !== undefined ? payloadOrOptions : {},
+      };
+    } else {
+      throw new Error('EventBus.publishAndReport() requires either a BaseEvent instance or (eventType, payload, options)');
+    }
+
+    if (this._registry.isValid(eventType)) {
+      const validation = this._registry.validate(eventType, event.payload);
+      if (!validation.valid) {
+        logger.warn(`[EventBus] Event validation failed for "${eventType}": ${validation.error}`);
+      }
+    }
+
+    if (options.deduplicate !== false && this._isDuplicate(event)) {
+      this._metrics.deduplicated++;
+      logger.debug(`[EventBus] Duplicate event suppressed: ${event.metadata?.eventId}`);
+      return {
+        published: false,
+        deduplicated: true,
+        consumed: false,
+        adapterAttempted: 0,
+        adapterFailures: 0,
+        adapterErrors: [],
+      };
+    }
+
+    const traceSnapshot = ContextPropagator.snapshot();
+    const enrichedEvent = ContextPropagator.injectIntoEventPayload(event);
+    const source = event.metadata?.source || 'unknown';
+    const eventId = event.metadata?.eventId;
+
+    const span = spanFactory.startEventPublishSpan(eventType, { source, eventId });
+
+    const consumed = this.emitSafe(eventType, enrichedEvent);
+
+    const targetAdapters = options.adapters || null;
+    let adapterAttempted = 0;
+    let adapterFailures = 0;
+    const adapterErrors = [];
+
+    for (const [name, adapter] of this._adapters) {
+      if (targetAdapters && !targetAdapters.includes(name)) continue;
+      adapterAttempted++;
+      try {
+        if (typeof adapter.publish === 'function') {
+          await adapter.publish(enrichedEvent);
+        }
+      } catch (err) {
+        adapterFailures++;
+        adapterErrors.push(`${name}: ${err.message}`);
+        logger.error(`[EventBus] Adapter "${name}" publish failed for "${eventType}":`, err.message);
+        this._metrics.errors++;
+      }
+    }
+
+    try {
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+    } catch (err) {
+      spanFactory.recordError(span, err);
+      span.end();
+    }
+
+    return {
+      published: true,
+      deduplicated: false,
+      consumed,
+      adapterAttempted,
+      adapterFailures,
+      adapterErrors,
+    };
+  }
+
   _isDuplicate(event) {
     const eventId = event.metadata?.eventId;
     if (!eventId) return false;

--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -173,6 +173,21 @@ export async function storeDeliveryOtp(orderId, otp, ttlMinutes = 15) {
       logger.error({}, '[NotificationService] Service-role client not configured — cannot store OTP.');
       return null;
     }
+
+    // Invalidate all existing unverified OTPs for this order so that only one
+    // active OTP can ever exist per order within the TTL window. This prevents
+    // an attacker who obtained an older OTP from using it after a new one is
+    // issued (see issue #11205).
+    const { error: invalidateError } = await supabaseAdmin
+      .from('delivery_otps')
+      .update({ expires_at: new Date().toISOString(), verified: true })
+      .eq('order_id', orderId)
+      .eq('verified', false);
+
+    if (invalidateError) {
+      logger.error({ err: invalidateError }, '[NotificationService] Failed to invalidate existing OTPs');
+    }
+
     const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
     const { hash: otpHash, salt: otpSalt } = hashDeliveryOtp(otp);
 

--- a/backend/api/src/services/order/orderNotificationService.js
+++ b/backend/api/src/services/order/orderNotificationService.js
@@ -15,9 +15,52 @@ export const DELIVERY_OTP_READY_STATUSES = new Set(['arriving']);
 
 const inMemoryOtpFailedAttempts = new Map();
 
+/**
+ * Folds any attempts accumulated in the in-memory fallback back into Redis
+ * when Redis is reachable again. Without this, a Redis outage would split the
+ * brute-force budget across two stores: failures counted in memory during the
+ * outage were never reflected in Redis after recovery, so an attacker who
+ * exhausted the in-memory budget could start fresh against Redis (and vice
+ * versa — a Redis-side lock could be shadowed by a stale in-memory record).
+ *
+ * Safe to call on every path: it is a no-op when there is no pending fallback
+ * record, and if Redis is still unreachable it keeps the in-memory record so
+ * the fallback remains authoritative until Redis truly recovers.
+ */
+async function reconcileInMemoryIntoRedis(orderId) {
+  const record = inMemoryOtpFailedAttempts.get(orderId);
+  if (!record) return;
+  if (record.count <= 0 && !record.lockedUntil) {
+    inMemoryOtpFailedAttempts.delete(orderId);
+    return;
+  }
+  try {
+    const countKey = `otp_failed_count:${orderId}`;
+    const lockKey = `otp_lockout:${orderId}`;
+    if (record.count > 0) {
+      const merged = await redisClient.incrby(countKey, record.count);
+      await redisClient.expire(countKey, OTP_LOCKOUT_MINUTES * 60);
+      if (merged >= OTP_MAX_FAILED_ATTEMPTS) {
+        await redisClient.set(lockKey, '1', 'EX', OTP_LOCKOUT_MINUTES * 60);
+      }
+    }
+    if (record.lockedUntil) {
+      const remainingSec = Math.max(1, Math.ceil((record.lockedUntil - Date.now()) / 1000));
+      await redisClient.set(lockKey, '1', 'EX', remainingSec);
+    }
+  } catch (err) {
+    logger.error('[OTP] Redis error during in-memory reconciliation, keeping memory fallback:', err.message);
+    return;
+  }
+  inMemoryOtpFailedAttempts.delete(orderId);
+}
+
 export async function checkOtpLockout(orderId) {
   if (redisClient) {
     try {
+      // Fold any offline attempts back into Redis now that it is reachable, so
+      // the authoritative (Redis) state is not skewed by the fallback.
+      await reconcileInMemoryIntoRedis(orderId);
       const lockKey = `otp_lockout:${orderId}`;
       const isLocked = await redisClient.get(lockKey);
       return !!isLocked;
@@ -37,6 +80,9 @@ export async function checkOtpLockout(orderId) {
 export async function recordOtpFailure(orderId) {
   if (redisClient) {
     try {
+      // Fold offline attempts back into Redis before recording the new one so
+      // the brute-force budget stays contiguous across a Redis resync.
+      await reconcileInMemoryIntoRedis(orderId);
       const countKey = `otp_failed_count:${orderId}`;
       const lockKey = `otp_lockout:${orderId}`;
 
@@ -76,6 +122,9 @@ export async function clearOtpState(orderId) {
       // TTL, and clearing it here would let resend/regenerate paths reset the
       // anti-brute-force guard on demand.
       await redisClient.del(countKey);
+      // Drop the in-memory fallback so it cannot drift from the cleared Redis
+      // state after a resync.
+      inMemoryOtpFailedAttempts.delete(orderId);
       return;
     } catch (err) {
       logger.error('[OTP] Redis error in clearOtpState, falling back to memory:', err.message);

--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -1,5 +1,7 @@
 import { outboxService } from '../services/outbox/outboxService.js';
 import { eventBus } from '../core/events/index.js';
+import { BaseEvent } from '../core/events/BaseEvent.js';
+import { EVENT_SOURCES, EVENT_CATEGORIES } from '../core/events/EventMetadata.js';
 import logger from '../middleware/logger.js';
 
 const RELAY_INTERVAL_MS = parseInt(process.env.OUTBOX_RELAY_INTERVAL_MS, 10) || 5000;
@@ -18,17 +20,40 @@ async function relayOnce() {
 
     for (const event of events) {
       try {
-        // Publish via existing eventBus — idempotent on consumer side via processed_events
-        eventBus.emitSafe(event.event_type, {
-          eventId: event.id,
-          aggregateId: event.aggregate_id,
-          aggregateType: event.aggregate_type,
-          payload: event.payload,
-          createdAt: event.created_at,
+        // Publish via eventBus.publishAndReport() with Kafka adapter. Unlike
+        // publishAsync(), publishAndReport awaits adapter delivery and reports
+        // whether an adapter actually consumed the event, so we only mark the
+        // outbox row published when it truly was delivered (issue #11209).
+        const baseEvent = new BaseEvent({
+          eventType: event.event_type,
+          payload: {
+            aggregateId: event.aggregate_id,
+            aggregateType: event.aggregate_type,
+            ...event.payload,
+          },
+          source: EVENT_SOURCES.INTERNAL,
+          category: EVENT_CATEGORIES.DOMAIN,
         });
+        const outcome = await eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] });
 
-        await outboxService.markPublished(event.id);
-        logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+        const delivered =
+          outcome.published &&
+          !outcome.deduplicated &&
+          outcome.adapterAttempted > 0 &&
+          outcome.adapterFailures === 0;
+
+        if (delivered) {
+          await outboxService.markPublished(event.id);
+          logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+        } else {
+          const reason = outcome.deduplicated
+            ? 'Event deduplicated by EventBus'
+            : outcome.adapterAttempted === 0
+              ? 'No event consumer/adapters handled the event'
+              : `Adapter failures: ${outcome.adapterErrors.join('; ')}`;
+          await outboxService.markFailed(event.id, reason);
+          logger.error('[OutboxRelay] Event not delivered, marked failed:', { eventId: event.id, reason });
+        }
       } catch (err) {
         logger.error('[OutboxRelay] Failed to publish event:', { eventId: event.id, err: err.message });
         await outboxService.markFailed(event.id, err.message);

--- a/backend/api/test/unit/headerSizeMonitor.test.js
+++ b/backend/api/test/unit/headerSizeMonitor.test.js
@@ -165,4 +165,22 @@ describe('headerSizeMonitor', () => {
       else delete process.env.HEADER_SIZE_LIMIT;
     }
   });
+
+  it('does not throw when a header value is a top-level undefined', () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originalLimit = process.env.HEADER_SIZE_LIMIT;
+    process.env.NODE_ENV = 'development';
+    process.env.HEADER_SIZE_LIMIT = '5000';
+    try {
+      const req = makeReq({ 'x-undefined': undefined, 'x-ok': 'value' });
+      const res = makeRes();
+      const next = vi.fn();
+      expect(() => headerSizeMonitor(req, res, next)).not.toThrow();
+      expect(next).toHaveBeenCalledOnce();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+      if (originalLimit !== undefined) process.env.HEADER_SIZE_LIMIT = originalLimit;
+      else delete process.env.HEADER_SIZE_LIMIT;
+    }
+  });
 });

--- a/backend/api/test/unit/orderNotificationService.reconcile.test.js
+++ b/backend/api/test/unit/orderNotificationService.reconcile.test.js
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for backend/api/src/services/order/orderNotificationService.js
+ *
+ * Regression test for issue #11211: the in-memory OTP lockout fallback (used
+ * when Redis is unreachable) drifted from Redis state during a resync. Because
+ * offline attempts were never folded back into Redis, an attacker who exhausted
+ * the in-memory budget could start fresh against Redis once it recovered, and a
+ * Redis-side lock could be shadowed by a stale in-memory record.
+ *
+ * These tests drive the module through a Redis outage -> recovery transition
+ * and assert the in-memory attempts are merged into Redis so the lockout is
+ * preserved.
+ *
+ * Run with:  npm test -- test/unit/orderNotificationService.reconcile.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const store = { counts: new Map(), locks: new Map() };
+let redisMode = 'up';
+
+const redisClient = {
+  get: vi.fn((k) => (redisMode === 'down' ? Promise.reject(new Error('down')) : Promise.resolve(store.locks.get(k) ?? null))),
+  set: vi.fn((k, v) => {
+    if (redisMode === 'down') return Promise.reject(new Error('down'));
+    store.locks.set(k, v);
+    return Promise.resolve('OK');
+  }),
+  del: vi.fn((k) => {
+    if (redisMode === 'down') return Promise.reject(new Error('down'));
+    store.locks.delete(k);
+    store.counts.delete(k);
+    return Promise.resolve(1);
+  }),
+  incr: vi.fn((k) => {
+    if (redisMode === 'down') return Promise.reject(new Error('down'));
+    const n = (store.counts.get(k) || 0) + 1;
+    store.counts.set(k, n);
+    return Promise.resolve(n);
+  }),
+  incrby: vi.fn((k, by) => {
+    if (redisMode === 'down') return Promise.reject(new Error('down'));
+    const n = (store.counts.get(k) || 0) + by;
+    store.counts.set(k, n);
+    return Promise.resolve(n);
+  }),
+  expire: vi.fn(() => (redisMode === 'down' ? Promise.reject(new Error('down')) : Promise.resolve(1))),
+};
+
+vi.mock('../../src/config/db.js', () => ({ redisClient }));
+vi.mock('../../src/services/notificationService.js', () => ({
+  sendDeliveryOtpNotification: vi.fn(),
+  storeDeliveryOtp: vi.fn(),
+  getActiveDeliveryOtp: vi.fn(),
+}));
+
+const { checkOtpLockout, recordOtpFailure, clearOtpState } = await import(
+  '../../src/services/order/orderNotificationService.js'
+);
+
+describe('OTP lockout fallback reconciliation (issue #11211)', () => {
+  beforeEach(() => {
+    store.counts.clear();
+    store.locks.clear();
+    redisMode = 'up';
+    vi.clearAllMocks();
+  });
+
+  it('accumulates attempts in memory and locks out while Redis is down', async () => {
+    redisMode = 'down';
+    for (let i = 0; i < 5; i += 1) await recordOtpFailure('order-down');
+    expect(await checkOtpLockout('order-down')).toBe(true);
+    // Nothing was persisted to Redis while it was down — the lock lives only
+    // in the in-memory fallback.
+    expect(store.counts.get('otp_failed_count:order-down')).toBeUndefined();
+    expect(store.locks.get('otp_lockout:order-down')).toBeUndefined();
+  });
+
+  it('folds offline attempts into Redis on recovery so the lockout is preserved', async () => {
+    redisMode = 'down';
+    for (let i = 0; i < 5; i += 1) await recordOtpFailure('order-resync');
+    expect(await checkOtpLockout('order-resync')).toBe(true);
+
+    redisMode = 'up';
+    // The next failure must reconcile the 5 offline attempts into Redis.
+    await recordOtpFailure('order-resync');
+
+    expect(redisClient.incrby).toHaveBeenCalledWith('otp_failed_count:order-resync', 5);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      'otp_lockout:order-resync',
+      '1',
+      'EX',
+      expect.any(Number),
+    );
+    // The merged lock is now the authoritative Redis state.
+    expect(await checkOtpLockout('order-resync')).toBe(true);
+  });
+
+  it('does not let an attacker restart the budget after recovery', async () => {
+    redisMode = 'down';
+    for (let i = 0; i < 5; i += 1) await recordOtpFailure('order-budget');
+
+    redisMode = 'up';
+    // A correct-looking check right after recovery must still report locked,
+    // because the offline attempts were merged into Redis first.
+    expect(await checkOtpLockout('order-budget')).toBe(true);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      'otp_lockout:order-budget',
+      '1',
+      'EX',
+      expect.any(Number),
+    );
+  });
+
+  it('drops the in-memory fallback after a successful Redis clear', async () => {
+    redisMode = 'down';
+    await recordOtpFailure('order-clear');
+    redisMode = 'up';
+    await clearOtpState('order-clear');
+    expect(store.counts.get('otp_failed_count:order-clear')).toBeUndefined();
+    expect(await checkOtpLockout('order-clear')).toBe(false);
+  });
+});

--- a/backend/kafka/repositories/event.repository.js
+++ b/backend/kafka/repositories/event.repository.js
@@ -101,6 +101,9 @@ class EventRepository {
       logger.warn(`No Kafka topic mapped for event type ${event.event_type}; skipping replay`);
       return;
     }
+    // The Kafka message key MUST be the event id, not the order id: consumers
+    // use the key as the idempotency claim key (eventId). Using order_id here
+    // caused replays to be claimed under the order id and silently dropped.
     await kafka.publishEvent(
       topic,
       {
@@ -111,9 +114,11 @@ class EventRepository {
         metadata: {
           ...event.metadata,
           isReplay: true,
+          eventId: event.event_id,
+          replayedFrom: event.event_id,
         },
       },
-      event.order_id
+      event.event_id
     );
   }
 

--- a/backend/kafka/test/event.repository.test.js
+++ b/backend/kafka/test/event.repository.test.js
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for backend/kafka/repositories/event.repository.js
+ *
+ * Regression test for issue #11210: event replay used the order id as the
+ * Kafka message key, but consumers derive the idempotency claim key from the
+ * Kafka message key (eventId). Replays were therefore claimed under the order
+ * id and silently dropped, so replays never reached read models.
+ *
+ * Coverage:
+ *   - reemitEvent uses the event id (not the order id) as the Kafka key
+ *   - reemitEvent mirrors eventId into metadata for the consumer's claim
+ *   - reemitEvent skips replay when no topic is mapped
+ *
+ * Run with:  npm test -- test/event.repository.test.js
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const publishEvent = vi.fn(() => Promise.resolve({}));
+
+vi.mock('../config/kafka.config.js', () => ({
+  default: { publishEvent },
+  TOPICS: { ORDER_CREATED: 'order.created', DRIVER_ASSIGNED: 'driver.assigned' },
+}));
+
+vi.mock('../../api/src/config/db.js', () => ({ supabase: {} }));
+vi.mock('../../api/src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import eventRepository from '../repositories/event.repository.js';
+
+describe('EventRepository.reemitEvent', () => {
+  beforeEach(() => {
+    publishEvent.mockClear();
+  });
+
+  it('uses the event id (not the order id) as the Kafka message key', async () => {
+    const event = {
+      event_id: 'evt-abc',
+      event_type: 'ORDER_CREATED',
+      order_id: 'order-xyz',
+      data: { foo: 'bar' },
+      metadata: { timestamp: '2020-01-01T00:00:00Z' },
+    };
+    await eventRepository.reemitEvent(event);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    const [, , key] = publishEvent.mock.calls[0];
+    expect(key).toBe('evt-abc');
+  });
+
+  it('mirrors eventId into metadata so the consumer idempotency claim matches', async () => {
+    const event = {
+      event_id: 'evt-abc',
+      event_type: 'ORDER_CREATED',
+      order_id: 'order-xyz',
+      data: {},
+      metadata: {},
+    };
+    await eventRepository.reemitEvent(event);
+    const [topic, payload, key] = publishEvent.mock.calls[0];
+    expect(topic).toBe('order.created');
+    expect(key).toBe('evt-abc');
+    expect(payload.metadata.eventId).toBe('evt-abc');
+    expect(payload.metadata.isReplay).toBe(true);
+  });
+
+  it('skips replay when no topic is mapped', async () => {
+    await eventRepository.reemitEvent({
+      event_id: 'e',
+      event_type: 'UNKNOWN_TYPE',
+      order_id: 'o',
+      metadata: {},
+    });
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

`orderNotificationService.js` keeps an in-memory `Map` (`inMemoryOtpFailedAttempts`) as a fallback when Redis is unreachable. The two stores were fully independent and never reconciled. During a Redis outage, failed OTP attempts accumulated only in memory; once Redis recovered, `checkOtpLockout`/`recordOtpFailure` read and wrote Redis as if nothing had happened. Concretely this caused:

- **Budget split / lost lockout:** an attacker who exhausted the in-memory budget (5 attempts → lock) could start fresh against Redis after recovery, since those attempts were never recorded in Redis.
- **Stale fallback shadowing:** a Redis-side lock could be overridden by a stale in-memory record (or vice versa), so lockout state drifted between the two stores during resync.

## Fix

- Added `reconcileInMemoryIntoRedis(orderId)` which folds any pending in-memory attempts (count + remaining lock TTL) back into Redis via `INCRBY`/lock `SET` when Redis is reachable, then drops the in-memory record. If Redis is still down it keeps the record so the fallback stays authoritative.
- `checkOtpLockout` now reconciles before reading Redis, so a lock earned during an outage is honored immediately on recovery (even on a correct-looking attempt).
- `recordOtpFailure` reconciles before recording the new attempt, keeping the brute-force budget contiguous across a resync.
- `clearOtpState` drops the in-memory record when the Redis clear succeeds, so the fallback cannot drift from the cleared state.

## Files changed

- `backend/api/src/services/order/orderNotificationService.js`
- `backend/api/test/unit/orderNotificationService.reconcile.test.js`

## Testing

- New unit test drives a Redis-down → Redis-up transition: asserts offline attempts are merged into Redis (`INCRBY 5`), the lock key is re-established, and the lockout survives recovery. Existing `orderNotificationService.test.js` and `deliveryVerificationService.test.js` still pass.

Closes #11211
