### PR TITLE
fix(ml/marl): use numerically stable softmax in MAPPO fleet balancer (Closes #11388)

### DIFF
--- a/backend/ml/marl/mappo_fleet.py
+++ b/backend/ml/marl/mappo_fleet.py
@@ -22,8 +22,19 @@ class MappoFleetBalancer:
         value_estimate = float(np.dot(global_state, self.critic_weights))
         action_logits = np.dot(global_state, self.actor_weights)
         
-        # Softmax probability mapping for load dispatch selection
-        probs = np.exp(action_logits) / np.sum(np.exp(action_logits))
+        # Numerically stable softmax for load dispatch selection.
+        # Subtracting the max prevents overflow when logits are large and
+        # avoids the inf/inf -> NaN -> argmax=0 collapse.
+        max_logit = np.max(action_logits)
+        z = action_logits - max_logit
+        e = np.exp(z)
+        sum_e = np.sum(e)
+        if not np.isfinite(sum_e) or sum_e <= 0:
+            # Degenerate all -inf case: fall back to a uniform distribution
+            # so the agent still selects a valid (non-NaN) action.
+            probs = np.full_like(action_logits, 1.0 / len(action_logits))
+        else:
+            probs = e / sum_e
         selected_agent = int(np.argmax(probs))
 
         return {

--- a/backend/ml/marl/test_mappo.py
+++ b/backend/ml/marl/test_mappo.py
@@ -15,5 +15,22 @@ class TestMAPPO(unittest.TestCase):
         self.assertIn("optimal_dispatch_agent_id", res)
         self.assertGreater(res["critic_state_value"], 0.0)
 
+    def test_stable_softmax_large_logits(self):
+        # Large-magnitude logits previously overflowed np.exp -> NaN -> argmax=0,
+        # collapsing the fleet to a fixed agent regardless of state.
+        state = np.array([1e3, -1e3, 5e2, -5e2])
+        res = self.balancer.compute_cooperative_actions(state)
+
+        probs = np.array(res["agent_selection_probabilities"])
+        self.assertTrue(np.all(np.isfinite(probs)), "softmax probs must be finite")
+        self.assertLess(abs(float(probs.sum()) - 1.0), 1e-3)
+
+        # Softmax is shift-invariant, so the selected agent must equal the
+        # argmax of the raw logits (this fails with the old NaN/argmax=0 path).
+        logits = state @ self.balancer.actor_weights
+        expected = int(np.argmax(logits))
+        self.assertEqual(res["optimal_dispatch_agent_id"], expected)
+        self.assertIn(res["optimal_dispatch_agent_id"], range(3))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,33 @@
+## Problem
+
+`backend/ml/marl/mappo_fleet.py` computes the stochastic policy with a numerically unstable softmax:
+
+```python
+probs = np.exp(action_logits) / np.sum(np.exp(action_logits))
+```
+
+`action_logits` is an unbounded dot product of `state × actor_weights`, so `np.exp(logits)` overflows to `inf` for moderately large logits. The resulting `inf/inf` (or `inf/sum`) yields `NaN`, and `np.argmax(NaN)` returns `0`. The fleet agent therefore collapses to a fixed action (`agent_id = 0`) regardless of state, and large/negative logits silently distort the distribution.
+
+## Fix
+
+Replaced the softmax with a numerically stable version that subtracts the max before exponentiating:
+
+```python
+z = action_logits - np.max(action_logits)
+e = np.exp(z)
+probs = e / np.sum(e)
+```
+
+Added a guard for the degenerate all-`-inf` case (falls back to a uniform distribution) and a unit test asserting finite probabilities, a normalized distribution, and that the selected agent matches the argmax of the raw logits (which fails on the old NaN/argmax=0 path).
+
+## Files changed
+
+- `backend/ml/marl/mappo_fleet.py`
+- `backend/ml/marl/test_mappo.py` (added `test_stable_softmax_large_logits`)
+
+## Testing
+
+- `python -c "import ast; ast.parse(...)"` for syntax validation.
+- `pytest backend/ml/marl/test_mappo.py` passes (2 passed). The new test feeds large-magnitude logits and verifies finite, normalized probabilities and a state-dependent selected agent.
+
+Closes #11388


### PR DESCRIPTION
## Problem

`backend/ml/marl/mappo_fleet.py` computes the stochastic policy with a numerically unstable softmax:

```python
probs = np.exp(action_logits) / np.sum(np.exp(action_logits))
```

`action_logits` is an unbounded dot product of `state × actor_weights`, so `np.exp(logits)` overflows to `inf` for moderately large logits. The resulting `inf/inf` (or `inf/sum`) yields `NaN`, and `np.argmax(NaN)` returns `0`. The fleet agent therefore collapses to a fixed action (`agent_id = 0`) regardless of state, and large/negative logits silently distort the distribution.

## Fix

Replaced the softmax with a numerically stable version that subtracts the max before exponentiating:

```python
z = action_logits - np.max(action_logits)
e = np.exp(z)
probs = e / np.sum(e)
```

Added a guard for the degenerate all-`-inf` case (falls back to a uniform distribution) and a unit test asserting finite probabilities, a normalized distribution, and that the selected agent matches the argmax of the raw logits (which fails on the old NaN/argmax=0 path).

## Files changed

- `backend/ml/marl/mappo_fleet.py`
- `backend/ml/marl/test_mappo.py` (added `test_stable_softmax_large_logits`)

## Testing

- `python -c "import ast; ast.parse(...)"` for syntax validation.
- `pytest backend/ml/marl/test_mappo.py` passes (2 passed). The new test feeds large-magnitude logits and verifies finite, normalized probabilities and a state-dependent selected agent.

Closes #11388
