### PR TITLE
fix(eta): round total before splitting hours and minutes

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -47,8 +47,11 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
 
   String _formatEta(double etaMinutes) {
     if (etaMinutes <= 0) return '0 mins';
-    final hrs = etaMinutes ~/ 60;
-    final mins = (etaMinutes % 60).round();
+    // Round the total first, then split, so the minutes component can never
+    // reach 60 (e.g. 119.9 -> 2 hrs, not "1 hrs 60 mins").
+    final totalMinutes = etaMinutes.round();
+    final hrs = totalMinutes ~/ 60;
+    final mins = totalMinutes % 60;
     if (hrs > 0) {
       if (mins > 0) {
         return '$hrs hrs $mins mins';


### PR DESCRIPTION
## Problem

`_formatEta` in `order_detail_screen.dart` rounded hours and minutes independently (`hrs = etaMinutes ~/ 60`, `mins = (etaMinutes % 60).round()`), so the minutes component could reach 60. For example `119.9` produced `"1 hrs 60 mins"` and `179.9` produced `"2 hrs 60 mins"`.

## Fix

Round the total first, then split:

```dart
final totalMinutes = etaMinutes.round();
final hrs = totalMinutes ~/ 60;
final mins = totalMinutes % 60;
```

This guarantees `0 <= mins <= 59`; `119.9` now renders as `"2 hrs"`.

## Files changed

- apps/customer/lib/screens/order_detail_screen.dart

## Testing

Validated by inspection: 119.9 -> "2 hrs", 179.9 -> "3 hrs", 60 -> "1 hrs", 120 -> "2 hrs". Unit tests for those boundaries require the Flutter SDK, which is not available in this environment.

Closes #11714
