### PR TITLE
fix : assert geofence on escrow retry path in deliveryVerificationService

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -481,9 +481,9 @@ export class DeliveryVerificationService {
           order.status === "payment_released" &&
           ["funded", "release_failed"].includes(order.escrow_status);
 
-        if (!isRetryForStuckEscrow) {
-          await this.assertDriverAtDropoff(order);
-        }
+        // Always assert driver is at dropoff — physical presence must be verified
+        // regardless of retry path to prevent bypassing geofence on escrow recovery.
+        await this.assertDriverAtDropoff(order);
 
         let releaseTxHash = null;
         let escrowAlreadyReleased = false;


### PR DESCRIPTION
Closes #11670.

Summary of What Has Been Done:
Removed the conditional skip of assertDriverAtDropoff() on the stuck-escrow retry path. Previously, when isRetryForStuckEscrow was true, the geofence and physical-presence check was bypassed entirely, allowing escrow release without verifying the driver was at the drop-off location.

Changes Made:
- Removed the if (!isRetryForStuckEscrow) guard around assertDriverAtDropoff()
- Geofence check now always runs before escrow release, regardless of retry path

Impact it Made:
- Physical presence at drop-off is always verified before escrow release
- Prevents bypassing WIM/geofence controls on the escrow recovery path
- Note: Some pre-existing test failures in deliveryVerificationService.test.js exist on main (unrelated to this change)

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.