### PR TITLE
fix(driver): replace print with debugPrint in image_compression_service.dart

### DIFF
--- a/apps/driver/lib/services/image_compression_service.dart
+++ b/apps/driver/lib/services/image_compression_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -20,7 +21,7 @@ class ImageCompressionService {
         return File(compressedFile.path);
       }
     } catch (e) {
-      print('Compression error: $e');
+      debugPrint('Compression error: $e');
     }
     return file; // Fallback to original if compression fails
   }


### PR DESCRIPTION
## Summary

Replaces the raw `print('Compression error: $e')` call in `ImageCompressionService.compressImage` with `debugPrint` and adds the missing `package:flutter/foundation.dart` import.

## Changes

- `apps/driver/lib/services/image_compression_service.dart`:
  - `print` -> `debugPrint` in the compression error handler.
  - Added `import 'package:flutter/foundation.dart';`.

## Impact

- Passes the `avoid_print` lint on the driver app.
- Consistent with the rest of the app, which logs via `debugPrint`.

Fixes #11642

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging when image compression encounters an error.
  * Prevented compression logs from being emitted in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->