### PR TITLE
fix(ebpf): probe userspace string args with bpf_probe_read_user_str

### DIFF
--- a/ebpf/programs/trace_security.c
+++ b/ebpf/programs/trace_security.c
@@ -17,7 +17,12 @@ struct {
 SEC("tracepoint/syscalls/sys_enter_open")
 int trace_file_open(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[0];
+    char filename[256];
+    // args->args[0] is a userspace pointer to the filename; it cannot be
+    // dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
+        return 0;
+    }
     bpf_printk("File open: %s\n", filename);
     
     return 0;
@@ -27,7 +32,12 @@ int trace_file_open(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/syscalls/sys_enter_execve")
 int trace_execve(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[0];
+    char filename[256];
+    // args->args[0] is a userspace pointer to the executable path; it cannot
+    // be dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
+        return 0;
+    }
     bpf_printk("Process executed: %s\n", filename);
     
     return 0;

--- a/ebpf/programs/trace_syscalls.c
+++ b/ebpf/programs/trace_syscalls.c
@@ -54,7 +54,12 @@ int trace_process_fork(struct trace_event_raw_sched_process_fork *args)
 SEC("tracepoint/syscalls/sys_enter_openat")
 int trace_openat(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[1];
+    char filename[256];
+    // args->args[1] is a userspace pointer to the filename; it cannot be
+    // dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[1]) < 0) {
+        return 0;
+    }
     bpf_printk("Opening file: %s\n", filename);
     
     return 0;

--- a/ebpf/security/file_integrity.c
+++ b/ebpf/security/file_integrity.c
@@ -6,6 +6,25 @@
 
 char LICENSE[] SEC("license") = "GPL";
 
+// Substring match helper over a bounded stack buffer (replaces libc strstr,
+// which is unavailable to the BPF verifier).
+static __always_inline int str_contains(const char *str, int str_len, const char *sub, int sub_len)
+{
+    for (int i = 0; i <= str_len - sub_len; i++) {
+        int match = 1;
+        for (int j = 0; j < sub_len; j++) {
+            if (str[i + j] != sub[j]) {
+                match = 0;
+                break;
+            }
+        }
+        if (match) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Map for file integrity
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -26,17 +45,25 @@ struct {
 SEC("tracepoint/syscalls/sys_enter_open")
 int trace_file_open(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[0];
+    char filename[256];
+    // args->args[0] is a userspace pointer to the filename; it cannot be
+    // dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
+        return 0;
+    }
     
     // Check for suspicious file extensions
-    const char *suspicious_extensions[] = {
-        ".exe", ".bat", ".sh", ".py",
-        ".js", ".vbs", ".ps1", ".cmd",
-        ".jar", ".dll", ".so", ".php"
+    struct {
+        const char *ext;
+        int len;
+    } suspicious_extensions[] = {
+        { ".exe", 4 }, { ".bat", 4 }, { ".sh", 3 }, { ".py", 3 },
+        { ".js", 3 }, { ".vbs", 4 }, { ".ps1", 4 }, { ".cmd", 4 },
+        { ".jar", 4 }, { ".dll", 4 }, { ".so", 3 }, { ".php", 4 }
     };
     
     for (int i = 0; i < 12; i++) {
-        if (strstr(filename, suspicious_extensions[i]) != NULL) {
+        if (str_contains(filename, sizeof(filename), suspicious_extensions[i].ext, suspicious_extensions[i].len)) {
             bpf_printk("Suspicious file opened: %s\n", filename);
         }
     }
@@ -64,7 +91,12 @@ int trace_file_write(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/syscalls/sys_enter_unlink")
 int trace_file_delete(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[0];
+    char filename[256];
+    // args->args[0] is a userspace pointer to the filename; it cannot be
+    // dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
+        return 0;
+    }
     bpf_printk("File deleted: %s\n", filename);
     
     return 0;
@@ -74,7 +106,12 @@ int trace_file_delete(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/syscalls/sys_enter_chmod")
 int trace_file_chmod(struct trace_event_raw_sys_enter *args)
 {
-    const char *filename = (const char *)args->args[0];
+    char filename[256];
+    // args->args[0] is a userspace pointer to the filename; it cannot be
+    // dereferenced from kernel context. Probe it into a bounded stack buffer.
+    if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
+        return 0;
+    }
     __u32 mode = (__u32)args->args[1];
     
     bpf_printk("File permissions changed: %s (mode: %d)\n", filename, mode);


### PR DESCRIPTION
## Problem

Three eBPF programs (`file_integrity.c`, `trace_syscalls.c`, `trace_security.c`) dereferenced the **userspace** syscall argument pointer directly inside BPF (`(const char *)args->args[N]`). On hardened kernels the verifier rejects this (`R# unbounded memory access`), and where it loads the read can return corrupted path data or fault, producing wrong security events.

## Fix

- Copy each filename/path argument into a bounded stack buffer with `bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[N])` and bail out on error before any use.
- In `file_integrity.c`, replace libc `strstr` (unavailable to the BPF verifier) with a verifier-safe `str_contains` substring helper over the bounded buffer, mirroring the existing pattern in `ebpf/security/threat_detection.c`.
- Applies to every userspace-pointer read in the three listed files: `file_integrity.c` (open/delete/chmod), `trace_syscalls.c` (openat), `trace_security.c` (open/execve).

## Files changed

- `ebpf/security/file_integrity.c`
- `ebpf/programs/trace_syscalls.c`
- `ebpf/programs/trace_security.c`

## Testing

- All userspace pointer reads are now `bpf_probe_read_user_str` copies into bounded buffers; no `args->args[N]` is used as a string pointer directly.

Closes #12019
