### PR TITLE
fix : used dynamic type check instead of unsafe as String on order id in live_tracking_screen

### DIFF
--- a/apps/customer/lib/screens/live_tracking_screen.dart
+++ b/apps/customer/lib/screens/live_tracking_screen.dart
@@ -368,7 +368,7 @@ class _LiveTrackingScreenState extends State<LiveTrackingScreen>
       if (order != null) {
         await _fetchDriverAndTruck(order['driver_id'], order['truck_id']);
         if (order['id'] != null) {
-          _subscribeToSupabaseRealtime(order['id'] as String);
+          _subscribeToSupabaseRealtime(order['id']?.toString() ?? '');
           _fetchInitialDriverLocation();
         }
       }


### PR DESCRIPTION
Closes #12212.

Summary of What Has Been Done:
Fixed live_tracking_screen.dart to use order['id']?.toString() instead of order['id'] as String. The unsafe cast would throw if the API returns id as an integer, causing the Supabase realtime subscription to silently never register.

Changes Made:
- apps/customer/lib/screens/live_tracking_screen.dart: replaced unsafe 'as String' cast on order['id'] with safe ?.toString()

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).