### PR TITLE
fix: escrowWebhookGuards test is not thenable and exercises a removed hook

### DIFF
--- a/backend/api/test/unit/escrowWebhookGuards.test.js
+++ b/backend/api/test/unit/escrowWebhookGuards.test.js
@@ -22,6 +22,7 @@ function chain(result) {
     in: vi.fn(() => q),
     maybeSingle: vi.fn(() => Promise.resolve(result)),
     update: vi.fn(() => q),
+    then: (resolve) => resolve(result.data ? { data: [result.data], error: result.error } : result),
   };
   return q;
 }
@@ -34,10 +35,6 @@ describe('escrowWebhookProcessor', () => {
 
   it('throws when event type is missing', async () => {
     await expect(processEscrowWebhookEvent('')).rejects.toThrow('Missing escrow webhook event type');
-  });
-
-  it('throws on simulated failure', async () => {
-    await expect(processEscrowWebhookEvent('PaymentReleased', { simulateFailure: true })).rejects.toThrow('Simulated database lock or processing failure');
   });
 
   it('acknowledges unknown event types without state change', async () => {


### PR DESCRIPTION
﻿## Summary
Fixes #12106

The mocked query chain in escrowWebhookGuards.test.js is not thenable, so the awaited update().eq().in().select(id) resolves undefined and the zero-row guard throws escrow_status not in reconcilable set. The suite also still exercises the simulateFailure debug hook, which has been removed from the source. Drops the stale hook test and makes the chain thenable.

## Test Plan
`npx vitest run test/unit/escrowWebhookGuards.test.js` — all tests pass.

## GSSOC
gssoc-ext
gssoc
