### PR TITLE
test : added unit tests for middleware/logger.js

### DIFF
--- a/backend/api/test/unit/logger.test.js
+++ b/backend/api/test/unit/logger.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { LOG_LEVELS, sanitizeLogLevel } from '../../../src/middleware/logger.js';
+
+describe('LOG_LEVELS', () => {
+  it('contains all expected log levels', () => {
+    expect(LOG_LEVELS).toEqual(['fatal', 'error', 'warn', 'info', 'debug', 'trace']);
+  });
+});
+
+describe('sanitizeLogLevel', () => {
+  it('returns the level when it is a valid log level', () => {
+    expect(sanitizeLogLevel('debug')).toBe('debug');
+    expect(sanitizeLogLevel('error')).toBe('error');
+    expect(sanitizeLogLevel('info')).toBe('info');
+  });
+
+  it('returns info for an invalid log level', () => {
+    expect(sanitizeLogLevel('invalid')).toBe('info');
+    expect(sanitizeLogLevel('')).toBe('info');
+    expect(sanitizeLogLevel('TRACE')).toBe('info');
+  });
+});


### PR DESCRIPTION
Summary of What Has Been Done:
Added a small vitest unit test for `backend/api/src/middleware/logger.js`, which had no existing test coverage. The test covers the `LOG_LEVELS` constant and the `sanitizeLogLevel()` helper.

Changes Made:
- Added `backend/api/test/unit/logger.test.js` with tests for `LOG_LEVELS` membership and `sanitizeLogLevel()` behavior (valid input passthrough + fallback to `info` for invalid input).

Impact it Made:
- First unit-test coverage for the logger middleware, protecting the small public API surface (`LOG_LEVELS`, `sanitizeLogLevel`) against regressions. This PR is part of GSSOC 2026 contributions — please assign to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for supported logging levels.
  * Added tests verifying that invalid logging-level inputs are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->