### PR TITLE
fix(contracts): validate tax rates and refund excess ETH in TaxSplitter

### DIFF
--- a/blockchain/contracts/TaxSplitter.sol
+++ b/blockchain/contracts/TaxSplitter.sol
@@ -27,6 +27,7 @@ contract TaxSplitter is Ownable {
     ) external payable returns (uint256 netPayout) {
         require(_totalAmount > 0, "Total amount must be > 0");
         require(msg.value >= _totalAmount, "Insufficient value sent for tax split");
+        require(_gstRatePct + _tdsRatePct <= 100, "Tax rates exceed 100%");
 
         uint256 gstAmount = (_totalAmount * _gstRatePct) / 100;
         uint256 tdsAmount = (_totalAmount * _tdsRatePct) / 100;
@@ -39,6 +40,13 @@ contract TaxSplitter is Ownable {
         // Route net payout to driver wallet
         (bool driverSent, ) = _driver.call{value: netPayout}("");
         require(driverSent, "Driver payout failed");
+
+        // Refund any excess ETH sent beyond the total amount so it is not
+        // permanently trapped in the contract.
+        if (msg.value > _totalAmount) {
+            (bool refunded, ) = payable(msg.sender).call{value: msg.value - _totalAmount}("");
+            require(refunded, "Excess refund failed");
+        }
 
         emit TaxDeducted(_payoutId, _driver, gstAmount, tdsAmount, netPayout);
     }

--- a/blockchain/test/TaxSplitter.test.js
+++ b/blockchain/test/TaxSplitter.test.js
@@ -26,4 +26,85 @@ describe("TaxSplitter Contract", function () {
     const driverBalance = await ethers.provider.getBalance(driver.address);
     expect(driverBalance).to.be.greaterThan(ethers.parseEther("10000.86")); // Default signers start with 10000 ETH
   });
+
+  it("Should revert when combined tax rates exceed 100%", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_OVERFLOW"));
+    const totalAmount = ethers.parseEther("1.0");
+
+    await expect(
+      splitter.splitPayout(
+        payoutId,
+        driver.address,
+        taxAuth.address,
+        totalAmount,
+        60,
+        50, // 60 + 50 = 110% > 100%
+        { value: totalAmount }
+      )
+    ).to.be.revertedWith("Tax rates exceed 100%");
+  });
+
+  it("Should route 100% to tax authority and leave driver with zero payout", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_ZERO_DRIVER"));
+    const totalAmount = ethers.parseEther("1.0");
+
+    const taxAuthBefore = await ethers.provider.getBalance(taxAuth.address);
+    const tx = await splitter.splitPayout(
+      payoutId,
+      driver.address,
+      taxAuth.address,
+      totalAmount,
+      100,
+      0, // 100% GST -> net driver payout is 0
+      { value: totalAmount }
+    );
+    await tx.wait();
+
+    const taxAuthAfter = await ethers.provider.getBalance(taxAuth.address);
+    // Tax authority receives the entire amount, contract holds nothing.
+    expect(taxAuthAfter - taxAuthBefore).to.equal(totalAmount);
+    expect(await ethers.provider.getBalance(splitter.getAddress())).to.equal(0n);
+  });
+
+  it("Should refund excess msg.value sent beyond the total amount", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_REFUND"));
+    const totalAmount = ethers.parseEther("1.0");
+    const excess = ethers.parseEther("0.5");
+    const sent = totalAmount + excess;
+
+    const senderBefore = await ethers.provider.getBalance(owner.address);
+    const taxAuthBefore = await ethers.provider.getBalance(taxAuth.address);
+    const tx = await splitter.splitPayout(
+      payoutId,
+      driver.address,
+      taxAuth.address,
+      totalAmount,
+      12,
+      1,
+      { value: sent }
+    );
+    const receipt = await tx.wait();
+    const gasUsed = receipt.gasUsed * receipt.gasPrice;
+
+    const senderAfter = await ethers.provider.getBalance(owner.address);
+    const taxAuthAfter = await ethers.provider.getBalance(taxAuth.address);
+
+    // Only the total amount is consumed (tax + driver); excess is refunded.
+    const consumed = senderBefore - senderAfter - gasUsed;
+    expect(consumed).to.equal(totalAmount);
+    expect(taxAuthAfter - taxAuthBefore).to.equal(ethers.parseEther("0.13"));
+    expect(await ethers.provider.getBalance(splitter.getAddress())).to.equal(0n);
+  });
 });


### PR DESCRIPTION
## Problem

`TaxSplitter.splitPayout` accepted caller-supplied `_gstRatePct`/`_tdsRatePct` with no upper-bound check. When the rates summed to >100% the `netPayout` subtraction underflowed and reverted (griefing); at exactly 100% the driver received 0 while 100% went to the tax wallet. Any `msg.value > _totalAmount` was also never refunded, permanently trapping excess ETH in the contract (no owner sweep existed).

## Fix

- Added `require(_gstRatePct + _tdsRatePct <= 100, "Tax rates exceed 100%");` before computing payouts.
- After routing the tax + driver payouts, refund `msg.value - _totalAmount` to `payable(msg.sender)` (reverts on failure).

## Files changed

- `blockchain/contracts/TaxSplitter.sol`
- `blockchain/test/TaxSplitter.test.js` (tests: >100% revert, 100% zero-driver case, excess-refund path)

## Testing

Hardhat unit tests added and run against `TaxSplitter.test.js` covering the three scenarios from the issue.

Closes #11392
