### PR TITLE
fix(api): fix wei conversion and TOCTOU in tokenization (#11493)

### DIFF
--- a/backend/api/test/unit/tokenization.test.ts
+++ b/backend/api/test/unit/tokenization.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for issue #11493.
+ *
+ * Covers the two defects reported in the backend tokenization service:
+ *   1. Float multiplication before `parseEther` silently lost wei precision.
+ *      `tokenCostWei` must compute the exact wei cost using integer math only.
+ *   2. Asset / trade IDs were read from `getTotalAssets()` / `getTotalTradeOrders()`
+ *      counters AFTER the tx was mined — a TOCTOU. `extractEventArg` must derive
+ *      the ID from the transaction's own emitted event, which is race-free.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+
+// The service constructs an ethers JsonRpcProvider / Wallet / Contract at import
+// time. Stub those three so the module loads without network or env secrets,
+// while keeping the real `parseEther` / `Interface` used by the helpers.
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual<typeof import('ethers')>('ethers');
+  const noop = class {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_a?: any, _b?: any, _c?: any) {
+      return { interface: new actual.Interface([]) };
+    }
+  };
+  return {
+    ...actual,
+    JsonRpcProvider: noop,
+    Wallet: noop,
+    Contract: noop,
+  };
+});
+
+vi.mock('../../src/config/db.js', () => ({
+  supabase: { from: () => ({}) },
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: () => {}, error: () => {}, warn: () => {} },
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+}));
+
+import { tokenCostWei, extractEventArg } from '../../../tokenization/token.service.js';
+
+const ASSET_CREATED = 'event AssetCreated(uint256 indexed assetId, string name, address indexed owner)';
+const TRADE_CREATED = 'event TradeOrderCreated(uint256 indexed orderId, uint256 tokenId, address indexed seller)';
+
+describe('tokenCostWei — exact wei conversion (no float drift)', () => {
+  it('computes 0.1 ETH/token * 3 tokens exactly as 0.3 ETH', () => {
+    // Old code: parseFloat('0.1') * 3 === 0.30000000000000004 -> drifted wei.
+    const wei = tokenCostWei('0.1', '3', true);
+    expect(wei).toBe(ethers.parseEther('0.3'));
+    expect(wei.toString()).toBe('300000000000000000');
+  });
+
+  it('computes 2.5 ETH/token * 3 tokens as 7.5 ETH', () => {
+    const wei = tokenCostWei('2.5', '3', true);
+    expect(wei).toBe(ethers.parseEther('7.5'));
+  });
+
+  it('does not rely on floating point for fractional results', () => {
+    // 0.0000001 * 0.0000001 should still be exact, not a rounded float.
+    const wei = tokenCostWei('0.0000001', '0.0000001', true);
+    // parseEther('0.0000001') = 1e11 wei; product = 1e22; /1e18 = 1e4 wei
+    expect(wei).toBe(10000n);
+  });
+
+  it('floor (trade) rounds down to match contract settlement', () => {
+    // 3 tokens * 0.1 ETH = 0.3 ETH exactly; floor == ceil here.
+    expect(tokenCostWei('0.1', '3', false)).toBe(ethers.parseEther('0.3'));
+  });
+});
+
+describe('extractEventArg — race-free ID from emitted event (no TOCTOU)', () => {
+  const contract = { interface: new ethers.Interface([ASSET_CREATED, TRADE_CREATED]) };
+
+  const assetReceipt = (id: bigint) => {
+    const fragment = contract.interface.getEvent('AssetCreated');
+    const enc = contract.interface.encodeEventLog(fragment, [
+      id,
+      'truck',
+      '0x0000000000000000000000000000000000000001',
+    ]);
+    return { logs: [{ topics: enc.topics, data: enc.data }] };
+  };
+
+  const tradeReceipt = (id: bigint) => {
+    const fragment = contract.interface.getEvent('TradeOrderCreated');
+    const enc = contract.interface.encodeEventLog(fragment, [
+      id,
+      7n,
+      '0x0000000000000000000000000000000000000002',
+    ]);
+    return { logs: [{ topics: enc.topics, data: enc.data }] };
+  };
+
+  it('reads the asset ID directly from the AssetCreated event', () => {
+    const id = extractEventArg(assetReceipt(42n), contract, 'AssetCreated', 0);
+    expect(id).toBe(42n);
+  });
+
+  it('reads the order ID directly from the TradeOrderCreated event', () => {
+    const id = extractEventArg(tradeReceipt(17n), contract, 'TradeOrderCreated', 0);
+    expect(id).toBe(17n);
+  });
+
+  it('is unaffected by a counter value, proving it is not a TOCTOU on the count', () => {
+    // Even if a concurrent create bumped the on-chain counter to 1000, the
+    // ID for THIS transaction must still come from its own event (42n).
+    const id = extractEventArg(assetReceipt(42n), contract, 'AssetCreated', 0);
+    expect(id).toBe(42n);
+  });
+
+  it('returns null when the expected event is absent', () => {
+    const id = extractEventArg({ logs: [] }, contract, 'AssetCreated', 0);
+    expect(id).toBeNull();
+  });
+
+  it('ignores logs emitted by other contracts', () => {
+    const foreign = {
+      // a log that cannot be decoded by our interface
+      topics: ['0xdeadbeef'],
+      data: '0x',
+    };
+    const id = extractEventArg({ logs: [foreign] }, contract, 'AssetCreated', 0);
+    expect(id).toBeNull();
+  });
+});

