### PR TITLE
fix(lint): add __ENV k6 global to eslint.config.js

### DIFF
--- a/backend/api/eslint.config.js
+++ b/backend/api/eslint.config.js
@@ -11,6 +11,7 @@ export default [
         ...globals.jest,
         ...globals.browser,
         fetch: 'readonly',
+        __ENV: 'readonly',
       }
     },
     rules: {


### PR DESCRIPTION
## GSSOC Contribution

**Upstream:** https://api.github.com/repos/KanishJebaMathewM/Truxify

### What
Added `__ENV: 'readonly'` to eslint.config.js globals. Resolves `__ENV is not defined` in k6 load test files.

### Why
k6 sets __ENV as a built-in; ESLint needs to know about it.