### PR TITLE
fix : added proper device-to-load authorization for IoT telemetry

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -68,7 +68,16 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       let isAuthorized = false;
 
       if (req.user.role === 'iot_device') {
-        isAuthorized = req.user.id === loadId;
+        // Look up the device-to-load assignment via the iot_device_loads table.
+        // The previous check (device_id === load_id) was semantically wrong since
+        // a device UUID and a load UUID are never meaningfully comparable.
+        const { data: assignment } = await supabaseAdmin
+          .from('iot_device_loads')
+          .select('id')
+          .eq('device_id', req.user.id)
+          .eq('load_id', loadId)
+          .maybeSingle();
+        isAuthorized = !!assignment;
       } else {
         isAuthorized = load.customer_id === req.user.id;
         if (!isAuthorized && load.order_display_id) {


### PR DESCRIPTION
Closes #12210.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed the IoT device telemetry authorization in `iotRoutes.js` to use a proper device-to-load mapping via the `iot_device_loads` table. The previous code compared `device_id === load_id` which was semantically wrong since a device UUID and a load UUID can never meaningfully authorize a telemetry submission.

Changes Made:
- backend/api/src/routes/iotRoutes.js: Replaced broken comparison with a DB lookup against `iot_device_loads` table to verify the device is assigned to the specific load

Impact it Made:
- Fixes the broken IoT device telemetry authorization path
- Correctly enforces the safety-critical device-to-load binding

Note: Please assign this PR to the `tmdeveloper007` account.