### PR TITLE
fix(api): clamp fraud risk scores to valid [0, 100] range

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -100,3 +100,18 @@ export const networkAnalysisMiddleware = async (req, res, next) => {
     });
   }
 };
+
+
+// === Spec 13: ===
+// === Spec 13: clamp fraud risk score [0, 100] ===
+export function clampRiskScore(v) {
+  if (!Number.isFinite(v)) return 0;
+  if (v < 0) return 0;
+  if (v > 100) return 100;
+  return v;
+}
+export function accumulateRisk(weights) {
+  if (!Array.isArray(weights)) return 0;
+  return clampRiskScore(weights.reduce((a, w) => a + (Number.isFinite(w) ? w : 0), 0));
+}
+

--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -93,3 +93,18 @@ describe('fraudMiddleware', () => {
     });
   });
 });
+
+
+// === Spec 13 test ===
+import { describe, it, expect } from 'vitest';
+import { clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
+describe('clampRiskScore', () => {
+  it('50 passes', () => { expect(clampRiskScore(50)).toBe(50); });
+  it('150 → 100', () => { expect(clampRiskScore(150)).toBe(100); });
+  it('NaN → 0', () => { expect(clampRiskScore(NaN)).toBe(0); });
+});
+describe('accumulateRisk', () => {
+  it('sums', () => { expect(accumulateRisk([10, 20, 30])).toBe(60); });
+  it('clamps', () => { expect(accumulateRisk([60, 50, 40])).toBe(100); });
+});
+


### PR DESCRIPTION
## Spec 13

**Problem:** Accumulated risk point weights can exceed 100 or drop below 0.

**Solution:** Math clamp risk calculations to bounds `[0, 100]`.

**Verification:** ``cd backend/api && npx vitest run test/unit/fraudMiddleware.test.js``

Closes spec #13