### PR TITLE
fix 

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -20,7 +20,7 @@ const SURGE_PEAK_AMPLITUDE = 1.3;
  */
 export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   try {
-    if (!pickupLat || !pickupLng) {
+    if (pickupLat == null || pickupLng == null) {
       return 1.0;
     }
 


### PR DESCRIPTION
 use null-check instead of falsy guard in trafficService.js:Closes #12507.\n\nSummary of What Has Been Done:\nChanged !pickupLat || !pickupLng to pickupLat == null || pickupLng == null to allow valid 0 coordinates (equator / prime meridian) while correctly rejecting null and undefined.\n\nChanges Made:\n- backend/api/src/services/trafficService.js: Replaced falsy guard with null/undefined check.\n\nImpact it Made:\n- Traffic multipliers are now calculated correctly for locations at the equator and prime meridian.\n\nThese pull requests are contributed through GSSOC (GirlScript Summer of Code).\n\nNote: Please assign this PR to the `tmdeveloper007` account.