### PR TITLE
fix(nginx): add TLS, security headers, and rate limiting on public edge (#11500)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,11 +41,43 @@ http {
     # Legacy IE6 mishandles gzip; excluded rather than risking corrupt bodies.
     gzip_disable "msie6";
 
+    # ------------------------------------------------------------------
+    # Rate limiting
+    #
+    # The /api/v1/auth endpoint is the platform login surface. A brute-force
+    # or credential-stuffing attack comes from one source spraying attempts,
+    # so key the zone on the client address and allow a modest burst.
+    # ------------------------------------------------------------------
+    limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
+
+    # ------------------------------------------------------------------
+    # Security headers
+    #
+    # Applied to every response (the "always" flag covers error responses
+    # too) so browsers refuse to sniff content, refuse framing, and pin the
+    # site to HTTPS for two years.
+    # ------------------------------------------------------------------
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
     server {
-        listen 8080;
+        # TLS termination at the public edge. Certificates are mounted into
+        # the container from a secret; without them nginx fails to start, so
+        # the deployment must provide /etc/nginx/tls/{fullchain,privkey}.pem.
+        listen 443 ssl;
+        ssl_certificate     /etc/nginx/tls/fullchain.pem;
+        ssl_certificate_key /etc/nginx/tls/privkey.pem;
+
+        # Redirect any plaintext access to the secure endpoint.
+        error_page 497 https://$host$request_uri;
 
         # Node.js Auth Service
         location /api/v1/auth {
+            # Brute-force protection: throttle login attempts per client.
+            limit_req zone=auth burst=10 nodelay;
+
             rewrite ^/api/v1/auth(/.*)?$ /api/auth$1 break;
             proxy_pass http://api:5000;
             proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

The public nginx edge (`nginx/nginx.conf`) terminated traffic with no transport security, no security headers, and no rate limiting. This exposed driver credentials and live location data to plaintext interception, allowed unlimited attempts against the auth endpoint (credential stuffing), and sent responses without browser hardening headers.

This change hardens the edge:
- **TLS termination** on `listen 443 ssl` using certificates mounted at `/etc/nginx/tls/` (with a `497` redirect so plaintext access is bounced to HTTPS).
- **Security headers** applied to every response via `add_header ... always`: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`.
- **Rate limiting** via a `limit_req_zone` keyed on client address (5 r/s, burst 10) applied to `/api/v1/auth` for brute-force protection.

All existing upstream routing (auth/trips/ml/pricing) is preserved unchanged.

## Testing Limitations

- `nginx -t` could not be run in this environment (nginx binary not installed), so the config was validated by manual review against the documented directive syntax. The deployment must supply the TLS secret at `/etc/nginx/tls/{fullchain,privkey}.pem` or nginx will fail to start — this should be wired up alongside the certificate provisioning in the deploy pipeline.
- A CI-level `nginx -t` step is recommended so future config changes are linted automatically; none currently exists.
- No automated regression test was added because the repo has no existing nginx config test harness.

## Related

Closes #11500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added HTTPS support with mounted certificates and automatic HTTP-to-HTTPS redirection.
  * Added security-related response headers.
  * Introduced rate limiting for authentication requests, allowing short bursts while helping prevent abuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->