### PR TITLE
fix(supabase): lock driver row when recomputing average rating

### DIFF
--- a/supabase/migrations/20260802030000_harden_submit_rating_tx.sql
+++ b/supabase/migrations/20260802030000_harden_submit_rating_tx.sql
@@ -78,6 +78,15 @@ BEGIN
     RAISE EXCEPTION 'Order not found or not eligible for rating: the order must be delivered or payment released, owned by you, and completed by this driver';
   END IF;
 
+  -- Lock the driver row BEFORE inserting/aggregating so concurrent rating
+  -- submissions for the same driver are serialized: without this, each
+  -- transaction computed avg(stars) at its own statement time and the last
+  -- UPDATE clobbered the first, losing a just-inserted row (#11718).
+  PERFORM 1
+    FROM driver_details
+   WHERE user_id = p_driver_id
+     FOR UPDATE;
+
   -- Upsert: first call inserts, subsequent calls replace the rating values.
   INSERT INTO ratings (order_display_id, customer_id, driver_id, stars, comment)
   VALUES (p_order_display_id, p_customer_id, p_driver_id, p_stars, p_comment)


### PR DESCRIPTION
## Problem

`submit_rating_tx` recomputed the driver's average rating with `AVG(stars)` and then updated `driver_details` without locking the driver row, so two concurrent rating submissions for the same driver could produce a lost update and leave an incorrect average.

## Fix

Added a row lock before the ratings insert/aggregate:

```sql
PERFORM 1
  FROM driver_details
 WHERE user_id = p_driver_id
   FOR UPDATE;
```

Concurrent submissions for the same driver now serialize on the lock, so each transaction recomputes the average from a set that includes the previously committed rows.

## Files changed

- supabase/migrations/20260802030000_harden_submit_rating_tx.sql

## Testing

Validated by inspection. A concurrency test asserting two simultaneous ratings yield the correct mean requires a live Postgres/Supabase instance, which is not available in this environment.

Closes #11718
