### PR TITLE
docs : added JSDoc to reverseGeocode getTimeoutMs and trafficService functions

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -4,6 +4,12 @@ import logger from '../middleware/logger.js';
 const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 const NOMINATIM_TIMEOUT_MS = 5000;
 
+/**
+ * Returns the Nominatim HTTP timeout in milliseconds.
+ * Reads NOMINATIM_TIMEOUT_MS from environment or falls back to NOMINATIM_TIMEOUT_MS constant.
+ *
+ * @returns {number} Timeout in milliseconds (minimum 1)
+ */
 function getTimeoutMs() {
   const configured = Number(process.env.NOMINATIM_TIMEOUT_MS);
   return Number.isFinite(configured) && configured > 0 ? configured : NOMINATIM_TIMEOUT_MS;

--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -8,6 +8,16 @@ const MIN_SURGE_MULTIPLIER = 1.2;
 const MAX_SURGE_MULTIPLIER = 2.5;
 const SURGE_PEAK_AMPLITUDE = 1.3;
 
+/**
+ * Calculates a live traffic multiplier for a given pickup location.
+ * Combines TOMTOM/Google Maps real-time traffic data with a sinusoidal rush-hour
+ * surge overlay (7-10 AM and 4-7 PM UTC). Falls back to rush-hour only if no API key
+ * is configured or the request fails.
+ *
+ * @param {number} pickupLat - Pickup latitude
+ * @param {number} pickupLng - Pickup longitude
+ * @returns {Promise<number>} Traffic multiplier (1.0 to 2.5), or 1.0 on error
+ */
 export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   try {
     if (!pickupLat || !pickupLng) {
@@ -56,6 +66,14 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   }
 }
 
+/**
+ * Returns a rush-hour surge multiplier based on the hour of day (UTC).
+ * Peaks at MIN_SURGE_MULTIPLIER + SURGE_PEAK_AMPLITUDE during the center of
+ * the rush-hour windows (morning 7-10 UTC, evening 16-19 UTC).
+ *
+ * @param {Date} date - Date/time to evaluate
+ * @returns {number} Surge multiplier between MIN_SURGE_MULTIPLIER and MAX_SURGE_MULTIPLIER
+ */
 function getRushHourMultiplier(date) {
   const hour = date.getUTCHours();
   const isMorningRush = hour >= RUSH_HOUR_START_AM && hour < RUSH_HOUR_END_AM;


### PR DESCRIPTION
Closes #11965.

Summary of What Has Been Done:
Added JSDoc documentation to undocumented functions in reverseGeocode.js and trafficService.js:
- reverseGeocode.js: Added JSDoc for getTimeoutMs() (environment-configurable Nominatim timeout)
- trafficService.js: Added JSDoc for getLiveTrafficMultiplier() and getRushHourMultiplier()

Changes Made:
- Added JSDoc @returns and @param tags to reverseGeocode.js getTimeoutMs()
- Added JSDoc to trafficService.js getLiveTrafficMultiplier() and getRushHourMultiplier()

Impact it Provided:
- Better IDE autocompletion and type safety for API consumers
- Documents that getLiveTrafficMultiplier falls back to rush-hour calculation when no API key is set

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.