### PR TITLE
fix(api): fix paisa/INR unit mix in matchEnRouteLoads (#11546)

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -72,6 +72,22 @@ function parseDimensions(dimensions) {
 }
 
 /**
+ * Normalize a load_offer's monetary value to paisa (1 INR = 100 paisa).
+ * `payment_inr` is stored in INR; `freight_value` is stored in paisa.
+ * Both are converted to a single unit (paisa) so arithmetic and the
+ * downstream `extra_earnings` field stay consistent.
+ */
+function toPaisa(offer) {
+  if (offer.payment_inr != null) {
+    return Math.round(Number(offer.payment_inr) * 100);
+  }
+  if (offer.freight_value != null) {
+    return Math.round(Number(offer.freight_value));
+  }
+  return 0;
+}
+
+/**
  * Utility: build headers with optional API key
  */
 function getHeaders() {
@@ -638,7 +654,7 @@ export async function matchEnRouteLoads({
         width_m: dims.width,
         height_m: dims.height,
         pickup_deadline: o.pickup_deadline ? new Date(o.pickup_deadline).toISOString() : new Date(Date.now() + ML_DEFAULT_PICKUP_LEAD_MS).toISOString(),
-        payment_inr: Number(o.payment_inr || (o.freight_value ? o.freight_value / 100 : 0)),
+        payment_inr: toPaisa(o),
       };
     })
     .filter(l => Number.isFinite(l.weight_kg) && l.weight_kg > 0);
@@ -680,7 +696,7 @@ export async function matchEnRouteLoads({
           detour_km: dtKm,
           distance_to_pickup_km: dtKm,
           match_score: Math.max(0, 1 - dtKm / maxDetourKm),
-          estimated_earnings: Number(o.payment_inr || (o.freight_value ? o.freight_value / 100 : 0)),
+          estimated_earnings: toPaisa(o),
           _fallback: true,
         };
       })
