### PR TITLE
fix(controllers): remove duplicate existing-document query in uploadDriverDocument (#11609)

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { supabaseAdmin, supabase } from '../config/db.js';
+import { supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import {
   validateDocumentBuffer,
@@ -63,19 +63,6 @@ export async function uploadDriverDocument(req, res) {
       return res.status(400).json({
         error: `documentType must be one of: ${ALLOWED_DOCUMENT_TYPES.join(', ')}`,
       });
-    }
-
-    // Retrieve existing document of the same type for this driver
-    const { data: existingDoc, error: checkError } = await supabase
-      .from('driver_documents')
-      .select('id, storage_path')
-      .eq('driver_id', driverId)
-      .eq('document_type', documentType)
-      .maybeSingle();
-
-    if (checkError) {
-      logger.error('[DocumentController] Failed to query existing document:', checkError.message);
-      return res.status(500).json({ error: 'Failed to verify existing documents' });
     }
 
     let verifiedMimeType;


### PR DESCRIPTION
Fixes #11609

## Summary

`uploadDriverDocument()` queried `driver_documents` **twice** for an existing record of the same type: once via the anon `supabase` client (its result was never used), and once via the service-role `supabaseAdmin` client (the one actually used for supersede-vs-insert). The redundant anon query is dead code and can 500 the whole upload when anon `SELECT` is restricted by RLS.

## Changes

- `backend/api/src/controllers/documentController.js` — removed the redundant anon-`supabase` lookup (and its now-unused import). The single service-role lookup remains the source of truth.

## Verification

`npx vitest run test/unit/controllers/documentController.test.js` → **9/9 passing** (previously 5/9 failing).

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
