### PR TITLE
feat: implement smart notification batching and context awareness (#11929)

### DIFF
--- a/apps/driver/lib/models/notification_batching_model.dart
+++ b/apps/driver/lib/models/notification_batching_model.dart
@@ -1,0 +1,27 @@
+class ContextNotification {
+  final String id;
+  final String title;
+  final String message;
+  final bool isUrgent;
+  final DateTime timestamp;
+
+  ContextNotification({
+    required this.id,
+    required this.title,
+    required this.message,
+    required this.isUrgent,
+    required this.timestamp,
+  });
+}
+
+class NotificationBatchingSession {
+  final double currentSpeedMph;
+  final List<ContextNotification> deliveredNotifications; // Shown immediately
+  final List<ContextNotification> batchedQueue; // Held back until stopped
+
+  NotificationBatchingSession({
+    required this.currentSpeedMph,
+    required this.deliveredNotifications,
+    required this.batchedQueue,
+  });
+}

--- a/apps/driver/lib/screens/notification_batching_screen.dart
+++ b/apps/driver/lib/screens/notification_batching_screen.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import '../models/notification_batching_model.dart';
+import '../services/notification_batching_service.dart';
+
+class NotificationBatchingScreen extends StatefulWidget {
+  const NotificationBatchingScreen({super.key});
+
+  @override
+  State<NotificationBatchingScreen> createState() => _NotificationBatchingScreenState();
+}
+
+class _NotificationBatchingScreenState extends State<NotificationBatchingScreen> {
+  final NotificationBatchingService _service = NotificationBatchingService();
+  NotificationBatchingSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.notificationStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.startSimulation();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Context-Aware Alerts'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+    bool isDriving = s.currentSpeedMph > 0;
+
+    return Column(
+      children: [
+        _buildHudHeader(s, isDriving),
+        _buildSpeedControls(s, isDriving),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.batchedQueue.isNotEmpty) ...[
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('SILENT BATCH QUEUE', style: TextStyle(color: Colors.orange, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                    Icon(Icons.notifications_paused, color: Colors.orange[800], size: 20),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                ...s.batchedQueue.map((n) => _buildNotificationCard(n, isBatched: true)),
+                const SizedBox(height: 24),
+              ],
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('DELIVERED NOTIFICATIONS', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                  Icon(Icons.notifications_active, color: Colors.grey[600], size: 20),
+                ],
+              ),
+              const SizedBox(height: 12),
+              if (s.deliveredNotifications.isEmpty)
+                const Center(child: Padding(
+                  padding: EdgeInsets.all(32.0),
+                  child: Text('No active alerts.', style: TextStyle(color: Colors.grey)),
+                ))
+              else
+                ...s.deliveredNotifications.map((n) => _buildNotificationCard(n, isBatched: false)),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildHudHeader(NotificationBatchingSession s, bool isDriving) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: isDriving ? Colors.blue[900] : Colors.green[800],
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(isDriving ? Icons.speed : Icons.local_parking, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              Text(
+                isDriving ? 'VEHICLE IN MOTION' : 'VEHICLE STOPPED',
+                style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            isDriving ? '${s.currentSpeedMph.toStringAsFixed(0)} MPH' : '0 MPH',
+            style: const TextStyle(color: Colors.white, fontSize: 36, fontWeight: FontWeight.bold)
+          ),
+          const SizedBox(height: 8),
+          Text(
+            isDriving ? 'Blocking non-urgent distractions' : 'Releasing batched notifications',
+            style: const TextStyle(color: Colors.white70)
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSpeedControls(NotificationBatchingSession s, bool isDriving) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: Colors.white,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          ElevatedButton(
+            onPressed: isDriving ? () => _service.toggleSpeed(0.0) : null,
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('Simulate Stop'),
+          ),
+          ElevatedButton(
+            onPressed: !isDriving ? () => _service.toggleSpeed(65.0) : null,
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+            child: const Text('Simulate Drive'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotificationCard(ContextNotification n, {required bool isBatched}) {
+    Color cardColor = isBatched ? Colors.orange[50]! : (n.isUrgent ? Colors.red[50]! : Colors.white);
+    Color iconColor = isBatched ? Colors.orange : (n.isUrgent ? Colors.red : Colors.blueGrey);
+    IconData icon = isBatched ? Icons.schedule : (n.isUrgent ? Icons.warning : Icons.info);
+
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.only(bottom: 8),
+      color: cardColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: n.isUrgent && !isBatched ? Colors.red[300]! : Colors.transparent),
+      ),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: iconColor.withOpacity(0.2),
+          child: Icon(icon, color: iconColor),
+        ),
+        title: Text(n.title, style: TextStyle(fontWeight: FontWeight.bold, color: n.isUrgent && !isBatched ? Colors.red[900] : Colors.black87)),
+        subtitle: Text(n.message),
+        trailing: isBatched 
+          ? const Text('HOLD', style: TextStyle(color: Colors.orange, fontWeight: FontWeight.bold))
+          : Text(n.isUrgent ? 'BYPASS' : 'DELIVERED', style: TextStyle(color: Colors.grey[500], fontSize: 10, fontWeight: FontWeight.bold)),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/notification_batching_service.dart
+++ b/apps/driver/lib/services/notification_batching_service.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import '../models/notification_batching_model.dart';
+
+class NotificationBatchingService {
+  final _sessionController = StreamController<NotificationBatchingSession>.broadcast();
+  
+  double _speed = 65.0; // Starts driving
+  final List<ContextNotification> _delivered = [];
+  final List<ContextNotification> _queue = [];
+  Timer? _simTimer;
+  int _tick = 0;
+
+  Stream<NotificationBatchingSession> get notificationStream => _sessionController.stream;
+
+  void startSimulation() {
+    _emitState();
+    _simTimer = Timer.periodic(const Duration(seconds: 3), (timer) {
+      _tick++;
+      if (_tick == 1) {
+        _handleIncomingNotification(
+          title: 'Company Newsletter',
+          message: 'Check out our driver of the month!',
+          isUrgent: false,
+        );
+      } else if (_tick == 2) {
+        _handleIncomingNotification(
+          title: 'URGENT: Load Cancelled',
+          message: 'Do NOT proceed to pickup. Contact dispatch.',
+          isUrgent: true,
+        );
+      } else if (_tick == 3) {
+        _handleIncomingNotification(
+          title: 'Safety Tip',
+          message: 'Remember to check tire pressure in winter.',
+          isUrgent: false,
+        );
+      } else if (_tick == 4) {
+        // Driver stops
+        _speed = 0.0;
+        _flushQueue();
+      } else if (_tick > 5) {
+        timer.cancel();
+      }
+      _emitState();
+    });
+  }
+
+  void _handleIncomingNotification({required String title, required String message, required bool isUrgent}) {
+    final notif = ContextNotification(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      message: message,
+      isUrgent: isUrgent,
+      timestamp: DateTime.now(),
+    );
+
+    if (isUrgent || _speed == 0.0) {
+      _delivered.insert(0, notif);
+    } else {
+      _queue.add(notif);
+    }
+  }
+
+  void _flushQueue() {
+    for (var n in _queue) {
+      _delivered.insert(0, n);
+    }
+    _queue.clear();
+  }
+
+  void toggleSpeed(double newSpeed) {
+    _speed = newSpeed;
+    if (_speed == 0.0) {
+      _flushQueue();
+    }
+    _emitState();
+  }
+
+  void _emitState() {
+    _sessionController.add(NotificationBatchingSession(
+      currentSpeedMph: _speed,
+      deliveredNotifications: List.from(_delivered),
+      batchedQueue: List.from(_queue),
+    ));
+  }
+
+  void dispose() {
+    _simTimer?.cancel();
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION

## Description
Resolves #11929

This PR introduces the frontend UI and mock telemetry services for the Smart Notification Batching & Context Awareness feature. Receiving non-urgent push notifications (such as company newsletters or generic surveys) while navigating an 80,000 lb semi-truck through a crowded highway interchange creates a massive safety hazard. To prevent drivers from disabling notifications entirely, this feature implements an intelligent attention-management engine. By tying directly into the device's GPS speed, the software intercepts non-urgent alerts while the vehicle is in motion, silently batching them in the background until the truck comes to a safe, complete stop (0 MPH).

### Changes Made:
- **`notification_batching_model.dart`**: Established the `NotificationBatchingSession` schema to manage the state of the active speed, alongside two separate queues (`deliveredNotifications` and `batchedQueue`) to handle the flow of data.
- **`notification_batching_service.dart`**: Implemented a mock `Stream` that accurately simulates the context engine. It successfully triages incoming data, allowing critical alerts (e.g., "Load Cancelled") to bypass the speed lock immediately, while intelligently holding back trivial messages until the driver simulates a stop.
- **`notification_batching_screen.dart`**: Built a transparent alert dashboard. The UI utilizes a dynamic header to indicate the current GPS speed state. To build trust with the driver, it explicitly renders the "Silent Batch Queue" in orange, allowing the user to see exactly which notifications are being safely withheld from their screen while they drive.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
