### PR TITLE
test(unit): fix stale fraud-detection marker in middleware order guard (#11612)

### DIFF
--- a/backend/api/test/unit/middlewareOrder.test.js
+++ b/backend/api/test/unit/middlewareOrder.test.js
@@ -32,7 +32,7 @@ const REQUIRED_BEFORE_ROUTES = [
   // Fraud detection is deliberately registered per-route (after authenticate)
   // for the high-value orders/payments/trips routers — see #6321 — so the
   // marker locks in that mount rather than a global registration.
-  { name: 'fraud detection', marker: "app.use('/api/orders', fraudDetectionMiddleware" },
+  { name: 'fraud detection', marker: "app.use('/api/orders', authenticate, fraudDetectionMiddleware" },
   { name: 'global rate limiter', marker: "app.use('/api/', globalLimiter)" },
 ];
 


### PR DESCRIPTION
Fixes #11612

## Summary

`middlewareOrder.test.js` guards the Express middleware registration order by scanning `src/index.js` for markers. The fraud-detection marker was stale: it searched for `app.use('/api/orders', fraudDetectionMiddleware` but the file registers `app.use('/api/orders', authenticate, fraudDetectionMiddleware, networkAnalysisMiddleware, orderRoutes)`. The marker matched zero times, so the guard falsely reported that fraud detection was missing.

## Changes

- `backend/api/test/unit/middlewareOrder.test.js` — updated the marker to `app.use('/api/orders', authenticate, fraudDetectionMiddleware`, matching the actual per-route registration documented in the test's own comment.

## Verification

`npx vitest run test/unit/middlewareOrder.test.js` → **12/12 passing** (previously 2 failing).

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
