### PR TITLE
fix(fraud): remove useless =[] init from page variable in FraudDetectionService

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -333,7 +333,7 @@ class FraudDetectionService {
     // Get all connections (orders, trips, shared routes)
     const connections = new Set();
     let offset = 0;
-    let page = [];
+    let page;
     do {
       const { data: orders, error } = await supabaseAdmin
         .from('orders')
@@ -380,7 +380,7 @@ class FraudDetectionService {
       // Each batch's row set is paged too, since a single prolific user can
       // still push one batch past PostgREST's 1000-row response cap.
       let offset = 0;
-      let page = [];
+      let page;
       do {
         const { data: batchOrders, error } = await supabaseAdmin
           .from('orders')


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Changed `let page = [];` to `let page;` in two pagination loops. Resolves `no-useless-assignment` in two places.

### Why
Initial empty-array value is always overwritten before use — misleading to readers, fails strict lint.