### PR TITLE
fix : added type guard for order id in live_tracking_screen.dart

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -368,7 +368,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
       if (order != null) {
         await _fetchDriverAndTruck(order['driver_id'], order['truck_id']);
         if (order['id'] != null) {
-          _subscribeToSupabaseRealtime(order['id'] as String);
+          _subscribeToSupabaseRealtime(order['id']?.toString() ?? '');
           _fetchInitialDriverLocation();
         }
       }


### PR DESCRIPTION
Closes #12224.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Summary of What Has Been Done:
Fixed `live_tracking_screen.dart` to use `?.toString()` instead of `as String` for the order id when subscribing to Supabase Realtime. This prevents a crash when the API returns a non-string id value.

Changes Made:
- apps/customer/lib/screens/live_tracking_screen.dart: Guard order id type before realtime subscription

Impact it Made:
- Fixes silent realtime subscription failure when API returns non-string id
- Ensures live tracking works for all API response formats

Note: Please assign this PR to the `tmdeveloper007` account.