### PR TITLE
fix: remove nonexistent from_driver filter in cross-dock nearby driver check

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -153,7 +153,7 @@ export async function findHandoffCandidates({
           lng: Number(d.lng),
           last_seen_at: d.last_seen_at,
         }))
-        .filter((d) => d.from_driver !== fromDriverId && d.driver_id !== fromDriverId)
+        .filter((d) => d.driver_id !== fromDriverId)
         .map((d) => ({
           driver_id: d.driver_id,
           name: d.name,


### PR DESCRIPTION
## Summary
`crossDockService.findHandoffCandidates` filters nearby drivers with `d.from_driver !== fromDriverId && d.driver_id !== fromDriverId`. The `d.from_driver` property does not exist on the mapped driver objects (they only carry `driver_id`), so `d.from_driver` is always `undefined`, making the first condition a no-op. The check is dead code that can never exclude the originating driver.

## Changes
- Drop the nonexistent `d.from_driver !== fromDriverId` condition from the nearby-driver filter, keeping `d.driver_id !== fromDriverId`.

## Impact
- The originating driver is correctly excluded from handoff candidates via the property that actually exists.
- No behavior change for the existing validation-path tests.

Fixes #12251
GSSOC
