### PR TITLE
[High] services/route-matrix-cpp/main.cpp - O(N^2) response amplification + unbounded thread-per-connection DoS

### DIFF
--- a/services/route-matrix-cpp/main.cpp
+++ b/services/route-matrix-cpp/main.cpp
@@ -9,6 +9,8 @@
 #include <cctype>
 #include <cstring>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 
 #if defined(_WIN32)
 #include <winsock2.h>
@@ -30,6 +32,21 @@ typedef int socklen_t;
 // Total request byte budget per connection. Oversized requests are answered
 // with 413 instead of being buffered, bounding memory per connection.
 const size_t MAX_REQUEST_BYTES = 64 * 1024;
+
+// Caps the number of locations a single /matrix request may carry. The output
+// is one JSON object per ordered pair (O(N^2)), so an unbounded count turns a
+// small request body into hundreds of MB of CPU/memory amplification.
+const size_t MAX_LOCATIONS = 512;
+
+// Bounds the number of connections handled concurrently. Each accepted
+// connection runs on its own thread; without a cap a flood of idle (slowloris)
+// connections would spawn unbounded threads and exhaust the process.
+const int MAX_CONCURRENT = 256;
+
+// Shared state for the bounded connection pool below.
+static std::mutex pool_mu;
+static std::condition_variable pool_cv;
+static int pool_active = 0;
 
 // Applies read/write idle timeouts so a slow or idle client cannot stall a
 // handler thread forever: recv returns after the timeout instead of blocking
@@ -265,6 +282,8 @@ void handle_client(SOCKET client) {
         std::vector<Location> locs = parse_locations(body);
         if (locs.empty()) {
             response = build_response("{\"success\":false,\"error\":\"no locations provided\"}", "400 Bad Request");
+        } else if (locs.size() > MAX_LOCATIONS) {
+            response = build_response("{\"error\":\"too many locations\"}", "413 Request Entity Too Large");
         } else {
             response = build_response(compute_matrix_json(locs), "200 OK");
         }
@@ -324,11 +343,22 @@ int main() {
 
         set_socket_timeouts(client);
 
-        // Handle each connection on its own thread so an idle or slow client
-        // can never block the accept loop (and thus the whole service).
+        // Admit the connection only once the number of in-flight handlers
+        // drops below MAX_CONCURRENT. This bounds thread/stack usage so a
+        // flood of idle (slowloris) connections cannot exhaust the process.
+        {
+            std::unique_lock<std::mutex> lk(pool_mu);
+            pool_cv.wait(lk, [] { return pool_active < MAX_CONCURRENT; });
+            ++pool_active;
+        }
         std::thread([client]() {
             handle_client(client);
             closesocket(client);
+            {
+                std::unique_lock<std::mutex> lk(pool_mu);
+                --pool_active;
+            }
+            pool_cv.notify_one();
         }).detach();
     }
 }


### PR DESCRIPTION
﻿## Problem

`services/route-matrix-cpp/main.cpp` exposes a raw socket server. Two scaling defects:
1. **O(N²) response amplification** — the request body is capped at `MAX_REQUEST_BYTES = 64*1024` (line 32) but `compute_matrix_json` (line 86) emits one JSON object per *ordered pair* of locations. A 64 KB body can carry ~2,000 locations → ~4,000,000 objects (hundreds of MB) built into a `std::stringstream` and `send()`d (line 269).
2. **Unbounded detached threads** — each accepted connection is handled by `std::thread(...).detach()` (line 332) with no pool or limit. With `SO_RCVTIMEO = 30s`, an attacker opens many idle connections (slowloris) → unbounded thread/stack exhaustion and process hang.

## Fix

Guard the location count and bound concurrency (multi-line change):

```cpp
if (locs.size() > 512) {
    response = build_response("{\"error\":\"too many locations\"}", "413 Request Entity Too Large");
} else {
    response = build_response(compute_matrix_json(locs), "200 OK");
}
// Bounded pool instead of detach():
static std::mutex pool_mu; static std::condition_variable pool_cv; static int active = 0;
{
    std::unique_lock<std::mutex> lk(pool_mu);
    pool_cv.wait(lk, []{ return active < MAX_CONCURRENT; });
    ++active;
}
std::thread([client]{ handle_client(client); closesocket(client);
    { std::unique_lock<std::mutex> lk(pool_mu); --active; } pool_cv.notify_one(); }).detach();
```

## Files changed

- services/route-matrix-cpp/main.cpp

## Testing

- Validated the changes against the issue requirements and the surrounding code; edited files remain syntactically valid.
- Added or updated tests where the issue specified them (see Files changed).

Closes #11421
