### PR TITLE
test(unit): expect fail-closed UNSUPPORTED from syncAndTransmitInternalWeights (#11617)

### DIFF
--- a/backend/api/test/unit/weighStationService.test.js
+++ b/backend/api/test/unit/weighStationService.test.js
@@ -32,7 +32,7 @@ describe('Weigh Station Service', () => {
   });
 
   describe('syncAndTransmitInternalWeights', () => {
-    it('returns BYPASS for completely legal weights', async () => {
+    it('fails closed as UNSUPPORTED instead of fabricating a BYPASS verdict', async () => {
       // 50 PSI * 250 + 5000 = 17,500 lbs (Well under 34k tandem max and 80k gross)
       const axles = [
         { position: 'steer', pressure_psi: 30 }, // 30 * 250 + 5000 = 12500
@@ -42,12 +42,12 @@ describe('Weigh Station Service', () => {
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
 
-      expect(result.action).toBe('BYPASS');
-      expect(result.gross_weight_lbs).toBe(47500);
-      expect(result.axles.length).toBe(3);
+      expect(result.action).toBe('UNSUPPORTED');
+      expect(result.supported).toBe(false);
+      expect(result.stationId).toBeNull();
     });
 
-    it('returns PULL_IN if a single axle is overweight', async () => {
+    it('does not fabricate a PULL_IN verdict for an overweight axle', async () => {
       // 120 PSI * 250 + 5000 = 35,000 lbs (Over 34k tandem limit)
       const axles = [
         { position: 'steer', pressure_psi: 30 },
@@ -57,11 +57,11 @@ describe('Weigh Station Service', () => {
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
 
-      expect(result.action).toBe('PULL_IN');
-      expect(result.reason).toContain('Axle drive overweight');
+      expect(['BYPASS', 'PULL_IN']).not.toContain(result.action);
+      expect(result.action).toBe('UNSUPPORTED');
     });
 
-    it('returns PULL_IN if gross weight is overweight', async () => {
+    it('reports that no WIM provider is configured and returns an ISO timestamp', async () => {
       // 110 PSI * 250 + 5000 = 32,500 lbs each * 3 = 97,500 lbs (Over 80k gross limit)
       const axles = [
         { position: 'steer', pressure_psi: 110 },
@@ -71,9 +71,9 @@ describe('Weigh Station Service', () => {
 
       const result = await syncAndTransmitInternalWeights('driver-1', 'truck-1', axles);
 
-      expect(result.action).toBe('PULL_IN');
-      expect(result.reason).toContain('Gross weight overweight');
-      expect(result.gross_weight_lbs).toBe(97500);
+      expect(result.action).toBe('UNSUPPORTED');
+      expect(result.reason).toContain('no WIM provider');
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
   });
 });


### PR DESCRIPTION
Fixes #11617

## Summary

Three tests in `weighStationService.test.js` still asserted the fabricated regulatory verdicts (`BYPASS` / `PULL_IN` and computed `gross_weight_lbs`) that the service previously produced with `Math.random()`. The service now **fails closed** — with no Drivewyze/PrePass WIM provider integrated, `syncAndTransmitInternalWeights` returns `{ action: 'UNSUPPORTED', supported: false }` and explicitly refuses to produce a regulatory verdict. The tests never run against the real provider API, so they were asserting behavior the service can no longer (and should no longer) produce.

## Changes

- `backend/api/test/unit/weighStationService.test.js`
  - "returns BYPASS for completely legal weights" → asserts the fail-closed `UNSUPPORTED` contract.
  - "returns PULL_IN if a single axle is overweight" → asserts no `BYPASS`/`PULL_IN` is fabricated for an overweight axle.
  - "returns PULL_IN if gross weight is overweight" → asserts the `UNSUPPORTED` reason names the missing WIM provider and returns an ISO timestamp.

## Verification

`npx vitest run test/unit/weighStationService.test.js` → **6/6 passing** (previously 3 failing).

## GSSOC

This PR is submitted as part of **GSSoC 2025 Extended**. Please add the `gssoc-ext` / `gssoc` labels.
