### PR TITLE
fix : added empty-string guard in demand.js parseNumber fallback

### DIFF
--- a/backend/api/src/config/demand.js
+++ b/backend/api/src/config/demand.js
@@ -1,4 +1,5 @@
 const parseNumber = (value, fallback) => {
+  if (value === null || value === undefined || value === '') return fallback;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
 };


### PR DESCRIPTION
Closes #12419.

Summary of What Has Been Done:
Added an explicit empty-string check to the parseNumber helper in demand.js. Previously, Number('') returned 0 which is finite, so the fallback was never used for empty-string env vars. Now parseNumber('', fallback) correctly returns fallback.

Changes Made:
- backend/api/src/config/demand.js: Added check for null/undefined/empty-string before calling Number().

Impact it Made:
- Demand config now correctly uses fallback values when env vars are set to empty string, preventing rate calculations from using 0 as a price multiplier.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.