### PR TITLE
fix: remove duplicate crypto import in otpHashing.js

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -49,7 +49,6 @@ export function verifyOtpHash(otp, otpRecord) {
 
 // === Spec 12: ===
 // === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;


### PR DESCRIPTION
## Summary
`otpHashing.js` imports `crypto` twice. A duplicate `import crypto from 'crypto';` sits at the top of the "Spec 12" block while the module already imports it at the top. The duplicate import is dead cruft inside a feature block.

## Changes
- Remove the duplicate `import crypto from 'crypto';` line.
- The `constantTimeEqualHex` helper that follows it is untouched and remains fully exported.

## Impact
- No behavior change; module-level side effects (if any) are unchanged.
- `constantTimeEqualHex` still passes its existing unit tests (the lone failing test, "invalid hex", fails on `main` too due to `Buffer.from(hex)` parsing semantics and is unrelated to this change).

Fixes #12266
GSSOC
