### PR TITLE
fix : validate ocrData.extracted_number is non-empty before storing kyc_doc_number

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -266,11 +266,14 @@ router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticat
     const ocrData = await mlResponse.json();
 
     if (ocrData.verified) {
+      const docNumber = ocrData.extracted_number && ocrData.extracted_number.trim()
+        ? ocrData.extracted_number.trim()
+        : null;
       const { error: verifyError } = await supabaseAdmin
         .from('driver_details')
-        .update({ 
+        .update({
           kyc_status: 'Verified',
-          kyc_doc_number: ocrData.extracted_number
+          kyc_doc_number: docNumber,
         })
         .eq('user_id', userId);
 


### PR DESCRIPTION
Closes #12306.

Summary of What Has Been Done:
`POST /api/verification/kyc/upload` stores `ocrData.extracted_number` directly when `ocrData.verified` is true, even if it is an empty string. An empty `kyc_doc_number` bypasses downstream identity verification.

Changes that Need to be Made:
- `backend/api/src/routes/verificationRoutes.js` line 268-275: Add a null/empty check for `ocrData.extracted_number`. Only store it if it is a non-empty trimmed string; otherwise store `null`.

Impact that it would Provide:
- Prevents empty document numbers from being stored, closing an identity verification bypass.
- Ensures downstream KYC checks have meaningful data.

Changes Made:
- `backend/api/src/routes/verificationRoutes.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).