### PR TITLE
fix : added type guards for amount and fuel_toll_deduction in EarningsDailyModel

### DIFF
--- a/apps/driver/lib/models/earnings_daily_model.dart
+++ b/apps/driver/lib/models/earnings_daily_model.dart
@@ -24,12 +24,27 @@ class EarningsDailyModel {
   double get netAmount => amount - fuelTollDeduction;
 
   factory EarningsDailyModel.fromMap(Map<String, dynamic> map) {
-    final gross = ((map['amount'] ?? 0) / 100.0) as double;
+    // Guard against non-numeric amount values (e.g. string from API).
+    final rawAmount = map['amount'];
+    double gross;
+    if (rawAmount is num) {
+      gross = (rawAmount / 100.0).toDouble();
+    } else if (rawAmount is String) {
+      gross = (num.tryParse(rawAmount)?.toDouble() ?? 0.0) / 100.0;
+    } else {
+      gross = 0.0;
+    }
     // If the backend ever starts sending 'fuel_toll_deduction', use it;
     // otherwise fall back to the 15% estimate.
-    final deduction = map['fuel_toll_deduction'] != null
-        ? ((map['fuel_toll_deduction'] as num) / 100.0)
-        : gross * 0.15;
+    final rawDeduction = map['fuel_toll_deduction'];
+    double deduction;
+    if (rawDeduction is num) {
+      deduction = (rawDeduction / 100.0).toDouble();
+    } else if (rawDeduction is String) {
+      deduction = (num.tryParse(rawDeduction)?.toDouble() ?? gross * 0.15) / 100.0;
+    } else {
+      deduction = gross * 0.15;
+    }
 
     return EarningsDailyModel(
       dayDate:


### PR DESCRIPTION
Closes #12231.
Closes #12232.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `fromMap` in `earnings_daily_model.dart` to guard against non-numeric `amount` and `fuel_toll_deduction` values. Added type checking for `num` and `String` before division and casting.

Changes Made:
- apps/driver/lib/models/earnings_daily_model.dart: Added type guards for amount and fuel_toll_deduction

Impact it Made:
- Prevents earnings parsing crash when API returns string-typed money fields
- Ensures daily earnings display works for all API response formats

Note: Please assign this PR to the `tmdeveloper007` account.