### PR TITLE
fix : prevent negative withdrawal amounts in payoutProvider

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -32,6 +32,9 @@ export function isPayoutProviderConfigured() {
 }
 
 export async function dispatchPayout({ driverId, withdrawal }) {
+  if (!Number.isFinite(withdrawal.amount) || withdrawal.amount <= 0) {
+    throw new Error(`Invalid withdrawal amount: ${withdrawal.amount}. Amount must be a positive number.`);
+  }
   const provider = process.env.WITHDRAWAL_PAYOUT_PROVIDER;
   const webhookUrl = process.env.WITHDRAWAL_PAYOUT_WEBHOOK_URL;
 


### PR DESCRIPTION
Closes #12315.

Summary of What Has Been Done:
`payoutProvider.js dispatchPayout` does not validate that `withdrawal.amount` is a positive number. A negative or zero amount could result in incorrect ledger entries.

Changes that Need to be Made:
- `backend/api/src/services/wallet/payoutProvider.js`: Add validation at the start of `dispatchPayout`: if `!Number.isFinite(withdrawal.amount) || withdrawal.amount <= 0`, throw a descriptive error before any side effects.

Impact that it would Provide:
- Prevents invalid payout dispatch for malformed withdrawal records.
- Fails fast with a clear error message.

Changes Made:
- `backend/api/src/services/wallet/payoutProvider.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).