### PR TITLE
fix : pass requester IP to logKeyRotationEvent instead of using server env IP

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -238,7 +238,7 @@ class KeyRotationService {
     }
   }
 
-  async logKeyRotationEvent(userId, walletAddress, reason, status, errorMessage = null) {
+  async logKeyRotationEvent(userId, walletAddress, reason, status, errorMessage = null, reqIp = null) {
     try {
       await supabase
         .from('key_rotation_audit_log')
@@ -249,7 +249,7 @@ class KeyRotationService {
           status,
           error_message: errorMessage,
           timestamp: new Date().toISOString(),
-          ip_address: process.env.REQUEST_IP || 'unknown',
+          ip_address: reqIp || process.env.REQUEST_IP || 'unknown',
         }]);
     } catch (err) {
       logger.error('[KeyRotationService] Failed to log rotation event:', err.message);


### PR DESCRIPTION
Summary of What Has Been Done:\nAdded a reqIp parameter to logKeyRotationEvent so callers can pass the actual requester IP address for the audit log, falling back to process.env.REQUEST_IP when not provided.\n\nChanges Made:\n- backend/api/src/services/security/keyRotationService.js: Added reqIp parameter with fallback to env var.\n\nCloses #12207.\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is part of the GirlScript Summer of Code (GSSOC) contribution program.