### PR TITLE
fix(websocket): bound WS handshake with timeout to avoid permanent hang

### DIFF
--- a/packages/truxify_shared/lib/src/services/resilient_websocket.dart
+++ b/packages/truxify_shared/lib/src/services/resilient_websocket.dart
@@ -130,8 +130,14 @@ class ResilientWebSocket {
     try {
       final targetUrl = urlFactory != null ? urlFactory!() : url;
       _channel = WebSocketChannel.connect(Uri.parse(targetUrl));
-      // Wait for the TCP/TLS handshake to complete before proceeding.
-      await _channel!.ready;
+      // Wait for the TCP/TLS handshake to complete before proceeding. Bound the
+      // wait so a stalled upgrade (proxy silently holds the connection open,
+      // flaky mobile network) cannot hang the wrapper in `connecting` forever —
+      // on timeout we throw and fall into the normal reconnect path.
+      await _channel!.ready.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw TimeoutException('WS handshake timed out'),
+      );
       _subscription = _channel!.stream.listen(
         (message) {
           _controller.add(message);

--- a/packages/truxify_shared/test/resilient_websocket_test.dart
+++ b/packages/truxify_shared/test/resilient_websocket_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truxify_shared/truxify_shared.dart';
 
@@ -165,6 +167,35 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 50));
       expect(connectCount, 0);
       await ws.close();
+    });
+
+    test('handshake timeout reconnects instead of hanging forever', () async {
+      // A raw TCP server accepts the connection but never completes the
+      // WebSocket upgrade — simulating a stalled handshake (proxy holding the
+      // connection open, flaky mobile network). The handshake await must time
+      // out and drive the wrapper into the reconnecting state rather than
+      // staying stuck in `connecting` permanently.
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((_) {/* keep connection open, never upgrade */});
+      final port = server.port;
+
+      final ws = ResilientWebSocket(
+        'ws://127.0.0.1:$port/ws',
+        initialDelay: const Duration(milliseconds: 20),
+        maxAttempts: 1,
+      );
+
+      await ws.connect();
+
+      // The 10s handshake timeout must fire and push the wrapper to reconnecting
+      // (which then gives up after maxAttempts=1). It must NOT hang.
+      final reachedReconnecting = await ws.connectionState
+          .firstWhere((s) => s == WsConnectionState.reconnecting)
+          .timeout(const Duration(seconds: 15));
+      expect(reachedReconnecting, WsConnectionState.reconnecting);
+
+      await ws.close();
+      await server.close();
     });
   });
 }


### PR DESCRIPTION
## Problem

`ResilientWebSocket._connectOnce()` did `await _channel!.ready;` with no timeout. When the TCP/TLS connection is accepted but the WebSocket upgrade never completes (proxy returns HTTP 401/redirect and keeps the connection open, or a flaky mobile network stalls the handshake), `ready` never resolves and `onDone`/`onError` never fire. The wrapper sat in `connecting` permanently, `_reconnecting` was never set, `_scheduleReconnect` was never invoked, and the heartbeat never started — live tracking / offline upload was dead for the rest of the session with no recovery.

## Fix

Bounded the ready await so a stalled handshake is treated as a failure and falls into the normal exponential-backoff reconnect path:

```dart
await _channel!.ready.timeout(
  const Duration(seconds: 10),
  onTimeout: () => throw TimeoutException('WS handshake timed out'),
);
```

## Files changed

- `packages/truxify_shared/lib/src/services/resilient_websocket.dart`
- `packages/truxify_shared/test/resilient_websocket_test.dart` (added a test that simulates a stalled handshake via a raw TCP server and asserts the socket transitions to `reconnecting`)

## Testing

Added `resilient_websocket_test.dart` case: a raw `ServerSocket` accepts a connection but never completes the upgrade (stalled handshake). After `connect()`, the wrapper is asserted to reach `WsConnectionState.reconnecting` within ~15s instead of hanging in `connecting`.

Closes #11406
