### PR TITLE
fix : used strict boolean check for paused toggle in internalRoutes instead of loose inequality

### DIFF
--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -140,7 +140,7 @@ router.get('/escrow-velocity', async (req, res) => {
  */
 router.post('/pause-escrow', async (req, res) => {
   try {
-    const paused = req.body?.paused !== false;
+    const paused = req.body?.paused !== false && req.body?.paused !== 'false';
     const result = await setEscrowPaused(paused);
     return res.json({
       paused: result.paused,


### PR DESCRIPTION
Closes #12215.

Summary of What Has Been Done:
Fixed the pause-escrow circuit breaker to reject string 'false' as opening the circuit. The previous  check treated string 'false' as truthy, keeping the circuit open when callers intended to close it.

Changes Made:
- backend/api/src/routes/internalRoutes.js: added '!== false && !== "false"' check to prevent string 'false' from opening the circuit

Impact it Made:
Fixes a bug or adds type safety to prevent runtime exceptions.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).