### PR TITLE
security : removed attacker-controlled Host header fallback in voiceRoutes.js

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -62,11 +62,11 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
 
     const result = await processVoiceQuery(req.user.id, bookingId, file.buffer, safeFilename);
     
-    // Prefix the audio_url with host if relative path
-    const protocol = req.headers['x-forwarded-proto'] || req.protocol;
-    const host = req.headers.host;
+    // Prefix the audio_url with host if relative path.
+    // SECURITY: when PUBLIC_BASE_URL is not set, fall back to a hardcoded default
+    // rather than req.headers.host, which is attacker-controlled.
     if (result.audio_url && result.audio_url.startsWith('/')) {
-      const baseUrl = process.env.PUBLIC_BASE_URL || `${protocol}://${host}`;
+      const baseUrl = process.env.PUBLIC_BASE_URL || 'https://truxify.app';
       result.audio_url = `${baseUrl}${result.audio_url}`;
     }
     


### PR DESCRIPTION
Closes #12442.

Summary of What Has Been Done:
Removed the fallback to attacker-controlled req.headers.host when PUBLIC_BASE_URL is not set. When PUBLIC_BASE_URL is absent, the route now falls back to a hardcoded https://truxify.app rather than constructing the base URL from the client-supplied Host header.

Changes Made:
- backend/api/src/routes/voiceRoutes.js: Replaced  with hardcoded 'https://truxify.app' as the fallback, and added a security comment explaining the change.

Impact it Made:
- Closes a Host header injection vector in the voice route audio URL construction. An attacker can no longer control the audio_url in the response by supplying an arbitrary Host header.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.