### PR TITLE
fix : added NaN guard for TRUST_PROXY in index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -332,7 +332,8 @@ app.use(headerSizeMonitor);
 //   - Production (behind Nginx/ALB/Cloudflare) → 1 (default)
 //   - Docker Compose (no proxy)                 → 0
 //   - Multiple proxy hops (e.g. Cloudflare→Nginx) → 2
-const trustProxy = process.env.TRUST_PROXY !== undefined ? Number(process.env.TRUST_PROXY) : 1
+const _parsedTrustProxy = process.env.TRUST_PROXY !== undefined ? Number(process.env.TRUST_PROXY) : 1
+const trustProxy = Number.isFinite(_parsedTrustProxy) ? _parsedTrustProxy : 1
 app.set('trust proxy', trustProxy)
 
 // ============================================================================


### PR DESCRIPTION
Closes #12440.

Summary of What Has Been Done:
Added a Number.isFinite guard around the TRUST_PROXY env-var parse. When TRUST_PROXY is set to a non-numeric value (e.g. empty string), Number() returns NaN; the guard now falls back to 1 (the documented default for production behind a single proxy).

Changes Made:
- backend/api/src/index.js: Extracted the Number() parse to _parsedTrustProxy, then guarded with Number.isFinite before assigning to trustProxy.

Impact it Made:
- Ensures req.ip is derived correctly regardless of misconfigured TRUST_PROXY env var, protecting rate-limiters and security middleware from operating on undefined IPs.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.