### PR TITLE
fix(api): export isValidUploadFilename validator helper in uploadFilename

### DIFF
--- a/backend/api/src/lib/uploadFilename.js
+++ b/backend/api/src/lib/uploadFilename.js
@@ -80,3 +80,12 @@ export function sanitizeUploadFilename(originalName, fallback = 'upload') {
 
   return name;
 }
+
+export function isValidUploadFilename(filename) {
+  if (typeof filename !== 'string' || filename.length === 0 || filename.length > MAX_FILENAME_LENGTH) {
+    return false;
+  }
+  const sanitized = sanitizeUploadFilename(filename, '__INVALID__');
+  return sanitized === filename && sanitized !== '__INVALID__';
+}
+

--- a/backend/api/test/unit/uploadFilename.test.js
+++ b/backend/api/test/unit/uploadFilename.test.js
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
+import { sanitizeUploadFilename, isValidUploadFilename } from '../../src/lib/uploadFilename.js';
 
-describe('sanitizeUploadFilename', () => {
-  it('returns original name when safe', () => {
-    expect(sanitizeUploadFilename('document.pdf', 'default')).toBe('document.pdf');
-  });
+describe('uploadFilename', () => {
+  describe('sanitizeUploadFilename', () => {
+    it('returns original name when safe', () => {
+      expect(sanitizeUploadFilename('document.pdf', 'default')).toBe('document.pdf');
+    });
+
 
   it('strips directory traversal sequences', () => {
     // Only the basename survives directory stripping; traversal segments are
@@ -61,3 +63,18 @@ describe('sanitizeUploadFilename', () => {
     expect(sanitizeUploadFilename('file...name.pdf', 'default')).toBe('file.name.pdf');
   });
 });
+
+  describe('isValidUploadFilename', () => {
+    it('returns true for safe filenames', () => {
+      expect(isValidUploadFilename('document.pdf')).toBe(true);
+      expect(isValidUploadFilename('driver_license_2026.png')).toBe(true);
+    });
+
+    it('returns false for unsafe or traversal filenames', () => {
+      expect(isValidUploadFilename('../../../etc/passwd')).toBe(false);
+      expect(isValidUploadFilename('CON.pdf')).toBe(false);
+      expect(isValidUploadFilename(null)).toBe(false);
+    });
+  });
+});
+


### PR DESCRIPTION
### Summary
Exported `isValidUploadFilename(filename)` helper function in `uploadFilename.js` to validate upload filenames against path traversal, control character, and reserved device name rules.

### Motivation
File upload endpoints (verification documents, maintenance photos, audio attachments) require a boolean validator helper to inspect client-supplied filenames prior to saving or logging.

### Changes
- Modified `backend/api/src/lib/uploadFilename.js`: Exported `isValidUploadFilename(filename)` helper function.
- Modified `backend/api/test/unit/uploadFilename.test.js`: Added unit tests asserting true/false validation on safe and unsafe filenames.

### Acceptance Criteria
- [x] `isValidUploadFilename` helper exported and validated
- [x] Unit test suite updated and 100% passing (13/13)

### How to Test
```bash
export PATH="/home/itsmaestro/.nvm/versions/node/v22.23.2/bin:$PATH"
cd backend/api
npx vitest run test/unit/uploadFilename.test.js
```
