### PR TITLE
[#11669] fix(anomaly): per-entity rolling windows in real-time detection

### DIFF
--- a/backend/ml/anomaly/detector.py
+++ b/backend/ml/anomaly/detector.py
@@ -40,8 +40,23 @@ class AnomalyDetector:
         
         self.max_history = 1000
         self.anomaly_history = deque(maxlen=self.max_history)
-        
+
+        # Per-(data_type, entity) rolling buffers of recent feature vectors.
+        # Real-time detection feeds these genuine windows to the model instead
+        # of tiling a single timestep into a constant sequence, which was out
+        # of distribution for models trained on diverse multi-step sequences
+        # (issue #11669).
+        self._feature_buffers = {}
+
         logger.info("✅ Anomaly Detector initialized")
+
+    def _get_feature_buffer(self, data_type: str, entity_key: str):
+        """Get (or create) the rolling feature buffer for an entity."""
+        key = (data_type, entity_key or 'default')
+        if key not in self._feature_buffers:
+            seq_len = self.models[data_type].sequence_length
+            self._feature_buffers[key] = deque(maxlen=seq_len)
+        return self._feature_buffers[key]
     
     def train_models(self, data: Dict[str, np.ndarray], epochs: int = 50):
         """Train all models"""
@@ -71,7 +86,7 @@ class AnomalyDetector:
         
         return results
     
-    def detect_anomaly(self, data_type: str, data: np.ndarray) -> Dict:
+    def detect_anomaly(self, data_type: str, data: np.ndarray, entity_key: str = None) -> Dict:
         """Detect anomalies in real-time data"""
         try:
             if data_type not in self.models:
@@ -89,9 +104,21 @@ class AnomalyDetector:
                 data_scaled = scaler.transform(data)
             else:
                 data_scaled = data
-            
+
+            # Build a genuine rolling window for this entity (padded at the
+            # front by repeating the earliest observation during warm-up)
+            # instead of tiling the single timestep (issue #11669).
+            buffer = self._get_feature_buffer(data_type, entity_key)
+            buffer.append(data_scaled[0])
+
+            seq = list(buffer)
+            seq_len = model.sequence_length
+            if len(seq) < seq_len:
+                seq = [seq[0]] * (seq_len - len(seq)) + seq
+            window = np.array(seq, dtype=np.float32)
+
             # Get anomaly score
-            result = model.get_anomaly_score(data_scaled)
+            result = model.get_anomaly_score(window)
             
             # Determine severity
             score = result['anomaly_score']
@@ -146,8 +173,12 @@ class AnomalyDetector:
             # Extract features
             features = self._extract_driver_features(driver_data)
             
-            # Detect anomaly
-            result = self.detect_anomaly('driver_behavior', features)
+            # Detect anomaly (window keyed per driver)
+            result = self.detect_anomaly(
+                'driver_behavior',
+                features,
+                entity_key=str(driver_data.get('driver_id') or '')
+            )
             
             # Add driver-specific info
             result['driver_id'] = driver_data.get('driver_id')
@@ -165,8 +196,12 @@ class AnomalyDetector:
             # Extract features
             features = self._extract_transaction_features(transaction)
             
-            # Detect anomaly
-            result = self.detect_anomaly('transactions', features)
+            # Detect anomaly (window keyed per transaction)
+            result = self.detect_anomaly(
+                'transactions',
+                features,
+                entity_key=str(transaction.get('transaction_id') or '')
+            )
             
             # Add transaction-specific info
             result['transaction_id'] = transaction.get('transaction_id')
@@ -184,8 +219,12 @@ class AnomalyDetector:
             # Extract features
             features = self._extract_gps_features(gps_data)
             
-            # Detect anomaly
-            result = self.detect_anomaly('gps_tracking', features)
+            # Detect anomaly (window keyed per driver)
+            result = self.detect_anomaly(
+                'gps_tracking',
+                features,
+                entity_key=str(gps_data.get('driver_id') or '')
+            )
             
             # Add GPS-specific info
             result['driver_id'] = gps_data.get('driver_id')

--- a/backend/ml/anomaly/models.py
+++ b/backend/ml/anomaly/models.py
@@ -108,18 +108,36 @@ class LSTMAutoencoder:
         }
     
     def get_anomaly_score(self, sequence):
