### PR TITLE
feat: implement gamified eco-driving leaderboard (#11916)

### DIFF
--- a/apps/driver/lib/models/eco_leaderboard_model.dart
+++ b/apps/driver/lib/models/eco_leaderboard_model.dart
@@ -1,0 +1,33 @@
+class DriverEcoScore {
+  final int rank;
+  final String driverName;
+  final String avatarUrl;
+  final int score;
+  final String trend; // "Up", "Down", "Same"
+  final List<String> badges; // "Smooth Braker", "Coasting King"
+
+  DriverEcoScore({
+    required this.rank,
+    required this.driverName,
+    required this.avatarUrl,
+    required this.score,
+    required this.trend,
+    required this.badges,
+  });
+}
+
+class EcoLeaderboardSession {
+  final String status;
+  final int currentDriverRank;
+  final int currentDriverScore;
+  final double fuelSavedGallons;
+  final List<DriverEcoScore> leaderboard;
+
+  EcoLeaderboardSession({
+    required this.status,
+    required this.currentDriverRank,
+    required this.currentDriverScore,
+    required this.fuelSavedGallons,
+    required this.leaderboard,
+  });
+}

--- a/apps/driver/lib/screens/eco_leaderboard_screen.dart
+++ b/apps/driver/lib/screens/eco_leaderboard_screen.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import '../models/eco_leaderboard_model.dart';
+import '../services/eco_leaderboard_service.dart';
+
+class EcoLeaderboardScreen extends StatefulWidget {
+  const EcoLeaderboardScreen({super.key});
+
+  @override
+  State<EcoLeaderboardScreen> createState() => _EcoLeaderboardScreenState();
+}
+
+class _EcoLeaderboardScreenState extends State<EcoLeaderboardScreen> {
+  final EcoLeaderboardService _service = EcoLeaderboardService();
+  EcoLeaderboardSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.leaderboardStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.fetchLeaderboard();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Eco-Driving Leaderboard'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[100],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildHeroSection(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              const Text('COMPANY RANKINGS', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              if (s.leaderboard.isEmpty)
+                const Center(child: CircularProgressIndicator())
+              else
+                ...s.leaderboard.map((driver) => _buildDriverCard(driver, isCurrentUser: driver.driverName.contains('You'))),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildHeroSection(EcoLeaderboardSession s) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.green[800]!, Colors.teal[700]!],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: Column(
+        children: [
+          const Icon(Icons.eco, color: Colors.white, size: 48),
+          const SizedBox(height: 16),
+          const Text('YOUR ECO SCORE', style: TextStyle(color: Colors.white70, fontSize: 14, fontWeight: FontWeight.bold, letterSpacing: 2.0)),
+          Text(s.currentDriverScore > 0 ? '${s.currentDriverScore}' : '--', style: const TextStyle(color: Colors.white, fontSize: 64, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.local_gas_station, color: Colors.white70, size: 16),
+              const SizedBox(width: 8),
+              Text('${s.fuelSavedGallons} Gal Saved This Week', style: const TextStyle(color: Colors.white70, fontSize: 14, fontWeight: FontWeight.bold)),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDriverCard(DriverEcoScore driver, {required bool isCurrentUser}) {
+    Color rankColor;
+    if (driver.rank == 1) rankColor = Colors.amber;
+    else if (driver.rank == 2) rankColor = Colors.blueGrey[300]!;
+    else if (driver.rank == 3) rankColor = Colors.brown[300]!;
+    else rankColor = Colors.grey[400]!;
+
+    IconData trendIcon;
+    Color trendColor;
+    if (driver.trend == 'Up') {
+      trendIcon = Icons.arrow_upward;
+      trendColor = Colors.green;
+    } else if (driver.trend == 'Down') {
+      trendIcon = Icons.arrow_downward;
+      trendColor = Colors.red;
+    } else {
+      trendIcon = Icons.remove;
+      trendColor = Colors.grey;
+    }
+
+    return Card(
+      elevation: isCurrentUser ? 8 : 1,
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: isCurrentUser ? Colors.teal : Colors.transparent, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: rankColor.withOpacity(0.2),
+                shape: BoxShape.circle,
+                border: Border.all(color: rankColor, width: 2),
+              ),
+              child: Center(child: Text('${driver.rank}', style: TextStyle(color: rankColor, fontWeight: FontWeight.bold, fontSize: 18))),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(driver.driverName, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: isCurrentUser ? Colors.teal[800] : Colors.black87)),
+                  const SizedBox(height: 4),
+                  if (driver.badges.isNotEmpty)
+                    Wrap(
+                      spacing: 4,
+                      children: driver.badges.map((b) => Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(color: Colors.green[50], borderRadius: BorderRadius.circular(12), border: Border.all(color: Colors.green[200]!)),
+                        child: Text(b, style: TextStyle(fontSize: 10, color: Colors.green[800], fontWeight: FontWeight.bold)),
+                      )).toList(),
+                    ),
+                ],
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text('${driver.score}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 24)),
+                Row(
+                  children: [
+                    Icon(trendIcon, size: 12, color: trendColor),
+                    Text(driver.trend, style: TextStyle(fontSize: 12, color: trendColor, fontWeight: FontWeight.bold)),
+                  ],
+                )
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/eco_leaderboard_service.dart
+++ b/apps/driver/lib/services/eco_leaderboard_service.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+import '../models/eco_leaderboard_model.dart';
+
+class EcoLeaderboardService {
+  final _sessionController = StreamController<EcoLeaderboardSession>.broadcast();
+
+  Stream<EcoLeaderboardSession> get leaderboardStream => _sessionController.stream;
+
+  void fetchLeaderboard() async {
+    _sessionController.add(EcoLeaderboardSession(
+      status: 'Analyzing Telemetry Data...',
+      currentDriverRank: 0,
+      currentDriverScore: 0,
+      fuelSavedGallons: 0.0,
+      leaderboard: [],
+    ));
+
+    await Future.delayed(const Duration(seconds: 2));
+
+    _sessionController.add(EcoLeaderboardSession(
+      status: 'Leaderboard Updated',
+      currentDriverRank: 2,
+      currentDriverScore: 890,
+      fuelSavedGallons: 42.5,
+      leaderboard: [
+        DriverEcoScore(rank: 1, driverName: 'Sarah Jenkins', avatarUrl: 'assets/avatars/1.png', score: 950, trend: 'Same', badges: ['Coasting King', 'Feather Foot']),
+        DriverEcoScore(rank: 2, driverName: 'You (Mohith)', avatarUrl: 'assets/avatars/2.png', score: 890, trend: 'Up', badges: ['Smooth Braker']),
+        DriverEcoScore(rank: 3, driverName: 'Marcus Cole', avatarUrl: 'assets/avatars/3.png', score: 820, trend: 'Down', badges: ['Idle Saver']),
+        DriverEcoScore(rank: 4, driverName: 'David Chen', avatarUrl: 'assets/avatars/4.png', score: 710, trend: 'Down', badges: []),
+        DriverEcoScore(rank: 5, driverName: 'Amanda Ross', avatarUrl: 'assets/avatars/5.png', score: 650, trend: 'Up', badges: ['Improving']),
+      ],
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11916

This PR introduces the frontend UI and mock telemetry services for the Gamified Eco-Driving Leaderboard feature. Fleet owners struggle to incentivize drivers to drive fuel-efficiently, as drivers find standard coaching reports boring and ignore them. This feature uses existing software telemetry (GPS speed and braking patterns) to generate a daily "Eco-Score" and turns fuel efficiency into a competitive mobile game. Drivers are ranked on a company-wide leaderboard with badges and animations, driving behavioral changes through gamification.

### Changes Made:
- **`eco_leaderboard_model.dart`**: Established the `EcoLeaderboardSession` schema to manage the gamification state, alongside the `DriverEcoScore` schema to track individual driver rankings, trend movements, and earned badges.
- **`eco_leaderboard_service.dart`**: Implemented a mock `Stream` simulating the backend analysis of fleet telemetry data, successfully populating a dynamic leaderboard with realistic scores, ranks, and behavioral badges (e.g., "Smooth Braker").
- **`eco_leaderboard_screen.dart`**: Built a highly engaging leaderboard dashboard. The UI features a premium gradient hero section displaying the user's current score and total gallons saved. It ranks all company drivers using visual indicators for rank changes (Up/Down) and visually highlights the current user's position on the board to drive engagement.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
