### PR TITLE
fix(contracts): pin driver and amount in createBooking commitment

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -393,9 +393,12 @@ export async function buildDepositTx (orderDisplayId, customerWalletAddress, dri
     // (issue #7734).
     const network = await escrowContract.runner.provider.getNetwork()
     const nonce = await escrowContract.commitmentNonces(customerWalletAddress)
+    // The commitment must pin the exact driver and amount the backend
+    // authorised, otherwise a customer could reuse a valid signature to create
+    // a booking for a different driver or an underfunded amount (issue #11393).
     const commitment = ethers.solidityPackedKeccak256(
-      ['uint256', 'address', 'address', 'uint256', 'uint256'],
-      [network.chainId, contractAddress, customerWalletAddress, bookingId, nonce]
+      ['uint256', 'address', 'address', 'uint256', 'address', 'uint256', 'uint256'],
+      [network.chainId, contractAddress, customerWalletAddress, bookingId, driverWalletAddress, amountWei, nonce]
     )
     const signature = await relayerWallet.signMessage(ethers.getBytes(commitment))
 

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -142,13 +142,17 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     /**
      * @dev Verify the owner's EIP-191 signature over the create commitment:
-     *      keccak256(chainId, this, customer, bookingId, commitmentNonces[customer]).
-     *      Only the contract owner (the backend relayer) can authorise a slot,
-     *      so an external party cannot claim a pending bookingId for 1 wei.
+     *      keccak256(chainId, this, customer, bookingId, driver, amount,
+     *      commitmentNonces[customer]). Pinning driver and amount prevents a
+     *      customer from reusing a valid commitment to create a booking whose
+     *      driver/amount diverge from what the backend authorised (issue #11393).
+     *      Only the contract owner (the backend relayer) can authorise a slot.
      */
     function _verifyCreateCommitment(
         address customer,
         uint256 bookingId,
+        address driver,
+        uint256 amount,
         bytes calldata signature
     ) private view returns (bool) {
         require(signature.length == 65, "TruxifyEscrow: Invalid signature length");
@@ -159,6 +163,8 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
                 address(this),
                 customer,
                 bookingId,
+                driver,
+                amount,
                 commitmentNonces[customer]
             )
         );
@@ -214,7 +220,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Booking already exists"
         );
         require(
-            _verifyCreateCommitment(msg.sender, bookingId, signature),
+            _verifyCreateCommitment(msg.sender, bookingId, driver, msg.value, signature),
             "TruxifyEscrow: Invalid commitment signature"
         );
 

--- a/blockchain/test/TruxifyEscrow.cancelBookingStarted.test.js
+++ b/blockchain/test/TruxifyEscrow.cancelBookingStarted.test.js
@@ -4,14 +4,16 @@ import { expect } from "chai";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
 // createBooking requires an owner-signed EIP-191 commitment over
