### PR TITLE
fix(cuda): use great-circle distance in meters for VRP cost (#11549)

### DIFF
--- a/services/gpu-routing-cuda/src/cuda_vrp.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp.cu
@@ -6,11 +6,25 @@
 namespace TruxifyCuda {
 
 namespace {
-// Euclidean distance between two locations.
+// Mean Earth radius (meters) for the great-circle approximation.
+constexpr float kEarthRadiusMeters = 6371000.0f;
+constexpr float kDeg2Rad = 3.14159265358979323846f / 180.0f;
+
+// Great-circle (haversine) distance in meters between two geographic
+// locations. `Location.x` is longitude (degrees) and `Location.y` is
+// latitude (degrees); both are converted to radians before the haversine
+// formula is applied. This replaces the previous Euclidean-on-degrees
+// metric, which treated one degree of longitude equal to one degree of
+// latitude and ignored meridian convergence.
 float distance(const Location& a, const Location& b) {
-    float dx = b.x - a.x;
-    float dy = b.y - a.y;
-    return std::sqrt(dx * dx + dy * dy);
+    float lat1 = a.y * kDeg2Rad;
+    float lat2 = b.y * kDeg2Rad;
+    float dLat = (b.y - a.y) * kDeg2Rad;
+    float dLng = (b.x - a.x) * kDeg2Rad;
+    float h = std::sin(dLat * 0.5f) * std::sin(dLat * 0.5f) +
+              std::cos(lat1) * std::cos(lat2) *
+                  std::sin(dLng * 0.5f) * std::sin(dLng * 0.5f);
+    return 2.0f * kEarthRadiusMeters * std::asin(std::sqrt(h));
 }
 } // namespace
 

--- a/services/gpu-routing-cuda/src/cuda_vrp_tests.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp_tests.cu
@@ -19,6 +19,46 @@ static float approx(float a, float b) {
     return std::fabs(a - b) < 1e-4f;
 }
 
+// Relative comparison used for great-circle distances, which are large (meters).
+static bool approxRel(float a, float b, float tol) {
+    float denom = std::fabs(a) > 1e-6f ? std::fabs(a) : 1.0f;
+    return std::fabs(a - b) / denom < tol;
+}
+
+// Independent (double-precision) reference haversine in meters. `x` is
+// longitude, `y` is latitude, both in degrees. Used to validate the CUDA
+// implementation and to guard against regressing to a Euclidean metric.
+static const double kPi = 3.14159265358979323846;
+static const double kEarthRadiusM = 6371000.0;
+
+static double refHaversine(double lat1, double lng1, double lat2, double lng2) {
+    double dLat = (lat2 - lat1) * kPi / 180.0;
+    double dLng = (lng2 - lng1) * kPi / 180.0;
+    double a = std::sin(dLat / 2.0) * std::sin(dLat / 2.0) +
+               std::cos(lat1 * kPi / 180.0) * std::cos(lat2 * kPi / 180.0) *
+                   std::sin(dLng / 2.0) * std::sin(dLng / 2.0);
+    return 2.0 * kEarthRadiusM * std::asin(std::sqrt(a));
+}
+
+// Reference great-circle total tour distance mirroring solveParallelVRP's
+// capacity-bounded routing, so the routing-logic assertions stay meaningful
+// under the new metric.
+static float refTourTotal(const Location& depot,
+                          const std::vector<Location>& stops,
+                          size_t cap) {
+    double tot = 0.0;
+    for (size_t rs = 0; rs < stops.size(); rs += cap) {
+        size_t re = std::min(rs + cap, stops.size());
+        Location prev = depot;
+        for (size_t i = rs; i < re; ++i) {
+            tot += refHaversine(prev.y, prev.x, stops[i].y, stops[i].x);
+            prev = stops[i];
+        }
+        tot += refHaversine(prev.y, prev.x, depot.y, depot.x);
+    }
+    return static_cast<float>(tot);
+}
+
 int main() {
     const Location depot{0.0f, 0.0f};
     const std::vector<Location> stops = {
@@ -44,30 +84,31 @@ int main() {
     }
 
     // capacity >= stops.size(): one out-and-back tour visiting every stop,
-    // 0->1->2->3->0 = 1+1+1+3 = 6.
+    // 0->1->2->3->0 equals the reference great-circle sum.
     {
         VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 3);
         check(s.isValid, "single-route solution is valid");
         check(s.routeCount == 1, "capacity >= n reports one route");
-        check(approx(s.totalDistance, 6.0f), "single-route distance matches tour");
+        check(approxRel(s.totalDistance, refTourTotal(depot, stops, 3), 1e-3f),
+              "single-route distance matches great-circle tour");
     }
 
-    // capacity == 1: each stop is its own depot out-and-back route;
-    // (1+1) + (2+2) + (3+3) = 12.
+    // capacity == 1: each stop is its own depot out-and-back route.
     {
         VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 1);
         check(s.isValid, "capacity 1 solution is valid");
         check(s.routeCount == 3, "capacity 1 reports one route per stop");
-        check(approx(s.totalDistance, 12.0f), "capacity 1 distance sums per-route tours");
+        check(approxRel(s.totalDistance, refTourTotal(depot, stops, 1), 1e-3f),
+              "capacity 1 distance sums per-route great-circle tours");
     }
 
-    // capacity == 2: routes [1,2] and [3];
-    // (0->1->2->0) + (0->3->0) = (1+1+2) + (3+3) = 10.
+    // capacity == 2: routes [1,2] and [3].
     {
         VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 2);
         check(s.isValid, "capacity 2 solution is valid");
         check(s.routeCount == 2, "capacity 2 reports ceil(3/2) = 2 routes");
-        check(approx(s.totalDistance, 10.0f), "capacity 2 distance sums both route tours");
+        check(approxRel(s.totalDistance, refTourTotal(depot, stops, 2), 1e-3f),
+              "capacity 2 distance sums both route tours");
     }
 
     // Consistency: the reported distance must equal the sum of the reported
@@ -75,7 +116,47 @@ int main() {
     {
         VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(depot, stops, 2);
         check(s.routeCount == 2, "consistency test: two routes reported");
-        check(!approx(s.totalDistance, 6.0f), "consistency: distance differs from single tour");
+        check(!approxRel(s.totalDistance, refTourTotal(depot, stops, 3), 1e-3f),
+              "consistency: distance differs from single tour");
+    }
+
+    // Regression test for #11549: distance() must compute great-circle meters
+    // on lat/lng inputs, not Euclidean degrees. Validated against a reference
+    // haversine for known city pairs (within 1%) and shown to differ sharply
+    // from the old Euclidean metric.
+    {
+        // (longitude, latitude) in degrees.
+        const Location newYork{-74.0060f, 40.7128f};
+        const Location london{-0.1278f, 51.5074f};
+        const Location paris{2.3522f, 48.8566f};
+
+        double refNY_London = refHaversine(newYork.y, newYork.x, london.y, london.x);
+        double refLondon_Paris = refHaversine(london.y, london.x, paris.y, paris.x);
+
+        // Reference great-circle distances are well known: NY-London ~5570 km,
+        // London-Paris ~344 km.
+        check(approxRel(static_cast<float>(refNY_London), 5570000.0f, 0.05),
+              "reference NY-London ~5,570 km");
+        check(approxRel(static_cast<float>(refLondon_Paris), 344000.0f, 0.05),
+              "reference London-Paris ~344 km");
+
+        std::vector<Location> cityStops = {london, paris};
+        VrpSolution s = TruxifyCuda::CudaVrpSolver::solveParallelVRP(newYork, cityStops, 2);
+        double refTour = refHaversine(newYork.y, newYork.x, london.y, london.x) +
+                         refHaversine(london.y, london.x, paris.y, paris.x) +
+                         refHaversine(paris.y, paris.x, newYork.y, newYork.x);
+
+        check(approxRel(s.totalDistance, static_cast<float>(refTour), 0.01f),
+              "VRP tour distance matches great-circle reference (<1% error)");
+
+        // The old Euclidean-on-degrees metric would report a value on the order
+        // of a few tens of degrees (near-zero), not thousands of kilometers.
+        // Guard against regressing to it.
+        double euclideanDeg = std::sqrt(std::pow(static_cast<double>(london.x - newYork.x), 2.0) +
+                                        std::pow(static_cast<double>(london.y - newYork.y), 2.0));
+        check(s.totalDistance > 1.0e6f, "distance is in meters (>> Euclidean degree value)");
+        check(s.totalDistance > 1000.0 * static_cast<float>(euclideanDeg),
+              "great-circle distance far exceeds Euclidean degree distance");
     }
 
     if (failures == 0) {


### PR DESCRIPTION
## Problem
The VRP cost function in `services/gpu-routing-cuda/src/cuda_vrp.cu` computed the per-leg distance with a plain Euclidean metric directly on raw latitude/longitude **degree** coordinates:

```cpp
float dx = b.x - a.x;
float dy = b.y - a.y;
return std::sqrt(dx * dx + dy * dy);
```

This is not a valid ground distance. One degree of longitude is much shorter than one degree of latitude except at the equator, and meridian convergence is ignored entirely. As a result the VRP optimizer's cost model was biased (e.g. long east-west legs were weighted identically to north-south legs of the same degree count), distorting route selection.

## Fix
Replaced `distance()` with a great-circle (haversine) implementation that:
- Converts latitude/longitude from degrees to radians up front (`kDeg2Rad`).
- Uses `Location.x` as longitude and `Location.y` as latitude.
- Applies the haversine formula with mean Earth radius `R ≈ 6371000.0 m`, returning **meters** instead of degree-units.

The routing logic (`solveParallelVRP`) is unchanged; only the cost metric was corrected.

## Files changed
- `services/gpu-routing-cuda/src/cuda_vrp.cu` — `distance()` now computes great-circle distance in meters.
- `services/gpu-routing-cuda/src/cuda_vrp_tests.cu` — updated existing host test harness:
  - Added a double-precision reference haversine and a reference great-circle tour total.
  - Re-based routing assertions on the reference metric.
  - Added a #11549 regression test that validates the implementation against well-known city pairs (New York–London ≈ 5,570 km, London–Paris ≈ 344 km) within 1% and guards against regressing to the Euclidean-degrees metric.

## Testing
- Existing routing tests (capacity 0 rejected, empty stops, capacity >= n, capacity 1, capacity 2, multi-route consistency) were re-based onto the great-circle metric and pass logically.
- New regression test asserts the computed tour distance matches a reference haversine within 1% and that the result is in meters (far larger than any raw-degree Euclidean value).
- Note: tests were written but not compiled locally because the CUDA toolchain is not available in this environment. They compile as a host executable (`gpu_vrp_tests` via the existing CMake target) and require no GPU device at runtime since the solver is host-side code.

Closes #11549
