### PR TITLE
chore(driver): remove leftover '// add this' dev marker and fix misindented block in trips_screen.dart

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -110,22 +110,22 @@ class _TripsScreenState extends State<TripsScreen> {
       final result = await _tripService.fetchTripHistory(limit: 20);
       final trips = result['trips'] as List<Map<String, dynamic>>;
 
-    final stopsByTrip = <String, List<Map<String, dynamic>>>{};
-    final routePointsByTrip = <String, List<Map<String, dynamic>>>{};
-    final itemsByTrip = <String, List<Map<String, dynamic>>>{};   // ← add this
+      final stopsByTrip = <String, List<Map<String, dynamic>>>{};
+      final routePointsByTrip = <String, List<Map<String, dynamic>>>{};
+      final itemsByTrip = <String, List<Map<String, dynamic>>>{};
 
-    await Future.wait(trips.map((trip) async {
-      final tripId = trip['trip_display_id']?.toString();
-      if (tripId == null || tripId.isEmpty) return;
+      await Future.wait(trips.map((trip) async {
+        final tripId = trip['trip_display_id']?.toString();
+        if (tripId == null || tripId.isEmpty) return;
 
-      final results = await Future.wait([
-        _tripService.fetchTripStops(tripId),
-        _tripService.fetchRouteMapPoints(tripId),
-        _tripService.fetchTripItems(tripId),   
-      ]);
-      stopsByTrip[tripId] = results[0];
-      routePointsByTrip[tripId]= results[1];
-      itemsByTrip[tripId] = results[2];   
+        final results = await Future.wait([
+          _tripService.fetchTripStops(tripId),
+          _tripService.fetchRouteMapPoints(tripId),
+          _tripService.fetchTripItems(tripId),
+        ]);
+        stopsByTrip[tripId] = results[0];
+        routePointsByTrip[tripId] = results[1];
+        itemsByTrip[tripId] = results[2];
       }));
 
       if (!mounted) return;


### PR DESCRIPTION
## Summary

Cleans up formatting leftovers in `_loadTrips()` in `trips_screen.dart`: removes the leftover `// ← add this` dev marker, fixes the misindented trip declarations and `Future.wait` block, fixes `routePointsByTrip[tripId]=` spacing, and removes trailing whitespace.

## Changes

- `apps/driver/lib/screens/trips_screen.dart` (lines 113-129):
  - Removed the `// ← add this` comment on the `itemsByTrip` declaration.
  - Re-indented the `stopsByTrip`/`routePointsByTrip`/`itemsByTrip` declarations and the `Future.wait` block to the correct nesting level.
  - Fixed `routePointsByTrip[tripId]=` to `routePointsByTrip[tripId] = ` and removed trailing whitespace.

## Impact

- Cleaner, more readable trip-loading code.
- Removes a confusing leftover dev marker that could be mistaken for an unfinished task.

Fixes #11645

GSSOC
