### PR TITLE
test(unit): wire maintenance-photo RPC tests to the per-user client mock (#11614)

### DIFF
--- a/backend/api/test/unit/maintenancePhotoController.test.js
+++ b/backend/api/test/unit/maintenancePhotoController.test.js
@@ -104,26 +104,26 @@ describe('maintenancePhotoController', () => {
   });
 
   it('returns 400 and cleans up storage when the RPC reports MAX_PHOTOS_EXCEEDED', async () => {
-    dbMock.supabase.from.mockReturnValue({
+    dbMock.userClient.from.mockReturnValue({
       select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { id: 't1', driver_id: 'driver-1', photo_urls: [] }, error: null }) })) })),
     });
-    dbMock.supabase.rpc.mockResolvedValue({ data: null, error: { message: 'MAX_PHOTOS_EXCEEDED' } });
+    dbMock.userClient.rpc.mockResolvedValue({ data: null, error: { message: 'MAX_PHOTOS_EXCEEDED' } });
     const { req, res } = makeReqRes({ files: [{ buffer: Buffer.from('a'), mimetype: 'image/jpeg' }] });
     await uploadMaintenancePhotos(req, res);
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('Maximum 3') }));
-    expect(dbMock.supabase.storage.from).toHaveBeenCalledWith('maintenance-photos');
+    expect(dbMock.userClient.storage.from).toHaveBeenCalledWith('maintenance-photos');
   });
 
   it('returns 500 and cleans up storage when the RPC fails unexpectedly', async () => {
-    dbMock.supabase.from.mockReturnValue({
+    dbMock.userClient.from.mockReturnValue({
       select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { id: 't1', driver_id: 'driver-1', photo_urls: [] }, error: null }) })) })),
     });
-    dbMock.supabase.rpc.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+    dbMock.userClient.rpc.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
     const { req, res } = makeReqRes({ files: [{ buffer: Buffer.from('a'), mimetype: 'image/jpeg' }] });
     await uploadMaintenancePhotos(req, res);
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Failed to save photo references' }));
-    expect(dbMock.supabase.storage.from).toHaveBeenCalledWith('maintenance-photos');
+    expect(dbMock.userClient.storage.from).toHaveBeenCalledWith('maintenance-photos');
   });
 });


### PR DESCRIPTION
Fixes #11614

## Summary

Two tests in `maintenancePhotoController.test.js` (`returns 400 ... MAX_PHOTOS_EXCEEDED` and `returns 500 ... RPC fails unexpectedly`) stubbed the query/RPC/storage on `dbMock.supabase`, but the controller runs every statement through `createUserClient(req.token)` — the per-user RLS client (the shared anon client is denied by RLS). The controller read undefined mocks and `res.status` was never called with the expected codes.

## Changes

- `backend/api/test/unit/maintenancePhotoController.test.js` — point the ticket query, `append_maintenance_photos` RPC and `maintenance-photos` storage assertions at `dbMock.userClient`, matching the already-passing tests (404/403/200).

## Verification

`npx vitest run test/unit/maintenancePhotoController.test.js` → **9/9 passing** (previously 2 failing).

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
