### PR TITLE
fix : corrected substring offset in did_peer.js resolveDidPeer2

### DIFF
--- a/backend/did/did_peer.js
+++ b/backend/did/did_peer.js
@@ -20,7 +20,7 @@ export class DidPeer2Engine {
     const keySegment = segments[1];
     const serviceSegment = segments[2];
 
-    const publicKeyHex = keySegment.substring(3); // Strip EzVz
+    const publicKeyHex = keySegment.substring(4); // Strip full EzVz prefix (4 chars)
     const endpoint = Buffer.from(serviceSegment.split('~')[1], 'base64url').toString('utf8');
 
     return {


### PR DESCRIPTION
Closes #11673.

Summary of What Has been Done:
Fixed the substring offset in resolveDidPeer2() from substring(3) to substring(4) to correctly strip the full 4-character EzVz prefix built by createDidPeer2(). Previously, the resolved publicKeyHex was corrupted (prefixed with 'z') on every resolution, making DID verification fail.

Changes Made:
- Changed keySegment.substring(3) to keySegment.substring(4) in resolveDidPeer2()
- Verified with the existing round-trip test: create(resolve(create(pub))) === pub

Impact it Made:
- DID resolution now correctly inverts DID creation
- Round-trip test passes: createDidPeer2(pubKey) -> resolveDidPeer2(did) now returns original pubKey
- Prevents corrupted public keys in DID verification

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.