### PR TITLE
fix(scripts): remove useless =null init from target in check-n8n-workflow-urls

### DIFF
--- a/backend/api/scripts/check-n8n-workflow-urls.js
+++ b/backend/api/scripts/check-n8n-workflow-urls.js
@@ -227,7 +227,7 @@ function pathFromUrl(raw) {
   } catch {
     return null;
   }
-  let target = null;
+  let target;
   if (isApiHost(parsed)) target = 'api';
   else if (isMlHost(parsed)) target = 'ml';
   else return null;


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Changed `let target = null;` to `let target;`. Resolves `no-useless-assignment` at line 230.

### Why
The null is never used; function returns null explicitly before target is referenced.