### PR TITLE
fix(contracts): enforce meaningful bounded blockMin timelock in MEVProtectedEscrow (#11457)

### DIFF
--- a/blockchain/contracts/MEVProtectedEscrow.sol
+++ b/blockchain/contracts/MEVProtectedEscrow.sol
@@ -16,6 +16,7 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
         uint256 amount;
         bool released;
         uint256 blockMin;
+        uint256 blockMax;
         bytes32 secretHash;
     }
 
@@ -24,6 +25,8 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
     address public trustedRelayer;
 
     uint256 public constant REFUND_WINDOW = 5760;
+    uint256 public constant MAX_RELEASE_WINDOW = 5760;
+    uint256 public constant MAX_RELEASE_DELAY = 5760;
 
     event DepositCreated(uint256 indexed depositId, address indexed shipper, address indexed driver, uint256 amount);
     event DepositReleasedMEV(uint256 indexed depositId, address indexed driver, uint256 amount);
@@ -48,12 +51,23 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
      * @dev The SHIPPER is responsible for minting the secret preimage and
      * committing keccak256(preimage) as _secretHash. The relayer can only
      * release after it learns the preimage out of band (e.g. a private
-     * Flashbots bundle); if it never does, refundDeposit returns the funds
-     * after blockMin + REFUND_WINDOW.
+     * Flashbots bundle) AND between _blockMin and _blockMin + MAX_RELEASE_WINDOW;
+     * if it never does, refundDeposit returns the funds after blockMin + REFUND_WINDOW.
+     *
+     * @param _driver The driver that will receive the released funds.
+     * @param _secretHash keccak256 of the secret preimage committed by the shipper.
+     * @param _blockMin The first block at which release is permitted. Must be strictly
+     * in the future so the "Release window not open" guard is not dead code.
      */
-    function createProtectedDeposit(address payable _driver, bytes32 _secretHash) external payable returns (uint256 depositId) {
+    function createProtectedDeposit(
+        address payable _driver,
+        bytes32 _secretHash,
+        uint256 _blockMin
+    ) external payable returns (uint256 depositId) {
         require(msg.value > 0, "Deposit must be > 0");
         require(_driver != address(0), "Invalid driver address");
+        require(_blockMin > block.number, "blockMin must be in the future");
+        require(_blockMin - block.number <= MAX_RELEASE_DELAY, "blockMin too far in the future");
 
         depositId = ++depositCount;
         deposits[depositId] = ProtectedDeposit({
@@ -61,7 +75,8 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
             driver: _driver,
             amount: msg.value,
             released: false,
-            blockMin: block.number,
+            blockMin: _blockMin,
+            blockMax: _blockMin + MAX_RELEASE_WINDOW,
             secretHash: _secretHash
         });
 
@@ -70,11 +85,13 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
 
     /**
      * @dev Private Flashbots bundle release function, enforcing block deadlines & preimage verification.
+     * Release is gated by: not yet released, block.number within [blockMin, blockMax], and a valid preimage.
      */
     function releaseDepositPrivate(uint256 _depositId, bytes32 _preimage) external onlyRelayer nonReentrant {
         ProtectedDeposit storage dep = deposits[_depositId];
         require(!dep.released, "Already released");
         require(block.number >= dep.blockMin, "Release window not open");
+        require(block.number <= dep.blockMax, "Release window closed");
         require(keccak256(abi.encodePacked(_preimage)) == dep.secretHash, "Invalid preimage");
 
         dep.released = true;

--- a/blockchain/test/MEVProtectedEscrow.timelock.test.js
+++ b/blockchain/test/MEVProtectedEscrow.timelock.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+import { mine } from "@nomicfoundation/hardhat-network-helpers";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, error => error.message.includes(message));
+}
+
+describe("MEVProtectedEscrow blockMin timelock", function () {
+  async function deployEscrow() {
+    const [owner, shipper, driver] = await ethers.getSigners();
+    const Escrow = await ethers.getContractFactory("MEVProtectedEscrow");
+    const escrow = await Escrow.deploy(owner.address);
+    await escrow.waitForDeployment();
+    return { escrow, owner, shipper, driver };
+  }
+
+  it("enforces the timelock relative to the release action time (not the creation block)", async function () {
+    const { escrow, owner, shipper, driver } = await deployEscrow();
+    const secret = ethers.id("mev-secret-timelock");
+    const secretHash = ethers.keccak256(ethers.solidityPacked(["bytes32"], [secret]));
+    const amount = ethers.parseEther("1");
+
+    const current = await ethers.provider.getBlockNumber();
+    const blockMin = current + 20;
+    await escrow.connect(shipper).createProtectedDeposit(driver.address, secretHash, blockMin, { value: amount });
+
+    const dep = await escrow.deposits(1);
+    assert.equal(dep.blockMin, blockMin);
+    assert.equal(dep.blockMax, blockMin + 5760);
+
+    await assertRejectsWith(
+      escrow.connect(owner).releaseDepositPrivate(1, secret),
+      "Release window not open"
+    );
+
+    await mine(blockMin - (await ethers.provider.getBlockNumber()));
+
+    const driverBefore = await ethers.provider.getBalance(driver.address);
+    await escrow.connect(owner).releaseDepositPrivate(1, secret);
+    const after = await escrow.deposits(1);
+    assert.equal(after.released, true);
+    assert.equal(await ethers.provider.getBalance(driver.address) - driverBefore, amount);
+  });
+
+  it("reverts when an out-of-bounds (too large) blockMin timelock is supplied", async function () {
+    const { escrow, shipper, driver } = await deployEscrow();
+    const secretHash = ethers.keccak256(ethers.toUtf8Bytes("secret"));
+    const current = await ethers.provider.getBlockNumber();
+
+    await assertRejectsWith(
+      escrow.connect(shipper).createProtectedDeposit(driver.address, secretHash, current + (5760 + 1), { value: ethers.parseEther("1") }),
+      "blockMin too far in the future"
+    );
+  });
+});


### PR DESCRIPTION
## Problem  createProtectedDeposit sets blockMin to the creation block, so the release-path `require(block.number >= blockMin)` is dead code (true forever) - zero MEV protection. There is also no upper bound, so release can happen at any future block.  ## Fix  Accept a caller-supplied future blockMin validated as blockMin > block.number (or derive it from a configured release delay), and add a blockMax upper bound so release is only allowed within the window.  ## Files changed  blockchain/contracts/MEVProtectedEscrow.sol  ## Testing  Added a test asserting the release guard actually enforces a delay (release before blockMin reverts) and/or respects an upper bound.  Closes #11457 