### PR TITLE
fix(flutter): validate A/B metrics in ml_dashboard (#11488)

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -3,6 +3,10 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 class MLDashboard extends StatefulWidget {
+  final Map<String, dynamic>? initialMetrics;
+
+  const MLDashboard({super.key, this.initialMetrics});
+
   @override
   _MLDashboardState createState() => _MLDashboardState();
 }
@@ -25,7 +29,12 @@ class _MLDashboardState extends State<MLDashboard> {
   @override
   void initState() {
     super.initState();
-    fetchMetrics();
+    if (widget.initialMetrics != null) {
+      metrics = widget.initialMetrics;
+      isLoading = false;
+    } else {
+      fetchMetrics();
+    }
   }
 
   Future<void> fetchMetrics() async {
@@ -93,12 +102,34 @@ class _MLDashboardState extends State<MLDashboard> {
   }
 
   Widget _buildMetricsCard() {
-    final results = metrics?['results'] as Map<String, dynamic>? ?? {};
+    final rawResults = metrics?['results'];
+    if (rawResults is! Map) {
+      return Card(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('📈 Performance Metrics', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              SizedBox(height: 8),
+              Text('No metrics available'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final results = Map<String, dynamic>.from(rawResults);
     final rows = <Widget>[];
     results.forEach((metric, values) {
-      final prod = values['production']?.toStringAsFixed(2);
-      final shadow = values['shadow']?.toStringAsFixed(2);
-      rows.add(_buildMetricRow(metric, prod, shadow, metric == 'rmse'));
+      if (values is! Map) return;
+      final rawValues = Map<String, dynamic>.from(values);
+      final prod = rawValues['production'];
+      final shadow = rawValues['shadow'];
+      final prodStr = prod is num ? prod.toStringAsFixed(2) : null;
+      final shadowStr = shadow is num ? shadow.toStringAsFixed(2) : null;
+      if (prodStr == null || shadowStr == null) return;
+      rows.add(_buildMetricRow(metric, prodStr, shadowStr, metric == 'rmse'));
     });
 
     if (rows.isEmpty) {

--- a/cutomer_app/test/ml_dashboard_test.dart
+++ b/cutomer_app/test/ml_dashboard_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../lib/screens/ml_dashboard.dart';
+
+void main() {
+  Widget buildDashboard(Map<String, dynamic>? metrics) {
+    return MaterialApp(home: Scaffold(body: MLDashboard(initialMetrics: metrics)));
+  }
+
+  testWidgets('renders safely when metrics is null', (tester) async {
+    await tester.pumpWidget(buildDashboard(null));
+    expect(tester.takeException(), isNull);
+    expect(find.text('No metrics available'), findsWidgets);
+  });
+
+  testWidgets('renders safely when results is a List (not a Map)', (tester) async {
+    await tester.pumpWidget(buildDashboard({
+      'results': [
+        {'production': 0.1, 'shadow': 0.2}
+      ]
+    }));
+    expect(tester.takeException(), isNull);
+    expect(find.text('No metrics available'), findsWidgets);
+  });
+
+  testWidgets('skips metrics whose production/shadow are non-numeric',
+      (tester) async {
+    await tester.pumpWidget(buildDashboard({
+      'results': {
+        'rmse': {'production': 1, 'shadow': 2},
+        'accuracy': {'production': 'N/A', 'shadow': 'N/A'},
+        'latency': {'production': 10},
+        'throughput': {'shadow': 20},
+      }
+    }));
+    expect(tester.takeException(), isNull);
+    // Only the numeric rmse row is rendered.
+    expect(find.text('Prod: 1.00'), findsOneWidget);
+    expect(find.text('Shadow: 2.00'), findsOneWidget);
+    // Non-numeric rows must not produce formatted values.
+    expect(find.text('Prod: N/A'), findsNothing);
+    expect(find.text('No metrics available'), findsNothing);
+  });
+
+  testWidgets('renders valid numeric metrics with formatting', (tester) async {
+    await tester.pumpWidget(buildDashboard({
+      'results': {
+        'rmse': {'production': 3.14159, 'shadow': 2.71828},
+      }
+    }));
+    expect(tester.takeException(), isNull);
+    expect(find.text('Prod: 3.14'), findsOneWidget);
+    expect(find.text('Shadow: 2.72'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem
`cutomer_app/lib/screens/ml_dashboard.dart` parsed the A/B-testing metrics response straight from `json.decode` with no schema validation. `_buildMetricsCard` assumed numeric `production`/`shadow` values and cast `results` to a `Map` unconditionally. This caused `NoSuchMethodError` (`int.toStringAsFixed` does not exist), a cast error when `results` was a `List`/non-Map, and crashes on null/`String` values. The ML governance screen red-screened on untrusted or changed backend payloads.

## Fix
- Guard the `results` cast: if `metrics['results']` is not a `Map`, render a safe "No metrics available" card instead of crashing.
- Skip non-`Map` entries and coerce `production`/`shadow` safely: only numeric values are formatted via `toStringAsFixed`; non-numeric rows are skipped.
- Added a testable `initialMetrics` injection point (no behavior change for normal usage) so the regression test can exercise invalid payloads.

## Files changed
- `cutomer_app/lib/screens/ml_dashboard.dart` — validated/safe A/B metric handling.
- `cutomer_app/test/ml_dashboard_test.dart` — regression test for null, non-Map, and non-numeric A/B metrics.

## Testing
Added `cutomer_app/test/ml_dashboard_test.dart` (`flutter_test`) asserting:
- `null` metrics render safely ("No metrics available").
- `results` as a `List` (non-Map) is tolerated without throwing.
- Rows with `int`, `String` (`'N/A'`), or missing `production`/`shadow` are skipped.
- Valid numeric metrics are formatted and displayed.

## Closes #11488
