### PR TITLE
fix(trip-detail): cancel gps connection status subscription

### DIFF
--- a/apps/driver/lib/screens/trip_detail_screen.dart
+++ b/apps/driver/lib/screens/trip_detail_screen.dart
@@ -35,6 +35,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
   // ── GPS tracking for active trips ──────────────────────────────────
   final GpsTrackingService _gpsTracking = GpsTrackingService();
   WsConnectionStatus _wsStatus = WsConnectionStatus.disconnected;
+  StreamSubscription<WsConnectionStatus>? _wsStatusSubscription;
 
   /// Statuses that require live GPS emission.
   static const _activeStatuses = {
@@ -56,6 +57,10 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
   @override
   void dispose() {
     _connectivitySubscription.cancel();
+    // Cancel the broadcast-stream listener so it never outlives the widget
+    // and retains the disposed State (issue #11711).
+    _wsStatusSubscription?.cancel();
+    _wsStatusSubscription = null;
     _mapController.dispose();
     // Disconnect WebSocket to prevent memory/battery leaks on screen exit.
     _gpsTracking.stop();
@@ -66,7 +71,7 @@ class _TripDetailScreenState extends State<TripDetailScreen> {
   void _maybeStartGpsTracking() {
     if (!_activeStatuses.contains(widget.trip.status)) return;
 
-    _gpsTracking.connectionStatus.listen((status) {
+    _wsStatusSubscription = _gpsTracking.connectionStatus.listen((status) {
       if (mounted) setState(() => _wsStatus = status);
     });
 


### PR DESCRIPTION
## Problem

`TripDetailScreen._maybeStartGpsTracking()` subscribed to the shared `connectionStatus` broadcast stream without storing the returned `StreamSubscription`, and it was never cancelled in `dispose()`. Every screen open added a listener that outlived the widget, retaining the disposed `State` object and accumulating redundant work on the singleton-owned stream.

## Fix

Stored the subscription in a `_wsStatusSubscription` field and cancel it in `dispose()` (alongside the existing connectivity subscription cancel), so no listener outlives the widget.

## Files changed

- apps/driver/lib/screens/trip_detail_screen.dart

## Testing

Validated by inspection. A `tester`-based test asserting the stream listener count does not grow across open/close cycles requires the Flutter SDK, which is not available in this environment.

Closes #11711
