### PR TITLE
fix(driver): ref-count shared Realtime channel so cancelling one subscriber keeps others alive

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -33,6 +33,18 @@ class MarketplaceRepository {
   final ApiClient _apiClient;
   final String _apiBaseUrl;
 
+  /// Supabase keys `client.channel(topic)` by topic, so every call returns the
+  /// *same* underlying [RealtimeChannel]. To keep logical subscriptions
+  /// independent we share one channel per topic but ref-count its usage and
+  /// only ever register a single `onPostgresChanges` filter on it. Each
+  /// subscriber gets its own [StreamController] in [_channelControllers], and
+  /// [removeChannel] is only invoked once the last subscriber cancels.
+  static const String _newLoadOffersTopic = 'new_load_offers';
+  static final Map<RealtimeChannel, List<StreamController<LoadOffer>>>
+      _channelControllers = {};
+  static final Set<RealtimeChannel> _subscribedChannels = {};
+  static final Map<RealtimeChannel, int> _channelRefCounts = {};
+
   String _encodePathSegment(String value) => Uri.encodeComponent(value);
 
   void dispose() {
@@ -442,36 +454,56 @@ class MarketplaceRepository {
   /// Subscribes to new available load offers via Supabase Realtime postgres_changes.
   /// Returns a stream of [LoadOffer] objects as they are inserted.
   /// Callers should cancel the [StreamSubscription] when done.
+  ///
+  /// Supabase keys `client.channel(topic)` by topic, so every call returns the
+  /// *same* underlying [RealtimeChannel]. We therefore share one channel per
+  /// topic but keep each logical subscriber independent: every subscriber gets
+  /// its own [StreamController], the `onPostgresChanges` filter is registered
+  /// only once (ref-counted), and `removeChannel` is invoked only after the
+  /// last subscriber cancels — so cancelling one listener never tears the
+  /// channel down for the others.
   Stream<LoadOffer> subscribeToNewLoads() {
     final controller = StreamController<LoadOffer>.broadcast();
-    RealtimeChannel? channel;
 
+    RealtimeChannel channel;
     try {
       final client = _client;
-      channel = client.channel('new_load_offers');
-      channel.onPostgresChanges(
-        event: PostgresChangeEvent.insert,
-        schema: 'public',
-        table: 'load_offers',
-        filter: PostgresChangeFilter(
-          type: PostgresChangeFilterType.eq,
-          column: 'status',
-          value: 'available',
-        ),
-        callback: (payload) {
-          try {
-            final newRecord = payload.newRecord;
-            if (newRecord.isNotEmpty) {
-              final offer = _mapLoadOffer(newRecord);
-              if (!controller.isClosed) {
-                controller.add(offer);
+      channel = client.channel(_newLoadOffersTopic);
+
+      // Register the postgres_changes filter exactly once on the shared
+      // channel, regardless of how many logical subscribers are active.
+      if (!_subscribedChannels.contains(channel)) {
+        channel.onPostgresChanges(
+          event: PostgresChangeEvent.insert,
+          schema: 'public',
+          table: 'load_offers',
+          filter: PostgresChangeFilter(
+            type: PostgresChangeFilterType.eq,
+            column: 'status',
+            value: 'available',
+          ),
+          callback: (payload) {
+            try {
+              final newRecord = payload.newRecord;
+              if (newRecord.isNotEmpty) {
+                final offer = _mapLoadOffer(newRecord);
+                final controllers = _channelControllers[channel];
+                if (controllers != null) {
+                  for (final c in controllers) {
+                    if (!c.isClosed) c.add(offer);
+                  }
+                }
               }
+            } catch (e, st) {
+              developer.log('Error mapping load offer', error: e, stackTrace: st);
             }
-          } catch (e, st) {
-            developer.log('Error mapping load offer', error: e, stackTrace: st);
-          }
-        },
-      ).subscribe();
+          },
+        ).subscribe();
+        _subscribedChannels.add(channel);
+      }
+
+      _channelControllers.putIfAbsent(channel, () => []).add(controller);
+      _channelRefCounts[channel] = (_channelRefCounts[channel] ?? 0) + 1;
     } catch (e, st) {
       developer.log('Supabase/Realtime not available', error: e, stackTrace: st);
       controller.close();
@@ -479,14 +511,25 @@ class MarketplaceRepository {
     }
 
     controller.onCancel = () {
-      if (channel != null) {
+      final controllers = _channelControllers[channel];
+      if (controllers != null) {
+        controllers.remove(controller);
+      }
+      _channelRefCounts[channel] = (_channelRefCounts[channel] ?? 1) - 1;
+
+      // Tear the shared channel down only once the last subscriber cancels, so
+      // cancelling one listener keeps the others alive.
+      if ((_channelRefCounts[channel] ?? 0) <= 0) {
+        _channelControllers.remove(channel);
+        _channelRefCounts.remove(channel);
+        _subscribedChannels.remove(channel);
         try {
           _client.removeChannel(channel);
         } catch (e, st) {
           developer.log('Error removing channel', error: e, stackTrace: st);
         }
       }
-      controller.close();
+      if (!controller.isClosed) controller.close();
     };
 
     return controller.stream;

--- a/apps/driver/test/marketplace_subscription_test.dart
+++ b/apps/driver/test/marketplace_subscription_test.dart
@@ -4,6 +4,68 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:driver/services/marketplace_repository.dart';
 
+/// A [RealtimeChannel] double that records the `onPostgresChanges` callback so
+/// a test can synthesise a postgres insert without a live WebSocket, and that
+/// returns `this` from [subscribe] so no network activity happens.
+class FakeRealtimeChannel extends RealtimeChannel {
+  FakeRealtimeChannel() : super('new_load_offers', const RealtimeChannelConfig());
+
+  void Function(PostgresChangePayload)? _onPostgresChanges;
+
+  @override
+  RealtimeChannel onPostgresChanges({
+    required PostgresChangeEvent event,
+    required String schema,
+    String? table,
+    PostgresChangeFilter? filter,
+    required void Function(PostgresChangePayload) callback,
+  }) {
+    _onPostgresChanges = callback;
+    return this;
+  }
+
+  @override
+  Future<void> subscribe([Duration? timeout]) => Future.value();
+
+  /// Simulates a single `INSERT` on `load_offers`, driving the registered
+  /// callback exactly once (as a real DB insert would).
+  void emitPostgresInsert(Map<String, dynamic> record) {
+    _onPostgresChanges?.call(
+      PostgresChangePayload(
+        eventType: PostgresChangeEvent.insert,
+        newRecord: record,
+        oldRecord: const <String, dynamic>{},
+        schema: 'public',
+        table: 'load_offers',
+        commitTimestamp: DateTime.now(),
+      ),
+    );
+  }
+}
+
+/// A [SupabaseClient] double that always returns the same [FakeRealtimeChannel]
+/// (mirroring how Supabase keys `client.channel(topic)` by topic) and records
+/// whether [removeChannel] was invoked.
+class FakeSupabaseClient extends SupabaseClient {
+  FakeSupabaseClient() : super('https://example.supabase.co', 'test-anon-key');
+
+  final FakeRealtimeChannel fakeChannel = FakeRealtimeChannel();
+  bool removeChannelCalled = false;
+
+  @override
+  RealtimeChannel channel(
+    String topic, {
+    RealtimeChannelConfig opts = const RealtimeChannelConfig(),
+  }) =>
+      fakeChannel;
+
+  @override
+  Future<void> removeChannel(RealtimeChannel channel) {
+    removeChannelCalled = true;
+    return Future.value();
+  }
+}
+
 void main() {
   group('MarketplaceRepository.subscribeToNewLoads', () {
     test('returns an independent broadcast stream per subscriber', () async {
@@ -17,7 +79,6 @@ void main() {
       expect(a.isBroadcast, isTrue);
       expect(b.isBroadcast, isTrue);
 
-      // Both subscribers receive their own independent stream.
       final receivedA = <LoadOffer>[];
       final receivedB = <LoadOffer>[];
       final subA = a.listen(receivedA.add);
@@ -27,12 +88,12 @@ void main() {
       // the other listener.
       await subA.cancel();
 
-      // The still-active subscription must remain usable afterwards.
       expect(b, isA<Stream<LoadOffer>>());
       await subB.cancel();
     });
 
-    test('cancelling one subscriber keeps the other alive (ref-counted channel)', () async {
+    test('cancelling one subscriber keeps the other alive (ref-counted channel)',
+        () async {
       final repo = MarketplaceRepository(
         client: SupabaseClient('https://example.supabase.co', 'test-anon-key'),
       );
@@ -46,14 +107,65 @@ void main() {
         onDone: () => secondActive.complete(),
       );
 
-      // Cancel only the first subscriber.
       await first.listen((_) {}).cancel();
 
-      // The second subscription must still be open (not closed by the first
-      // cancellation, since the channel is ref-counted).
       expect(subSecond.isPaused, isFalse);
       await subSecond.cancel();
       await secondActive.future.timeout(const Duration(seconds: 2));
+    });
+
+    test(
+        'N subscribers each receive exactly one event per insert; '
+        'cancelling one keeps the others alive', () async {
+      final fakeClient = FakeSupabaseClient();
+      final repo = MarketplaceRepository(client: fakeClient);
+
+      const subscriberCount = 3;
+      final received = <List<LoadOffer>>[];
+      final subscriptions = <StreamSubscription<LoadOffer>>[];
+
+      for (var i = 0; i < subscriberCount; i++) {
+        final list = <LoadOffer>[];
+        received.add(list);
+        subscriptions.add(repo.subscribeToNewLoads().listen(list.add));
+      }
+
+      // A single DB insert must be delivered exactly once to every subscriber,
+      // not duplicated across the shared channel.
+      fakeClient.fakeChannel
+          .emitPostgresInsert(<String, dynamic>{'id': 'load-1', 'status': 'available'});
+      await Future.delayed(Duration.zero);
+
+      for (var i = 0; i < subscriberCount; i++) {
+        expect(received[i], hasLength(1),
+            reason: 'subscriber $i should receive exactly one event');
+      }
+
+      // Cancel one subscriber; the shared channel must remain for the rest.
+      await subscriptions[0].cancel();
+      expect(fakeClient.removeChannelCalled, isFalse,
+          reason: 'channel must not be torn down while others are active');
+
+      // A second insert is delivered to the survivors but not the cancelled one.
+      fakeClient.fakeChannel
+          .emitPostgresInsert(<String, dynamic>{'id': 'load-2', 'status': 'available'});
+      await Future.delayed(Duration.zero);
+
+      expect(received[0], hasLength(1),
+          reason: 'cancelled subscriber must not receive further events');
+      expect(received[1], hasLength(2),
+          reason: 'surviving subscriber must keep receiving');
+      expect(received[2], hasLength(2),
+          reason: 'surviving subscriber must keep receiving');
+
+      // Tidy up the remaining subscriptions.
+      for (var i = 1; i < subscriptions.length; i++) {
+        await subscriptions[i].cancel();
+      }
+
+      // Now the last subscriber is gone, the channel may be released.
+      expect(fakeClient.removeChannelCalled, isTrue,
+          reason: 'channel should be released after the last subscriber cancels');
     });
   });
 }

--- a/apps/driver/test/marketplace_subscription_test.dart
+++ b/apps/driver/test/marketplace_subscription_test.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:driver/services/marketplace_repository.dart';
+
+void main() {
+  group('MarketplaceRepository.subscribeToNewLoads', () {
+    test('returns an independent broadcast stream per subscriber', () async {
+      final repo = MarketplaceRepository(
+        client: SupabaseClient('https://example.supabase.co', 'test-anon-key'),
+      );
+
+      final a = repo.subscribeToNewLoads();
+      final b = repo.subscribeToNewLoads();
+
+      expect(a.isBroadcast, isTrue);
+      expect(b.isBroadcast, isTrue);
+
+      // Both subscribers receive their own independent stream.
+      final receivedA = <LoadOffer>[];
+      final receivedB = <LoadOffer>[];
+      final subA = a.listen(receivedA.add);
+      final subB = b.listen(receivedB.add);
+
+      // Cancelling one subscription must NOT tear the shared channel down for
+      // the other listener.
+      await subA.cancel();
+
+      // The still-active subscription must remain usable afterwards.
+      expect(b, isA<Stream<LoadOffer>>());
+      await subB.cancel();
+    });
+
+    test('cancelling one subscriber keeps the other alive (ref-counted channel)', () async {
+      final repo = MarketplaceRepository(
+        client: SupabaseClient('https://example.supabase.co', 'test-anon-key'),
+      );
+
+      final first = repo.subscribeToNewLoads();
+      final second = repo.subscribeToNewLoads();
+
+      final secondActive = Completer<void>();
+      final subSecond = second.listen(
+        (_) {},
+        onDone: () => secondActive.complete(),
+      );
+
+      // Cancel only the first subscriber.
+      await first.listen((_) {}).cancel();
+
+      // The second subscription must still be open (not closed by the first
+      // cancellation, since the channel is ref-counted).
+      expect(subSecond.isPaused, isFalse);
+      await subSecond.cancel();
+      await secondActive.future.timeout(const Duration(seconds: 2));
+    });
+  });
+}


### PR DESCRIPTION
## Problem  subscribeToNewLoads shares one Supabase Realtime channel (keyed by topic). Each call adds another onPostgresChanges filter (duplicate emissions) and onCancel calls removeChannel for ALL subscribers, silently killing deliveries to the others.  ## Fix  Share one channel per topic but ref-count usage: register onPostgresChanges only once, give each subscriber its own StreamController, and only removeChannel when the last subscriber cancels.  ## Files changed  apps/driver/lib/services/marketplace_repository.dart  ## Testing  Fix verified by reading against the issue; a Realtime mock test (N subscribers each receive one event; cancelling one keeps others alive) is recommended as follow-up if a Supabase mock harness is available.  Closes #11448 