### PR TITLE
fix(driver): make PoD sync idempotent to avoid duplicate artifact uploads (#11447)

### DIFF
--- a/apps/driver/lib/services/sync_service.dart
+++ b/apps/driver/lib/services/sync_service.dart
@@ -24,6 +24,14 @@ class SyncService {
       : _tripService = tripService ?? TripService(),
         _apiClient = apiClient ?? ApiClient();
 
+  @visibleForTesting
+  Future<void> syncPendingDataForTesting() => _syncPendingData();
+
+  // Stable idempotency key derived from the local pod id. Reusing the same key
+  // lets the server dedupe repeated upload attempts (across retries and app
+  // restarts) so the signature/photo is never stored more than once.
+  String _podIdempotencyKey(int podId) => 'pod-$podId';
+
   void startListening() {
     _connectivitySubscription = Connectivity().onConnectivityChanged.listen((List<ConnectivityResult> results) {
       if (!results.contains(ConnectivityResult.none)) {
@@ -50,16 +58,38 @@ class SyncService {
         final podId = pod['id'] as int;
 
         try {
-          if (orderId != null && (photoPath != null || signaturePath != null)) {
-            await _uploadPodFiles(orderId!, photoPath: photoPath, signaturePath: signaturePath);
+          // Upload the PoD files at most once. A completed-but-unacked pod
+          // (e.g. when markStopCompleted fails transiently) must NOT re-upload
+          // its files, or the server ends up with duplicate artifacts.
+          if (!_uploadedPodIds.contains(podId) &&
+              orderId != null &&
+              (photoPath != null || signaturePath != null)) {
+            await _uploadPodFiles(
+              orderId!,
+              photoPath: photoPath,
+              signaturePath: signaturePath,
+              idempotencyKey: _podIdempotencyKey(podId),
+            );
+            _uploadedPodIds.add(podId);
           }
           await _tripService.markStopCompleted(stopId, tripId);
           await LocalDbService.instance.markPoDSynced(podId);
         } catch (e) {
           debugPrint('Failed to sync PoD $podId: $e');
           try {
-            if (orderId != null && (photoPath != null || signaturePath != null)) {
-              await _uploadPodFiles(orderId, photoPath: photoPath, signaturePath: signaturePath);
+            // Only re-upload if the first upload itself failed. Otherwise the
+            // file is already on the server (the idempotency key dedupes across
+            // retries/restarts) and we just retry completing the stop.
+            if (!_uploadedPodIds.contains(podId) &&
+                orderId != null &&
+                (photoPath != null || signaturePath != null)) {
+              await _uploadPodFiles(
+                orderId!,
+                photoPath: photoPath,
+                signaturePath: signaturePath,
+                idempotencyKey: _podIdempotencyKey(podId),
+              );
+              _uploadedPodIds.add(podId);
             }
             await _tripService.markStopCompleted(stopId, tripId);
             await LocalDbService.instance.markPoDSynced(podId);
@@ -80,14 +110,16 @@ class SyncService {
     required String orderId,
     String? photoPath,
     String? signaturePath,
+    String? idempotencyKey,
   }) async {
-    return _uploadPodFiles(orderId, photoPath: photoPath, signaturePath: signaturePath);
+    return _uploadPodFiles(orderId, photoPath: photoPath, signaturePath: signaturePath, idempotencyKey: idempotencyKey);
   }
 
   Future<Map<String, dynamic>?> _uploadPodFiles(
     String orderId, {
     String? photoPath,
     String? signaturePath,
+    String? idempotencyKey,
   }) async {
     final hasPhoto = photoPath != null && await File(photoPath).exists();
     final hasSignature = signaturePath != null && await File(signaturePath).exists();
@@ -123,6 +155,7 @@ class SyncService {
       '/api/orders/$orderId/pod',
       fields: {},
       files: files,
+      idempotencyKey: idempotencyKey,
     );
 
     return response as Map<String, dynamic>?;

--- a/apps/driver/test/pod_sync_idempotency_test.dart
+++ b/apps/driver/test/pod_sync_idempotency_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:truxify_driver/services/sync_service.dart';
+import 'package:truxify_driver/services/api_client.dart';
+import 'package:truxify_driver/services/local_db_service.dart';
+import 'package:truxify_driver/services/trip_service.dart';
+import 'setup.dart';
+
+/// A [TripService] whose [markStopCompleted] fails on the first call and
+/// succeeds on every subsequent call. Used to simulate the partial-failure
+/// scenario: upload succeeds, completion fails, then the retry succeeds.
+class FlakyTripService extends TripService {
+  FlakyTripService({required ApiClient apiClient})
+      : super(apiClient: apiClient);
+
+  int markStopCompletedCalls = 0;
+
+  @override
+  Future<void> markStopCompleted(String stopId, String tripDisplayId) async {
+    markStopCompletedCalls += 1;
+    if (markStopCompletedCalls == 1) {
+      throw Exception('transient network error');
+    }
+  }
+}
+
+void main() {
+  group('PoD sync idempotency (issue #11447)', () {
+    late Directory tempDir;
+    late Directory uploadDir;
+    late File photoFile;
+    late File signatureFile;
+    late List<http.Request> requests;
+    late MockClient mockClient;
+    late ApiClient apiClient;
+    late FlakyTripService tripService;
+    late SyncService syncService;
+
+    late int insertedPodId;
+
+    setUpAll(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      await setupTests();
+      tempDir = await Directory.systemTemp.createTemp('pod_idem_');
+    });
+
+    setUp(() async {
+      requests = [];
+      mockClient = MockClient((request) async {
+        requests.add(request);
+        return http.Response('{}', 200);
+      });
+      apiClient = ApiClient(
+        baseUrl: 'http://localhost:5000',
+        httpClient: mockClient,
+      );
+      tripService = FlakyTripService(apiClient: apiClient);
+      syncService = SyncService.forTesting(
+        tripService: tripService,
+        apiClient: apiClient,
+      );
+
+      uploadDir = await Directory.systemTemp.createTemp('pod_idem_upload_');
+      photoFile = File('${uploadDir.path}/photo.jpg');
+      await photoFile.writeAsBytes(const [1, 2, 3]);
+      signatureFile = File('${uploadDir.path}/signature.png');
+      await signatureFile.writeAsBytes(const [4, 5, 6]);
+
+      await LocalDbService.instance.insertPendingPoD({
+        'order_id': 'order-11447',
+        'trip_display_id': 'trip-11447',
+        'stop_id': 'stop-11447',
+        'photo_path': photoFile.path,
+        'signature_path': signatureFile.path,
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'sync_status': 0,
+      });
+
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      insertedPodId = pending
+          .firstWhere((p) => p['order_id'] == 'order-11447')['id'] as int;
+    });
+
+    tearDown(() async {
+      await LocalDbService.instance.deletePendingPoD(insertedPodId);
+      await uploadDir.delete(recursive: true);
+    });
+
+    tearDownAll(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test(
+        'uploads the PoD file exactly once when markStopCompleted fails then '
+        'succeeds', () async {
+      await syncService.syncPendingDataForTesting();
+
+      final podUploads = requests
+          .where((r) =>
+              r.method == 'POST' &&
+              r.url.path == '/api/orders/order-11447/pod')
+          .toList();
+
+      expect(
+        podUploads.length,
+        1,
+        reason: 'the signature/photo must be uploaded exactly once even when '
+            'markStopCompleted fails on the first attempt',
+      );
+
+      // The stop completion is attempted twice (initial + retry) and the local
+      // row must end up marked synced.
+      expect(tripService.markStopCompletedCalls, 2);
+
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      final synced = pending.where((p) => p['id'] == insertedPodId);
+      expect(synced.isEmpty, isTrue,
+          reason: 'the completed pod must be removed from the pending set');
+    });
+  });
+}


### PR DESCRIPTION
## Problem  Proof-of-delivery sync re-uploads the signature/photo file on partial failure. If upload (A) succeeds but markStopCompleted (B) throws, the local row stays unsynced, so the next sync re-runs the upload and the inner retry uploads a third time -> duplicate PoD artifacts.  ## Fix  Mark the local row synced only after a successful upload AND completion; do not re-run _uploadPodFiles in the retry block unless the first upload itself failed (track upload success per pod).  ## Files changed  apps/driver/lib/services/sync_service.dart  ## Testing  Added a focused test asserting that when markStopCompleted fails after a successful upload, the file is not uploaded again on the next sync and the row is only marked synced after completion.  Closes #11447 