### PR TITLE
fix : use strict boolean for internalRoutes paused toggle

### DIFF
--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -140,7 +140,7 @@ router.get('/escrow-velocity', async (req, res) => {
  */
 router.post('/pause-escrow', async (req, res) => {
   try {
-    const paused = req.body?.paused !== false;
+    const paused = req.body?.paused === true;
     const result = await setEscrowPaused(paused);
     return res.json({
       paused: result.paused,


### PR DESCRIPTION
Closes #12292.

Summary of What Has Been Done:
Changed the escrow circuit breaker paused toggle from loose coercion () to strict boolean check () in internalRoutes.js.

Changes Made:
- backend/api/src/routes/internalRoutes.js: Changed  to .

Impact it Made:
- Fixes a critical safety issue where the emergency circuit breaker could fail to close in edge cases.
- Makes the circuit breaker behavior predictable and consistent.

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GSSOC (GirlScript Summer of Code).