### PR TITLE
[High] fix: make createOrder atomic and idempotent via create_order_tx (Closes #11374)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1,4 +1,5 @@
 import { DomainError } from './domainError.js';
+import { createHash } from 'crypto';
 import { DeliveryVerificationService } from './deliveryVerificationService.js';
 import { expireDeliveryOtps, sendPushNotification } from '../notificationService.js';
 import { invalidateDriverOrderCache } from '../../sockets/tracker.js';
@@ -114,14 +115,28 @@ export class OrderLifecycleService {
         logger.warn({ err: mlErr.message }, 'Price prediction unavailable, falling back to base pricing');
       }
 
+      // Atomic, idempotent creation. The create_order_tx RPC inserts the order,
+      // its default timeline, and the load offer in a single transaction, so a
+      // partial failure can no longer leave orphaned rows. The idempotency key
+      // is derived from the request content so retried / duplicate submissions
+      // are de-duplicated instead of creating multiple orders.
+      const idempotencyKey = `create_order:${createHash('sha256').update(JSON.stringify({
+        customerId,
+        pickup_address,
+        drop_address,
+        weight_tonnes,
+        goods_type,
+        pickup_date,
+        pickup_time,
+      })).digest('hex')}`;
+
       const MAX_ID_RETRIES = ORDER_DISPLAY_ID_MAX_RETRIES;
       let order = null;
-      let orderErr = null;
-      let orderDisplayId = null;
+      let lastErr = null;
 
       for (let attempt = 0; attempt < MAX_ID_RETRIES; attempt++) {
-        orderDisplayId = generateOrderDisplayId();
-        const result = await this.orderRepository.createOrder({
+        const orderDisplayId = generateOrderDisplayId();
+        const orderData = {
           order_display_id: orderDisplayId,
           customer_id: customerId,
           status: 'pending',
@@ -137,52 +152,56 @@ export class OrderLifecycleService {
           estimated_price: estimatedPrice,
           payment_method_id, upi_id,
           waypoints: optimizedWaypoints,
-        });
+        };
+        const loadOfferData = {
+          customer_name: customerName || 'Customer',
+          route_label: `${pickup_address.split(',')[0]} \u2192 ${drop_address.split(',')[0]}`,
+          route_subtitle: `${weight_tonnes} tonnes \u2022 ${goods_type}`,
+          pickup_address, pickup_lat, pickup_lng,
+          drop_address, drop_lat, drop_lng,
+          goods_type,
+          weight: `${weight_tonnes} tonnes`,
+          freight_value: pricing.totalAmount,
+          fuel_cost: pricing.fuelCost,
+          toll_cost: pricing.tollEstimate,
+          net_profit: pricing.netProfit,
+          extra_distance_km: pricing.distanceKm,
+          status: 'available',
+          waypoints: optimizedWaypoints,
+        };
 
-        order = result.data;
-        orderErr = result.error;
-
-        if (!orderErr || orderErr.code !== '23505') break;
-        logger.warn(`[Orders] display ID collision on ${orderDisplayId}, retrying (attempt ${attempt + 1}/${MAX_ID_RETRIES})`);
+        try {
+          const txResult = await createOrderTransactional({
+            idempotencyKey,
+            orderData,
+            timelineData: null,
+            loadOfferData,
+          });
+          order = {
+            id: txResult.order_id,
+            order_display_id: txResult.display_id,
+            status: txResult.status,
+          };
+          lastErr = null;
+          break;
+        } catch (err) {
+          lastErr = err;
+          // Retry only on a display-id uniqueness collision; surface everything
+          // else (the RPC already rolled back any partial writes).
+          if (
+            err?.code === '23505' ||
+            (err?.message && /duplicate key.*order_display_id/i.test(err.message))
+          ) {
+            logger.warn(`[Orders] display ID collision on ${orderDisplayId}, retrying (attempt ${attempt + 1}/${MAX_ID_RETRIES})`);
+            continue;
+          }
+          throw err;
+        }
       }
 
-      if (orderErr) {
-        logger.error('Order Insertion Error:', orderErr.message);
-        throw new DomainError(500, { error: 'Failed to create order record.', details: orderErr.message });
-      }
-
-      const { error: timelineErr } = await this.orderTimelineService.generateDefaultTimeline(orderDisplayId);
-
-      if (timelineErr) {
-        logger.error('Timeline Insertion Error:', timelineErr.message);
-        await this.orderRepository.deleteOrder(order.id);
-        throw new DomainError(500, { error: 'Failed to create order timeline.', details: timelineErr.message });
-      }
-
-      const { error: offerErr } = await this.orderRepository.createLoadOffer({
-        order_display_id: orderDisplayId,
-        customer_id: customerId,
-        customer_name: customerName || 'Customer',
-        route_label: `${pickup_address.split(',')[0]} \u2192 ${drop_address.split(',')[0]}`,
-        route_subtitle: `${weight_tonnes} tonnes \u2022 ${goods_type}`,
-        pickup_address, pickup_lat, pickup_lng,
-        drop_address, drop_lat, drop_lng,
-        goods_type,
-        weight: `${weight_tonnes} tonnes`,
-        freight_value: pricing.totalAmount,
-        fuel_cost: pricing.fuelCost,
-        toll_cost: pricing.tollEstimate,
-        net_profit: pricing.netProfit,
-        extra_distance_km: pricing.distanceKm,
-        status: 'available',
-        waypoints: optimizedWaypoints,
-      });
-
-      if (offerErr) {
-        logger.error('Load Offer Insertion Error:', offerErr.message);
-        await this.orderTimelineService.deleteTimeline(orderDisplayId);
-        await this.orderRepository.deleteOrder(order.id);
-        throw new DomainError(500, { error: 'Failed to create load offer.', details: offerErr.message });
+      if (lastErr) {
+        logger.error('Order Insertion Error:', lastErr.message);
+        throw new DomainError(500, { error: 'Failed to create order record.', details: lastErr.message });
       }
 
       return { order };

--- a/supabase/migrations/20260810000001_fix_create_order_tx_columns.sql
+++ b/supabase/migrations/20260810000001_fix_create_order_tx_columns.sql
@@ -83,7 +83,7 @@ BEGIN
         goods_type, weight_tonnes, length_ft, width_ft, height_ft,
         is_stackable, is_fragile, special_requirements,
         base_freight, toll_estimate, platform_fee, total_amount, estimated_price,
-        payment_method_id, upi_id
+        payment_method_id, upi_id, waypoints
     ) VALUES (
         p_order_data->>'order_display_id',
         v_customer_id,
@@ -112,7 +112,8 @@ BEGIN
         (p_order_data->>'total_amount')::INTEGER,
         (p_order_data->>'estimated_price')::INTEGER,
         (p_order_data->>'payment_method_id')::UUID,
-        p_order_data->>'upi_id'
+        p_order_data->>'upi_id',
+        COALESCE((p_order_data->'waypoints')::JSONB, '[]'::jsonb)
     )
     RETURNING id, status INTO v_order_id, v_status;
 
@@ -151,7 +152,7 @@ BEGIN
             drop_address, drop_lat, drop_lng,
             goods_type, weight,
             freight_value, fuel_cost, toll_cost, net_profit, extra_distance_km,
-            status
+            status, waypoints
         ) VALUES (
             p_order_data->>'order_display_id',
             v_customer_id,
@@ -171,7 +172,8 @@ BEGIN
             (p_load_offer_data->>'toll_cost')::INTEGER,
             (p_load_offer_data->>'net_profit')::INTEGER,
             (p_load_offer_data->>'extra_distance_km')::INTEGER,
-            COALESCE(p_load_offer_data->>'status', 'available')
+            COALESCE(p_load_offer_data->>'status', 'available'),
+            COALESCE((p_load_offer_data->'waypoints')::JSONB, '[]'::jsonb)
         );
     END IF;
 


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/orderLifecycleService.js`, `createOrder` performed three separate writes (order, timeline, load offer) with no transaction, then relied on manual `deleteOrder`/`deleteTimeline` cleanup. Problems:

1. No atomic transaction — a failure mid-flow left orphaned orders/timelines/load offers.
2. Manual cleanup was not in a `finally` block and could fail silently, leaving inconsistent state.
3. No idempotency key — retried / duplicated submissions could create multiple orders.
4. The `create_order_tx` RPC (`createOrderTransactional`) already existed but was unused.

## Fix

- Refactored `createOrder` to call `createOrderTransactional`, which wraps the order + timeline + load-offer inserts in the `create_order_tx` database transaction. A failure now rolls back all three writes (no orphans, no manual cleanup needed).
- Added an idempotency key derived from the request content (`customerId` + core order fields), so identical/retried submissions are de-duplicated by the `order_idempotency_records` table instead of creating duplicate orders.
- The display-id collision retry loop is preserved and now retries only on a `23505` uniqueness violation, surfacing other errors.
- Extended the `create_order_tx` RPC (`supabase/migrations/20260810000001_fix_create_order_tx_columns.sql`) to persist the `waypoints` column on both `orders` and `load_offers`, preserving the previous behavior that the non-transactional path stored.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js`
- `supabase/migrations/20260810000001_fix_create_order_tx_columns.sql`

## Testing

- Order creation is now all-or-nothing via the transactional RPC.
- Duplicate submissions with identical content return the original order via idempotency.
- `waypoints` is still persisted (RPC extended accordingly).

Closes #11374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Order creation now saves order and load-offer details, including waypoint information, together for more consistent results.
- **Bug Fixes**
  - Improved order creation reliability with safer retry handling when duplicate display IDs occur.
  - Prevented partially created orders by ensuring related records are saved atomically.
  - Preserved waypoint data for both orders and load offers, defaulting gracefully when no waypoints are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->