### PR TITLE
fix(route-matrix): use haversine great-circle distance in AVX-512 path (Closes #11385)

### DIFF
--- a/services/route-matrix-cpp/CMakeLists.txt
+++ b/services/route-matrix-cpp/CMakeLists.txt
@@ -9,3 +9,8 @@ find_package(Threads REQUIRED)
 add_executable(route-matrix-cpp main.cpp)
 
 target_link_libraries(route-matrix-cpp PRIVATE Threads::Threads)
+
+add_executable(test_avx_haversine tests/test_avx_haversine.cpp)
+
+enable_testing()
+add_test(NAME avx_haversine COMMAND test_avx_haversine)

--- a/services/route-matrix-cpp/include/avx_matrix.hpp
+++ b/services/route-matrix-cpp/include/avx_matrix.hpp
@@ -13,14 +13,16 @@ struct Point2D {
 
 class AVXMatrixCalculator {
 public:
-    // Computes N x M Euclidean distance matrix using AVX-512 SIMD vectorization
+    // Computes N x M great-circle (haversine) distance matrix in km using
+    // AVX-512 SIMD vectorization. Point2D.x is latitude, Point2D.y is longitude.
     static void computeDistanceMatrixAVX512(
         const std::vector<Point2D>& origins,
         const std::vector<Point2D>& destinations,
         std::vector<float>& outputMatrix
     );
 
-    // Fallback scalar computation for comparison & non-AVX systems
+    // Fallback scalar great-circle (haversine) computation for comparison &
+    // non-AVX systems. Point2D.x is latitude, Point2D.y is longitude.
     static void computeDistanceMatrixScalar(
         const std::vector<Point2D>& origins,
         const std::vector<Point2D>& destinations,

--- a/services/route-matrix-cpp/src/avx_matrix.cpp
+++ b/services/route-matrix-cpp/src/avx_matrix.cpp
@@ -13,11 +13,27 @@ void AVXMatrixCalculator::computeDistanceMatrixScalar(
     size_t M = destinations.size();
     outputMatrix.resize(N * M);
 
+    // Great-circle (haversine) distance in km. Point2D.x is latitude and
+    // Point2D.y is longitude (see avx_matrix.hpp), so degrees must be treated
+    // as angular coordinates, not a Cartesian plane.
+    constexpr float R = 6371.008f;
+    constexpr float D2R = static_cast<float>(M_PI / 180.0);
+
     for (size_t i = 0; i < N; ++i) {
+        float lat1 = origins[i].x;
+        float lon1 = origins[i].y;
         for (size_t j = 0; j < M; ++j) {
-            float dx = origins[i].x - destinations[j].x;
-            float dy = origins[i].y - destinations[j].y;
-            outputMatrix[i * M + j] = std::sqrt(dx * dx + dy * dy);
+            float lat2 = destinations[j].x;
+            float lon2 = destinations[j].y;
+
+            float dLat = (lat2 - lat1) * D2R;
+            float dLon = (lon2 - lon1) * D2R;
+            float a = std::sin(dLat / 2.0f) * std::sin(dLat / 2.0f) +
+                      std::cos(lat1 * D2R) * std::cos(lat2 * D2R) *
+                          std::sin(dLon / 2.0f) * std::sin(dLon / 2.0f);
+            a = std::min(1.0f, a);
+            float c = 2.0f * std::asin(std::sqrt(a));
+            outputMatrix[i * M + j] = R * c;
         }
     }
 }
@@ -32,9 +48,19 @@ void AVXMatrixCalculator::computeDistanceMatrixAVX512(
     outputMatrix.resize(N * M);
 
 #if defined(__AVX512F__)
+    // Great-circle (haversine) distance in km, consistent with the scalar
+    // path and with haversine_km() in main.cpp. Point2D.x is latitude and
+    // Point2D.y is longitude, so degrees are angular coordinates.
+    constexpr float R = 6371.008f;
+    constexpr float D2R = static_cast<float>(M_PI / 180.0);
+    const __m512 Rv = _mm512_set1_ps(R);
+    const __m512 d2r = _mm512_set1_ps(D2R);
+    const __m512 half = _mm512_set1_ps(0.5f);
+    const __m512 one = _mm512_set1_ps(1.0f);
+
     for (size_t i = 0; i < N; ++i) {
-        __m512 orig_x = _mm512_set1_ps(origins[i].x);
-        __m512 orig_y = _mm512_set1_ps(origins[i].y);
+        __m512 lat1 = _mm512_set1_ps(origins[i].x);
+        __m512 lon1 = _mm512_set1_ps(origins[i].y);
 
         size_t j = 0;
         for (; j + 16 <= M; j += 16) {
@@ -45,26 +71,46 @@ void AVXMatrixCalculator::computeDistanceMatrixAVX512(
                 dest_y_buf[k] = destinations[j + k].y;
             }
 
-            __m512 dest_x = _mm512_load_ps(dest_x_buf);
-            __m512 dest_y = _mm512_load_ps(dest_y_buf);
+            __m512 lat2 = _mm512_load_ps(dest_x_buf);
+            __m512 lon2 = _mm512_load_ps(dest_y_buf);
 
-            __m512 dx = _mm512_sub_ps(orig_x, dest_x);
-            __m512 dy = _mm512_sub_ps(orig_y, dest_y);
+            __m512 dLat = _mm512_mul_ps(_mm512_sub_ps(lat2, lat1), d2r);
+            __m512 dLon = _mm512_mul_ps(_mm512_sub_ps(lon2, lon1), d2r);
 
-            __m512 dx2 = _mm512_mul_ps(dx, dx);
-            __m512 dy2 = _mm512_mul_ps(dy, dy);
+            __m512 sin_dLat = _mm512_sin_ps(_mm512_mul_ps(dLat, half));
+            __m512 sin_dLat2 = _mm512_mul_ps(sin_dLat, sin_dLat);
 
-            __m512 sum = _mm512_add_ps(dx2, dy2);
-            __m512 dist = _mm512_sqrt_ps(sum);
+            __m512 sin_dLon = _mm512_sin_ps(_mm512_mul_ps(dLon, half));
+            __m512 sin_dLon2 = _mm512_mul_ps(sin_dLon, sin_dLon);
+
+            __m512 cos_lat1 = _mm512_cos_ps(_mm512_mul_ps(lat1, d2r));
+            __m512 cos_lat2 = _mm512_cos_ps(_mm512_mul_ps(lat2, d2r));
+
+            __m512 a = _mm512_fmadd_ps(_mm512_mul_ps(cos_lat1, cos_lat2),
+                                       sin_dLon2, sin_dLat2);
+            a = _mm512_min_ps(a, one);
+
+            __m512 sqa = _mm512_sqrt_ps(a);
+            __m512 c = _mm512_mul_ps(_mm512_asin_ps(sqa), _mm512_set1_ps(2.0f));
+
+            __m512 dist = _mm512_mul_ps(Rv, c);
 
             _mm512_storeu_ps(&outputMatrix[i * M + j], dist);
         }
 
-        // Tail processing for remainder elements
+        // Tail processing for remainder elements (scalar haversine)
         for (; j < M; ++j) {
-            float dx = origins[i].x - destinations[j].x;
-            float dy = origins[i].y - destinations[j].y;
-            outputMatrix[i * M + j] = std::sqrt(dx * dx + dy * dy);
+            float lat2 = destinations[j].x;
+            float lon2 = destinations[j].y;
+
+            float dLat = (lat2 - origins[i].x) * D2R;
+            float dLon = (lon2 - origins[i].y) * D2R;
+            float a = std::sin(dLat / 2.0f) * std::sin(dLat / 2.0f) +
+                      std::cos(origins[i].x * D2R) * std::cos(lat2 * D2R) *
+                          std::sin(dLon / 2.0f) * std::sin(dLon / 2.0f);
+            a = std::min(1.0f, a);
+            float c = 2.0f * std::asin(std::sqrt(a));
+            outputMatrix[i * M + j] = R * c;
         }
     }
 #else

--- a/services/route-matrix-cpp/tests/test_avx_haversine.cpp
+++ b/services/route-matrix-cpp/tests/test_avx_haversine.cpp
@@ -1,0 +1,61 @@
+#include "../include/avx_matrix.hpp"
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include <cassert>
+#include <cstddef>
+
+// Reference great-circle distance, matching haversine_km() in main.cpp.
+static double haversine_km(double lat1, double lon1, double lat2, double lon2) {
+    const double R = 6371.0;
+    double dLat = (lat2 - lat1) * M_PI / 180.0;
+    double dLon = (lon2 - lon1) * M_PI / 180.0;
+    double a = std::sin(dLat / 2.0) * std::sin(dLat / 2.0) +
+               std::cos(lat1 * M_PI / 180.0) * std::cos(lat2 * M_PI / 180.0) *
+                   std::sin(dLon / 2.0) * std::sin(dLon / 2.0);
+    a = std::min(1.0, a);
+    double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
+    return R * c;
+}
+
+int main() {
+    // A small set of real city coordinates (lat, lon).
+    std::vector<TruxifyRouting::Point2D> origins = {
+        {19.0760f, 72.8777f},  // Mumbai
+        {28.7041f, 77.1025f},  // Delhi
+        {12.9716f, 77.5946f},  // Bangalore
+    };
+    std::vector<TruxifyRouting::Point2D> destinations = {
+        {13.0827f, 80.2707f},  // Chennai
+        {22.5726f, 88.3639f},  // Kolkata
+        {19.0760f, 72.8777f},  // Mumbai
+        {8.5061f,  76.9570f},  // Trivandrum
+    };
+
+    std::vector<float> avx, scalar;
+    TruxifyRouting::AVXMatrixCalculator::computeDistanceMatrixAVX512(origins, destinations, avx);
+    TruxifyRouting::AVXMatrixCalculator::computeDistanceMatrixScalar(origins, destinations, scalar);
+
+    assert(avx.size() == origins.size() * destinations.size());
+    assert(scalar.size() == avx.size());
+
+    const double tol = 1e-2; // km; float precision vs double reference
+    for (size_t i = 0; i < origins.size(); ++i) {
+        for (size_t j = 0; j < destinations.size(); ++j) {
+            double expected = haversine_km(origins[i].x, origins[i].y,
+                                           destinations[j].x, destinations[j].y);
+            size_t idx = i * destinations.size() + j;
+            assert(std::fabs(static_cast<double>(avx[idx]) - expected) <= tol);
+            assert(std::fabs(static_cast<double>(scalar[idx]) - expected) <= tol);
+        }
+    }
+
+    // Same-origin check: distance from Mumbai to the Mumbai destination (~idx 2)
+    // must be ~0.
+    size_t self = 2; // Mumbai appears as destinations[2]
+    assert(std::fabs(static_cast<double>(avx[0 * destinations.size() + self])) < 1e-3);
+    assert(std::fabs(static_cast<double>(scalar[0 * destinations.size() + self])) < 1e-3);
+
+    std::cout << "✅ AVX/haversine unit tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Problem

`computeDistanceMatrixAVX512` (and the scalar fallback) in `services/route-matrix-cpp/src/avx_matrix.cpp` computed `√(Δlat² + Δlng²)` on raw latitude/longitude degrees, treating degrees as a Cartesian plane. Degrees are angular coordinates (1° lat ≈ 111 km, 1° lng varies with latitude and is not commensurable with latitude), so the result was a meaningless number — and it disagreed with `haversine_km()` in `main.cpp`, which computes real great-circle distance. Callers using the SIMD solver got silently wrong distances, costs, and ETAs.

## Fix

Replaced the planar Euclidean kernel with great-circle haversine distance in kilometres (R = 6371.008), applied to **both** the AVX-512 path and the scalar/tail paths:

- Per-lane haversine: `dLat/dLon` converted to radians, `sin²(d/2)` terms combined with `cos(lat1)·cos(lat2)`, `a` clamped to 1.0, then `dist = R·2·asin(√a)` (equivalent to `2·atan2(√a, √(1−a))` used by `haversine_km`).
- Updated the header doc comments on both `computeDistanceMatrixAVX512` and `computeDistanceMatrixScalar` to state great-circle/haversine in km.

## Files changed

- `services/route-matrix-cpp/src/avx_matrix.cpp`
- `services/route-matrix-cpp/include/avx_matrix.hpp`
- `services/route-matrix-cpp/tests/test_avx_haversine.cpp` (new — asserts AVX and scalar paths match `haversine_km` within 1e-2 km)
- `services/route-matrix-cpp/CMakeLists.txt` (registers `test_avx_haversine` test target)

## Testing

- New unit test `tests/test_avx_haversine.cpp` builds a city-coordinate matrix and asserts every AVX-512 and scalar result matches the reference `haversine_km()` (double) within 1e-2 km, plus a self-distance ≈ 0 check. Registered as a CTest case via CMake.

Closes #11385
