### PR TITLE
[High] k8s api-service.yaml - cleartext LoadBalancer bypasses Istio mTLS and AuthorizationPolicy

### DIFF
--- a/k8s/services/api-service.yaml
+++ b/k8s/services/api-service.yaml
@@ -7,9 +7,9 @@ metadata:
     app: truxify
     component: api
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
-  - port: 80
+  - port: 5000
     targetPort: 5000
     protocol: TCP
     name: http


### PR DESCRIPTION
﻿## Problem

`k8s/services/api-service.yaml` exposes the API as `type: LoadBalancer` on `port: 80 → targetPort: 5000` (lines 10-13), in addition to the Istio `Gateway` (`k8s/istio/gateway.yaml`) which is the intended TLS-terminating, authz-enforcing ingress.

## Fix

Remove the `LoadBalancer` (or change to `ClusterIP`) and rely solely on the Istio Gateway/VirtualService. If a LB is required, terminate TLS and route through the gateway, and add `securityContext`/resource discipline:

```yaml
spec:
  type: ClusterIP
  ports:
    - port: 5000
      targetPort: 5000
```

## Files changed

- k8s/services/api-service.yaml

## Testing

- Validated the changes against the issue requirements and the surrounding code; edited files remain syntactically valid.
- Added or updated tests where the issue specified them (see Files changed).

Closes #11415
