### PR TITLE
fix(escrow): remove useless =null init from tripData

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -701,7 +701,7 @@ export class DeliveryVerificationService {
 
         // 2. Execute Postgres RPC to complete the trip AFTER blockchain success
         let verifiedOrder;
-        let tripData = null;
+        let tripData;
 
         if (!isRetryForStuckEscrow) {
           const guardResult = await this._writeRepository.updateOrderGuardStatus(


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Changed `let tripData = null;` to `let tripData;`. Resolves `no-useless-assignment` at line 704.

### Why
tripData = rpcResult.data is never consumed after assignment.