### PR TITLE
fix(api): flush FraudDetectionService map to DB before clearing (#11454)

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -148,8 +148,8 @@ class FraudDetectionService {
     // Capture the current batch without clearing the map yet. The map must
     // not be emptied before the write succeeds, otherwise a failed/interrupted
     // upsert silently loses the pending risk-score updates.
-    const entries = Array.from(this.pendingUpserts.entries());
-    const records = entries.map(([, record]) => record);
+    const snapshot = Array.from(this.pendingUpserts.entries());
+    const records = snapshot.map(([, record]) => record);
 
     try {
       const { error: dbErr } = await supabaseAdmin
@@ -161,8 +161,15 @@ class FraudDetectionService {
         return; // keep pending entries queued for the next flush
       }
 
-      // Only clear the entries we successfully persisted.
-      entries.forEach(([key]) => this.pendingUpserts.delete(key));
+      // Only drop the entries we actually persisted. A newer update for the
+      // same user may have arrived during the await and replaced the map value
+      // with a fresh object reference — that entry is still pending and must be
+      // kept for the next flush.
+      for (const [key, record] of snapshot) {
+        if (this.pendingUpserts.get(key) === record) {
+          this.pendingUpserts.delete(key);
+        }
+      }
     } catch (error) {
       logger.error('[FraudDetection] Batch upsert error:', error);
       // Keep pending entries queued so updates are not silently lost.

--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -144,10 +144,12 @@ class FraudDetectionService {
 
   async _flushPendingUpserts() {
     if (this.pendingUpserts.size === 0 || !supabaseAdmin) return;
-    
-    // Extract records and clear the map for the next batch
-    const records = Array.from(this.pendingUpserts.values());
-    this.pendingUpserts.clear();
+
+    // Capture the current batch without clearing the map yet. The map must
+    // not be emptied before the write succeeds, otherwise a failed/interrupted
+    // upsert silently loses the pending risk-score updates.
+    const entries = Array.from(this.pendingUpserts.entries());
+    const records = entries.map(([, record]) => record);
 
     try {
       const { error: dbErr } = await supabaseAdmin
@@ -156,9 +158,14 @@ class FraudDetectionService {
 
       if (dbErr) {
         logger.error('[FraudDetection] Failed to batch persist behavioral profiles to DB:', dbErr.message);
+        return; // keep pending entries queued for the next flush
       }
+
+      // Only clear the entries we successfully persisted.
+      entries.forEach(([key]) => this.pendingUpserts.delete(key));
     } catch (error) {
       logger.error('[FraudDetection] Batch upsert error:', error);
+      // Keep pending entries queued so updates are not silently lost.
     }
   }
 

--- a/backend/api/test/unit/FraudDetectionService.flush.test.js
+++ b/backend/api/test/unit/FraudDetectionService.flush.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFrom = vi.fn();
+const mockRedisGet = vi.fn();
+const mockRedisSetex = vi.fn();
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: mockFrom },
+  supabaseAdmin: { from: mockFrom },
+  redisClient: {
+    get: mockRedisGet,
+    setex: mockRedisSetex,
+  },
+}));
+
+function chain(overrides = {}) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    count: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+}
+
+describe('FraudDetectionService._flushPendingUpserts', () => {
+  let FraudDetectionService;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    FraudDetectionService = (await import('../../src/services/fraud/FraudDetectionService.js')).default;
+    // Stop the background intervals so they don't flush/clear state mid-test.
+    clearInterval(FraudDetectionService._flushInterval);
+    clearInterval(FraudDetectionService._cleanupInterval);
+  });
+
+  async function trackOneUser(userId) {
+    mockFrom.mockReturnValue(chain({
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }));
+    mockRedisGet.mockResolvedValue(null);
+    return FraudDetectionService.trackBehavior(userId, {
+      type: 'transaction',
+      amount: 100,
+      transactionType: 'pay',
+    });
+  }
+
+  it('retains pending risk-score updates when the DB upsert fails', async () => {
+    await trackOneUser('user-flush');
+    expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+
+    mockFrom.mockReturnValue(chain({
+      upsert: vi.fn().mockResolvedValue({ error: { message: 'db unavailable' } }),
+    }));
+
+    await FraudDetectionService._flushPendingUpserts();
+
+    expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+    expect(FraudDetectionService.pendingUpserts.has('user-flush')).toBe(true);
+  });
+
+  it('retains pending risk-score updates when the DB upsert throws', async () => {
+    await trackOneUser('user-throw');
+    expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+
+    mockFrom.mockReturnValue(chain({
+      upsert: vi.fn().mockRejectedValue(new Error('network down')),
+    }));
+
+    await FraudDetectionService._flushPendingUpserts();
+
+    expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+    expect(FraudDetectionService.pendingUpserts.has('user-throw')).toBe(true);
+  });
+
+  it('clears pending updates only after a successful DB upsert', async () => {
+    await trackOneUser('user-ok');
+    expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+
+    mockFrom.mockReturnValue(chain({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    }));
+
+    await FraudDetectionService._flushPendingUpserts();
+
+    expect(FraudDetectionService.pendingUpserts.size).toBe(0);
+  });
+});

