### PR TITLE
fix(wallet): attach cause to TimeoutError in payoutProvider

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -63,7 +63,7 @@ export async function dispatchPayout({ driverId, withdrawal }) {
       // failure so the caller keeps its existing fail-safe handling rather
       // than hanging the settlement worker forever.
       if (err.name === 'TimeoutError' || err.name === 'AbortError') {
-        throw new Error(`Payout webhook did not respond within ${timeoutMs}ms.`);
+        throw new Error(`Payout webhook did not respond within ${timeoutMs}ms.`, { cause: err });
       }
       throw err;
     }


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Changed `throw new Error(msg)` to `throw new Error(msg, { cause: err })` for timeout/abort paths. Resolves `preserve-caught-error` lint rule.

### Why
Without a cause chain, debugging payout webhook timeouts is significantly harder — the original error context is lost.