### PR TITLE
fix(order): remove duplicate newAmountWei declaration

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -578,7 +578,6 @@ export class OrderLifecycleService {
         // against at deposit time and on release), so it must track
         // total_amount using the same canonical paisa→wei conversion the rest
         // of the escrow pipeline uses.
-        const newAmountWei = paisaToMaticWei(pricing.totalAmount);
         const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount));
 
         const updates = {


### PR DESCRIPTION
## Problem

`orderLifecycleService.js` declared `const newAmountWei` twice in the same scope — `const newAmountWei = paisaToMaticWei(pricing.totalAmount)` and `const newAmountWei = BigInt(paisaToMaticWei(pricing.totalAmount))`. Redeclaring a `const` in the same scope is a `SyntaxError`, so the module could not load.

## Fix

Kept the BigInt-wrapped declaration (`paisaToMaticWei` already returns a bigint; the explicit `BigInt()` wrapper keeps the arithmetic exact) and removed the duplicate.

## Files changed

- backend/api/src/services/order/orderLifecycleService.js

## Testing

`node --check backend/api/src/services/order/orderLifecycleService.js` passes.

Closes #11722
