### PR TITLE
fix(api): deliver outbox events to Kafka via publishAndReport (fixes #11285)

### DIFF
--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -1,5 +1,7 @@
 import { outboxService } from '../services/outbox/outboxService.js';
 import { eventBus } from '../core/events/index.js';
+import { BaseEvent } from '../core/events/BaseEvent.js';
+import { EVENT_SOURCES, EVENT_CATEGORIES } from '../core/events/EventMetadata.js';
 import logger from '../middleware/logger.js';
 
 const RELAY_INTERVAL_MS = parseInt(process.env.OUTBOX_RELAY_INTERVAL_MS, 10) || 5000;
@@ -18,17 +20,40 @@ async function relayOnce() {
 
     for (const event of events) {
       try {
-        // Publish via existing eventBus — idempotent on consumer side via processed_events
-        eventBus.emitSafe(event.event_type, {
-          eventId: event.id,
-          aggregateId: event.aggregate_id,
-          aggregateType: event.aggregate_type,
-          payload: event.payload,
-          createdAt: event.created_at,
+        // Publish via eventBus.publishAndReport() with Kafka adapter. Unlike
+        // publishAsync(), publishAndReport awaits adapter delivery and reports
+        // whether an adapter actually consumed the event, so we only mark the
+        // outbox row published when it truly was delivered (issue #11209).
+        const baseEvent = new BaseEvent({
+          eventType: event.event_type,
+          payload: {
+            aggregateId: event.aggregate_id,
+            aggregateType: event.aggregate_type,
+            ...event.payload,
+          },
+          source: EVENT_SOURCES.INTERNAL,
+          category: EVENT_CATEGORIES.DOMAIN,
         });
+        const outcome = await eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] });
 
-        await outboxService.markPublished(event.id);
-        logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+        const delivered =
+          outcome.published &&
+          !outcome.deduplicated &&
+          outcome.adapterAttempted > 0 &&
+          outcome.adapterFailures === 0;
+
+        if (delivered) {
+          await outboxService.markPublished(event.id);
+          logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+        } else {
+          const reason = outcome.deduplicated
+            ? 'Event deduplicated by EventBus'
+            : outcome.adapterAttempted === 0
+              ? 'No event consumer/adapters handled the event'
+              : `Adapter failures: ${outcome.adapterErrors.join('; ')}`;
+          await outboxService.markFailed(event.id, reason);
+          logger.error('[OutboxRelay] Event not delivered, marked failed:', { eventId: event.id, reason });
+        }
       } catch (err) {
         logger.error('[OutboxRelay] Failed to publish event:', { eventId: event.id, err: err.message });
         await outboxService.markFailed(event.id, err.message);

--- a/backend/api/test/unit/outboxRelayWorker.test.js
+++ b/backend/api/test/unit/outboxRelayWorker.test.js
@@ -23,7 +23,14 @@ vi.mock('../../src/services/outbox/outboxService.js', () => ({
 }));
 
 const mockEventBus = vi.hoisted(() => ({
-  emitSafe: vi.fn(),
+  publishAndReport: vi.fn().mockResolvedValue({
+    published: true,
+    deduplicated: false,
+    consumed: true,
+    adapterAttempted: 1,
+    adapterFailures: 0,
+    adapterErrors: [],
+  }),
 }));
 
 vi.mock('../../src/core/events/index.js', () => ({
@@ -50,7 +57,6 @@ describe('outboxRelayWorker', () => {
   });
 
   it('publishes pending events and marks them published', async () => {
-    // Trigger a relay cycle by starting the worker, then await the immediate run.
     mockOutboxService.fetchPendingEvents.mockResolvedValue([
       {
         id: 'evt-1',
@@ -63,16 +69,11 @@ describe('outboxRelayWorker', () => {
     ]);
 
     worker.startOutboxRelayWorker();
-    // Wait for the immediate relayOnce() to finish.
     await vi.waitFor(() => {
-      expect(mockEventBus.emitSafe).toHaveBeenCalled();
+      expect(mockEventBus.publishAndReport).toHaveBeenCalled();
     });
 
-    expect(mockEventBus.emitSafe).toHaveBeenCalledWith('order.created', expect.objectContaining({
-      eventId: 'evt-1',
-      aggregateId: 'order-1',
-      payload: { a: 1 },
-    }));
+    expect(mockEventBus.publishAndReport).toHaveBeenCalledWith(expect.any(Object), { adapters: ['kafka'] });
     expect(mockOutboxService.markPublished).toHaveBeenCalledWith('evt-1');
     worker.stopOutboxRelayWorker();
   });
@@ -88,7 +89,7 @@ describe('outboxRelayWorker', () => {
         created_at: '2026-08-11T00:00:00.000Z',
       },
     ]);
-    mockEventBus.emitSafe.mockImplementation(() => {
+    mockEventBus.publishAndReport.mockImplementation(() => {
       throw new Error('bus down');
     });
 
@@ -98,6 +99,38 @@ describe('outboxRelayWorker', () => {
     });
 
     expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-2', expect.stringContaining('bus down'));
+    worker.stopOutboxRelayWorker();
+  });
+
+  it('does NOT mark an event published when no adapter handled it (regression #11209)', async () => {
+    mockOutboxService.fetchPendingEvents.mockResolvedValue([
+      {
+        id: 'evt-3',
+        event_type: 'order.created',
+        aggregate_id: 'order-3',
+        aggregate_type: 'order',
+        payload: { a: 1 },
+        created_at: '2026-08-11T00:00:00.000Z',
+      },
+    ]);
+    // Simulate the case where the kafka adapter is not registered / no consumer
+    // handled the event: adapterAttempted as 0 and no failures.
+    mockEventBus.publishAndReport.mockResolvedValue({
+      published: true,
+      deduplicated: false,
+      consumed: false,
+      adapterAttempted: 0,
+      adapterFailures: 0,
+      adapterErrors: [],
+    });
+
+    worker.startOutboxRelayWorker();
+    await vi.waitFor(() => {
+      expect(mockOutboxService.markFailed).toHaveBeenCalled();
+    });
+
+    expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-3', expect.stringContaining('No event consumer'));
+    expect(mockOutboxService.markPublished).not.toHaveBeenCalledWith('evt-3');
     worker.stopOutboxRelayWorker();
   });
 });


### PR DESCRIPTION
## Summary
Make the outbox relay actually deliver outbox events to Kafka (via the EventBus Kafka adapter) instead of only emitting them to in-process listeners.

## Motivation
Fixes #11285 — `outboxRelayWorker.js` used `eventBus.emitSafe(...)`, which only notifies local subscribers and never invokes registered adapters. Kafka consumers (order-service, notification-service, analytics-service, fraud-service) never received outbox-path events, and the relay marked each row `published` anyway, so events were silently dropped with no retry and no alert.

## Changes
- Modified `backend/api/src/workers/outboxRelayWorker.js`:
  - Replaced `eventBus.emitSafe(...)` with a proper `BaseEvent` published via `eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] })`, which awaits adapter delivery.
  - A row is marked `published` only when the event was truly delivered (`published && !deduplicated && adapterAttempted > 0 && adapterFailures === 0`).
  - Otherwise the row is marked `failed` with a reason (deduplicated / no adapter handled it / adapter errors), so the event can be retried.
- Updated `backend/api/test/unit/outboxRelayWorker.test.js` for the new publish path and delivery checks.

## Acceptance Criteria
- [x] Outbox events are published through the EventBus Kafka adapter (not just in-process `emitSafe`).
- [x] `markPublished` happens only after confirmed adapter delivery.
- [x] Non-delivered events are marked failed with an explicit reason and remain retryable.
- [x] Relay unit tests cover the delivered and non-delivered branches.

## Impact & Side Effects
Relay behavior now reflects real delivery; rows that previously were marked `published` despite never reaching Kafka will now surface as failed and be retried. No change to the outbox schema or consumer code.

## How to Test
1. `cd backend/api`
2. Run the relay tests: `npx vitest run test/unit/outboxRelayWorker.test.js`

## Quality Checklist
- [x] `npx vitest run test/unit/outboxRelayWorker.test.js` passes (4 tests)
- [x] No scratch/temp files committed
