### PR TITLE
fix : run authenticate before multer in verificationRoutes kyc upload

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -202,7 +202,7 @@ const upload = multer({
   },
 });
 
-router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
+router.post('/kyc/upload', kycUploadLimiter, authenticate, upload.single('image'), async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {


### PR DESCRIPTION
Closes #12295.

Summary of What Has Been Done:
`verificationRoutes.js` `/kyc/upload` runs `upload.single('image')` (Multer, buffers up to 10 MB for malware scanning) **before** `authenticate`. Any unauthenticated client can force memory allocation and trigger the malware scanner.

Changes that Need to be Made:
- `backend/api/src/routes/verificationRoutes.js` line 205: Swap the middleware order from `upload.single('image'), authenticate` to `authenticate, upload.single('image')`.

Impact that it would Provide:
- Prevents unauthenticated resource exhaustion on the KYC upload endpoint.
- Ensures the expensive memory buffer only runs for authenticated users.

Changes Made:
- `backend/api/src/routes/verificationRoutes.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).