### PR TITLE
fix(flutter): actually validate OTP in AuthService.verifyOtp (#11491)

### DIFF
--- a/packages/truxify_shared/lib/src/services/auth_service.dart
+++ b/packages/truxify_shared/lib/src/services/auth_service.dart
@@ -104,11 +104,19 @@ class AuthService {
   Future<UserCredential> verifyOtp(
       String verificationId, String smsCode) async {
     if (_auth == null) throw Exception('Firebase Auth is not available');
-    final credential = PhoneAuthProvider.credential(
-      verificationId: verificationId,
-      smsCode: smsCode,
-    );
-    return _auth.signInWithCredential(credential);
+    if (!_validateOtp(smsCode)) {
+      throw ArgumentError(_lastAuthError ?? 'Invalid OTP');
+    }
+    _isAuthenticating = true;
+    try {
+      final credential = PhoneAuthProvider.credential(
+        verificationId: verificationId,
+        smsCode: smsCode,
+      );
+      return await _auth.signInWithCredential(credential);
+    } finally {
+      _isAuthenticating = false;
+    }
   }
 
   /// Sign out the current user.

--- a/packages/truxify_shared/pubspec.yaml
+++ b/packages/truxify_shared/pubspec.yaml
@@ -27,4 +27,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  firebase_auth_mocks: ^0.15.2
 

--- a/packages/truxify_shared/test/auth_service_test.dart
+++ b/packages/truxify_shared/test/auth_service_test.dart
@@ -1,0 +1,69 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_shared/truxify_shared.dart';
+
+void main() {
+  group('AuthService.verifyOtp', () {
+    test('rejects an OTP that is too short before contacting Firebase', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(auth: auth);
+
+      expect(
+        () => service.verifyOtp('verification-id', '12'),
+        throwsA(isA<ArgumentError>()),
+      );
+      // The flag must never be left dangling after a validation failure.
+      expect(service.isAuthenticating, isFalse);
+    });
+
+    test('rejects a non-digit OTP before contacting Firebase', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(auth: auth);
+
+      expect(
+        () => service.verifyOtp('verification-id', 'abc123'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(service.isAuthenticating, isFalse);
+    });
+
+    test('signs in and clears the authenticating flag on success', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(auth: auth);
+
+      final credential = await service.verifyOtp('verification-id', '123456');
+
+      expect(credential, isA<UserCredential>());
+      expect(service.isAuthenticating, isFalse);
+    });
+
+    test('isAuthenticating is true while the network call is in flight', () async {
+      final auth = MockFirebaseAuth();
+      final service = AuthService(auth: auth);
+
+      final future = service.verifyOtp('verification-id', '123456');
+      // The flag should be raised immediately around the network call.
+      expect(service.isAuthenticating, isTrue);
+
+      await future;
+      expect(service.isAuthenticating, isFalse);
+    });
+
+    test('clears the flag even when sign-in fails', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(Invocation.method(#signInWithCredential, null))
+          .on(auth)
+          .thenThrow(
+            FirebaseAuthException(code: 'invalid-verification-code'),
+          );
+      final service = AuthService(auth: auth);
+
+      expect(
+        () => service.verifyOtp('verification-id', '123456'),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+      expect(service.isAuthenticating, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`AuthService.verifyOtp` never validated the SMS OTP before handing it to Firebase, and the `isAuthenticating` flag was dead state (initialized `false`, never set). This change actually validates the OTP locally and manages the loading flag around the network sign-in.

## Changes

- In `packages/truxify_shared/lib/src/services/auth_service.dart`:
  - `verifyOtp` now calls the existing `_validateOtp` (length 6, digits-only) and throws `ArgumentError` for malformed input before contacting Firebase, avoiding unnecessary network round-trips and confusing Firebase errors.
  - `_isAuthenticating` is now set to `true` while signing in and cleared in a `finally` block, so any UI spinner driven by `isAuthenticating` works and concurrent double-taps are prevented.
- Added `packages/truxify_shared/test/auth_service_test.dart` with regression tests covering: rejection of short/non-digit OTPs, successful sign-in, the flag being raised in-flight, and the flag being cleared even on failure.
- Added `firebase_auth_mocks` dev dependency to enable the tests.

## Related

Fixes #11491
