### PR TITLE
fix : added coordinate guards in _buildRouteMap to prevent map crash

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -1621,7 +1621,9 @@ class _TripsScreenState extends State<TripsScreen> {
       );
     }
 
-    final points = routePoints.map((point) {
+    final points = routePoints.where((point) {
+      return point['latitude'] is num && point['longitude'] is num;
+    }).map((point) {
       return ll.LatLng(
         (point['latitude'] as num).toDouble(),
         (point['longitude'] as num).toDouble(),
@@ -1658,7 +1660,8 @@ class _TripsScreenState extends State<TripsScreen> {
               p == routePoints.first ||
               p == routePoints.last ||
               p['is_claimed'] == true
-            ).map<Marker>((point) {
+            ).where((p) => p['latitude'] is num && p['longitude'] is num)
+            .map<Marker>((point) {
               return Marker(
                 point: ll.LatLng(
                   (point['latitude'] as num).toDouble(),


### PR DESCRIPTION
Closes #12235.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `_buildRouteMap` in `trips_screen.dart` to filter out points with null/non-numeric latitude/longitude before casting to `num`. Prevents the entire map widget from crashing on geocoded address stops that have no numeric coordinates.

Changes Made:
- apps/driver/lib/screens/trips_screen.dart: Added coordinate type guards in `_buildRouteMap`

Impact it Made:
- Prevents map widget crash on geocoded address-only stops
- Ensures the trip screen renders even for edge-case route data

Note: Please assign this PR to the `tmdeveloper007` account.