### PR TITLE
[High] fix: duplicate/incorrect driverId filter logic in getAllOrdersReadModel (Closes #11366)

### DIFF
--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -263,10 +263,6 @@ class OrderReadModel {
   async getAllOrdersReadModel(filters = {}) {
     try {
       let query = supabase
-        .from('orders_read_model')
-        .select('*');
-
-      // Payload is the full order row snapshot, so filters target payload keys.
         .from(ORDER_READ_MODEL_TABLE)
         .select('*');
 
@@ -279,10 +275,6 @@ class OrderReadModel {
       }
       if (filters.driverId) {
         query = query.eq('payload->>driver_id', filters.driverId);
-        query = query.eq('payload->customer_id', filters.customerId);
-      }
-      if (filters.driverId) {
-        query = query.eq('payload->driver_id', filters.driverId);
       }
       if (filters.fromDate) {
         query = query.gte('updated_at', filters.fromDate);


### PR DESCRIPTION
## Problem

In `backend/kafka/cqrs/order.read.model.js`, `getAllOrdersReadModel` had two independent bugs:

1. A broken query chain — the first `.from('orders_read_model').select('*')` was terminated by a semicolon, and a second orphan `.from(ORDER_READ_MODEL_TABLE).select('*')` followed. The second `.from()` overwrites the first and is redundant.
2. Duplicate and incorrect `driverId` filter logic:

```javascript
if (filters.driverId) {
  query = query.eq('payload->>driver_id', filters.driverId);
  query = query.eq('payload->customer_id', filters.customerId); // wrong: applies customer_id when only driverId is set
}
if (filters.driverId) {
  query = query.eq('payload->driver_id', filters.driverId); // different operator, overwrites previous
}
```

The spurious `payload->customer_id` filter corrupts driver-only queries, and the `->` operator (returns JSON) never matches a scalar string, making that branch a no-op.

## Fix

- Collapsed the query chain to a single `.from(ORDER_READ_MODEL_TABLE).select('*')`.
- Consolidated the `driverId` filter into one correct clause using the `->>` (text) operator, and removed the bogus `customer_id` filter.

## Files changed

- `backend/kafka/cqrs/order.read.model.js` — `getAllOrdersReadModel`

## Testing

- Each filter now applies exactly once with the correct JSON extraction operator.
- `driverId` queries no longer apply a spurious `customer_id` filter.

Closes #11366
