### PR TITLE
fix: accept numeric-string fields in DeadheadRecommendation.fromJson

### DIFF
--- a/apps/driver/lib/models/deadhead_recommendation.dart
+++ b/apps/driver/lib/models/deadhead_recommendation.dart
@@ -27,7 +27,14 @@ class DeadheadRecommendation {
   final String deadline;
 
   factory DeadheadRecommendation.fromJson(Map<String, dynamic> json) {
-    num _n(String key, [num fallback = 0]) => (json[key] as num?) ?? fallback;
+    // The ML API may emit numeric fields as JSON numbers or as numeric
+    // strings ('12.5'); accept both instead of crashing on a strict cast.
+    num _n(String key, [num fallback = 0]) {
+      final value = json[key];
+      if (value is num) return value;
+      if (value is String) return num.tryParse(value) ?? fallback;
+      return fallback;
+    }
     return DeadheadRecommendation(
       loadId: (json['load_id'] ?? '').toString(),
       distanceToPickupKm: _n('distance_to_pickup_km').toDouble(),

--- a/apps/driver/test/deadhead_recommendation_test.dart
+++ b/apps/driver/test/deadhead_recommendation_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/models/deadhead_recommendation.dart';
+
+void main() {
+  group('DeadheadRecommendation.fromJson', () {
+    test('parses JSON numbers', () {
+      final rec = DeadheadRecommendation.fromJson(const {
+        'load_id': 'L-1',
+        'distance_to_pickup_km': 12.5,
+        'match_score': 78,
+        'detour_km': 3.2,
+        'estimated_earnings': 4500,
+        'route': 'Surat -> Jaipur',
+      });
+
+      expect(rec.loadId, 'L-1');
+      expect(rec.distanceToPickupKm, 12.5);
+      expect(rec.matchScore, 78);
+      expect(rec.detourKm, 3.2);
+      expect(rec.estimatedEarnings, 4500);
+    });
+
+    test('parses numeric strings emitted by the ML API', () {
+      final rec = DeadheadRecommendation.fromJson(const {
+        'load_id': 'L-2',
+        'distance_to_pickup_km': '18.75',
+        'match_score': '91',
+        'detour_km': '1.5',
+        'estimated_earnings': '6200',
+      });
+
+      expect(rec.distanceToPickupKm, 18.75);
+      expect(rec.matchScore, 91);
+      expect(rec.detourKm, 1.5);
+      expect(rec.estimatedEarnings, 6200);
+    });
+
+    test('falls back to default on missing or malformed values', () {
+      final rec = DeadheadRecommendation.fromJson(const {
+        'load_id': 'L-3',
+        'match_score': 'not-a-number',
+      });
+
+      expect(rec.distanceToPickupKm, 0);
+      expect(rec.matchScore, 0);
+      expect(rec.route, '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
`DeadheadRecommendation.fromJson` reads numeric fields with a strict cast: `(json[key] as num?) ?? fallback`. The ML deadhead endpoint can emit these as numeric strings (e.g. `"12.5"`, `"91"`), which throws `TypeError: type 'String' is not a subtype of type 'num?'` and drops the entire recommendation list in `marketplace_repository`.

## Changes
- `_n()` now accepts JSON numbers, parses numeric strings via `num.tryParse`, and falls back to the default on missing/malformed values.
- Add `test/deadhead_recommendation_test.dart` covering numbers, numeric strings, and malformed/missing values.

## Impact
- Mixed number/string payloads from the ML API parse correctly instead of crashing.

Fixes #12280
GSSOC
