### PR TITLE
fix(earnings): build chart buckets from UTC midnight

### DIFF
--- a/backend/api/src/services/driver/earningsReportService.js
+++ b/backend/api/src/services/driver/earningsReportService.js
@@ -140,19 +140,27 @@ export function parseDistanceKm(value) {
  */
 export function buildWeeklyChart(trips, { period = 'week', now = new Date() } = {}) {
   const frameDays = period === 'day' ? 1 : period === 'month' ? 30 : 7;
+  // Anchor the frame at UTC midnight so the bucket keys and the trip_date
+  // (YYYY-MM-DD) keys share one zone. The previous code built buckets from
+  // local-time midnight but formatted them via toISOString() (UTC), so on any
+  // non-UTC server the keys shifted by the UTC offset and trips landed in the
+  // wrong day or were dropped entirely (#11723).
+  const anchor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
   const buckets = {};
   for (let i = frameDays - 1; i >= 0; i -= 1) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i);
+    const d = new Date(anchor);
+    d.setUTCDate(d.getUTCDate() - i);
     buckets[toDateKey(d)] = 0;
   }
 
   for (const trip of Array.isArray(trips) ? trips : []) {
-    const tripDate = new Date(trip.trip_date);
-    if (Number.isNaN(tripDate.getTime())) {
+    // trip_date is already the YYYY-MM-DD calendar-day key the column stores;
+    // use it directly (stripping any timestamp) so no time-zone shifting can
+    // mis-bucket a trip.
+    const key = String(trip.trip_date || '').split('T')[0];
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) {
       continue;
     }
-    const key = toDateKey(tripDate);
     if (buckets[key] !== undefined) {
       buckets[key] += toAmount(trip.total_earnings);
     }

--- a/backend/api/test/unit/earningsReportService.test.js
+++ b/backend/api/test/unit/earningsReportService.test.js
@@ -231,6 +231,40 @@ describe('buildWeeklyChart', () => {
     expect(chart.every((b) => Number.isFinite(b.earnings))).toBe(true);
   });
 
+  it('keys the bucket from UTC midnight, not the local calendar day (#11723)', () => {
+    // now = 2026-08-05T17:30:00Z == 2026-08-05T23:00:00+05:30 (IST). The local
+    // day is still Aug 5, but a bucket built with local midnight and then
+    // formatted in UTC (old behaviour) produced 2026-08-04 and dropped this
+    // "today" trip. The frame must follow the UTC components like trip_date.
+    const chart = buildWeeklyChart(
+      [{ trip_date: '2026-08-05', total_earnings: 4000 }],
+      { period: 'day', now: new Date('2026-08-05T17:30:00Z') }
+    );
+    expect(chart).toHaveLength(1);
+    expect(chart[0].day).toBe('2026-08-05');
+    expect(chart[0].earnings).toBe(4000);
+  });
+
+  it('buckets a trip with a timestamp by its trip_date calendar day (#11723)', () => {
+    const chart = buildWeeklyChart(
+      [{ trip_date: '2026-08-05T09:00:00Z', total_earnings: 1500 }],
+      { period: 'week', now: new Date('2026-08-10T12:00:00Z') }
+    );
+    const bucketsWithEarnings = chart.filter((b) => b.earnings > 0);
+    expect(bucketsWithEarnings).toHaveLength(1);
+    expect(bucketsWithEarnings[0].day).toBe('2026-08-05');
+  });
+
+  it('starts the week frame at UTC midnight seven days back (#11723)', () => {
+    const chart = buildWeeklyChart([], {
+      period: 'week',
+      now: new Date('2026-08-05T23:30:00+05:30'),
+    });
+    expect(chart).toHaveLength(7);
+    expect(chart[0].day).toBe('2026-07-30');
+    expect(chart[chart.length - 1].day).toBe('2026-08-05');
+  });
+
   it('handles empty and non-array input', () => {
     expect(buildWeeklyChart(null, { period: 'week', now: BASE })).toHaveLength(7);
     expect(buildWeeklyChart(undefined, { period: 'week', now: BASE })).toHaveLength(7);


### PR DESCRIPTION
## Problem

`buildWeeklyChart` in `earningsReportService.js` mixed UTC and local date keys. Buckets were built from `new Date(now)` (local midnight) but formatted via `toISOString()` (UTC), while trips were keyed via `new Date(trip_date)` (UTC midnight). On any non-UTC server (e.g. IST) the bucket keys shifted by the UTC offset, so trips landed in the wrong day or were dropped entirely from the earnings chart.

## Fix

- Buckets are now anchored at UTC midnight (`new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))`), so bucket keys and trip keys share one zone.
- Trips are keyed directly by their `trip_date` (already `YYYY-MM-DD`), stripping any timestamp, so no time-zone shifting can mis-bucket them.
- Added unit tests covering an IST-late-evening "now" (a "today" trip must appear in today's bucket), a timestamped `trip_date`, and the UTC-midnight week frame.

## Files changed

- backend/api/src/services/driver/earningsReportService.js
- backend/api/test/unit/earningsReportService.test.js

## Testing

Ran the aggregation scenarios with Node (vitest could not load its config inside the git worktree without a fresh `npm install`): all 15 assertions pass, including the existing bucket/date behaviours and the new IST/UTC regression cases.

Closes #11723
