### PR TITLE
fix : added NaN guards for compression threshold and level in compression.js

### DIFF
--- a/backend/api/src/config/compression.js
+++ b/backend/api/src/config/compression.js
@@ -18,16 +18,20 @@ import compression from 'compression';
  * CPU cost is not repaid, and very small payloads can grow once the gzip
  * header and trailer are added.
  */
-export const COMPRESSION_THRESHOLD_BYTES = Number(
-  process.env.COMPRESSION_THRESHOLD_BYTES || 1024
-);
+const _parsedThreshold = Number(process.env.COMPRESSION_THRESHOLD_BYTES || 1024);
+export const COMPRESSION_THRESHOLD_BYTES = Number.isFinite(_parsedThreshold) && _parsedThreshold > 0
+  ? Math.floor(_parsedThreshold)
+  : 1024;
 
 /**
  * zlib level, 1 (fastest) to 9 (smallest). 6 is zlib's default and sits at
  * the knee of the curve: levels above it cost noticeably more CPU for very
  * little additional saving on JSON.
  */
-export const COMPRESSION_LEVEL = Number(process.env.COMPRESSION_LEVEL || 6);
+const _parsedLevel = Number(process.env.COMPRESSION_LEVEL || 6);
+export const COMPRESSION_LEVEL = Number.isFinite(_parsedLevel) && _parsedLevel >= 1 && _parsedLevel <= 9
+  ? Math.round(_parsedLevel)
+  : 6;
 
 /**
  * Content types that are already compressed. Re-compressing them burns CPU


### PR DESCRIPTION
Closes #12441.

Summary of What Has Been Done:
Added Number.isFinite guards to both COMPRESSION_THRESHOLD_BYTES and COMPRESSION_LEVEL. The threshold now floors to a positive integer and falls back to 1024 (1KB). The level is clamped to the valid zlib range [1, 9] and falls back to 6 (the documented default).

Changes Made:
- backend/api/src/config/compression.js: Both exported constants now use a two-step parse + guard pattern, replacing bare Number() calls.

Impact it Made:
- Compression middleware always starts with valid numeric parameters, preventing NaN propagation into the zlib stream and protecting bandwidth for truck drivers on metered connections.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.