### PR TITLE
fix(contracts): authenticate first handoff and compute verified in AssetProvenance (#11452)

### DIFF
--- a/blockchain/contracts/AssetProvenance.sol
+++ b/blockchain/contracts/AssetProvenance.sol
@@ -32,16 +32,25 @@ contract AssetProvenance is Ownable {
     ) external {
         Record[] storage records = provenanceTrail[_cargoHash];
         address current = msg.sender;
-        
-        if (records.length > 0) {
+
+        // The first handoff seeds the provenance trail and may only be initiated
+        // by the contract owner, otherwise an arbitrary address could attribute
+        // initial custody to anyone. Subsequent handoffs must be signed by the
+        // current holder.
+        if (records.length == 0) {
+            require(msg.sender == owner(), "Only owner can seed initial custody");
+        } else {
             require(records[records.length - 1].currentHolder == msg.sender, "Caller must hold current custody");
         }
 
+        // The ZK proof itself cannot be cheaply verified on-chain, so we only
+        // mark a record "verified" when a non-zero proof hash is supplied.
+        // Verification is performed off-chain against the referenced proof.
         records.push(Record({
             cargoHash: _cargoHash,
             currentHolder: _to,
             timestamp: block.timestamp,
-            verified: true
+            verified: _zkpProofHash != bytes32(0)
         }));
 
         emit CustodyTransferred(_cargoHash, current, _to, _zkpProofHash);

--- a/blockchain/test/AssetProvenance.test.js
+++ b/blockchain/test/AssetProvenance.test.js
@@ -22,4 +22,79 @@ describe("AssetProvenance Handoffs", function () {
     const record = await provenance.provenanceTrail(cargoHash, 1);
     expect(record.currentHolder).to.equal(carrierB.address);
   });
+
+  it("Should reject an unauthorized address seeding the first handoff", async function () {
+    const [owner, attacker, carrierA] = await ethers.getSigners();
+    const AssetProvenance = await ethers.getContractFactory("AssetProvenance");
+    const provenance = await AssetProvenance.deploy();
+
+    const cargoHash = ethers.keccak256(ethers.toUtf8Bytes("CARGO_CONTAINER_INDEX_2002"));
+    const zkpHash = ethers.keccak256(ethers.toUtf8Bytes("ZK_PROOF_DATA_200"));
+
+    await expect(
+      provenance.connect(attacker).recordHandoff(cargoHash, carrierA.address, zkpHash)
+    ).to.be.revertedWith("Only owner can seed initial custody");
+  });
+
+  it("Should not mark a record verified when no proof hash is supplied", async function () {
+    const [owner, carrierA] = await ethers.getSigners();
+    const AssetProvenance = await ethers.getContractFactory("AssetProvenance");
+    const provenance = await AssetProvenance.deploy();
+
+    const cargoHash = ethers.keccak256(ethers.toUtf8Bytes("CARGO_CONTAINER_INDEX_3003"));
+
+    await provenance.recordHandoff(cargoHash, carrierA.address, ethers.ZeroHash);
+
+    const record = await provenance.provenanceTrail(cargoHash, 0);
+    expect(record.verified).to.equal(false);
+  });
+
+  it("Should mark a record verified when a proof hash is supplied", async function () {
+    const [owner, carrierA] = await ethers.getSigners();
+    const AssetProvenance = await ethers.getContractFactory("AssetProvenance");
+    const provenance = await AssetProvenance.deploy();
+
+    const cargoHash = ethers.keccak256(ethers.toUtf8Bytes("CARGO_CONTAINER_INDEX_4004"));
+    const zkpHash = ethers.keccak256(ethers.toUtf8Bytes("ZK_PROOF_DATA_400"));
+
+    await provenance.recordHandoff(cargoHash, carrierA.address, zkpHash);
+
+    const record = await provenance.provenanceTrail(cargoHash, 0);
+    expect(record.verified).to.equal(true);
+  });
+});
+
+  it("Should reject an unauthenticated first handoff from a non-owner", async function () {
+    const [owner, stranger] = await ethers.getSigners();
+    const AssetProvenance = await ethers.getContractFactory("AssetProvenance");
+    const provenance = await AssetProvenance.deploy();
+
+    const cargoHash = ethers.keccak256(ethers.toUtf8Bytes("CARGO_CONTAINER_INDEX_2002"));
+    const zkpHash = ethers.keccak256(ethers.toUtf8Bytes("ZK_PROOF_DATA_200"));
+
+    await expect(
+      provenance.connect(stranger).recordHandoff(cargoHash, stranger.address, zkpHash)
+    ).to.be.revertedWith("Only the asset owner can open the provenance trail");
+  });
+
+  it("Should allow the owner to open the trail and not hard-code verified true", async function () {
+    const [owner, carrierA] = await ethers.getSigners();
+    const AssetProvenance = await ethers.getContractFactory("AssetProvenance");
+    const provenance = await AssetProvenance.deploy();
+
+    const cargoHash = ethers.keccak256(ethers.toUtf8Bytes("CARGO_CONTAINER_INDEX_3003"));
+
+    // A handoff with an empty proof hash must be rejected and not marked verified.
+    await expect(
+      provenance.recordHandoff(cargoHash, carrierA.address, ethers.ZeroHash)
+    ).to.be.revertedWith("A non-empty ZK proof hash is required to verify the handoff");
+
+    // A genuine proof hash yields a record whose verified flag reflects the proof.
+    const zkpHash = ethers.keccak256(ethers.toUtf8Bytes("ZK_PROOF_DATA_300"));
+    await provenance.recordHandoff(cargoHash, carrierA.address, zkpHash);
+
+    const record = await provenance.provenanceTrail(cargoHash, 0);
+    expect(record.currentHolder).to.equal(carrierA.address);
+    expect(record.verified).to.equal(true);
+  });
 });


### PR DESCRIPTION
## Problem  recordHandoff enforces custody only when records exist, so the FIRST handoff for any cargo can be seeded by anyone attributing custody to an arbitrary holder. verified is unconditionally hard-coded true while the zkp proof is never checked.  ## Fix  Gate the first handoff to the contract owner (existing Ownable) and only set verified from a supplied proof hash (_zkpProofHash != bytes32(0)), documenting that on-chain verification is off-chain.  ## Files changed  blockchain/contracts/AssetProvenance.sol  ## Testing  Added a Hardhat test asserting an unauthorized address cannot seed the first handoff and that verified reflects proof-hash presence.  Closes #11452 