### PR TITLE
feat: implement expense receipt categorization ai (#11930)

### DIFF
--- a/apps/driver/lib/models/receipt_categorization_model.dart
+++ b/apps/driver/lib/models/receipt_categorization_model.dart
@@ -1,0 +1,31 @@
+class ExpenseReceipt {
+  final String id;
+  final String vendorName;
+  final double amount;
+  final String category; // "Fuel", "Repairs", "Tolls", "Meals", "Uncategorized"
+  final String taxStatus; // "Tax Deductible", "Non-Deductible"
+  final DateTime dateScanned;
+
+  ExpenseReceipt({
+    required this.id,
+    required this.vendorName,
+    required this.amount,
+    required this.category,
+    required this.taxStatus,
+    required this.dateScanned,
+  });
+}
+
+class ReceiptCategorizationSession {
+  final String status;
+  final bool isScanning;
+  final List<ExpenseReceipt> categorizedExpenses;
+  final double totalDeductible;
+
+  ReceiptCategorizationSession({
+    required this.status,
+    required this.isScanning,
+    required this.categorizedExpenses,
+    required this.totalDeductible,
+  });
+}

--- a/apps/driver/lib/screens/receipt_categorization_screen.dart
+++ b/apps/driver/lib/screens/receipt_categorization_screen.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import '../models/receipt_categorization_model.dart';
+import '../services/receipt_categorization_service.dart';
+
+class ReceiptCategorizationScreen extends StatefulWidget {
+  const ReceiptCategorizationScreen({super.key});
+
+  @override
+  State<ReceiptCategorizationScreen> createState() => _ReceiptCategorizationScreenState();
+}
+
+class _ReceiptCategorizationScreenState extends State<ReceiptCategorizationScreen> {
+  final ReceiptCategorizationService _service = ReceiptCategorizationService();
+  ReceiptCategorizationSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.categorizationStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.initializeDashboard();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Expense AI'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _session?.isScanning == true ? null : () => _showUploadOptions(context),
+        backgroundColor: Colors.indigo,
+        icon: const Icon(Icons.camera_alt),
+        label: const Text('Scan Receipt'),
+      ),
+    );
+  }
+  
+  void _showUploadOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.local_gas_station),
+                title: const Text('Simulate Fuel Receipt'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _service.simulateReceiptUpload();
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.build),
+                title: const Text('Simulate Repair Invoice'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _service.simulateRepairUpload();
+                },
+              ),
+            ],
+          ),
+        );
+      }
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildTaxSummaryCard(s.totalDeductible),
+              const SizedBox(height: 24),
+              const Text('ACCOUNTING LEDGER', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              const SizedBox(height: 12),
+              if (s.categorizedExpenses.isEmpty)
+                const Center(child: Padding(
+                  padding: EdgeInsets.all(32.0),
+                  child: Text('No expenses logged. Tap Scan Receipt to begin.', style: TextStyle(color: Colors.grey)),
+                ))
+              else
+                ...s.categorizedExpenses.map((e) => _buildExpenseCard(e)),
+              const SizedBox(height: 80), // Padding for FAB
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(ReceiptCategorizationSession s) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: s.isScanning ? Colors.indigo[600] : Colors.blueGrey[800],
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              s.isScanning 
+                ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: Colors.white, strokeWidth: 3))
+                : const Icon(Icons.account_balance_wallet, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('AI CATEGORIZATION', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTaxSummaryCard(double total) {
+    return Card(
+      elevation: 4,
+      color: Colors.green[50],
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: Colors.green[300]!, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.shield, color: Colors.green),
+                    SizedBox(width: 8),
+                    Text('Est. Tax Deductions', style: TextStyle(color: Colors.green, fontWeight: FontWeight.bold)),
+                  ],
+                ),
+                SizedBox(height: 4),
+                Text('YTD Tracked', style: TextStyle(color: Colors.grey, fontSize: 12)),
+              ],
+            ),
+            Text('\$${total.toStringAsFixed(2)}', style: TextStyle(color: Colors.green[800], fontSize: 28, fontWeight: FontWeight.bold)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpenseCard(ExpenseReceipt e) {
+    IconData catIcon;
+    Color catColor;
+
+    switch (e.category) {
+      case 'Fuel':
+        catIcon = Icons.local_gas_station;
+        catColor = Colors.orange;
+        break;
+      case 'Repairs':
+        catIcon = Icons.build;
+        catColor = Colors.red;
+        break;
+      default:
+        catIcon = Icons.receipt;
+        catColor = Colors.blueGrey;
+    }
+
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: catColor.withOpacity(0.2),
+          child: Icon(catIcon, color: catColor),
+        ),
+        title: Text(e.vendorName, style: const TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: Text('${e.category} • ${e.taxStatus}'),
+        trailing: Text('\$${e.amount.toStringAsFixed(2)}', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/receipt_categorization_service.dart
+++ b/apps/driver/lib/services/receipt_categorization_service.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import '../models/receipt_categorization_model.dart';
+
+class ReceiptCategorizationService {
+  final _sessionController = StreamController<ReceiptCategorizationSession>.broadcast();
+  final List<ExpenseReceipt> _expenses = [];
+
+  Stream<ReceiptCategorizationSession> get categorizationStream => _sessionController.stream;
+
+  void initializeDashboard() {
+    _emitState('Awaiting Receipt Upload', false);
+  }
+
+  void simulateReceiptUpload() async {
+    _emitState('OCR Extracting Text...', true);
+    await Future.delayed(const Duration(seconds: 1));
+    
+    _emitState('NLP Categorizing Vendor...', true);
+    await Future.delayed(const Duration(seconds: 1));
+
+    // Create a mock extracted receipt
+    final receipt = ExpenseReceipt(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      vendorName: 'Loves Travel Stop #312',
+      amount: 450.75,
+      category: 'Fuel',
+      taxStatus: 'Tax Deductible',
+      dateScanned: DateTime.now(),
+    );
+
+    _expenses.insert(0, receipt);
+
+    _emitState('Receipt Successfully Categorized', false);
+  }
+  
+  void simulateRepairUpload() async {
+    _emitState('OCR Extracting Text...', true);
+    await Future.delayed(const Duration(seconds: 1));
+    
+    _emitState('NLP Categorizing Vendor...', true);
+    await Future.delayed(const Duration(seconds: 1));
+
+    // Create a mock extracted receipt
+    final receipt = ExpenseReceipt(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      vendorName: 'TA Truck Service',
+      amount: 1240.00,
+      category: 'Repairs',
+      taxStatus: 'Tax Deductible',
+      dateScanned: DateTime.now(),
+    );
+
+    _expenses.insert(0, receipt);
+
+    _emitState('Receipt Successfully Categorized', false);
+  }
+
+  void _emitState(String status, bool isScanning) {
+    double total = _expenses
+        .where((e) => e.taxStatus == 'Tax Deductible')
+        .fold(0.0, (sum, e) => sum + e.amount);
+
+    _sessionController.add(ReceiptCategorizationSession(
+      status: status,
+      isScanning: isScanning,
+      categorizedExpenses: List.from(_expenses),
+      totalDeductible: total,
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11930

This PR introduces the frontend UI and mock telemetry services for the Expense Receipt Categorization AI. Owner-operators are notoriously terrible at accounting. They typically throw hundreds of paper receipts into a shoebox, forcing them to spend agonizing days manually typing the data into spreadsheets at the end of the year to avoid the IRS. This feature automates that massive pain point. By utilizing OCR and an NLP classification engine, drivers can simply snap a photo of a receipt. The backend reads the text, identifies the vendor, categorizes the expense (e.g., Fuel, Repairs, Tolls), and automatically updates a tax-deduction ledger.

### Changes Made:
- **`receipt_categorization_model.dart`**: Established the `ReceiptCategorizationSession` schema to manage the state of the active ledger, alongside the `ExpenseReceipt` schema to track extracted data such as `vendorName` and `taxStatus`.
- **`receipt_categorization_service.dart`**: Implemented a mock `Stream` simulating the OCR/NLP backend pipeline. It accurately simulates the ingestion delay of parsing an image, successfully categorizes a "$450 Loves Travel Stop" receipt as 'Fuel', and a "$1240 TA Truck Service" invoice as 'Repairs'.
- **`receipt_categorization_screen.dart`**: Built an automated accounting UI. Drivers can tap "Scan Receipt" to trigger the simulation. As the AI parses the mock image, the UI header updates to reflect the OCR status. Once parsed, the expense is dynamically appended to the ledger, and a prominent green "Est. Tax Deductions" card updates in real-time to show the driver their year-to-date savings.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
