### PR TITLE
fix : added header-only API key acceptance in requireApiKey middleware

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,7 +8,9 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  // Accept API key from header only. Query-string keys leak into server logs,
+  // CDN caches, and browser referrer headers.
+  const apiKey = req.headers['x-api-key'];
   
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);


### PR DESCRIPTION
Closes #12241.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `requireApiKey` middleware in `apiKey.js` to accept API keys from `x-api-key` header only. Removed the `|| req.query.api_key` fallback that was leaking secrets into server logs, CDN caches, and browser referrer headers.

Changes Made:
- backend/api/src/middleware/apiKey.js: Accept API key from header only

Impact it Made:
- Prevents API key leakage via query strings
- Aligns with security best practice of header-only API key transport

Note: Please assign this PR to the `tmdeveloper007` account.