### PR TITLE
fix: mock createUserClient in demandRoutes tests

### DIFF
--- a/backend/api/test/unit/demandRoutes.test.js
+++ b/backend/api/test/unit/demandRoutes.test.js
@@ -15,12 +15,16 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
 }));
 
 const { dbMock, mlMock } = vi.hoisted(() => ({
-  dbMock: { supabase: { from: vi.fn() } },
+  dbMock: {
+    supabase: { from: vi.fn() },
+    createUserClient: vi.fn(),
+  },
   mlMock: { predictDemand: vi.fn() },
 }));
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return dbMock.supabase; },
+  createUserClient: (token) => dbMock.createUserClient(token),
 }));
 
 vi.mock('../../src/services/ml.js', () => mlMock);
@@ -45,8 +49,10 @@ describe('demandRoutes', () => {
 
   describe('GET /', () => {
     it('returns a heatmap payload on success', async () => {
-      dbMock.supabase.from.mockReturnValue({
-        select: vi.fn(() => ({ in: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [{ pickup_address: 'A', pickup_lat: 10, pickup_lng: 20, status: 'available' }], error: null }) })) })),
+      dbMock.createUserClient.mockReturnValue({
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({ in: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [{ pickup_address: 'A', pickup_lat: 10, pickup_lng: 20, status: 'available' }], error: null }) })) })),
+        })),
       });
       const res = await request(makeApp()).get('/');
       expect(res.status).toBe(200);
@@ -56,8 +62,10 @@ describe('demandRoutes', () => {
     });
 
     it('returns 500 when the loads query errors', async () => {
-      dbMock.supabase.from.mockReturnValue({
-        select: vi.fn(() => ({ in: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'db down' } }) })) })),
+      dbMock.createUserClient.mockReturnValue({
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({ in: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'db down' } }) })) })),
+        })),
       });
       const res = await request(makeApp()).get('/');
       expect(res.status).toBe(500);


### PR DESCRIPTION
Fixes #11201

## Problem
`demandRoutes.js` now reads load offers through the **user-scoped** client: `createUserClient(req.token).from('load_offers').select(...).in(...).limit(100)` (so the RLS policy sees the authenticated identity). The test still mocked only `supabase.from`, so `createUserClient` was `undefined` at runtime and the route fell into the catch-all `500 Internal Server Error` instead of the real success/domain-error paths.

Result: `test/unit/demandRoutes.test.js` 0/2 passed (both returned 500 `{ error: 'Internal Server Error' }`).

## Change
The db mock now provides `createUserClient(token)` and the two tests stub the client's `from(...)` chain through it.

## Verification
`npx vitest run test/unit/demandRoutes.test.js` → **2/2 passing** (was 0/2). Success case now returns 200 with the GeoJSON payload; error case returns 500 `'Failed to fetch heatmap data.'`.

This PR is part of GSSOC (GirlScript Summer of Code).
