### PR TITLE
fix : added type guards for EarningsStatementModel date fields

### DIFF
--- a/apps/driver/lib/models/earnings_statement_model.dart
+++ b/apps/driver/lib/models/earnings_statement_model.dart
@@ -38,8 +38,8 @@ class EarningsStatementModel {
     return EarningsStatementModel(
       driverName: json['driver_name'] as String? ?? 'Driver',
       driverPhone: json['driver_phone'] as String?,
-      startDate: DateTime.tryParse(json['start_date'] as String? ?? '') ?? DateTime.now(),
-      endDate: DateTime.tryParse(json['end_date'] as String? ?? '') ?? DateTime.now(),
+      startDate: DateTime.tryParse(json['start_date']?.toString() ?? '') ?? DateTime.now(),
+      endDate: DateTime.tryParse(json['end_date']?.toString() ?? '') ?? DateTime.now(),
       totalTrips: (summary['total_trips'] ?? json['total_trips'] as num?)?.toInt() ?? tripsList.length,
       totalEarnings: _parsePaisa(summary['total_base_freight'] ?? json['total_earnings']),
       platformFees: _parsePaisa(summary['total_platform_fees'] ?? json['platform_fees']),
@@ -101,10 +101,10 @@ class TripEarningRow {
         (pickup != null && drop != null ? '$pickup → $drop' : json['route_label'] as String?);
 
     return TripEarningRow(
-      tripId: json['trip_id'] as String? ?? json['id'] as String?,
-      displayId: json['display_id'] as String? ?? json['order_display_id'] as String?,
+      tripId: json['trip_id']?.toString() ?? json['id']?.toString(),
+      displayId: json['display_id']?.toString() ?? json['order_display_id']?.toString(),
       tripDate: (json['trip_date'] ?? json['pickup_date']) != null
-          ? DateTime.tryParse((json['trip_date'] ?? json['pickup_date']) as String)
+          ? DateTime.tryParse((json['trip_date'] ?? json['pickup_date']).toString())
           : null,
       route: route,
       customerName: json['customer_name'] as String? ??


### PR DESCRIPTION
Closes #12225.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `fromJson` in `earnings_statement_model.dart` to use `.toString()` instead of `as String` for `DateTime.tryParse` calls, preventing crashes when API returns non-string date values (int timestamps or nested objects).

Changes Made:
- apps/driver/lib/models/earnings_statement_model.dart: Replaced unsafe casts with `.toString()`

Impact it Made:
- Fixes statement parsing crashes on non-string date values
- Improves robustness of earnings statement model parsing

Note: Please assign this PR to the `tmdeveloper007` account.