### PR TITLE
fix(cancel): render missing fee as no cancellation fee

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -16,6 +16,13 @@ import '../theme/app_theme.dart';
 import '../constants/supabase_config.dart';
 import '../services/supabase_service.dart';
 import '../widgets/common_widgets.dart';
+
+/// Shared cancellation-fee parser so the preview and confirm flows treat a
+/// missing fee identically (both must render "no fee", never "₹0.00 charged").
+double? parseFeeRupees(dynamic raw) {
+  return raw is num ? raw / 100 : null;
+}
+
 class LiveTrackingScreen extends StatefulWidget {
   final String orderId;
   final OrderService? orderService;
@@ -725,9 +732,10 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
 
   Future<void> _showCancel() async {
     bool isLoading = false;
-    final rawFee = _order?['cancellation_fee'];
-    final feeInRupees = rawFee is num ? rawFee / 100 : null;
-    String? feeText = feeInRupees != null ? 'Cancellation fee ₹${feeInRupees.toStringAsFixed(2)}' : null;
+    final feeInRupees = parseFeeRupees(_order?['cancellation_fee']);
+    String? feeText = feeInRupees != null
+        ? 'Cancellation fee ₹${feeInRupees.toStringAsFixed(2)}'
+        : 'No cancellation fee';
 
     await showModalBottomSheet<void>(
       context: context,
@@ -759,12 +767,14 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
                           setModalState(() => isLoading = true);
                           try {
                             final resp = await _orderService.cancelOrder(orderDisplayId: widget.orderId);
-                            final rawFee = resp['cancellation_fee'];
-                            final feeInRupees = rawFee is num ? rawFee / 100 : 0;
+                            final feeInRupees = parseFeeRupees(resp['cancellation_fee']);
                             await _loadOrder();
                             if (!context.mounted) return;
                             Navigator.of(context).pop();
-                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Order cancelled. Fee: ₹${feeInRupees.toStringAsFixed(2)}')));
+                            final feeMsg = feeInRupees != null
+                                ? 'Order cancelled. Fee: ₹${feeInRupees.toStringAsFixed(2)}'
+                                : 'Order cancelled. No cancellation fee.';
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(feeMsg)));
                           } catch (e) {
                             setModalState(() => isLoading = false);
                             if (!context.mounted) return;


### PR DESCRIPTION
## Problem

The cancel flow in `live_tracking_screen.dart` handled a missing `cancellation_fee` inconsistently. The preview parsed `rawFee is num ? rawFee / 100 : null` (showing "Cancellation fee calculating..."), while the confirmed-cancel path used `rawFee is num ? rawFee / 100 : 0` and showed "Order cancelled. Fee: ₹0.00" — falsely implying a zero-rupee fee was levied.

## Fix

- Extracted a shared helper `double? parseFeeRupees(dynamic raw)` that returns `null` for null/non-numeric input.
- Both the preview and confirm paths now use it, so a missing fee renders as "No cancellation fee" in the preview and "Order cancelled. No cancellation fee." in the success snackbar — never ₹0.00.

## Files changed

- apps/customer/lib/screens/live_tracking_screen.dart

## Testing

Validated by inspection. A test asserting a null fee renders as "no fee" in both paths requires the Flutter SDK, which is not available in this environment.

Closes #11710


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation fee handling during live tracking.
  * Displays “No cancellation fee” when the fee is unavailable or invalid.
  * Post-cancellation messages now clearly distinguish between charged fees and no fee, instead of showing ₹0.00 for missing amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->