### PR TITLE
[High] fix: send rate-limit error response instead of silent drop (Closes #11371)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -854,6 +854,11 @@ export async function isMessageRateLimited(ws) {
 
 export async function handleTrackingMessage(ws, message, req) {
   if (await isMessageRateLimited(ws)) {
+    ws.send(JSON.stringify({
+      error: 'Rate limit exceeded: too many messages per second',
+      code: 429,
+      retryAfter: 1,
+    }));
     return;
   }
 


### PR DESCRIPTION
## Problem

In `backend/api/src/sockets/tracker.js`, `handleTrackingMessage` called `isMessageRateLimited(ws)` and `return`ed immediately when the limit was exceeded. The client received nothing — no error frame, no close code, no `retryAfter` hint — so messages simply "disappeared" and clients could not distinguish rate limiting from a network issue or server bug.

## Fix

When rate-limited, the server now sends a structured error before returning:

```javascript
ws.send(JSON.stringify({
  error: 'Rate limit exceeded: too many messages per second',
  code: 429,
  retryAfter: 1,
}));
```

## Files changed

- `backend/api/src/sockets/tracker.js` — `handleTrackingMessage`

## Testing

- Rate-limited clients now receive a `429` structured error with a `retryAfter` hint instead of a silent drop.

Closes #11371
