### PR TITLE
fix : pass resolved number not Promise as retry_count in outboxService

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -80,12 +80,18 @@ export class OutboxService {
    * Mark an event as failed and increment retry_count.
    */
   async markFailed(eventId, errorMessage) {
+    const { data: existing } = await supabase
+      .from('outbox_events')
+      .select('retry_count')
+      .eq('id', eventId)
+      .maybeSingle();
+    const currentRetry = (existing?.retry_count ?? -1) + 1;
     const { error } = await supabase
       .from('outbox_events')
       .update({
         status: 'failed',
         last_error: String(errorMessage).slice(0, 1000),
-        retry_count: supabase.rpc('increment', { row_id: eventId }),
+        retry_count: currentRetry,
         last_attempted_at: new Date().toISOString(),
       })
       .eq('id', eventId);


### PR DESCRIPTION
Closes #12294.

Summary: Changed outboxService.markFailed to fetch current retry_count first then increment in JS, instead of passing a Promise (supabase.rpc call result) as retry_count.

Changes Made:
- backend/api/src/services/outbox/outboxService.js: Fetch existing retry_count first, compute currentRetry, then use numeric value in update.

Impact it Made:
- Prevents database storing a Promise object as retry_count.

Note: Please assign this PR to the tmdeveloper007 account.

---
This PR is submitted as part of GSSOC (GirlScript Summer of Code).