### PR TITLE
fix : add wallet address presence check in digilocker verifyAndSyncDocuments

### DIFF
--- a/backend/api/src/services/digilockerService.js
+++ b/backend/api/src/services/digilockerService.js
@@ -244,9 +244,12 @@ class DigilockerService {
         .maybeSingle();
 
       const walletAddress = profile?.polygon_wallet_address;
+      if (!walletAddress || walletAddress === '0x0000000000000000000000000000000000000000') {
+        logger.warn(`[DigilockerService] Skipping blockchain registration for user ${driverId}: no valid wallet address`);
+      }
       let txHash = null;
 
-      if (this.contract && walletAddress) {
+      if (this.contract && walletAddress && walletAddress !== '0x0000000000000000000000000000000000000000') {
         try {
           const tx = await this.contract.registerDocument(walletAddress, doc.type, docHash, true);
           await tx.wait();


### PR DESCRIPTION
Closes #12318.

Summary of What Has Been Done:
`digilockerService.verifyAndSyncDocuments` proceeds with blockchain registration even when `walletAddress` is the zero address. On-chain writes with the zero address waste gas and create invalid records.

Changes that Need to be Made:
- `backend/api/src/services/digilockerService.js`: In the document loop, after resolving `walletAddress`, check that it is not the zero address before calling `this.contract.registerDocument`. Log a warning and skip the blockchain registration if the address is zero.

Impact that it would Provide:
- Prevents wasted gas on zero-address blockchain writes.
- More robust handling of accounts without wallet addresses.

Changes Made:
- `backend/api/src/services/digilockerService.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).