### PR TITLE
test(lint): remove redundant global-vi comment from predictionValidator.test.js

### DIFF
--- a/backend/api/test/unit/predictionValidator.test.js
+++ b/backend/api/test/unit/predictionValidator.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect, vi } from 'vitest';
 import {
   validatePricePrediction,


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Removed `/* global vi: writable */` from predictionValidator.test.js. Resolves `no-redeclare` lint error.

### Why
Same issue — redundant global declaration conflicts with ESLint vitest config.