### PR TITLE
fix : transition escrow funding heal path to funded status instead of leaving order stranded

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -117,6 +117,7 @@ async function finalizeOrRevert(order, orderRepository) {
       }
 
       await orderRepository.updateOrderWithFilter(order.id, {
+        escrow_status: 'funded',
         escrow_funding_attempts: 0,
         escrow_funding_error: null,
         escrow_funding_last_attempt_at: null,


### PR DESCRIPTION
Summary of What Has Been Done:\nAdded escrow_status: 'funded' to the heal path update so orders exit the funding state after successful heal, preventing infinite re-heal loops.\n\nChanges Made:\n- backend/api/src/services/escrowFundingReconciliation.js: Add escrow_status: 'funded' to the updateOrderWithFilter call.\n\nCloses #12287.\n\nNote: Please assign this PR to the  account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.