### PR TITLE
fix(api): use UTC date keys in earnings summary

### DIFF
--- a/backend/api/src/services/driver/earningsSummaryService.js
+++ b/backend/api/src/services/driver/earningsSummaryService.js
@@ -24,18 +24,21 @@ export const MAX_TRIPS_PER_SUMMARY = 500;
 /**
  * Start of the requested reporting period.
  *
+ * The `trip_date` column is written in UTC (`toISOString().slice(0, 10)`, see
+ * tripRoutes), so the lower bound is computed in UTC too. Mixing local calendar
+ * components here would shift the window by the server's UTC offset and by an
+ * extra hour across a DST boundary.
+ *
  * @param {'weekly'|'monthly'} period
  * @returns {Date} Inclusive lower bound for `trip_date`.
  */
 export function getPeriodStart(period) {
   const now = new Date();
   if (period === 'weekly') {
-    const d = new Date(now);
-    d.setDate(d.getDate() - 7);
-    return d;
+    return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   }
-  // monthly (default) — from the first of the current month
-  return new Date(now.getFullYear(), now.getMonth(), 1);
+  // monthly (default) — from the first of the current month, in UTC
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 }
 
 /**

--- a/backend/api/src/services/driverEarningsService.js
+++ b/backend/api/src/services/driverEarningsService.js
@@ -6,12 +6,13 @@ export const calculateEarningsAggregation = (trips, allCompletedTrips, lifetimeT
   // Weekly Chart Aggregation (always shows past 7 days)
   const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const weeklyChartMap = {};
-  const pad = (n) => String(n).padStart(2, '0');
-  const toDateKey = (date) => `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  // `trip_date` is stored in UTC (see tripRoutes), so keys are built from UTC
+  // date parts; using local getDate()/getMonth() shifts buckets by the UTC
+  // offset and across DST boundaries.
+  const toDateKey = (date) => date.toISOString().slice(0, 10);
   for (let i = 6; i >= 0; i--) {
-    const d = new Date();
-    d.setDate(d.getDate() - i);
-    weeklyChartMap[toDateKey(d)] = { day: daysOfWeek[d.getDay()], earnings: 0 };
+    const d = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
+    weeklyChartMap[toDateKey(d)] = { day: daysOfWeek[d.getUTCDay()], earnings: 0 };
   }
 
   let totalKm = 0;

--- a/backend/api/test/unit/earningsSummary.test.js
+++ b/backend/api/test/unit/earningsSummary.test.js
@@ -33,16 +33,17 @@ describe('getPeriodStart', () => {
     expect(diffDays).toBe(7);
   });
 
-  it('returns the first of the current month for the monthly window', () => {
+  it('returns the first of the current month in UTC for the monthly window', () => {
     const start = getPeriodStart('monthly');
-    expect(start.getDate()).toBe(1);
-    expect(start.getMonth()).toBe(new Date().getMonth());
+    const now = new Date();
+    const monthPrefix = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    expect(start.toISOString()).toBe(`${monthPrefix}-01T00:00:00.000Z`);
   });
 
   it('defaults to the monthly window for an unrecognised period', () => {
     // Validation rejects these before the handler runs; this is defence in depth.
-    expect(getPeriodStart(undefined).getDate()).toBe(1);
-    expect(getPeriodStart('yearly').getDate()).toBe(1);
+    expect(getPeriodStart(undefined).toISOString().slice(0, 10).endsWith('-01')).toBe(true);
+    expect(getPeriodStart('yearly').toISOString().slice(0, 10).endsWith('-01')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

Daily earnings aggregation mixes **local-time calendar components** with queries/filters that operate in **UTC**, producing off-by-one-day buckets for drivers in non-UTC timezones and around DST transitions.

- `getPeriodStart` built the weekly/monthly window from local wall-clock (`setDate`/`new Date(y, m, 1)`) while the query bound was rendered with `toISOString().split('T')[0]` (UTC), shifting the window by the server's UTC offset.
- `toDateKey` in `driverEarningsService.js` built weekly chart keys from local `getFullYear()/getMonth()/getDate()` while `trip_date` is stored in UTC (written via `toISOString().slice(0, 10)` in tripRoutes), shifting buckets by the local offset and an extra hour across DST.

## Fix

Compute period bounds and date keys in UTC, matching how `trip_date` is stored:

- `earningsSummaryService.js` (`getPeriodStart`): weekly window uses `now.getTime() - 7 * 24h`, monthly window uses `Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)`. The existing `periodStart.toISOString().split('T')[0]` bound in the route is now correct end-to-end.
- `driverEarningsService.js` (`toDateKey`): keys are built with `date.toISOString().slice(0, 10)` and the 7-day chart buckets are built from UTC time and `getUTCDay()`, consistent with the UTC-stored `trip_date`.

## Files changed

- `backend/api/src/services/driver/earningsSummaryService.js`
- `backend/api/src/services/driverEarningsService.js`
- `backend/api/test/unit/earningsSummary.test.js` (assert UTC components so the tests are timezone-independent)

## Testing

- `npx vitest run test/unit/earningsSummary.test.js` — 15 tests pass.
- Weekly/monthly period bounds now yield the correct UTC date string that matches the `trip_date` column in any timezone.

Closes #12013
