### PR TITLE
fix: correct bytelastChecked typo in divergence metrics

### DIFF
--- a/backend/api/src/services/blockchain/stateDivergenceDetector.js
+++ b/backend/api/src/services/blockchain/stateDivergenceDetector.js
@@ -299,7 +299,7 @@ class StateDivergenceDetector {
     const metrics = {
       totalDivergences: this.divergences.size,
       activeDivergences: Array.from(this.divergences.values()).filter(d => !d.resolved).length,
-      bytelastChecked: new Date().toISOString(),
+      lastChecked: new Date().toISOString(),
       rpcNodeCount: this.rpcNodes.length,
     };
 


### PR DESCRIPTION
## Summary
`stateDivergenceDetector.getDivergenceMetrics` writes the last-checked timestamp under the misspelled key `bytelastChecked`. Downstream consumers querying `lastChecked` (as the surrounding code and other modules use) will never see an update, so divergence re-checking can appear stale forever.

## Changes
- Rename the `bytelastChecked` property to `lastChecked` in `getDivergenceMetrics`.

## Impact
- The timestamp is now written under the conventional key; existing tests pass unchanged.

Fixes #12290
GSSOC
