### PR TITLE
fix(core): preserve BaseEvent prototype in ContextPropagator enrichment (#11610)

### DIFF
--- a/backend/api/src/core/telemetry/ContextPropagator.js
+++ b/backend/api/src/core/telemetry/ContextPropagator.js
@@ -46,7 +46,13 @@ export class ContextPropagator {
     if (!event) return event;
 
     const serialized = TraceContext.serialize();
-    const enriched = { ...event };
+    // Preserve the event's prototype (e.g. BaseEvent getters such as
+    // eventType/eventId) — a plain `{ ...event }` spread drops them, so
+    // subscribers would receive events where event.eventType is undefined.
+    const enriched = Object.assign(
+      Object.create(Object.getPrototypeOf(event)),
+      event
+    );
 
     if (enriched.metadata && typeof enriched.metadata === 'object') {
       enriched.metadata = {


### PR DESCRIPTION
Fixes #11610

## Summary

`ContextPropagator.injectIntoEventPayload()` rebuilt the event with a shallow spread (`{ ...event }`), which dropped the `BaseEvent` prototype getters — subscribers received a plain object where `event.eventType`, `event.eventId`, `event.source` are `undefined` — and replaced the `EventMetadata` instance with a plain object.

## Changes

- `backend/api/src/core/telemetry/ContextPropagator.js` — enrich the event via `Object.assign(Object.create(Object.getPrototypeOf(event)), event)` so the class shape (and its getters) is preserved. Behavior for plain `{ metadata, payload }` events is unchanged.

## Verification

- `npx vitest run test/unit/core/eventBus.test.js` → passes (was 1 failing: "should publish and receive BaseEvent instances").
- `npx vitest run test/unit/core/telemetry test/unit/core/eventBus.test.js test/unit/core/backwardCompat.test.js` → **133/133 passing**.

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
