### PR TITLE
fix(wasi): env var allowlist and remove host PID/cwd leak

### DIFF
--- a/wasi/src/lib.rs
+++ b/wasi/src/lib.rs
@@ -252,6 +252,15 @@ mod tests {
         assert!(is_url_allowed("https://attacker.io@api.truxify.com/x").is_err());
         assert!(is_url_allowed("https://user:pass@127.0.0.1/x").is_err());
     }
+
+    #[test]
+    fn env_allowlist_blocks_secrets() {
+        assert!(is_env_allowed("TRUXIFY_SANDBOX_MODE"));
+        assert!(is_env_allowed("TRUXIFY_REGION"));
+        assert!(!is_env_allowed("JWT_SECRET"));
+        assert!(!is_env_allowed("DATABASE_URL"));
+        assert!(!is_env_allowed("PRIVATE_KEY"));
+    }
 }
 
 // ============ Network System Calls ============
@@ -336,13 +345,26 @@ fn is_url_allowed(url: &str) -> Result<(), String> {
 
 // ============ Process System Calls ============
 
+// Capability-based security for host environment access. Untrusted WASM guests
+// must only ever read from a curated allowlist, never the host `std::env`, so
+// secret-bearing variables (JWT_SECRET, DATABASE_URL, PRIVATE_KEY, ...) are
+// never reachable from a guest module.
+fn is_env_allowed(name: &str) -> bool {
+    matches!(name, "TRUXIFY_SANDBOX_MODE" | "TRUXIFY_REGION")
+}
+
 #[wasm_bindgen]
 pub fn wasi_get_process_id() -> u32 {
-    std::process::id()
+    // Do not leak the host process id to the guest sandbox. Return a synthetic,
+    // constant sandboxed id instead.
+    0
 }
 
 #[wasm_bindgen]
 pub fn wasi_get_env_var(name: &str) -> Result<String, String> {
+    if !is_env_allowed(name) {
+        return Err("Access denied: environment variable not permitted".to_string());
+    }
     match std::env::var(name) {
         Ok(value) => Ok(value),
         Err(_) => Err("Environment variable not found".to_string()),
@@ -351,10 +373,9 @@ pub fn wasi_get_env_var(name: &str) -> Result<String, String> {
 
 #[wasm_bindgen]
 pub fn wasi_get_current_dir() -> Result<String, String> {
-    match std::env::current_dir() {
-        Ok(path) => Ok(path.to_string_lossy().to_string()),
-        Err(e) => Err(format!("Failed to get current directory: {}", e)),
-    }
+    // Do not expose the host's real working directory (which may reveal
+    // filesystem layout / secrets paths) to the guest sandbox.
+    Ok("/sandbox".to_string())
 }
 
 // ============ Memory System Calls ============


### PR DESCRIPTION
## Problem

`wasi_get_env_var` (wasi/src/lib.rs) was exported to untrusted WASM guests and called `std::env::var(name)` directly, reading the **host process** environment — so a guest could exfiltrate `JWT_SECRET`, `DATABASE_URL`, `PRIVATE_KEY`, etc. `wasi_get_process_id` additionally leaked the host PID, and `wasi_get_current_dir` leaked the host working directory.

## Fix

- Added `is_env_allowed` allowlist; `wasi_get_env_var` now rejects anything other than `TRUXIFY_SANDBOX_MODE` / `TRUXIFY_REGION` with an "Access denied" error.
- `wasi_get_process_id` no longer calls `std::process::id()`; it returns a fixed synthetic sandboxed id (`0`).
- `wasi_get_current_dir` now returns a synthetic `/sandbox` path instead of the real host directory.
- Audited all `#[wasm_bindgen]` host functions: the file-system calls were already gated by `is_path_allowed` and the HTTP call by `is_url_allowed`, so no further direct `std::env`/`fs` host access remains.
- Added a unit test covering the env allowlist.

## Files changed

- `wasi/src/lib.rs`

## Testing

Unit test `env_allowlist_blocks_secrets` added to the crate's test module. (Rust toolchain was unavailable here for a live `cargo test`; change verified by manual review of the existing capability guards.)

Closes #11404
