### PR TITLE
fix : write FlashbotsRelay.bundleResults to DB and emit BundleExecuted event after successful submission

### DIFF
--- a/blockchain/contracts/FlashbotsRelay.sol
+++ b/blockchain/contracts/FlashbotsRelay.sol
@@ -31,8 +31,10 @@ contract FlashbotsRelay is Ownable {
 
         bytes32 result = relay.submitBundle(signedTxs, blockNumber);
         submittedBundles[bundleId] = true;
-        
+        bundleResults[bundleId] = blockNumber;
+
         emit BundleSubmitted(bundleId, blockNumber);
+        emit BundleExecuted(bundleId, true);
         return result;
     }
 


### PR DESCRIPTION
Summary of What Has Been Done:\nAdded writes to the bundleResults mapping and emitted the BundleExecuted event in submitBundle so bundle submission outcomes are trackable.\n\nChanges Made:\n- blockchain/contracts/FlashbotsRelay.sol: Write bundleResults[bundleId] = blockNumber and emit BundleExecuted after successful submission.\n\nCloses #12284.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.