### PR TITLE
fix(api): remove duplicate outbox relay worker imports

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -32,7 +32,6 @@ import CacheManager from './cache/CacheManager.js'
 import { closeWebSocketServer, initWebSocketServer, __testing as wsTesting } from './sockets/tracker.js'
 import { initLocationServer, closeLocationServer } from './sockets/locationServer.js'
 import { startEscrowReleaseReconciliation, stopEscrowReleaseReconciliation } from './services/escrowReleaseReconciliation.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import { validateEscrowSetup } from './services/escrow.js'
 import digilockerService from './services/digilockerService.js'
 
@@ -163,19 +162,13 @@ import {
   stopDlqWorker,
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
 import EscalationHandler from './services/blockchain/escalationHandler.js'
 import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
-import {
-  startOutboxRelayWorker,
-  stopOutboxRelayWorker,
-} from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 
 // Configuration load from root folder is handled in db.js
 


### PR DESCRIPTION
## Problem

`backend/api/src/index.js` declared `startOutboxRelayWorker, stopOutboxRelayWorker` from `./workers/outboxRelayWorker.js` five times (lines 10, 35, 166, 173-176, 178). Duplicate ES module imports of the same binding throw a `SyntaxError`, so the backend could not start.

## Fix

Removed the four redundant import statements, keeping the single declaration at line 10. The worker is still started exactly once and stopped exactly once.

## Files changed

- backend/api/src/index.js

## Testing

`node --check backend/api/src/index.js` passes. Confirmed exactly one import of `outboxRelayWorker` remains and `startOutboxRelayWorker()` / `stopOutboxRelayWorker()` are each invoked once.

Closes #11721
