### PR TITLE
fix(supabase): enforce unique outbox versions with row lock

### DIFF
--- a/supabase/migrations/20260810000000_event_outbox_and_read_model.sql
+++ b/supabase/migrations/20260810000000_event_outbox_and_read_model.sql
@@ -74,7 +74,11 @@ create table if not exists event_outbox (
   next_attempt_at timestamptz not null default now(),
   created_at      timestamptz not null default now(),
   published_at    timestamptz,
-  constraint event_outbox_status_check check (status in ('pending', 'publishing', 'published'))
+  constraint event_outbox_status_check check (status in ('pending', 'publishing', 'published')),
+  -- Versions must be strictly sequential per aggregate: this constraint is the
+  -- backstop that makes duplicate (aggregate_id, version) rows impossible even
+  -- if two enqueues race on a brand-new aggregate that has no rows to lock.
+  constraint event_outbox_aggregate_version_unique unique (aggregate_id, version)
 );
 
 create index if not exists idx_event_outbox_dispatch
@@ -137,6 +141,16 @@ begin
       return NEW;
     end if;
   end if;
+
+  -- Serialize concurrent enqueues for the same aggregate: lock the
+  -- aggregate's existing outbox rows so the max(version) + 1 compute below
+  -- is race-free. When no rows exist yet (very first event), the UNIQUE
+  -- (aggregate_id, version) constraint is the backstop and surfaces a
+  -- retryable error on collision (#11716).
+  perform 1
+    from event_outbox
+   where aggregate_id = NEW.id::text
+     for update;
 
   select coalesce(max(version), 0) + 1
     into v_next_version


### PR DESCRIPTION
## Problem

`enqueue_order_event` computed the next outbox version with `select coalesce(max(version), 0) + 1` with no row lock and no `UNIQUE` constraint on `(aggregate_id, version)`. Two concurrent mutations of the same order could read the same `max(version)` and insert two rows with the same version for one aggregate, breaking the ordering guarantee for downstream consumers.

## Fix

- Added a `UNIQUE (aggregate_id, version)` constraint on `event_outbox` — the backstop that makes duplicate versions impossible even for a brand-new aggregate that has no rows to lock yet (the INSERT then surfaces a retryable error).
- Locked the aggregate's outbox rows (`SELECT ... FOR UPDATE`) inside the trigger before computing the next version, serializing concurrent enqueues so `max(version) + 1` is race-free.

## Files changed

- supabase/migrations/20260810000000_event_outbox_and_read_model.sql

## Testing

Change is DDL/PLpgSQL; validated by inspection. A concurrency test firing two simultaneous order updates and asserting no duplicate version exists would need a live Postgres/Supabase instance, which is not available in this environment.

Closes #11716
