### PR TITLE
fix : call supabase.rpc increment directly in outboxService markFailed instead of embedding it as update value

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -80,16 +80,16 @@ export class OutboxService {
    * Mark an event as failed and increment retry_count.
    */
   async markFailed(eventId, errorMessage) {
+    const { data: incrementedCount, error: rpcError } = await supabase.rpc('increment', { row_id: eventId });
     const { error } = await supabase
       .from('outbox_events')
       .update({
         status: 'failed',
         last_error: String(errorMessage).slice(0, 1000),
-        retry_count: supabase.rpc('increment', { row_id: eventId }),
+        retry_count: incrementedCount ?? 1,
         last_attempted_at: new Date().toISOString(),
       })
       .eq('id', eventId);
-
     if (error) {
       logger.error('[OutboxService] Failed to mark event failed:', error.message, { eventId });
     }


### PR DESCRIPTION
Summary of What Has Been Done:\nChanged outboxService.markFailed to await the RPC call and use the returned incremented value as the retry_count, instead of embedding an unresolved Promise object in the update call.\n\nChanges Made:\n- backend/api/src/services/outbox/outboxService.js: Await supabase.rpc() separately and use the result in retry_count.\n\nCloses #12205.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.