### PR TITLE
fix : collapsed duplicate key deactivation writes in keyManagementService.js

### DIFF
--- a/backend/api/src/services/security/keyManagementService.js
+++ b/backend/api/src/services/security/keyManagementService.js
@@ -106,12 +106,20 @@ class KeyManagementService {
   async storeEncryptedKey(userId, walletAddress, encryptedKeyData, deviceId, version = 1) {
     return measureExecution('KeyManagementService.storeEncryptedKey', async () => {
       try {
+        const keyId = crypto.randomUUID();
+        const now = new Date().toISOString();
+
         // Deactivate any previously active row for this user/wallet scope so
         // exactly one active row exists and retrieveEncryptedKey's
         // .eq('active', true).single() never 406s on multiple rows.
+        // Collapse the two prior updates into one that also sets archive metadata.
         const { error: deactivateError } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
-          .update({ active: false })
+          .update({
+            active: false,
+            archived_at: now,
+            archive_reason: 'rotated',
+          })
           .eq('user_id', userId)
           .eq('wallet_address', walletAddress)
           .eq('active', true);
@@ -120,20 +128,6 @@ class KeyManagementService {
           logger.error('[KeyManagementService] Failed to deactivate prior active keys:', deactivateError);
           throw deactivateError;
         }
-
-        const keyId = crypto.randomUUID();
-
-        // Deactivate any previously active key for this user+wallet
-        await (supabaseAdmin || supabase)
-          .from('encrypted_wallet_keys')
-          .update({
-            active: false,
-            archived_at: new Date().toISOString(),
-            archive_reason: 'rotated',
-          })
-          .eq('user_id', userId)
-          .eq('wallet_address', walletAddress)
-          .eq('active', true);
 
         const { data, error } = await (supabaseAdmin || supabase)
           .from('encrypted_wallet_keys')
@@ -145,8 +139,8 @@ class KeyManagementService {
             device_id: deviceId,
             version,
             active: true,
-            created_at: new Date().toISOString(),
-            last_used_at: new Date().toISOString(),
+            created_at: now,
+            last_used_at: now,
           }]);
 
         if (error) {


### PR DESCRIPTION
Closes #12475.

Summary of What Has Been Done:
Collapsed two separate update calls in storeEncryptedKey into a single update that sets active=false, archived_at, and archive_reason='rotated' in one call. The first update was missing archive metadata and the second was redundant. Also reuses the now timestamp.

Changes Made:
- backend/api/src/services/security/keyManagementService.js: Single deactivation update with full metadata instead of two separate updates.

Impact it Made:
- Reduces redundant database writes on key rotation; archive metadata is now always set correctly.

These pull requests are contributed through GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.