### PR TITLE
fix: import and use isValidCachedProfile in profileService

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -4,6 +4,7 @@ import {
   getCachedSupabaseProfile, setCachedSupabaseProfile,
   getCachedCustomerStats, setCachedCustomerStats,
   getCachedDriverDetails, setCachedDriverDetails,
+  isValidCachedProfile,
 } from '../lib/profileCache.js';
 import logger from '../middleware/logger.js';
 

--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -75,6 +75,7 @@ const profileCacheRef = vi.hoisted(() => ({
   setCachedCustomerStats: vi.fn().mockResolvedValue(undefined),
   getCachedDriverDetails: vi.fn().mockResolvedValue(null),
   setCachedDriverDetails: vi.fn().mockResolvedValue(undefined),
+  isValidCachedProfile: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('../../src/config/db.js', () => ({


### PR DESCRIPTION
## Summary
`profileService` calls `isValidCachedProfile(userId, cached)` in its cache-hit path but never imports it from `lib/profileCache.js`. The name resolves at runtime as an undefined function call, so every cache hit throws `TypeError: isValidCachedProfile is not a function` and falls back to the DB — silently defeating the profile cache.

## Changes
- Import `isValidCachedProfile` from `../lib/profileCache.js` in `profileService.js`.
- Add `isValidCachedProfile` to the mocked `profileCache` module in `profileService.test.js` so the cache-hit path is exercised (fixes a failing test).

## Impact
- Cache hits now work as intended: no `TypeError`, no needless DB round-trip.
- `test/unit/profileService.test.js` passes 27/27.

Fixes #12247
GSSOC
