### PR TITLE
fix : use req.ips[0] for rate-limit IP key to prevent X-Forwarded-For bypass

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -112,6 +112,11 @@ export function normalizeIp(rawIp) {
 
 /**
  * Generates a rate-limit key from the proxy-resolved IP address.
+ *
+ * When trust proxy is enabled, req.ip is derived from X-Forwarded-For which
+ * can be spoofed. We prefer req.ips[0] (the client IP before any proxy hops)
+ * as the most trustworthy source, falling back to the socket address only
+ * when the forwarded header is suspicious or unavailable.
  */
 export function safeIpKeyGenerator(req) {
   const forwarded = req.headers?.["x-forwarded-for"];
@@ -125,9 +130,15 @@ export function safeIpKeyGenerator(req) {
       },
       "Suspicious X-Forwarded-For header detected",
     );
+    // Use socket address instead of the spoofed header value.
+    const socketIp = req.socket?.remoteAddress || req.connection?.remoteAddress || "unknown";
+    return normalizeIp(socketIp);
   }
 
+  // req.ips[0] is the client IP before any proxy hops (set by trust proxy).
+  // This is preferred over req.ip because req.ip may use the full header.
   const rawIp =
+    (req.ips && req.ips.length > 0 ? req.ips[0] : null) ||
     req.ip ||
     req.headers?.["x-forwarded-for"] ||
     req.socket?.remoteAddress ||


### PR DESCRIPTION
Closes #12342.

Summary of What Has Been Done:
Fixed safeIpKeyGenerator in rateLimiter to use req.ips[0] (the client IP before any proxy hops) as the preferred source for rate-limit keys, falling back to socket address when the X-Forwarded-For header is suspicious. Previously, the suspicious header was only logged but still used, enabling bypass.

Changes Made:
- backend/api/src/middleware/rateLimiter.js: Use req.ips[0] for IP key generation; fall back to socket address on suspicious header

Impact it Made:
- Rate limiters can no longer be bypassed by spoofing X-Forwarded-For headers
- Strengthens auth/OTP brute-force protections

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).