### PR TITLE
fix: remove duplicate newAmountWei declaration breaking module parse

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -578,7 +578,6 @@ export class OrderLifecycleService {
         // against at deposit time and on release), so it must track
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
-        const newAmountWei = paisaToMaticWei(pricing.totalAmount);
         const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {


### PR DESCRIPTION
Fixes #11195

## Problem
`backend/api/src/services/order/orderLifecycleService.js` declared `const newAmountWei` twice in the same scope (lines 581-582). The module failed to parse, so `npx vitest run test/unit/orderLifecycleService.test.js` threw `SyntaxError: Identifier 'newAmountWei' has already been declared` before any test ran, and ESLint reported `581:15 Parsing error` for every open PR.

## Change
Removed the stale duplicate (`const newAmountWei = paisaToMaticWei(pricing.totalAmount);`), keeping the canonical `BigInt(paisaToMaticWei(pricing.totalAmount))` used by the escrow pipeline. Diff is a single deletion.

## Verification
- The module's own parse break is gone (the suite gets past the previous SyntaxError).
- The remaining `orderLifecycleService.test.js` failures are a separate pre-existing issue (Mongoose `Cannot overwrite 'GpsLog' model once compiled`), unrelated to this change.

This PR is part of GSSOC (GirlScript Summer of Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when recording escrow amounts during order changes by ensuring values are stored in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->