### PR TITLE
fix: correct inverted shard assertions in ShardManager tests

### DIFF
--- a/backend/api/test/unit/ShardManager.test.js
+++ b/backend/api/test/unit/ShardManager.test.js
@@ -27,14 +27,14 @@ describe('ShardManager', () => {
       expect(shard1).toBe(shard2);
     });
 
-    it('returns north shard for lat < 20', () => {
+    it('returns south shard for Tamil Nadu coordinates', () => {
       const shard = ShardManager.getShardForLocation(15.0, 77.2090);
-      expect(shard).toBe('north');
+      expect(shard).toBe('south');
     });
 
-    it('returns south shard for lat < 10', () => {
+    it('returns north shard (default) for coordinates outside any bounding box', () => {
       const shard = ShardManager.getShardForLocation(5.0, 77.2090);
-      expect(shard).toBe('south');
+      expect(shard).toBe('north');
     });
   });
 


### PR DESCRIPTION
Fixes #11199

## Problem
`backend/api/test/unit/ShardManager.test.js` asserted inverted shard expectations. The actual, sensible mapping in `ShardManager.getStateFromCoordinates` (src/services/sharding/ShardManager.js):
- lat 15, lng 77 falls in the Tamil Nadu bounding box (`lat > 8 && lat < 20 && lng > 72 && lng < 82`) → `tamilnadu` → **south** shard.
- lat 5 matches no bounding box → default `delhi` → **north** shard.

The tests claimed the opposite ("north shard for lat < 20", "south shard for lat < 10"), so 2/5 tests failed with `expected 'south' to be 'north'` and `expected 'north' to be 'south'`.

## Change
Corrected the two assertions (and their names) to match the source's coordinate → shard logic.

## Verification
`npx vitest run test/unit/ShardManager.test.js` → **5/5 passing** (was 3/5).

This PR is part of GSSOC (GirlScript Summer of Code).
