### PR TITLE
fix : enforce req.user.id in digilocker verify endpoint and trim ML env vars

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -165,10 +165,10 @@ router.post('/digilocker/token', digilockerLimiter, authenticate, async (req, re
 
 router.post('/digilocker/verify', digilockerLimiter, authenticate, async (req, res) => {
   try {
-    const { accessToken, userId: bodyUserId } = req.body;
-    const userId = req.user?.id || bodyUserId;
+    const { accessToken } = req.body;
+    const userId = req.user.id;
     if (!userId) {
-      return res.status(400).json({ success: false, error: 'User ID is required' });
+      return res.status(401).json({ success: false, error: 'Authentication required' });
     }
     if (!accessToken) {
       return res.status(400).json({ success: false, error: 'Access token is required' });
@@ -241,11 +241,11 @@ router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticat
     const blob = new Blob([req.file.buffer], { type: req.file.mimetype });
     formData.append('file', blob, req.file.originalname);
 
-    const mlBaseUrl = (process.env.ML_API_URL || process.env.ML_ENGINE_URL || process.env.ML_SERVICE_URL || '').replace(/\/$/, '');
-    const mlApiKey = process.env.ML_API_KEY;
+    const mlBaseUrl = (process.env.ML_API_URL || process.env.ML_ENGINE_URL || process.env.ML_SERVICE_URL || '').replace(/\/$/, '').trim();
+    const mlApiKey = (process.env.ML_API_KEY || '').trim();
 
     if (!mlBaseUrl || !mlApiKey) {
-      logger.error({ event: 'OCR_SERVICE_NOT_CONFIGURED' }, '[OCR] ML service URL (ML_API_URL) or API key (ML_API_KEY) not configured');
+      logger.error({ event: 'OCR_SERVICE_NOT_CONFIGURED', ip: req.ip }, '[OCR] ML service URL (ML_API_URL) or API key (ML_API_KEY) not configured');
       return res.status(503).json({ success: false, error: 'KYC OCR service is unconfigured' });
     }
 


### PR DESCRIPTION
Closes #12308.

Summary of fixes:
1. **IDOR fix**: Removed bodyUserId fallback in /digilocker/verify - now uses only req.user.id
2. **req.ip logging**: Added ip: req.ip to OCR_SERVICE_NOT_CONFIGURED logger
3. **mlApiKey trim**: Added .trim() to ML_API_KEY env var
4. **mlBaseUrl trim**: Added .trim() to mlBaseUrl before use

Changes Made:
- backend/api/src/routes/verificationRoutes.js: Multiple hardening fixes in KYC/digilocker routes.

Impact it Made:
- Prevents IDOR in digilocker verify endpoint
- Better audit logging with requester IP
- Handles whitespace in ML service configuration

Note: Please assign this PR to the tmdeveloper007 account.

---
This PR is submitted as part of GSSOC (GirlScript Summer of Code).