### PR TITLE
fix(api): abort underlying request on circuit breaker timeout (fixes #11286)

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -13,10 +13,12 @@ export class CircuitBreaker {
     this.resetTimeoutMs = options.resetTimeoutMs || 30000;
     this.requestTimeoutMs = options.requestTimeoutMs || 5000;
     this.fallback = options.fallback || null;
+    this.countTimeoutAsFailure = options.countTimeoutAsFailure !== false;
 
     this.state = CircuitState.CLOSED;
     this.failureCount = 0;
     this.successCount = 0;
+    this.timeoutCount = 0;
     this.nextAttempt = Date.now();
     this._halfOpenTimer = null;
   }
@@ -51,6 +53,7 @@ export class CircuitBreaker {
     this.state = CircuitState.CLOSED;
     this.failureCount = 0;
     this.successCount = 0;
+    this.timeoutCount = 0;
     this.nextAttempt = Date.now();
   }
 
@@ -69,19 +72,34 @@ export class CircuitBreaker {
       throw new Error(`CircuitBreaker:${this.name} is OPEN`);
     }
 
+    const controller = new AbortController();
+    const signal = controller.signal;
+
     let timer;
+    let timedOut = false;
+
     try {
       const timeoutPromise = new Promise((_, reject) => {
         timer = setTimeout(() => {
+          timedOut = true;
+          controller.abort();
           reject(new Error(`[CircuitBreaker:${this.name}] Request timed out after ${this.requestTimeoutMs}ms`));
         }, this.requestTimeoutMs);
         timer.unref?.();
       });
 
-      const result = await Promise.race([fn(...args), timeoutPromise]);
+      const result = await Promise.race([fn(...args, { signal }), timeoutPromise]);
       this.onSuccess();
       return result;
     } catch (err) {
+      if (timedOut) {
+        this.timeoutCount += 1;
+        logger.warn({ timeouts: this.timeoutCount }, `[CircuitBreaker:${this.name}] Request timed out`);
+        if (this.countTimeoutAsFailure) {
+          return this.onFailure(err, args);
+        }
+        throw err;
+      }
       return this.onFailure(err, args);
     } finally {
       if (timer) {
@@ -91,6 +109,7 @@ export class CircuitBreaker {
   }
 
   onSuccess() {
+    this.successCount += 1;
     if (this.state === CircuitState.HALF_OPEN) {
       this.reset();
       logger.info(`[CircuitBreaker:${this.name}] Service recovered. State reset to CLOSED`);
@@ -115,5 +134,14 @@ export class CircuitBreaker {
       return this.fallback(...args);
     }
     throw err;
+  }
+
+  getMetrics() {
+    return {
+      state: this.state,
+      failureCount: this.failureCount,
+      timeoutCount: this.timeoutCount,
+      successCount: this.successCount,
+    };
   }
 }

--- a/backend/api/test/unit/circuitBreaker.test.js
+++ b/backend/api/test/unit/circuitBreaker.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CircuitBreaker, CircuitState } from '../../src/lib/circuitBreaker.js';
 
 describe('CircuitBreaker Unit Tests', () => {
@@ -123,5 +123,128 @@ describe('CircuitBreaker Unit Tests', () => {
 
     expect(result).toBe('fallback:val1:42');
     expect(fallback).toHaveBeenCalledWith('val1', 42);
+  });
+
+  it('passes AbortSignal to the wrapped function', async () => {
+    const breaker = new CircuitBreaker('testSignalBreaker', {
+      requestTimeoutMs: 1000,
+    });
+    let capturedSignal = null;
+    const fn = vi.fn().mockImplementation(async ({ signal }) => {
+      capturedSignal = signal;
+      return 'ok';
+    });
+
+    await breaker.execute(fn);
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal.aborted).toBe(false);
+  });
+
+  it('does not count timeout as failure when countTimeoutAsFailure is false', async () => {
+    const breaker = new CircuitBreaker('testTimeoutNotFailure', {
+      requestTimeoutMs: 50,
+      failureThreshold: 1,
+      countTimeoutAsFailure: false,
+    });
+    const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+    await expect(breaker.execute(slowFn)).rejects.toThrow('Request timed out after 50ms');
+
+    expect(breaker.getState()).toBe(CircuitState.CLOSED);
+    expect(breaker.failureCount).toBe(0);
+    expect(breaker.timeoutCount).toBe(1);
+  });
+
+  it('counts timeout as failure when countTimeoutAsFailure is true (default)', async () => {
+    const breaker = new CircuitBreaker('testTimeoutIsFailure', {
+      requestTimeoutMs: 50,
+      failureThreshold: 1,
+      countTimeoutAsFailure: true,
+    });
+    const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+    await expect(breaker.execute(slowFn)).rejects.toThrow('Request timed out after 50ms');
+
+    expect(breaker.getState()).toBe(CircuitState.OPEN);
+    expect(breaker.failureCount).toBe(1);
+    expect(breaker.timeoutCount).toBe(1);
+  });
+
+  it('does not open circuit on timeout when countTimeoutAsFailure is false even with multiple timeouts', async () => {
+    const breaker = new CircuitBreaker('testMultipleTimeouts', {
+      requestTimeoutMs: 50,
+      failureThreshold: 2,
+      countTimeoutAsFailure: false,
+    });
+    const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+    await expect(breaker.execute(slowFn)).rejects.toThrow('Request timed out after 50ms');
+    await expect(breaker.execute(slowFn)).rejects.toThrow('Request timed out after 50ms');
+
+    expect(breaker.getState()).toBe(CircuitState.CLOSED);
+    expect(breaker.failureCount).toBe(0);
+    expect(breaker.timeoutCount).toBe(2);
+  });
+
+  it('opens circuit on actual failures even when countTimeoutAsFailure is false', async () => {
+    const breaker = new CircuitBreaker('testActualFailuresOpen', {
+      requestTimeoutMs: 50,
+      failureThreshold: 2,
+      countTimeoutAsFailure: false,
+    });
+    const failFn = vi.fn().mockRejectedValue(new Error('Actual failure'));
+
+    await expect(breaker.execute(failFn)).rejects.toThrow('Actual failure');
+    await expect(breaker.execute(failFn)).rejects.toThrow('Actual failure');
+
+    expect(breaker.getState()).toBe(CircuitState.OPEN);
+    expect(breaker.failureCount).toBe(2);
+    expect(breaker.timeoutCount).toBe(0);
+  });
+
+  it('tracks metrics including timeout count', async () => {
+    const breaker = new CircuitBreaker('testMetrics', {
+      requestTimeoutMs: 50,
+      failureThreshold: 2,
+      countTimeoutAsFailure: false,
+    });
+    const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+    const failFn = vi.fn().mockRejectedValue(new Error('Failure'));
+
+    await breaker.execute(vi.fn().mockResolvedValue('ok'));
+    await breaker.execute(vi.fn().mockResolvedValue('ok'));
+    await expect(breaker.execute(slowFn)).rejects.toThrow();
+    await expect(breaker.execute(failFn)).rejects.toThrow();
+
+    const metrics = breaker.getMetrics();
+    expect(metrics.state).toBe(CircuitState.CLOSED);
+    expect(metrics.successCount).toBe(2);
+    expect(metrics.timeoutCount).toBe(1);
+    expect(metrics.failureCount).toBe(1);
+  });
+
+  it('does not count timeout as failure if the underlying promise later resolves', async () => {
+    const breaker = new CircuitBreaker('testLateResolve', {
+      requestTimeoutMs: 50,
+      failureThreshold: 1,
+      countTimeoutAsFailure: false,
+    });
+
+    let resolveSlow;
+    const slowPromise = new Promise((resolve) => {
+      resolveSlow = resolve;
+    });
+    const fn = vi.fn().mockReturnValue(slowPromise);
+
+    const executePromise = breaker.execute(fn);
+
+    await expect(executePromise).rejects.toThrow('Request timed out after 50ms');
+    expect(breaker.getState()).toBe(CircuitState.CLOSED);
+    expect(breaker.failureCount).toBe(0);
+    expect(breaker.timeoutCount).toBe(1);
+
+    resolveSlow('late result');
+    await slowPromise;
   });
 });


### PR DESCRIPTION
## Summary
Make `CircuitBreaker.execute` cancel the underlying operation when its timeout fires, and stop treating every timeout as a circuit-opening failure.

## Motivation
Fixes #11286 — `execute` used `Promise.race` with a timeout, so when the timer rejected, the wrapped `fn(...args)` kept running in the background. Side effects (DB writes, external calls, on-chain transactions) still completed while the circuit recorded a failure and opened — causing state divergence and blocking legitimate traffic after an eventual success.

## Changes
- Modified `backend/api/src/lib/circuitBreaker.js`:
  - Timeout now uses an `AbortController`; the signal is passed to the wrapped function as `fn(...args, { signal })` so cancellable operations are actually aborted.
  - Added a `countTimeoutAsFailure` option (default `true` to preserve existing behavior); callers can set `countTimeoutAsFailure: false` so timeouts no longer open the circuit.
  - Timeouts are tracked separately (`timeoutCount`) from failures and surfaced via a new `getMetrics()`.
  - `onSuccess` now increments `successCount`.
- Added/extended `backend/api/test/unit/circuitBreaker.test.js` with assertions that a timed-out promise which later resolves does not affect circuit state.

## Acceptance Criteria
- [x] Timeout aborts the underlying operation via `AbortController` (signal passed to the wrapped function).
- [x] Timeout can be excluded from circuit-opening failures via `countTimeoutAsFailure: false`.
- [x] Timeouts tracked separately from failures (`timeoutCount`, `getMetrics()`).
- [x] Unit tests assert a timed-out promise that later resolves does not affect circuit state.
- [ ] Cancellation only takes effect for functions that honor the passed `AbortSignal`; callers using non-cancellable dependencies should set `countTimeoutAsFailure: false`.

## Impact & Side Effects
Behavior is unchanged by default (`countTimeoutAsFailure` defaults to `true`). The wrapped function is now called with an extra `{ signal }` argument, which is ignored by functions that do not declare it.

## How to Test
1. `cd backend/api`
2. Run the circuit breaker tests: `npx vitest run test/unit/circuitBreaker.test.js`

## Quality Checklist
- [x] `npx vitest run test/unit/circuitBreaker.test.js` passes (15 tests)
- [x] No scratch/temp files committed
