### PR TITLE
test(unit): expect getEscrowBooking twice for not-started bookings (#12051)

### DIFF
--- a/backend/api/test/unit/escrowRefundReconciliation.test.js
+++ b/backend/api/test/unit/escrowRefundReconciliation.test.js
@@ -403,7 +403,7 @@ describe('reconcilePendingEscrowRefunds — issue #8891 started-trip guard', () 
 
     await reconcilePendingEscrowRefunds(orderRepository);
 
-    expect(getEscrowBooking).toHaveBeenCalledTimes(1);
+    expect(getEscrowBooking).toHaveBeenCalledTimes(2);
     expect(submitEscrowRefund).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #12051

## Summary

For a not-started booking with a zero cancellation fee, `escrowRefundReconciliation.js` intentionally calls `getEscrowBooking` twice: once for the started-trip guard and again as a defense-in-depth re-check when `driverFeeWei` is zero. The test asserted `toHaveBeenCalledTimes(1)` and failed (verified the source performs both reads; `submitEscrowRefund` is called exactly once).

## Changes

- Align the expectation to `toHaveBeenCalledTimes(2)` while keeping the single `submitEscrowRefund` assertion.

## Verification

`npx vitest run test/unit/escrowRefundReconciliation.test.js` -> 20/20 passing (previously 1 failing).

## GSSOC

This PR is submitted as part of GSSoC 2025 Extended. Please add the `gssoc-ext` / `gssoc` labels.
