### PR TITLE
fix(api): export generateOtpSecret helper and expand OTP unit test coverage

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -58,3 +58,11 @@ export function verifyOtpHash(otp, otpRecord) {
   }
   return false;
 }
+
+export function generateOtpSecret(length = 6) {
+  const len = Math.max(4, Math.min(10, Number(length) || 6));
+  const min = Math.pow(10, len - 1);
+  const max = Math.pow(10, len) - 1;
+  return String(crypto.randomInt(min, max + 1));
+}
+

--- a/backend/api/test/unit/otpHashing.test.js
+++ b/backend/api/test/unit/otpHashing.test.js
@@ -1,7 +1,22 @@
-import { hashOtp, verifyOtpHash } from '../../src/lib/otpHashing.js';
+import { hashOtp, verifyOtpHash, generateOtpSecret } from '../../src/lib/otpHashing.js';
 import crypto from 'crypto';
 
 describe('otpHashing', () => {
+  describe('generateOtpSecret', () => {
+    it('generates a numeric string of requested length', () => {
+      const otp6 = generateOtpSecret(6);
+      expect(otp6).toMatch(/^\d{6}$/);
+
+      const otp4 = generateOtpSecret(4);
+      expect(otp4).toMatch(/^\d{4}$/);
+    });
+
+    it('clamps requested length within bounds [4, 10]', () => {
+      expect(generateOtpSecret(2)).toMatch(/^\d{4}$/);
+      expect(generateOtpSecret(20)).toMatch(/^\d{10}$/);
+    });
+  });
+
   describe('hashOtp', () => {
     it('generates different hashes and salts for the same OTP', () => {
       const otp = '123456';


### PR DESCRIPTION
### Summary
Exported `generateOtpSecret(length)` helper function in `otpHashing.js` to securely generate numeric OTP strings with cryptographic random integer bounds.

### Motivation
OTP authentication flows require a cryptographically secure random number generator helper that produces bounded numeric OTP secrets without bias.

### Changes
- Modified `backend/api/src/lib/otpHashing.js`: Exported `generateOtpSecret(length = 6)` using `crypto.randomInt`.
- Modified `backend/api/test/unit/otpHashing.test.js`: Added unit test suite asserting numeric formatting and length clamping `[4, 10]`.

### Acceptance Criteria
- [x] `generateOtpSecret` helper exported and validated
- [x] Unit test suite updated and 100% passing (17/17)

### How to Test
```bash
export PATH="/home/itsmaestro/.nvm/versions/node/v22.23.2/bin:$PATH"
cd backend/api
npx vitest run test/unit/otpHashing.test.js
```
