### PR TITLE
fix(flutter): clamp RateLimitException retryAfter to stop retry storm (#11492)

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -518,8 +518,8 @@ Future<http.Response> _execute(
     if (response.statusCode == 429) {
         final retryAfterHeader = response.headers['retry-after'];
 
-        final retryAfterSeconds =
-            int.tryParse(retryAfterHeader ?? '') ?? 0;
+        final rawRetryAfterSeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
+        final retryAfterSeconds = rawRetryAfterSeconds.clamp(1, 30);
 
         throw RateLimitException(
             response.statusCode,

--- a/packages/truxify_shared/test/api_client_rate_limit_test.dart
+++ b/packages/truxify_shared/test/api_client_rate_limit_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:truxify_shared/src/services/api_client.dart';
+
+/// A fake [http.Client] that always answers with HTTP 429 so we can exercise
+/// [ApiClient._decode]'s [RateLimitException] construction without touching a
+/// real backend.
+class _FakeRateLimitClient extends http.BaseClient {
+  _FakeRateLimitClient(this.retryAfterHeader, this.body);
+
+  final String? retryAfterHeader;
+  final String body;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final headers = <String, String>{};
+    if (retryAfterHeader != null) {
+      headers['retry-after'] = retryAfterHeader!;
+    }
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      429,
+      request: request,
+      headers: headers,
+      reasonPhrase: 'Too Many Requests',
+    );
+  }
+
+  @override
+  void close() {}
+}
+
+void main() {
+  group('ApiClient._decode RateLimitException retryAfter clamping', () {
+    test('missing retry-after header defaults to 1s (no zero delay)', () async {
+      final client = ApiClient(
+        httpClient: _FakeRateLimitClient(null, '{"error":"rate limited"}'),
+        baseUrl: 'https://example.test',
+      );
+
+      late RateLimitException error;
+      try {
+        await client.get('/x');
+      } on RateLimitException catch (e) {
+        error = e;
+      }
+
+      expect(error.retryAfter, const Duration(seconds: 1),
+          reason: 'a missing Retry-After must never produce a zero delay');
+      client.close();
+    });
+
+    test('retry-after: 0 is clamped to a minimum of 1s', () async {
+      final client = ApiClient(
+        httpClient: _FakeRateLimitClient('0', '{"error":"rate limited"}'),
+        baseUrl: 'https://example.test',
+      );
+
+      late RateLimitException error;
+      try {
+        await client.get('/x');
+      } on RateLimitException catch (e) {
+        error = e;
+      }
+
+      expect(error.retryAfter, const Duration(seconds: 1),
+          reason: 'retryAfter == 0 previously caused a retry storm');
+      client.close();
+    });
+
+    test('retry-after: 100 is clamped to a maximum of 30s', () async {
+      final client = ApiClient(
+        httpClient: _FakeRateLimitClient('100', '{"error":"rate limited"}'),
+        baseUrl: 'https://example.test',
+      );
+
+      late RateLimitException error;
+      try {
+        await client.get('/x');
+      } on RateLimitException catch (e) {
+        error = e;
+      }
+
+      expect(error.retryAfter, const Duration(seconds: 30));
+      client.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`ApiClient._decode` (in `packages/truxify_shared`) built `RateLimitException`
with `retryAfter` parsed as `int.tryParse(header ?? '') ?? 0` — no default of `1`
and **no clamp**. When a caller honors `e.retryAfter` (e.g.
`await Future.delayed(e.retryAfter)`), a `Retry-After` of `0` (or a missing
header) produced a **zero-delay retry storm** against an already-overloaded
endpoint.

This also diverged from the other 429 handler in `_execute`, which already
defaults to `1` and clamps to `30s`.

## Fix

Mirror the `_execute` backoff policy in `_decode`:

- default a missing/garbage `Retry-After` to `1`
- clamp the value to `[1, 30]` seconds

```dart
final rawRetryAfterSeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
final retryAfterSeconds = rawRetryAfterSeconds.clamp(1, 30);
throw RateLimitException(
  response.statusCode,
  message,
  body: response.body,
  retryAfter: Duration(seconds: retryAfterSeconds),
);
```

## Test plan

- Added `packages/truxify_shared/test/api_client_rate_limit_test.dart` asserting:
  - missing `Retry-After` → `retryAfter == 1s`
  - `Retry-After: 0` → clamped to `1s` (previously `0s` → retry storm)
  - `Retry-After: 100` → clamped to `30s`

Closes #11492
