### PR TITLE
fix : added pending_bid_acceptance clear in confirm-deposit refund path

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -719,6 +719,12 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
         }
 
         // Refund confirmed on-chain — safe to release the escrow booking reference.
+        // Also clear pending_bid_acceptance so the order can accept a new bid.
+        await orderRepository.updateOrder(orderId, {
+          pending_bid_acceptance: null,
+        }).catch((clearErr) => {
+          logger.error('[confirm-deposit] Failed to clear pending_bid_acceptance:', clearErr.message);
+        });
         await orderRepository.revertEscrowStatus(orderId).catch((revertErr) => {
           logger.error('[confirm-deposit] Failed to revert escrow status:', revertErr.message);
         });


### PR DESCRIPTION
Closes #12236.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed the confirm-deposit refund path in `orderRoutes.js` to clear `pending_bid_acceptance` when the `accept_bid_tx` fails and the deposit is refunded on-chain. Previously, `pending_bid_acceptance` was left set, stranding the order and preventing retry.

Changes Made:
- backend/api/src/routes/orderRoutes.js: Added `updateOrder` call to clear `pending_bid_acceptance` in the refund path

Impact it Made:
- Fixes stranded orders that cannot retry deposit after a failed accept_bid_tx
- Enables the retry flow to work correctly after on-chain transaction failures

Note: Please assign this PR to the `tmdeveloper007` account.