### PR TITLE
fix(python): fix 4000-char window in check-definer-search-path.py (#11554)

### DIFF
--- a/scripts/check-definer-search-path.py
+++ b/scripts/check-definer-search-path.py
@@ -31,8 +31,10 @@ def main() -> int:
         sql = open(path, encoding="utf-8", errors="replace").read()
 
         for match in FUNC_RE.finditer(sql):
-            # The header is everything before the `AS $$` body marker.
-            header = BODY_RE.split(sql[match.start() : match.start() + 4000])[0]
+            # The header is everything before the `AS $$` body marker. Search the
+            # whole remainder of the file so that long function definitions (whose
+            # header exceeds 4000 chars) are not truncated and misclassified.
+            header = BODY_RE.split(sql[match.start() :])[0]
             latest[match.group(1)] = (
                 os.path.basename(path),
                 bool(re.search(r"security\s+definer", header, re.I)),

--- a/scripts/test_check_definer_search_path.py
+++ b/scripts/test_check_definer_search_path.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Regression tests for scripts/check-definer-search-path.py.
+
+Reproduces #11554: a SECURITY DEFINER function whose declaration header is
+longer than 4000 characters must still be recognised as pinning its
+search_path (the old code only inspected the first 4000 chars of the
+definition).
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "check-definer-search-path.py")
+
+
+def _run(tmp_path, sql: str) -> int:
+    migrations = tmp_path / "supabase" / "migrations"
+    migrations.mkdir(parents=True)
+    (migrations / "0001_long_func.sql").write_text(sql, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, SCRIPT],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    ).returncode
+
+
+def _long_header(prefix: str) -> str:
+    # Pad the declaration with comment lines so the header exceeds 4000 chars
+    # and the `SET search_path` clause lands well past the old 4000-char window.
+    padding = "\n".join(f"-- padding line {i:04d} for issue #11554" for i in range(120))
+    return textwrap.dedent(
+        f"""
+        create or replace function public.very_long_function({prefix})
+        returns void
+        language plpgsql
+        {padding}
+        security definer
+        set search_path = public, pg_temp
+        as $$
+        begin
+            null;
+        end;
+        $$ language plpgsql;
+        """
+    )
+
+
+def test_long_function_with_search_path_passes(tmp_path):
+    sql = _long_header("arg1 int, arg2 int, arg3 int")
+    assert _run(tmp_path, sql) == 0
+
+
+def test_long_function_without_search_path_fails(tmp_path):
+    # Same length, but no `SET search_path` -> correctly flagged.
+    padding = "\n".join(f"-- padding line {i:04d} for issue #11554" for i in range(120))
+    sql = textwrap.dedent(
+        f"""
+        create or replace function public.very_long_unpinned(arg1 int, arg2 int, arg3 int)
+        returns void
+        language plpgsql
+        {padding}
+        security definer
+        as $$
+        begin
+            null;
+        end;
+        $$ language plpgsql;
+        """
+    )
+    assert _run(tmp_path, sql) == 1
+
+
+def test_short_function_with_search_path_passes(tmp_path):
+    sql = textwrap.dedent(
+        """
+        create or replace function public.short_func()
+        returns void
+        language plpgsql
+        security definer
+        set search_path = public, pg_temp
+        as $$
+        begin
+            null;
+        end;
+        $$ language plpgsql;
+        """
+    )
+    assert _run(tmp_path, sql) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem
scripts/check-definer-search-path.py only inspected the first 4000 characters of each function definition when locating the `AS $$` body marker. For SECURITY DEFINER functions whose declaration header is longer than 4000 chars, the header was truncated and functions that correctly pin `SET search_path` were misclassified (or missed), defeating the search_path audit.

## Fix
Search the entire remainder of the file (from the match start) for the `AS $$` body marker instead of a fixed 4000-char window, so long function headers are parsed correctly.

## Files changed
- scripts/check-definer-search-path.py
- scripts/test_check_definer_search_path.py (new regression tests)

## Testing
- pytest regression tests: a >4000-char header function WITH search_path now passes (exit 0); one WITHOUT search_path still fails (exit 1); short functions unchanged.

Closes #11554
