### PR TITLE
fix : use np.radians in physics_loss compute_physics_residual

### DIFF
--- a/backend/ml/pinns/physics_loss.py
+++ b/backend/ml/pinns/physics_loss.py
@@ -11,8 +11,9 @@ class PhysicsConstrainedLoss:
 
     def compute_physics_residual(self, speed: float, slope: float, mass: float, predicted_wear: float) -> float:
         # F_net = m * a + m * g * sin(theta)
+        # slope is provided in degrees; convert to radians for np.sin
         g = 9.81
-        force = mass * (speed * 0.05) + mass * g * np.sin(slope)
+        force = mass * (speed * 0.05) + mass * g * np.sin(np.radians(slope))
         
         # Physical constraint: Wear must be non-negative and proportional to applied force
         expected_min_wear = max(0.0, force * 1e-6)


### PR DESCRIPTION
Closes #11667.

Summary of What Has been Done:
Fixed the trigonometric conversion in compute_physics_residual(). The slope parameter is provided in degrees but was passed directly to np.sin() which expects radians. Added np.radians() conversion to correctly compute the physics constraint.

Changes Made:
- Changed np.sin(slope) to np.sin(np.radians(slope))
- Added comment documenting the degree-to-radian conversion

Impact it Made:
- Correct physics force calculation for non-zero slopes
- Previously np.sin(5) computed as sin(5 radians) ≈ -0.96 instead of sin(5°) ≈ 0.087
- PINN physics-informed loss is now correct for all slope values

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.