### PR TITLE
fix : add null guard for accessToken in digilocker verifyDocuments

### DIFF
--- a/backend/api/src/services/digilockerService.js
+++ b/backend/api/src/services/digilockerService.js
@@ -81,6 +81,10 @@ class DigilockerService {
   }
 
   async verifyDocuments(userId, accessToken) {
+    if (!accessToken) {
+      logger.warn('[DigilockerService] verifyDocuments called with null/undefined accessToken');
+      return { success: false, error: 'Access token is required', is_digilocker_verified: false };
+    }
     if (!this.isMock) {
       logger.warn('[DigilockerService] DigiLocker integration not configured; refusing auto-approval');
       return { success: false, error: 'DigiLocker verification is not configured', is_digilocker_verified: false };


### PR DESCRIPTION
Closes #12313.

Summary of What Has Been Done:
`digilockerService.verifyDocuments` does not guard against `null` or `undefined` `accessToken`. Passing a null token can cause unexpected behavior in the mock path and silent failures.

Changes that Need to be Made:
- `backend/api/src/services/digilockerService.js`: Add a falsy guard at the top of `verifyDocuments`. If `accessToken` is falsy, return `{ success: false, error: 'Access token is required' }`.

Impact that it would Provide:
- Prevents runtime errors from null access tokens.
- Returns a clear error message instead of silent failures.

Changes Made:
- `backend/api/src/services/digilockerService.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).