### PR TITLE
fix(blockchain): scope escalation alert ids to the booking and fix test wiring (#11611)

### DIFF
--- a/backend/api/src/services/blockchain/escalationHandler.js
+++ b/backend/api/src/services/blockchain/escalationHandler.js
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import logger from '../../middleware/logger.js';
 import * as Sentry from '@sentry/node';
 import { supabase, supabaseAdmin } from '../../config/db.js';
@@ -179,8 +180,10 @@ class EscalationHandler {
   }
 
   generateAlertId(alert) {
-    const key = [alert.type, alert.driver || alert.wallet || alert.shipmentId || 'unknown'].join('_');
-    return Buffer.from(key).toString('hex').slice(0, 16);
+    const actor = alert.driver || alert.wallet || 'unknown';
+    const scopedId = alert.shipmentId || alert.orderId || alert.bookingId || '';
+    const key = [alert.type, actor, scopedId].join('_');
+    return createHash('sha256').update(key).digest('hex').slice(0, 16);
   }
 
   async storeEscalation(record) {

--- a/backend/api/test/unit/escalationHandler.test.js
+++ b/backend/api/test/unit/escalationHandler.test.js
@@ -11,11 +11,11 @@ const mockLogger = {
   error: vi.fn(),
 };
 
-vi.mock('../../middleware/logger.js', () => ({
+vi.mock('../../src/middleware/logger.js', () => ({
   default: mockLogger,
 }));
 
-const { default: EscalationHandler, ESCALATION_LEVELS, ESCALATION_THRESHOLDS } = require('../../src/services/blockchain/escalationHandler.js');
+const { default: EscalationHandler, ESCALATION_LEVELS, ESCALATION_THRESHOLDS } = await import('../../src/services/blockchain/escalationHandler.js');
 
 describe('EscalationHandler', () => {
   let handler;


### PR DESCRIPTION
Fixes #11611

## Summary

`EscalationHandler.generateAlertId()` built the dedup id from only `type` + actor and truncated it to 8 bytes, so **distinct** alerts of the same type for the same driver (e.g. two `PAYMENT_RELEASED` events for different bookings) produced the same id — the second was silently dropped as "already being tracked" and never escalated.

## Changes

- `backend/api/src/services/blockchain/escalationHandler.js`
  - `generateAlertId` now includes the booking-scoped identity (`shipmentId` / `orderId` / `bookingId`) and hashes the key (SHA-256, 16 hex chars) so the actor/order differentiation actually survives — the old 8-byte `Buffer` truncation collapsed any two keys sharing a long type prefix.
- `backend/api/test/unit/escalationHandler.test.js`
  - import the ESM service with `await import(...)` instead of `require(...)`, which bypassed `vi.mock`;
  - fixed the logger mock path (`../../src/middleware/logger.js`) — the old path didn't match the module the service imports, so the mocked logger was never used.

## Verification

`npx vitest run test/unit/escalationHandler.test.js` → **2/2 passing** (previously 2/2 failing).

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