-// keccak256(abi.encodePacked(chainId, escrow, customer, bookingId, nonce)).
-// The shared deployWithBooking fixture omits the signature, so this file keeps
-// its own fixture to exercise cancelBooking's started-trip guard (issue #8891).
-async function signCommitment(owner, escrow, customer, bookingId, nonce) {
+// keccak256(abi.encodePacked(chainId, escrow, customer, bookingId, driver,
+// amount, nonce)). The shared deployWithBooking fixture omits the signature, so
+// this file keeps its own fixture to exercise cancelBooking's started-trip guard
+// (issue #8891). The driver and amount are pinned so a stale signature cannot be
+// reused for a different driver/amount (issue #11393).
+async function signCommitment(owner, escrow, customer, bookingId, driver, amount, nonce) {
   const chainId = (await ethers.provider.getNetwork()).chainId;
   const commitment = ethers.solidityPackedKeccak256(
-    ["uint256", "address", "address", "uint256", "uint256"],
-    [chainId, await escrow.getAddress(), customer.address, bookingId, nonce]
+    ["uint256", "address", "address", "uint256", "address", "uint256", "uint256"],
+    [chainId, await escrow.getAddress(), customer.address, bookingId, driver, amount, nonce]
   );
   return owner.signMessage(ethers.getBytes(commitment));
 }
@@ -24,7 +26,7 @@ describe("TruxifyEscrow #8891 — cancelBooking started-trip guard", function ()
 
     const bookingId = 1n;
     const amount = ethers.parseEther("1.0");
-    const signature = await signCommitment(owner, escrow, customer, bookingId, 0n);
+    const signature = await signCommitment(owner, escrow, customer, bookingId, driver.address, amount, 0n);
 
     await escrow
       .connect(customer)

--- a/blockchain/test/TruxifyEscrow.test.js
+++ b/blockchain/test/TruxifyEscrow.test.js
@@ -6,19 +6,21 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 describe("TruxifyEscrow", function () {
 
   // createBooking requires an owner-signed EIP-191 commitment binding the
-  // chain, contract, customer wallet, bookingId and the customer's current
-  // nonce (issue #7734). This mirrors what buildDepositTx() produces in
-  // backend/api/src/services/escrow.js.
-  async function signCreateCommitment(escrow, customerAddress, bookingId) {
+  // chain, contract, customer wallet, bookingId, the authorised driver, the
+  // authorised amount and the customer's current nonce (issue #7734 + #11393).
+  // This mirrors what buildDepositTx() produces in backend/api/src/services/escrow.js.
+  async function signCreateCommitment(escrow, customerAddress, bookingId, driverAddress, amount) {
     const [owner] = await ethers.getSigners();
     const { chainId } = await ethers.provider.getNetwork();
     const commitment = ethers.solidityPackedKeccak256(
-      ["uint256", "address", "address", "uint256", "uint256"],
+      ["uint256", "address", "address", "uint256", "address", "uint256", "uint256"],
       [
         chainId,
         await escrow.getAddress(),
         customerAddress,
         bookingId,
+        driverAddress,
+        amount,
         await escrow.commitmentNonces(customerAddress),
       ],
     );
@@ -40,7 +42,7 @@ describe("TruxifyEscrow", function () {
     const bookingId = 1;
     const amount = ethers.parseEther("1.0");
 
-    await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount });
+    await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId, driver.address, amount), { value: amount });
 
     return { escrow, owner, customer, driver, attacker, bookingId, amount };
   }
@@ -55,9 +57,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 1;
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), {
-        value: amount,
-      });
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId, driver.address, amount), { value: amount });
 
       const booking = await escrow.getBooking(bookingId);
       expect(booking.amount).to.equal(amount);
@@ -72,17 +72,17 @@ describe("TruxifyEscrow", function () {
 
       expect(await escrow.bookingCount()).to.equal(0);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       expect(await escrow.bookingCount()).to.equal(1);
 
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       expect(await escrow.bookingCount()).to.equal(2);
     });
 
     it("records createdAt timestamp", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      const tx = await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      const tx = await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       const receipt = await tx.wait();
       const block = await ethers.provider.getBlock(receipt.blockNumber);
 
@@ -97,7 +97,7 @@ describe("TruxifyEscrow", function () {
       const amount = ethers.parseEther("2.5");
 
       await expect(
-        escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount })
+        escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId, driver.address, amount), { value: amount })
       )
         .to.emit(escrow, "BookingCreated")
         .withArgs(bookingId, customer.address, driver.address, amount);
@@ -107,7 +107,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
       await expect(
-        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: 0 })
+        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, 0), { value: 0 })
       ).to.be.revertedWith("TruxifyEscrow: Payment required");
     });
 
