### PR TITLE
fix(location): let in-app throttle own ping cadence

### DIFF
--- a/apps/driver/lib/services/location_service.dart
+++ b/apps/driver/lib/services/location_service.dart
@@ -200,7 +200,12 @@ class LocationService {
     _positionSubscription = Geolocator.getPositionStream(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.high,
-        distanceFilter: 10, // Geolocator filters to 10m minimum movement
+        // No platform-level distance gate: distanceFilter 10 matched
+        // _minDistanceMeters (10.0), so the in-app distance condition was
+        // always satisfied and the 5s time throttle was never the controlling
+        // factor. Letting the platform emit every fix lets the throttle below
+        // own the cadence (issue #11715).
+        distanceFilter: 0,
       ),
     ).listen(
       (position) {
@@ -211,7 +216,8 @@ class LocationService {
       },
     );
 
-    // Fallback timer: ensure a ping is sent at least every 30 seconds
+    // Fallback timer: ensure a ping is sent at least every 5 seconds
+    // (the throttle's _maxInterval), even when the device barely moves.
     _maxIntervalTimer?.cancel();
     _maxIntervalTimer = Timer.periodic(_maxInterval, (_) {
       if (_lastSentPosition != null && _isTracking) {
@@ -245,7 +251,7 @@ class LocationService {
       position.longitude,
     );
 
-    // Send if: moved 15m+ OR max interval (30s) has elapsed
+    // Send if: moved >= 10m OR the 5s max interval has elapsed.
     if (distanceMoved >= _minDistanceMeters ||
         timeSinceLastSend.compareTo(_maxInterval) >= 0) {
       final result = await _sendLocationPing(position);


### PR DESCRIPTION
## Problem

`location_service.dart` defeated its own GPS ping throttle. The position stream was created with `distanceFilter: 10`, which equals `_minDistanceMeters` (10.0), so every platform emission already satisfied the in-app distance condition and the 5s time gate was never the controlling factor. Pings flooded the backend well above the documented cadence. Comments also claimed "15m" and "30s" while the code used 10m and a 5s `_maxInterval`.

## Fix

- Set `distanceFilter: 0` so the platform emits every fix and the in-app throttle (`moved >= 10m OR 5s elapsed`) fully controls cadence.
- Reconciled the stale comments: the send condition now reads "moved >= 10m OR the 5s max interval has elapsed", the fallback timer comment now says "at least every 5 seconds", and the `distanceFilter` comment explains why no platform-level gate is set.

## Files changed

- apps/driver/lib/services/location_service.dart

## Testing

Config + comment change, validated by inspection. A test simulating sub-5s emissions and asserting only one ping per 5s window requires the Flutter SDK, which is not available in this environment.

Closes #11715
