### PR TITLE
fix : tripRoutes GET /:id/events stores display-id but queries by order UUID

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -534,7 +534,7 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
   try {
     const { data: order, error: orderErr } = await supabaseAdmin
       .from('orders')
-      .select('id, driver_id, customer_id')
+      .select('id, order_display_id, driver_id, customer_id')
       .eq('id', tripId)
       .maybeSingle();
 
@@ -555,10 +555,11 @@ router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSch
       }
     }
 
+    const tripDisplayId = order.order_display_id;
     let eventsQuery = supabase
       .from('trip_events')
       .select('event_id, user_id, trip_id, event_type, event_timestamp, latitude, longitude, metadata, created_at', { count: 'exact' })
-      .eq('trip_id', tripId);
+      .eq('trip_id', tripDisplayId);
 
     if (type && typeof type === 'string') {
       eventsQuery = eventsQuery.eq('event_type', type);


### PR DESCRIPTION
Summary of What Has Been Done:\nChanged the GET /api/trips/:id/events handler to query trip_events by the bare order_display_id (without TX- prefix) instead of the order UUID, matching how events are stored during batch sync.\n\nChanges Made:\n- backend/api/src/routes/tripRoutes.js: Query using order_display_id as tripDisplayId instead of tripId UUID.\n\nCloses #12288.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.