--- a/backend/api/test/unit/FraudDetectionService.test.js
+++ b/backend/api/test/unit/FraudDetectionService.test.js
@@ -153,4 +153,70 @@ describe('FraudDetectionService', () => {
       expect(network.isInFraudRing).toBe(false);
     });
   });
+
+  describe('_flushPendingUpserts', () => {
+    function makeProfile(userId) {
+      return {
+        user_id: userId,
+        events: [{ type: 'typing', timestamp: Date.now(), data: {} }],
+        patterns: {
+          typingSpeed: [],
+          mouseMovements: [],
+          deviceFingerprint: null,
+          locationHistory: [],
+          transactionPatterns: [],
+        },
+        last_activity: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+    }
+
+    it('retains pending upserts when the DB upsert fails so they are retried', async () => {
+      mockFrom.mockReturnValue(chain({
+        upsert: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'connection reset' },
+        }),
+      }));
+
+      FraudDetectionService.pendingUpserts.set('user-fail', makeProfile('user-fail'));
+
+      await FraudDetectionService._flushPendingUpserts();
+
+      // The failed entry must NOT be lost — it stays in the map for retry.
+      expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+      expect(FraudDetectionService.pendingUpserts.has('user-fail')).toBe(true);
+
+      // On the next flush, with a healthy DB, the entry is persisted and cleared.
+      mockFrom.mockReturnValue(chain({
+        upsert: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }));
+
+      await FraudDetectionService._flushPendingUpserts();
+
+      expect(FraudDetectionService.pendingUpserts.size).toBe(0);
+    });
+
+    it('keeps a newer pending update that arrives during a successful flush', async () => {
+      let resolveUpsert;
+      mockFrom.mockReturnValue(chain({
+        upsert: vi.fn().mockImplementation(() => new Promise((res) => {
+          resolveUpsert = () => res({ data: [], error: null });
+        })),
+      }));
+
+      FraudDetectionService.pendingUpserts.set('user-race', makeProfile('user-race'));
+      const flushPromise = FraudDetectionService._flushPendingUpserts();
+
+      // A newer update for the same user replaces the snapshot entry.
+      FraudDetectionService.pendingUpserts.set('user-race', makeProfile('user-race'));
+
+      resolveUpsert();
+      await flushPromise;
+
+      // The older snapshot was persisted; the newer in-flight update must remain.
+      expect(FraudDetectionService.pendingUpserts.size).toBe(1);
+      expect(FraudDetectionService.pendingUpserts.has('user-race')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Problem  _flushPendingUpserts clears the in-memory pending map BEFORE the DB upsert. If the upsert fails/throws or the process crashes, behavioral-profile / risk-score updates are permanently lost (only a log line remains).  ## Fix  Switch to write-then-delete: snapshot the batch but only clear successfully-persisted entries; on DB error/exception keep entries queued for retry (and preserve newer in-flight updates).  ## Files changed  backend/api/src/services/fraud/FraudDetectionService.js  ## Testing  Added regression tests: failed upsert -> entries retained then persisted on next flush; a newer in-flight update during a successful flush is not lost.  Closes #11454 