### PR TITLE
fix : enforce non-empty KYC OCR code in digilocker token exchange

### DIFF
--- a/backend/api/src/services/digilockerService.js
+++ b/backend/api/src/services/digilockerService.js
@@ -46,7 +46,7 @@ class DigilockerService {
 
   async exchangeCode(code) {
     if (!this.isMock) {
-      if (!this.clientId || !this.clientSecret || !code) {
+      if (!this.clientId || !this.clientSecret || !code || !code.trim()) {
         logger.warn('[DigilockerService] DigiLocker integration missing credentials or code; refusing mock fallback');
         return { success: false, error: 'DigiLocker verification is not configured' };
       }


### PR DESCRIPTION
Closes #12320.

Summary of What Has Been Done:
`digilockerService.exchangeCode` accepts any truthy `code` value but does not validate that it is a non-empty string. An empty string `''` passes the truthiness check and is sent to the DigiLocker OAuth endpoint.

Changes that Need to be Made:
- `backend/api/src/services/digilockerService.js`: Change `if (!this.clientId || !this.clientSecret || !code)` to `if (!this.clientId || !this.clientSecret || !code || !code.trim())`.

Impact that it would Provide:
- Prevents unnecessary OAuth API calls with empty codes.
- More defensive input validation.

Changes Made:
- `backend/api/src/services/digilockerService.js`: Applied fix per issue specification.

Impact it Made:
- Addresses a security, correctness, or reliability issue in the backend API.
- All changes verified locally with backend unit tests.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).