### PR TITLE
fix : called supabase.rpc increment directly in outboxService markFailed

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -80,19 +80,22 @@ export class OutboxService {
    * Mark an event as failed and increment retry_count.
    */
   async markFailed(eventId, errorMessage) {
-    const { error } = await supabase
-      .from('outbox_events')
-      .update({
-        status: 'failed',
-        last_error: String(errorMessage).slice(0, 1000),
-        retry_count: supabase.rpc('increment', { row_id: eventId }),
-        last_attempted_at: new Date().toISOString(),
-      })
-      .eq('id', eventId);
+    await supabase.rpc('increment', { row_id: eventId }).then(async () => {
+      const { error } = await supabase
+        .from('outbox_events')
+        .update({
+          status: 'failed',
+          last_error: String(errorMessage).slice(0, 1000),
+          last_attempted_at: new Date().toISOString(),
+        })
+        .eq('id', eventId);
 
-    if (error) {
-      logger.error('[OutboxService] Failed to mark event failed:', error.message, { eventId });
-    }
+      if (error) {
+        logger.error('[OutboxService] Failed to mark event failed:', error.message, { eventId });
+      }
+    }).catch((rpcErr) => {
+      logger.error('[OutboxService] Failed to increment retry count:', rpcErr?.message, { eventId });
+    });
   }
 
   /**


### PR DESCRIPTION
Closes #12205.

Summary of What Has Been Done:
Fixed outboxService.markFailed to call supabase.rpc('increment') as a separate call instead of embedding the RPC object in the update payload. The previous approach stored the RPC call object as JSON instead of executing the SQL increment.

Changes Made:
- backend/api/src/services/outbox/outboxService.js: called RPC increment as a separate await before the update call instead of embedding in update payload

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).