### PR TITLE
fix : added type guards in truck_models for Truck.fromJson and TruckMaintenanceTicket.fromJson

### DIFF
--- a/apps/driver/lib/models/truck_models.dart
+++ b/apps/driver/lib/models/truck_models.dart
@@ -29,10 +29,10 @@ class Truck {
 
   factory Truck.fromJson(Map<String, dynamic> json) {
     return Truck(
-      id: json['id'] as String,
-      driverId: json['driver_id'] as String,
-      name: json['name'] as String,
-      numberPlate: json['number_plate'] as String,
+      id: json['id']?.toString() ?? '',
+      driverId: json['driver_id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      numberPlate: json['number_plate']?.toString() ?? '',
       maxCapacityTons: (json['max_capacity_tons'] as num?)?.toDouble() ?? 0.0,
       averageMpg: (json['average_mpg'] as num?)?.toDouble() ?? 6.0,
       insuranceExpiry: json['insurance_expiry'] != null
@@ -91,17 +91,17 @@ class TruckMaintenanceTicket {
 
   factory TruckMaintenanceTicket.fromJson(Map<String, dynamic> json) {
     return TruckMaintenanceTicket(
-      id: json['id'].toString(),
-      truckId: json['truck_id'].toString(),
-      driverId: json['driver_id'].toString(),
-      category: json['category'] as String,
-      description: json['description'] as String,
-      status: json['status'] as String,
+      id: json['id']?.toString() ?? '',
+      truckId: json['truck_id']?.toString() ?? '',
+      driverId: json['driver_id']?.toString() ?? '',
+      category: json['category']?.toString() ?? '',
+      description: json['description']?.toString() ?? '',
+      status: json['status']?.toString() ?? '',
       createdAt: json['created_at'] != null
-          ? DateTime.tryParse(json['created_at'] as String)
+          ? DateTime.tryParse(json['created_at']?.toString() ?? '')
           : null,
       photoUrls: json['photo_urls'] != null
-          ? List<String>.from(json['photo_urls'] as List)
+          ? List<String>.from((json['photo_urls'] as List?)?.map((e) => e?.toString() ?? '') ?? [])
           : const [],
     );
   }


### PR DESCRIPTION
Closes #12226.

Summary of What Has Been Done:
Added type guards in truck_models.dart to prevent runtime crashes. Truck.fromJson now uses safe toString() instead of unsafe as String casts. TruckMaintenanceTicket.fromJson now uses safe toString() and null guards for all field casts.

Changes Made:
- apps/driver/lib/models/truck_models.dart: replaced as String casts with safe toString() for Truck and TruckMaintenanceTicket; added null guard for photo_urls list

Impact it Made:
Fixes a type safety issue preventing runtime crashes when API returns unexpected data types.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).