### PR TITLE
fix : added Supabase Realtime channel cleanup on tracker unsubscribe

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1689,6 +1689,27 @@ async function handleUnsubscribe(ws, data) {
       }
     }
 
+    // Clean up Supabase Realtime channel when the last subscriber for this
+    // display ID unsubscribes. Without this, channels for driver-only orders
+    // (where only the driver subscribes) are never removed, leaking channels.
+    if (trackingSubscriptions.get(targetId).size === 0) {
+      trackingSubscriptions.delete(targetId);
+      const channelKeys = displayIdToLocationChannelKeys.get(targetId);
+      if (channelKeys) {
+        for (const uuidKey of channelKeys) {
+          if (locationChannels.has(uuidKey)) {
+            const channel = locationChannels.get(uuidKey);
+            if (supabase) {
+              supabase.removeChannel(channel);
+            }
+            locationChannels.delete(uuidKey);
+            logger.info({ uuidKey }, 'Removed Supabase Realtime channel on last subscriber unsubscribe');
+          }
+        }
+        displayIdToLocationChannelKeys.delete(targetId);
+      }
+    }
+
     logger.info({ targetId }, 'Client unsubscribed from updates');
     ws.send(JSON.stringify({ status: 'unsubscribed', target: targetId }));
   }


### PR DESCRIPTION
Closes #12240.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `handleUnsubscribe` in `tracker.js` to clean up Supabase Realtime channels when the last subscriber for a display ID unsubscribes. Previously, channel cleanup only happened on disconnect (`removeClientFromAllSubscriptions`).

Changes Made:
- backend/api/src/sockets/tracker.js: Added channel cleanup to handleUnsubscribe

Impact it Made:
- Fixes Supabase Realtime channel leaks for driver-only orders
- Prevents unbounded channel accumulation on the Supabase Realtime server

Note: Please assign this PR to the `tmdeveloper007` account.