### PR TITLE
fix : use authenticated client for verificationRoutes GET /order/:orderId

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -61,7 +61,7 @@ const kycUploadLimiter = rateLimit({
 router.get('/order/:orderId', orderVerificationLimiter, authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
-    const { data: order, error: orderError } = await supabase
+    const { data: order, error: orderError } = await (req.userClient || supabase)
       .from('orders')
       .select('id, customer_id, driver_id')
       .eq('id', orderId)


### PR DESCRIPTION
Closes #12297.

Summary of What Has Been Done:
`verificationRoutes.js` `GET /order/:orderId` reads `orders` with the anonymous `supabase` client, which has no RLS policy for `orders`. Every caller gets a 404 regardless of authentication.

Changes that Need to be Made:
- `backend/api/src/routes/verificationRoutes.js` line 64: Replace `supabase` with `req.userClient || supabase` for the orders query. The `authenticate` middleware already attaches a user-scoped client to `req.userClient`.

Impact that it would Provide:
- The order verification endpoint returns actual data for authenticated users instead of always 404.
- Fixes a complete functional break in the order verification flow.

Changes Made:
- `backend/api/src/routes/verificationRoutes.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).