### PR TITLE
fix(n8n): report real rollback result in ml-rollback alert (#11553)

### DIFF
--- a/automation/n8n/ml-rollback-workflow.json
+++ b/automation/n8n/ml-rollback-workflow.json
@@ -121,8 +121,59 @@
         1000,
         -100
       ],
+      "onError": "continueRegularOutput",
       "id": "execute-rollback",
       "name": "Execute Rollback"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "combinator": "and",
+          "conditions": [
+            {
+              "leftValue": "={{$json.statusCode}}",
+              "operator": {
+                "type": "number",
+                "operation": "gte",
+                "value": 200
+              }
+            },
+            {
+              "leftValue": "={{$json.statusCode}}",
+              "operator": {
+                "type": "number",
+                "operation": "lt",
+                "value": 300
+              }
+            }
+          ]
+        }
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1200,
+        -100
+      ],
+      "id": "rollback-http-ok",
+      "name": "Rollback Succeeded?"
+    },
+    {
+      "parameters": {
+        "toEmail": "ml-alerts@truxify.org",
+        "subject": "❌ ML Model Rollback FAILED: {{$node[\"Decision\"].json.test_id}}",
+        "htmlFormat": true,
+        "message": "<h3>ML Model Auto-Rollback FAILED</h3><p>Auto-rollback could not be completed for test ID: <strong>{{$node[\"Decision\"].json.test_id}}</strong> (degradation {{$node[\"Decision\"].json.degradation}}).</p><p>The rollback endpoint returned a non-success response (status: {{$node[\"Execute Rollback\"].json.statusCode}}).</p><p>Previous stable model baseline may NOT have been restored. Manual intervention required.</p>",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1.1,
+      "position": [
+        1400,
+        0
+      ],
+      "id": "send-failure-alert",
+      "name": "Send Failure Alert"
     },
     {
       "parameters": {
@@ -202,7 +253,25 @@
       "main": [
         [
           {
+            "node": "rollback-http-ok",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "rollback-http-ok": {
+      "main": [
+        [
+          {
             "node": "send-alert",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "send-failure-alert",
             "type": "main",
             "index": 0
           }

--- a/automation/n8n/validate_ml_rollback.py
+++ b/automation/n8n/validate_ml_rollback.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Regression check for ml-rollback-workflow.json (issue #11553).
+
+n8n has no unit-test framework, so this standalone validator asserts the
+structural invariants of the fix: the rollback HTTP response status must be
+checked by an IF node before any alert is sent, and a failure alert must exist
+for the non-success branch.
+
+Run: python automation/n8n/validate_ml_rollback.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parent / "ml-rollback-workflow.json"
+
+EXPECTED_IF_NODE = "rollback-http-ok"
+SUCCESS_ALERT = "send-alert"
+FAILURE_ALERT = "send-failure-alert"
+ROLLBACK_NODE = "execute-rollback"
+
+
+def main() -> int:
+    data = json.loads(WORKFLOW.read_text())
+    nodes = {n["id"]: n for n in data["nodes"]}
+    connections = data["connections"]
+
+    errors = []
+
+    if EXPECTED_IF_NODE not in nodes:
+        errors.append("missing IF node '%s' that checks rollback HTTP status" % EXPECTED_IF_NODE)
+
+    if FAILURE_ALERT not in nodes:
+        errors.append("missing failure alert node '%s'" % FAILURE_ALERT)
+
+    # Execute Rollback must NOT directly feed the success alert.
+    rollback_targets = [
+        c["node"]
+        for branch in connections.get(ROLLBACK_NODE, {}).get("main", [])
+        for c in (branch or [])
+    ]
+    if SUCCESS_ALERT in rollback_targets:
+        errors.append("'%s' still reports success directly from '%s' (status not checked)" % (SUCCESS_ALERT, ROLLBACK_NODE))
+
+    # The status-check IF node must feed both a success and a failure alert.
+    if EXPECTED_IF_NODE in connections:
+        if_node_conns = connections[EXPECTED_IF_NODE]["main"]
+        true_targets = [c["node"] for c in (if_node_conns[0] or [])]
+        false_targets = [c["node"] for c in (if_node_conns[1] or [])]
+        if SUCCESS_ALERT not in true_targets:
+            errors.append("success alert not wired to the true (2xx) branch of '%s'" % EXPECTED_IF_NODE)
+        if FAILURE_ALERT not in false_targets:
+            errors.append("failure alert not wired to the false (non-2xx) branch of '%s'" % EXPECTED_IF_NODE)
+
+    if errors:
+        for e in errors:
+            print("FAIL: %s" % e)
+        return 1
+
+    print("PASS: ml-rollback reports real rollback result (status-checked alert branches)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem
The ml-rollback n8n workflow wired the rollback HTTP node directly to the success ("model rolled back") alert. If the rollback endpoint returned a non-2xx status, operators were still notified that the rollback succeeded, masking a failed restore.

## Fix
Added an IF node ("Rollback Succeeded?") that checks the rollback response statusCode is in 2xx. The success alert is now driven only by the true branch, and a dedicated failure alert ("Send Failure Alert") is sent on the false branch. The rollback node also uses `onError: continueRegularOutput` so the status is inspectable.

## Files changed
- automation/n8n/ml-rollback-workflow.json
- automation/n8n/validate_ml_rollback.py (new regression validator)

## Testing
- Standalone Python validator asserts: the IF status node exists, a failure alert node exists, the success alert is no longer fed directly from the rollback node, and the IF node wires the success alert to its true branch and the failure alert to its false branch.
- (n8n has no unit-test runner; validator covers the structural contract.)

Closes #11553


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rollback processing now distinguishes successful and failed HTTP responses.
  * Failed rollbacks trigger a dedicated failure notification, while successful rollbacks retain the existing alert flow.

* **Tests**
  * Added automated validation to verify rollback routing, status checks, and success/failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->