### PR TITLE
fix(scripts): add verification, encryption, retention, compression to backup.sh (#11551)

### DIFF
--- a/infrastructure/backup/Dockerfile
+++ b/infrastructure/backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache bash postgresql-client mongodb-tools tar aws-cli
+RUN apk add --no-cache bash postgresql-client mongodb-tools tar aws-cli openssl coreutils
 
 COPY backup.sh /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/backup.sh

--- a/infrastructure/backup/backup.sh
+++ b/infrastructure/backup/backup.sh
@@ -5,25 +5,73 @@ TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 BACKUP_DIR="/tmp/backup_${TIMESTAMP}"
 mkdir -p "$BACKUP_DIR"
 
+BACKUP_RETENTION_COUNT="${BACKUP_RETENTION_COUNT:-30}"
+BACKUP_ENCRYPTION_PASSPHRASE="${BACKUP_ENCRYPTION_PASSPHRASE:-}"
+
 echo "Running pg_dump for main database..."
-PGPASSWORD="${DB_PASSWORD}" pg_dump -h "db" -U postgres -d "truxify" > "${BACKUP_DIR}/db_${TIMESTAMP}.sql"
+PGPASSWORD="${DB_PASSWORD}" pg_dump -Fc -Z 9 -h "db" -U postgres -d "truxify" > "${BACKUP_DIR}/db_${TIMESTAMP}.dump"
+
+echo "Verifying main database dump..."
+PGPASSWORD="${DB_PASSWORD}" pg_restore --list "${BACKUP_DIR}/db_${TIMESTAMP}.dump" > /dev/null
 
 for SHARD in north south east west; do
   echo "Running pg_dump for shard-${SHARD}..."
-  PGPASSWORD="${SHARD_PASSWORD}" pg_dump -h "shard-${SHARD}" -U postgres -d "truxify_${SHARD}" > "${BACKUP_DIR}/shard_${SHARD}_${TIMESTAMP}.sql"
+  PGPASSWORD="${SHARD_PASSWORD}" pg_dump -Fc -Z 9 -h "shard-${SHARD}" -U postgres -d "truxify_${SHARD}" > "${BACKUP_DIR}/shard_${SHARD}_${TIMESTAMP}.dump"
+  echo "Verifying shard-${SHARD} dump..."
+  PGPASSWORD="${SHARD_PASSWORD}" pg_restore --list "${BACKUP_DIR}/shard_${SHARD}_${TIMESTAMP}.dump" > /dev/null
 done
 
 echo "Running mongodump..."
 mongodump --uri="mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@mongo:27017/?authSource=admin" --archive="${BACKUP_DIR}/mongo_${TIMESTAMP}.archive"
 
 echo "Compressing backups..."
-tar -czvf "/tmp/backup_${TIMESTAMP}.tar.gz" -C /tmp "backup_${TIMESTAMP}"
+TARBALL="/tmp/backup_${TIMESTAMP}.tar.gz"
+tar -czvf "$TARBALL" -C /tmp "backup_${TIMESTAMP}"
+
+echo "Computing SHA256 checksum..."
+sha256sum "$TARBALL" > "${TARBALL}.sha256"
+
+UPLOAD_OBJECT="backups/backup_${TIMESTAMP}.tar.gz"
+
+if [ -n "$BACKUP_ENCRYPTION_PASSPHRASE" ]; then
+  echo "Encrypting backup archive..."
+  openssl enc -aes-256-cbc -salt -pbkdf2 -pass env:BACKUP_ENCRYPTION_PASSPHRASE -in "$TARBALL" -out "${TARBALL}.enc"
+  openssl enc -aes-256-cbc -salt -pbkdf2 -pass env:BACKUP_ENCRYPTION_PASSPHRASE -in "${TARBALL}.sha256" -out "${TARBALL}.sha256.enc"
+  UPLOAD_FILE="${TARBALL}.enc"
+  UPLOAD_CHECKSUM="${TARBALL}.sha256.enc"
+  UPLOAD_OBJECT="backups/backup_${TIMESTAMP}.tar.gz.enc"
+else
+  echo "No BACKUP_ENCRYPTION_PASSPHRASE set; skipping encryption."
+  UPLOAD_FILE="$TARBALL"
+  UPLOAD_CHECKSUM="${TARBALL}.sha256"
+fi
 
 echo "Uploading to S3..."
-aws s3 cp "/tmp/backup_${TIMESTAMP}.tar.gz" "s3://${AWS_S3_BUCKET}/backups/"
+aws s3 cp "$UPLOAD_FILE" "s3://${AWS_S3_BUCKET}/${UPLOAD_OBJECT}"
+aws s3 cp "$UPLOAD_CHECKSUM" "s3://${AWS_S3_BUCKET}/${UPLOAD_OBJECT}.sha256"
 
-echo "Cleaning up..."
+echo "Verifying upload..."
+LOCAL_SIZE=$(stat -c%s "$UPLOAD_FILE")
+REMOTE_SIZE=$(aws s3api head-object --bucket "${AWS_S3_BUCKET}" --key "${UPLOAD_OBJECT}" --query ContentLength --output text)
+if [ "$LOCAL_SIZE" != "$REMOTE_SIZE" ]; then
+  echo "Upload verification failed: size mismatch (local $LOCAL_SIZE, remote $REMOTE_SIZE)"
+  exit 1
+fi
+
+echo "Applying retention policy (keep ${BACKUP_RETENTION_COUNT} newest backups)..."
+EXISTING=$(aws s3 ls "s3://${AWS_S3_BUCKET}/backups/" | grep -E '\.tar\.gz(\.enc)?$' | awk '{print $4}' | sort)
+TOTAL=$(printf '%s\n' "$EXISTING" | grep -c . || true)
+if [ "$TOTAL" -gt "$BACKUP_RETENTION_COUNT" ]; then
+  TO_DELETE=$((TOTAL - BACKUP_RETENTION_COUNT))
+  printf '%s\n' "$EXISTING" | head -n "$TO_DELETE" | while read -r OLD; do
+    echo "Pruning old backup: $OLD"
+    aws s3 rm "s3://${AWS_S3_BUCKET}/backups/${OLD}"
+    aws s3 rm "s3://${AWS_S3_BUCKET}/backups/${OLD}.sha256" || true
+  done
+fi
+
+echo "Cleaning up local artifacts..."
 rm -rf "$BACKUP_DIR"
-rm "/tmp/backup_${TIMESTAMP}.tar.gz"
+rm -f "$TARBALL" "${TARBALL}.sha256" "${TARBALL}.enc" "${TARBALL}.sha256.enc"
 
 echo "Backup completed successfully."

--- a/infrastructure/backup/test_backup.sh
+++ b/infrastructure/backup/test_backup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Regression check for infrastructure/backup/backup.sh
+# Verifies the backup script is syntactically valid and contains the
+# hardening features introduced for issue #11551.
+#
+# Testing limitations: this does NOT execute a real pg_dump / mongodump /
+# aws s3 upload (no database, no S3 credentials, no network). It only
+# performs static validation so it can run in CI without side effects.
+
+set -e
+
+export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="${SCRIPT_DIR}/backup.sh"
+
+echo "Running syntax check (bash -n)..."
+bash -n "$TARGET"
+
+echo "Checking required hardening features are present..."
+
+missing=0
+
+check() {
+  if ! grep -q "$1" "$TARGET"; then
+    echo "MISSING: $2"
+    missing=1
+  else
+    echo "OK: $2"
+  fi
+}
+
+check 'pg_dump -Fc -Z 9' "compressed custom-format pg_dump"
+check 'pg_restore --list' "dump verification via pg_restore --list"
+check 'sha256sum' "SHA256 checksum generation"
+check 'openssl enc' "encryption with openssl"
+check 'BACKUP_ENCRYPTION_PASSPHRASE' "encryption key read from environment"
+check 'head-object' "upload verification via head-object"
+check 'BACKUP_RETENTION_COUNT' "configurable retention count"
+check 'aws s3 rm' "retention prune of old backups"
+
+if [ "$missing" -ne 0 ]; then
+  echo "Regression check FAILED: one or more required features missing."
+  exit 1
+fi
+
+echo "Regression check PASSED."


### PR DESCRIPTION
## Summary

This PR hardens `infrastructure/backup/backup.sh` to address #11551 by adding the missing integrity, security, and lifecycle controls around `pg_dump` / `mongodump` backups:

- **Compression**: `pg_dump` now uses the custom `-Fc -Z 9` format (verifiable and smaller than plain SQL); the tarball remains gzip-compressed.
- **Verification**: each PostgreSQL dump is verified with `pg_restore --list` before upload, and the uploaded object is validated against a local `head-object` size check. A SHA256 checksum is also uploaded alongside the archive.
- **Encryption**: when `BACKUP_ENCRYPTION_PASSPHRASE` is set, the archive and checksum are encrypted with `openssl` (`aes-256-cbc` + `pbkdf2`). The passphrase is read **only from the environment** — no secrets are hard-coded. When unset, the script logs and proceeds unencrypted.
- **Retention**: a `BACKUP_RETENTION_COUNT` (default 30) policy prunes the oldest S3 backups after a successful upload.
- **Conditional cleanup**: local artifacts are removed only after a verified, successful upload (the existing `set -e` aborts before cleanup on failure).

`infrastructure/backup/Dockerfile` now installs `openssl` and `coreutils` (for `stat`/`sha256sum`).

A new regression check, `infrastructure/backup/test_backup.sh`, statically validates the script (`bash -n`) and asserts the presence of each hardening feature.

## Testing limitations

The regression script only performs **static** validation (`bash -n` syntax check + feature grep). It does **not** execute a real `pg_dump`, `mongodump`, or `aws s3` upload because this environment has no database, S3 credentials, or network access. The runtime path (encryption, upload verification, retention prune) should be validated in an environment with a real PostgreSQL instance and S3 bucket before relying on it in production.

## Environment configuration

| Variable | Default | Purpose |
| --- | --- | --- |
| `BACKUP_RETENTION_COUNT` | `30` | Number of newest backups to keep in S3 |
| `BACKUP_ENCRYPTION_PASSPHRASE` | _(unset)_ | Passphrase for OpenSSL encryption; if empty, backups are not encrypted |
