### PR TITLE
[#11671] fix(tracker): strictly-monotonic telemetry sequence gate

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1013,7 +1013,8 @@ export async function handleLocationPing(ws, data, req) {
     return;
   }
 
-  // Fix 1: Always use server time for sequence comparison
+  // Fix 1: Server receive time, used as the monotonic order key fallback
+  // when the device does not supply a device_timestamp (issue #11671).
   const serverNow = Date.now();
 
   // Fix 4: IDEMPOTENCY GATE & OUT-OF-ORDER SEQUENCER + Circuit breaker
@@ -1021,33 +1022,45 @@ export async function handleLocationPing(ws, data, req) {
     try {
       const seqKey = `driver:sequence:${driver_id}`;
       const lastRecordedEpochStr = await redisClient.get(seqKey);
+      const lastRecordedEpoch = Number.parseInt(lastRecordedEpochStr, 10);
 
-      if (lastRecordedEpochStr) {
-        const lastRecordedEpoch = parseInt(lastRecordedEpochStr, 10);
+      // Strictly-increasing gate: compare with `<` (not `<=`) and use the
+      // device-supplied timestamp when available so two legitimate updates
+      // that share a server-side millisecond are never dropped as "out of
+      // order" (issue #11671). Genuinely stale updates whose order key has
+      // already advanced past the current receive time are still discarded.
+      const orderKey = deviceTime ? deviceTime.getTime() : serverNow;
+      if (!Number.isNaN(lastRecordedEpoch) && orderKey < lastRecordedEpoch) {
+        logger.warn(`[TRUXIFY SEQUENCE CONTROL] Out-of-order telemetry dropped for Driver: ${driver_id}. Stale jitter detected.`);
 
-        if (serverNow <= lastRecordedEpoch) {
-          logger.warn(`[TRUXIFY SEQUENCE CONTROL] Out-of-order telemetry dropped for Driver: ${driver_id}. Stale jitter detected.`);
-
-          // Circuit breaker: if too many consecutive drops, reset the sequence
-          const prevEntry = consecutiveDropCount.get(driver_id);
-          const currentCount = (prevEntry ? prevEntry.count : 0) + 1;
-          consecutiveDropCount.set(driver_id, { count: currentCount, lastUpdated: serverNow });
-          sweepStaleDriverState(serverNow);
-          if (currentCount >= MAX_CONSECUTIVE_DROPS) {
-            logger.warn(
-              `[TRUXIFY CIRCUIT BREAKER] Driver ${driver_id} exceeded max consecutive drops ` +
-              `(${MAX_CONSECUTIVE_DROPS}). Resetting sequence.`
-            );
-            await redisClient.del(seqKey);
-            consecutiveDropCount.delete(driver_id);
-          }
-          return;
+        // Circuit breaker: if too many consecutive drops, reset the sequence
+        const prevEntry = consecutiveDropCount.get(driver_id);
+        const currentCount = (prevEntry ? prevEntry.count : 0) + 1;
+        consecutiveDropCount.set(driver_id, { count: currentCount, lastUpdated: serverNow });
+        sweepStaleDriverState(serverNow);
+        if (currentCount >= MAX_CONSECUTIVE_DROPS) {
+          logger.warn(
+            `[TRUXIFY CIRCUIT BREAKER] Driver ${driver_id} exceeded max consecutive drops ` +
+            `(${MAX_CONSECUTIVE_DROPS}). Resetting sequence.`
+          );
+          await redisClient.del(seqKey);
+          consecutiveDropCount.delete(driver_id);
         }
+        return;
       }
 
       // Reset circuit breaker on successful sequence advancement
       consecutiveDropCount.delete(driver_id);
-      await redisClient.set(seqKey, serverNow.toString(), 'EX', 86400);
+
+      // Advance a strictly-increasing monotonic counter: when the update
+      // shares a timestamp with the previous accepted one, bump the stored
+      // sequence by 1 instead of rewriting the same value so the gate keeps
+      // moving forward.
+      const nextSequence =
+        Number.isNaN(lastRecordedEpoch) || orderKey > lastRecordedEpoch
+          ? orderKey
+          : lastRecordedEpoch + 1;
+      await redisClient.set(seqKey, nextSequence.toString(), 'EX', 86400);
     } catch (err) {
       logger.error('Redis sequence verification cache error:', err.message);
     }


### PR DESCRIPTION
﻿## Problem

[TS][P2] tracker.js telemetry sequencer drops same-ms updates (`<=` + server time)

## Description
`backend/api/src/sockets/tracker.js` telemetry sequencer drops legitimate same-millisecond updates because the out-of-order gate is keyed on server receive time with 1 ms granularity and uses `<=` (not `<`).

```js
// lines ~1022-1050
const seqKey = `driver:sequence:${driver_id}`;
const lastRecordedEpochStr = await redisClient.get(seqKey);
if (lastRecordedEpochStr) {
  const lastRecordedEpoch = parseInt(lastRecordedEpochStr, 10);
  if (serverNow <= lastRecordedEpoch) {        // uses SERVER time, `<=` (not `<`)
    // ... drop as "out-of-order" and return;
  }
}
await redisClient.set(seqKey, serverNow.toString(), 'EX', 86400);
```

## Actual Behavior
Two legitimate telemetry messages processed in the same millisecond (offline batch replay, GPS bursts, or fast loop iterations) are unconditionally dropped as "out of order," creating gaps in the driver's location/telemetry history. The gate should not discard genuinely sequential updates that merely share a millisecond.

## Expected Behavior
Out-of-order protection should not discard sequential updates that share a millisecond; ordering should use a strictly-increasing monotonic counter (or the device's own sequence number / device timestamp).

## Proposed Fix
- Use a strictly-increasing monotonic counter (or the device-supplied sequence number / device timestamp) for ordering, and compare with `<` (or tolerate the same value when the payload differs).
Multi-line change in `tracker.js`.


## Fix

The out-of-order gate now uses the device timestamp when present as its order key with a strict `<` comparison. Two legitimate updates that share a server-side millisecond advance a monotonic counter (lastRecordedEpoch + 1) instead of being dropped as stale; genuinely stale updates are still discarded.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:12:08 2026 +0530

    fix(tracker): strictly-monotonic telemetry sequence gate

 backend/api/src/sockets/tracker.js | 59 +++++++++++++++++++++++---------------
 1 file changed, 36 insertions(+), 23 deletions(-)

## Testing

node --check passes.

Closes #11671
