### PR TITLE
fix: rlsSecurity test resolves a migration filename that does not exist

### DIFF
--- a/backend/api/test/unit/rlsSecurity.test.js
+++ b/backend/api/test/unit/rlsSecurity.test.js
@@ -290,7 +290,7 @@ describe('accept_bid_tx — two-phase acceptance guard preserved (issue #8971)',
   let ownershipFixContent;
 
   beforeAll(async () => {
-    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql');
+    const p = path.resolve(__dirname, '../../../../supabase/migrations/20260805120001_fix_rpc_ownership_checks.sql');
     ownershipFixContent = await fs.readFile(p, 'utf8');
   });
 


### PR DESCRIPTION
﻿## Summary
Fixes #12102

lsSecurity.test.js resolves supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql, but the migration on disk is 20260805120001_fix_rpc_ownership_checks.sql. The eforeAll file read throws and the entire accept_bid_tx guard suite errors. Updates the test to the real migration filename.

## Test Plan
`npx vitest run test/unit/rlsSecurity.test.js` — all tests pass.

## GSSOC
gssoc-ext
gssoc
