### PR TITLE
fix: validate Redis cache TTL

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -32,7 +32,10 @@ async function _publishProfileInvalidation(eventOpts) {
   }
 }
 
-export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || "120", 10); // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
+const _parsedTtlSeconds = parseInt(process.env.REDIS_CACHE_TTL, 10);
+export const TTL_SECONDS = Number.isFinite(_parsedTtlSeconds) && _parsedTtlSeconds > 0
+  ? _parsedTtlSeconds
+  : 120; // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 
 let cacheHits = 0;


### PR DESCRIPTION
## Description

Fix invalid Redis cache TTL handling in `profileCache.js`.

Previously, `REDIS_CACHE_TTL` was parsed directly using `parseInt()`. If the environment variable contained a non-numeric value such as `abc`, the result became `NaN`, which could be passed to Redis as an invalid `EX` TTL.

This fix validates the parsed TTL and falls back to the default value of `120` seconds when the value is invalid, zero, or negative.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:** Manual verification of TTL parsing behavior
- **Test Steps / Prerequisites:**
  - Tested valid numeric TTL values.
  - Tested invalid non-numeric values such as `abc`.
  - Verified that missing, zero, and negative TTL values fall back to `120` seconds.
- **Expected Result:** Only valid positive numeric TTL values are used; invalid values safely default to `120` seconds.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Tested via Docker Compose

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/12435

## PR Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.