### PR TITLE
fix: safely parse on-chain reputation score

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -147,10 +147,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
         if (data is Map<String, dynamic>) {
           setState(() {
-            _platformRating = (data['supabaseRating'] as num?)?.toDouble() ?? 0.0;
-            _onChainScore = data['onChainScore'] != null
-                ? (data['onChainScore'] as num).toInt()
-                : null;
+            _platformRating = _parseDouble(data['supabaseRating']) ?? 0.0;
+            _onChainScore = _parseInt(data['onChainScore']);
             _walletAddress = data['walletAddress']?.toString() ?? '';
             _isLoadingReputation = false;
           });
@@ -171,6 +169,20 @@ class _ProfileScreenState extends State<ProfileScreen> {
         });
       }
     }
+  }
+
+  int? _parseInt(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value) ?? double.tryParse(value)?.toInt();
+    return null;
+  }
+
+  double? _parseDouble(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
   }
 
 


### PR DESCRIPTION
## Description

This PR fixes a potential crash in the driver profile/reputation screen when `onChainScore` is returned by the backend in a non-numeric format.

Previously, the value was directly cast using `as num`, which could throw a `CastError` if the backend returned a value such as `"85"` instead of `85`.

The parsing logic now safely handles both numeric values and numeric strings. Invalid or unsupported values safely resolve to `null`, preventing the profile screen from crashing.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:** Not applicable
- **Test Steps / Prerequisites:**
  - Verified numeric values such as `85` are handled correctly.
  - Verified numeric strings such as `"85"` are safely parsed.
  - Verified `null` and invalid values do not cause an unsafe cast or crash.
- **Expected Result:** The profile/reputation screen safely handles different `onChainScore` formats without throwing a `CastError`.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/12058

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reputation data handling for numeric and text-based ratings and scores.
  * Invalid or unsupported values are now safely ignored instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->