### PR TITLE
fix : validate payout HTTP response body in dispatchPayout before marking transfer as COMPLETED

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -73,6 +73,9 @@ export async function dispatchPayout({ driverId, withdrawal }) {
     }
 
     const body = await response.json().catch(() => ({}));
+    if (body && (body.error || body.status === 'failed' || body.status === 'error' || body.status === 'rejected')) {
+      throw new Error(`Payout webhook returned HTTP 200 but body indicates failure: ${JSON.stringify(body).slice(0, 200)}`);
+    }
     return {
       success: true,
       settlementRef:


### PR DESCRIPTION
Summary of What Has Been Done:\nAdded validation of the payout webhook response body to reject HTTP-200 responses that contain error indicators (body.error, body.status === 'failed'/'error'/'rejected').\n\nChanges Made:\n- backend/api/src/services/wallet/payoutProvider.js: Check response body for error indicators before treating HTTP-200 as success.\n\nCloses #12283.\n\nNote: Please assign this PR to the  account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.