### PR TITLE
fix : orderRoutes geofence-confirm undeclared variable id and wrong mount path

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -200,7 +200,7 @@ const getOrderResource = async (req) => {
 };
 
 
-router.post('/api/deliveries/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
+router.post('/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);


### PR DESCRIPTION
Summary of What Has Been Done:\nFixed the geofence-confirm route path from /api/deliveries/:id/geofence-confirm to /:id/geofence-confirm to prevent double-prefix.\n\nChanges Made:\n- backend/api/src/routes/orderRoutes.js: Fixed route path to /:id/geofence-confirm.\n\nCloses #12053.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.