### PR TITLE
fix : added type guards in trips_screen for net_earnings and route point coordinates

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -324,7 +324,7 @@ class _TripsScreenState extends State<TripsScreen> {
         fuelDeducted: '₹0',
         tollDeducted: '₹0',
         platformFee: '₹0',
-        netEarnings: '₹${((row['net_earnings'] ?? 0) / 100).toStringAsFixed(0)}',
+        netEarnings: '₹${((row['net_earnings'] is num ? row['net_earnings'] as num : 0) / 100).toStringAsFixed(0)}',
       ),
       tripItems: tripItems,
       escrowStatus: row['escrow_status']?.toString(),
@@ -453,8 +453,8 @@ class _TripsScreenState extends State<TripsScreen> {
         final routePoints = tripId != null ? (_routePointsByTripId[tripId] ?? []) : [];
         if (routePoints.isNotEmpty) {
           final lastPoint = routePoints.last;
-          currentLat = (lastPoint['latitude'] as num?)?.toDouble();
-          currentLng = (lastPoint['longitude'] as num?)?.toDouble();
+          currentLat = lastPoint['latitude'] is num ? (lastPoint['latitude'] as num).toDouble() : null;
+          currentLng = lastPoint['longitude'] is num ? (lastPoint['longitude'] as num).toDouble() : null;
         }
       }
 


### PR DESCRIPTION
Closes #12222.

Summary of What Has Been Done:
Added type guards in trips_screen.dart to prevent runtime crashes. The _mapSupabaseTripsToUiTrips method now safely converts net_earnings using type check. The _buildRouteMap method now safely converts latitude and longitude using type checks instead of unsafe casts.

Changes Made:
- apps/driver/lib/screens/trips_screen.dart: added type guard for net_earnings in PaymentBreakdown; added type checks for route point coordinates

Impact it Made:
Fixes a type safety issue preventing runtime crashes when API returns unexpected data types.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).