### PR TITLE
fix 

### DIFF
--- a/backend/api/src/core/retry.js
+++ b/backend/api/src/core/retry.js
@@ -22,7 +22,7 @@ function isTransientHttpStatus(status) {
   if (status === null) return false;
   if (status === 408) return true;
   if (status >= 500 && status <= 599) return true;
-  if (status === 429 || status === 408) return true;
+  if (status === 429) return true;
   return false;
 }
 


### PR DESCRIPTION
 removed duplicate 408 check in retry.js isTransientHttpStatus:Closes #12506.\n\nSummary of What Has Been Done:\nRemoved the redundant || status === 408 from the compound condition in isTransientHttpStatus. Status 408 was already checked on the line above.\n\nChanges Made:\n- backend/api/src/core/retry.js: Changed if (status === 429 || status === 408) to if (status === 429).\n\nImpact it Made:\n- Removed dead code from the retry condition, improving code clarity.\n\nThese pull requests are contributed through GSSOC (GirlScript Summer of Code).\n\nNote: Please assign this PR to the `tmdeveloper007` account.