@@ -700,8 +716,8 @@ export async function matchEnRouteLoads({
         ...o,
         detour_km: rec.detour_km ?? rec.distance_to_pickup_km ?? 0,
         extra_earnings: rec.estimated_earnings
-          ? Math.round(rec.estimated_earnings * 100) // convert to paisa for consistency
-          : (o.freight_value || 0),
+          ? Math.round(rec.estimated_earnings)
+          : (o.freight_value != null ? Math.round(Number(o.freight_value)) : 0),
         match_score: rec.match_score ?? 0,
         extra_distance_km: rec.detour_km ?? 0,
         ml_used: mlUsed,

--- a/backend/api/test/unit/mlEnRoutePaisa.test.js
+++ b/backend/api/test/unit/mlEnRoutePaisa.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { matchEnRouteLoads } from '../../src/services/ml.js';
+
+const mockLogger = vi.hoisted(() => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+vi.mock('../../src/middleware/logger.js', () => ({ default: mockLogger }));
+
+describe('matchEnRouteLoads monetary unit handling (#11546)', () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.ML_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ML_API_KEY = 'test-key';
+    // Force the haversine fallback so earnings are computed locally.
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('ML engine unreachable'));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.ML_API_KEY;
+    else process.env.ML_API_KEY = originalKey;
+  });
+
+  it('normalizes payment_inr (INR) to paisa in extra_earnings', async () => {
+    const result = await matchEnRouteLoads({
+      currentLat: 12.9,
+      currentLng: 77.5,
+      maxDetourKm: 2000,
+      offers: [
+        {
+          id: 'load-inr',
+          pickup_lat: 12.9,
+          pickup_lng: 77.5,
+          drop_lat: 13.0,
+          drop_lng: 80.2,
+          weight: '3 tonnes',
+          payment_inr: 1000, // INR
+          freight_value: null,
+        },
+      ],
+    });
+
+    expect(result[0].extra_earnings).toBe(1000 * 100); // 100000 paisa
+  });
+
+  it('keeps freight_value (paisa) as-is in extra_earnings', async () => {
+    const result = await matchEnRouteLoads({
+      currentLat: 12.9,
+      currentLng: 77.5,
+      maxDetourKm: 2000,
+      offers: [
+        {
+          id: 'load-paisa',
+          pickup_lat: 12.9,
+          pickup_lng: 77.5,
+          drop_lat: 13.0,
+          drop_lng: 80.2,
+          weight: '3 tonnes',
+          payment_inr: null,
+          freight_value: 250000, // paisa
+        },
+      ],
+    });
+
+    expect(result[0].extra_earnings).toBe(250000);
+  });
+
+  it('does not produce a 100x error when both fields are present', async () => {
+    const result = await matchEnRouteLoads({
+      currentLat: 12.9,
+      currentLng: 77.5,
+      maxDetourKm: 2000,
+      offers: [
+        {
+          id: 'load-both',
+          pickup_lat: 12.9,
+          pickup_lng: 77.5,
+          drop_lat: 13.0,
+          drop_lng: 80.2,
+          weight: '3 tonnes',
+          payment_inr: 1000, // INR -> 100000 paisa
+          freight_value: 250000, // paisa
+        },
+      ],
+    });
+
+    // payment_inr takes precedence and is normalized to paisa (no extra *100).
+    expect(result[0].extra_earnings).toBe(100000);
+    expect(result[0].extra_earnings).not.toBe(1000);
+  });
+
+  it('treats equivalent INR and paisa values as equal earnings', async () => {
+    const inrResult = await matchEnRouteLoads({
+      currentLat: 12.9,
+      currentLng: 77.5,
+      maxDetourKm: 2000,
+      offers: [
+        {
+          id: 'a',
+          pickup_lat: 12.9,
+          pickup_lng: 77.5,
+          drop_lat: 13.0,
+          drop_lng: 80.2,
+          weight: '3 tonnes',
+          payment_inr: 1000, // INR
+          freight_value: null,
+        },
+      ],
+    });
+    const paisaResult = await matchEnRouteLoads({
+      currentLat: 12.9,
+      currentLng: 77.5,
+      maxDetourKm: 2000,
+      offers: [
+        {
+          id: 'b',
+          pickup_lat: 12.9,
+          pickup_lng: 77.5,
+          drop_lat: 13.0,
+          drop_lng: 80.2,
+          weight: '3 tonnes',
+          payment_inr: null,
+          freight_value: 100000, // paisa == 1000 INR
+        },
+      ],
+    });
+
+    expect(inrResult[0].extra_earnings).toBe(paisaResult[0].extra_earnings);
+    expect(inrResult[0].extra_earnings).toBe(100000);
+  });
+});


### PR DESCRIPTION
## Summary

`matchEnRouteLoads` in `backend/api/src/services/ml.js` mixed monetary units:
`payment_inr` (stored in INR) and `freight_value` (stored in paisa) were handled
by inconsistent branches (`/ 100` vs raw), and the downstream `extra_earnings`
computation multiplied by 100 assuming the opposite unit — yielding earnings
figures that could be 100x too large or too small depending on which field was
populated.

This change introduces a single `toPaisa()` normalizer so both inputs are
converted to paisa (1 INR = 100 paisa) consistently before any arithmetic, and
removes the contradictory `* 100` at the `extra_earnings` step.

## Changes

- Added `toPaisa(offer)` helper that returns `payment_inr * 100` when present
  (INR → paisa) and otherwise `freight_value` (already paisa).
- Used `toPaisa()` for both the ML `availableLoads` mapping and the haversine
  fallback `estimated_earnings`.
- Changed `extra_earnings` to use the already-normalized paisa value (no extra
  `* 100`).

## Test plan

- Added `backend/api/test/unit/mlEnRoutePaisa.test.js` asserting:
  - `payment_inr` (INR) normalizes to paisa in `extra_earnings`.
  - `freight_value` (paisa) is used as-is.
  - Both fields present → no 100x error (payment_inr wins).
  - Equivalent INR/paisa values produce equal earnings.

Closes #11546
