### PR TITLE
fix(settlement): mark dispatched withdrawals terminal after bounded settle retries

### DIFF
--- a/backend/api/src/workers/withdrawalSettlementWorker.js
+++ b/backend/api/src/workers/withdrawalSettlementWorker.js
@@ -123,7 +123,7 @@ export async function settlePendingWithdrawals() {
 
   const { data: withdrawals, error } = await supabaseAdmin
     .from("wallet_transactions")
-    .select("id, driver_id, amount, payout_attempted_at, settlement_ref")
+      .select("id, driver_id, amount, payout_attempted_at, settlement_ref, settle_attempts")
     .eq("txn_type", "withdrawal")
     .eq("status", "pending")
     .is("settled_at", null)
@@ -209,9 +209,35 @@ export async function settlePendingWithdrawals() {
         `[WithdrawalSettlementWorker] Settled withdrawal ${withdrawal.id} (ref: ${settlementRef}).`,
       );
     } catch (err) {
+      // The payout has already left the platform (payout_attempted_at is set),
+      // so funds must NEVER be restored. Instead we bound the retries: once the
+      // per-row settle attempt count exceeds the limit we mark the row terminal
+      // (settlement_failed) so it is excluded from the next sweep, and emit a
+      // one-time alert for manual reconciliation (issue #11395).
+      const attempts = (withdrawal.settle_attempts || 0) + 1;
+      const terminal = attempts >= SETTLE_RETRY_ATTEMPTS;
+
       logger.error(
-        `[WithdrawalSettlementWorker] Settlement of withdrawal ${withdrawal.id} deferred — payout already dispatched, funds NOT restored: ${err.message}`,
+        `[WithdrawalSettlementWorker] Settlement of withdrawal ${withdrawal.id} ${terminal ? "FAILED TERMINALLY" : "deferred"} — payout already dispatched, funds NOT restored: ${err.message}`,
       );
+
+      const { error: recErr } = await supabaseAdmin.rpc("record_settle_failure", {
+        p_withdrawal_id: withdrawal.id,
+        p_error: String(err.message || "Unknown error").slice(0, 1000),
+        p_terminal: terminal,
+      });
+
+      if (recErr) {
+        logger.error(
+          `[WithdrawalSettlementWorker] Failed to record settle failure for ${withdrawal.id}: ${recErr.message}`,
+        );
+      } else if (terminal) {
+        // One-time terminal alert — the row is now settlement_failed and will
+        // no longer be selected by the pending sweep.
+        logger.error(
+          `[WithdrawalSettlementWorker] ALERT: withdrawal ${withdrawal.id} marked settlement_failed after ${attempts} settle attempts — manual reconciliation required (payout already dispatched).`,
+        );
+      }
     }
   }
 }

--- a/supabase/migrations/20260813000000_withdrawal_settlement_terminal.sql
+++ b/supabase/migrations/20260813000000_withdrawal_settlement_terminal.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- Withdrawal settlement: terminal failure after bounded settle retries (Issue #11395)
+-- -----------------------------------------------------------------------------
+-- Problem:
+--   The dispatch-failure path is fail-closed (fail_withdrawal_tx restores
+--   funds), but the settle-failure path only logged and left the row at
+--   status='pending'. Because the sweep re-selects `status='pending' AND
+--   settled_at IS NULL`, an already-dispatched withdrawal whose on-chain settle
+--   permanently fails was retried forever, every minute, and never resolved.
+--
+-- Fix:
+--   Track a per-row settle attempt count and, after SETTLE_RETRY_ATTEMPTS
+--   failed settle cycles, transition the row to the terminal `settlement_failed`
+--   status. `settlement_failed` is excluded by the existing sweep predicate
+--   (status='pending'), so the row is no longer retried. Funds are NEVER
+--   restored because the payout already left the platform. A one-time terminal
+--   alert is emitted by the worker when the row transitions to terminal.
+-- =============================================================================
+
+-- 1. Per-row settle attempt counter.
+ALTER TABLE wallet_transactions
+  ADD COLUMN IF NOT EXISTS settle_attempts integer NOT NULL DEFAULT 0;
+
+-- 2. Record a settle failure. When p_terminal is true the row is moved to the
+--    terminal `settlement_failed` status; otherwise only the error and attempt
+--    counter are updated and the row stays retryable. Funds are never restored
+--    because the payout was already dispatched. Idempotent: only matches rows
+--    still in 'pending', so a terminal row is not re-touched.
+CREATE OR REPLACE FUNCTION record_settle_failure(
+  p_withdrawal_id uuid,
+  p_error text,
+  p_terminal boolean
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_driver_id uuid;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only the backend service can record settlement failures';
+  END IF;
+
+  SELECT driver_id
+    INTO v_driver_id
+  FROM wallet_transactions
+  WHERE id = p_withdrawal_id
+    AND txn_type = 'withdrawal'
+    AND status = 'pending'
+  FOR UPDATE;
+
+  IF v_driver_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_terminal THEN
+    UPDATE wallet_transactions
+    SET status = 'settlement_failed',
+        settlement_error = left(p_error, 1000),
+        settle_attempts = settle_attempts + 1
+    WHERE id = p_withdrawal_id
+      AND txn_type = 'withdrawal'
+      AND status = 'pending';
+  ELSE
+    UPDATE wallet_transactions
+    SET settlement_error = left(p_error, 1000),
+        settle_attempts = settle_attempts + 1
+    WHERE id = p_withdrawal_id
+      AND txn_type = 'withdrawal'
+      AND status = 'pending';
+  END IF;
+
+  RETURN true;
+END;
+$$;


### PR DESCRIPTION
## Problem

`withdrawalSettlementWorker` is fail-closed on dispatch failure (`fail_withdrawal_tx` restores funds), but the **settle**-failure path only logged and left the row at `status='pending'`. The per-minute sweep re-selects `status='pending' AND settled_at IS NULL`, so an already-dispatched withdrawal whose on-chain settle permanently fails was retried **forever, every minute** — the record never reached a terminal state, flooding logs/alerts and never resolving in reconciliation.

## Fix

- Added a per-row `settle_attempts` counter on `wallet_transactions`.
- Added RPC `record_settle_failure(p_withdrawal_id, p_error, p_terminal)`. When `p_terminal` is true it transitions the row to the terminal `settlement_failed` status (funds are **never** restored because the payout already left the platform); otherwise it only records the error and increments the counter, keeping the row retryable. It only matches `status='pending'`, so a terminal row is not re-touched.
- The worker now increments the attempt count each failed settle cycle and, once `settle_attempts >= SETTLE_RETRY_ATTEMPTS`, marks the row terminal. Because `settlement_failed` is excluded by the existing sweep predicate (`status='pending'`), the row is no longer re-selected. A one-time terminal alert is emitted on the transition (naturally once, since the row won't be selected again).

## Files changed

- `backend/api/src/workers/withdrawalSettlementWorker.js`
- `supabase/migrations/20260813000000_withdrawal_settlement_terminal.sql` (new: `settle_attempts` column + `record_settle_failure` RPC)

## Testing

Regression test approach (SQL): apply the migration, then in a transaction (1) insert a `pending` withdrawal with `payout_attempted_at` set, (2) call `settle_withdrawal_tx` failing repeatedly / call `record_settle_failure(..., false)` up to `SETTLE_RETRY_ATTEMPTS-1` times and assert the row stays `pending`, (3) call `record_settle_failure(..., true)` on the next failure and assert status becomes `settlement_failed` and that it is no longer returned by the `status='pending' AND settled_at IS NULL` sweep query. Verify `settle_attempts` increments and that the row is excluded from the sweep.

Closes #11395
