### PR TITLE
fix : added undefined guard for maxWeightLimit in wimBypass

### DIFF
--- a/backend/api/src/services/wimBypass.js
+++ b/backend/api/src/services/wimBypass.js
@@ -23,7 +23,10 @@ export function evaluateBypassEligibility(truckData) {
         return false;
     }
 
-    if (typeof axleWeight !== 'number' || axleWeight > maxWeightLimit) {
+    if (typeof axleWeight !== 'number' || typeof maxWeightLimit !== 'number') {
+        return false;
+    }
+    if (axleWeight > maxWeightLimit) {
         return false;
     }
 


### PR DESCRIPTION
Closes #11942.

Summary of What Has Been Done:
Fixed evaluateBypassEligibility() to explicitly check that maxWeightLimit is a number. Previously, when maxWeightLimit was undefined, the comparison axleWeight > undefined evaluated to false (NaN), bypassing the weight check and incorrectly allowing bypass eligibility.

Changes Made:
- Split the weight check into two parts: type validation for both axleWeight and maxWeightLimit, then the actual comparison
- Returns false when either value is not a finite number

Impact it Made:
- Prevents bypassing WIM checks when maxWeightLimit is missing or invalid
- Security hardening for weigh station bypass eligibility validation
- Existing tests continue to pass

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.