### PR TITLE
[Medium] fix: periodic cleanup of wsUpgradeMemoryLimits fallback (Closes #11369)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -393,6 +393,17 @@ function enforceWsUpgradeMemoryLimit(ipAddress) {
   return entry.count <= WS_UPGRADE_RATE_LIMIT;
 }
 
+const WS_UPGRADE_LIMITS_SWEEP_INTERVAL_MS = 30000;
+
+// Periodically purge expired per-IP upgrade-limit entries so the in-memory
+// fallback map does not grow unbounded during a Redis outage.
+function sweepWsUpgradeMemoryLimits() {
+  const now = Date.now();
+  for (const [key, e] of wsUpgradeMemoryLimits) {
+    if (now >= e.resetAt) wsUpgradeMemoryLimits.delete(key);
+  }
+}
+
 export async function isWebSocketUpgradeAllowed(request) {
   const ipAddress = getClientIp(request);
   const key = `ws:upgrade:${ipAddress}`;
@@ -807,6 +818,12 @@ export function initWebSocketServer(server, orderRepository) {
       wsHeartbeatInterval = null;
     }
   });
+
+  // Periodically purge expired per-IP WebSocket upgrade-limit entries, so the
+  // in-memory fallback map does not leak during Redis outages.
+  wsUpgradeLimitsCleanupInterval = setInterval(() => {
+    sweepWsUpgradeMemoryLimits();
+  }, WS_UPGRADE_LIMITS_SWEEP_INTERVAL_MS);
 
   if (!isSchedulerActive) {
     initTelemetryScheduler();
@@ -1487,6 +1504,11 @@ export async function closeWebSocketServer() {
   if (wsHeartbeatInterval) {
     clearInterval(wsHeartbeatInterval);
     wsHeartbeatInterval = null;
+  }
+
+  if (wsUpgradeLimitsCleanupInterval) {
+    clearInterval(wsUpgradeLimitsCleanupInterval);
+    wsUpgradeLimitsCleanupInterval = null;
   }
 
   // Wait for MongoDB to be available before final flush


### PR DESCRIPTION
## Problem

In `backend/api/src/sockets/tracker.js`, `wsUpgradeMemoryLimits` is the in-memory fallback used for WebSocket upgrade rate limiting when Redis is unavailable. Its only cleanup ran inside `enforceWsUpgradeMemoryLimit` and only when the Map size exceeded 10,000 entries. With fewer than 10,000 unique IPs, expired entries were never removed, so the Map grew unbounded during a Redis outage and could be used for a DoS via an upgrade flood.

## Fix

- Added `sweepWsUpgradeMemoryLimits()` which deletes any entry whose `resetAt` has passed.
- Added a `setInterval` (`wsUpgradeLimitsCleanupInterval`, every 30s) that runs the sweep, and cleared it in `closeWebSocketServer`.

## Files changed

- `backend/api/src/sockets/tracker.js`

## Testing

- Expired per-IP upgrade-limit entries are now reclaimed on a schedule regardless of Map size.
- The interval is cleared on server shutdown.

Closes #11369
