### PR TITLE
fix : reordered kyc/upload authenticate before multer and used authenticated client in verificationRoutes

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import rateLimit from 'express-rate-limit';
 import { verificationService } from '../core/container.js';
-import { supabase, supabaseAdmin } from '../config/db.js';
+import { supabase, supabaseAdmin, createUserClient } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
@@ -61,7 +61,7 @@ const kycUploadLimiter = rateLimit({
 router.get('/order/:orderId', orderVerificationLimiter, authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
-    const { data: order, error: orderError } = await supabase
+    const { data: order, error: orderError } = await createUserClient(req.token)
       .from('orders')
       .select('id, customer_id, driver_id')
       .eq('id', orderId)
@@ -202,7 +202,7 @@ const upload = multer({
   },
 });
 
-router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
+router.post('/kyc/upload', kycUploadLimiter, authenticate, upload.single('image'), async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {


### PR DESCRIPTION
Closes #12206.
Closes #12211.

Summary of What Has Been Done:
Fixed two issues in verificationRoutes.js:
1. Reordered /kyc/upload middleware so authenticate runs before upload.single, preventing unauthenticated file buffering and malware scanning.
2. Fixed GET /order/:orderId to use createUserClient(req.token) instead of the anonymous supabase client which has no RLS policy for orders.

Changes Made:
- backend/api/src/routes/verificationRoutes.js: moved authenticate before upload.single; replaced anon supabase client with createUserClient(req.token)

Impact it Made:
Prevents unauth resource exhaustion via /kyc/upload and fixes broken order verification endpoint.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).