### PR TITLE
fix(socket): defensively parse GPS timestamps in location server

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -96,6 +96,19 @@ export function getActiveDriverCount() {
   return activeDrivers.size;
 }
 
+/**
+ * Parses a client-supplied GPS timestamp defensively.
+ *
+ * Falls back to the current time when the value is missing or unparseable so
+ * that a single malformed telemetry frame (e.g. `"abc"` or a bad epoch)
+ * cannot turn into an Invalid Date whose `toISOString()` throws and kills the
+ * driver's live location broadcast.
+ */
+export function parseGpsTimestamp(timestamp) {
+  const parsed = timestamp ? new Date(timestamp) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
 // ─── Server init ─────────────────────────────────────────────────────────────
 
 /**
@@ -216,7 +229,7 @@ export function initLocationServer(httpServer) {
           return;
         }
 
-        const gpsTimestamp = timestamp ? new Date(timestamp) : new Date();
+        const gpsTimestamp = parseGpsTimestamp(timestamp);
 
         // 1. Persist GPS point to MongoDB time-series collection
         // Use authenticated bookingId from socket, NOT from payload

--- a/backend/api/test/unit/sockets/locationServer.test.js
+++ b/backend/api/test/unit/sockets/locationServer.test.js
@@ -1,8 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { getActiveDriverCount } from '../../../src/sockets/locationServer.js';
+import { getActiveDriverCount, parseGpsTimestamp } from '../../../src/sockets/locationServer.js';
 
 describe('locationServer Socket', () => {
   it('returns active driver count', () => {
     expect(typeof getActiveDriverCount()).toBe('number');
+  });
+});
+
+describe('parseGpsTimestamp', () => {
+  it('falls back to the current time for missing timestamps', () => {
+    for (const bad of [undefined, null, '']) {
+      const ts = parseGpsTimestamp(bad);
+      expect(Number.isNaN(ts.getTime())).toBe(false);
+    }
+  });
+
+  it('falls back to the current time for malformed timestamps', () => {
+    for (const bad of ['abc', '0', 'not-a-date', '2026-13-99T99:99:99Z']) {
+      const ts = parseGpsTimestamp(bad);
+      expect(Number.isNaN(ts.getTime())).toBe(false);
+    }
+  });
+
+  it('preserves valid timestamps', () => {
+    const ts = parseGpsTimestamp('2026-01-01T12:00:00.000Z');
+    expect(ts.toISOString()).toBe('2026-01-01T12:00:00.000Z');
   });
 });


### PR DESCRIPTION
## Summary
The live-location broadcast in `backend/api/src/sockets/locationServer.js` built `new Date(timestamp)` directly from the client-supplied `gpsTimestamp`. A missing or malformed value (e.g. `"abc"`, `"0"`, `"2026-13-99T99:99:99Z"`) produced an Invalid Date whose later `toISOString()` throws, dropping the driver's telemetry frame.

## Changes
- Added an exported `parseGpsTimestamp(timestamp)` helper that falls back to the current time when the value is missing or unparseable (`Number.isNaN(parsed.getTime())`), so a single bad frame can never kill the broadcast.
- Wired it into the socket handler in place of the inline `new Date(timestamp)`.
- Added 3 unit tests covering missing, malformed, and valid timestamps in `test/unit/sockets/locationServer.test.js`.

## Impact
- Malformed GPS timestamps no longer crash the location broadcast; valid timestamps are preserved.
- Verified with `test/unit/sockets/locationServer.test.js` (4/4 passing).

Fixes #12128

GSSOC
