### PR TITLE
[High] n8n dispute-resolution.json - broken wiring: real node orphaned, alert attached to phantom node

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -37,6 +37,25 @@
     },
     {
       "parameters": {
+        "method": "POST",
+        "url": "={{$env.BACKEND_API_URL}}/api/payments/{{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}/freeze",
+        "options": {}
+      },
+      "id": "freeze-escrow-payment",
+      "name": "Freeze Escrow Payment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        600,
+        300
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
         "toEmail": "admin@truxify.com",
         "subject": "=Escrow Alert: Freeze Payment Contract Failed for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
         "textBody": "=CRITICAL: The Freeze Payment Contract step failed after 3 retries for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}. Disputed funds were not frozen on-chain. Immediate manual intervention required.",
@@ -236,6 +255,25 @@
     },
     {
       "parameters": {
+        "method": "POST",
+        "url": "={{$env.BACKEND_API_URL}}/api/payments/{{$json.body.bookingId}}/release",
+        "options": {}
+      },
+      "id": "release-escrow-payment",
+      "name": "Release Escrow Payment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        350,
+        600
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
         "method": "GET",
         "url": "={{$env.BACKEND_API_URL}}/api/payments/{{$json.body.bookingId}}/status",
         "options": {}
@@ -286,12 +324,7 @@
       "main": [
         [
           {
-            "node": "Query MongoDB GPS Trail",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Query Supabase OTP Logs",
+            "node": "Freeze Escrow Payment",
             "type": "main",
             "index": 0
           }
@@ -391,7 +424,30 @@
       "main": [
         [
           {
-            "node": "Verify Escrow Release",
+            "node": "Release Escrow Payment",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Freeze Escrow Payment": {
+      "main": [
+        [
+          {
+            "node": "Query MongoDB GPS Trail",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Query Supabase OTP Logs",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Alert Admin — Escrow Freeze Failed",
             "type": "main",
             "index": 0
           }
@@ -399,6 +455,24 @@
       ]
     },
     "Release Escrow Payment": {
+      "main": [
+        [
+          {
+            "node": "Verify Escrow Release",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Alert Admin — Escrow Release Failed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Verify Escrow Release": {
       "main": [
         [],
         [

--- a/automation/n8n/tests/dispute-resolution.test.js
+++ b/automation/n8n/tests/dispute-resolution.test.js
@@ -1,0 +1,86 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+const workflow = require(path.join(__dirname, "..", "dispute-resolution.json"));
+
+function nodeByName(name) {
+  return workflow.nodes.find((n) => n.name === name);
+}
+
+function errorTargets(nodeName) {
+  const conn = workflow.connections[nodeName];
+  if (!conn || !conn.main) return [];
+  const errorOutputs = conn.main[1] || [];
+  return errorOutputs.map((t) => t.node);
+}
+
+function reachableViaErrorOutputs(startNode, targetNode) {
+  const visited = new Set();
+  const stack = [startNode];
+  while (stack.length) {
+    const current = stack.pop();
+    if (current === targetNode) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    for (const next of errorTargets(current)) stack.push(next);
+  }
+  return false;
+}
+
+let failures = 0;
+function test(title, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${title}`);
+  } catch (err) {
+    failures++;
+    console.error(`FAILED: ${title}\n  ${err.message}`);
+  }
+}
+
+test("has a real Release Escrow Payment node (no phantom) with retry + onError", () => {
+  const release = nodeByName("Release Escrow Payment");
+  assert.ok(release, "Release Escrow Payment node must exist");
+  assert.strictEqual(release.retryOnFail, true, "Release Escrow Payment must retry on fail");
+  assert.strictEqual(release.onError, "continueErrorOutput", "Release Escrow Payment must continue error output");
+});
+
+test("has a Freeze Escrow Payment node with retry + onError", () => {
+  const freeze = nodeByName("Freeze Escrow Payment");
+  assert.ok(freeze, "Freeze Escrow Payment node must exist");
+  assert.strictEqual(freeze.retryOnFail, true, "Freeze Escrow Payment must retry on fail");
+  assert.strictEqual(freeze.onError, "continueErrorOutput", "Freeze Escrow Payment must continue error output");
+});
+
+test("Verify Escrow Release error output reaches Alert Admin — Escrow Release Failed", () => {
+  assert.ok(
+    reachableViaErrorOutputs("Verify Escrow Release", "Alert Admin — Escrow Release Failed"),
+    "Alert Admin — Escrow Release Failed must be reachable from Verify Escrow Release error path",
+  );
+});
+
+test("Release Escrow Payment error output reaches Alert Admin — Escrow Release Failed", () => {
+  assert.ok(
+    reachableViaErrorOutputs("Release Escrow Payment", "Alert Admin — Escrow Release Failed"),
+    "Alert Admin — Escrow Release Failed must be reachable from Release Escrow Payment error path",
+  );
+});
+
+test("every connection source and target references an existing node", () => {
+  const nodeNames = new Set(workflow.nodes.map((n) => n.name));
+  for (const [source, outputs] of Object.entries(workflow.connections)) {
+    assert.ok(nodeNames.has(source), `connection source '${source}' must be a real node`);
+    for (const branch of outputs.main || []) {
+      for (const edge of branch) {
+        assert.ok(nodeNames.has(edge.node), `connection target '${edge.node}' must be a real node`);
+      }
+    }
+  }
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll tests passed");


### PR DESCRIPTION
﻿## Problem

`automation/n8n/dispute-resolution.json` has broken node wiring. The `connections` block (around lines 273-406) contains a key `"Release Escrow Payment"` (line 401) that is **not a node** — the actual node is named `"Verify Escrow Release"` (line 244). Consequently:
- `"Verify Escrow Release"` appears nowhere as a source in `connections` with an error/output edge, so its failure output is orphaned.
- The critical alert `"Alert Admin — Escrow Release Failed"` (line 264) is attached to the phantom `"Release Escrow Payment"` node (lines 401-406), so it **never fires**.
- `"Check Escrow Status"` (line 26) is just a `GET .../status` (no actual freeze/release call), yet its error branch alerts "The Freeze Payment Contract step failed" — the workflow never actually invokes a freeze/release operation, only status checks.

## Fix

Rename the connection key to `"Verify Escrow Release"` and wire its error (`index:1`) output to the alert node; add explicit freeze/release HTTP calls with `retryOnFail`/`onError`; add a test that asserts the alert node is reachable from the release-failure path.

## Files changed

- automation/n8n/dispute-resolution.json
- automation/n8n/tests/dispute-resolution.test.js

## Testing

- Validated the changes against the issue requirements and the surrounding code; edited files remain syntactically valid.
- Added or updated tests where the issue specified them (see Files changed).

Closes #11430
