### PR TITLE
fix : removed self-verification from VDF fairness evaluation

### DIFF
--- a/backend/vdf/vdf_allocator.py
+++ b/backend/vdf/vdf_allocator.py
@@ -62,14 +62,15 @@ class VdfLoadAllocator:
     def evaluate_bid_fairness(self, load_id: str, driver_id: str, bid_timestamp: float):
         seed = f"{load_id}:{driver_id}:{bid_timestamp}"
         output_y, proof = self.vdf.eval(seed)
-        is_valid = self.vdf.verify(seed, output_y, proof)
-        
+        # NOTE: self.vdf.verify(seed, output_y, proof) is self-referential and
+        # always returns True — removed to avoid false fairness guarantee.
+        # A proper implementation accepts externally supplied (output, proof)
+        # from the bidder and verifies it against the seed.
         return {
             "load_id": load_id,
             "driver_id": driver_id,
             "vdf_output": output_y,
             "proof": proof,
-            "is_fairly_allocated": is_valid
         }
 
 vdf_allocator = VdfLoadAllocator()


### PR DESCRIPTION
Closes #11675.

Summary of What Has Been Done:
Removed the self-referential VDF verification call from evaluate_bid_fairness(). The call self.vdf.verify(seed, output_y, proof) always returns True because it verifies the output the VDF itself just generated — not any externally supplied value. This made the fairness gate a no-op. Removed the verification call and returned only the VDF output as a commitment with a note explaining that independent verification is needed.

Changes Made:
- Removed is_valid = self.vdf.verify(seed, output_y, proof) from evaluate_bid_fairness
- Removed is_fairly_allocated field from return value (was always True, now removed to avoid false guarantee)
- Added comment explaining that callers must implement independent fairness verification

Impact it Made:
- No longer misleads callers into thinking VDF fairness is verified
- API is honest about what it provides (VDF output commitment)
- Clear documentation that callers need independent verification

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.