### PR TITLE
fix : removed api_key query string from requireApiKey middleware

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,7 +8,7 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
-  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const apiKey = req.headers['x-api-key'];
   
   const validKeysStr = process.env.VALID_API_KEYS || '';
   const validKeys = validKeysStr.split(',').map(k => k.trim()).filter(Boolean);

--- a/backend/api/test/unit/apiKey.test.js
+++ b/backend/api/test/unit/apiKey.test.js
@@ -135,15 +135,16 @@ describe('requireApiKey', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('calls next() when valid key provided via query.api_key', () => {
+  it('returns 401 when valid key provided only via query.api_key (query string no longer accepted)', () => {
     const { req, res, next } = createMocks({
       req: { headers: {}, query: { api_key: 'test-key-2' } },
     });
 
     requireApiKey(req, res, next);
 
-    expect(next).toHaveBeenCalled();
-    expect(res.status).not.toHaveBeenCalled();
+    // query.api_key is no longer accepted — secrets must come from x-api-key header
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('accepts second key in comma-separated VALID_API_KEYS list', () => {


### PR DESCRIPTION
Closes #12204.

Summary of What Has Been Done:
Removed API key acceptance from query string in requireApiKey middleware. API keys must now be provided via the x-api-key header only, preventing secrets from leaking into server logs, CDN caches, and referrer headers.

Changes Made:
- backend/api/src/middleware/apiKey.js: removed req.query.api_key to prevent secret leakage via query strings; backend/api/test/unit/apiKey.test.js: updated test to expect 401 for query string API keys

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions when the API returns unexpected data types.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).