### PR TITLE
fix(zk): reject zero zkp proof hash in asset provenance

### DIFF
--- a/blockchain/contracts/AssetProvenance.sol
+++ b/blockchain/contracts/AssetProvenance.sol
@@ -43,6 +43,11 @@ contract AssetProvenance is Ownable {
             require(records[records.length - 1].currentHolder == msg.sender, "Caller must hold current custody");
         }
 
+        // A zero proof hash must not be treated as valid provenance: accepting
+        // it would let an unverified/forged transition enter the trail and be
+        // mistaken for a real handoff. Fail closed instead.
+        require(_zkpProofHash != bytes32(0), "A non-empty ZK proof hash is required to verify the handoff");
+
         // The ZK proof itself cannot be cheaply verified on-chain, so we only
         // mark a record "verified" when a non-zero proof hash is supplied.
         // Verification is performed off-chain against the referenced proof.

--- a/index.js';
describe('derivePartitionKey', () => {
  it('deterministic', () => { expect(derivePartitionKey('x')).toBe(derivePartitionKey('x')); });
  it('null', () => { expect(derivePartitionKey(null)).toBe('0'); });
});

+++ b/index.js';
describe('derivePartitionKey', () => {
  it('deterministic', () => { expect(derivePartitionKey('x')).toBe(derivePartitionKey('x')); });
  it('null', () => { expect(derivePartitionKey(null)).toBe('0'); });
});

@@ -1,1 +1,0 @@
-backend/kafka/test/order.consumer.test.js

--- a/repositories/event.repository.js';
describe('insertEventsWithTransaction', () => {
  it('commits', async () => {
    const c = { query: vi.fn().mockResolvedValue() };
    expect(await insertEventsWithTransaction(c, [{ a: 1 }])).toBe(1);
  });
});

+++ b/repositories/event.repository.js';
describe('insertEventsWithTransaction', () => {
  it('commits', async () => {
    const c = { query: vi.fn().mockResolvedValue() };
    expect(await insertEventsWithTransaction(c, [{ a: 1 }])).toBe(1);
  });
});

@@ -1,1 +1,0 @@
-backend/kafka/test/order.consumer.test.js


### PR DESCRIPTION
## Problem

`AssetProvenance.recordHandoff` accepted a zero proof hash and merely marked the record `verified: false`, so an uninitialized/zeroed proof could still enter the provenance trail and be treated as a valid custody transition. The repo's own `AssetProvenance.test.js` already expects a zero proof hash to be rejected (`"A non-empty ZK proof hash is required to verify the handoff"`), which the contract did not do.

## Fix

`recordHandoff` now fails closed: it requires `_zkpProofHash != bytes32(0)` before recording a handoff, so a zero hash is never accepted as valid provenance. A genuine non-zero proof hash still produces a `verified` record as before.

## Files changed

- `blockchain/contracts/AssetProvenance.sol`

## Testing

- Logic aligns with the existing `blockchain/test/AssetProvenance.test.js` cases ("Should not mark a record verified when no proof hash is supplied" / "A non-empty ZK proof hash is required to verify the handoff").
- Change is a single `require` guard; the record-push logic is otherwise unchanged.

Closes #12014
