### PR TITLE
test(api): added unit tests for middleware/index.js barrel exports

### DIFF
--- a/backend/api/test/unit/middleware/index.test.js
+++ b/backend/api/test/unit/middleware/index.test.js
@@ -2,38 +2,38 @@ import { describe, it, expect } from 'vitest';
 
 describe('middleware/index.js barrel exports', () => {
   it('exports requestIdMiddleware from requestId.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.requestIdMiddleware).toBe('function');
   });
 
   it('exports requestLogger from requestId.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.requestLogger).toBe('function');
   });
 
   it('exports addTracingHeaders from requestId.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.addTracingHeaders).toBe('function');
   });
 
   it('exports securityHeaders as default', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.securityHeaders).toBe('function');
   });
 
   it('exports requirePolicy from requirePolicy.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.requirePolicy).toBe('function');
   });
 
   it('exports authenticate and requireRole from auth.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.authenticate).toBe('function');
     expect(typeof mod.requireRole).toBe('function');
   });
 
   it('exports requireIdempotency from idempotency.js', async () => {
-    const mod = await import('../../src/middleware/index.js');
+    const mod = await import('../../../src/middleware/index.js');
     expect(typeof mod.requireIdempotency).toBe('function');
   });
 });

--- a/backend/api/test/unit/middleware/index.test.js
+++ b/backend/api/test/unit/middleware/index.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+describe('middleware/index.js barrel exports', () => {
+  it('exports requestIdMiddleware from requestId.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.requestIdMiddleware).toBe('function');
+  });
+
+  it('exports requestLogger from requestId.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.requestLogger).toBe('function');
+  });
+
+  it('exports addTracingHeaders from requestId.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.addTracingHeaders).toBe('function');
+  });
+
+  it('exports securityHeaders as default', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.securityHeaders).toBe('function');
+  });
+
+  it('exports requirePolicy from requirePolicy.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.requirePolicy).toBe('function');
+  });
+
+  it('exports authenticate and requireRole from auth.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.authenticate).toBe('function');
+    expect(typeof mod.requireRole).toBe('function');
+  });
+
+  it('exports requireIdempotency from idempotency.js', async () => {
+    const mod = await import('../../src/middleware/index.js');
+    expect(typeof mod.requireIdempotency).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
Added unit tests for `backend/api/src/middleware/index.js` barrel export file.

## Coverage
- requestIdMiddleware, requestLogger, addTracingHeaders from requestId.js
- securityHeaders as default export
- requirePolicy from requirePolicy.js
- authenticate and requireRole from auth.js
- requireIdempotency from idempotency.js

---
*GSSOC 2026 — batch automation run*