### PR TITLE
fix : use strict boolean check for paused toggle in internalRoutes instead of loose inequality

### DIFF
--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -140,7 +140,7 @@ router.get('/escrow-velocity', async (req, res) => {
  */
 router.post('/pause-escrow', async (req, res) => {
   try {
-    const paused = req.body?.paused !== false;
+    const paused = req.body?.paused === true;
     const result = await setEscrowPaused(paused);
     return res.json({
       paused: result.paused,


### PR DESCRIPTION
Summary of What Has Been Done:\nChanged the paused toggle condition from  to  so that non-boolean values like the string 'false' no longer incorrectly keep the circuit open.\n\nChanges Made:\n- backend/api/src/routes/internalRoutes.js: Changed condition to strict boolean check.\n\nCloses #12208.\n\nNote: Please assign this PR to the  account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.