### PR TITLE
feat: implement swipable freight load board ui (#11921)

### DIFF
--- a/apps/driver/lib/models/swipable_load_model.dart
+++ b/apps/driver/lib/models/swipable_load_model.dart
@@ -1,0 +1,35 @@
+class FreightLoad {
+  final String loadId;
+  final String origin;
+  final String destination;
+  final int miles;
+  final double payout;
+  final double ratePerMile;
+  final String equipmentType;
+  final String weightLbs;
+
+  FreightLoad({
+    required this.loadId,
+    required this.origin,
+    required this.destination,
+    required this.miles,
+    required this.payout,
+    required this.ratePerMile,
+    required this.equipmentType,
+    required this.weightLbs,
+  });
+}
+
+class SwipableSession {
+  final String status;
+  final List<FreightLoad> pendingLoads;
+  final List<FreightLoad> acceptedLoads;
+  final List<FreightLoad> rejectedLoads;
+
+  SwipableSession({
+    required this.status,
+    required this.pendingLoads,
+    required this.acceptedLoads,
+    required this.rejectedLoads,
+  });
+}

--- a/apps/driver/lib/screens/swipable_load_screen.dart
+++ b/apps/driver/lib/screens/swipable_load_screen.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import '../models/swipable_load_model.dart';
+import '../services/swipable_load_service.dart';
+
+class SwipableLoadScreen extends StatefulWidget {
+  const SwipableLoadScreen({super.key});
+
+  @override
+  State<SwipableLoadScreen> createState() => _SwipableLoadScreenState();
+}
+
+class _SwipableLoadScreenState extends State<SwipableLoadScreen> {
+  final SwipableLoadService _service = SwipableLoadService();
+  SwipableSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.loadStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.fetchLoads();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tinder for Freight'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              if (s.pendingLoads.isEmpty)
+                const Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.search_off, size: 64, color: Colors.blueGrey),
+                    SizedBox(height: 16),
+                    Text('No more loads in your area.', style: TextStyle(fontSize: 18, color: Colors.blueGrey, fontWeight: FontWeight.bold)),
+                  ],
+                )
+              else
+                // Render the cards in reverse order so the top one is the first item
+                ...s.pendingLoads.reversed.map((load) => _buildSwipableCard(load, isTop: load == s.pendingLoads.first)),
+            ],
+          ),
+        ),
+        _buildActionButtons(s),
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(SwipableSession s) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      color: Colors.blue[800],
+      child: Text(s.status, textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  Widget _buildSwipableCard(FreightLoad load, {required bool isTop}) {
+    // Basic implementation of a swipable card using Dismissible
+    return Positioned(
+      top: 32,
+      left: 16,
+      right: 16,
+      bottom: 64,
+      child: IgnorePointer(
+        ignoring: !isTop, // Only the top card can be swiped
+        child: Dismissible(
+          key: Key(load.loadId),
+          onDismissed: (direction) {
+            if (direction == DismissDirection.endToStart) {
+              _service.swipeLeft(load); // Swipe Left = Reject
+            } else if (direction == DismissDirection.startToEnd) {
+              _service.swipeRight(load); // Swipe Right = Accept
+            }
+          },
+          background: _buildSwipeBackground(Colors.green, Icons.check_circle, Alignment.centerLeft, "BOOK LOAD"),
+          secondaryBackground: _buildSwipeBackground(Colors.red, Icons.cancel, Alignment.centerRight, "PASS"),
+          child: Card(
+            elevation: isTop ? 12 : 2,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(24),
+                gradient: LinearGradient(
+                  colors: [Colors.white, Colors.grey[50]!],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                )
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      children: [
+                        Text('\$${load.payout.toStringAsFixed(0)}', style: TextStyle(fontSize: 56, fontWeight: FontWeight.bold, color: Colors.green[800])),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                          decoration: BoxDecoration(color: Colors.green[50], borderRadius: BorderRadius.circular(20)),
+                          child: Text('\$${load.ratePerMile.toStringAsFixed(2)} / mile', style: TextStyle(color: Colors.green[800], fontWeight: FontWeight.bold, fontSize: 18)),
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Row(
+                          children: [
+                            const Icon(Icons.location_on, color: Colors.blue),
+                            const SizedBox(width: 12),
+                            Text(load.origin, style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                        Container(
+                          height: 40,
+                          margin: const EdgeInsets.only(left: 11),
+                          decoration: const BoxDecoration(
+                            border: Border(left: BorderSide(color: Colors.grey, width: 2, style: BorderStyle.solid)),
+                          ),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Padding(
+                              padding: const EdgeInsets.only(left: 20),
+                              child: Text('${load.miles} Miles', style: const TextStyle(color: Colors.blueGrey, fontWeight: FontWeight.bold)),
+                            ),
+                          ),
+                        ),
+                        Row(
+                          children: [
+                            const Icon(Icons.flag, color: Colors.red),
+                            const SizedBox(width: 12),
+                            Text(load.destination, style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        _buildDetailChip(Icons.local_shipping, load.equipmentType),
+                        _buildDetailChip(Icons.scale, '${load.weightLbs} lbs'),
+                      ],
+                    )
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSwipeBackground(Color color, IconData icon, Alignment alignment, String text) {
+    return Container(
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(24),
+      ),
+      padding: const EdgeInsets.all(32),
+      alignment: alignment,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, color: Colors.white, size: 64),
+          const SizedBox(height: 12),
+          Text(text, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 24)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetailChip(IconData icon, String text) {
+    return Column(
+      children: [
+        Icon(icon, color: Colors.blueGrey),
+        const SizedBox(height: 8),
+        Text(text, style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.blueGrey)),
+      ],
+    );
+  }
+
+  Widget _buildActionButtons(SwipableSession s) {
+    if (s.pendingLoads.isEmpty) return const SizedBox(height: 80);
+
+    return Container(
+      padding: const EdgeInsets.only(bottom: 32, left: 32, right: 32),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          FloatingActionButton(
+            heroTag: 'pass_btn',
+            onPressed: () => _service.swipeLeft(s.pendingLoads.first),
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.red,
+            elevation: 4,
+            child: const Icon(Icons.close, size: 32),
+          ),
+          FloatingActionButton.large(
+            heroTag: 'book_btn',
+            onPressed: () => _service.swipeRight(s.pendingLoads.first),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            elevation: 8,
+            child: const Icon(Icons.local_shipping, size: 40),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/swipable_load_service.dart
+++ b/apps/driver/lib/services/swipable_load_service.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import '../models/swipable_load_model.dart';
+
+class SwipableLoadService {
+  final _sessionController = StreamController<SwipableSession>.broadcast();
+  
+  List<FreightLoad> _pending = [];
+  List<FreightLoad> _accepted = [];
+  List<FreightLoad> _rejected = [];
+
+  Stream<SwipableSession> get loadStream => _sessionController.stream;
+
+  void fetchLoads() async {
+    _pending = [
+      FreightLoad(loadId: 'LD-9921', origin: 'Dallas, TX', destination: 'Chicago, IL', miles: 925, payout: 2150.0, ratePerMile: 2.32, equipmentType: '53ft Dry Van', weightLbs: '42,000'),
+      FreightLoad(loadId: 'LD-8834', origin: 'Houston, TX', destination: 'Atlanta, GA', miles: 790, payout: 1400.0, ratePerMile: 1.77, equipmentType: '53ft Dry Van', weightLbs: '15,000'),
+      FreightLoad(loadId: 'LD-7711', origin: 'Austin, TX', destination: 'Denver, CO', miles: 980, payout: 3100.0, ratePerMile: 3.16, equipmentType: '53ft Flatbed', weightLbs: '48,000'),
+      FreightLoad(loadId: 'LD-6652', origin: 'San Antonio, TX', destination: 'Phoenix, AZ', miles: 990, payout: 1850.0, ratePerMile: 1.86, equipmentType: '53ft Reefer', weightLbs: '35,000'),
+    ];
+
+    _updateState('Searching for Freight matching your criteria...');
+  }
+
+  void swipeRight(FreightLoad load) {
+    _pending.removeWhere((l) => l.loadId == load.loadId);
+    _accepted.add(load);
+    _updateState('Load ${load.loadId} Booked Successfully!');
+  }
+
+  void swipeLeft(FreightLoad load) {
+    _pending.removeWhere((l) => l.loadId == load.loadId);
+    _rejected.add(load);
+    _updateState('Load Passed.');
+  }
+  
+  void _updateState(String status) {
+    _sessionController.add(SwipableSession(
+      status: status,
+      pendingLoads: List.from(_pending),
+      acceptedLoads: List.from(_accepted),
+      rejectedLoads: List.from(_rejected),
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11921

This PR introduces the frontend UI and mock telemetry services for the "Swipable" Freight Load Board UI feature. Traditional freight load boards resemble massive, dense Excel spreadsheets. Pinching and zooming to find a load on a 6-inch smartphone screen is incredibly frustrating for mobile owner-operators. This feature dramatically modernizes the user experience by introducing a "Tinder for Freight" concept. Drivers are presented with massive, highly readable cards containing the route, rate per mile, and payout. They simply swipe right to book the load, or swipe left to dismiss it.

### Changes Made:
- **`swipable_load_model.dart`**: Established the `SwipableSession` schema to manage the state arrays of pending, accepted, and rejected freight, alongside the `FreightLoad` schema containing the core financial and routing data.
- **`swipable_load_service.dart`**: Implemented a mock `Stream` simulating the backend dispatch engine. It successfully manages the queue of incoming loads and handles the state transitions when a driver executes a `swipeRight` (book) or `swipeLeft` (pass) action.
- **`swipable_load_screen.dart`**: Built a modern, card-based dispatch dashboard. The UI utilizes an interactive `Dismissible` stack. Drivers can drag the massive freight card across the screen, revealing dynamic colored backgrounds (Red for Reject, Green for Book) providing an incredibly fluid, tactile dispatching experience.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
