### PR TITLE
fix : added await for RPC result in outboxService.markFailed

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -80,12 +80,22 @@ export class OutboxService {
    * Mark an event as failed and increment retry_count.
    */
   async markFailed(eventId, errorMessage) {
+    // Await the RPC call to get the actual incremented retry_count value,
+    // then pass it as a scalar to the update. Passing the query-builder
+    // Promise directly (as was done previously) means Supabase treats it as
+    // a JSON-serializable scalar and never executes the SQL increment.
+    const { data: newRetryCount, error: rpcErr } = await supabase.rpc('increment', { row_id: eventId });
+    if (rpcErr) {
+      logger.error('[OutboxService] Failed to increment retry count:', rpcErr.message, { eventId });
+      return;
+    }
+
     const { error } = await supabase
       .from('outbox_events')
       .update({
         status: 'failed',
         last_error: String(errorMessage).slice(0, 1000),
-        retry_count: supabase.rpc('increment', { row_id: eventId }),
+        retry_count: newRetryCount,
         last_attempted_at: new Date().toISOString(),
       })
       .eq('id', eventId);


### PR DESCRIPTION
Closes #12216.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `outboxService.markFailed` to await the `supabase.rpc('increment')` call before passing the result as `retry_count`. Previously, the query-builder Promise was passed directly, so Supabase never executed the SQL increment.

Changes Made:
- backend/api/src/services/outbox/outboxService.js: Added await for RPC call and error handling, then passed the resolved integer as `retry_count`

Impact it Made:
- Fixes dead-letter queue retry triggering for failed outbox events
- Ensures failed events can be retried with properly incremented retry count

Note: Please assign this PR to the `tmdeveloper007` account.