### PR TITLE
fix(quantum): add degree/connectivity constraints so route QUBO yields a valid route

### DIFF
--- a/backend/quantum/quantum_circuit.py
+++ b/backend/quantum/quantum_circuit.py
@@ -8,7 +8,8 @@ from qiskit_optimization.algorithms import MinimumEigenOptimizer
 from qiskit_algorithms.minimum_eigensolvers import QAOA
 from qiskit_algorithms.optimizers import COBYLA
 import networkx as nx
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
+import itertools
 import logging
 
 logger = logging.getLogger(__name__)
@@ -97,43 +98,89 @@ class QUBOFormatter:
         logger.info("✅ QUBO Formatter initialized")
     
     def formulate_route_optimization(self, graph: nx.Graph) -> QuadraticProgram:
-        """Formulate route optimization as QUBO"""
+        """Formulate route optimization as QUBO.
+
+        The objective minimizes the total edge weight. To prevent the trivial
+        empty-route optimum (x_i = 0 for every edge), we add:
+          * degree constraints: every node must have exactly degree 2, and
+          * connectivity (subtour-elimination) constraints: no proper subset of
+            nodes may form its own closed cycle, guaranteeing a single route.
+        Together these force a valid Hamiltonian cycle as the optimum.
+        """
         # Create quadratic program
         qubo = QuadraticProgram()
-        
+
         # Add binary variables for each edge
         edge_vars = {}
         for i, (u, v) in enumerate(graph.edges()):
             var_name = f'x_{u}_{v}'
             qubo.binary_var(var_name)
             edge_vars[(u, v)] = var_name
-        
+
         # Objective: minimize total distance
-        # Constraint: each node must have degree 2 (Hamiltonian cycle)
-        
-        # Objective function
         objective = {}
         for (u, v), var in edge_vars.items():
             weight = graph[u][v].get('weight', 1)
             objective[(var, var)] = weight
-        
+
         qubo.minimize(quadratic=objective)
-        
-        # Constraints (simplified)
-        # In production: add degree constraints
-        
+
+        # Degree constraints: each node must have degree exactly 2.
+        for node in graph.nodes():
+            incident = [
+                var for (u, v), var in edge_vars.items()
+                if u == node or v == node
+            ]
+            if not incident:
+                continue
+            qubo.linear_constraint(
+                linear={var: 1 for var in incident},
+                sense='==',
+                rhs=2,
+                name=f'degree_{node}',
+            )
+
+        # Connectivity / subtour-elimination constraints: for every proper
+        # non-empty subset S of nodes, the number of selected edges entirely
+        # inside S must be <= |S| - 1. This forbids disconnected cycles and
+        # guarantees the selected edges form a single connected cycle. Only
+        # applied for small graphs to avoid the exponential subset blow-up.
+        nodes = list(graph.nodes())
+        if len(nodes) <= 8:
+            for size in range(2, len(nodes)):
+                for subset in itertools.combinations(nodes, size):
+                    s = set(subset)
+                    inner = [
+                        var for (u, v), var in edge_vars.items()
+                        if u in s and v in s
+                    ]
+                    if len(inner) <= size - 1:
+                        continue
+                    qubo.linear_constraint(
+                        linear={var: 1 for var in inner},
+                        sense='<=',
+                        rhs=size - 1,
+                        name=f'subtour_{size}_{"_".join(str(n) for n in subset)}',
+                    )
+
         self.qubo = qubo
         self.variables = list(edge_vars.values())
-        
+
         return qubo
-    
-    def solve_qubo(self, qubo: QuadraticProgram) -> Dict:
-        """Solve QUBO using quantum optimizer"""
+
+    def solve_qubo(self, qubo: QuadraticProgram,
+                   eigensolver: Optional[Any] = None) -> Dict:
+        """Solve QUBO using quantum optimizer.
+
+        By default a QAOA based MinimumEigenOptimizer is used. A classical
+        eigensolver (e.g. NumPyMinimumEigensolver) may be passed in for fast,
+        deterministic solving in tests or resource-constrained environments.
+        """
         try:
-            # Use QAOA
-            qaoa = QAOA(optimizer=COBYLA(), reps=1)
-            optimizer = MinimumEigenOptimizer(qaoa)
-            
+            if eigensolver is None:
+                eigensolver = QAOA(optimizer=COBYLA(), reps=1)
+            optimizer = MinimumEigenOptimizer(eigensolver)
+
             # Solve
             result = optimizer.solve(qubo)
             