--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -2,6 +2,58 @@ import { ethers } from 'ethers';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
 
+const WEI_UNIT = 10n ** 18n;
+
+/**
+ * Compute the exact wei cost of an amount of tokens at a given price.
+ *
+ * Both inputs are decimal strings (e.g. "0.1" ETH/token and "3" tokens). The
+ * contract multiplies the two wei values and divides by 1e18, so we replicate
+ * that with integer math only — no `parseFloat` — which avoids the float
+ * drift that previously lost wei (e.g. 0.1 * 3 rounded to 0.30000000000000004).
+ *
+ * @param {string|number} price   price per token in ether units
+ * @param {string|number} amount  number of tokens in ether units
+ * @param {boolean} roundUp       match the contract's ceiling (purchase) vs floor (trade)
+ * @returns {bigint} total cost in wei
+ */
+function tokenCostWei(price, amount, roundUp = true) {
+    const priceWei = ethers.parseEther(price.toString());
+    const amountWei = ethers.parseEther(amount.toString());
+    const product = priceWei * amountWei;
+    return roundUp ? (product + WEI_UNIT - 1n) / WEI_UNIT : product / WEI_UNIT;
+}
+
+/**
+ * Extract an argument from the first matching event in a transaction receipt.
+ *
+ * The on-chain asset/trade IDs are assigned inside the same transaction that
+ * performs the mint/order, so reading them from the emitted event is
+ * race-free. This replaces the previous `getTotalAssets()` / `getTotalTradeOrders()`
+ * counters, which were a TOCTOU: after the tx was mined but before the count
+ * was read, a concurrent create could shift the value and produce a wrong ID.
+ *
+ * @param {object} receipt  ethers v6 transaction receipt with `.logs`
+ * @param {object} contract ethers Contract (or object exposing `.interface`)
+ * @param {string} eventName
+ * @param {number} argIndex
+ * @returns {any} the requested event argument, or null if not found
+ */
+function extractEventArg(receipt, contract, eventName, argIndex = 0) {
+    if (!receipt || !contract || !contract.interface) return null;
+    for (const log of receipt.logs || []) {
+        try {
+            const parsed = contract.interface.parseLog(log);
+            if (parsed && parsed.name === eventName) {
+                return parsed.args[argIndex];
+            }
+        } catch {
+            // log emitted by a different contract / not decodable here
+        }
+    }
+    return null;
+}
+
 class TokenizationService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);
@@ -19,7 +71,9 @@ class TokenizationService {
             'function getAsset(uint256 assetId) external view returns (tuple(uint256,string,string,string,uint256,uint256,uint256,uint256,address,bool,string,uint256,uint256))',
             'function getFractionalOwnership(uint256 assetId, address owner) external view returns (tuple(address,uint256,uint256,uint256,uint256))',
             'function getTotalAssets() external view returns (uint256)',
-            'function getTotalTradeOrders() external view returns (uint256)'
+            'function getTotalTradeOrders() external view returns (uint256)',
+            'event AssetCreated(uint256 indexed assetId, string name, address indexed owner)',
+            'event TradeOrderCreated(uint256 indexed orderId, uint256 tokenId, address indexed seller)'
         ];
 
         this.token = new ethers.Contract(this.tokenAddress, this.tokenABI, this.wallet);
@@ -42,8 +96,9 @@ class TokenizationService {
             );
             const receipt = await tx.wait();
 
