### PR TITLE
fix : add releaseVotes function to DAO.sol for voter token withdrawal

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -20,9 +20,12 @@ contract DAO is Ownable {
     IERC20 public governanceToken;
     Proposal[] public proposals;
     mapping(uint256 => mapping(address => uint256)) public votesCast;
+    // Track deposited token amounts per (proposalId, voter) for withdrawal.
+    mapping(uint256 => mapping(address => uint256)) public depositedAmount;
 
     event ProposalCreated(uint256 indexed proposalId, string description, uint256 deadline);
     event VotedQuadratic(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 tokenCost);
+    event VotesReleased(uint256 indexed proposalId, address indexed voter, uint256 tokenAmount);
 
     constructor(address _tokenAddress) Ownable(msg.sender) {
         governanceToken = IERC20(_tokenAddress);
@@ -52,8 +55,27 @@ contract DAO is Ownable {
         require(governanceToken.transferFrom(msg.sender, address(this), tokenCost), "Token transfer failed");
 
         votesCast[_proposalId][msg.sender] += _votes;
+        depositedAmount[_proposalId][msg.sender] += tokenCost;
         proposal.voteCount += _votes;
 
         emit VotedQuadratic(_proposalId, msg.sender, _votes, tokenCost);
+    }
+
+    /**
+     * @dev Release deposited governance tokens for a proposal after the voting deadline.
+     * Voters must call this after voting deadline to reclaim their tokens.
+     */
+    function releaseVotes(uint256 _proposalId) external {
+        Proposal storage proposal = proposals[_proposalId];
+        require(block.timestamp >= proposal.votingDeadline, "Voting period not yet ended");
+        require(proposal.executed || block.timestamp > proposal.votingDeadline, "Cannot release before deadline");
+
+        uint256 amount = depositedAmount[_proposalId][msg.sender];
+        require(amount > 0, "No tokens deposited for this proposal");
+
+        depositedAmount[_proposalId][msg.sender] = 0;
+        require(governanceToken.transfer(msg.sender, amount), "Token transfer failed");
+
+        emit VotesReleased(_proposalId, msg.sender, amount);
     }
 }


### PR DESCRIPTION
Closes #11663.

Summary of What Has Been Done:
Added a releaseVotes() function to DAO.sol and a depositedAmount tracking mapping. Previously, voteQuadratic transferred governance tokens into the contract with no path to return them — every vote permanently destroyed the voter's tokens. Now voters can reclaim their tokens after the voting deadline.

Changes Made:
- Added depositedAmount mapping (proposalId -> voter -> amount) to track deposited tokens
- Modified voteQuadratic to record depositedAmount on each vote
- Added releaseVotes(proposalId) function to return deposited tokens after deadline
- Added VotesReleased event

Impact it Made:
- Governance token holders can now reclaim tokens after voting
- Quadratic voting participation is economically viable
- Fixes the permanent token loss vulnerability

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.