### PR TITLE
test(unit): add .limit link to the mongo telemetry mock (#12049)

### DIFF
--- a/backend/api/test/unit/truckSearchServiceRole.test.js
+++ b/backend/api/test/unit/truckSearchServiceRole.test.js
@@ -33,7 +33,7 @@ vi.mock('../../src/config/db.js', () => ({
   mongoDb: {
     collection: () => ({
       find: () => ({
-        toArray: () => Promise.resolve(mockTelemetryResults),
+        limit: () => ({ toArray: () => Promise.resolve(mockTelemetryResults) }),
       }),
     }),
   },


### PR DESCRIPTION
Fixes #12049

## Summary

The truck search path calls `mongoDb.collection('telemetry').find(...).limit(200).toArray()`, but the mocked `find()` returned an object with only `toArray`, so the request failed with `find(...).limit is not a function` and both tests errored.

## Changes

- Insert the `.limit()` link into the mongo mock chain so `find().limit().toArray()` resolves.

## Verification

`npx vitest run test/unit/truckSearchServiceRole.test.js` -> 2/2 passing (previously 2 failing).

## GSSOC

This PR is submitted as part of GSSoC 2025 Extended. Please add the `gssoc-ext` / `gssoc` labels.
