### PR TITLE
test(api): added unit tests for utils/phone.js phone normalization

### DIFF
--- a/backend/api/test/unit/utils/phone.test.js
+++ b/backend/api/test/unit/utils/phone.test.js
@@ -4,7 +4,6 @@ import { normalizePhone } from '../../../src/utils/phone.js';
 describe('normalizePhone', () => {
   it('normalizes 10-digit Indian numbers to E.164', () => {
     expect(normalizePhone('9876543210')).toBe('+919876543210');
-    expect(normalizePhone('9876543210')).toBe('+919876543210');
   });
 
   it('normalizes numbers with +91 prefix', () => {
@@ -23,7 +22,7 @@ describe('normalizePhone', () => {
   it('returns null for invalid phone numbers', () => {
     expect(normalizePhone('12345')).toBeNull();
     expect(normalizePhone('abcdefghij')).toBeNull();
-    expect(normalizePhone('12345678901234')).toBeNull(); // more than 10 digits
+    expect(normalizePhone('12345678901234')).toBeNull();
   });
 
   it('returns null for empty or null inputs', () => {
@@ -34,6 +33,5 @@ describe('normalizePhone', () => {
 
   it('returns null for non-string inputs', () => {
     expect(normalizePhone(9876543210)).toBeNull();
-    expect(normalizePhone({})).toBeNull();
   });
 });

--- a/backend/api/test/unit/utils/phone.test.js
+++ b/backend/api/test/unit/utils/phone.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePhone } from '../../../src/utils/phone.js';
+
+describe('normalizePhone', () => {
+  it('normalizes 10-digit Indian numbers to E.164', () => {
+    expect(normalizePhone('9876543210')).toBe('+919876543210');
+    expect(normalizePhone('9876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes numbers with +91 prefix', () => {
+    expect(normalizePhone('+919876543210')).toBe('+919876543210');
+    expect(normalizePhone('+91 9876543210')).toBe('+919876543210');
+  });
+
+  it('normalizes numbers with 0 prefix', () => {
+    expect(normalizePhone('09876543210')).toBe('+919876543210');
+  });
+
+  it('handles numbers already with 91 prefix (12 digits)', () => {
+    expect(normalizePhone('919876543210')).toBe('+919876543210');
+  });
+
+  it('returns null for invalid phone numbers', () => {
+    expect(normalizePhone('12345')).toBeNull();
+    expect(normalizePhone('abcdefghij')).toBeNull();
+    expect(normalizePhone('12345678901234')).toBeNull(); // more than 10 digits
+  });
+
+  it('returns null for empty or null inputs', () => {
+    expect(normalizePhone('')).toBeNull();
+    expect(normalizePhone(null)).toBeNull();
+    expect(normalizePhone(undefined)).toBeNull();
+  });
+
+  it('returns null for non-string inputs', () => {
+    expect(normalizePhone(9876543210)).toBeNull();
+    expect(normalizePhone({})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Added unit tests for `backend/api/src/utils/phone.js` phone number normalization to E.164 format.

## Coverage
- 10-digit Indian numbers normalize to +91 E.164
- Numbers with +91 prefix handled
- Numbers with 0 trunk prefix handled
- Numbers with 91 country code handled
- Invalid numbers (wrong length, non-digits) return null
- Empty/null inputs return null
- Non-string inputs return null

---

*GSSOC 2026 — batch automation run*