### PR TITLE
[Medium] fix: remove redundant double .from() call in getOrderReadModel (Closes #11364)

### DIFF
--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -235,7 +235,6 @@ class OrderReadModel {
 
     try {
       const { data, error } = await supabase
-        .from('orders_read_model')
         .from(ORDER_READ_MODEL_TABLE)
         .select('*')
         .eq('order_id', key)


### PR DESCRIPTION
## Problem

In `backend/kafka/cqrs/order.read.model.js`, the `getOrderReadModel` function chained two `.from()` calls:

```javascript
const { data, error } = await supabase
  .from('orders_read_model')
  .from(ORDER_READ_MODEL_TABLE)
  .select('*')
  .eq('order_id', key)
  .single();
```

`supabase.from()` returns a new query builder each call, so the second `.from(ORDER_READ_MODEL_TABLE)` overwrites the first. It "works" today only because `ORDER_READ_MODEL_TABLE === 'orders_read_model'`, but it is a latent bug that silently targets the wrong table if the constant ever changes.

## Fix

Removed the hardcoded first `.from('orders_read_model')` and kept the single canonical `.from(ORDER_READ_MODEL_TABLE)` call.

## Files changed

- `backend/kafka/cqrs/order.read.model.js` — `getOrderReadModel`

## Testing

- Verified the query now uses the single canonical table constant.
- No change in query semantics since both constants resolve to `orders_read_model`.

Closes #11364
