### PR TITLE
fix(eventsourcing): optimize event store query memory footprint

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -627,3 +627,18 @@ class EventStore {
 
 export default new EventStore();
 export { EventStore, EventStoreVersionConflictError, EventStorePersistenceError };
+
+
+// === Spec 38: ===
+// === Spec 38: stream cursor ===
+export async function* iterateEventsInChunks(client, n = 100) {
+  let off = 0;
+  while (true) {
+    const r = await client.query('SELECT * FROM events ORDER BY sequence_nr LIMIT $1 OFFSET $2', [n, off]);
+    if (!r || r.length === 0) break;
+    for (const x of r) yield x;
+    if (r.length < n) break;
+    off += n;
+  }
+}
+

--- a/backend/eventsourcing/test_divergence.js
+++ b/backend/eventsourcing/test_divergence.js
@@ -26,3 +26,15 @@ assert.strictEqual(logs.length, 1);
 assert.strictEqual(logs[0].gapSize, 3);
 
 console.log('✅ Divergence Detector tests passed successfully.');
+
+
+// === Spec 38 test ===
+import { describe, it, expect } from 'vitest';
+import { iterateEventsInChunks } from '../../event-store.js';
+describe('iterateEventsInChunks', () => {
+  it('async iterator', () => {
+    const c = { query: async () => [] };
+    expect(typeof iterateEventsInChunks(c, 10)[Symbol.asyncIterator]).toBe('function');
+  });
+});
+


### PR DESCRIPTION
## Spec 38

**Problem:** Fetching full event history loads thousands of objects into RAM at once.

**Solution:** Implement stream cursor iterator for processing historical events in chunks.

**Verification:** ``cd backend/eventsourcing && node test_divergence.js``

Closes spec #38