### PR TITLE
[#11670] fix(delivery): enforce geofence on stuck-escrow retry

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -482,9 +482,12 @@ export class DeliveryVerificationService {
           order.status === "payment_released" &&
           ["funded", "release_failed"].includes(order.escrow_status);
 
-        if (!isRetryForStuckEscrow) {
-          await this.assertDriverAtDropoff(order);
-        }
+        // Geofence must still apply on the stuck-escrow retry path. The retry
+        // flag only relaxes OTP-readiness and the Postgres RPC guard below; it
+        // must never bypass the driver-at-dropoff control, which would let a
+        // release be re-attempted without physical presence at the drop-off
+        // location (issue #11670).
+        await this.assertDriverAtDropoff(order);
 
         let releaseTxHash = null;
         let escrowAlreadyReleased = false;


### PR DESCRIPTION
﻿## Problem

[TS][P1] deliveryVerificationService.js: stuck-escrow retry skips geofence check

## Description
`backend/api/src/services/order/deliveryVerificationService.js` `verifyDelivery` skips the `assertDriverAtDropoff` geofence/freshness check on the stuck-escrow retry path.

```js
// lines ~481-487
const isRetryForStuckEscrow =
  order.status === "payment_released" &&
  ["funded", "release_failed"].includes(order.escrow_status);
if (!isRetryForStuckEscrow) {
  await this.assertDriverAtDropoff(order);   // geofence skipped on the retry path
}
```

## Actual Behavior
When healing a stuck escrow (order already `payment_released`, escrow `funded`/`release_failed`), the drop-off geofence and fresh location-ping check are entirely bypassed, so escrow can be released without verifying the driver is physically at the drop-off. The physical-presence control should still apply (or the skip must be an explicit, documented, risk-bounded decision). (Distinct from the separate filed issue "Stuck Escrow Retry Path Skips complete_trip_tx RPC — Driver Not Paid", which is about the RPC call, not the geofence.)

## Expected Behavior
The geofence/freshness check should still run on the retry (or be explicitly relaxed with a compensating control documented in the threat model).

## Proposed Fix
- Re-run (or relax-but-keep) `assertDriverAtDropoff` on the retry path, or add a documented compensating control and a test asserting the geofence still applies.
Multi-line change in `deliveryVerificationService.js`.


## Fix

The geofence control assertDriverAtDropoff is now enforced unconditionally in verifyDelivery. The isRetryForStuckEscrow flag still relaxes OTP-readiness and the Postgres RPC guard, but no longer bypasses the driver-at-dropoff check on the retry path.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:12:04 2026 +0530

    fix(delivery): enforce geofence on stuck-escrow retry

 backend/api/src/services/order/deliveryVerificationService.js | 9 ++++++---
 1 file changed, 6 insertions(+), 3 deletions(-)

## Testing

node --check passes.

Closes #11670
