### PR TITLE
fix : added error variable to bare catch in cursorPagination.js

### DIFF
--- a/backend/api/src/utils/cursorPagination.js
+++ b/backend/api/src/utils/cursorPagination.js
@@ -26,7 +26,7 @@ export function decodeCursor(cursor) {
   try {
     const json = Buffer.from(cursor, 'base64url').toString('utf8');
     return JSON.parse(json);
-  } catch {
+  } catch (_) {
     return null;
   }
 }


### PR DESCRIPTION
Closes #12443.

Summary of What Has Been Done:
Changed bare catch {} to catch (_) in the decodeCursor function. The bare catch block silently swallowed errors from base64 decoding and JSON parsing. Adding the error variable makes the intent explicit.

Changes Made:
- backend/api/src/utils/cursorPagination.js: Changed catch {} to catch (_).

Impact it Made:
- Error handling is now explicit and consistent with the codebase convention for unnamed caught errors.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.