### PR TITLE
fix : added order custody reassignment in crossDockService verifyHandoff

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -500,6 +500,18 @@ export async function verifyHandoff({ transferId, driverId, handoffCode }) {
       throw new DomainError(409, { error: 'Transfer was modified concurrently; please retry.' });
     }
 
+    // Reassign order custody to the receiving driver now that handoff is verified.
+    if (verified.order_id) {
+      const { error: orderErr } = await supabaseAdmin
+        .from('orders')
+        .update({ driver_id: verified.to_driver_id })
+        .eq('id', verified.order_id)
+        .eq('driver_id', verified.from_driver_id); // Only update if still assigned to from_driver
+      if (orderErr) {
+        logger.warn?.({ err: orderErr.message, orderId: verified.order_id, toDriverId: verified.to_driver_id }, '[cross-dock] failed to reassign order custody');
+      }
+    }
+
     try {
       await sendPushNotification(
         verified.from_driver_id,


### PR DESCRIPTION
Closes #12238.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `verifyHandoff` in `crossDockService.js` to reassign the order's `driver_id` to the receiving driver after the transfer is marked as `VERIFIED`. Previously, the transfer was marked verified but the order remained assigned to the original driver.

Changes Made:
- backend/api/src/services/order/crossDockService.js: Added order update to reassign `driver_id` to `to_driver_id`

Impact it Made:
- Completes the cross-dock custody transfer workflow end-to-end
- Prevents orders from remaining assigned to the original driver after handoff

Note: Please assign this PR to the `tmdeveloper007` account.