### PR TITLE
[High] Invalidate tracker cache on order resolution DB error

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1127,6 +1127,15 @@ export async function handleLocationPing(ws, data, req) {
       }
     } catch (err) {
       logger.error('Failed to resolve order details in tracker:', err.message);
+      // A transient database failure during cache re-verification (or the
+      // authoritative lookup) must never let this ping bind telemetry to a
+      // stale or unverified order mapping. Invalidate the cached driver→order
+      // entry so the next ping performs a fresh authoritative lookup, and drop
+      // the order binding for this ping so geofence/telemetry provenance
+      // cannot point at the wrong order (issue #11190).
+      orderUUID = null;
+      orderDisplayId = null;
+      await invalidateDriverOrderCache(driver_id);
     }
   }
 

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -1979,6 +1979,48 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
       expect(ws.send).not.toHaveBeenCalled();
     });
 
+    it('invalidates the cached mapping and drops the order binding when DB re-verification fails (issue #11190)', async () => {
+      const redisGet = vi.fn().mockResolvedValue(
+        JSON.stringify({ orderId: 'uuid-123', orderDisplayId: 'ORDER-789' })
+      );
+      const redisSet = vi.fn().mockResolvedValue('OK');
+      const redisDel = vi.fn().mockResolvedValue(1);
+      const mockChannel = { subscribe: vi.fn(), send: vi.fn().mockResolvedValue(undefined) };
+
+      vi.doMock('../../src/config/db.js', () => ({
+        mongoDb: null,
+        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
+        firebaseAdmin: null,
+        supabaseAdmin: null,
+        supabase: { from: vi.fn(), channel: vi.fn().mockReturnValue(mockChannel) },
+      }));
+
+      const { handleLocationPing: hlp, __testing: t } = await import('../../src/sockets/tracker.js');
+      const findOrderByAnyId = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+      t.setOrderRepository({ findOrderByAnyId });
+
+      const ws = { driverId: 'driver-cached', user: { id: 'driver-cached', role: 'driver' }, send: vi.fn() };
+
+      await hlp(ws, {
+        driver_id: 'driver-cached',
+        order_id: 'uuid-123',
+        latitude: 12.9,
+        longitude: 77.5,
+      });
+
+      // The cached mapping was re-verified against the DB (issue #10676)
+      expect(findOrderByAnyId).toHaveBeenCalledWith('uuid-123', 'id, order_display_id, driver_id, status');
+      // A transient DB failure must not leave the stale mapping in the cache
+      expect(redisDel).toHaveBeenCalledWith('driver:active-order:driver-cached');
+      // Telemetry is buffered without the stale order binding
+      const buffer = await t.getTelemetryWriteBuffer().toArray();
+      const record = buffer[buffer.length - 1];
+      expect(record.order_id).toBeNull();
+      expect(record.order_display_id).toBeNull();
+      // No error surfaced to the driver socket
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+
     it('queries DB on cache miss and populates cache', async () => {
       const redisGet = vi.fn().mockResolvedValue(null);
       const redisSet = vi.fn().mockResolvedValue('OK');


### PR DESCRIPTION
## Problem

In `backend/api/src/sockets/tracker.js`, `handleLocationPing` acquires the driver's active order from Redis cache and re-verifies it against the database. If the re-verification query itself fails (network error, timeout), the `catch` block only logs the error and continues, leaving the stale cached mapping in place. The ping then proceeds to bind telemetry/geofence provenance to a potentially stale or wrong order.

## Fix

In the `catch` block of the order-resolution step in `handleLocationPing`:

- Set `orderUUID = null` and `orderDisplayId = null` so this ping's telemetry is not bound to an unverified order.
- Call `await invalidateDriverOrderCache(driver_id)` so the next ping performs a fresh authoritative lookup instead of reusing the stale mapping.

`invalidateDriverOrderCache` is safe to call here — it never throws (it guards on missing driver ID / Redis client and catches internally).

## Files changed

- `backend/api/src/sockets/tracker.js` — invalidate the driver→order cache and drop the order binding when DB resolution fails.
- `backend/api/test/unit/tracker.test.js` — new test asserting that a DB failure during cache re-verification invalidates the cache and buffers telemetry without a stale order binding.

## Testing

- `node --check backend/api/src/sockets/tracker.js` passes.
- `npx vitest run test/unit/tracker.test.js` passes (104 passed, 2 skipped; the 3 remaining failures are a pre-existing `makeHandler is not defined` bug in the test file, unrelated to this change).

Closes #11190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order tracking when database verification fails, preventing stale or unverified order information from being used.
  * Ensured telemetry no longer includes invalid order identifiers after verification errors.
  * Prevented unnecessary socket errors during transient database failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->