### PR TITLE
fix(webhook): recognize terminal 'refunded' status in handleWithdrawalSettled (#11445)

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -7,7 +7,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 // Escrow statuses a release/withdrawal webhook may legitimately reconcile.
 const RELEASE_RECONCILABLE_STATUSES = ['funded', 'release_failed'];
 // Escrow statuses a cancellation/refund webhook may legitimately reconcile.
-const REFUND_RECONCILABLE_STATUSES = ['funded', 'refund_pending', 'refund_failed'];
+const REFUND_RECONCILABLE_STATUSES = ['funded', 'refund_pending', 'refund_failed', 'refunded'];
 
 function requireDb() {
   if (!supabaseAdmin) {
@@ -221,7 +221,7 @@ async function handleWithdrawalSettled(payload) {
   const now = new Date().toISOString();
   const txHash = payload.txHash || null;
 
-  const isRefund = ['refund_pending', 'refund_failed'].includes(order.escrow_status);
+  const isRefund = ['refunded', 'refund_pending', 'refund_failed'].includes(order.escrow_status);
 
   // Idempotency: the same withdrawal webhook may be delivered more than once.
   // If the order already reflects the intended terminal state, short-circuit.

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -241,6 +241,45 @@ describe('processEscrowWebhookEvent — idempotency (crash-after-side-effect / d
     expect(updatePayloads().filter(p => p.escrow_status === 'refunded')).toHaveLength(0);
   });
 
+  it('ignores a duplicate WithdrawalReady when the order is already refunded', async () => {
+    // Regression: a benign duplicate withdrawal delivery for an already-refunded
+    // order must short-circuit (no throw, no order re-apply) instead of becoming
+    // a permanent poison DLQ message.
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD8',
+      driver_id: null,
+      escrow_status: 'refunded',
+      release_tx_hash: null,
+      refund_tx_hash: '0xref',
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+
+    await expect(
+      processEscrowWebhookEvent('WithdrawalReady', { orderId: '#OD8' })
+    ).resolves.toEqual({ received: true });
+
+    expect(updatePayloads().filter(p => p.escrow_status === 'refunded')).toHaveLength(0);
+  });
+
+  it('ignores a duplicate Withdrawn when the order is already refunded', async () => {
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD9',
+      driver_id: null,
+      escrow_status: 'refunded',
+      release_tx_hash: null,
+      refund_tx_hash: '0xref',
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+
+    await expect(
+      processEscrowWebhookEvent('Withdrawn', { orderId: '#OD9' })
+    ).resolves.toEqual({ received: true });
+
+    expect(updatePayloads().filter(p => p.escrow_status === 'refunded')).toHaveLength(0);
+  });
+
   it('ignores a duplicate WithdrawalReady when the order is already released', async () => {
     const order = {
       id: 'order-uuid',


### PR DESCRIPTION
## Problem  handleWithdrawalSettled does not recognize the terminal `refunded` escrow status. A benign duplicate WithdrawalReady/Withdrawn webhook for an already-refunded order falls through to a settle UPDATE that matches 0 rows, throws "escrow_status not in reconcilable set", and becomes a permanent poison DLQ message (retried forever). Sibling handlers already short-circuit their terminal states.  ## Fix  Compute isRefund from ['refunded','refund_pending','refund_failed'] and targetStatus accordingly, and add 'refunded' to REFUND_RECONCILABLE_STATUSES, so the idempotency guard fires for already-refunded orders (no-op instead of poison).  ## Files changed  backend/api/src/services/webhook/escrowWebhookProcessor.js backend/api/test/unit/escrowWebhookProcessor.test.js  ## Testing  Added regression tests asserting a duplicate WithdrawalReady/Withdrawn delivery on a refunded order is a no-op (does not throw / does not poison).  Closes #11445 