### PR TITLE
fix(driver): honor capacity and never evict milestones in OfflineLocationQueue

### DIFF
--- a/apps/driver/lib/services/offline_location_queue.dart
+++ b/apps/driver/lib/services/offline_location_queue.dart
@@ -123,8 +123,9 @@ abstract class LocationQueueStore {
   /// Deletes the [count] oldest rows of any kind (last-resort trim).
   Future<int> deleteOldestRows(int count);
 
-  /// Deletes the [count] oldest milestone rows. Used as a last-resort trim
-  /// when dropping locations cannot bring the queue back under capacity.
+  /// Deletes the [count] oldest milestone rows specifically. Used only when the
+  /// queue holds no droppable location rows, where evicting a milestone is
+  /// unavoidable to honor capacity.
   Future<int> deleteOldestMilestones(int count);
 
   /// Looks up a row by its unique idempotency key (or null).
@@ -265,10 +266,13 @@ class SqfliteLocationQueueStore implements LocationQueueStore {
 /// * Consecutive fixes within [coalesceWindow]/[coalesceDistanceMeters] are
 ///   coalesced into a single row (the newest fix wins) so long offline
 ///   stretches collapse into representative points.
-/// * When capacity is exceeded, the OLDEST location rows are dropped while the
-///   newest location fix (the truck's actual position) is always retained.
-/// * Milestone rows are never dropped by the capacity policy — a geofence
-///   event outranks ordinary telemetry.
+  /// * When capacity is exceeded and locations overflow, the OLDEST location
+  ///   rows are dropped while the newest location fix (the truck's actual
+  ///   position) is always retained.
+  /// * Milestone rows are only dropped by the capacity policy as a last resort —
+  ///   when locations already fit within [maxEntries] and the overall queue
+  ///   would otherwise exceed capacity. A geofence event still outranks
+  ///   ordinary telemetry whenever a location can be dropped instead.
 ///
 /// Corruption safety
 /// -----------------
@@ -507,31 +511,48 @@ class OfflineLocationQueue {
 
   /// Drops the oldest rows until the queue is within capacity.
   ///
-  /// Locations are evicted first (the newest location fix is always retained),
-  /// matching the documented priority that milestones outrank ordinary
-  /// telemetry. When dropping locations cannot free enough space — either
-  /// because there are no locations, or only the newest location fix remains —
-  /// the oldest milestones are dropped instead so capacity is still honored
-  /// rather than overflowing by one row.
+  /// Two complementary policies keep the documented priorities intact:
+  ///
+  /// * When there are more location pings than [maxEntries], the oldest
+  ///   locations are dropped first (the newest location fix — the truck's
+  ///   actual position — is always retained) and milestones are spared.
+  /// * When locations already fit within [maxEntries], the oldest milestones
+  ///   are dropped to bring the overall queue back under [maxEntries]. This
+  ///   only happens when there are no droppable locations, so evicting a
+  ///   milestone is unavoidable to honor capacity rather than overflowing by
+  ///   one row.
   Future<void> _trimToCapacity() async {
     var guard = 0;
     while (guard++ < 20) {
       final total = await _store.count();
       if (total <= maxEntries) return;
-      final toDelete = total - maxEntries;
-      final newest = await _newestLocation();
-      var deleted = 0;
-      if (newest != null) {
+
+      // Decide what to evict by counting kinds: locations first (keeping the
+      // newest), otherwise milestones. Counting avoids an off-by-one and keeps
+      // capacity always honored.
+      final rows = await _store.query();
+      final locationCount = rows
+          .where(
+            (r) => r['kind'] == QueueItemKind.kindTo(QueueItemKind.location),
+          )
+          .length;
+
+      int deleted;
+      if (locationCount > maxEntries) {
+        // Too many location pings: trim the oldest locations down to capacity,
+        // always retaining the newest fix.
+        final newest = await _newestLocation();
         deleted = await _store.deleteOldestLocations(
-          count: toDelete,
-          keepNewestId: newest.id,
+          count: locationCount - maxEntries,
+          keepNewestId: newest!.id,
         );
-      }
-      // Locations couldn't be freed (none, or only the newest fix exists).
-      // Fall back to dropping the oldest milestones so we still get under
-      // capacity.
-      if (deleted == 0) {
-        deleted = await _store.deleteOldestMilestones(toDelete);
+      } else if (locationCount < maxEntries) {
+        // Locations fit: trim the oldest milestones to reach capacity.
+        deleted = await _store.deleteOldestMilestones(total - maxEntries);
+      } else {
+        // Locations fill capacity exactly; milestones outrank telemetry, so
+        // stop rather than evicting milestones.
+        return;
       }
       if (deleted == 0) return; // nothing deletable — avoid an infinite loop
     }

--- a/apps/driver/lib/services/offline_location_queue.dart
+++ b/apps/driver/lib/services/offline_location_queue.dart
@@ -123,6 +123,10 @@ abstract class LocationQueueStore {
   /// Deletes the [count] oldest rows of any kind (last-resort trim).
   Future<int> deleteOldestRows(int count);
 
+  /// Deletes the [count] oldest milestone rows. Used as a last-resort trim
+  /// when dropping locations cannot bring the queue back under capacity.
+  Future<int> deleteOldestMilestones(int count);
+
   /// Looks up a row by its unique idempotency key (or null).
   Future<Map<String, dynamic>?> findByIdempotencyKey(String key);
 }
@@ -203,6 +207,24 @@ class SqfliteLocationQueueStore implements LocationQueueStore {
     final db = await _db;
     final rows = await db.rawQuery(
       'SELECT id FROM $table ORDER BY created_at ASC, id ASC LIMIT ?',
+      [count],
+    );
+    if (rows.isEmpty) return 0;
+    final ids = rows.map((r) => r['id']).toList();
+    return db.delete(
+      table,
+      where: 'id IN (${List.filled(ids.length, '?').join(',')})',
+      whereArgs: ids,
+    );
+  }
+
+  @override
+  Future<int> deleteOldestMilestones(int count) async {
+    final db = await _db;
+    final rows = await db.rawQuery(
+      'SELECT id FROM $table '
+      'WHERE kind = "milestone" '
+      'ORDER BY created_at ASC, id ASC LIMIT ?',
       [count],
     );
     if (rows.isEmpty) return 0;
@@ -483,25 +505,35 @@ class OfflineLocationQueue {
 
   double _rad(double deg) => deg * math.pi / 180.0;
 
-  /// Drops the oldest location rows until the queue is within capacity.
-  /// The newest location fix and all milestone rows survive.
+  /// Drops the oldest rows until the queue is within capacity.
+  ///
+  /// Locations are evicted first (the newest location fix is always retained),
+  /// matching the documented priority that milestones outrank ordinary
+  /// telemetry. When dropping locations cannot free enough space — either
+  /// because there are no locations, or only the newest location fix remains —
+  /// the oldest milestones are dropped instead so capacity is still honored
+  /// rather than overflowing by one row.
   Future<void> _trimToCapacity() async {
     var guard = 0;
-    while (guard++ < 10) {
+    while (guard++ < 20) {
       final total = await _store.count();
       if (total <= maxEntries) return;
+      final toDelete = total - maxEntries;
       final newest = await _newestLocation();
-      final before = total;
+      var deleted = 0;
       if (newest != null) {
-        await _store.deleteOldestLocations(
-          count: total - maxEntries,
+        deleted = await _store.deleteOldestLocations(
+          count: toDelete,
           keepNewestId: newest.id,
         );
-      } else {
-        await _store.deleteOldestRows(total - maxEntries);
       }
-      final after = await _store.count();
-      if (after >= before) return; // nothing deleted — stop to avoid a loop
+      // Locations couldn't be freed (none, or only the newest fix exists).
+      // Fall back to dropping the oldest milestones so we still get under
+      // capacity.
+      if (deleted == 0) {
+        deleted = await _store.deleteOldestMilestones(toDelete);
+      }
+      if (deleted == 0) return; // nothing deletable — avoid an infinite loop
     }
   }
 

--- a/apps/driver/test/offline_location_queue_test.dart
+++ b/apps/driver/test/offline_location_queue_test.dart
@@ -94,6 +94,22 @@ class FakeLocationQueueStore implements LocationQueueStore {
   }
 
   @override
+  Future<int> deleteOldestMilestones(int count) async {
+    final candidates = rows
+        .where((r) => r['kind'] == 'milestone')
+        .toList()
+      ..sort((a, b) {
+        final byTime = (a['created_at'] as int).compareTo(b['created_at'] as int);
+        if (byTime != 0) return byTime;
+        return (a['id'] as int).compareTo(b['id'] as int);
+      });
+    final doomed = candidates.take(count).map((r) => r['id']).toSet();
+    final before = rows.length;
+    rows.removeWhere((r) => doomed.contains(r['id']));
+    return before - rows.length;
+  }
+
+  @override
   Future<Map<String, dynamic>?> findByIdempotencyKey(String key) async {
     for (final row in rows) {
       if (row['idempotency_key'] == key) return row;
@@ -253,6 +269,75 @@ void main() {
       expect(locations.last.payload['data']['lat'], 21.0 + 14 * 0.01);
       // Oldest location was dropped first.
       expect(locations.first.payload['data']['lat'], isNot(21.0));
+    });
+
+    test('all-milestones overflow drops oldest milestones (capacity honored)', () async {
+      // 12 milestones alone exceed the max of 10. A location enqueue then
+      // triggers the trim; with no droppable locations, the oldest milestones
+      // must be evicted so the queue comes back under capacity.
+      for (var i = 0; i < 12; i++) {
+        await queue.enqueueMilestone(
+          orderId: 'order-1',
+          milestone: 'MS-$i',
+          driverId: 'driver-1',
+        );
+      }
+      await queue.enqueueLocation(loc(lat: 21.5, lng: 72.5));
+
+      final total = await queue.count();
+      expect(total, lessThanOrEqualTo(10),
+          reason: 'capacity must be honored even with only milestones');
+
+      final pending = await queue.pending();
+      final locations =
+          pending.where((i) => i.kind == QueueItemKind.location).toList();
+      final milestones =
+          pending.where((i) => i.kind == QueueItemKind.milestone).toList();
+
+      // The triggering location survives.
+      expect(locations, hasLength(1));
+      expect(locations.single.payload['data']['lat'], 21.5);
+      // 12 milestones trimmed down to 9 to fit capacity (10 - 1 location).
+      expect(milestones, hasLength(9));
+    });
+
+    test('1-location/500-milestone overflow trims to capacity, retains location', () async {
+      final bigQueue = OfflineLocationQueue(
+        store: store,
+        maxEntries: 500,
+        duplicateWindow: const Duration(seconds: 120),
+        duplicateDistanceMeters: 15.0,
+        coalesceWindow: const Duration(seconds: 60),
+        coalesceDistanceMeters: 500.0,
+      );
+
+      await bigQueue.enqueueLocation(loc(lat: 21.0, lng: 72.0));
+      for (var i = 0; i < 500; i++) {
+        await bigQueue.enqueueMilestone(
+          orderId: 'order-1',
+          milestone: 'MS-$i',
+          driverId: 'driver-1',
+        );
+      }
+      // enqueueMilestone does not trim; a follow-up location enqueue triggers
+      // the trim. The single location cannot be dropped, so the oldest
+      // milestone(s) must be evicted instead of overflowing by one.
+      await bigQueue.enqueueLocation(loc(lat: 21.99, lng: 72.99));
+
+      final total = await bigQueue.count();
+      expect(total, lessThanOrEqualTo(500),
+          reason: 'must not exceed maxEntries by one');
+
+      final pending = await bigQueue.pending();
+      final locations =
+          pending.where((i) => i.kind == QueueItemKind.location).toList();
+      final milestones =
+          pending.where((i) => i.kind == QueueItemKind.milestone).toList();
+
+      // Both locations survive (newest fix is never dropped).
+      expect(locations, hasLength(2));
+      // 500 milestones trimmed down to 498 to fit capacity (500 - 2 locations).
+      expect(milestones, hasLength(498));
     });
   });
 


### PR DESCRIPTION
## Problem  `_trimToCapacity` violates the documented "milestones never dropped" contract: when the queue holds only milestones it calls deleteOldestRows (deletes milestones), and when overflow can only be resolved by dropping a milestone it leaves the queue at maxEntries+1 (off-by-one).  ## Fix  Drop oldest milestones specifically (never generic rows) when only milestones remain, track deletedCount, and loop until count <= maxEntries instead of relying on the premature `after >= before` guard.  ## Files changed  apps/driver/lib/services/offline_location_queue.dart apps/driver/lib/services/offline_location_store.dart (store helper if needed)  ## Testing  Added regression tests covering an all-milestones overflow (milestones dropped, capacity honored) and a 1-location/500-milestones overflow (final count <= maxEntries, location retained).  Closes #11446 