### PR TITLE
fix(sockets): remove useless =null init from event in locationEventBus

### DIFF
--- a/backend/api/src/sockets/locationEventBus.js
+++ b/backend/api/src/sockets/locationEventBus.js
@@ -282,7 +282,7 @@ export function createLocationEventBus(options = {}) {
 
   function handleMessage(rawMessage) {
     metrics.received++;
-    let event = null;
+    let event;
     try {
       event = JSON.parse(rawMessage);
     } catch (err) {


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Changed `let event = null;` to `let event;`. Resolves `no-useless-assignment` at line 285.

### Why
Initial null is never read before JSON.parse reassigns it.