### PR TITLE
fix: rewrite VerificationService tests against real API

### DIFF
--- a/backend/api/test/unit/VerificationService.test.js
+++ b/backend/api/test/unit/VerificationService.test.js
@@ -1,66 +1,172 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockFrom = vi.fn();
+const { mockFrom } = vi.hoisted(() => {
+  const mockFrom = vi.fn();
+  return { mockFrom };
+});
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: { from: mockFrom },
 }));
 
-describe('VerificationService', () => {
-  let VerificationService;
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
 
-  beforeEach(async () => {
+import VerificationService from '../../src/services/verification/VerificationService.js';
+
+function makeOrder(overrides = {}) {
+  return {
+    id: 'order-1',
+    order_display_id: 'TRX-1',
+    status: 'in_transit',
+    customer_id: 'cust-1',
+    driver_id: 'driver-1',
+    truck_id: 'truck-1',
+    otp_verified: true,
+    blockchain_tx_hash: null,
+    escrow_status: 'funded',
+    ...overrides,
+  };
+}
+
+describe('VerificationService', () => {
+  let service;
+  let tables;
+
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
-    VerificationService = (await import('../../src/services/verification/VerificationService.js')).default;
+    tables = {};
+    mockFrom.mockImplementation((table) => {
+      if (!tables[table]) {
+        throw new Error(`No mock configured for table "${table}"`);
+      }
+      return tables[table]();
+    });
+    service = new VerificationService({
+      oracleService: {
+        confirmDelivery: vi.fn().mockResolvedValue({
+          confirmed: true,
+          consensusCount: 3,
+          threshold: 2,
+          totalProviders: 3,
+          providerResults: [],
+          timestamp: '2025-01-01T00:00:00Z',
+        }),
+        verifyCrossChain: vi.fn().mockResolvedValue({ verified: false, ipfsHash: null }),
+      },
+    });
   });
 
-  describe('verifyDocument', () => {
-    it('marks document as verified when all checks pass', async () => {
-      const mockDoc = { id: 'doc-1', user_id: 'user-1', status: 'pending' };
-      mockFrom
-        .mockReturnValueOnce({
-          select: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockDoc, error: null }),
-        })
-        .mockReturnValueOnce({
-          update: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockResolvedValue({ error: null }),
-        });
+  function stubTable(table, resolve) {
+    tables[table] = () => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue(resolve) })),
+      })),
+    });
+  }
 
