### PR TITLE
fix: auth.js no longer parses due to duplicate query, stray braces and a missing catch

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -102,14 +102,6 @@ export async function verifyAuthToken(token) {
       .eq("firebase_uid", firebaseUid)
       .maybeSingle();
 
-      const userClient = createUserClient?.(token) || supabase;
-      const { data: profile, error } = await userClient
-        .from("profiles")
-        .select("id, firebase_uid, role, full_name, phone")
-        .eq("firebase_uid", firebaseUid)
-        .eq("is_active", true)
-        .maybeSingle();
-
       if (error) {
         throw new Error("Database query failed verification: " + error.message);
       }
@@ -129,7 +121,6 @@ export async function verifyAuthToken(token) {
         }, cacheTtl);
       }
     }
-  }
 
   if (!userProfile) {
     throw new Error("User profile not found in database.");
@@ -406,6 +397,8 @@ export async function authenticate(req, res, next) {
             tombstonePayload,
             TOMBSTONE_TTL_SECONDS,
           );
+        } catch (err) {
+          logger.error({ err }, "Cache set failed");
         }
       }
       if (supabaseUserId) {
@@ -430,7 +423,6 @@ export async function authenticate(req, res, next) {
         error: "User profile not found in database.",
         hint: "Register user in profiles table first.",
       });
-    }
 
     req.user = formatUserProfile(userProfile);
 


### PR DESCRIPTION
﻿## Summary
Fixes #12101


auth.js no longer parses: 
ode --check fails on four masked syntax errors from a botched merge. (1) A stale duplicate const userClient / const { data: profile, error } Firebase profile query block redeclares userClient. (2) A stray closing brace ends erifyAuthToken early, leaving eturn formatUserProfile(...) at top level (Illegal return statement). (3) The Firebase tombstone cache-write 	ry has no catch. (4) A stray closing brace after the not-found 403 return closes uthenticate early and orphans its catch. The module is imported by every route, so the API cannot boot. This restores the file to a parseable, buildable state.

## Test Plan
`npx vitest run test/unit/requireRoleSyntax.test.js` — all tests pass.

## GSSOC
gssoc-ext
gssoc