-            // Get asset ID from logs
-            const assetId = await this.token.getTotalAssets();
+            // Derive the asset ID from the emitted event (race-free) instead of
+            // reading the asset counter, which is a TOCTOU after mining.
+            const assetId = extractEventArg(receipt, this.token, 'AssetCreated', 0);
 
             await this.storeAsset({
                 ...assetData,
@@ -69,14 +124,14 @@ class TokenizationService {
             if (!asset) {
                 throw new Error('Asset not found');
             }
-            const totalCost = parseFloat(asset.tokenPrice) * amount;
+            const totalCost = tokenCostWei(asset.tokenPrice, amount, true);
 
             const userContract = new ethers.Contract(this.tokenAddress, this.tokenABI, signer || this.wallet);
             const tx = await userContract.purchaseFraction(
                 assetId,
                 ethers.parseEther(amount.toString()),
                 {
-                    value: ethers.parseEther(totalCost.toString()),
+                    value: totalCost,
                     gasLimit: 200000
                 }
             );
@@ -86,7 +141,7 @@ class TokenizationService {
                 assetId,
                 userAddress,
                 amount,
-                totalCost,
+                totalCost: ethers.formatEther(totalCost),
                 type: 'purchase',
                 txHash: receipt.hash
             });
@@ -96,7 +151,7 @@ class TokenizationService {
                 success: true,
                 assetId,
                 amount,
-                totalCost,
+                totalCost: ethers.formatEther(totalCost),
                 txHash: receipt.hash
             };
         } catch (error) {
@@ -149,7 +204,9 @@ class TokenizationService {
             );
             const receipt = await tx.wait();
 
-            const orderId = await this.token.getTotalTradeOrders();
+            // Derive the order ID from the emitted event (race-free) instead of
+            // reading the trade counter, which is a TOCTOU after mining.
+            const orderId = extractEventArg(receipt, this.token, 'TradeOrderCreated', 0);
 
             await this.storeTradeOrder({
                 assetId,
@@ -205,13 +262,13 @@ class TokenizationService {
                 throw new Error(`Trade order ${order.orderId} is not active`);
             }
 
-            const totalCost = parseFloat(order.price) * parseFloat(order.amount);
+            const totalCost = tokenCostWei(order.price, order.amount, false);
 
             const tx = await this.token.executeTradeOrder(
                 assetId,
                 orderIndex,
                 {
-                    value: ethers.parseEther(totalCost.toString()),
+                    value: totalCost,
                     gasLimit: 200000
                 }
             );
@@ -221,7 +278,7 @@ class TokenizationService {
                 assetId,
                 userAddress: buyerAddress,
                 amount: order.amount,
-                totalCost,
+                totalCost: ethers.formatEther(totalCost),
                 type: 'trade',
                 txHash: receipt.hash,
                 orderId: order.orderId


### PR DESCRIPTION
## Summary

Fixes #11493 — two defects in `backend/tokenization/token.service.js`:

- **Wei precision loss (float math):** cost was computed with `parseFloat(price) * amount` and then re-parsed via `parseEther(totalCost.toString())`. The intermediate `Number` multiply drifts (e.g. `0.1 * 3 === 0.30000000000000004`), silently losing/subtracting wei on every mint and trade settlement. Replaced with `tokenCostWei()`, which does exact integer math (`priceWei * amountWei / 1e18`, with ceiling for purchases and floor for trades) to mirror the contract's own `totalCost` computation.
- **TOCTOU on IDs:** asset/trade IDs were read from the `getTotalAssets()` / `getTotalTradeOrders()` counters *after* the transaction was mined. A concurrent create (or post-delete counter reuse) could shift the value and persist a wrong ID. IDs are now derived from the transaction's own `AssetCreated` / `TradeOrderCreated` event via `extractEventArg()`, which is race-free because the ID is assigned inside the same transaction.

## Changes

- `backend/tokenization/token.service.js`
  - Added `tokenCostWei(price, amount, roundUp)` — exact wei cost via `ethers.parseEther` + `BigInt` math.
  - Added `extractEventArg(receipt, contract, eventName, argIndex)` — reads the ID from the emitted event.
  - `createAsset` / `createTradeOrder` now source `assetId` / `orderId` from the event log instead of the counters.
  - `purchaseFraction` / `executeTradeOrder` use `tokenCostWei` and pass the wei `BigInt` directly as `value`.
- `backend/api/test/unit/tokenization.test.ts` — regression tests asserting exact wei conversion (incl. the `0.1 * 3` drift case) and that IDs come from the event regardless of any counter value.

## Test plan

- `node --check backend/tokenization/token.service.js` passes.
- New vitest suite `backend/api/test/unit/tokenization.test.ts` covers both defects (exact wei math + race-free ID extraction from the event log).
