### PR TITLE
fix : reject API keys from query string in requireApiKey

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,7 +8,7 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const apiKey = req.headers['x-api-key'];
   
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);


### PR DESCRIPTION
Closes #12304.

Summary of What Has Been Done:
`apiKey.js` accepts API keys from the URL query string (`req.query.api_key`) as well as the header. Secrets in query strings leak into logs, CDN caches, and referrer headers.

Changes that Need to be Made:
- `backend/api/src/middleware/apiKey.js` line 11: Remove `|| req.query.api_key`. Accept the key only from `x-api-key` header.

Impact that it would Provide:
- Eliminates API key exposure through URL query strings.
- Required for security compliance.

Changes Made:
- `backend/api/src/middleware/apiKey.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).