### PR TITLE
[#11673] fix(did): trim 4-char key prefix in did:peer resolution

### DIFF
--- a/backend/did/did_peer.js
+++ b/backend/did/did_peer.js
@@ -20,7 +20,7 @@ export class DidPeer2Engine {
     const keySegment = segments[1];
     const serviceSegment = segments[2];
 
-    const publicKeyHex = keySegment.substring(3); // Strip EzVz
+    const publicKeyHex = keySegment.substring(4); // Strip EzVz (4-char prefix)
     const endpoint = Buffer.from(serviceSegment.split('~')[1], 'base64url').toString('utf8');
 
     return {


### PR DESCRIPTION
﻿## Problem

[TS][P2] did_peer.js: `substring(3)` strips wrong length vs 4-char `EzVz` prefix → corrupted key

## Description
`backend/did/did_peer.js` `createDidPeer2` builds a 4-character prefix `EzVz<key>` but `resolveDidPeer2` strips only 3 characters, corrupting the resolved public key on every resolution.

```js
// createDidPeer2 (lines ~9-11)
const encKey = `Vz${publicKeyHex}`;                       // "Vz" + key
return `did:peer:2.Ez${encKey}.Service~${encEndpoint}`;   // "EzVz" + key  => 4-char prefix
// resolveDidPeer2 (line ~23)
const publicKeyHex = keySegment.substring(3); // Strip EzVz   // only strips 3 -> leaves "z<key>"
```

## Actual Behavior
`createDidPeer2` emits `Ez` + `Vz` + key = `EzVz<key>` (a 4-character prefix). `resolveDidPeer2` strips only 3 characters (`EzV`), leaving `z<key>` — a corrupted public key on every resolution. Any consumer using the resolved `publicKeyHex` for verification fails; the DID is non-invertible. (Distinct from the WASI `is_url_allowed` substring SSRF issue — different code, different bug.)

## Expected Behavior
Resolution must invert creation exactly: strip the full 4-character `EzVz` prefix (`keySegment.substring(4)`).

## Proposed Fix
- Change `keySegment.substring(3)` to `keySegment.substring(4)` (and add a round-trip test: `resolve(create(pub)) === pub`).
Multi-line change in `did_peer.js`.


## Fix

keySegment.substring(3) -> substring(4): the EzVz prefix is 4 characters, so the previous slice kept a leading junk byte in the resolved public key. The existing did:peer:2 round-trip test passes.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:12:16 2026 +0530

    fix(did): trim 4-char key prefix in did:peer resolution

 backend/did/did_peer.js | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Testing

node --check passes; backend/did/test_did_peer.js round-trip test passes.

Closes #11673
