### PR TITLE
test(api): added unit tests for utils/pagination.js

### DIFF
--- a/backend/api/test/unit/utils/pagination.test.js
+++ b/backend/api/test/unit/utils/pagination.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildPagination } from '../../../src/utils/pagination.js';
+
+describe('buildPagination', () => {
+  it('uses defaults when no params given', () => {
+    const result = buildPagination();
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.offset).toBe(0);
+  });
+
+  it('calculates correct offset', () => {
+    const result = buildPagination({ page: 3, limit: 10 });
+    expect(result.offset).toBe(20);
+    expect(result.from).toBe(20);
+    expect(result.to).toBe(29);
+  });
+
+  it('enforces max limit of 100', () => {
+    const result = buildPagination({ limit: 500 });
+    expect(result.limit).toBe(100);
+  });
+
+  it('enforces minimum limit of 1', () => {
+    const result = buildPagination({ limit: 0 });
+    expect(result.limit).toBe(1);
+  });
+
+  it('floors non-integer page and limit', () => {
+    const result = buildPagination({ page: 2.7, limit: 15.3 });
+    expect(result.page).toBe(3);
+    expect(result.limit).toBe(15);
+  });
+
+  it('handles string numeric params', () => {
+    const result = buildPagination({ page: '2', limit: '10' });
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(10);
+  });
+
+  it('returns defaults for invalid params', () => {
+    const result = buildPagination({ page: 'abc', limit: 'xyz' });
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
Added unit tests for `backend/api/src/utils/pagination.js` pagination utility.

## Coverage
- Uses default page=1, limit=20 when no params
- Calculates correct offset ((page-1) * limit)
- Calculates from/to range
- Enforces max limit of 100
- Enforces minimum limit of 1
- Floors non-integer page and limit
- Handles string numeric params
- Returns defaults for invalid params

---
*GSSOC 2026 — batch automation run*