### PR TITLE
fix: safely parse locked load color hex in dispatch screen

### DIFF
--- a/apps/driver/lib/screens/collaborative_dispatch_screen.dart
+++ b/apps/driver/lib/screens/collaborative_dispatch_screen.dart
@@ -93,10 +93,20 @@ class _CollaborativeDispatchScreenState extends State<CollaborativeDispatchScree
     );
   }
 
+  static Color _parseLockColor(String? hex) {
+    // lock colors are sent as '0xFF2196F3'; a locked load may also arrive
+    // without any color (null) or with a malformed value. Fall back to the
+    // default blue rather than crashing the whole load list.
+    if (hex == null || hex.isEmpty) return const Color(0xFF2196F3);
+    final cleaned = hex.startsWith('0x') ? hex.substring(2) : hex;
+    final value = int.tryParse(cleaned, radix: 16);
+    return value != null ? Color(value) : const Color(0xFF2196F3);
+  }
+
   Widget _buildLoadCard(DispatchLoadItem load) {
     bool isLocked = load.isLocked;
     bool isLockedByMe = load.lockedByUserId == 'ME';
-    Color lockColor = isLocked ? Color(int.parse(load.lockedColorHex!)) : Colors.transparent;
+    Color lockColor = isLocked ? _parseLockColor(load.lockedColorHex) : Colors.transparent;
 
     return GestureDetector(
       onTap: () {


### PR DESCRIPTION
## Summary
`_buildLoadCard` builds the lock color with `Color(int.parse(load.lockedColorHex!))`. `lockedColorHex` is `String?` and the dispatch service sends values like `'0xFF2196F3'` — `int.parse` (radix 10) throws `FormatException` on the `0x` prefix, and a null value throws a null-assert error. A single locked load therefore crashes the whole live dispatch board.

## Changes
- Add `_parseLockColor(String?)` helper: handles `0x`-prefixed and plain hex, falls back to the default blue on null/malformed values.
- Use it in `_buildLoadCard` instead of the raw `int.parse`.

## Impact
- Locked loads render correctly; malformed/missing colors no longer crash the dispatch screen.

Fixes #12277
GSSOC
