### PR TITLE
fix(zk): make zkSTARKVerifier fail closed

### DIFF
--- a/blockchain/contracts/zkSTARKVerifier.sol
+++ b/blockchain/contracts/zkSTARKVerifier.sol
@@ -2,25 +2,18 @@
 pragma solidity ^0.8.19;
 
 contract zkSTARKVerifier {
-    // Simplified zk-STARK verifier
-    // In production: use actual STARK verification
+    // Placeholder zk-STARK verifier. No actual STARK proof system / AIR is
+    // wired in yet, so this contract FAILS CLOSED: it rejects every proof
+    // instead of accepting fabricated ones. Callers can never be tricked
+    // into trusting a proof that was never verified.
+    // In production: replace verifyProof with the real STARK verifier
+    // (FRI + Merkle root commitment + constraint-checking) for the circuit.
 
     function verifyProof(
         bytes calldata proof,
         bytes calldata publicInputs
     ) external pure returns (bool) {
-        // Reject empty and all-zero proofs instead of accepting every proof
-        if (!_hasNonZeroByte(proof) || !_hasNonZeroByte(publicInputs)) {
-            return false;
-        }
-        // Placeholder verification
-        return true;
-    }
-
-    function _hasNonZeroByte(bytes calldata data) internal pure returns (bool) {
-        for (uint i = 0; i < data.length; i++) {
-            if (data[i] != 0) return true;
-        }
+        // No real verification logic exists yet, so no proof can be accepted.
         return false;
     }
 }

--- a/blockchain/test/zkVerifier.test.js
+++ b/blockchain/test/zkVerifier.test.js
@@ -85,14 +85,14 @@ describe("ZK proof verification", function () {
     );
   });
 
-  it("rejects zero/empty proofs in zkSTARKVerifier", async function () {
+  it("fails closed for every proof in zkSTARKVerifier", async function () {
     const zkSTARKVerifier = await (await ethers.getContractFactory("zkSTARKVerifier")).deploy();
     await zkSTARKVerifier.waitForDeployment();
 
     assert.equal(await zkSTARKVerifier.verifyProof("0x", "0x1234"), false);
     assert.equal(await zkSTARKVerifier.verifyProof("0x1234", "0x"), false);
     assert.equal(await zkSTARKVerifier.verifyProof("0x0000", "0x0000"), false);
-    assert.equal(await zkSTARKVerifier.verifyProof("0x1234", "0x5678"), true);
+    assert.equal(await zkSTARKVerifier.verifyProof("0x1234", "0x5678"), false);
   });
 
   it("rejects zero proofs in KYCVerifier.verifyKYC", async function () {


### PR DESCRIPTION
## Problem

`zkSTARKVerifier.sol` is a placeholder whose `verifyProof` accepted **every** non-empty proof (`return true` after a non-zero-byte check), so a caller could be tricked into trusting a fabricated proof. There is no real STARK verification being performed.

## Fix

- Fail closed: `verifyProof` now rejects every proof (`return false`) because no actual STARK proof system (FRI + Merkle root commitment + constraint-checking) is wired in yet.
- Mirrors the existing `Verifier.sol` fail-closed stance, so callers can never accept a proof that was never verified. The comment documents the replacement path for production.
- Updated `zkVerifier.test.js` to assert the fail-closed behavior (a fabricated `"0x1234"/"0x5678"` proof now returns `false`).

## Files changed

- `blockchain/contracts/zkSTARKVerifier.sol`
- `blockchain/test/zkVerifier.test.js`

## Testing

- `zkSTARKVerifier.verifyProof` returns `false` for empty, all-zero, and arbitrary non-zero proofs.

Closes #12021
