### PR TITLE
test(unit): update expectedAmountWei declaration regex (#12052)

### DIFF
--- a/backend/api/test/unit/deliveryVerificationSyntax.test.js
+++ b/backend/api/test/unit/deliveryVerificationSyntax.test.js
@@ -52,8 +52,8 @@ describe('deliveryVerificationService.js syntax (issue #8892)', () => {
     }
   });
 
-  it('expectedAmountWei is declared via a single `let expectedAmountWei = null;`', () => {
+  it('expectedAmountWei is declared via a single `let expectedAmountWei;`', () => {
     const source = readFileSync(serviceFile, 'utf8');
-    expect(occurrences(source, /let expectedAmountWei = null;/g)).toBe(1);
+    expect(occurrences(source, /let expectedAmountWei;/g)).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #12052

## Summary

The syntax-gate test asserted exactly one `let expectedAmountWei = null;`, but the current source declares `let expectedAmountWei;` — the `= null` initializer was removed in the #8892 refactor; every branch now assigns it or throws a DomainError. The "declared exactly once" invariant is still enforced by the sibling binding-count test.

## Changes

- Update the test title and regex to the current declaration form `let expectedAmountWei;`.

## Verification

`npx vitest run test/unit/deliveryVerificationSyntax.test.js` -> 3/3 passing (previously 1 failing).

## GSSOC

This PR is submitted as part of GSSoC 2025 Extended. Please add the `gssoc-ext` / `gssoc` labels.
