### PR TITLE
fix(live-tracking): refresh Supabase token and re-auth on error

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -177,17 +177,26 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     _trackingWebSocket = ResilientWebSocket(
       initialWsUrl,
       urlFactory: buildUrl,
-      onConnect: () {
+      onConnect: () async {
         debugPrint('WebSocket connected, authenticating...');
-        if (mounted) setState(() => _wsConnected = true);
-        final session = SupabaseService.client.auth.currentSession;
-        final token = session?.accessToken ?? '';
-        _trackingWebSocket?.send({
-          'event': 'auth',
-          'data': {
-            'token': token,
-          },
-        });
+        if (!mounted) return;
+        setState(() => _wsConnected = true);
+        try {
+          // Refresh the Supabase session so we never send a stale/expired token
+          // after a long trip. Fall back to the current session if refresh fails.
+          final res = await SupabaseService.client.auth.refreshSession();
+          final token = res.session?.accessToken ??
+              SupabaseService.client.auth.currentSession?.accessToken ??
+              '';
+          _trackingWebSocket?.send({
+            'event': 'auth',
+            'data': {
+              'token': token,
+            },
+          });
+        } catch (_) {
+          if (mounted) setState(() => _wsConnected = false);
+        }
       },
     );
 
@@ -222,7 +231,11 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
           _loadTimeline();
         } else if (payload['event'] == null && payload['error'] != null) {
           debugPrint('[LiveTracking] WS server error: ${payload['error']}');
+          // Auth/subscribe was rejected (e.g. token expired). Mark disconnected
+          // and schedule a re-auth by forcing a fresh reconnect, which re-runs
+          // onConnect (refresh + re-auth). Avoids silently dropping tracking.
           if (mounted) setState(() => _wsConnected = false);
+          _scheduleReAuth();
         }
       } catch (e) {
         debugPrint('Error parsing tracking WebSocket message: $e');
@@ -234,6 +247,23 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
     });
 
     _trackingWebSocket!.connect();
+  }
+
+  /// Re-establishes the tracking socket after an auth/subscribe error so the
+  /// server-side session can be refreshed and re-validated. A short backoff
+  /// prevents a tight reconnect loop when the backend keeps rejecting us.
+  void _scheduleReAuth() {
+    if (!mounted || _trackingWebSocket == null) return;
+    Future<void>.delayed(const Duration(seconds: 3), () async {
+      if (!mounted || _trackingWebSocket == null) return;
+      try {
+        await SupabaseService.client.auth.refreshSession();
+      } catch (_) {
+        // Ignore — the reconnect below surfaces the connection state; a fresh
+        // onConnect will re-attempt auth with whatever token is available.
+      }
+      await _trackingWebSocket!.connect();
+    });
   }
 
   void _updateTruckPosition(LatLng newPosition) {


### PR DESCRIPTION
## Problem

In `LiveTrackingScreen`, `onConnect` built the auth frame from `SupabaseService.client.auth.currentSession?.accessToken ?? ''` with no token refresh. The stream handler only reacted to a successful `authenticated` frame and, on an `error` response, just set `_wsConnected = false` with no retry. After the Supabase session expired (normal on long trips), the old/expired token was sent, the server rejected auth, the subscription never (re)established, and tracking died silently with no user-visible error.

## Fix

- `onConnect` now refreshes the Supabase session before sending auth and falls back to the current session token if refresh fails:

```dart
onConnect: () async {
  if (!mounted) return;
  setState(() => _wsConnected = true);
  try {
    final res = await SupabaseService.client.auth.refreshSession();
    final token = res.session?.accessToken ??
        SupabaseService.client.auth.currentSession?.accessToken ?? '';
    _trackingWebSocket?.send({'event': 'auth', 'data': {'token': token}});
  } catch (_) {
    if (mounted) setState(() => _wsConnected = false);
  }
},
```

- The `error` payload branch now schedules a re-auth: `_scheduleReAuth()` refreshes the session and forces a fresh `connect()` (with backoff) so `onConnect` re-sends auth.

## Files changed

- `apps/customer/lib/screens/live_tracking_screen.dart`

## Testing

Manual review of the reconnect/token-refresh path. The auth frame is built from a refreshed session, and an `error` response now triggers a backoff reconnect that re-runs `onConnect` instead of permanently disabling tracking.

Closes #11407
