### PR TITLE
test : added unit tests for postgresHealth.js

### DIFF
--- a/backend/api/test/unit/postgresHealth.test.js
+++ b/backend/api/test/unit/postgresHealth.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/config/db.js', () => ({
+  redisClient: null,
+  supabase: null,
+  supabaseAdmin: null,
+}));
+
+vi.mock('../../../src/core/health/HealthCheck.js', () => ({
+  HealthStatus: { HEALTHY: 'healthy', DEGRADED: 'degraded', UNHEALTHY: 'unhealthy' },
+  executeCheck: (name, checkFn) => checkFn(),
+}));
+
+describe('postgresHealth', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns UNHEALTHY when pgPool is not configured', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: null,
+      redisClient: null,
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: postgresHealth } = await import('../../../src/core/health/checks/postgresHealth.js');
+    const result = await postgresHealth()();
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toBe('not_configured');
+  });
+
+  it('returns HEALTHY when pgPool query succeeds', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: { query: vi.fn().mockResolvedValue({ rows: [{ ok: 1 }], totalCount: 5, idleCount: 2 }) },
+      redisClient: null,
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: postgresHealth } = await import('../../../src/core/health/checks/postgresHealth.js');
+    const result = await postgresHealth()();
+    expect(result.status).toBe('healthy');
+    expect(result.metadata.poolTotalCount).toBe(5);
+    expect(result.metadata.poolIdleCount).toBe(2);
+  });
+
+  it('returns UNHEALTHY when query returns unexpected result', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: { query: vi.fn().mockResolvedValue({ rows: [{}] }) },
+      redisClient: null,
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: postgresHealth } = await import('../../../src/core/health/checks/postgresHealth.js');
+    const result = await postgresHealth()();
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toBe('unexpected_query_result');
+  });
+});


### PR DESCRIPTION
Closes #12500.

Summary of What Has Been Done:
Added unit tests for the postgresHealth health check module. Tests cover: not_configured state when pgPool is null, healthy state when the query returns ok=1, and unexpected_query_result state when the response lacks the expected ok field.

Changes Made:
- backend/api/test/unit/postgresHealth.test.js: New test file with 3 test cases.

Impact it Made:
- PostgreSQL health check tests ensure database connectivity monitoring operates correctly for critical path monitoring.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for PostgreSQL health checks, including missing configuration, successful database queries, pool metadata, and unexpected results.
  * Improved validation of healthy and unhealthy status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->