### PR TITLE
[#11665] fix(oracle): prevent silent verification overwrite and add flag update

### DIFF
--- a/blockchain/contracts/VerificationOracle.sol
+++ b/blockchain/contracts/VerificationOracle.sol
@@ -15,6 +15,7 @@ contract VerificationOracle {
     
     event VerificationCreated(string indexed orderId, string ipfsHash, uint256 timestamp);
     event VerificationUpdated(string indexed orderId, bool verified);
+    event VerificationFlagUpdated(string indexed orderId, bool previousVerified, bool newVerified);
     
     modifier onlyAdmin() {
         require(msg.sender == admin, "Only admin can call this");
@@ -25,10 +26,16 @@ contract VerificationOracle {
         admin = msg.sender;
     }
     
+    /**
+     * @dev Creates a verification record. Rejects an orderId that already has
+     *      an attestation instead of silently overwriting the prior
+     *      ipfsHash/timestamp, preserving the audit trail (issue #11665).
+     */
     function createVerification(
         string memory orderId, 
         string memory ipfsHash
     ) public onlyAdmin {
+        require(verifications[orderId].timestamp == 0, "Order already verified");
         verifications[orderId] = VerificationRecord({
             orderId: orderId,
             ipfsHash: ipfsHash,
@@ -38,6 +45,20 @@ contract VerificationOracle {
         });
         
         emit VerificationCreated(orderId, ipfsHash, block.timestamp);
+    }
+    
+    /**
+     * @dev Sets the verification outcome explicitly (true or false) after an
+     *      attestation exists. This makes `verified` a genuine, mutable flag
+     *      rather than a constant true (issue #11665).
+     */
+    function updateVerification(string memory orderId, bool isValid) public onlyAdmin {
+        VerificationRecord storage record = verifications[orderId];
+        require(record.timestamp != 0, "No verification exists for this order");
+        bool previousVerified = record.verified;
+        record.verified = isValid;
+        emit VerificationFlagUpdated(orderId, previousVerified, isValid);
+        emit VerificationUpdated(orderId, isValid);
     }
     
     function verifyOrder(string memory orderId) public view returns (bool) {


### PR DESCRIPTION
﻿## Problem

[Solidity][P2] VerificationOracle.createVerification overwrites prior attestation; `verified` always true

## Description
`blockchain/contracts/VerificationOracle.sol` `createVerification` silently overwrites any existing attestation for the same `orderId` (no existence/version guard), and `verified` is always written `true` with no way to set it `false`.

```solidity
// lines 28-45
function createVerification(string memory orderId, string memory ipfsHash) public onlyAdmin {
    verifications[orderId] = VerificationRecord({
        orderId: orderId,
        ipfsHash: ipfsHash,
        timestamp: block.timestamp,
        verified: true,                 // line 36 — hard-coded
        verifier: msg.sender
    });
    emit VerificationCreated(orderId, ipfsHash, block.timestamp);
}
function verifyOrder(string memory orderId) public view returns (bool) {
    return verifications[orderId].verified;   // equivalent to "a record exists"
}
```

## Actual Behavior
1. An admin can mutate a prior attestation (including its `ipfsHash`/timestamp) with no audit trail — `createVerification` just overwrites the mapping entry.
2. `verified` is always `true`; there is no function that can ever set it `false`, so `verifyOrder` is exactly equivalent to "a record exists for this orderId" — the boolean carries no real meaning.

## Expected Behavior
Enforce idempotency/versioning (reject or event-version an existing `orderId`), and make `verified` a genuine, mutable outcome (e.g. a separate `updateVerification(orderId, isValid)`), or drop the redundant flag.

## Proposed Fix
- `require(verifications[orderId].timestamp == 0, "Already verified")` (or append to a history array) in `createVerification`.
- Add a real `setVerified(orderId, bool)` path; emit the previous value on update.
Multi-line change in `VerificationOracle.sol`.


## Fix

createVerification now rejects an orderId that already has an attestation (timestamp != 0) instead of silently overwriting the prior ipfsHash/timestamp, preserving the audit trail. New updateVerification(orderId, isValid) makes `verified` a genuine mutable flag and emits VerificationFlagUpdated(previous, new).

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:11:42 2026 +0530

    fix(oracle): prevent silent verification overwrite and add flag update

 blockchain/contracts/VerificationOracle.sol | 21 +++++++++++++++++++++
 1 file changed, 21 insertions(+)

## Testing

Contract compiles with solcjs.

Closes #11665
