### PR TITLE
[#11675] fix(vdf): fail closed on missing external bid proof

### DIFF
--- a/backend/vdf/vdf_allocator.py
+++ b/backend/vdf/vdf_allocator.py
@@ -59,11 +59,25 @@ class VdfLoadAllocator:
     def __init__(self):
         self.vdf = WesolowskiVDF(iterations=2000)
 
-    def evaluate_bid_fairness(self, load_id: str, driver_id: str, bid_timestamp: float):
+    def evaluate_bid_fairness(self, load_id: str, driver_id: str, bid_timestamp: float,
+                              output_y: int = None, proof: str = None):
         seed = f"{load_id}:{driver_id}:{bid_timestamp}"
-        output_y, proof = self.vdf.eval(seed)
+
+        # Fairness gate must verify the bidder-supplied (output, proof) against
+        # the public seed and parameters, never its own freshly generated
+        # output — self-verification could never fail and the anti-MEV gate was
+        # a no-op (issue #11675). Missing claims fail closed.
+        if output_y is None or proof is None:
+            return {
+                "load_id": load_id,
+                "driver_id": driver_id,
+                "vdf_output": output_y,
+                "proof": proof,
+                "is_fairly_allocated": False
+            }
+
         is_valid = self.vdf.verify(seed, output_y, proof)
-        
+
         return {
             "load_id": load_id,
             "driver_id": driver_id,


### PR DESCRIPTION
﻿## Problem

[Python][P2] vdf_allocator.py: verifies own freshly-generated output → always fair

## Description
`backend/vdf/vdf_allocator.py` `evaluate_bid_fairness` verifies the VDF's *own freshly generated* output, so it can never fail — the anti-MEV "fairness" gate is a no-op.

```python
# lines ~62-73
output_y, proof = self.vdf.eval(seed)
is_valid = self.vdf.verify(seed, output_y, proof)
return { ..., "is_fairly_allocated": is_valid }
```

## Actual Behavior
`eval()` returns `(y, proof)` where `proof = sha256(f"{x}:{y}:{T}")`; `verify()` recomputes the same `y` and the same proof, so it **always returns `True`**. The function verifies its own freshly generated output, so `is_fairly_allocated` is unconditionally `True`. (The `WesolowskiVDF` "proof" is also just a hash with no real Wesolowski relation, but the decisive bug is self-verification.) The endpoint advertises fairness protection that does not exist.

## Expected Behavior
Verify an *externally supplied* proof (e.g. from the bidder), or compare against an independent fairness criterion, so the gate can actually fail.

## Proposed Fix
- Accept the bidder-supplied `(output, proof)` and verify that against the public seed/parameters; reject when verification fails.
- Implement a real Wesolowski/PIE proof relation (not a hash) so the VDF is actually sequential.
Multi-line change in `vdf_allocator.py` / `vdf_core.py`.


## Fix

evaluate_bid_fairness no longer self-generates the VDF output (self-verification could never fail). It verifies the bidder-supplied (output_y, proof) against the public seed and fails closed (is_fairly_allocated: False) when either is missing.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:12:25 2026 +0530

    fix(vdf): fail closed on missing external bid proof

 backend/vdf/vdf_allocator.py | 20 +++++++++++++++++---
 1 file changed, 17 insertions(+), 3 deletions(-)

## Testing

Python syntax check passes (py -m py_compile).

Closes #11675
