### PR TITLE
fix : auth.js fails to parse due to duplicate profile query stray braces and missing catch

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -187,9 +187,14 @@ export async function authenticate(req, res, next) {
       process.env.DEV_ACCESS_TOKEN &&
       devToken === process.env.DEV_ACCESS_TOKEN
     ) {
+      const devIdentity = {
+        id: req.headers["x-user-id"],
+        role: req.headers["x-user-role"] || "customer",
+        name: req.headers["x-user-name"] || "Test User",
+      };
       const testUserId = devIdentity.id;
-      const testUserRole = devIdentity.role || "customer";
-      const testFullName = devIdentity.name || "Test User";
+      const testUserRole = devIdentity.role;
+      const testFullName = devIdentity.name;
 
       if (testUserId) {
         req.user = {


### PR DESCRIPTION
Summary of What Has Been Done:\nDefined the devIdentity object in the dev token bypass path so testUserId, testUserRole, and testFullName are correctly sourced from request headers instead of an undefined devIdentity reference.\n\nChanges Made:\n- backend/api/src/middleware/auth.js: Define devIdentity from request headers before using it.\n\nCloses #12101.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.