### PR TITLE
test(driver): add unit tests for local_db_service

### DIFF
--- a/apps/driver/pubspec.yaml
+++ b/apps/driver/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^6.0.0
+  sqflite_common_ffi: ^2.3.4
   flutter_test:
     sdk: flutter
   firebase_core_platform_interface: any
@@ -65,3 +66,4 @@ dev_dependencies:
 flutter:
   generate: true
   uses-material-design: true
+

--- a/apps/driver/test/local_db_service_test.dart
+++ b/apps/driver/test/local_db_service_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:truxify_driver/services/local_db_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  tearDown(() async {
+    final db = await LocalDbService.instance.database;
+    await db.delete('pending_pods');
+    await db.delete('location_queue');
+  });
+
+  group('LocalDbService schema', () {
+    test('creates pending_pods and location_queue tables', () async {
+      final db = await LocalDbService.instance.database;
+      final tables = await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+        "('pending_pods', 'location_queue')",
+      );
+
+      expect(
+        tables.map((t) => t['name']),
+        containsAll(['pending_pods', 'location_queue']),
+      );
+    });
+
+    test('location_queue enforces a unique idempotency_key', () async {
+      final db = await LocalDbService.instance.database;
+      const row = {
+        'kind': 'milestone',
+        'order_id': 'o1',
+        'idempotency_key': 'milestone:o1:Arriving',
+        'payload': '{}',
+        'created_at': 1,
+      };
+
+      await db.insert('location_queue', row);
+
+      expect(
+        () => db.insert('location_queue', row),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+  });
+
+  group('LocalDbService pending PoDs', () {
+    test('insertPendingPoD stores a row retrievable as pending', () async {
+      await LocalDbService.instance.insertPendingPoD({
+        'order_id': 'o1',
+        'trip_display_id': 'TRIP-1',
+        'stop_id': 's1',
+        'photo_path': '/tmp/a.jpg',
+        'timestamp': 123,
+        'sync_status': 0,
+      });
+
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      expect(pending, hasLength(1));
+      expect(pending.first['trip_display_id'], 'TRIP-1');
+      expect(pending.first['order_id'], 'o1');
+      expect(pending.first['photo_path'], '/tmp/a.jpg');
+    });
+
+    test('getPendingPoDs excludes already-synced rows', () async {
+      final db = await LocalDbService.instance.database;
+      await db.insert('pending_pods', {
+        'trip_display_id': 'TRIP-2',
+        'stop_id': 'sx',
+        'timestamp': 1,
+        'sync_status': 1,
+      });
+
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      expect(pending, isEmpty);
+    });
+
+    test('markPoDSynced flips sync_status and clearSyncedPoDs removes it', () async {
+      await LocalDbService.instance.insertPendingPoD({
+        'trip_display_id': 'TRIP-3',
+        'stop_id': 's2',
+        'timestamp': 2,
+        'sync_status': 0,
+      });
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      final id = pending.first['id'] as int;
+
+      await LocalDbService.instance.markPoDSynced(id);
+
+      expect(await LocalDbService.instance.getPendingPoDs(), isEmpty);
+
+      await LocalDbService.instance.clearSyncedPoDs();
+
+      final rows = await (await LocalDbService.instance.database).query('pending_pods');
+      expect(rows, isEmpty);
+    });
+
+    test('deletePendingPoD removes the row', () async {
+      await LocalDbService.instance.insertPendingPoD({
+        'trip_display_id': 'TRIP-4',
+        'stop_id': 's3',
+        'timestamp': 3,
+        'sync_status': 0,
+      });
+      final pending = await LocalDbService.instance.getPendingPoDs();
+      final id = pending.first['id'] as int;
+
+      await LocalDbService.instance.deletePendingPoD(id);
+
+      expect(await LocalDbService.instance.getPendingPoDs(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds unit tests for `LocalDbService`, the driver's sqflite-backed local database.

## Changes
- `apps/driver/test/local_db_service_test.dart` (new):
  - Schema creation for `pending_pods` and `location_queue`.
  - `location_queue` unique `idempotency_key` constraint.
  - `insertPendingPoD`/`getPendingPoDs` (unsynced-only filtering).
  - `markPoDSynced` + `clearSyncedPoDs` lifecycle.
  - `deletePendingPoD` removal.
- `apps/driver/pubspec.yaml`: add `sqflite_common_ffi` dev dependency for host-side DB tests.

## Impact
- Covers the durable offline queue the driver app relies on.
- Verifies PoD persistence and sync-status transitions.

Fixes #11654

GSSOC
