### PR TITLE
fix: add missing logger import in weighStationService

### DIFF
--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -4,6 +4,8 @@
  * to check carrier credentials and safety scores against the specific weigh station.
  */
 
+import logger from '../middleware/logger.js';
+
 const SIMULATED_NETWORK_DELAY_MS = 800;
 const STATION_ID_RANGE = 1000;
 


### PR DESCRIPTION
**Description:**

## 🐛 Bug Fix — Missing `logger` Import in `weighStationService.js`

### Problem
`syncAndTransmitInternalWeights()` called `logger.warn()` on line 41, but `logger` was **never imported** in the file. This would cause a `ReferenceError: logger is not defined` crash at runtime whenever that function was invoked.

### Root Cause
The function was likely refactored to add a warning log when returning the `UNSUPPORTED` stub response, but the corresponding import statement was accidentally omitted.

### Fix
Added the missing import at the top of the file:
```js
import logger from '../middleware/logger.js';
```

### Files Changed
- `backend/api/src/services/weighStationService.js` — added 1 import line

### Testing
This is a single-line import fix. The existing test suite (`weighStationService.test.js`) covers the service behaviour and will continue to pass.

---

> **No breaking changes.** This fix only prevents a runtime crash — the observable behaviour of the function is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging support for weigh station service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->