### PR TITLE
chore(customer): remove leftover debugPrint of full Supabase order lists in orders_screen.dart

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -136,9 +136,7 @@ class _OrdersScreenState extends State<OrdersScreen>
     try {
       if (hasNetwork) {
         final activeOrders = await _orderService.fetchActiveOrders();
-        debugPrint("Supabase active orders: $activeOrders");
         final historyOrders = await _orderService.fetchHistoryOrders();
-        debugPrint("Supabase history orders: $historyOrders");
 
         String? updatedAt;
 


### PR DESCRIPTION
## Summary

Removes leftover debug statements in `_loadOrders()` that dumped the entire active/history Supabase order lists to the device console on every orders-screen load.

## Changes

- `apps/customer/lib/screens/orders_screen.dart`:
  - Removed `debugPrint("Supabase active orders: $activeOrders");`
  - Removed `debugPrint("Supabase history orders: $historyOrders");`

## Impact

- Reduces console/log noise and log size on the customer app.
- Avoids logging full order objects (some of which may contain address PII) in release-mode console output.

Fixes #11643

GSSOC
