### PR TITLE
fix(profile): import isValidCachedProfile from profileCache.js

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -4,6 +4,7 @@ import {
   getCachedSupabaseProfile, setCachedSupabaseProfile,
   getCachedCustomerStats, setCachedCustomerStats,
   getCachedDriverDetails, setCachedDriverDetails,
+  isValidCachedProfile,
 } from '../lib/profileCache.js';
 import logger from '../middleware/logger.js';
 


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Added `isValidCachedProfile` to the profileCache.js import in profileService.js. Resolves `no-undef: 'isValidCachedProfile' is not defined`.

### Why
isValidCachedProfile was used but never imported, causing ReferenceError whenever getProfile checks the cache.