### PR TITLE
chore(driver): remove leftover per-item debugPrint in trips_screen.dart trip mapping

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -305,7 +305,6 @@ class _TripsScreenState extends State<TripsScreen> {
         specialRequirements:
           item['special_requirements']?.toString(),
       );
-      debugPrint(item.toString());
     }).toList();
 
     return Trip(


### PR DESCRIPTION
## Summary

Removes a leftover `debugPrint(item.toString())` inside the `_mapSupabaseTripsToUiTrips` item mapping loop that printed every trip item on each trip list load/refresh.

## Changes

- `apps/driver/lib/screens/trips_screen.dart`:
  - Removed `debugPrint(item.toString());` from the item mapping loop.

## Impact

- Removes leftover debug logging from a hot code path.
- Reduces log volume on trip list loads.

Fixes #11644

GSSOC
