### PR TITLE
test : added maxWeightLimit edge case coverage in wimBypass unit tests

### DIFF
--- a/backend/api/src/services/wimBypass.js
+++ b/backend/api/src/services/wimBypass.js
@@ -23,7 +23,10 @@ export function evaluateBypassEligibility(truckData) {
         return false;
     }
 
-    if (typeof axleWeight !== 'number' || axleWeight > maxWeightLimit) {
+    if (typeof axleWeight !== 'number' || typeof maxWeightLimit !== 'number') {
+        return false;
+    }
+    if (axleWeight > maxWeightLimit) {
         return false;
     }
 

--- a/backend/api/test/unit/wimBypass.test.js
+++ b/backend/api/test/unit/wimBypass.test.js
@@ -130,5 +130,43 @@ describe('wimBypass service', () => {
       expect(result.packet).toBeDefined();
       expect(result.signature).toBeDefined();
     });
+
+  describe('maxWeightLimit edge cases', () => {
+    it('returns false when maxWeightLimit is undefined', () => {
+      const result = evaluateBypassEligibility({
+        safetyScore: 90,
+        axleWeight: 15000,
+        // maxWeightLimit intentionally omitted
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when maxWeightLimit is null', () => {
+      const result = evaluateBypassEligibility({
+        safetyScore: 90,
+        axleWeight: 15000,
+        maxWeightLimit: null,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when maxWeightLimit is a string', () => {
+      const result = evaluateBypassEligibility({
+        safetyScore: 90,
+        axleWeight: 15000,
+        maxWeightLimit: '20000',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when axleWeight is undefined but maxWeightLimit is present', () => {
+      const result = evaluateBypassEligibility({
+        safetyScore: 90,
+        // axleWeight intentionally omitted
+        maxWeightLimit: 20000,
+      });
+      expect(result).toBe(false);
+    });
+  });
   });
 });


### PR DESCRIPTION
Closes #11968.

Summary of What Has Been Done:
Added 4 test cases to wimBypass.test.js covering maxWeightLimit edge cases and applied the fix for the undefined guard from PR #11948. Tests verify that evaluateBypassEligibility returns false when maxWeightLimit is undefined, null, or a string, and when axleWeight is undefined.

Changes Made:
- Added 4 unit tests for maxWeightLimit edge cases
- Applied undefined guard fix (splitting the combined check into separate guards)
- All 17 tests pass

Impact it Made:
- Full regression coverage for the maxWeightLimit undefined guard

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.