### PR TITLE
fix : added type guards in EarningsStatementModel.fromJson for date and string fields

### DIFF
--- a/apps/driver/lib/models/earnings_statement_model.dart
+++ b/apps/driver/lib/models/earnings_statement_model.dart
@@ -36,10 +36,10 @@ class EarningsStatementModel {
         .toList();
 
     return EarningsStatementModel(
-      driverName: json['driver_name'] as String? ?? 'Driver',
-      driverPhone: json['driver_phone'] as String?,
-      startDate: DateTime.tryParse(json['start_date'] as String? ?? '') ?? DateTime.now(),
-      endDate: DateTime.tryParse(json['end_date'] as String? ?? '') ?? DateTime.now(),
+      driverName: json['driver_name']?.toString() ?? 'Driver',
+      driverPhone: json['driver_phone']?.toString(),
+      startDate: DateTime.tryParse(json['start_date']?.toString() ?? '') ?? DateTime.now(),
+      endDate: DateTime.tryParse(json['end_date']?.toString() ?? '') ?? DateTime.now(),
       totalTrips: (summary['total_trips'] ?? json['total_trips'] as num?)?.toInt() ?? tripsList.length,
       totalEarnings: _parsePaisa(summary['total_base_freight'] ?? json['total_earnings']),
       platformFees: _parsePaisa(summary['total_platform_fees'] ?? json['platform_fees']),


### PR DESCRIPTION
Closes #12228.

Summary of What Has Been Done:
Added type guards in EarningsStatementModel.fromJson to prevent runtime crashes on unexpected date and string field types. All as String casts now use safe toString() with appropriate defaults.

Changes Made:
- apps/driver/lib/models/earnings_statement_model.dart: replaced as String casts with safe toString() for driver_name, driver_phone, start_date, end_date

Impact it Made:
Fixes a type safety issue preventing runtime crashes when API returns unexpected data types.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).