### PR TITLE
fix(sockets): declare wsUpgradeLimitsCleanupInterval with let

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -812,7 +812,7 @@ export function initWebSocketServer(server, orderRepository) {
 
   // Periodically purge expired per-IP WebSocket upgrade-limit entries, so the
   // in-memory fallback map does not leak during Redis outages.
-  wsUpgradeLimitsCleanupInterval = setInterval(() => {
+  let wsUpgradeLimitsCleanupInterval = setInterval(() => {
     sweepWsUpgradeMemoryLimits();
   }, WS_UPGRADE_LIMITS_SWEEP_INTERVAL_MS);
 


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Added `let` to the `wsUpgradeLimitsCleanupInterval` assignment in tracker.js. Resolves `no-undef`.

### Why
Variable was used (cleared on shutdown) but never declared, causing ReferenceError in strict mode.