### PR TITLE
fix : validate settlement_ref presence in dispatchPayout webhook response

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -72,11 +72,16 @@ export async function dispatchPayout({ driverId, withdrawal }) {
       throw new Error(`Payout webhook returned HTTP ${response.status}.`);
     }
 
-    const body = await response.json().catch(() => ({}));
+    const body = await response.json().catch(() => null);
+    const settlementRef = body && typeof body === 'object'
+      ? (body.settlement_ref || body.reference)
+      : null;
+    if (!settlementRef) {
+      throw new Error('Payout webhook returned HTTP 200 but body contains no settlement_ref or reference.');
+    }
     return {
       success: true,
-      settlementRef:
-        body.settlement_ref || body.reference || `w${withdrawal.id}`,
+      settlementRef,
     };
   }
 


### PR DESCRIPTION
Closes #12299.

Summary of What Has Been Done:
`payoutProvider.js dispatchPayout` synthesises a `settlement_ref` when the webhook body carries none. Any HTTP-200 response — including error JSON — is accepted as successful and marks the transfer COMPLETED.

Changes that Need to be Made:
- `backend/api/src/services/wallet/payoutProvider.js`: After reading the response body, validate that it contains a non-empty `settlement_ref` or `reference`. If absent, throw an error.

Impact that it would Provide:
- Prevents silent money misallocation where failed webhook calls are recorded as successful.
- Critical financial integrity fix.

Changes Made:
- `backend/api/src/services/wallet/payoutProvider.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).