### PR TITLE
fix(n8n): bind dispute-resolution admin alerts to ADMIN_ALERT_EMAIL instead of placeholder recipient

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,17 @@ N8N_USER_MANAGEMENT_JWT_SECRET=<generate-a-secure-random-key>
 # dispute-resolution workflow's HTTP nodes ({{$env.BACKEND_API_URL}}).
 BACKEND_API_URL=http://api:5000
 
+# Recipient for operator alerts raised by the dispute-resolution workflow
+# ({{$env.ADMIN_ALERT_EMAIL}}): on-chain escrow freeze/release failures and the
+# 24h arbitration escalation. Must be a mailbox a real operator monitors — these
+# alerts fire when disputed funds are stuck on-chain and need manual action.
+#
+# Deliberately left EMPTY: docker compose reads this file for interpolation, so
+# shipping a default here would silently satisfy the production guard and route
+# critical alerts to a placeholder. docker-compose.prod.yml refuses to start n8n
+# until you set a real address; dev falls back to admin@localhost.
+ADMIN_ALERT_EMAIL=
+
 # Dedicated database credentials for n8n. Provisioned at DB init time into the
 # `truxify_n8n` database owned by the `n8n` role (never the app `truxify` DB).
 N8N_DB_PASSWORD=<generate-a-secure-random-password>

--- a/automation/n8n/README.md
+++ b/automation/n8n/README.md
@@ -25,6 +25,7 @@ When importing workflows into your n8n instance, ensure the following environmen
 | `ML_API_KEY` | API Key for authenticating against the FastAPI ML Engine | `local_ml_secret` |
 | `ML_ENGINE_URL` | Base URL of the ML service container | `http://ml-engine:8000` |
 | `BACKEND_API_URL` | Base URL of the backend Express API, reachable from the n8n container on the internal Docker network | `http://api:5000` |
+| `ADMIN_ALERT_EMAIL` | Operator mailbox for the `dispute-resolution.json` alert nodes: escrow **freeze failed**, escrow **release failed**, and the 24h **arbitration escalation**. Must be a monitored address — these fire when disputed funds are stuck on-chain and need manual intervention. **Required in production**: `docker-compose.prod.yml` refuses to start n8n if it is unset | `admin@localhost` |
 | `ALCHEMY_WS_URL` | Full Polygon mempool WebSocket URL including the Alchemy API key (e.g. `wss://polygon-mainnet.g.alchemy.com/v2/<API_KEY>`), consumed by the sentinel workflow | Not set |
 | `N8N_ENCRYPTION_KEY` | Master encryption key for n8n credentials | Configured in `docker-compose.prod.yml` |
 

