### PR TITLE
[#11663] fix(dao): add releaseVotes exit path after voting deadline

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -20,9 +20,11 @@ contract DAO is Ownable {
     IERC20 public governanceToken;
     Proposal[] public proposals;
     mapping(uint256 => mapping(address => uint256)) public votesCast;
+    mapping(uint256 => mapping(address => bool)) public votesReleased;
 
     event ProposalCreated(uint256 indexed proposalId, string description, uint256 deadline);
     event VotedQuadratic(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 tokenCost);
+    event VotesReleased(uint256 indexed proposalId, address indexed voter, uint256 refund);
 
     constructor(address _tokenAddress) Ownable(msg.sender) {
         governanceToken = IERC20(_tokenAddress);
@@ -64,5 +66,28 @@ contract DAO is Ownable {
         proposal.voteCount += _votes;
 
         emit VotedQuadratic(_proposalId, msg.sender, _votes, tokenCost);
+    }
+
+    /**
+     * @dev Return the governance tokens deposited for a proposal once the
+     *      voting window has closed. The contract holds the voter's final
+     *      quadratic cost (votes^2) in escrow while voting is open; this is
+     *      the only exit path so participation is not a permanent token burn
+     *      (issue #11663).
+     */
+    function releaseVotes(uint256 _proposalId) external {
+        Proposal storage proposal = proposals[_proposalId];
+        require(block.timestamp >= proposal.votingDeadline, "Voting period not ended");
+
+        uint256 votes = votesCast[_proposalId][msg.sender];
+        require(votes > 0, "No votes to release");
+        require(!votesReleased[_proposalId][msg.sender], "Votes already released");
+
+        votesReleased[_proposalId][msg.sender] = true;
+
+        uint256 refund = votes * votes;
+        require(governanceToken.transfer(msg.sender, refund), "Token transfer failed");
+
+        emit VotesReleased(_proposalId, msg.sender, refund);
     }
 }


### PR DESCRIPTION
﻿## Problem

[Solidity][P2] DAO.sol: voteQuadratic transfers governance tokens in with no withdraw/release — permanent loss

## Description
`blockchain/contracts/DAO.sol` pulls governance tokens into the contract when a user votes (`voteQuadratic`, lines 52-67) but provides **no** path to return them — no `withdraw`, no `releaseVotes`, no `refund`, and no `executeProposal` that would consume/release the deposited tokens.

```solidity
// line 61
require(governanceToken.transferFrom(msg.sender, address(this), tokenCost), "Token transfer failed");
votesCast[_proposalId][msg.sender] = totalVotes;
proposal.voteCount += _votes;
// ... no withdraw / releaseVotes / executeProposal anywhere in the contract
```

## Actual Behavior
Voter tokens are transferred into `address(this)` and never returned. Every vote permanently destroys the voter's governance tokens; legitimate governance participation is economically impossible. (Distinct from the already-filed "DAO `voteQuadratic` quadratic cost is bypassable" issue — that is about the *cost formula*; this is a *fund-accounting / missing-exit* defect.)

## Expected Behavior
Quadratic-voting deposits are held as an escrow and returned after the voting window (or only "locked" via a deposit/withdraw pair). At minimum a `releaseVotes(proposalId)`/`withdraw` path is required, or the tokens should be a snapshot of balance rather than transferred.

## Proposed Fix
- Track deposited amounts per `(proposalId, voter)` in a mapping and add `releaseVotes(proposalId)` (or `withdraw`) that returns `tokenCost` via `governanceToken.transfer(msg.sender, tokenCost)`.
- Or replace the `transferFrom` with a balance snapshot (no token movement).
Multi-line change in `DAO.sol`.


## Fix

Adds a releaseVotes(proposalId) exit path: governance tokens deposited for a proposal can be returned once block.timestamp >= votingDeadline. A new votesReleased mapping prevents double-withdraw, and a VotesReleased event records the refund (votes^2, the quadratic voting cost held in escrow).

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:11:30 2026 +0530

    fix(dao): add releaseVotes exit path after voting deadline

 blockchain/contracts/DAO.sol | 25 +++++++++++++++++++++++++
 1 file changed, 25 insertions(+)

## Testing

Contract compiles with solcjs.

Closes #11663
