### PR TITLE
fix(security): encode transferKeyOwnership with matching ABI args (#11608)

### DIFF
--- a/backend/api/test/unit/security/keyRotationService.test.js
+++ b/backend/api/test/unit/security/keyRotationService.test.js
@@ -38,7 +38,8 @@ vi.mock('../../../src/config/db.js', () => ({
         eq: vi.fn().mockResolvedValue({ error: null })
       }))
     }))
-  }
+  },
+  supabaseAdmin: { from: vi.fn() },
 }));
 
 vi.mock('../../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
## Summary
Fixes #11608 — on-chain key rotation was failing because `transferKeyOwnership` was encoded with 3 args against a 2-param ABI (`transferKeyOwnership(address newKeyAddress, uint256 nonce)`).

The source-side fix for the ABI mismatch already landed upstream via #11141 (now encoded as `[newWalletAddress, Date.now()]`). This PR was rebuilt on top of current `main` and now contributes the remaining piece: the `config/db.js` mock in the unit test exports `supabaseAdmin` so the mock mirrors the real module exports.

## Changes
- `backend/api/test/unit/security/keyRotationService.test.js` — add `supabaseAdmin: { from }` to the `config/db.js` mock.

## Verification
- `npx vitest run test/unit/security/keyRotationService.test.js` → all pass.
- Branch is rebased on latest `main`; mergeable clean.

## GSSOC
This PR is submitted as part of GSSoC 2025 Extended. Please add the gssoc-ext / gssoc labels.
