### PR TITLE
fix : added order custody reassignment in crossDockService verifyHandoff

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -500,6 +500,13 @@ export async function verifyHandoff({ transferId, driverId, handoffCode }) {
       throw new DomainError(409, { error: 'Transfer was modified concurrently; please retry.' });
     }
 
+    // Transfer custody: reassign the order to the receiving driver.
+    await supabaseAdmin
+      .from('orders')
+      .update({ driver_id: verified.to_driver_id })
+      .eq('id', verified.order_id)
+      .eq('driver_id', verified.from_driver_id);
+
     try {
       await sendPushNotification(
         verified.from_driver_id,


### PR DESCRIPTION
Closes #12326.

Summary of What Has Been Done:
Added an order reassignment step in verifyHandoff: after the transfer is marked VERIFIED, the order's driver_id is updated to the receiving driver's ID, completing the custody transfer.

Changes Made:
- backend/api/src/services/order/crossDockService.js: After marking transfer VERIFIED, update orders.driver_id to the to_driver_id

Impact it Made:
- Completes the cross-dock custody transfer workflow end-to-end
- Prevents orders from remaining assigned to the original driver after handoff

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).