### PR TITLE
fix(api): fix rollback/undo snapshots in GlobalStore (#11496)

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -21,6 +21,7 @@ class StoreTransaction {
         
         this.snapshot = this.store.createSnapshot();
         this.isActive = true;
+        this.txStartIndex = this.store.historyIndex;
         this.startTime = Date.now();
         this.store.emit('transactionStarted', { id: this.id });
         logger.debug(`Transaction ${this.id} started`);
@@ -60,7 +61,13 @@ class StoreTransaction {
         
         this.endTime = Date.now();
         this.isActive = false;
-        
+
+        // Record the transaction's net effect as a single undo entry so that
+        // one undo reverts the whole transaction, not an intermediate step.
+        if (JSON.stringify(this.snapshot.state) !== JSON.stringify(this.store.state)) {
+            this.store.saveHistory();
+        }
+
         this.store.emit('transactionCommitted', {
             id: this.id,
             duration: this.endTime - this.startTime,
@@ -83,6 +90,12 @@ class StoreTransaction {
         
         if (this.snapshot) {
             this.store.restoreSnapshot(this.snapshot);
+        }
+        
+        // Restore the undo history cursor to the pre-transaction point so the
+        // pointer does not diverge from the restored state.
+        if (this.txStartIndex !== undefined && this.txStartIndex !== null) {
+            this.store.historyIndex = this.txStartIndex;
         }
         
         this.endTime = Date.now();
@@ -135,8 +148,11 @@ class GlobalStore extends EventEmitter {
             return;
         }
         
-        // Save history for undo
-        this.saveHistory();
+        // Save history for undo (skip while a transaction is active so that
+        // intermediate mutations do not pollute the undo history).
+        if (!this.activeTransaction) {
+            this.saveHistory();
+        }
         
         const oldValue = this.state[key];
         this.state[key] = value;
@@ -153,7 +169,11 @@ class GlobalStore extends EventEmitter {
             return;
         }
         
-        this.saveHistory();
+        // Skip while a transaction is active so intermediate mutations do not
+        // pollute the undo history.
+        if (!this.activeTransaction) {
+            this.saveHistory();
+        }
         const oldState = { ...this.state };
         Object.assign(this.state, updates);
         
@@ -256,7 +276,7 @@ class GlobalStore extends EventEmitter {
     
     createSnapshot() {
         return {
-            state: { ...this.state },
+            state: structuredClone(this.state),
             timestamp: Date.now(),
             id: `snapshot_${Date.now()}`
         };
@@ -268,7 +288,7 @@ class GlobalStore extends EventEmitter {
         }
         
         const oldState = { ...this.state };
-        this.state = { ...snapshot.state };
+        this.state = structuredClone(snapshot.state);
         
         this.notifyStateDiff(oldState, this.state);
         this.emit('snapshotRestored', { oldState, newState: this.state });

--- a/backend/store/GlobalStore.rollback.test.ts
+++ b/backend/store/GlobalStore.rollback.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for GlobalStore transaction rollback / undo snapshots.
+ *
+ * Covers issue #11496:
+ *  - set/update inside a transaction must not pollute undo history
+ *  - snapshots must be deep so nested state is restored correctly
+ *  - rollback must restore the pre-transaction state and leave the undo
+ *    history cursor consistent
+ *  - a committed transaction must collapse to a single undo entry
+ */
+
+import { describe, it, expect } from 'vitest';
+import GlobalStore from '../store/GlobalStore.js';
+
+describe('GlobalStore transaction rollback / undo snapshots (#11496)', () => {
+    it('coalesces transaction mutations into a single undo entry', async () => {
+        const store = new GlobalStore({ count: 0, nested: { value: 1 } });
+        store.saveHistory(); // establish a baseline undo entry
+
+        await store.transaction(async () => {
+            store.set('count', 1);
+            store.set('count', 2);
+            store.update({ nested: { value: 99 } });
+        });
+
+        // Only the net transaction effect should have been recorded.
+        expect(store.history.length).toBe(2);
+        expect(store.historyIndex).toBe(store.history.length - 1);
+
+        // One undo reverts the whole transaction.
+        const ok = store.undo();
+        expect(ok).toBe(true);
+        expect(store.get('count')).toBe(0);
+        expect(store.get('nested')).toEqual({ value: 1 });
+    });
+
+    it('rollback restores deep (nested) state and leaves undo history intact', async () => {
+        const store = new GlobalStore({ profile: { name: 'a', meta: { age: 10 } } });
+        store.saveHistory();
+        store.set('extra', 1);
+
+        const baselineHistoryLength = store.history.length;
+        const baselineIndex = store.historyIndex;
+
+        let rolledBack = false;
+        try {
+            await store.transaction(async () => {
+                store.set('profile', { name: 'b', meta: { age: 20 } });
+                throw new Error('boom');
+            });
+        } catch (err) {
+            rolledBack = true;
+        }
+
+        expect(rolledBack).toBe(true);
+
+        // State fully restored to the pre-transaction snapshot (deep).
+        expect(store.get('profile')).toEqual({ name: 'a', meta: { age: 10 } });
+
+        // The restored state must not be aliased to the baseline history entry.
+        expect(store.get('profile')).not.toBe(store.history[baselineIndex].profile);
+        expect(store.get('profile').meta).not.toBe(store.history[baselineIndex].profile?.meta);
+
+        // Undo history is untouched by the rolled-back transaction.
+        expect(store.history.length).toBe(baselineHistoryLength);
+        expect(store.historyIndex).toBe(baselineIndex);
+        expect(store.canUndo()).toBe(true);
+
+        // Undo still works back to the pre-transaction baseline state.
+        expect(store.undo()).toBe(true);
+        expect(store.get('profile')).toEqual({ name: 'a', meta: { age: 10 } });
+    });
+
+    it('createSnapshot / restoreSnapshot perform deep copies', () => {
+        const store = new GlobalStore({ a: { b: { c: 1 } } });
+        const snapshot = store.createSnapshot();
+
+        store.set('a', { b: { c: 2 } });
+        store.restoreSnapshot(snapshot);
+
+        expect(store.get('a')).toEqual({ b: { c: 1 } });
+
+        // Mutating the live state must not leak into the captured snapshot.
+        store.get('a').b.c = 42;
+        expect(snapshot.state.a.b.c).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

`backend/store/GlobalStore.js` managed undo/redo via snapshots, but the
transaction path corrupted history in two ways:

- `set`/`update` called `saveHistory()` on **every** intermediate mutation while a
  transaction was in progress, so a single "undo" reverted one sub-step of a
  transaction (or replayed stale entries) instead of the whole transaction.
- `createSnapshot`/`restoreSnapshot` used shallow `{ ... }` copies, so nested
  object edits were silently dropped on rollback, leaving partially-restored state.
- `rollback` rewound state but never adjusted the undo history cursor, so the
  pointer and the restored state diverged.

## Fix

- `set`/`update` now skip `saveHistory()` while `this.activeTransaction` is active.
- `commit()` records exactly one history entry for the transaction's net effect, so
  a single undo reverts the entire transaction.
- `createSnapshot`/`restoreSnapshot` use `structuredClone` for deep snapshots.
- `rollback` restores the deep pre-transaction snapshot and resets the undo history
  cursor (`historyIndex`) to the pre-transaction point.

## Test plan

- Added `backend/store/GlobalStore.rollback.test.ts` (vitest) covering:
  - transaction mutations coalesce into a single undo entry,
  - rollback restores deep nested state and leaves undo history intact,
  - `createSnapshot`/`restoreSnapshot` perform independent deep copies.

## Metadata

- Issue: #11496
- Area: backend / GlobalStore
