### PR TITLE
[#11676] fix(pqc): injective length-prefixed framing in hybrid crypto

### DIFF
--- a/backend/pqc/hybrid_crypto.py
+++ b/backend/pqc/hybrid_crypto.py
@@ -2,6 +2,7 @@ import json
 import hashlib
 import time
 from datetime import datetime
+from typing import Dict
 import numpy as np
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
@@ -57,6 +58,18 @@ class HybridCrypto:
         
         return hybrid_keys
     
+    @staticmethod
+    def _rsa_oaep_max_plaintext(public_key) -> int:
+        """Max OAEP-SHA256 plaintext bytes for the RSA key: k - 2*hLen - 2.
+
+        k = key size in bytes, hLen = 32 (SHA-256). Used to reject oversized
+        payloads up front instead of letting the ciphertext primitive throw
+        (issue #11676).
+        """
+        key_size_bytes = public_key.key_size // 8
+        hlen = hashes.SHA256().digest_size
+        return key_size_bytes - 2 * hlen - 2
+
     def hybrid_encrypt(self, data: bytes, hybrid_key: Dict) -> Dict:
         """Encrypt using hybrid approach"""
         try:
@@ -65,9 +78,26 @@ class HybridCrypto:
                 hybrid_key['quantum']['public']
             )
             
-            # Classical RSA encryption of data + quantum secret
-            encrypted_data = hybrid_key['classical']['public'].encrypt(
-                data + quantum_secret,
+            secret_len = len(quantum_secret)
+            public_key = hybrid_key['classical']['public']
+
+            # Injective framing: 4-byte big-endian length prefix + data +
+            # quantum secret. The prefix disambiguates a data payload that
+            # genuinely ends with the secret bytes (issue #11676).
+            frame_header_len = 4
+            max_plaintext = self._rsa_oaep_max_plaintext(public_key)
+            if len(data) + frame_header_len + secret_len > max_plaintext:
+                raise ValueError(
+                    f"Data too large for RSA-OAEP: {len(data)} bytes exceeds "
+                    f"the {max_plaintext - frame_header_len - secret_len}-byte "
+                    "per-call limit. Chunk large payloads before encrypting."
+                )
+
+            framed = len(data).to_bytes(frame_header_len, 'big') + data + quantum_secret
+
+            # Classical RSA encryption of the framed payload
+            encrypted_data = public_key.encrypt(
+                framed,
                 padding.OAEP(
                     mgf=padding.MGF1(algorithm=hashes.SHA256()),
                     algorithm=hashes.SHA256(),
@@ -110,17 +140,24 @@ class HybridCrypto:
                 )
             )
             
-            # Remove quantum secret from decrypted data
+            # Recover data via the 4-byte length prefix. A trailing-secret
+            # comparison alone was non-injective: genuine data ending with the
+            # same bytes was silently truncated (issue #11676).
             secret_len = len(quantum_secret)
-            if len(decrypted) < secret_len:
+            if len(decrypted) < 4 + secret_len:
                 raise ValueError(
-                    f"Decrypted payload length ({len(decrypted)}) is shorter than quantum secret size ({secret_len})"
+                    f"Decrypted payload length ({len(decrypted)}) is shorter than "
+                    f"the framing header + quantum secret ({4 + secret_len})"
                 )
-            
-            if decrypted[-secret_len:] != quantum_secret:
-                raise ValueError("Quantum secret suffix verification failed on decrypted payload")
 
-            return decrypted[:-secret_len]
+            payload_len = int.from_bytes(decrypted[:4], 'big')
+            if payload_len > len(decrypted) - 4 - secret_len:
+                raise ValueError("Invalid length prefix in decrypted payload")
+
+            if decrypted[4 + payload_len:] != quantum_secret:
+                raise ValueError("Quantum secret verification failed on decrypted payload")
+
+            return decrypted[4:4 + payload_len]
             
         except Exception as e:
             logger.error(f"Hybrid decryption failed: {e}")


### PR DESCRIPTION
﻿## Problem

[Python][P2] pqc/hybrid_crypto.py: RSA-OAEP size cap + non-injective secret suffix framing

## Description
`backend/pqc/hybrid_crypto.py` `hybrid_encrypt`/`hybrid_decrypt` has two genuine defects: a non-injective RSA-OAEP payload framing and a secret-length cap that breaks on large inputs.

```python
# line 69 — concatenate data + 32-byte quantum_secret, then RSA-OAEP encrypt
encrypted_data = hybrid_key['classical']['public'].encrypt(data + quantum_secret, padding.OAEP(...))
# line 120 — recover data by stripping a trailing 32-byte suffix equal to quantum_secret
if decrypted[-secret_len:] != quantum_secret:
    raise ValueError("Quantum secret suffix verification failed ...")
return decrypted[:-secret_len]
```

## Actual Behavior
1. **Size cap:** RSA-2048/OAEP-SHA256 plaintext cap is `256 - 2*32 - 2 = 190` bytes. When `len(data) > 158`, the encrypt throws (no chunking / no size guard).
2. **Non-injective framing:** the decryptor recovers `data` by stripping a trailing 32-byte suffix equal to `quantum_secret`. If the genuine `data` itself ends with those exact 32 bytes, they are wrongly stripped and the payload is corrupted (a false-positive "verification").

## Expected Behavior
Use length-prefix/`AAD` framing (e.g. `len(data)` prefix) instead of a magic suffix, and add a payload-size check / chunking for large inputs.

## Proposed Fix
- Prefix the payload with its length (or use OAEP `AAD`), and decrypt by reading the length prefix rather than a magic 32-byte suffix.
- Enforce/advertise a max plaintext size (or chunk large payloads).
Multi-line change in `hybrid_crypto.py`.


## Fix

Hybrid encryption now uses an injective framing of 4-byte length prefix + data + quantum_secret so payloads that genuinely end with the secret bytes round-trip exactly; decryption reads the length prefix. An RSA-OAEP plaintext-size cap raises a descriptive error instead of a primitive-level throw. Also fixes the missing typing.Dict import that made the module unimportable.

## Files changed

Author: ionfwsrijan <201338831+ionfwsrijan@users.noreply.github.com>
Date:   Thu Aug 13 13:12:30 2026 +0530

    fix(pqc): injective length-prefixed framing in hybrid crypto

 backend/pqc/hybrid_crypto.py | 57 ++++++++++++++++++++++++++++++++++++--------
 1 file changed, 47 insertions(+), 10 deletions(-)

## Testing

Python syntax check passes; framing round-trip verified with a mock kyber module, including payloads ending in the quantum secret bytes and the oversized-payload guard.

Closes #11676