@@ -115,18 +115,37 @@ describe("TruxifyEscrow", function () {
       const { escrow, customer } = await loadFixture(deployEscrowFixture);
 
       await expect(
-        escrow.connect(customer).createBooking(1, ethers.ZeroAddress, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") })
+        escrow.connect(customer).createBooking(1, ethers.ZeroAddress, await signCreateCommitment(escrow, customer.address, 1, ethers.ZeroAddress, ethers.parseEther("1")), { value: ethers.parseEther("1") })
       ).to.be.revertedWith("TruxifyEscrow: Invalid driver address");
     });
 
     it("reverts if booking already exists", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       await expect(
-        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") })
+        escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") })
       ).to.be.revertedWith("TruxifyEscrow: Booking already exists");
+    });
+
+    it("reverts if the commitment driver/amount diverges from the booking (issue #11393)", async function () {
+      const { escrow, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
+
+      const bookingId = 1;
+      const authorizedAmount = ethers.parseEther("1.0");
+      // Owner signs a commitment for the legitimate driver + authorised amount.
+      const signature = await signCreateCommitment(escrow, customer.address, bookingId, driver.address, authorizedAmount);
+
+      // A mismatched driver must be rejected even with the correct amount sent.
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, attacker.address, signature, { value: authorizedAmount })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
+
+      // The correct driver with a mismatched (underfunded) amount must be rejected.
+      await expect(
+        escrow.connect(customer).createBooking(bookingId, driver.address, signature, { value: ethers.parseEther("0.5") })
+      ).to.be.revertedWith("TruxifyEscrow: Invalid commitment signature");
     });
 
     it("stores correct booking for each ID", async function () {
@@ -135,8 +154,8 @@ describe("TruxifyEscrow", function () {
       const addr1 = "0x0000000000000000000000000000000000000001";
       const addr2 = "0x0000000000000000000000000000000000000002";
 
-      await escrow.connect(customer).createBooking(100, driver.address, await signCreateCommitment(escrow, customer.address, 100), { value: ethers.parseEther("1") });
-      await escrow.connect(customer).createBooking(200, addr2, await signCreateCommitment(escrow, customer.address, 200), { value: ethers.parseEther("2") });
+      await escrow.connect(customer).createBooking(100, driver.address, await signCreateCommitment(escrow, customer.address, 100, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(200, addr2, await signCreateCommitment(escrow, customer.address, 200, addr2, ethers.parseEther("2")), { value: ethers.parseEther("2") });
 
       const booking1 = await escrow.getBooking(100);
       const booking2 = await escrow.getBooking(200);
@@ -158,9 +177,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 1;
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), {
-        value: amount,
-      });
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId, driver.address, amount), { value: amount });
 
       const driverBalanceBefore = await ethers.provider.getBalance(driver.address);
 
@@ -183,7 +200,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("3.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       expect(await escrow.pendingWithdrawals(driver.address)).to.equal(amount);
@@ -192,7 +209,7 @@ describe("TruxifyEscrow", function () {
     it("sets releaseTimestamps for driver", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       const tx = await escrow.connect(owner).releasePayment(1);
       const receipt = await tx.wait();
@@ -207,7 +224,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 7;
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId), { value: amount });
+      await escrow.connect(customer).createBooking(bookingId, driver.address, await signCreateCommitment(escrow, customer.address, bookingId, driver.address, amount), { value: amount });
 
       const tx = escrow.connect(owner).releasePayment(bookingId);
 
@@ -222,9 +239,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
 
       await expect(
         escrow.connect(attacker).releasePayment(1)
@@ -234,9 +249,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by customer", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
 
       await expect(
         escrow.connect(customer).releasePayment(1)
@@ -246,9 +259,7 @@ describe("TruxifyEscrow", function () {
     it("reverts on double payment attempt", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
 
       await escrow.connect(owner).releasePayment(1);
 
@@ -260,9 +271,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is cancelled", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).cancelBooking(1);
 
       await expect(
@@ -273,9 +282,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is disputed", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).raiseDispute(1);
 
       await expect(
@@ -296,9 +303,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).pause();
 
       await expect(
@@ -309,8 +314,8 @@ describe("TruxifyEscrow", function () {
     it("handles multiple bookings independently", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("2")), { value: ethers.parseEther("2") });
 
       await escrow.connect(owner).releasePayment(1);
 
@@ -336,9 +341,7 @@ describe("TruxifyEscrow", function () {
       const bookingId = 99;
       const amount = ethers.parseEther("5.0");
 
-      await escrow.connect(customer).createBooking(bookingId, await malicious.getAddress(), await signCreateCommitment(escrow, customer.address, bookingId), {
-        value: amount,
-      });
+      await escrow.connect(customer).createBooking(bookingId, await malicious.getAddress(), await signCreateCommitment(escrow, customer.address, bookingId, await malicious.getAddress(), amount), { value: amount });
 
       await owner.sendTransaction({
         to: await escrow.getAddress(),
@@ -367,7 +370,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
 
       const balanceBefore = await ethers.provider.getBalance(customer.address);
       await escrow.connect(owner).cancelBooking(1);
@@ -387,7 +390,7 @@ describe("TruxifyEscrow", function () {
     it("allows owner to cancel booking", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).cancelBooking(1);
 
       const booking = await escrow.getBooking(1);
@@ -398,7 +401,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).cancelBooking(1);
 
       expect(await escrow.pendingWithdrawals(customer.address)).to.equal(amount);
@@ -407,7 +410,7 @@ describe("TruxifyEscrow", function () {
     it("sets releaseTimestamps for customer", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       const tx = await escrow.connect(owner).cancelBooking(1);
       const receipt = await tx.wait();
@@ -421,7 +424,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(5, driver.address, await signCreateCommitment(escrow, customer.address, 5), { value: amount });
+      await escrow.connect(customer).createBooking(5, driver.address, await signCreateCommitment(escrow, customer.address, 5, driver.address, amount), { value: amount });
 
       const tx = escrow.connect(owner).cancelBooking(5);
 
@@ -436,9 +439,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if not customer or owner", async function () {
       const { escrow, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
 
       await expect(
         escrow.connect(attacker).cancelBooking(1)
@@ -449,9 +450,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if driver tries to cancel", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
 
       await expect(
         escrow.connect(driver).cancelBooking(1)
@@ -462,9 +461,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is already paid", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -483,9 +480,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).pause();
 
       await expect(
@@ -496,9 +491,7 @@ describe("TruxifyEscrow", function () {
     it("reverts once the trip has started", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), {
-        value: ethers.parseEther("1.0"),
-      });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).markBookingStarted(1);
 
       await expect(
@@ -606,7 +599,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(customer).markBookingStarted(1)
@@ -632,7 +625,7 @@ describe("TruxifyEscrow", function () {
     it("allows owner to raise dispute", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).raiseDispute(1);
 
       const booking = await escrow.getBooking(1);
@@ -642,7 +635,7 @@ describe("TruxifyEscrow", function () {
     it("emits BookingDisputed event with correct args", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       // Owner raises dispute on booking 1
       await expect(escrow.connect(owner).raiseDispute(1))
@@ -653,7 +646,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if customer tries to raise dispute", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(customer).raiseDispute(1)
@@ -664,7 +657,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if driver tries to raise dispute", async function () {
       const { escrow, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
 
       await expect(
         escrow.connect(driver).raiseDispute(1)
@@ -675,7 +668,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is not active", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -686,7 +679,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if booking is already cancelled", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).cancelBooking(1);
 
       await expect(
@@ -711,7 +704,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -730,7 +723,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -745,7 +738,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).cancelBooking(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -763,7 +756,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses
@@ -776,7 +769,7 @@ describe("TruxifyEscrow", function () {
     it("clears releaseTimestamps after withdrawal", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       expect(await escrow.releaseTimestamps(driver.address)).to.be.gt(0);
@@ -799,7 +792,7 @@ describe("TruxifyEscrow", function () {
     it("reverts when contract is paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).pause();
 
@@ -813,8 +806,8 @@ describe("TruxifyEscrow", function () {
       const amount1 = ethers.parseEther("1");
       const amount2 = ethers.parseEther("2");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount1 });
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: amount2 });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount1), { value: amount1 });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, amount2), { value: amount2 });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).releasePayment(2);
 
@@ -841,7 +834,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("1.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Fast-forward past withdrawal timeout (30 days)
@@ -859,7 +852,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("0.5");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -872,7 +865,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by non-owner", async function () {
       const { escrow, owner, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -885,7 +878,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if recipient is zero address", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -898,7 +891,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if withdrawal period is still active", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       // Don't fast-forward — timeout hasn't passed
@@ -910,7 +903,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if amount exceeds pending withdrawals", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -932,7 +925,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
       const amount = ethers.parseEther("2.0");
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -986,7 +979,7 @@ describe("TruxifyEscrow", function () {
       await escrow.connect(owner).pause();
 
       // createBooking has no whenNotPaused modifier, so this succeeds
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       const booking = await escrow.getBooking(1);
       expect(booking.amount).to.equal(ethers.parseEther("1"));
     });
@@ -997,7 +990,7 @@ describe("TruxifyEscrow", function () {
       await escrow.connect(owner).pause();
       await escrow.connect(owner).unpause();
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       const booking = await escrow.getBooking(1);
       expect(booking.amount).to.equal(ethers.parseEther("1"));
     });
@@ -1005,7 +998,7 @@ describe("TruxifyEscrow", function () {
     it("prevents withdrawal when paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).releasePayment(1);
       await escrow.connect(owner).pause();
 
@@ -1017,7 +1010,7 @@ describe("TruxifyEscrow", function () {
     it("prevents cancellation when paused", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).pause();
 
       await expect(
@@ -1100,7 +1093,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       // Withdraw after the withdrawal timelock elapses so the timestamp is cleared
@@ -1117,7 +1110,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       const WITHDRAWAL_TIMEOUT = await escrow.WITHDRAWAL_TIMEOUT();
@@ -1131,7 +1124,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: amount });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, amount), { value: amount });
       await escrow.connect(owner).releasePayment(1);
 
       await expect(
@@ -1146,7 +1139,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking for driver — sets deadline D1
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
       const deadline1 = await escrow.releaseTimestamps(driver.address);
 
@@ -1154,7 +1147,7 @@ describe("TruxifyEscrow", function () {
       await time.increase(3600); // 1 hour
 
       // Second booking for same driver — must extend deadline
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("2.0")), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
       const deadline2 = await escrow.releaseTimestamps(driver.address);
 
@@ -1165,7 +1158,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking for customer — sets deadline D1
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).cancelBooking(1);
       const deadline1 = await escrow.releaseTimestamps(customer.address);
 
@@ -1173,7 +1166,7 @@ describe("TruxifyEscrow", function () {
       await time.increase(3600);
 
       // Second booking for same customer — must extend deadline
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("2.0")), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).cancelBooking(2);
       const deadline2 = await escrow.releaseTimestamps(customer.address);
 
@@ -1184,7 +1177,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       // First booking — release, withdraw (clears timestamp)
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
       // Withdraw after the withdrawal timelock elapses
       await time.increase(30 * 24 * 60 * 60 + 1);
@@ -1194,7 +1187,7 @@ describe("TruxifyEscrow", function () {
       expect(await escrow.releaseTimestamps(driver.address)).to.equal(0n);
 
       // Second booking — must set a fresh timestamp
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("2.0")), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
       const newDeadline = await escrow.releaseTimestamps(driver.address);
       expect(newDeadline).to.be.gt(0n);
@@ -1203,10 +1196,10 @@ describe("TruxifyEscrow", function () {
     it("allows withdraw after each booking independently", async function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1), { value: ethers.parseEther("1.0") });
+      await escrow.connect(customer).createBooking(1, driver.address, await signCreateCommitment(escrow, customer.address, 1, driver.address, ethers.parseEther("1.0")), { value: ethers.parseEther("1.0") });
       await escrow.connect(owner).releasePayment(1);
 
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: ethers.parseEther("2.0") });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, ethers.parseEther("2.0")), { value: ethers.parseEther("2.0") });
       await escrow.connect(owner).releasePayment(2);
 
       // Both funds should be withdrawable
@@ -1228,7 +1221,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2), { value: amount });
+      await escrow.connect(customer).createBooking(2, driver.address, await signCreateCommitment(escrow, customer.address, 2, driver.address, amount), { value: amount });
 
       // Raise dispute (owner-only)
       await escrow.connect(owner).raiseDispute(2);
@@ -1253,7 +1246,7 @@ describe("TruxifyEscrow", function () {
       const { escrow, owner, customer, driver } = await loadFixture(deployEscrowFixture);
 
       const amount = ethers.parseEther("1.0");
-      await escrow.connect(customer).createBooking(3, driver.address, await signCreateCommitment(escrow, customer.address, 3), { value: amount });
+      await escrow.connect(customer).createBooking(3, driver.address, await signCreateCommitment(escrow, customer.address, 3, driver.address, amount), { value: amount });
 
       // Raise dispute (owner-only)
       await escrow.connect(owner).raiseDispute(3);
@@ -1267,7 +1260,7 @@ describe("TruxifyEscrow", function () {
     it("reverts if called by a non-owner before timeout expires", async function () {
       const { escrow, owner, customer, driver, attacker } = await loadFixture(deployEscrowFixture);
 
-      await escrow.connect(customer).createBooking(4, driver.address, await signCreateCommitment(escrow, customer.address, 4), { value: ethers.parseEther("1") });
+      await escrow.connect(customer).createBooking(4, driver.address, await signCreateCommitment(escrow, customer.address, 4, driver.address, ethers.parseEther("1")), { value: ethers.parseEther("1") });
       await escrow.connect(owner).raiseDispute(4);
 
       await hre.network.provider.send("evm_increaseTime", [8 * 24 * 60 * 60]);


### PR DESCRIPTION
## Problem

`TruxifyEscrow.createBooking` lets the caller freely set `driver` and `amount = msg.value`, while the owner-signed EIP-191 commitment only bound `(chainId, this, customer, bookingId, nonce)`. A customer with a valid commitment for booking `B` could call `createBooking(B, attackerDriver, sig)` with `msg.value = 1 wei`, creating an on-chain booking whose driver/amount diverged from what the backend authorised — desyncing escrow vs backend state and enabling underfunding.

## Fix

- Extended the commitment hash to `keccak256(abi.encodePacked(chainId, this, customer, bookingId, driver, amount, nonce))`.
- `_verifyCreateCommitment` now receives the caller-supplied `driver`/`amount` and recovers against them, requiring `recovered == owner()`.
- `createBooking` passes `driver`/`msg.value` into the verification, so a mismatched driver or amount fails the signature check.
- Updated the backend signing path in `backend/api/src/services/escrow.js` (`buildDepositTx`) to include `driverWalletAddress` and `amountWei` so produced signatures match the new commitment.
- Updated the contract test helper and the standalone `TruxifyEscrow.cancelBookingStarted.test.js` helper, and added a regression test asserting a commitment for a different driver or underfunded amount is rejected.

## Files changed

- `blockchain/contracts/TruxifyEscrow.sol`
- `backend/api/src/services/escrow.js`
- `blockchain/test/TruxifyEscrow.test.js`
- `blockchain/test/TruxifyEscrow.cancelBookingStarted.test.js`

## Testing

Hardhat unit tests updated to the new commitment format; new `createBooking` test rejects a commitment whose driver/amount diverge from the call.

Closes #11393
