### PR TITLE
fix: guard empty driver name in retention dashboard

### DIFF
--- a/apps/driver/lib/screens/retention_dashboard_screen.dart
+++ b/apps/driver/lib/screens/retention_dashboard_screen.dart
@@ -119,7 +119,10 @@ class _RetentionDashboardScreenState extends State<RetentionDashboardScreen> {
                   children: [
                     CircleAvatar(
                       backgroundColor: riskColor,
-                      child: Text(driver.driverName[0], style: const TextStyle(color: Colors.white)),
+                      child: Text(
+                        driver.driverName.isNotEmpty ? driver.driverName[0] : '?',
+                        style: const TextStyle(color: Colors.white),
+                      ),
                     ),
                     const SizedBox(width: 12),
                     Column(


### PR DESCRIPTION
## Summary
The retention dashboard avatar renders `driver.driverName[0]` directly. `driverName` is a non-null `String` on the model, but the backing data can arrive empty (e.g. a driver record with no name), which throws `RangeError (index): Invalid value: Not in range 0..0` and crashes the whole dashboard.

## Changes
- Render `driverName.isNotEmpty ? driverName[0] : '?'` as the avatar initial.

## Impact
- Drivers with empty names render a placeholder initial instead of crashing the dashboard.

Fixes #12282
GSSOC
