### PR TITLE
test(lint): remove redundant global-vi comment from voiceAssistantRoute.test.js

### DIFF
--- a/backend/api/test/unit/voiceAssistantRoute.test.js
+++ b/backend/api/test/unit/voiceAssistantRoute.test.js
@@ -1,4 +1,3 @@
-/* global vi: writable */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../middleware/logger.js', () => ({ default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }));


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Removed `/* global vi: writable */` from voiceAssistantRoute.test.js. Resolves `no-redeclare` lint error.

### Why
Same pattern as the other test files.