### PR TITLE
fix(sync-engine): clear queue on any 2xx and dead-letter exhausted retries

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -13,6 +13,10 @@ class SyncEngine {
   static Database? _db;
   static bool _isSyncing = false;
 
+  /// Maximum number of failed sync attempts before an event is dead-lettered
+  /// so it is never re-POSTed indefinitely.
+  static const int maxRetries = 5;
+
   /// Backend base URL, injected at build time via --dart-define.
   /// Mirrors ApiClient so this service never bakes in a hardcoded
   /// cleartext host (previously `http://10.0.2.2:5000`).
@@ -38,7 +42,7 @@ class SyncEngine {
 
     return await openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE sync_queue (
@@ -46,9 +50,19 @@ class SyncEngine {
             trip_id TEXT,
             event_type TEXT NOT NULL,
             payload TEXT NOT NULL,
-            occurred_at TEXT NOT NULL
+            occurred_at TEXT NOT NULL,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            state TEXT NOT NULL DEFAULT 'pending'
           )
         ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute(
+              "ALTER TABLE sync_queue ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0");
+          await db.execute(
+              "ALTER TABLE sync_queue ADD COLUMN state TEXT NOT NULL DEFAULT 'pending'");
+        }
       },
     );
   }
@@ -69,6 +83,8 @@ class SyncEngine {
       'event_type': eventType,
       'payload': jsonEncode(payload),
       'occurred_at': occurredAt,
+      'retry_count': 0,
+      'state': 'pending',
     });
 
     debugPrint('[SyncEngine] Queued $eventType for trip $tripId.');
@@ -88,7 +104,11 @@ class SyncEngine {
       if (connectivityResults.contains(ConnectivityResult.none)) return;
 
       final db = await database;
-      final events = await db.query('sync_queue', orderBy: 'occurred_at ASC');
+      final events = await db.query(
+        'sync_queue',
+        where: "state = 'pending'",
+        orderBy: 'occurred_at ASC',
+      );
       if (events.isEmpty) return;
 
       final user = FirebaseAuth.instance.currentUser;
@@ -120,8 +140,10 @@ class SyncEngine {
         body: jsonEncode(requestBody),
       );
 
-      if (response.statusCode == 202) {
-        // Successfully synced, clear the queue
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        // Successfully synced, clear the queue. Any 2xx is treated as success
+        // (the backend returns 200 for an empty batch and 202 otherwise), so a
+        // 200 does not leave the events in the queue for duplicate re-delivery.
         final eventIds = events.map((e) => e['id']).toList();
         await db.delete(
           'sync_queue',
@@ -131,6 +153,18 @@ class SyncEngine {
         debugPrint('[SyncEngine] Successfully synced ${events.length} events.');
       } else {
         debugPrint('[SyncEngine] Sync failed with status ${response.statusCode}');
+        // Increment the per-event retry counter and dead-letter events that
+        // have exhausted their attempts so they are never re-POSTed forever.
+        final failedIds = events.map((e) => e['id']).toList();
+        await db.rawUpdate(
+          'UPDATE sync_queue SET retry_count = retry_count + 1 WHERE id IN (${List.filled(failedIds.length, '?').join(',')})',
+          failedIds,
+        );
+        await db.rawUpdate(
+          "UPDATE sync_queue SET state = 'dead_lettered' WHERE retry_count >= $maxRetries AND state = 'pending'",
+        );
+        debugPrint(
+            '[SyncEngine] Sync failed, marked ${failedIds.length} events for retry (max $maxRetries attempts).');
       }
     } catch (e) {
       debugPrint('[SyncEngine] Sync exception: $e');


### PR DESCRIPTION
## Problem

`apps/driver/lib/services/sync_engine.dart` `attemptSync()` only deleted the synced local rows when the backend returned exactly HTTP `202`. A `200` (which the backend returns for a successfully processed batch) fell into the `else` branch, so the events were never removed from the local queue and were re-POSTed on every connectivity change. There was also no per-event retry cap, so a permanently failing event looped forever.

## Fix

- Treat the whole `2xx` family as success so any 2xx clears the synced batch from the local `sync_queue`.
- Added a `retry_count` column (with a schema migration to version 2) and a `state` column.
- Failed batches now increment `retry_count` per event; events that exceed `maxRetries` (5) are moved to a `dead_lettered` state and are no longer re-POSTed.
- `attemptSync()` only selects events still in the `pending` state.

## Files changed

- `apps/driver/lib/services/sync_engine.dart`

## Testing

- No automated tests added: the service is a static class backed by sqflite/firebase/connectivity plugins and Flutter is not available in this environment. Manual reasoning: a `200`/`202` response now clears the queue, failures increment `retry_count`, and events past `maxRetries` move to `dead_lettered`.

Closes #11709
