### PR TITLE
fix : added guard for empty coords in routeWithFailover osrm.js

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -291,6 +291,9 @@ export function haversineFallbackKm(lat1, lon1, lat2, lon2) {
 export async function routeWithFailover(primary, _fb, coords) {
   try { return await primary(coords); }
   catch (err) {
+    if (!coords || !coords[0] || !coords[0][0] || !coords[0][1]) {
+      return { distance: 0, source: 'haversine-fallback', error: 'No valid coordinates for haversine fallback' };
+    }
     const [a, b] = coords[0];
     return { distance: haversineFallbackKm(a[1], a[0], b[1], b[0]), source: 'haversine-fallback' };
   }


### PR DESCRIPTION
Closes #11905.

Summary of What Has Been Done:
Added a null guard for coords and coords[0] in the catch block of routeWithFailover to prevent a secondary TypeError when primary() throws on empty input.

Changes Made:
- backend/api/src/services/osrm.js: Added check for !coords || !coords[0] || !coords[0][0] || !coords[0][1] before destructuring coords[0]. Returns a safe fallback object with distance=0 and an error message instead of throwing.

Impact it Made:
- Prevents secondary TypeErrors from propagating uncaught when primary() fails on invalid input
- Makes the failover path more robust for edge-case inputs
- Existing routeWithFailover test passes

Note: This PR is from GSSOC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route handling when location coordinates are missing or invalid.
  * Provides a safe zero-distance fallback and clear error information instead of failing during route calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->