### PR TITLE
fix(sync-engine): reconcile stuck syncing events on every pass

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -53,6 +53,11 @@ class SyncEngine {
     if (_isSyncing) return 0;
     _isSyncing = true;
     try {
+      // Recover events orphaned in the transient `syncing` state by a failed DB
+      // write mid-loop. This must run on every pass (not just at init) so an
+      // event stranding in `syncing` is retried while the app is alive rather
+      // than only on the next cold start.
+      await db.reconcileStuckSyncing();
       return await _syncPendingInternal();
     } finally {
       _isSyncing = false;

--- a/apps/customer/test/core/offline/sync_engine_test.dart
+++ b/apps/customer/test/core/offline/sync_engine_test.dart
@@ -9,6 +9,7 @@ class FakeOfflineEventDb extends OfflineEventDb {
   final List<Map<String, dynamic>> rejected = [];
   final List<Map<String, dynamic>> failed = [];
   final List<String> synced = [];
+  int reconcileCallCount = 0;
 
   @override
   Future<List<TripEvent>> pendingEvents({int limit = 50}) async =>
@@ -31,6 +32,12 @@ class FakeOfflineEventDb extends OfflineEventDb {
 
   @override
   Future<void> markSyncing(String id) async {}
+
+  @override
+  Future<int> reconcileStuckSyncing() async {
+    reconcileCallCount++;
+    return 0;
+  }
 }
 
 void main() {
@@ -77,5 +84,23 @@ void main() {
     expect(db.failed, [
       {'id': 'evt-eligible', 'retryCount': 1},
     ]);
+  });
+
+  test('syncPending reconciles stuck `syncing` events on every pass (issue #11408)', () async {
+    final db = FakeOfflineEventDb();
+    db.pending.add(event('evt-1'));
+    final engine = SyncEngine(
+      db: db,
+      apiBaseUrl: 'http://localhost:8080',
+      maxRetries: 5,
+    );
+
+    await engine.syncPending();
+    expect(db.reconcileCallCount, 1);
+
+    // The recovery path must also run on subsequent passes while the app is
+    // alive, not only at init.
+    await engine.syncPending();
+    expect(db.reconcileCallCount, 2);
   });
 }


### PR DESCRIPTION
## Problem

After a successful upload, `SyncEngine._syncPendingInternal()` marks each event synced in a loop via `db.markSynced(event.id)` (or `db.markFailed`). If any of those writes throws (transient SQLite I/O error, disk-full, isolate teardown), the exception propagates, the remaining events stay in `syncing`, and `_isSyncing` is reset. `pendingEvents()` only queries `WHERE sync_status IN ('pending','failed')`, so `syncing` rows are never picked up again. Recovery (`reconcileStuckSyncing`) was called **only once at `init()`**, so events were orphaned until the next cold start.

## Fix

`SyncEngine.syncPending()` now reconciles stuck `syncing` events at the start of every pass, while the app is alive:

```dart
Future<int> syncPending() async {
  if (_isSyncing) return 0;
  _isSyncing = true;
  try {
    await db.reconcileStuckSyncing();
    return await _syncPendingInternal();
  } finally {
    _isSyncing = false;
  }
}
```

`reconcileStuckSyncing()` exists on `OfflineEventDb` and resets `syncing` rows back to `pending`, so they are re-queued on the same pass.

## Files changed

- `apps/customer/lib/core/offline/sync/sync_engine.dart`
- `apps/customer/test/core/offline/sync_engine_test.dart` (added a test asserting `reconcileStuckSyncing` is invoked on every `syncPending` call)

## Testing

Extended `sync_engine_test.dart` with a `FakeOfflineEventDb` that records `reconcileStuckSyncing` calls; the test verifies it is invoked on each `syncPending()` pass, not just once.

Closes #11408
