### PR TITLE
fix(ebpf): guard socket buffer length underflow

### DIFF
--- a/ebpf/socket_buffer_filter.c
+++ b/ebpf/socket_buffer_filter.c
@@ -77,6 +77,12 @@ int socket_telemetry_filter(struct __sk_buff *skb) {
         bpf_map_update_elem(&rate_limit_map, &rate_key, &one, BPF_ANY);
     }
 
+    // Guard against short/truncated packets: subtracting the L2/L3/L4 header
+    // sizes from an undersized skb->len wraps the __u32 and would emit a bogus
+    // near-UINT_MAX payload_len in the ring buffer event.
+    if (skb->len < ETH_HLEN + sizeof(ip) + (tcp.doff * 4))
+        return 0;
+
     // Calculate payload length
 >>>>>>> upstream/main
     __u32 payload_len = skb->len - (ETH_HLEN + sizeof(ip) + (tcp.doff * 4));


### PR DESCRIPTION
## Problem

`socket_buffer_filter.c` computed the TCP payload length with `skb->len - (ETH_HLEN + sizeof(ip) + tcp.doff * 4)` and no length validation. For short or malformed packets the `__u32` subtraction wrapped to a near-`UINT_MAX` value, producing a bogus multi-gigabyte `payload_len` in the ring buffer event.

## Fix

Guard the computation before deriving `payload_len`: when `skb->len` is smaller than the summed L2/L3/L4 header sizes, the packet is truncated and the program returns early (drop) instead of computing a wrapping value.

## Files changed

- `ebpf/socket_buffer_filter.c`

## Testing

- Logic verified: packets shorter than the header sizes exit before the subtraction; valid packets are unchanged.

Closes #12018
