### PR TITLE
test(unit): add supabaseAdmin export to the db mock (#12050)

### DIFF
--- a/backend/api/test/unit/reputationSubscriber.test.js
+++ b/backend/api/test/unit/reputationSubscriber.test.js
@@ -31,7 +31,7 @@ vi.mock('../../src/repositories/orderRepository.js', () => ({
     }
   },
 }))
-vi.mock('../../src/config/db.js', () => ({ supabase: {} }))
+vi.mock('../../src/config/db.js', () => ({ supabase: {}, supabaseAdmin: {} }))
 vi.mock('../../src/middleware/logger.js', () => ({ default: mocks.logger }))
 vi.mock('../../src/core/telemetry/ContextPropagator.js', () => ({
   ContextPropagator: { extractFromEventPayload: vi.fn().mockReturnValue({}) },


### PR DESCRIPTION
Fixes #12050

## Summary

The `config/db.js` mock only exported `supabase`, but the subscriber now imports `supabaseAdmin` for service-role failure logging. Vitest threw "No supabaseAdmin export defined on the mock" inside the catch path, so `insertReputationFailure` was never invoked and the failure-logging test failed.

## Changes

- Add `supabaseAdmin` to the `vi.mock` of `../../src/config/db.js`.

## Verification

`npx vitest run test/unit/reputationSubscriber.test.js` -> 4/4 passing (previously 1 failing).

## GSSOC

This PR is submitted as part of GSSoC 2025 Extended. Please add the `gssoc-ext` / `gssoc` labels.
