### PR TITLE
fix(ml): derive shadow model version from logged variants in A/B evaluation

### DIFF
--- a/backend/ml/services/ab_testing.py
+++ b/backend/ml/services/ab_testing.py
@@ -96,12 +96,21 @@ class ABTestModel:
             
             # Calculate average metrics per model
             results = {}
+            # Shadow metrics are logged under the real shadow model version
+            # (e.g. 'eta_v1'), not the literal bucket name 'shadow'. Derive
+            # the shadow bucket from the versions actually logged for this
+            # test so the A/B comparison measures the real models.
+            logged_versions = df['model_version'].unique()
+            shadow_version = next(
+                (v for v in logged_versions if v != 'production'),
+                'shadow'
+            )
             for metric in df['metric_name'].unique():
                 metric_df = df[df['metric_name'] == metric]
                 avg_metrics = metric_df.groupby('model_version')['metric_value'].mean()
                 
                 prod_val = avg_metrics.get('production', None)
-                shadow_val = avg_metrics.get('shadow', None)
+                shadow_val = avg_metrics.get(shadow_version, None)
                 lower_is_better_keywords = {'rmse', 'mae', 'mse', 'loss', 'error_rate', 'latency', 'error'}
                 higher_is_better = not any(k in metric.lower() for k in lower_is_better_keywords)
 


### PR DESCRIPTION
## Summary
`ABTestModel.evaluate_test` in `backend/ml/services/ab_testing.py` read shadow metrics with a literal `'shadow'` bucket key. Metrics are actually logged under the real shadow model version (e.g. `eta_v1`), so `avg_metrics.get('shadow', None)` always returned `None` and every test was mis-scored as "no shadow data".

## Changes
- `evaluate_test` now derives the shadow version from the `model_version` values actually logged for the test (the first version that is not `production`), and compares `production` against that real version.
- Falls back to `'shadow'` only when no non-production version exists (no-op case), preserving the old behavior when there is genuinely no shadow traffic.

## Impact
- `shadow_val` is populated from real shadow traffic, so `improvement`, `shadow_better`, and the promotion/rollback decision now reflect actual model performance.
- End-to-end verified with an in-memory SQLite DB: rows logged as `production`/`eta_v1` yield `accuracy production=0.89, shadow=0.94, improvement=5.6%`, `shadow_better=True`.

Fixes #12132

GSSOC