--- a/backend/quantum/tests/test_quantum_circuit.py
+++ b/backend/quantum/tests/test_quantum_circuit.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+import networkx as nx
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from quantum_circuit import QUBOFormatter  # noqa: E402
+
+from qiskit_algorithms.minimum_eigensolvers import NumPyMinimumEigensolver  # noqa: E402
+
+
+def _selected_edges(formatter, result):
+    """Map a solver result back to the set of selected graph edges."""
+    selected = set()
+    for var_name, value in zip(formatter.variables, result.x):
+        if value is not None and abs(value - 1) < 1e-6:
+            _, u, v = var_name.split('_')
+            selected.add((u, v))
+    return selected
+
+
+def _node_degrees(edges, nodes):
+    deg = {n: 0 for n in nodes}
+    for u, v in edges:
+        deg[u] += 1
+        deg[v] += 1
+    return deg
+
+
+def _square_graph():
+    g = nx.Graph()
+    g.add_edge('A', 'B', weight=1.0)
+    g.add_edge('B', 'C', weight=2.0)
+    g.add_edge('C', 'D', weight=1.0)
+    g.add_edge('D', 'A', weight=2.0)
+    return g
+
+
+def test_route_optimization_non_empty_cycle():
+    formatter = QUBOFormatter()
+    graph = _square_graph()
+
+    qubo = formatter.formulate_route_optimization(graph)
+    result = formatter.solve_qubo(qubo, eigensolver=NumPyMinimumEigensolver())
+
+    assert result['success'] is True
+    selected = _selected_edges(formatter, result)
+
+    # A valid route must select at least one edge (not the empty route).
+    assert len(selected) >= 1
+
+    # Every node must have degree exactly 2 -> a single cycle.
+    degrees = _node_degrees(selected, list(graph.nodes()))
+    assert all(d == 2 for d in degrees.values())
+
+
+def test_route_optimization_triangle():
+    formatter = QUBOFormatter()
+    graph = nx.Graph()
+    graph.add_edge('A', 'B', weight=1.0)
+    graph.add_edge('B', 'C', weight=1.0)
+    graph.add_edge('C', 'A', weight=1.0)
+
+    qubo = formatter.formulate_route_optimization(graph)
+    result = formatter.solve_qubo(qubo, eigensolver=NumPyMinimumEigensolver())
+
+    assert result['success'] is True
+    selected = _selected_edges(formatter, result)
+    assert len(selected) >= 1
+    degrees = _node_degrees(selected, list(graph.nodes()))
+    assert all(d == 2 for d in degrees.values())

--- a/backend/quantum/tests/test_route_qubo_non_empty.py
+++ b/backend/quantum/tests/test_route_qubo_non_empty.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+import networkx as nx
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from quantum_circuit import QUBOFormatter  # noqa: E402
+
+from qiskit_algorithms.minimum_eigensolvers import NumPyMinimumEigensolver  # noqa: E402
+
+
+def _selected_edges(formatter, result):
+    """Map a solver result back to the set of selected graph edges."""
+    selected = set()
+    for var_name, value in zip(formatter.variables, result.x):
+        if value is not None and abs(value - 1) < 1e-6:
+            _, u, v = var_name.split('_')
+            selected.add((u, v))
+    return selected
+
+
+def _node_degrees(edges, nodes):
+    deg = {n: 0 for n in nodes}
+    for u, v in edges:
+        deg[u] += 1
+        deg[v] += 1
+    return deg
+
+
+def _square_graph():
+    g = nx.Graph()
+    g.add_edge('A', 'B', weight=1.0)
+    g.add_edge('B', 'C', weight=2.0)
+    g.add_edge('C', 'D', weight=1.0)
+    g.add_edge('D', 'A', weight=2.0)
+    return g
+
+
+def test_formulation_adds_constraints():
+    """The route QUBO must constrain the edges (degree == 2) so the trivial
+    empty route (all x_i = 0) is no longer a feasible optimum."""
+    formatter = QUBOFormatter()
+    qubo = formatter.formulate_route_optimization(_square_graph())
+
+    # Previously the program had no constraints and the empty route was optimal.
+    assert len(qubo.linear_constraints) > 0
+
+
+def test_route_optimization_non_empty_route():
+    """The optimizer must return a non-empty, valid route (not all x_i = 0)."""
+    formatter = QUBOFormatter()
+    graph = _square_graph()
+
+    qubo = formatter.formulate_route_optimization(graph)
+    result = formatter.solve_qubo(qubo, eigensolver=NumPyMinimumEigensolver())
+
+    assert result['success'] is True
+    selected = _selected_edges(formatter, result)
+
+    # A valid route must select at least one edge (not the empty route).
+    assert len(selected) >= 1
+
+    # Every node must have degree exactly 2 -> a single cycle.
+    degrees = _node_degrees(selected, list(graph.nodes()))
+    assert all(d == 2 for d in degrees.values())


### PR DESCRIPTION
## Problem  formulate_route_optimization builds an unconstrained QUBO. With all-positive weights the optimizer minimizes sum(w_i * x_i) whose global optimum is x_i=0 for every edge -> empty route. The function is functionally broken.  ## Fix  Add degree constraints (each node degree == 2) and subtour-elimination/connectivity constraints so the optimum is a valid single cycle. Also allow a classical eigensolver for deterministic test solving.  ## Files changed  backend/quantum/quantum_circuit.py backend/quantum/tests/test_quantum_circuit.py backend/quantum/tests/test_route_qubo_non_empty.py  ## Testing  Added tests: the QUBO now has constraints, and the solver returns a non-empty route where every node has degree 2.  Closes #11458 