### PR TITLE
fix : added type guard for net_earnings in TripsController.totalEarningsPaise

### DIFF
--- a/apps/driver/lib/controllers/trips_controller.dart
+++ b/apps/driver/lib/controllers/trips_controller.dart
@@ -45,7 +45,12 @@ class TripsController extends ChangeNotifier {
 
   int totalEarningsPaise() => trips.fold(
         0,
-        (sum, row) => sum + ((row['net_earnings'] ?? 0) as num).toInt(),
+        (sum, row) {
+          final val = row['net_earnings'];
+          if (val is num) return sum + val.toInt();
+          if (val is String) return sum + (num.tryParse(val)?.toInt() ?? 0);
+          return sum + ((val ?? 0) as num).toInt();
+        },
       );
 
   int completedCount() =>


### PR DESCRIPTION
Closes #12233.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `totalEarningsPaise` in `trips_controller.dart` to handle non-numeric `net_earnings` values. Added type checking for string and numeric values before casting.

Changes Made:
- apps/driver/lib/controllers/trips_controller.dart: Added type guards in `totalEarningsPaise`

Impact it Made:
- Prevents Riverpod controller crash when API returns string-typed net_earnings
- Ensures driver app earnings view works for all API response formats

Note: Please assign this PR to the `tmdeveloper007` account.