### PR TITLE
fix: null-safe signedAt and signatureHash in EBoL screen

### DIFF
--- a/apps/driver/lib/screens/geofenced_ebol_screen.dart
+++ b/apps/driver/lib/screens/geofenced_ebol_screen.dart
@@ -228,12 +228,12 @@ class _GeofencedEbolScreenState extends State<GeofencedEbolScreen> {
             const SizedBox(height: 8),
             const Text('LEGALLY BINDING HASH', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.green)),
             const Divider(height: 24),
-            Text('Signed at: ${_document!.signedAt.toString().split('.')[0]}', style: const TextStyle(color: Colors.grey)),
+            Text('Signed at: ${_document!.signedAt?.toIso8601String() ?? 'Not recorded'}', style: const TextStyle(color: Colors.grey)),
             const SizedBox(height: 8),
             Container(
               padding: const EdgeInsets.all(8),
               color: Colors.white,
-              child: Text(_document!.signatureHash!, style: const TextStyle(fontFamily: 'monospace', fontSize: 12)),
+              child: Text(_document!.signatureHash ?? 'Hash pending', style: const TextStyle(fontFamily: 'monospace', fontSize: 12)),
             )
           ],
         ),


### PR DESCRIPTION
## Summary
The geofenced EBoL screen null-asserts two optional fields on the loaded document: `_document!.signatureHash!` and (via `signedAt.toString()`) a `DateTime?` that renders as the literal string `'null'`. If a document has been created but not yet signed, rendering the detail view crashes.

## Changes
- `signatureHash!` → `signatureHash ?? 'Hash pending'`
- `signedAt.toString().split('.')[0]` → `signedAt?.toIso8601String() ?? 'Not recorded'`

## Impact
- Unsigned documents render gracefully instead of crashing.

Fixes #12278
GSSOC
