### PR TITLE
fix 

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -19,7 +19,8 @@ import logger from '../middleware/logger.js';
 
 export function sanitizePrice(value) {
   const num = Number(value);
-  return Number.isFinite(num) && num >= 0 ? Math.round(num) : 0;
+  const clamped = Math.max(MIN_FREIGHT_PAISa, Math.min(MAX_FREIGHT_PAISa, num));
+  return Number.isFinite(clamped) && clamped >= 0 ? Math.round(clamped) : MIN_FREIGHT_PAISa;
 }
 
 const EARTH_RADIUS_KM = 6371.0088;


### PR DESCRIPTION
 apply MIN_FREIGHT_PAISa and MAX_FREIGHT_PAISa bounds in sanitizePrice:Closes #12505.\n\nSummary of What Has Been Done:\nUpdated sanitizePrice to clamp values to the [MIN_FREIGHT_PAISa, MAX_FREIGHT_PAISa] range (0 to 1 crore paisa) using Math.max/Math.min. Previously, any non-negative number was accepted.\n\nChanges Made:\n- backend/api/src/lib/pricing.js: Added Math.max(MIN_FREIGHT_PAISa, Math.min(MAX_FREIGHT_PAISa, num)) clamping and changed the fallback to MIN_FREIGHT_PAISa.\n\nImpact it Made:\n- Prices are bounded within legitimate freight ranges, preventing extreme values from reaching the database.\n\nThese pull requests are contributed through GSSOC (GirlScript Summer of Code).\n\nNote: Please assign this PR to the `tmdeveloper007` account.