### PR TITLE
fix: apply unused settlement object in escrow webhook order update

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -238,14 +238,7 @@ async function handleWithdrawalSettled(payload) {
 
   const { data: updatedOrders, error } = await requireDb()
     .from('orders')
-    .update({
-      escrow_status: isRefund ? 'refunded' : 'released',
-      release_tx_hash: isRefund ? undefined : (txHash || order.release_tx_hash || null),
-      refund_tx_hash: isRefund ? (txHash || order.refund_tx_hash || null) : undefined,
-      escrow_released_at: isRefund ? undefined : now,
-      escrow_release_error: isRefund ? undefined : null,
-      updated_at: now,
-    })
+    .update({ ...settlement, updated_at: now })
     .eq('id', order.id)
     .in('escrow_status', [...REFUND_RECONCILABLE_STATUSES, ...RELEASE_RECONCILABLE_STATUSES])
     .select('id');


### PR DESCRIPTION
## Summary
In `escrowWebhookProcessor` the handler builds a `settlement` object (escrow status, release/refund tx hash, released-at, release-error) that is never used — the subsequent `.update()` call re-derives the exact same fields inline. The unused object is dead code and a source of confusion (both paths can drift).

## Changes
- Spread `settlement` into the `.update()` payload instead of the inline literal (`{ ...settlement, updated_at: now }`).
- The resulting payload keys are identical to before: `escrow_status`, `release_tx_hash`/`refund_tx_hash`, `escrow_released_at`, `escrow_release_error`, `updated_at`.

## Impact
- Behavior is unchanged; the now-used object guarantees release and refund paths stay in sync.
- The 6 pre-existing test failures in `escrowWebhookProcessor.test.js` also fail on `main` (mock `.update()` returns no rows) and are unrelated to this refactor.

Fixes #12274
GSSOC
