### PR TITLE
fix(flutter): LanguageProvider.of no longer returns detached decoy (#11545)

### DIFF
--- a/apps/customer/lib/providers/language_provider.dart
+++ b/apps/customer/lib/providers/language_provider.dart
@@ -15,10 +15,15 @@ class LanguageProvider extends ChangeNotifier {
     if (scope != null && scope.notifier != null) {
       return scope.notifier!;
     }
-    return _defaultInstance;
+    throw FlutterError(
+      'LanguageProvider.of() called with a context that does not contain a '
+      'LanguageProviderScope.\n'
+      'This usually happens because the context is not a descendant of a '
+      'LanguageProviderScope widget. In non-UI contexts (background isolates, '
+      'notification handlers, deep links) inject the real provider instance or '
+      'read the persisted locale directly instead of relying on a static decoy.',
+    );
   }
-
-  static final LanguageProvider _defaultInstance = LanguageProvider();
 }
 
 class LanguageProviderScope extends InheritedNotifier<LanguageProvider> {

--- a/apps/customer/test/language_provider_test.dart
+++ b/apps/customer/test/language_provider_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify/providers/language_provider.dart';
+
+void main() {
+  testWidgets('LanguageProvider.of throws when no LanguageProviderScope is present',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final BuildContext context = tester.element(find.byType(SizedBox));
+
+    expect(() => LanguageProvider.of(context), throwsA(isA<FlutterError>()));
+  });
+
+  testWidgets('LanguageProvider.of returns the real provider inside scope',
+      (WidgetTester tester) async {
+    final provider = LanguageProvider();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LanguageProviderScope(
+          provider: provider,
+          child: const SizedBox(),
+        ),
+      ),
+    );
+    final BuildContext context = tester.element(find.byType(SizedBox));
+
+    expect(LanguageProvider.of(context), same(provider));
+  });
+}

--- a/apps/driver/lib/providers/language_provider.dart
+++ b/apps/driver/lib/providers/language_provider.dart
@@ -15,10 +15,15 @@ class LanguageProvider extends ChangeNotifier {
     if (scope != null && scope.notifier != null) {
       return scope.notifier!;
     }
-    return _defaultInstance;
+    throw FlutterError(
+      'LanguageProvider.of() called with a context that does not contain a '
+      'LanguageProviderScope.\n'
+      'This usually happens because the context is not a descendant of a '
+      'LanguageProviderScope widget. In non-UI contexts (background isolates, '
+      'notification handlers, deep links) inject the real provider instance or '
+      'read the persisted locale directly instead of relying on a static decoy.',
+    );
   }
-
-  static final LanguageProvider _defaultInstance = LanguageProvider();
 }
 
 class LanguageProviderScope extends InheritedNotifier<LanguageProvider> {

--- a/apps/driver/test/language_provider_test.dart
+++ b/apps/driver/test/language_provider_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/providers/language_provider.dart';
+
+void main() {
+  testWidgets('LanguageProvider.of throws when no LanguageProviderScope is present',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final BuildContext context = tester.element(find.byType(SizedBox));
+
+    expect(() => LanguageProvider.of(context), throwsA(isA<FlutterError>()));
+  });
+
+  testWidgets('LanguageProvider.of returns the real provider inside scope',
+      (WidgetTester tester) async {
+    final provider = LanguageProvider();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LanguageProviderScope(
+          provider: provider,
+          child: const SizedBox(),
+        ),
+      ),
+    );
+    final BuildContext context = tester.element(find.byType(SizedBox));
+
+    expect(LanguageProvider.of(context), same(provider));
+  });
+}


### PR DESCRIPTION
## Summary

`LanguageProvider.of(BuildContext)` silently fell back to a detached `_defaultInstance` singleton whenever it was called outside a `LanguageProviderScope`. That decoy was never wired to the live `ChangeNotifier` or persistence, so locale changes made through it were never saved or notified — producing the "language randomly resets / preference not surviving restart" reports from entry points like deep links, notification taps, and background handlers.

This change removes the `_defaultInstance` decoy. `LanguageProvider.of` now returns the real provider from the widget tree, or throws a `FlutterError` with actionable guidance when called outside a valid scope, so misuse is caught during development instead of silently corrupting state.

## Changes

- `apps/customer/lib/providers/language_provider.dart`
- `apps/driver/lib/providers/language_provider.dart`
  - Removed `static final LanguageProvider _defaultInstance`.
  - `of` now throws `FlutterError` when no `LanguageProviderScope` ancestor is found, with guidance to inject the real provider / read persisted locale in non-UI contexts.
- `apps/customer/test/language_provider_test.dart`
- `apps/driver/test/language_provider_test.dart`
  - Regression tests asserting `of` throws outside the scope and returns the real instance inside it.

## Test plan

- `flutter test apps/customer/test/language_provider_test.dart`
- `flutter test apps/driver/test/language_provider_test.dart`

## Related

Closes #11545
