### PR TITLE
fix: validatePagination test mock lacks a status method

### DIFF
--- a/backend/api/test/unit/validatePagination.test.js
+++ b/backend/api/test/unit/validatePagination.test.js
@@ -16,6 +16,7 @@ function makeRes() {
   return {
     getHeader: vi.fn(n => h[n]),
     setHeader: vi.fn((n, v) => { h[n] = v; }),
+    status: vi.fn(function(s) { this.statusCode = s; return this; }),
     json: vi.fn(function(b) { return this; }),
     on: vi.fn(),
   };


### PR DESCRIPTION
﻿## Summary
Fixes #12103

The pagination middleware calls es.status(400).json(...) when limit is non-numeric, but the test's makeRes() fixture has no status method, so the test dies with TypeError: res.status is not a function instead of asserting the 400 response. Adds a chainable status mock to the fixture.

## Test Plan
`npx vitest run test/unit/validatePagination.test.js` — all tests pass.

## GSSOC
gssoc-ext
gssoc
