### PR TITLE
[High] Extend order cancellation lock TTL for blockchain refund window

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -579,7 +579,6 @@ export class OrderLifecycleService {
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
         const newAmountWei = paisaToMaticWei(pricing.totalAmount);
-        const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {
           drop_address,
@@ -651,7 +650,10 @@ export class OrderLifecycleService {
       if (order.customer_id !== customerId) throw new DomainError(403, { error: 'Access Denied: You do not own this order.' });
 
       const lockKey = `escrow_lock:${order.id}`;
-      const lockValue = await acquireLock(lockKey, 30000);
+      // Blockchain refund submission + confirmation can take 30-60s, so the
+      // lock TTL must cover the full cancellation window to prevent a
+      // concurrent attempt from double-processing the order (issue #11191).
+      const lockValue = await acquireLock(lockKey, 180000);
       if (!lockValue) {
         throw new DomainError(409, { error: 'Cancellation is currently being processed. Please try again later.' });
       }


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/orderLifecycleService.js`, `cancelOrder` acquires the per-order Redis lock with a 30-second TTL (`acquireLock(lockKey, 30000)`) while inside the lock it submits an on-chain escrow refund and waits for blockchain confirmation — operations that can take 30-60+ seconds. If the lock expires mid-operation, a second concurrent cancellation attempt can acquire the lock and process the same order, causing double refunds or inconsistent escrow state.

## Fix

Raise the cancellation lock TTL from 30s to 180s (3 minutes) so the lock covers the maximum expected duration of the refund submission + confirmation window, matching the issue's proposed fix. This is consistent with `verifyDeliveryFn`, which already holds the same `escrow_lock:${orderId}` for 120s because it also performs a blockchain escrow release.

Also removed a pre-existing duplicate `const newAmountWei` declaration in `orderLifecycleService.js` (a syntax error present on `main` that prevented the module from parsing/loading at all, and would block this fix from ever executing). This is the identical change as in PR #11223.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js` — cancellation lock TTL 30s → 180s; removed duplicate `newAmountWei` declaration.

## Testing

- `node --check backend/api/src/services/order/orderLifecycleService.js` passes after the duplicate-declaration removal.
- No regression introduced: the existing `orderLifecycleService` / `changeDrop` / `verifyDelivery` test suites fail identically on `origin/main` before this change (pre-existing duplicate `getRushHourMultiplier` in `trafficService.js` and a pre-existing `GpsLog` model-overwrite error), so they cannot pass with or without this PR.

Closes #11191
