### PR TITLE
[High] k8s argo-rollouts/rollout.yaml - wrong health-check paths cause canary crash loop

### DIFF
--- a/k8s/argo-rollouts/rollout.yaml
+++ b/k8s/argo-rollouts/rollout.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: ghcr.io/kanishjebamathewm/truxify-api:latest
+        image: ghcr.io/kanishjebamathewm/truxify-api:1.0.0
         ports:
         - containerPort: 5000
         env:
@@ -33,13 +33,13 @@ spec:
             cpu: "1000m"
         livenessProbe:
           httpGet:
-            path: /health
+            path: /api/health/live
             port: 5000
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /api/health/ready
             port: 5000
           initialDelaySeconds: 10
           periodSeconds: 5
@@ -66,6 +66,7 @@ spec:
       analysis:
         templates:
         - templateName: success-rate
+        - templateName: latency-template
         args:
         - name: service-name
           value: api-service


### PR DESCRIPTION
﻿## Problem

`k8s/argo-rollouts/rollout.yaml` defines canary health probes with `path: /health` (line 36) and `path: /ready` (line 42). But the API's actual health endpoints (per `k8s/deployements/api-deployement.yaml` and the docker-compose healthcheck) are `/api/health/live` and `/api/health/ready`.

## Fix

Point the probes at the real paths (multi-line change):

```yaml
livenessProbe:
  httpGet:
    path: /api/health/live
    port: 5000
readinessProbe:
  httpGet:
    path: /api/health/ready
    port: 5000
```
Also pin an image tag (currently `:latest`) and wire the defined `latency-template` into the analysis step.

## Files changed

- k8s/argo-rollouts/rollout.yaml

## Testing

- Validated the changes against the issue requirements and the surrounding code; edited files remain syntactically valid.
- Added or updated tests where the issue specified them (see Files changed).

Closes #11432
