### PR TITLE
fix : added REDIS_CACHE_TTL NaN fallback guard in profileCache.js

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -32,7 +32,8 @@ async function _publishProfileInvalidation(eventOpts) {
   }
 }
 
-export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || "120", 10); // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
+const _parsedTTL = parseInt(process.env.REDIS_CACHE_TTL || "120", 10);
+export const TTL_SECONDS = Number.isFinite(_parsedTTL) && _parsedTTL > 0 ? _parsedTTL : 120; // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 
 let cacheHits = 0;


### PR DESCRIPTION
Closes #12439.

Summary of What Has Been Done:
Added a Number.isFinite guard around the REDIS_CACHE_TTL parseInt result, exporting TTL_SECONDS as 120 (the documented 2-minute default) when the env var is missing, empty, or non-numeric. This matches the clamping pattern already used in setCachedSupabaseProfile, setCachedCustomerStats, and setCachedDriverDetails.

Changes Made:
- backend/api/src/lib/profileCache.js: Changed TTL_SECONDS from a bare parseInt export to a two-line guard that validates the parsed value is a positive finite number before exporting it.

Impact it Made:
- Backend tests: 14/14 profileCache tests pass. Redis TTL values are now always positive integers, preventing profiles from being cached indefinitely.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.