### PR TITLE
fix : reject missing content-length header in uploadFilename checkContentLength

### DIFF
--- a/backend/api/src/lib/uploadFilename.js
+++ b/backend/api/src/lib/uploadFilename.js
@@ -82,7 +82,18 @@ export function sanitizeUploadFilename(originalName, fallback = 'upload') {
 // === Spec 18: max body size ===
 const DEFAULT_MAX = 25 * 1024 * 1024;
 export function checkContentLength(req, maxBytes = DEFAULT_MAX) {
-  const len = Number(req.headers?.['content-length'] || 0);
+  const raw = req.headers?.['content-length'];
+  if (raw === undefined || raw === null || raw === '') {
+    const err = new Error('Content-Length header is required');
+    err.status = 411; err.code = 'LENGTH_REQUIRED';
+    return { ok: false, error: err };
+  }
+  const len = Number(raw);
+  if (!Number.isFinite(len) || len < 0) {
+    const err = new Error('Content-Length must be a non-negative integer');
+    err.status = 400; err.code = 'BAD_REQUEST';
+    return { ok: false, error: err };
+  }
   if (len > maxBytes) {
     const err = new Error(`body ${len} > max ${maxBytes}`);
     err.status = 413; err.code = 'PAYLOAD_TOO_LARGE';


### PR DESCRIPTION
Closes #12452.

Summary of What Has Been Done:
Added a guard in checkContentLength to reject requests with missing or non-numeric content-length headers. Previously, missing content-length evaluated to 0 and passed the size check. Now returns 411 LENGTH_REQUIRED for missing headers and 400 BAD_REQUEST for non-numeric values.

Changes Made:
- backend/api/src/lib/uploadFilename.js: Added explicit checks for undefined/null/empty content-length and NaN guards.

Impact it Made:
- Closes a bypass in payload size enforcement protecting the API from oversized request bodies through missing content-length.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.