### PR TITLE
fix : remove api_key query string acceptance from requireApiKey middleware

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,7 +8,7 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const apiKey = req.headers['x-api-key'];
   
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);


### PR DESCRIPTION
Summary of What Has Been Done:\nRemoved the `|| req.query.api_key` fallback from the requireApiKey middleware so only the x-api-key header is accepted. Query-string API keys leak into logs, CDN cache keys, and browser referrer headers.\n\nChanges Made:\n- backend/api/src/middleware/apiKey.js: Removed `|| req.query.api_key` from the apiKey variable initialization.\n\nCloses #12204.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.