### PR TITLE
fix : verify on-chain txHash in escrowWebhookProcessor before marking order released

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -114,9 +114,10 @@ async function verifyPolygonTransactionReceipt(txHash) {
 }
 
 async function handlePaymentReleased(payload) {
-  if (payload.txHash) {
-    await verifyPolygonTransactionReceipt(payload.txHash);
+  if (!payload.txHash) {
+    throw new Error('Missing txHash in escrow release webhook payload — release requires on-chain proof');
   }
+  await verifyPolygonTransactionReceipt(payload.txHash);
   const order = await findOrderByIdOrDisplayId(payload.orderId);
   const now = new Date().toISOString();
 


### PR DESCRIPTION
Summary of What Has Been Done:\nChanged handlePaymentReleased to throw an error when txHash is missing, ensuring escrow releases are only processed with on-chain proof.\n\nChanges Made:\n- backend/api/src/services/webhook/escrowWebhookProcessor.js: Require payload.txHash before proceeding.\n\nCloses #12286.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.