### PR TITLE
fix : added delete method to RequestCache class

### DIFF
--- a/backend/api/src/lib/requestCache.js
+++ b/backend/api/src/lib/requestCache.js
@@ -16,6 +16,10 @@ export class RequestCache {
     return this._cache.has(key);
   }
 
+  delete(key) {
+    return this._cache.delete(key);
+  }
+
   clear() {
     this._cache.clear();
   }


### PR DESCRIPTION
Closes #11940.

Summary of What Has Been Done:
Added a delete(key) method to the RequestCache class in backend/api/src/lib/requestCache.js. This completes the Map-based cache API with individual entry eviction capability.

Changes Made:
- Added delete(key) method that wraps Map.delete()
- Returns boolean (true if key existed, false otherwise)

Impact it Made:
- RequestCache now has complete Map-like API: get, set, has, delete, clear, size
- Enables selective cache entry eviction without clearing the entire cache
- Existing tests still pass

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.