### PR TITLE
fix(api): export isSecureCookieConfig validator helper and expand cookie security tests

### DIFF
--- a/backend/api/src/middleware/cookieSecurityValidator.js
+++ b/backend/api/src/middleware/cookieSecurityValidator.js
@@ -39,3 +39,10 @@ function validateCookies(req, value) {
     );
   }
 }
+
+export function isSecureCookieConfig(cookieHeader) {
+  if (!cookieHeader || typeof cookieHeader !== 'string') return false;
+  const lower = cookieHeader.toLowerCase();
+  return RECOMMENDED_ATTRIBUTES.every((attr) => lower.includes(attr.toLowerCase()));
+}
+

--- a/backend/api/test/unit/cookieSecurityValidator.test.js
+++ b/backend/api/test/unit/cookieSecurityValidator.test.js
@@ -102,4 +102,18 @@ describe('cookieSecurityValidator', () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
+
+  describe('isSecureCookieConfig', () => {
+    it('returns true when all attributes are present', async () => {
+      const { isSecureCookieConfig } = await import('../../src/middleware/cookieSecurityValidator.js');
+      expect(isSecureCookieConfig('session=123; HttpOnly; Secure; SameSite=Strict; Path=/')).toBe(true);
+    });
+
+    it('returns false when any recommended attribute is missing', async () => {
+      const { isSecureCookieConfig } = await import('../../src/middleware/cookieSecurityValidator.js');
+      expect(isSecureCookieConfig('session=123; Path=/')).toBe(false);
+      expect(isSecureCookieConfig(null)).toBe(false);
+    });
+  });
 });
+


### PR DESCRIPTION
### Summary
Exported `isSecureCookieConfig` helper function in `cookieSecurityValidator.js` and expanded unit test coverage to validate security flags (`HttpOnly`, `SameSite`, `Path`, `Secure`).

### Motivation
Downstream authentication middleware and route handlers require a lightweight helper to verify cookie string security attributes programmatically before emitting response headers.

### Changes
- Modified `backend/api/src/middleware/cookieSecurityValidator.js`: Exported `isSecureCookieConfig(cookieHeader)` validator helper function.
- Modified `backend/api/test/unit/cookieSecurityValidator.test.js`: Added unit tests verifying `isSecureCookieConfig` true/false assertions across complete and partial cookie headers.

### Acceptance Criteria
- [x] `isSecureCookieConfig` helper exported and validated
- [x] Unit test suite updated and 100% passing

### How to Test
```bash
export PATH="/home/itsmaestro/.nvm/versions/node/v22.23.2/bin:$PATH"
cd backend/api
npx vitest run test/unit/cookieSecurityValidator.test.js
```
