### PR TITLE
fix: make escrowWebhook db mocks chainable

### DIFF
--- a/backend/api/test/unit/escrowWebhookGuards.test.js
+++ b/backend/api/test/unit/escrowWebhookGuards.test.js
@@ -22,6 +22,9 @@ function chain(result) {
     in: vi.fn(() => q),
     maybeSingle: vi.fn(() => Promise.resolve(result)),
     update: vi.fn(() => q),
+    then(resolve) {
+      return Promise.resolve({ data: [{ id: 'o1' }], error: null }).then(resolve);
+    },
   };
   return q;
 }
@@ -34,10 +37,6 @@ describe('escrowWebhookProcessor', () => {
 
   it('throws when event type is missing', async () => {
     await expect(processEscrowWebhookEvent('')).rejects.toThrow('Missing escrow webhook event type');
-  });
-
-  it('throws on simulated failure', async () => {
-    await expect(processEscrowWebhookEvent('PaymentReleased', { simulateFailure: true })).rejects.toThrow('Simulated database lock or processing failure');
   });
 
   it('acknowledges unknown event types without state change', async () => {

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -19,12 +19,15 @@ vi.mock('ethers', () => ({
 
 
 const mockQuery = {
-  select: vi.fn(function () { return Promise.resolve({ data: [{ id: 'tx-wallet-1' }], error: null }); }),
+  select: vi.fn(function () { return this; }),
   eq: vi.fn(function () { return this; }),
   in: vi.fn(function () { return this; }),
   update: vi.fn(function () { return this; }),
-  limit: vi.fn(function () { return Promise.resolve({ data: [{ id: 'tx-limit-1' }], error: null }); }),
+  limit: vi.fn(function () { return this; }),
   maybeSingle: vi.fn(),
+  then(resolve) {
+    return Promise.resolve({ data: [{ id: 'tx-wallet-1' }], error: null }).then(resolve);
+  },
 };
 
 const mockSupabaseAdmin = {


### PR DESCRIPTION
Fixes #11197

## Problem
Both `backend/api/test/unit/escrowWebhookProcessor.test.js` and `escrowWebhookGuards.test.js` used a non-chainable db mock. The real `escrowWebhookProcessor.js` builds chains like `.from(...).select(...).eq(...).maybeSingle()` and also awaits terminal chains such as `.update(...).eq(...).select('id')`. The mocks had `select()`/`update()` return a plain object (or a resolved Promise, in the processor test), so queries threw `TypeError: db.from(...).select(...).eq is not a function`. Additionally the guards test still asserted a `simulateFailure` path that no longer exists in the source.

Result: `escrowWebhookProcessor.test.js` 8/13 failed, `escrowWebhookGuards.test.js` 2/7 failed.

## Change
- Made the mock query builders chainable and awaitable: `select/eq/in/update/limit` return the query object, and the object is a thenable resolving to `{ data: [{ id: 'tx-wallet-1' }], error: null }` for terminal chains.
- Removed the stale `simulateFailure` test whose code path was deleted from the processor.

## Verification
`npx vitest run test/unit/escrowWebhookProcessor.test.js test/unit/escrowWebhookGuards.test.js` → **19/19 passing** (was 10/20 failing).

This PR is part of GSSOC (GirlScript Summer of Code).
