### PR TITLE
[High] fix: on-chain status guard before escrow refund submission (Closes #11375)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -9,6 +9,8 @@ import {
   submitEscrowRefund,
   submitEscrowCancelWithPenalty,
   confirmEscrowRefund,
+  getEscrowBookingId,
+  getEscrowBooking,
   paisaToMaticWei,
 } from '../escrow.js';
 import { computeOrderPricing } from '../../lib/pricing.js';
@@ -740,9 +742,18 @@ export class OrderLifecycleService {
           try {
             let receipt;
 
-            if (refundTxHash) {
+            // Guard against double submission: check the authoritative on-chain
+            // booking state before issuing another cancel tx. The contract
+            // reverts cancelBooking for an already-cancelled booking, which the
+            // app would otherwise misinterpret as a refund failure.
+            const bookingId = getEscrowBookingId(workingOrder.order_display_id);
+            const onChainBooking = await getEscrowBooking(bookingId);
+            const alreadyCancelled =
+              onChainBooking && Number(onChainBooking.status) === 2; // BookingStatus.Cancelled
+
+            if (refundTxHash && !alreadyCancelled) {
               receipt = await confirmEscrowRefund(refundTxHash);
-            } else {
+            } else if (!alreadyCancelled) {
               const submitted = driverFeeWei > 0n
                 ? await submitEscrowCancelWithPenalty(workingOrder.order_display_id, driverFeeWei)
                 : await submitEscrowRefund(workingOrder.order_display_id);
@@ -759,6 +770,9 @@ export class OrderLifecycleService {
               });
 
               receipt = await submitted.waitForConfirmation();
+            } else {
+              logger.info(`[escrow] Booking ${workingOrder.order_display_id} already cancelled on-chain; skipping duplicate refund submission.`);
+              receipt = { hash: refundTxHash ?? null, alreadyCancelled: true };
             }
 
             const refundedAt = new Date().toISOString();


### PR DESCRIPTION
## Problem

In `backend/api/src/services/order/orderLifecycleService.js`, the `cancelOrder` refund flow submitted a `cancelBooking` transaction without first checking the on-chain booking state. Problems:

1. On a retried confirmation, `submitEscrowRefund` / `submitEscrowCancelWithPenalty` would submit a **second** `cancelBooking` tx even though the first may have succeeded. The contract reverts `cancelBooking` for an already-cancelled booking, which the app then treated as a refund failure and marked `escrow_status: 'refund_failed'` — even though funds were already returned.
2. A stale `refund_tx_hash` from `workingOrder.refund_tx_hash` was blindly passed to `confirmEscrowRefund` without verifying on-chain state first.
3. Unlike `escrowRelease` (which checks `booking.paid === true` before releasing), there was no pre-submission on-chain status check for refunds.

## Fix

- Added an on-chain status pre-check using `getEscrowBookingId` + `getEscrowBooking` (mirroring `escrowRelease`'s pattern). If the booking is already `Cancelled` (`BookingStatus.Cancelled === 2`), the code skips submitting/confirming another cancel tx and proceeds straight to finalization.
- `getEscrowBooking` safely returns `null` when the contract is unavailable, so the guard is a no-op in that case (preserving prior behavior).
- A duplicate submission is now logged and finalized instead of triggering a misleading `refund_failed`.

## Files changed

- `backend/api/src/services/order/orderLifecycleService.js`

## Testing

- Re-submitting a refund for an already-cancelled booking no longer issues a second `cancelBooking` tx or mislabels it `refund_failed`.
- When the escrow contract is unavailable, behavior is unchanged.

Closes #11375
