### PR TITLE
fix : validated payout HTTP response body in dispatchPayout before marking COMPLETED

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -73,6 +73,13 @@ export async function dispatchPayout({ driverId, withdrawal }) {
     }
 
     const body = await response.json().catch(() => ({}));
+
+    // Treat explicit failure indicators as a failed payout even on HTTP 200.
+    if (body.success === false || body.status === 'failed' || body.status === 'error') {
+      const reason = body.message || body.error || 'Webhook indicated failure';
+      throw new Error(`Payout webhook indicated failure: ${reason}`);
+    }
+
     return {
       success: true,
       settlementRef:


### PR DESCRIPTION
Closes #12213.

Summary of What Has Been Done:
Added validation of the payout webhook response body. Previously any HTTP 200 response was treated as success, allowing a malicious webhook to mark a failed transfer as COMPLETED. Now checks for body.success === false or body.status === 'failed'.

Changes Made:
- backend/api/src/services/wallet/payoutProvider.js: added body validation to check for success === false or status === failed before marking payout as success

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).