### PR TITLE
[Critical] fix: duplicate const declaration in changeDrop (Closes #11367)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -578,7 +578,6 @@ export class OrderLifecycleService {
         // against at deposit time and on release), so it must track
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
-        const newAmountWei = paisaToMaticWei(pricing.totalAmount);
         const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/orderLifecycleService.js`, the `changeDrop` method declared the same identifier twice in the same block scope:

```javascript
const newAmountWei = paisaToMaticWei(pricing.totalAmount);
const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
```

This is a `SyntaxError: Identifier 'newAmountWei' has already been declared` and prevents the file from parsing/executing in modern JavaScript engines. Only the second declaration (the `BigInt` wrapper used at `escrow_amount_wei: newAmountWei.toString()`) is required.

## Fix

Removed the redundant first declaration, leaving the single correct `BigInt(paisaToMaticWei(pricing.totalAmount))` declaration.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js` — `changeDrop`

## Testing

- The file now parses without a duplicate-declaration syntax error.
- `escrow_amount_wei` is still computed from the `BigInt` conversion.

Closes #11367