-        """Get anomaly score for a single sequence"""
+        """Get anomaly score for a sequence.
+
+        Expects a genuine (sequence_length, input_dim) window. Tiling a single
+        feature vector into a constant 60-step sequence fed the model
+        out-of-distribution inputs for a model trained on diverse multi-step
+        sequences (issue #11669); callers must supply the real rolling window
+        instead, so single-step inputs are rejected rather than silently
+        tiled.
+        """
         if self.model is None:
             raise ValueError("Model not trained yet")
-        
-        sequence = np.array(sequence)
-        if sequence.size == self.input_dim:
-            sequence = np.tile(sequence.reshape(1, self.input_dim), (self.sequence_length, 1))
-        sequence = sequence.reshape(1, self.sequence_length, self.input_dim)
+
+        sequence = np.array(sequence, dtype=np.float32)
+        if sequence.ndim == 1:
+            sequence = sequence.reshape(1, -1)
+        if sequence.shape[1] != self.input_dim:
+            raise ValueError(
+                f"Expected {self.input_dim} features per timestep, got {sequence.shape[1]}"
+            )
+        if sequence.shape[0] < self.sequence_length:
+            raise ValueError(
+                f"Expected at least {self.sequence_length} timesteps, got {sequence.shape[0]}. "
+                "Feed a genuine rolling window (issue #11669)."
+            )
+
+        sequence = sequence[:self.sequence_length].reshape(1, self.sequence_length, self.input_dim)
         reconstruction = self.model.predict(sequence, verbose=0)
         error = np.mean(np.square(reconstruction - sequence))
         score = error / self.threshold if self.threshold else error
-        
+
         return {
             'reconstruction_error': float(error),
             'anomaly_score': float(score),


### PR DESCRIPTION
﻿## Problem

[Python][P2] anomaly/detector.py + models.py: tiles single timestep into constant 60-step sequence (train/serve skew)

## Description
`backend/ml/anomaly/detector.py` (and `ml/anomaly/models.py`) builds real-time detection by tiling a single extracted feature vector into a constant 60-step sequence, so the reconstruction model never sees a temporal signal.

```python
# models.py:116-118 (get_anomaly_score) tiles one timestep into 60 identical steps
seq = np.tile(feature_vector, (60, 1))   # constant sequence
score = model.reconstruct(seq)
```

## Actual Behavior
`_extract_*_features` produce only one timestep, and real-time detection wraps it into a constant 60-step sequence. The autoencoder/threshold was trained on real multi-step sequences, so the reconstruction threshold is no longer meaningful for a constant input — every real-time input becomes an out-of-distribution constant sequence and anomaly scores are biased. (Distinct from the JS `anomalyDetectionService` table/DDL issues — this is the Python ML detector's train/serve representation skew.)

## Expected Behavior
Real-time detection should maintain a genuine rolling window of the last 60 observations (or the model should be trained/served on single-step inputs), so the input distribution matches training.

## Proposed Fix
- Keep a per-entity ring buffer of recent feature vectors and feed the real window to `model.reconstruct`.
- Or retrain/serve the detector on single-step inputs and drop the tiling.
Multi-line change in `detector.py` / `models.py`.


## Fix

LSTMAutoencoder.get_anomaly_score rejects single-step/tiled inputs and requires a genuine (sequence_length, input_dim) window. AnomalyDetector keeps per-entity rolling buffers keyed by driver_id/transaction_id and builds padded real windows before scoring, instead of tiling a single timestep.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:11:59 2026 +0530

    fix(anomaly): per-entity rolling windows in real-time detection

 backend/ml/anomaly/detector.py | 59 +++++++++++++++++++++++++++++++++++-------
 backend/ml/anomaly/models.py   | 32 ++++++++++++++++++-----
 2 files changed, 74 insertions(+), 17 deletions(-)

## Testing

Python syntax check passes (py -m py_compile).

Closes #11669
