### PR TITLE
test : added unit tests for redisHealth.js

### DIFF
--- a/backend/api/test/unit/redisHealth.test.js
+++ b/backend/api/test/unit/redisHealth.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/config/db.js', () => ({
+  pgPool: null,
+  supabase: null,
+  supabaseAdmin: null,
+}));
+
+vi.mock('../../../src/core/health/HealthCheck.js', () => ({
+  HealthStatus: { HEALTHY: 'healthy', DEGRADED: 'degraded', UNHEALTHY: 'unhealthy' },
+  executeCheck: (name, checkFn) => checkFn(),
+}));
+
+describe('redisHealth', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns UNHEALTHY when redisClient is not configured', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: null,
+      redisClient: null,
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: redisHealth } = await import('../../../src/core/health/checks/redisHealth.js');
+    const result = await redisHealth()();
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toBe('not_configured');
+  });
+
+  it('returns HEALTHY when redis ping returns PONG', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: null,
+      redisClient: { ping: vi.fn().mockResolvedValue('PONG') },
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: redisHealth } = await import('../../../src/core/health/checks/redisHealth.js');
+    const result = await redisHealth()();
+    expect(result.status).toBe('healthy');
+  });
+
+  it('returns UNHEALTHY when redis ping returns unexpected reply', async () => {
+    vi.doMock('../../../src/config/db.js', () => ({
+      pgPool: null,
+      redisClient: { ping: vi.fn().mockResolvedValue('ERROR') },
+      supabase: null,
+      supabaseAdmin: null,
+    }));
+    const { default: redisHealth } = await import('../../../src/core/health/checks/redisHealth.js');
+    const result = await redisHealth()();
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('unexpected reply');
+  });
+});


### PR DESCRIPTION
Closes #12501.

Summary of What Has Been Done:
Added unit tests for the redisHealth health check module. Tests cover: not_configured state when redisClient is null, healthy state when ping returns PONG, and unhealthy state for unexpected replies.

Changes Made:
- backend/api/test/unit/redisHealth.test.js: New test file with 3 test cases.

Impact it Made:
- Redis health check tests ensure distributed lock and rate-limiter infrastructure is monitored correctly.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.