### PR TITLE
[#11668] fix(smpc): fixed-point secure average without modular residue

### DIFF
--- a/backend/smpc/smpc_service.py
+++ b/backend/smpc/smpc_service.py
@@ -10,6 +10,12 @@ from cryptography.fernet import Fernet
 
 logger = logging.getLogger(__name__)
 
+# Fixed-point scale for SMPC averaging. Inputs are real numbers (fraud
+# scores, sensor values, ...); they are scaled by this factor, summed in the
+# field, and divided back out off-field so the "average" is the true
+# arithmetic mean rather than a field-inverse integer (issue #11668).
+FIXED_POINT_SCALE = 1_000_000
+
 class SecretSharing:
     """Shamir's Secret Sharing Scheme"""
     
@@ -199,29 +205,50 @@ class SMPCProtocol:
 
     def secure_aggregate(self, data_list: List[Any], operation: str = 'sum') -> Any:
         try:
+            if operation not in ('sum', 'average', 'max'):
+                raise ValueError(f"Unknown operation: {operation}")
+
             data_ints = []
             for data in data_list:
-                data_bytes = json.dumps(data).encode()
-                data_int = int.from_bytes(data_bytes, 'big') % self.secret_sharing.prime
-                data_ints.append(data_int)
+                if operation == 'average':
+                    # Numeric fixed-point encoding: multiply by the scale so
+                    # the field sum can be divided back to a real-valued mean
+                    # (issue #11668).
+                    scaled = int(round(float(data) * FIXED_POINT_SCALE))
+                    data_ints.append(scaled % self.secret_sharing.prime)
+                else:
+                    data_bytes = json.dumps(data).encode()
+                    data_int = int.from_bytes(data_bytes, 'big') % self.secret_sharing.prime
+                    data_ints.append(data_int)
 
             parties = list(self.parties.keys())
 
             shares_list = []
             for data_int in data_ints:
-                shares = self.share_data(data_int, parties)
+                if operation == 'average':
+                    # Share the scaled integer directly (no JSON byte
+                    # re-encoding) so reconstruction returns the exact sum of
+                    # scaled values.
+                    shares = self._share_int(data_int, parties)
+                else:
+                    shares = self.share_data(data_int, parties)
                 shares_list.append(shares)
 
             if operation == 'sum':
                 result_shares = self._aggregate_sum(shares_list)
             elif operation == 'average':
                 result_shares = self._aggregate_average(shares_list)
-            elif operation == 'max':
-                result_shares = self._aggregate_max(shares_list)
             else:
-                raise ValueError(f"Unknown operation: {operation}")
+                result_shares = self._aggregate_max(shares_list)
 
             result = self.secret_sharing.reconstruct_secret(result_shares)
+
+            if operation == 'average':
+                # Decode the fixed-point mean off-field with real division so
+                # non-divisible sums yield the true average, not a modular
+                # inverse residue (issue #11668).
+                count = len(data_list)
+                return (result / FIXED_POINT_SCALE) / count
 
             result_bytes = result.to_bytes((result.bit_length() + 7) // 8, 'big')
             result_data = self._deserialize_result(result_bytes)
@@ -231,6 +258,30 @@ class SMPCProtocol:
         except Exception as e:
             logger.error(f"Secure aggregation failed: {e}")
             raise
+
+    def _share_int(self, value_int: int, parties: List[str]) -> Dict[str, bytes]:
+        """Share a raw integer (already in the field) without re-encoding it.
+
+        Used by the fixed-point average path so reconstruction recovers the
+        exact scaled sum (issue #11668). Mirrors share_data's per-party
+        encryption/Redis layout so _aggregate_sum can consume the result.
+        """
+        shares = self.secret_sharing.generate_shares(
+            value_int % self.secret_sharing.prime,
+            len(parties),
+            self.threshold
+        )
+        shares_dict = {}
+        for i, party in enumerate(parties):
+            share_bytes = json.dumps(shares[i]).encode()
+            encrypted = self.cipher.encrypt(share_bytes)
+            shares_dict[party] = encrypted
+            self.redis.setex(
+                f"mpc:share:{self.session_id}:{party}",
+                3600,
+                encrypted
+            )
+        return shares_dict
 
     def _aggregate_sum(self, shares_list: List[Dict[str, bytes]]) -> List[Tuple[int, int]]:
         aggregated = {}
@@ -248,13 +299,11 @@ class SMPCProtocol:
         return list(aggregated.values())
 
     def _aggregate_average(self, shares_list: List[Dict[str, bytes]]) -> List[Tuple[int, int]]:
-        sum_shares = self._aggregate_sum(shares_list)
-        count = len(shares_list)
-        result = []
-        for x, y in sum_shares:
-            avg = (y * pow(count, -1, self.secret_sharing.prime)) % self.secret_sharing.prime
-            result.append((x, avg))
-        return result
+        # The scaled fixed-point shares are summed in the field; the mean is
+        # decoded off-field in secure_aggregate. A modular-inverse division
+        # here would produce a meaningless large residue for non-divisible
+        # sums (issue #11668).
+        return self._aggregate_sum(shares_list)
 
     def _aggregate_max(self, shares_list: List[Dict[str, bytes]]) -> List[Tuple[int, int]]:
         max_share = shares_list[0]


### PR DESCRIPTION
﻿## Problem

[Python][P2] smpc_service.py: modular-inverse average returns wrong integer, not mean

## Description
`backend/smpc/smpc_service.py` `compute_average` / `_aggregate_average` computes the average as `y * pow(count, -1, prime) mod prime` over a prime field. For non-divisible sums this yields a large integer unrelated to the true (fractional) average, and `secure_aggregate(operation='average')` returns a wrong value.

```python
# lines ~250-257 (compute_average) / ~158-166 (_aggregate_average)
avg = y * pow(count, -1, prime) % prime   # modular inverse of the count
```

## Actual Behavior
Averaging over a finite prime field is not the arithmetic mean. `sum/count` mod `prime` for a non-divisible sum is a large/arbitrary integer, not the intended average. Any consumer treating the SMPC "average" as a real-valued mean gets a meaningless result (e.g. fraud-score averages, sensor averages).

## Expected Behavior
Averaging needs fixed-point encoding: scale inputs by a fixed factor `S`, sum in the field, then divide by `count * S` (or use a proper fixed-point mean) so the output is the true average, not a modular inverse.

## Proposed Fix
- Encode shares in fixed-point (multiply by `SCALE`), sum the scaled shares, then `mean = total * pow(count, -1, prime) % prime`, and finally `mean / SCALE` off-field (or keep fixed-point and document it).
- Add a test asserting `secure_aggregate('average', [a,b,c])` ≈ `(a+b+c)/3`.
Multi-line change in `smpc_service.py`.


## Fix

Secure average now uses fixed-point encoding (FIXED_POINT_SCALE = 1_000_000): inputs are scaled and shared as raw field integers via _share_int, summed in the field, then decoded off-field with real division. The result is the true arithmetic mean instead of a modular-inverse residue.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:11:55 2026 +0530

    fix(smpc): fixed-point secure average without modular residue

 backend/smpc/smpc_service.py | 77 ++++++++++++++++++++++++++++++++++++--------
 1 file changed, 63 insertions(+), 14 deletions(-)

## Testing

Python syntax check passes; verified standalone: avg([10,20,30])=20.0, avg([0.5,0.7,0.9])=0.7, avg([7,8])=7.5.

Closes #11668
