### PR TITLE
fix(api): support SECURE_HSTS_PRELOAD option in securityHeaders middleware

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -39,9 +39,11 @@ export default function securityHeaders(req, res, next) {
   // Enforce HTTPS for sensitive headers
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
     if (!res.getHeader('Strict-Transport-Security')) {
-      res.setHeader('Strict-Transport-Security', `max-age=${resolveHstsMaxAge()}; includeSubDomains`);
+      const preload = process.env.SECURE_HSTS_PRELOAD === 'true' ? '; preload' : '';
+      res.setHeader('Strict-Transport-Security', `max-age=${resolveHstsMaxAge()}; includeSubDomains${preload}`);
     }
   }
+
 
   // Control referrer information
   if (!res.getHeader('Referrer-Policy')) {

--- a/backend/api/test/unit/securityHeadersHsts.test.js
+++ b/backend/api/test/unit/securityHeadersHsts.test.js
@@ -63,4 +63,13 @@ describe('securityHeaders HSTS max-age', () => {
     securityHeaders(req, res, next);
     expect(res._headers['strict-transport-security']).toBeUndefined();
   });
+
+  it('includes preload flag when SECURE_HSTS_PRELOAD is true', () => {
+    process.env.SECURE_HSTS_PRELOAD = 'true';
+    const { req, res, next } = makeMocks();
+    securityHeaders(req, res, next);
+    expect(res._headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains; preload');
+    delete process.env.SECURE_HSTS_PRELOAD;
+  });
 });
+


### PR DESCRIPTION
### Summary
Added support for `SECURE_HSTS_PRELOAD` configuration flag in `securityHeaders.js` middleware to permit appending `; preload` directive to Strict-Transport-Security headers.

### Motivation
Deployments configured for HSTS preload list submission require appending `; preload` directive to `Strict-Transport-Security` headers on HTTPS connections.

### Changes
- Modified `backend/api/src/middleware/securityHeaders.js`: Check `process.env.SECURE_HSTS_PRELOAD === 'true'` and conditionally append `; preload`.
- Modified `backend/api/test/unit/securityHeadersHsts.test.js`: Added unit test asserting `; preload` directive emission.

### Acceptance Criteria
- [x] `SECURE_HSTS_PRELOAD` flag support added
- [x] Unit test suite updated and 100% passing (6/6)

### How to Test
```bash
export PATH="/home/itsmaestro/.nvm/versions/node/v22.23.2/bin:$PATH"
cd backend/api
npx vitest run test/unit/securityHeadersHsts.test.js
```