--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -46,7 +46,7 @@
     },
     {
       "parameters": {
-        "toEmail": "admin@truxify.com",
+        "toEmail": "={{$env.ADMIN_ALERT_EMAIL}}",
         "subject": "=Escrow Alert: Freeze Payment Contract Failed for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
         "textBody": "=CRITICAL: The Freeze Payment Contract step failed after 3 retries for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}. Disputed funds were not frozen on-chain. Immediate manual intervention required.",
         "options": {}
@@ -230,7 +230,7 @@
     },
     {
       "parameters": {
-        "toEmail": "admin@truxify.com",
+        "toEmail": "={{$env.ADMIN_ALERT_EMAIL}}",
         "subject": "=Escalation Alert: Arbitration Required for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
         "textBody": "=The dispute for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}} has remained unresolved for 24 hours. Please review the packaged GPS trail and OTP logs.",
         "options": {}
@@ -293,7 +293,7 @@
     },
     {
       "parameters": {
-        "toEmail": "admin@truxify.com",
+        "toEmail": "={{$env.ADMIN_ALERT_EMAIL}}",
         "subject": "=Escrow Alert: Release Escrow Payment Failed for Booking {{$json.body.bookingId}}",
         "textBody": "=CRITICAL: The Release Escrow Payment step failed after 3 retries for Booking {{$json.body.bookingId}}. Escrow payment was not released on-chain. Immediate manual intervention required.",
         "options": {}

--- a/automation/n8n/tests/dispute-resolution.test.js
+++ b/automation/n8n/tests/dispute-resolution.test.js
@@ -1,8 +1,21 @@
 "use strict";
 
 const assert = require("assert");
+const fs = require("fs");
 const path = require("path");
 const workflow = require(path.join(__dirname, "..", "dispute-resolution.json"));
+
+const REPO_ROOT = path.join(__dirname, "..", "..", "..");
+const ALERT_EMAIL_EXPRESSION = "={{$env.ADMIN_ALERT_EMAIL}}";
+const LITERAL_EMAIL = /^[^={}\s]+@[^={}\s]+$/;
+
+function emailNodes() {
+  return workflow.nodes.filter((n) => n.type === "n8n-nodes-base.emailSend");
+}
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
 
 function nodeByName(name) {
   return workflow.nodes.find((n) => n.name === name);
@@ -77,6 +90,66 @@ test("every connection source and target references an existing node", () => {
       }
     }
   }
+});
+
+test("no emailSend node hardcodes a literal recipient address", () => {
+  const nodes = emailNodes();
+  assert.ok(nodes.length > 0, "workflow must contain emailSend nodes");
+  for (const node of nodes) {
+    const toEmail = node.parameters && node.parameters.toEmail;
+    assert.ok(toEmail, `${node.name} must define a recipient`);
+    assert.ok(
+      !LITERAL_EMAIL.test(toEmail),
+      `${node.name} must not hardcode a recipient address (found '${toEmail}')`,
+    );
+  }
+});
+
+test("every alert/escalation email routes to $env.ADMIN_ALERT_EMAIL", () => {
+  const expected = [
+    "Alert Admin — Escrow Freeze Failed",
+    "Email Admin",
+    "Alert Admin — Escrow Release Failed",
+  ];
+  for (const name of expected) {
+    const node = nodeByName(name);
+    assert.ok(node, `${name} node must exist`);
+    assert.strictEqual(
+      node.parameters.toEmail,
+      ALERT_EMAIL_EXPRESSION,
+      `${name} must resolve its recipient from ADMIN_ALERT_EMAIL`,
+    );
+  }
+  assert.strictEqual(
+    emailNodes().length,
+    expected.length,
+    "a new emailSend node was added without being covered by this test",
+  );
+});
+
+test("ADMIN_ALERT_EMAIL is plumbed into the n8n container and documented", () => {
+  assert.match(
+    readRepoFile("docker-compose.yml"),
+    /ADMIN_ALERT_EMAIL=\$\{ADMIN_ALERT_EMAIL:-/,
+    "dev compose must pass ADMIN_ALERT_EMAIL to n8n with a fallback",
+  );
+  assert.match(
+    readRepoFile("docker-compose.prod.yml"),
+    /ADMIN_ALERT_EMAIL:\s*\$\{ADMIN_ALERT_EMAIL:\?/,
+    "prod compose must require ADMIN_ALERT_EMAIL (:? form) so alerts cannot be misrouted",
+  );
+  // Must ship EMPTY: docker compose interpolates from .env, so any default here
+  // would satisfy the prod `:?` guard and re-route alerts to a placeholder.
+  assert.match(
+    readRepoFile(".env.example"),
+    /^ADMIN_ALERT_EMAIL=\s*$/m,
+    ".env.example must declare ADMIN_ALERT_EMAIL with no default value",
+  );
+  assert.match(
+    readRepoFile(path.join("automation", "n8n", "README.md")),
+    /ADMIN_ALERT_EMAIL/,
+    "n8n README env table must document ADMIN_ALERT_EMAIL",
+  );
 });
 
 if (failures > 0) {

--- a/automation/n8n/tests/dispute-resolution.test.js
+++ b/automation/n8n/tests/dispute-resolution.test.js
@@ -17,6 +17,26 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
 }
 
+// Returns just the lines of one top-level compose service, so an assertion
+// cannot be satisfied by the variable being wired into some *other* service.
+// Deliberately text-based rather than YAML-parsed: both compose files currently
+// carry committed merge-conflict markers on main, so they do not parse as YAML.
+// Only a sibling service key at the same indent ends the block; conflict marker
+// lines sit at column 0 and are skipped over rather than truncating it.
+function composeServiceBlock(relativePath, service) {
+  const lines = readRepoFile(relativePath).split("\n");
+  const start = lines.findIndex((l) => new RegExp(`^ {2}${service}:\\s*$`).test(l));
+  assert.notStrictEqual(start, -1, `${relativePath} must define a '${service}' service`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}[A-Za-z_][A-Za-z0-9_-]*:/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
 function nodeByName(name) {
   return workflow.nodes.find((n) => n.name === name);
 }
@@ -128,15 +148,17 @@ test("every alert/escalation email routes to $env.ADMIN_ALERT_EMAIL", () => {
 });
 
 test("ADMIN_ALERT_EMAIL is plumbed into the n8n container and documented", () => {
+  // Scoped to the n8n service block: the workflow runs in that container, so
+  // the variable reaching any other service would not deliver the alerts.
   assert.match(
-    readRepoFile("docker-compose.yml"),
+    composeServiceBlock("docker-compose.yml", "n8n"),
     /ADMIN_ALERT_EMAIL=\$\{ADMIN_ALERT_EMAIL:-/,
-    "dev compose must pass ADMIN_ALERT_EMAIL to n8n with a fallback",
+    "dev compose must pass ADMIN_ALERT_EMAIL to the n8n service with a fallback",
   );
   assert.match(
-    readRepoFile("docker-compose.prod.yml"),
+    composeServiceBlock("docker-compose.prod.yml", "n8n"),
     /ADMIN_ALERT_EMAIL:\s*\$\{ADMIN_ALERT_EMAIL:\?/,
-    "prod compose must require ADMIN_ALERT_EMAIL (:? form) so alerts cannot be misrouted",
+    "prod compose must require ADMIN_ALERT_EMAIL (:? form) on the n8n service so alerts cannot be misrouted",
   );
   // Must ship EMPTY: docker compose interpolates from .env, so any default here
   // would satisfy the prod `:?` guard and re-route alerts to a placeholder.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -264,6 +264,10 @@ services:
       EXECUTIONS_DATA_MAX_AGE: 336
       N8N_METRICS: "true"
       BACKEND_API_URL: ${BACKEND_API_URL:?BACKEND_API_URL is required}
+      # Operator mailbox for escrow freeze/release failures and arbitration
+      # escalation. Required: a stuck-escrow alert that reaches nobody is worse
+      # than a boot failure, so n8n refuses to start until this is set.
+      ADMIN_ALERT_EMAIL: ${ADMIN_ALERT_EMAIL:?ADMIN_ALERT_EMAIL is required}
     volumes:
       - n8n_data:/home/node/.n8n
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,6 +274,7 @@ services:
       - ML_API_KEY=${ML_API_KEY:-local_ml_secret}
       - ML_ENGINE_URL=http://ml-engine:8000
       - BACKEND_API_URL=${BACKEND_API_URL:-http://api:5000}
+      - ADMIN_ALERT_EMAIL=${ADMIN_ALERT_EMAIL:-admin@localhost}
     volumes:
       - n8n_data:/home/node/.n8n
     healthcheck:


### PR DESCRIPTION
Fixes #12073

## Root cause

`automation/n8n/dispute-resolution.json` contains three `n8n-nodes-base.emailSend` nodes, and all three hardcoded their recipient:

| Line | Node | Fires when |
| :--- | :--- | :--- |
| 49 | `Alert Admin — Escrow Freeze Failed` | `Freeze Payment Contract` exhausts its 3 retries — disputed funds were **not frozen on-chain** |
| 233 | `Email Admin` | Dispute still unresolved after 24h — **arbitration escalation** |
| 296 | `Alert Admin — Escrow Release Failed` | `Release Escrow Payment` exhausts its 3 retries — escrow **not released on-chain** |

```json
"toEmail": "admin@truxify.com"
```

`admin@truxify.com` is a placeholder that does not route to a real operator. These three nodes are the *only* notification path on the workflow's error branches (`onError: continueErrorOutput`), so every one of them is a terminal alert: when it fails to reach a human, a stuck-escrow condition is silently dropped and money stays frozen or unreleased on-chain with nobody paged.

The workflow's HTTP nodes already resolve their target from the environment (`={{$env.BACKEND_API_URL}}`, documented in [`automation/n8n/README.md`](automation/n8n/README.md) and [`.env.example`](.env.example)) — the email nodes simply never adopted that pattern.

## Fix

Bind each recipient to the same `$env` mechanism the rest of the workflow already uses:

```diff
-        "toEmail": "admin@truxify.com",
+        "toEmail": "={{$env.ADMIN_ALERT_EMAIL}}",
```

Making the value configurable is only half of it — a variable nothing supplies is still an alert that reaches nobody. So `ADMIN_ALERT_EMAIL` is plumbed end-to-end:

- **`docker-compose.prod.yml`** — `${ADMIN_ALERT_EMAIL:?ADMIN_ALERT_EMAIL is required}`, matching how `BACKEND_API_URL` is already treated in prod. n8n refuses to start rather than run with unroutable alerting; a boot failure is loud, a silently misrouted stuck-escrow alert is not.
- **`docker-compose.yml`** (dev) — `${ADMIN_ALERT_EMAIL:-admin@localhost}`, matching the existing dev fallback style, so local development is unaffected.
- **`.env.example`** — declared and documented under section 9 (n8n).
- **`automation/n8n/README.md`** — added to the environment-configuration table.

### One subtlety worth flagging

`ADMIN_ALERT_EMAIL` is shipped **empty** in `.env.example`, not with a default. Docker Compose interpolates variables from `.env`, so the standard `cp .env.example .env` flow would have made any default there satisfy the production `:?` guard — silently reintroducing this exact bug under a different address. Empty is treated as unset by both `:?` and `:-`, so prod hard-fails and dev still gets its fallback. This is verified below (case B). `SENTRY_DSN=` on line 157 sets the same precedent in this file.

## Proof of solution

### 1. Automated tests

Three tests added to the existing [`automation/n8n/tests/dispute-resolution.test.js`](automation/n8n/tests/dispute-resolution.test.js):

```
$ node automation/n8n/tests/dispute-resolution.test.js

PASS: no emailSend node hardcodes a literal recipient address
PASS: every alert/escalation email routes to $env.ADMIN_ALERT_EMAIL
PASS: ADMIN_ALERT_EMAIL is plumbed into the n8n container and documented
```

The second test also asserts the emailSend node count, so a newly added alert node fails the suite rather than quietly shipping another hardcoded address.

**Negative control** — reverting only `dispute-resolution.json` to `main` while keeping the tests, to confirm they actually catch the defect:

```
$ git checkout upstream/main -- automation/n8n/dispute-resolution.json
$ node automation/n8n/tests/dispute-resolution.test.js

FAILED: no emailSend node hardcodes a literal recipient address
FAILED: every alert/escalation email routes to $env.ADMIN_ALERT_EMAIL
  Alert Admin — Escrow Freeze Failed must resolve its recipient from ADMIN_ALERT_EMAIL
  - '={{$env.ADMIN_ALERT_EMAIL}}'
```

### 2. Config resolves correctly in both environments

Verified with `docker compose config` (Compose v5.4.0), reading the resolved `services.n8n.environment`:

**A. Production, real address supplied → delivered to n8n**
```
$ ADMIN_ALERT_EMAIL=ops@real-operator.example docker compose -f docker-compose.prod.yml config
ADMIN_ALERT_EMAIL = 'ops@real-operator.example'
BACKEND_API_URL   = '[link removed for security]'
```

**B. Production, operator copied `.env.example` and left it unset → startup refused**
```
$ docker compose -f docker-compose.prod.yml config
error while interpolating services.n8n.environment.ADMIN_ALERT_EMAIL:
required variable ADMIN_ALERT_EMAIL is missing a value: ADMIN_ALERT_EMAIL is required
```

**C. Development, unset → harmless local fallback**
```
$ docker compose -f docker-compose.yml config
n8n ADMIN_ALERT_EMAIL = 'admin@localhost'
```

`dispute-resolution.json` was re-validated as parseable JSON after editing, and `grep -n toEmail` on the file returns only the three `$env` expressions.

## Notes for the reviewer

Two things I ran into that are **pre-existing on `main` and deliberately left untouched** by this PR:

1. **Two tests in `dispute-resolution.test.js` already fail on `main`**, before and after this change. They assert nodes named `Freeze Escrow Payment` and `Verify Escrow Release`, which do not exist in the workflow (the corresponding node is `Freeze Payment Contract`). Introduced by #11483; unrelated to this issue, so fixing them would mean renaming workflow nodes well outside its scope. Baseline on `main` is 3 pass / 2 fail; with this PR it is 6 pass / 2 fail — the same two.

2. **`docker-compose.yml` and `docker-compose.prod.yml` have committed merge-conflict markers on `main`** (`<<<<<<< HEAD` / `>>>>>>> upstream/main`, 9 and 3 lines respectively), which means neither file currently parses as YAML. My edits are in clean regions and do not touch the markers; for the verification above I resolved them to the `upstream/main` side in a throwaway copy purely so Compose could parse the file. Happy to open a separate issue or PR for this — it looked like it wants its own fix rather than being folded in here.

Also out of scope per the issue, but the same hardcoded recipient appears in `automation/n8n/dispute_resolution.json:58,258` and `automation/n8n/document-integrity-workflow.json:81` (and `ml-alerts@truxify.org` in `ml_retraining.json` / `ml-rollback-workflow.json`). The issue scopes this to `dispute-resolution.json`, so I kept the change tight — glad to extend the same `$env` treatment to the others in a follow-up if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrative alerts for escrow failures and arbitration escalations can now be sent to a configurable mailbox.
  - Development environments use a local fallback address when no mailbox is configured.
  - Production startup now requires an alert mailbox to be specified, preventing incomplete alert setup.

- **Documentation**
  - Added configuration guidance covering alert usage, production requirements, startup validation, and development behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> ⚠️ **Security Notice:** Links posted by non-contributors have been automatically removed.