### PR TITLE
fix(api): stop cross-user GPS fallback in getDriverLocation (#11548)

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -429,9 +429,14 @@ class WebRTCSignalingServer {
       return [];
     }
     // Rows are keyed by the owning profile id (matches the `peerId =
-    // get_profile_id()` RLS policy); resolve it from the active peer session
-    // and fall back to the caller's own id.
-    const ownerId = this.peers.get(peerId)?.userId || requestingUser.id;
+    // get_profile_id()` RLS policy). Resolve it strictly from the live peer
+    // session: a missing peer must be treated as not-found rather than
+    // silently scoped to the requester's own id.
+    const ownerId = this.peers.get(peerId)?.userId;
+    if (!ownerId) {
+      logger.warn(`[WebRTC] Offline GPS data requested for unknown peer ${peerId}`);
+      return [];
+    }
     const client = requestingUser.role === 'admin' ? supabaseAdmin : (token ? createUserClient(token) : supabase);
     const { data } = await client
       .from('gps_offline_data')
@@ -448,7 +453,11 @@ class WebRTCSignalingServer {
       logger.warn(`[WebRTC] Unauthorized sync offline data attempt for peer ${peerId}`);
       return;
     }
-    const ownerId = this.peers.get(peerId)?.userId || requestingUser.id;
+    const ownerId = this.peers.get(peerId)?.userId;
+    if (!ownerId) {
+      logger.warn(`[WebRTC] Sync requested for unknown peer ${peerId}`);
+      return;
+    }
     const client = requestingUser.role === 'admin' ? supabaseAdmin : (token ? createUserClient(token) : supabase);
     // Mark data as synced for this peer
     await client

--- a/backend/api/test/unit/WebRTCSignalingServer.test.js
+++ b/backend/api/test/unit/WebRTCSignalingServer.test.js
@@ -444,6 +444,40 @@ describe('WebRTCSignalingServer', () => {
     });
   });
 
+  describe('getOfflineGPSData()/syncOfflineData() missing-peer isolation (#11548)', () => {
+    it('never falls back to the requester id for an admin with a disconnected peer', async () => {
+      // The peer is absent from the in-memory registry (driver socket dropped),
+      // so a cross-user fallback to the requester id must be prevented.
+      const result = await server.getOfflineGPSData('peer-gone', 0, {
+        id: 'admin-1',
+        role: 'admin',
+      });
+
+      expect(result).toEqual([]);
+      expect(supabaseMock.from).not.toHaveBeenCalled();
+      expect(supabaseQuery.eq).not.toHaveBeenCalledWith('peerId', 'admin-1');
+    });
+
+    it('does not mutate rows for an admin when the peer is missing', async () => {
+      await server.syncOfflineData('peer-gone', { id: 'admin-1', role: 'admin' });
+
+      expect(supabaseMock.from).not.toHaveBeenCalled();
+    });
+
+    it('still scopes to the owner id when the peer is present', async () => {
+      addPeer(server, 'peer-1', { userId: 'user-1' });
+      supabaseQuery.order.mockResolvedValue({ data: [{ peerId: 'user-1' }] });
+
+      const result = await server.getOfflineGPSData('peer-1', 0, {
+        id: 'admin-1',
+        role: 'admin',
+      });
+
+      expect(supabaseQuery.eq).toHaveBeenCalledWith('peerId', 'user-1');
+      expect(result).toEqual([{ peerId: 'user-1' }]);
+    });
+  });
+
   describe('handleGPSData() persistence', () => {
     it('keys the offline GPS row by the owning profile id, not the session peerId', async () => {
       addPeer(server, 'peer-1', { userId: 'user-1' });


### PR DESCRIPTION
## Problem
In WebRTCSignalingServer.getOfflineGPSData() and syncOfflineData(), when a peer is absent from the live in-memory peer registry the code fell back to `requestingUser.id` as the owner id. An admin (or any caller) could thereby read/modify another driver's offline GPS data simply by passing a disconnected peer id.

## Fix
Resolve the owner id strictly from the live peer session. If the peer is unknown, return an empty result (and skip the mutation) instead of silently scoping the query to the requester's own id. This removes the cross-user fallback path entirely.

## Files changed
- backend/api/src/services/webrtc/WebRTCSignalingServer.js
- backend/api/test/unit/WebRTCSignalingServer.test.js

## Testing
- Unit test added: a disconnected-peer request now returns [] and never hits supabase; an extant peer is still scoped to its owner id.
- (Node test suite not executed locally — no node_modules in worktree.)

Closes #11548
