### PR TITLE
fix : added type guards in EarningsDailyModel fromMap for amount and fuel_toll_deduction

### DIFF
--- a/apps/driver/lib/models/earnings_daily_model.dart
+++ b/apps/driver/lib/models/earnings_daily_model.dart
@@ -24,10 +24,10 @@ class EarningsDailyModel {
   double get netAmount => amount - fuelTollDeduction;
 
   factory EarningsDailyModel.fromMap(Map<String, dynamic> map) {
-    final gross = ((map['amount'] ?? 0) / 100.0) as double;
+    final gross = ((map['amount'] is num ? map['amount'] as num : 0) / 100.0);
     // If the backend ever starts sending 'fuel_toll_deduction', use it;
     // otherwise fall back to the 15% estimate.
-    final deduction = map['fuel_toll_deduction'] != null
+    final deduction = map['fuel_toll_deduction'] != null && map['fuel_toll_deduction'] is num
         ? ((map['fuel_toll_deduction'] as num) / 100.0)
         : gross * 0.15;
 


### PR DESCRIPTION
Closes #12219.

Summary of What Has Been Done:
Added type guards in EarningsDailyModel.fromMap to prevent runtime crashes. The amount field now checks if the value is a number before dividing. The fuel_toll_deduction field now checks for num type before casting, falling back to the 15% estimate for non-numeric values.

Changes Made:
- apps/driver/lib/models/earnings_daily_model.dart: added type guard for amount before division; added is num check for fuel_toll_deduction before cast

Impact it Made:
Fixes a type safety issue preventing runtime crashes when API returns unexpected data types.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).