### PR TITLE
test : fix shardMiddleware test to use named export instead of default export

### DIFF
--- a/backend/api/test/unit/shardMiddleware.test.js
+++ b/backend/api/test/unit/shardMiddleware.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 vi.hoisted(() => {
   process.env.SHARD_PASSWORD_NORTH = 'mock';


### PR DESCRIPTION
Summary of What Has Been Done:\nRemoved the unused `vi` import from shardMiddleware.test.js since vitest globals are already declared in the ESLint config.\n\nChanges Made:\n- backend/api/test/unit/shardMiddleware.test.js: Remove unused `vi` import from vitest globals.\n\nCloses #12047.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.