### PR TITLE
fix: paginated() hasNextPage is true for invalid page 0

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -43,7 +43,7 @@ export function paginated(data = [], page = 1, limit = 10, total = 0, message = 
       limit: safeLimit,
       total: safeTotal,
       totalPages,
-      hasNextPage: safePage < totalPages,
+      hasNextPage: safePage > 0 && safePage < totalPages,
       hasPrevPage: safePage > 1,
     },
   };


### PR DESCRIPTION
Fixes #11198

## Problem
`paginated()` in `backend/api/src/lib/apiResponse.js` computed `hasNextPage: safePage < totalPages`. When the client requests page `0` (1-indexed pages, so page 0 is out of range), `0 < totalPages` was `true` for any data set — the envelope claimed there is a next page from an invalid page. `test/unit/apiResponse.test.js > handles page 0 gracefully` failed (`expected true to be false`).

## Change
`hasNextPage` is now `safePage > 0 && safePage < totalPages` — only a valid, non-terminal page reports a successor.

## Verification
`npx vitest run test/unit/apiResponse.test.js` → **15/15 passing** (was 14/15).

This PR is part of GSSOC (GirlScript Summer of Code).
