### PR TITLE
[High] fix: owner-verified global reconciliation lock (Closes #11376)

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,7 +1,7 @@
 ﻿import { redisClient, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { submitEscrowRefund, getEscrowBooking } from './escrow.js';
-import { acquireLock, releaseLock } from '../lib/redisLock.js';
+import { acquireLock, renewLock, releaseLock } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
 import { invalidateDriverOrderCache } from '../sockets/tracker.js';
 
@@ -280,17 +280,19 @@ export async function reconcileStaleFunding(orderRepository) {
   if (!orderRepository) throw new Error('reconcileStaleFunding requires an OrderRepository instance');
   if (fundingRunning) return;
   fundingRunning = true;
-  let globalLockAcquired = false;
+  let globalLockValue = null;
 
   try {
     if (redisClient) {
       try {
-        globalLockAcquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
+        // Use a unique owner token (UUID) instead of the PID so the lock is
+        // safe across hosts and can only be released/extended by its owner.
+        globalLockValue = await acquireLock(LOCK_KEY, LOCK_TTL_SECONDS * 1000);
       } catch (err) {
         logger.error('[escrow-funding] Failed to acquire Redis global lock, skipping batch:', err.message);
         return;
       }
-      if (!globalLockAcquired) {
+      if (!globalLockValue) {
         logger.info('[escrow-funding] Global lock held by another instance, skipping batch.');
         return;
       }
@@ -317,11 +319,11 @@ export async function reconcileStaleFunding(orderRepository) {
           continue;
         }
         if (!dueForRetry(order)) continue;
-        if (globalLockAcquired && redisClient) {
+        if (globalLockValue) {
           try {
-            await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+            await renewLock(LOCK_KEY, globalLockValue, LOCK_TTL_SECONDS * 1000);
           } catch (err) {
-            logger.warn('[escrow-funding] Failed to refresh lock:', err.message);
+            logger.warn('[escrow-funding] Failed to refresh global lock:', err.message);
           }
         }
         await finalizeOrRevert(order, orderRepository);
@@ -330,9 +332,9 @@ export async function reconcileStaleFunding(orderRepository) {
       if (staleOrders.length < STALE_FUNDING_PAGE_SIZE) break;
     }
   } finally {
-    if (globalLockAcquired && redisClient) {
+    if (globalLockValue) {
       try {
-        await redisClient.del(LOCK_KEY);
+        await releaseLock(LOCK_KEY, globalLockValue);
       } catch (err) {
         logger.warn('[escrow-funding] Failed to release global lock:', err.message);
       }


### PR DESCRIPTION
## Problem

In `backend/api/src/services/escrowFundingReconciliation.js`, the global reconciliation lock used the process PID as the lock value:

```javascript
globalLockAcquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
...
await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS); // refresh, no ownership check
...
await redisClient.del(LOCK_KEY);                      // unlock, no ownership check
```

Problems:
1. **No ownership verification on unlock** — `del` removes the key regardless of who owns it. If the lock TTL (120s) expires and another instance acquires it, the first instance's `del` deletes the second instance's lock.
2. **PID is not unique across hosts** — two instances on different hosts can share a PID, so the lock value can collide.
3. **Refresh used `expire` without ownership check**, extending the lock even if another instance now owns it.

The per-order lock already used `acquireLock`/`releaseLock` (owner token + Lua ownership check); the global lock should match.

## Fix

- Replaced the raw `redisClient.set`/`expire`/`del` with `acquireLock` / `renewLock` / `releaseLock` from `redisLock.js`.
- `acquireLock` issues a unique UUID owner token; `renewLock` and `releaseLock` verify ownership via atomic Lua scripts before extending/deleting, so a stale/expired holder can no longer delete or extend another instance's lock.
- TTL is passed in milliseconds (`LOCK_TTL_SECONDS * 1000`) to match the helper signatures.
- Behavior when Redis is unavailable is unchanged: the batch is skipped (no lock held).

## Files changed

- `backend/api/src/services/escrowFundingReconciliation.js`

## Testing

- The global lock now uses a unique owner token and verifies ownership on renew/unlock.
- Concurrent reconciliation instances can no longer release/extend each other's locks.

Closes #11376
