### PR TITLE
fix(driver): avoid StateError when no recommended route

### DIFF
--- a/apps/driver/lib/screens/toll_route_optimizer_screen.dart
+++ b/apps/driver/lib/screens/toll_route_optimizer_screen.dart
@@ -28,16 +28,23 @@ class _TollRouteOptimizerScreenState extends State<TollRouteOptimizerScreen> {
       setState(() {
         _routes = routes;
         _isLoading = false;
-        try {
-          _selectedRouteId = routes.firstWhere((r) => r.isRecommended).routeId;
-        } catch (_) {}
+        // Fall back to the first route when none is flagged as recommended,
+        // instead of letting firstWhere throw StateError on an empty/no-match list.
+        _selectedRouteId = routes.isNotEmpty
+            ? routes.firstWhere((r) => r.isRecommended, orElse: () => routes.first).routeId
+            : null;
       });
     }
   }
 
   void _startNavigation() {
-    if (_selectedRouteId == null) return;
-    final selected = _routes.firstWhere((r) => r.routeId == _selectedRouteId);
+    if (_selectedRouteId == null || _routes.isEmpty) return;
+    final selected = _routes.firstWhere(
+      (r) => r.routeId == _selectedRouteId,
+      // Never throw StateError if the previously selected route is gone;
+      // fall back to the first available route.
+      orElse: () => _routes.first,
+    );
     
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(


### PR DESCRIPTION
## Problem

`TollRouteOptimizerScreen` had two unguarded `firstWhere` calls that throw `StateError` and crash the screen:

1. `_loadRoutes`: `routes.firstWhere((r) => r.isRecommended)` throws when no route is flagged recommended or the list is empty (the `try/catch` around it silently swallowed the error, leaving the selection unset).
2. `_startNavigation`: `_routes.firstWhere((r) => r.routeId == _selectedRouteId)` throws if the previously selected route is no longer in the list.

## Fix

- `_loadRoutes`: guard the empty list and use `firstWhere(..., orElse: () => routes.first)` so the recommended route falls back to the first route instead of throwing; remove the now-unneeded `try/catch`.
- `_startNavigation`: early-return when `_selectedRouteId` is null or `_routes` is empty, and add `orElse: () => _routes.first` so a stale selection never raises `StateError`.

## Files changed

- `apps/driver/lib/screens/toll_route_optimizer_screen.dart`

## Testing

- Recommended-route selection falls back to the first route when none is recommended.
- Starting navigation with an empty or stale route list returns safely instead of crashing.

Closes #12024
