### PR TITLE
fix: keep settle action reachable for already-signed BOL contracts

### DIFF
--- a/apps/driver/lib/screens/wallet_settlement_screen.dart
+++ b/apps/driver/lib/screens/wallet_settlement_screen.dart
@@ -3,16 +3,25 @@ import '../models/smart_contract_payment_model.dart';
 import '../services/smart_contract_payment_service.dart';
 
 class WalletSettlementScreen extends StatefulWidget {
-  const WalletSettlementScreen({super.key});
+  const WalletSettlementScreen({super.key, this.paymentService});
+
+  /// Injection seam for tests. Defaults to the real blockchain-backed service.
+  final SmartContractPaymentService? paymentService;
 
   @override
   State<WalletSettlementScreen> createState() => _WalletSettlementScreenState();
 }
 
 class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
-  final SmartContractPaymentService _paymentService = SmartContractPaymentService();
+  late final SmartContractPaymentService _paymentService =
+      widget.paymentService ?? SmartContractPaymentService();
   List<SmartContractPayment> _contracts = [];
   bool _isLoading = true;
+
+  /// Contracts with a settlement call currently in flight. Guards against a
+  /// double tap landing two `executeSmartContract` calls on the same escrow
+  /// before the modal barrier is mounted.
+  final Set<String> _settlingContractIds = {};
 
   @override
   void initState() {
@@ -31,6 +40,14 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
   }
 
   Future<void> _signBolAndSettle(SmartContractPayment contract) async {
+    // Idempotent entry: an already-settled escrow has nothing left to release,
+    // and a contract mid-settlement must not be executed twice. Re-entry is a
+    // no-op rather than a second on-chain payout.
+    if (contract.status == 'Settled' ||
+        !_settlingContractIds.add(contract.contractId)) {
+      return;
+    }
+
     showDialog<void>(
       context: context,
       barrierDismissible: false,
@@ -75,6 +92,8 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
         ),
       );
     } finally {
+      // Released on every exit path so a failed settlement stays retryable.
+      _settlingContractIds.remove(contract.contractId);
       // Always close the non-dismissible dialog, even when the call throws,
       // so the driver is never stuck on a permanently spinning barrier.
       if (mounted) {
@@ -129,7 +148,11 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
 
   Widget _buildContractCard(SmartContractPayment contract) {
     final isSettled = contract.status == 'Settled';
-    final canSettle = contract.geoFenceBreached && !contract.bolSigned;
+    // Delivery is proven by the geo-fence breach; funds stay releasable until
+    // the escrow actually settles. Keying this off `!contract.bolSigned` left a
+    // contract whose BOL was signed elsewhere with no badge and no button, so
+    // the driver could never trigger a payout that was already earned.
+    final canSettle = contract.geoFenceBreached && !isSettled;
 
     return Card(
       margin: const EdgeInsets.only(bottom: 16),
@@ -167,8 +190,10 @@ class _WalletSettlementScreenState extends State<WalletSettlementScreen> {
                 width: double.infinity,
                 child: ElevatedButton.icon(
                   onPressed: () => _signBolAndSettle(contract),
-                  icon: const Icon(Icons.draw),
-                  label: const Text('SIGN BOL & RELEASE FUNDS'),
+                  icon: Icon(contract.bolSigned ? Icons.lock_open : Icons.draw),
+                  label: Text(contract.bolSigned
+                      ? 'RELEASE FUNDS'
+                      : 'SIGN BOL & RELEASE FUNDS'),
                   style: ElevatedButton.styleFrom(backgroundColor: Colors.indigo[900], foregroundColor: Colors.white),
                 ),
               )

--- a/apps/driver/test/wallet_settlement_screen_test.dart
+++ b/apps/driver/test/wallet_settlement_screen_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/models/smart_contract_payment_model.dart';
+import 'package:truxify_driver/screens/wallet_settlement_screen.dart';
+import 'package:truxify_driver/services/smart_contract_payment_service.dart';
+
+/// Regression coverage for GitHub issue #12006.
+///
+/// `_buildContractCard` gated the release button on
+/// `geoFenceBreached && !bolSigned`. A contract whose BOL was signed through
+/// another path but whose escrow had not settled matched neither `isSettled`
+/// nor `canSettle`, so the card fell through to the status-text branch: no
+/// badge, no button, and no way for the driver to claim funds already earned.
+
+/// Fake service with the artificial network delays removed so `pumpAndSettle`
+/// resolves. Mirrors the real contract: settlement returns a signed, settled
+/// copy of the escrow.
+class _FakePaymentService extends SmartContractPaymentService {
+  _FakePaymentService(this.contracts);
+
+  final List<SmartContractPayment> contracts;
+  int executeCallCount = 0;
+
+  @override
+  Future<List<SmartContractPayment>> getActiveContracts() async => contracts;
+
+  @override
+  Future<SmartContractPayment> executeSmartContract(
+      SmartContractPayment contract) async {
+    executeCallCount++;
+    return SmartContractPayment(
+      contractId: contract.contractId,
+      loadId: contract.loadId,
+      brokerName: contract.brokerName,
+      amountUsd: contract.amountUsd,
+      cryptoEquivalent: contract.cryptoEquivalent,
+      geoFenceBreached: true,
+      bolSigned: true,
+      status: 'Settled',
+      settlementTime: DateTime.now(),
+    );
+  }
+}
+
+SmartContractPayment _contract({
+  required bool geoFenceBreached,
+  required bool bolSigned,
+  required String status,
+}) {
+  return SmartContractPayment(
+    contractId: '0x8f2a...4b1c',
+    loadId: 'LD-99321',
+    brokerName: 'TQL Logistics',
+    amountUsd: 2150.00,
+    cryptoEquivalent: '2150.00 USDC',
+    geoFenceBreached: geoFenceBreached,
+    bolSigned: bolSigned,
+    status: status,
+  );
+}
+
+Future<_FakePaymentService> _pumpScreen(
+  WidgetTester tester,
+  SmartContractPayment contract,
+) async {
+  final service = _FakePaymentService([contract]);
+  await tester.pumpWidget(
+    MaterialApp(home: WalletSettlementScreen(paymentService: service)),
+  );
+  await tester.pumpAndSettle();
+  return service;
+}
+
+void main() {
+  testWidgets(
+      'geo-fence breached with BOL already signed still exposes the release action',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+      tester,
+      _contract(
+        geoFenceBreached: true,
+        bolSigned: true,
+        status: 'Awaiting Settlement',
+      ),
+    );
+
+    // The bug: this card rendered only 'AWAITING SETTLEMENT' with no action.
+    expect(find.text('RELEASE FUNDS'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+    expect(find.text('AWAITING SETTLEMENT'), findsNothing);
+  });
+
+  testWidgets('unsigned BOL keeps the sign-and-release action',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+      tester,
+      _contract(
+        geoFenceBreached: true,
+        bolSigned: false,
+        status: 'Awaiting BOL Signature',
+      ),
+    );
+
+    expect(find.text('SIGN BOL & RELEASE FUNDS'), findsOneWidget);
+    expect(find.text('AWAITING BOL SIGNATURE'), findsNothing);
+  });
+
+  testWidgets('settled contract shows the badge and offers no action',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+      tester,
+      _contract(geoFenceBreached: true, bolSigned: true, status: 'Settled'),
+    );
+
+    expect(find.text('SETTLED'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+
+  testWidgets('undelivered contract shows status only',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+      tester,
+      _contract(
+        geoFenceBreached: false,
+        bolSigned: false,
+        status: 'Awaiting Delivery',
+      ),
+    );
+
+    expect(find.text('AWAITING DELIVERY'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+
+  testWidgets('releasing an already-signed contract settles it exactly once',
+      (WidgetTester tester) async {
+    final service = await _pumpScreen(
+      tester,
+      _contract(
+        geoFenceBreached: true,
+        bolSigned: true,
+        status: 'Awaiting Settlement',
+      ),
+    );
+
+    await tester.tap(find.text('RELEASE FUNDS'));
+    await tester.pumpAndSettle();
+
+    expect(service.executeCallCount, 1);
+    expect(find.text('SETTLED'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+
+  testWidgets('a double tap does not execute the contract twice',
+      (WidgetTester tester) async {
+    final service = await _pumpScreen(
+      tester,
+      _contract(
+        geoFenceBreached: true,
+        bolSigned: false,
+        status: 'Awaiting BOL Signature',
+      ),
+    );
+
+    // The handler is invoked directly rather than tapped twice: once the modal
+    // barrier is mounted a second `tap()` no longer hit-tests, so it cannot
+    // reproduce the window a real double tap exploits — the two presses that
+    // land before the first `showDialog` renders.
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    button.onPressed!();
+    button.onPressed!();
+    await tester.pumpAndSettle();
+
+    expect(service.executeCallCount, 1);
+    expect(find.text('SETTLED'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Fixes #12006

## Root cause

`_buildContractCard` derived the two card states from predicates that do not cover the full state space:

```dart
final isSettled = contract.status == 'Settled';
final canSettle = contract.geoFenceBreached && !contract.bolSigned;
```

`canSettle` asks *"is the BOL still unsigned?"* — but signing the BOL is only the **trigger** for release, not a condition that disqualifies it. Escrow release actually depends on delivery being proven (`geoFenceBreached`) and the payout not having happened yet (`status != 'Settled'`).

That leaves one reachable state matching neither branch:

| `geoFenceBreached` | `bolSigned` | `status` | `isSettled` | `canSettle` | rendered |
|---|---|---|---|---|---|
| true | false | `Awaiting BOL Signature` | false | **true** | sign & release button |
| true | true | `Settled` | **true** | false | SETTLED badge |
| false | false | `Awaiting Delivery` | false | false | status text (correct — undelivered) |
| **true** | **true** | **not `Settled`** | **false** | **false** | **status text — no badge, no button** |

The last row is a contract whose BOL was signed through another path while the escrow had not yet settled. It fell through to the `else` branch, which renders status text and nothing else. Both conditions the smart contract requires were met, the funds were earned, and the UI offered the driver no way to claim them — permanently, since nothing in the screen can advance that contract's state.

The predicate was also the *only* thing preventing re-entry into `_signBolAndSettle`. Because `showDialog` needs a frame before its modal barrier covers the button, two presses landing in that window both reached `executeSmartContract` on the same escrow.

## Fix

`apps/driver/lib/screens/wallet_settlement_screen.dart`

1. **Gate the action on settlement state, not signature state** — `canSettle = contract.geoFenceBreached && !isSettled`. The two branches are now exhaustive for any geo-fence-breached contract: it either shows the badge or the action, never neither.
2. **Label the action for what it does** — when the BOL is already signed there is nothing to sign, so the button reads `RELEASE FUNDS` (`lock_open`) instead of `SIGN BOL & RELEASE FUNDS` (`draw`).
3. **Make `_signBolAndSettle` idempotent** — it returns early for an already-settled contract and for a contract whose settlement is already in flight, tracked by `contractId` and released in `finally` so a *failed* settlement stays retryable.

The screen also takes an optional `paymentService` (defaulting to the real service, so no call site changes) purely as an injection seam for the tests below. `WalletSettlementScreen` has no other callers in the repo.

## Proof

New regression test: `apps/driver/test/wallet_settlement_screen_test.dart` — 6 widget tests covering every row of the table above plus settlement and re-entry.

**With the fix — all green:**

```
00:00 +0: geo-fence breached with BOL already signed still exposes the release action
00:00 +1: unsigned BOL keeps the sign-and-release action
00:00 +2: settled contract shows the badge and offers no action
00:00 +3: undelivered contract shows status only
00:00 +4: releasing an already-signed contract settles it exactly once
00:00 +5: a double tap does not execute the contract twice
00:00 +6: All tests passed!
```

**Reverting only `canSettle` to `geoFenceBreached && !contract.bolSigned` — red, and red on exactly the stuck-contract cases:**

```
00:00 +0: geo-fence breached with BOL already signed still exposes the release action
  Expected: exactly one matching candidate
    Actual: _TextWidgetFinder:<Found 0 widgets with text "RELEASE FUNDS": []>
    Which: means none were found but one was expected
00:00 +0 -1: geo-fence breached with BOL already signed still exposes the release action [E]
00:00 +3 -2: releasing an already-signed contract settles it exactly once [E]
00:01 +4 -2: Some tests failed.
```

The other four tests still pass against the old predicate, confirming the change does not alter behaviour for the states that already worked.

**Removing only the idempotency guard (keeping the `canSettle` fix) — red on exactly that test:**

```
00:00 +5: a double tap does not execute the contract twice
  Expected: <1>
    Actual: <2>
00:00 +5 -1: a double tap does not execute the contract twice [E]
```

So each half of the fix is independently pinned by a test that fails without it.

**No collateral damage.** `flutter analyze` on both changed files reports `No issues found!`. Comparing the full `apps/driver` suite before and after this change, the set of failing tests is byte-identical (37 pre-existing failures both runs; 0 introduced, and my 6 added on top):

```
baseline failures: 37   with-fix failures: 37
NEW failures introduced by the change:   (none)
```

### Note on the local test environment (pre-existing, not introduced here)

`flutter pub get` does not currently resolve in `apps/driver` on `main`, for two reasons unrelated to this PR:

- `apps/driver` and `apps/customer` pin `intl: ^0.19.0` while `packages/truxify_shared` requires `intl: ^0.20.2`.
- `flutter_webrtc: ^0.10.4` needs `web ^0.5.1` while `printing: ^5.13.4` needs `web ^1.0.0`.

I ran the suite with local, **uncommitted** `dependency_overrides` for those two packages; no dependency change is part of this PR. The 37 pre-existing failures above come from that environment (e.g. `background_sync_service.dart` references `Workmanager`, which is not declared in `pubspec.yaml`). Happy to open a separate issue for the dependency graph if that is useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settlement actions now reflect whether a BOL is signed, including sign-and-release options when needed.
  * Settlement eligibility now accounts for geo-fence breaches and unsettled status.
  * Already-completed or in-progress settlements are protected from duplicate actions.

* **Bug Fixes**
  * Failed settlements can now be retried successfully.
  * Settlement state is cleared reliably after completion or failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->