### PR TITLE
test(unit): stub .range to match getFraudStats paging (#12048)

### DIFF
--- a/backend/api/test/unit/fraudDetectionServiceGuard.test.js
+++ b/backend/api/test/unit/fraudDetectionServiceGuard.test.js
@@ -31,7 +31,7 @@ describe('FraudDetectionService stats', () => {
 
     it('buckets scores into risk bands', async () => {
       dbMock.supabaseAdmin.from.mockReturnValue({
-        select: vi.fn(() => ({ order: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [
+        select: vi.fn(() => ({ order: vi.fn(() => ({ range: vi.fn().mockResolvedValue({ data: [
           { risk_score: 0.9 }, { risk_score: 0.5 }, { risk_score: 0.2 },
         ] }) })) })),
       });
@@ -44,17 +44,17 @@ describe('FraudDetectionService stats', () => {
     });
 
     it('caps the query at 1000 rows', async () => {
-      const limit = vi.fn().mockResolvedValue({ data: [], });
+      const range = vi.fn().mockResolvedValue({ data: [], });
       dbMock.supabaseAdmin.from.mockReturnValue({
-        select: vi.fn(() => ({ order: vi.fn(() => ({ limit })) })),
+        select: vi.fn(() => ({ order: vi.fn(() => ({ range })) })),
       });
       await FraudDetectionService.getFraudStats();
-      expect(limit).toHaveBeenCalledWith(1000);
+      expect(range).toHaveBeenCalledWith(0, 999);
     });
 
     it('handles a null scores payload', async () => {
       dbMock.supabaseAdmin.from.mockReturnValue({
-        select: vi.fn(() => ({ order: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: null }) })) })),
+        select: vi.fn(() => ({ order: vi.fn(() => ({ range: vi.fn().mockResolvedValue({ data: null }) })) })),
       });
       const stats = await FraudDetectionService.getFraudStats();
       expect(stats.total).toBe(0);


### PR DESCRIPTION
Fixes #12048

## Summary

`FraudDetectionService.getFraudStats` pages the score query with `.order(...).range(from, from + pageSize - 1)` (page size 1000), but the three DB-backed tests stubbed `.limit` after `.order`, so every one hit `range is not a function`. The "caps" test also asserted the wrong verb (`.limit(1000)` instead of `.range(0, 999)`).

## Changes

- Stub `.range` instead of `.limit` in the three mock chains.
- Assert `range` is called with `(0, 999)`, the same 1000-row page contract.

## Verification

`npx vitest run test/unit/fraudDetectionServiceGuard.test.js` -> 4/4 passing (previously 3 failing).

## GSSOC

This PR is submitted as part of GSSoC 2025 Extended. Please add the `gssoc-ext` / `gssoc` labels.
