### PR TITLE
fix : passed requester IP to logKeyRotationEvent instead of server env IP

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -18,7 +18,7 @@ class KeyRotationService {
     this.rotationLocks = new Set();
   }
 
-  async initiateKeyRotation(userId, walletAddress, currentPrivateKey, newPrivateKey, reason = 'routine') {
+  async initiateKeyRotation(userId, walletAddress, currentPrivateKey, newPrivateKey, reason = 'routine', requestIp = null) {
     return measureExecution('KeyRotationService.initiateKeyRotation', async () => {
       const lockKey = `${userId}:${walletAddress}`;
 
@@ -48,7 +48,7 @@ class KeyRotationService {
           completed_at: new Date().toISOString(),
         });
 
-        await this.logKeyRotationEvent(userId, walletAddress, reason, 'success');
+        await this.logKeyRotationEvent(userId, walletAddress, reason, 'success', null, requestIp);
 
         logger.info('[KeyRotationService] Key rotation completed:', rotationId);
 
@@ -63,7 +63,7 @@ class KeyRotationService {
         logger.error('[KeyRotationService] Key rotation failed:', err.message);
         Sentry.captureException(err);
 
-        await this.logKeyRotationEvent(userId, walletAddress, reason, 'failed', err.message);
+        await this.logKeyRotationEvent(userId, walletAddress, reason, 'failed', err.message, null, requestIp);
 
         this.rotationLocks.delete(lockKey);
 
@@ -238,7 +238,7 @@ class KeyRotationService {
     }
   }
 
-  async logKeyRotationEvent(userId, walletAddress, reason, status, errorMessage = null) {
+  async logKeyRotationEvent(userId, walletAddress, reason, status, errorMessage = null, requestIp = null) {
     try {
       await supabase
         .from('key_rotation_audit_log')
@@ -249,7 +249,7 @@ class KeyRotationService {
           status,
           error_message: errorMessage,
           timestamp: new Date().toISOString(),
-          ip_address: process.env.REQUEST_IP || 'unknown',
+          ip_address: requestIp || process.env.REQUEST_IP || 'unknown',
         }]);
     } catch (err) {
       logger.error('[KeyRotationService] Failed to log rotation event:', err.message);


### PR DESCRIPTION
Closes #12207.

Summary of What Has Been Done:
Added requestIp parameter to logKeyRotationEvent so the audit log records the actual requester IP instead of the fixed server environment IP. Updated initiateKeyRotation to accept and pass requestIp to the logging method.

Changes Made:
- backend/api/src/services/security/keyRotationService.js: added requestIp parameter to initiateKeyRotation and logKeyRotationEvent; audit log now records actual requester IP

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).