### PR TITLE
fix : added null guard for weather service in fuelAdvisorService

### DIFF
--- a/backend/api/src/services/fuelAdvisorService.js
+++ b/backend/api/src/services/fuelAdvisorService.js
@@ -28,6 +28,15 @@ export class FuelAdvisorService {
 
     // 2. Get weather forecast for destination
     const weather = await this.weatherService.getWeatherForecast(destinationLat, destinationLng);
+    if (!weather || !Number.isFinite(weather.temperature_c)) {
+      this.logger?.warn('[FuelAdvisorService] Weather service unavailable or returned invalid data — using safe default B20.');
+      return {
+        recommended_blend: 'B20',
+        reasoning: 'Weather forecast unavailable. B20 is recommended as the safest default blend for all conditions.',
+        risk_level: 'LOW',
+        factors: { weather_forecast: null, average_engine_load_percent: Math.round(avgEngineLoad) },
+      };
+    }
     const tempC = weather.temperature_c;
 
     // 3. Compute recommendation


### PR DESCRIPTION
Closes #11941.

Summary of What Has Been Done:
Added null/undefined guard in getFuelRecommendation() for when weatherService.getWeatherForecast returns null or invalid data. Previously, accessing weather.temperature_c on a null/undefined value would throw a TypeError. Now returns a safe default B20 recommendation with appropriate logging.

Changes Made:
- Added null check for weather object and Number.isFinite guard for temperature_c
- Returns safe default recommendation when weather is unavailable

Impact it Made:
- Prevents TypeError crashes when weather service is unavailable
- Service degrades gracefully with safe default B20 recommendation
- Existing tests continue to pass

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.