### PR TITLE
fix(customer): deep-merge all PoD payload fields on conflict resolution

### DIFF
--- a/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
+++ b/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
@@ -124,6 +124,12 @@ class ConflictResolver {
       mergedPayload['attachments'] = merged;
     }
 
+    for (final entry in incomingPayload.entries) {
+      if (entry.key != 'attachments') {
+        mergedPayload[entry.key] = entry.value;
+      }
+    }
+
     return existing.copyWith(payload: mergedPayload, occurredAt: incoming.occurredAt);
   }
 }

--- a/apps/customer/test/core/offline/conflict_resolver_test.dart
+++ b/apps/customer/test/core/offline/conflict_resolver_test.dart
@@ -30,5 +30,45 @@ void main() {
       expect(resolved, hasLength(1));
       expect(resolved.single.payload['stopId'], 'stop-1');
     });
+
+    test('deep-merges all PoD payload fields and keeps corrected values', () {
+      final resolver = ConflictResolver();
+      final events = <TripEvent>[
+        TripEvent.podMetadata(
+          'trip-1',
+          {
+            'podNumber': 'POD-001',
+            'remarks': 'original',
+            'signee': 'Alice',
+            'attachments': [
+              {'name': 'sig.png', 'hash': 'a1'},
+            ],
+          },
+          occurredAt: '2024-01-01T00:00:00.000Z',
+        ),
+        TripEvent.podMetadata(
+          'trip-1',
+          {
+            'podNumber': 'POD-002',
+            'remarks': 'corrected',
+            'attachments': [
+              {'name': 'sig.png', 'hash': 'a1'},
+              {'name': 'photo.png', 'hash': 'b2'},
+            ],
+          },
+          occurredAt: '2024-01-01T00:00:05.000Z',
+        ),
+      ];
+
+      final resolved = resolver.resolve(events);
+
+      expect(resolved, hasLength(1));
+      final payload = resolved.single.payload;
+      expect(payload['podNumber'], 'POD-002');
+      expect(payload['remarks'], 'corrected');
+      expect(payload['signee'], 'Alice');
+      final attachments = payload['attachments'] as List;
+      expect(attachments, hasLength(2));
+    });
   });
 }


### PR DESCRIPTION
## Problem  _mergePodMetadata only merges the attachments list; every other payload key (podNumber, remarks, status, signee, ...) from the incoming/corrected event is discarded, so corrected PoD values are silently lost during offline conflict resolution.  ## Fix  Deep-merge all payload fields (latest-wins) while keeping the attachment de-dup-by-hash behavior intact.  ## Files changed  apps/customer/lib/core/offline/conflict/conflict_resolver.dart  ## Testing  Added a test asserting corrected podNumber/remarks survive a conflict merge.  Closes #11455 