### PR TITLE
fix(conflict): key pod metadata per stop

### DIFF
--- a/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
+++ b/apps/customer/lib/core/offline/conflict/conflict_resolver.dart
@@ -34,7 +34,7 @@ class ConflictResolver {
     final stopByTripStop = <String, TripEvent>{};
     final lifecycleByTrip = <String, TripEvent>{};
     final routeEvents = <TripEvent>[];
-    final podByTrip = <String, TripEvent>{};
+    final podByTripStop = <String, TripEvent>{};
 
     for (final event in sorted) {
       switch (event.type) {
@@ -53,8 +53,12 @@ class ConflictResolver {
           stopByTripStop.putIfAbsent(key, () => event);
           break;
         case 'podMetadata':
-          final key = event.tripId;
-          podByTrip[key] = _mergePodMetadata(podByTrip[key], event);
+          // Key per stop (like stopArrival), not per trip: a multi-stop trip
+          // shares one tripId, so a trip-level key collapsed every stop's POD
+          // into a single event, overwriting occurredAt with the last-merged
+          // stop and losing each stop's attachment boundaries (#11713).
+          final key = '${event.tripId}:${event.payload['stopId']}';
+          podByTripStop[key] = _mergePodMetadata(podByTripStop[key], event);
           break;
         case 'routeDeviation':
           routeEvents.add(event);
@@ -74,7 +78,7 @@ class ConflictResolver {
       ...gpsByTrip.values,
       ...otpByStop.values,
       ...stopByTripStop.values,
-      ...podByTrip.values,
+      ...podByTripStop.values,
       ...routeEvents,
       ...lifecycleByTrip.values,
     ]


### PR DESCRIPTION
## Problem

`conflict_resolver.dart` merged proof-of-delivery metadata only at the trip level: `podByTrip` was keyed by `tripId`, so for a multi-stop trip every stop's `podMetadata` event collapsed into a single event, and `_mergePodMetadata` overwrote `occurredAt` with the last-merged stop's timestamp, losing each stop's individual POD timing and per-stop attachment boundaries.

## Fix

Key POD events by `tripId:stopId` — matching the sibling `stopArrival` case — so each stop survives as a distinct resolved event with its own `occurredAt`, while attachments still merge within a stop.

## Files changed

- apps/customer/lib/core/offline/conflict/conflict_resolver.dart

## Testing

Validated by inspection. A two-stop test asserting both stops survive resolution with distinct timestamps requires the Flutter SDK, which is not available in this environment.

Closes #11713
