### PR TITLE
fix: redisLock unit tests reference undefined redisHolder/makeRedis

### DIFF
--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -1,9 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock the db module before importing redisLock
+// Mock the db module before importing redisLock. redisClient is a live
+// getter so tests can swap the backing redis instance via redisHolder.client.
+const redisHolder = vi.hoisted(() => ({ client: null }));
+
 vi.mock('../../src/config/db.js', () => ({
-  redisClient: null,
+  get redisClient() {
+    return redisHolder.client;
+  },
 }));
+
+import { acquireLock, renewLock, releaseLock, LockAcquisitionError } from '../../src/lib/redisLock.js';
+
+function makeRedis({ setResult = 'OK', evalResult = 1, throwOn } = {}) {
+  const redis = {
+    set: vi.fn(async () => {
+      if (throwOn === 'set') throw new Error('Redis connection lost');
+      return setResult;
+    }),
+    eval: vi.fn(async () => {
+      if (throwOn === 'eval') throw new Error('Redis eval failed');
+      return evalResult;
+    }),
+  };
+  return redis;
+}
 
 describe('redisLock', () => {
   beforeEach(() => {
@@ -11,12 +32,10 @@ describe('redisLock', () => {
   });
 
   it('acquireLock throws (fails closed) when redisClient is null', async () => {
-    const { acquireLock, LockAcquisitionError } = await import('../../src/lib/redisLock.js');
     await expect(acquireLock('test-resource', 5000)).rejects.toBeInstanceOf(LockAcquisitionError);
   });
 
   it('releaseLock does not throw when redisClient is null', async () => {
-    const { releaseLock } = await import('../../src/lib/redisLock.js');
     await expect(releaseLock('non-existent-lock')).resolves.not.toThrow();
   });
 });


### PR DESCRIPTION
Fixes #11196

## Problem
`backend/api/test/unit/redisLock.test.js` referenced `redisHolder` and `makeRedis` which were never defined, and its later `describe` blocks used `releaseLock` / `renewLock` / `acquireLock` / `LockAcquisitionError` without importing them (the only imports were inside two tests via dynamic `import()`). Result: `ReferenceError: redisHolder is not defined` / `releaseLock is not defined` — 20 of 22 tests crashed.

## Change
- Added a mutable `redisHolder` (via `vi.hoisted`) and a `makeRedis()` fake helper with `set` / `eval` / `throwOn` behavior.
- Mocked `../../src/config/db.js` so `redisClient` is a live getter reflecting `redisHolder.client`.
- Imported the module once at the top and removed the redundant dynamic imports.

## Verification
`npx vitest run test/unit/redisLock.test.js` → **22/22 passing** (was 20/22 crashing).

This PR is part of GSSOC (GirlScript Summer of Code).