-      const result = await VerificationService.verifyDocument('doc-1');
-      expect(result).toBeTruthy();
+  function stubDocuments(documents, error = null) {
+    tables.driver_documents = () => ({
+      select: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: documents, error }) })),
+    });
+  }
+
+  function stubProfile(profile) {
+    stubTable('profiles', { data: profile, error: null });
+  }
+
+  describe('verifyOrder', () => {
+    it('marks an order verified when oracle confirms and driver checks pass', async () => {
+      stubTable('orders', { data: makeOrder(), error: null });
+      stubProfile({ id: 'driver-1', is_active: true, role: 'driver' });
+      stubDocuments([
+        { document_type: 'rc_book', status: 'approved' },
+        { document_type: 'driving_licence', status: 'approved' },
+      ]);
+
+      const result = await service.verifyOrder('order-1');
+      expect(result.deliveryVerified).toBe(true);
+      expect(result.oracleDetails.confirmed).toBe(true);
+      expect(result.driverVerification.verified).toBe(true);
+      expect(result.documentIntegrity.verified).toBe(true);
+      expect(result.verified).toBeUndefined();
     });
 
-    it('returns false when document not found', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
+    it('does not mark delivery verified when the oracle is not confirmed', async () => {
+      stubTable('orders', { data: makeOrder(), error: null });
+      stubProfile(null);
+      stubDocuments([]);
+      service.oracleService.confirmDelivery.mockResolvedValue({
+        confirmed: false,
+        consensusCount: 1,
+        threshold: 2,
+        totalProviders: 3,
+        providerResults: [],
+        timestamp: '2025-01-01T00:00:00Z',
       });
 
-      const result = await VerificationService.verifyDocument('doc-nonexistent');
-      expect(result).toBe(false);
+      const result = await service.verifyOrder('order-1');
+      expect(result.deliveryVerified).toBe(false);
+      expect(result.driverVerification.verified).toBe(false);
+    });
+
+    it('returns verified false when the order is not found', async () => {
+      stubTable('orders', { data: null, error: null });
+
+      const result = await service.verifyOrder('missing');
+      expect(result).toEqual({ verified: false, error: 'Order not found' });
+    });
+
+    it('verifies cross-chain when the order has a blockchain tx hash', async () => {
+      stubTable('orders', { data: makeOrder({ blockchain_tx_hash: '0xabc' }), error: null });
+      stubProfile(null);
+      stubDocuments([]);
+      service.oracleService.verifyCrossChain.mockResolvedValue({ verified: true, ipfsHash: 'ipfs://abc' });
+
+      const result = await service.verifyOrder('order-1');
+      expect(result.crossChainVerified).toBe(true);
+      expect(result.ipfsHash).toBe('ipfs://abc');
+      expect(service.oracleService.verifyCrossChain).toHaveBeenCalledWith('order-1', '0xabc');
     });
   });
 
-  describe('rejectDocument', () => {
-    it('updates document status to rejected', async () => {
-      const mockDoc = { id: 'doc-1', status: 'pending' };
-      mockFrom
-        .mockReturnValueOnce({
-          select: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockDoc, error: null }),
-        })
-        .mockReturnValueOnce({
-          update: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockResolvedValue({ error: null }),
-        });
+  describe('checkDocumentIntegrity', () => {
+    it('returns verified when all required documents are approved', async () => {
+      stubDocuments([
+        { document_type: 'rc_book', status: 'approved' },
+        { document_type: 'driving_licence', status: 'approved' },
+      ]);
 
-      const result = await VerificationService.rejectDocument('doc-1', 'Document is blurry');
-      expect(result).toBeTruthy();
+      const result = await service.checkDocumentIntegrity('driver-1');
+      expect(result.verified).toBe(true);
+      expect(result.documentsChecked).toHaveLength(2);
+      expect(result.documentsChecked.every(d => d.status === 'approved')).toBe(true);
+    });
+
+    it('returns not verified when a required document is missing', async () => {
+      stubDocuments([{ document_type: 'rc_book', status: 'approved' }]);
+
+      const result = await service.checkDocumentIntegrity('driver-1');
+      expect(result.verified).toBe(false);
+      expect(result.documentsChecked).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: 'driving_licence', uploaded: false, status: 'missing' }),
+      ]));
+    });
+
+    it('returns all documents missing when no driver is assigned', async () => {
+      const result = await service.checkDocumentIntegrity(null);
+      expect(result.verified).toBe(false);
+      expect(result.documentsChecked.every(d => d.status === 'missing')).toBe(true);
+    });
+
+    it('reports an error state when the documents query fails', async () => {
+      stubDocuments(null, { message: 'db down' });
+
+      const result = await service.checkDocumentIntegrity('driver-1');
+      expect(result.verified).toBe(false);
+      expect(result.documentsChecked.every(d => d.status === 'error')).toBe(true);
+      expect(result.error).toBe('db down');
     });
   });
 });


### PR DESCRIPTION
Fixes #11202

## Problem
`backend/api/test/unit/VerificationService.test.js` called `VerificationService.verifyDocument()` and `VerificationService.rejectDocument()`, which do not exist in `src/services/verification/VerificationService.js` (the real API is `verifyOrder(orderId)` and `checkDocumentIntegrity(driverId)`). Every test threw `TypeError: VerificationService.verifyDocument is not a function` — 3/3 failed.

## Change
Rewrote the suite against the real API, injecting a stub `oracleService` (no network calls) and a table-dispatcher `supabase.from` mock that handles `orders` / `profiles` / `driver_documents` chains. Covers:
- `verifyOrder`: verified when oracle confirms + driver active + documents approved; not verified when oracle unconfirmed; not found; cross-chain verification when `blockchain_tx_hash` present.
- `checkDocumentIntegrity`: all-approved → verified; missing required doc → not verified; no driver → all missing; query failure → `error` statuses + error message.

## Verification
`npx vitest run test/unit/VerificationService.test.js` → **8/8 passing** (was 0/3).

This PR is part of GSSOC (GirlScript Summer of Code).
