### PR TITLE
test(lint): remove redundant global-vi comment from reverseGeocode.test.js

### DIFF
--- a/backend/api/test/unit/lib/reverseGeocode.test.js
+++ b/backend/api/test/unit/lib/reverseGeocode.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../../../middleware/logger.js', () => ({ default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } }));


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Removed `/* global vi: writable */` from reverseGeocode.test.js. Resolves `no-redeclare: 'vi' is already defined as a built-in global variable`.

### Why
vitest globals are already configured in ESLint; the comment conflicts, causing CI lint to fail.