### PR TITLE
fix: remove duplicate getRushHourMultiplier declaration in trafficService

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -77,17 +77,3 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
     return 1.0;
   }
 }
-
-function getRushHourMultiplier(date) {
-  const hour = date.getUTCHours();
-  const isMorningRush = hour >= RUSH_HOUR_START_AM && hour < RUSH_HOUR_END_AM;
-  const isEveningRush = hour >= RUSH_HOUR_START_PM && hour < RUSH_HOUR_END_PM;
-  if (!isMorningRush && !isEveningRush) {
-    return 1.0;
-  }
-  const peakHour = isMorningRush
-    ? (hour - RUSH_HOUR_START_AM) / (RUSH_HOUR_END_AM - RUSH_HOUR_START_AM)
-    : (hour - RUSH_HOUR_START_PM) / (RUSH_HOUR_END_PM - RUSH_HOUR_START_PM);
-  const surge = MIN_SURGE_MULTIPLIER + SURGE_PEAK_AMPLITUDE * Math.sin(peakHour * Math.PI);
-  return Number(Math.min(MAX_SURGE_MULTIPLIER, Math.max(MIN_SURGE_MULTIPLIER, surge)).toFixed(2));
-}


### PR DESCRIPTION
Fixes #11200

## Problem
`backend/api/src/services/trafficService.js` declares `function getRushHourMultiplier(date)` twice (lines 16 and 81). The module fails to parse with `SyntaxError: Identifier 'getRushHourMultiplier' has already been declared`, so `npx vitest run test/unit/trafficService.test.js` crashed at import (4/15 tests failing) and any service transitively importing this module broke too.

## Change
Removed the redundant second declaration (14 lines). The first implementation at line 16 is already wired into `getLiveTrafficMultiplier` (line 68), so the rush-hour surge now actually works.

## Verification
- `trafficService.test.js`: 16/17 passing (was 4/15 failing at load). The one remaining failure is unrelated log-string drift (`'Live traffic surge detected'` vs expected `'Live traffic data'`).
- Morning/evening rush-hour surge tests pass: `getRushHourMultiplier` now returns `>= 1.2` during rush hours.

This PR is part of GSSOC (GirlScript Summer of Code).
