### PR TITLE
fix : use strict less-than for telemetry sequence comparison in tracker

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1016,7 +1016,7 @@ export async function handleLocationPing(ws, data, req) {
       if (lastRecordedEpochStr) {
         const lastRecordedEpoch = parseInt(lastRecordedEpochStr, 10);
 
-        if (serverNow <= lastRecordedEpoch) {
+        if (serverNow < lastRecordedEpoch) {
           logger.warn(`[TRUXIFY SEQUENCE CONTROL] Out-of-order telemetry dropped for Driver: ${driver_id}. Stale jitter detected.`);
 
           // Circuit breaker: if too many consecutive drops, reset the sequence


### PR DESCRIPTION
Closes #11671.

Summary of What Has Been Done:
Changed the telemetry sequence comparison from serverNow <= lastRecordedEpoch to serverNow < lastRecordedEpoch. The <= comparison incorrectly dropped legitimate telemetry updates arriving in the same millisecond (e.g., from offline batch replay, GPS bursts, or fast loop iterations), creating gaps in driver location history.

Changes Made:
- Changed <= to < in the sequence comparison gate in tracker.js
- Sequential updates sharing a millisecond timestamp are now correctly allowed through

Impact it Made:
- Fixes dropped telemetry for same-millisecond updates
- Prevents gaps in driver location history during high-frequency GPS bursts
- Out-of-order messages (true past timestamps) are still correctly rejected

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.