### PR TITLE
fix(zk): enforce compliance in asset token transfers

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -400,8 +400,13 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
 
     // ============ Compliance ============
 
+    // Persisted KYC/AML verification status. Only verified users can take
+    // part in compliant P2P transfers of tokenized assets.
+    mapping(address => bool) public isCompliant;
+
     function verifyCompliance(address user) external onlyOwner {
         // KYC/AML check
+        isCompliant[user] = true;
         emit ComplianceCheck(user, true);
     }
 
@@ -416,6 +421,8 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         require(assetExists[assetId], "Asset not found");
         require(to != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be > 0");
+        require(isCompliant[msg.sender], "Sender not compliant");
+        require(isCompliant[to], "Recipient not compliant");
 
         FractionalOwnership storage senderOwnership = fractionalOwnership[assetId][msg.sender];
         require(senderOwnership.amount >= amount, "Insufficient fractional ownership");

--- a/blockchain/test/AssetToken.test.js
+++ b/blockchain/test/AssetToken.test.js
@@ -11,6 +11,13 @@ describe("AssetToken", function () {
     return { assetToken, owner, buyer1, buyer2, outsider };
   }
 
+  async function markCompliant(assetToken, owner, addresses) {
+    for (const address of addresses) {
+      await assetToken.connect(owner).verifyCompliance(address);
+      assert.equal(await assetToken.isCompliant(address), true);
+    }
+  }
+
   it("should create an asset and update assetCounter", async function () {
     const { assetToken, owner } = await deployAssetToken();
     const name = "Truck 1";
@@ -223,6 +230,7 @@ describe("AssetToken", function () {
     });
 
     // P2P transfer of 4 tokens: the backed flag rides along
+    await markCompliant(assetToken, owner, [buyer1.address, buyer2.address]);
     await assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4"));
 
     let buyer1Ownership = await assetToken.getFractionalOwnership(1, buyer1.address);
@@ -250,6 +258,40 @@ describe("AssetToken", function () {
     await assetToken.connect(buyer2).claimPayout();
     await assetToken.connect(buyer1).claimPayout();
     assert.equal(await ethers.provider.getBalance(assetToken.target), 0n);
+  });
+
+  it("should reject transferWithCompliance for non-compliant parties", async function () {
+    const { assetToken, owner, buyer1, buyer2 } = await deployAssetToken();
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("100"),
+      "ipfs://..."
+    );
+
+    await assetToken.connect(buyer1).purchaseFraction(1, ethers.parseEther("10"), {
+      value: ethers.parseEther("10")
+    });
+
+    // Neither party has passed KYC/AML yet: the transfer must be blocked.
+    await assert.rejects(
+      assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4")),
+      /Sender not compliant/
+    );
+
+    // Only the sender verified: still blocked because the recipient is not compliant.
+    await assetToken.connect(owner).verifyCompliance(buyer1.address);
+    await assert.rejects(
+      assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4")),
+      /Recipient not compliant/
+    );
+
+    // Once both parties are verified the transfer succeeds.
+    await assetToken.connect(owner).verifyCompliance(buyer2.address);
+    await assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4"));
+    assert.equal((await assetToken.getFractionalOwnership(1, buyer2.address)).amount, ethers.parseEther("4"));
   });
 
   it("should block plain ERC20 transfer/transferFrom so the fractional-ownership ledger cannot desync", async function () {
@@ -289,6 +331,7 @@ describe("AssetToken", function () {
     assert.equal(await assetToken.balanceOf(buyer2.address), 0n);
 
     // The asset-aware path still works and keeps the ledger in sync.
+    await markCompliant(assetToken, owner, [buyer1.address, buyer2.address]);
     await assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("4"));
     assert.equal((await assetToken.getFractionalOwnership(1, buyer1.address)).amount, ethers.parseEther("6"));
     assert.equal((await assetToken.getFractionalOwnership(1, buyer2.address)).amount, ethers.parseEther("4"));
@@ -354,6 +397,7 @@ describe("AssetToken", function () {
 
     // transferWithCompliance carries backing for exactly the tokens it moved,
     // so a seller can never sell back more than the backed portion
+    await markCompliant(assetToken, owner, [buyer1.address, buyer2.address]);
     await assetToken.connect(buyer1).transferWithCompliance(1, buyer2.address, ethers.parseEther("10"));
 
     // buyer1 no longer holds any tokens and has no backing left


### PR DESCRIPTION
## Problem

`verifyCompliance` performed a "KYC/AML check" but only emitted an event — it stored nothing. As a result, `transferWithCompliance` accepted P2P transfers from and to **any** address, regardless of KYC/AML status, making the compliance check a no-op.

## Fix

- Add `mapping(address => bool) public isCompliant` and persist the KYC/AML result in it inside `verifyCompliance`.
- Enforce compliance in `transferWithCompliance`: `require(isCompliant[msg.sender], "Sender not compliant")` and `require(isCompliant[to], "Recipient not compliant")`.
- Update the existing `AssetToken` tests to mark participants compliant (via a new `markCompliant` helper) before compliant transfers, and add a test covering the enforcement path (both-parties-unverified and recipient-only-unverified reverts, then a successful transfer once both are verified).

## Files changed

- `blockchain/contracts/AssetToken.sol`
- `blockchain/test/AssetToken.test.js`

## Testing

- Non-compliant sender reverts with `Sender not compliant`; verified sender + non-compliant recipient reverts with `Recipient not compliant`; transfer succeeds once both are verified.

Closes #12025
