### PR TITLE
fix : added authenticate before multer in verificationRoutes /kyc/upload

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import rateLimit from 'express-rate-limit';
 import { verificationService } from '../core/container.js';
-import { supabase, supabaseAdmin } from '../config/db.js';
+import { supabase, supabaseAdmin, createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
@@ -61,7 +61,8 @@ const kycUploadLimiter = rateLimit({
 router.get('/order/:orderId', orderVerificationLimiter, authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
-    const { data: order, error: orderError } = await supabase
+    const userClient = createUserClient(req.token);
+    const { data: order, error: orderError } = await userClient
       .from('orders')
       .select('id, customer_id, driver_id')
       .eq('id', orderId)
@@ -202,7 +203,7 @@ const upload = multer({
   },
 });
 
-router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
+router.post('/kyc/upload', kycUploadLimiter, authenticate, upload.single('image'), async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {


### PR DESCRIPTION
Closes #12217.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `/kyc/upload` route in `verificationRoutes.js` to run `authenticate` middleware before `upload.single('image')`. Also fixed `GET /order/:orderId` to use `createUserClient(req.token)` instead of the anonymous `supabase` client so RLS policies are enforced.

Changes Made:
- backend/api/src/routes/verificationRoutes.js: Reordered middleware and fixed client usage

Impact it Made:
- Prevents unauthenticated memory/malware scanning of large file uploads
- Fixes broken order verification endpoint that always returned 404

Note: Please assign this PR to the `tmdeveloper007` account.