### PR TITLE
fix(driver): decode sync_events rows defensively instead of casting

### DIFF
--- a/apps/driver/lib/models/offline_sync_event_model.dart
+++ b/apps/driver/lib/models/offline_sync_event_model.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class OfflineSyncEvent {
   final String eventId;
   final String eventType; // 'STATUS_UPDATE', 'LOCATION_PING', 'POD_UPLOAD'
@@ -14,4 +16,52 @@ class OfflineSyncEvent {
     this.isSynced = false,
     this.syncedAt,
   });
+
+  /// Decodes one `sync_events` row into an event, or returns `null` when the
+  /// row cannot be trusted.
+  ///
+  /// Rows can drift from the schema through a partial write, a schema change
+  /// or an interrupted migration. Reading such a row with a non-nullable `as`
+  /// throws, and because the callers map over a whole result set one bad row
+  /// used to abort the entire read (issue #12426). Returning `null` lets the
+  /// caller drop that single row and keep going.
+  ///
+  /// Identity and content columns are required rather than defaulted:
+  /// `event_id` addresses the row in every UPDATE/DELETE and doubles as the
+  /// backend idempotency key, `payload`/`event_type` are the event itself, and
+  /// `queued_at` is sent as `occurred_at`. Substituting a placeholder for any
+  /// of them would push wrong data to the backend or target the wrong row, so
+  /// an undecodable row is dropped instead. `is_synced` and `synced_at` are
+  /// advisory, so they fall back to "not synced" — the worst case is a resend
+  /// that the idempotency key absorbs.
+  static OfflineSyncEvent? fromRow(Map<String, Object?> row) {
+    final eventId = row['event_id'];
+    final eventType = row['event_type'];
+    final rawPayload = row['payload'];
+    final queuedAt = row['queued_at'];
+
+    if (eventId is! String || eventId.isEmpty) return null;
+    if (eventType is! String || eventType.isEmpty) return null;
+    if (rawPayload is! String) return null;
+    if (queuedAt is! int) return null;
+
+    Object? payload;
+    try {
+      payload = jsonDecode(rawPayload);
+    } on FormatException {
+      return null;
+    }
+    if (payload is! Map<String, dynamic>) return null;
+
+    final syncedAt = row['synced_at'];
+    return OfflineSyncEvent(
+      eventId: eventId,
+      eventType: eventType,
+      payload: payload,
+      queuedAt: DateTime.fromMillisecondsSinceEpoch(queuedAt),
+      isSynced: row['is_synced'] == 1,
+      syncedAt:
+          syncedAt is int ? DateTime.fromMillisecondsSinceEpoch(syncedAt) : null,
+    );
+  }
 }

--- a/apps/driver/lib/services/offline_first_sync_service.dart
+++ b/apps/driver/lib/services/offline_first_sync_service.dart
@@ -135,16 +135,34 @@ class OfflineFirstSyncService {
     if (db == null) return [];
 
     final rows = await db.query('sync_events', orderBy: 'queued_at ASC');
-    return rows.map((row) => OfflineSyncEvent(
-      eventId: row['event_id'] as String,
-      eventType: row['event_type'] as String,
-      payload: jsonDecode(row['payload'] as String) as Map<String, dynamic>,
-      queuedAt: DateTime.fromMillisecondsSinceEpoch(row['queued_at'] as int),
-      isSynced: (row['is_synced'] as int) == 1,
-      syncedAt: row['synced_at'] != null
-          ? DateTime.fromMillisecondsSinceEpoch(row['synced_at'] as int)
-          : null,
-    )).toList();
+
+    // Skip rows that cannot be decoded instead of letting one of them throw
+    // out of the snapshot. This feeds [databaseStream]; a single corrupt row
+    // used to leave the dashboard permanently stale (issue #12426).
+    final events = <OfflineSyncEvent>[];
+    for (final row in rows) {
+      final event = OfflineSyncEvent.fromRow(row);
+      if (event == null) {
+        debugPrint('offline-sync: skipping undecodable sync_events row in snapshot');
+        continue;
+      }
+      events.add(event);
+    }
+    return events;
+  }
+
+  /// Marks a row that [OfflineSyncEvent.fromRow] rejected as dead-lettered.
+  /// Addressed by `rowid` because `event_id` is one of the columns that may be
+  /// the reason the row is undecodable.
+  Future<void> _deadLetterRow(Database db, Map<String, Object?> row) async {
+    final rowId = row['rowid'];
+    if (rowId is! int) return;
+    await db.update(
+      'sync_events',
+      {'state': stateDeadLetter},
+      where: 'rowid = ?',
+      whereArgs: [rowId],
+    );
   }
 
   Future<void> _emitDbSnapshot() async {
@@ -216,6 +234,8 @@ class OfflineFirstSyncService {
 
     final unsynced = await db.query(
       'sync_events',
+      // rowid is selected so an undecodable row can still be addressed.
+      columns: ['rowid', '*'],
       where: 'is_synced = 0 AND state = ?',
       whereArgs: [statePending],
       orderBy: 'queued_at ASC',
@@ -225,18 +245,31 @@ class OfflineFirstSyncService {
 
     final batchSize = 10;
     for (int i = 0; i < unsynced.length; i += batchSize) {
-      final batch = unsynced.skip(i).take(batchSize).toList();
-      final results = await Future.wait(
-        batch.map((row) => _syncSingleEvent(OfflineSyncEvent(
-          eventId: row['event_id'] as String,
-          eventType: row['event_type'] as String,
-          payload: jsonDecode(row['payload'] as String) as Map<String, dynamic>,
-          queuedAt: DateTime.fromMillisecondsSinceEpoch(row['queued_at'] as int),
-        ))),
-      );
+      final rows = unsynced.skip(i).take(batchSize).toList();
 
-      for (int j = 0; j < batch.length; j++) {
-        final eventId = batch[j]['event_id'] as String;
+      // Decode before dispatching. A row that cannot be decoded can never be
+      // POSTed, so it is terminal: dead-letter it via the same state the retry
+      // ceiling uses, rather than letting it throw out of the pass (which
+      // stranded every well-formed event behind it) or be re-read on every
+      // connectivity change forever.
+      final batch = <Map<String, Object?>>[];
+      final events = <OfflineSyncEvent>[];
+      for (final row in rows) {
+        final event = OfflineSyncEvent.fromRow(row);
+        if (event == null) {
+          debugPrint('offline-sync: dead-lettering undecodable sync_events row');
+          await _deadLetterRow(db, row);
+          continue;
+        }
+        batch.add(row);
+        events.add(event);
+      }
+      if (events.isEmpty) continue;
+
+      final results = await Future.wait(events.map(_syncSingleEvent));
+
+      for (int j = 0; j < events.length; j++) {
+        final eventId = events[j].eventId;
         if (results[j]) {
           // Successfully synced: remove the row so the local store does not
           // grow without bound (is_synced alone kept every historical row).

--- a/apps/driver/test/offline_sync_row_decode_test.dart
+++ b/apps/driver/test/offline_sync_row_decode_test.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/models/offline_sync_event_model.dart';
+
+/// Regression tests for issue #12426: `sync_events` rows were read with
+/// non-nullable `as` casts, so a single NULL or mistyped column threw a
+/// `TypeError` out of the whole read.
+void main() {
+  Map<String, Object?> row({
+    Object? eventId = 'EVT-1',
+    Object? eventType = 'STATUS_UPDATE',
+    Object? payload = '{"trip_id":"T-1"}',
+    Object? queuedAt = 1700000000000,
+    Object? isSynced = 0,
+    Object? syncedAt,
+  }) {
+    return {
+      'event_id': eventId,
+      'event_type': eventType,
+      'payload': payload,
+      'queued_at': queuedAt,
+      'is_synced': isSynced,
+      'synced_at': syncedAt,
+      'retry_count': 0,
+      'state': 'pending',
+    };
+  }
+
+  group('OfflineSyncEvent.fromRow', () {
+    test('decodes a well-formed row', () {
+      final event = OfflineSyncEvent.fromRow(row())!;
+
+      expect(event.eventId, 'EVT-1');
+      expect(event.eventType, 'STATUS_UPDATE');
+      expect(event.payload, {'trip_id': 'T-1'});
+      expect(event.queuedAt.millisecondsSinceEpoch, 1700000000000);
+      expect(event.isSynced, isFalse);
+      expect(event.syncedAt, isNull);
+    });
+
+    test('reads sync markers when the row is marked synced', () {
+      final event = OfflineSyncEvent.fromRow(
+        row(isSynced: 1, syncedAt: 1700000009999),
+      )!;
+
+      expect(event.isSynced, isTrue);
+      expect(event.syncedAt!.millisecondsSinceEpoch, 1700000009999);
+    });
+
+    test('returns null instead of throwing on a NULL required column', () {
+      expect(OfflineSyncEvent.fromRow(row(eventId: null)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(eventType: null)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(payload: null)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(queuedAt: null)), isNull);
+    });
+
+    test('returns null instead of throwing on a mistyped column', () {
+      expect(OfflineSyncEvent.fromRow(row(eventId: 42)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(eventType: 42)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(payload: 42)), isNull);
+      expect(OfflineSyncEvent.fromRow(row(queuedAt: '1700000000000')), isNull);
+    });
+
+    test('returns null on an empty identity or type', () {
+      expect(OfflineSyncEvent.fromRow(row(eventId: '')), isNull);
+      expect(OfflineSyncEvent.fromRow(row(eventType: '')), isNull);
+    });
+
+    test('returns null when the payload is not a JSON object', () {
+      // jsonDecode throws FormatException here rather than a cast error, which
+      // the reported `as` casts would not have caught either.
+      expect(OfflineSyncEvent.fromRow(row(payload: 'not json')), isNull);
+      expect(OfflineSyncEvent.fromRow(row(payload: '')), isNull);
+      // Valid JSON, but not an object: the `as Map<String, dynamic>` cast.
+      expect(OfflineSyncEvent.fromRow(row(payload: '[1,2,3]')), isNull);
+      expect(OfflineSyncEvent.fromRow(row(payload: '"a string"')), isNull);
+    });
+
+    test('treats advisory sync columns as "not synced" rather than dropping',
+        () {
+      // is_synced/synced_at never address a row or reach the backend, so a bad
+      // value degrades to a resend that the idempotency key absorbs.
+      final nullMarkers = OfflineSyncEvent.fromRow(row(isSynced: null))!;
+      expect(nullMarkers.isSynced, isFalse);
+
+      final badMarkers =
+          OfflineSyncEvent.fromRow(row(isSynced: 'yes', syncedAt: 'nope'))!;
+      expect(badMarkers.isSynced, isFalse);
+      expect(badMarkers.syncedAt, isNull);
+    });
+
+    test('one corrupt row no longer aborts the surrounding read', () {
+      final rows = [
+        row(eventId: 'EVT-1'),
+        row(eventId: null), // partial write / schema drift
+        row(eventId: 'EVT-2', payload: 'not json'),
+        row(eventId: 'EVT-3'),
+      ];
+
+      // The pre-fix mapping: an unguarded cast over the same result set.
+      expect(
+        () => rows
+            .map((r) => OfflineSyncEvent(
+                  eventId: r['event_id'] as String,
+                  eventType: r['event_type'] as String,
+                  payload:
+                      jsonDecode(r['payload'] as String) as Map<String, dynamic>,
+                  queuedAt: DateTime.fromMillisecondsSinceEpoch(
+                      r['queued_at'] as int),
+                ))
+            .toList(),
+        throwsA(isA<TypeError>()),
+      );
+
+      // The fixed mapping keeps every well-formed event.
+      final decoded = rows
+          .map(OfflineSyncEvent.fromRow)
+          .whereType<OfflineSyncEvent>()
+          .toList();
+
+      expect(decoded.map((e) => e.eventId), ['EVT-1', 'EVT-3']);
+    });
+  });
+}


### PR DESCRIPTION
## Description

### Root cause

`_loadAllEvents` maps **every** `sync_events` row through non-nullable `as` casts, inside a single `.map()` over the whole result set and with no error handling:

```dart
return rows.map((row) => OfflineSyncEvent(
  eventId: row['event_id'] as String,
  ...
)).toList();
```

`Map.[]` returns `Object?`, so each `as String` / `as int` is an unchecked downcast from a nullable value. If any column is `NULL` or holds an unexpected type — partial write, schema drift, interrupted migration — the cast throws a `TypeError`. Because the cast happens inside the `.map()`, the throw escapes `_loadAllEvents` entirely: **one bad row takes down the read for every row**, not just itself. `_loadAllEvents` feeds `_emitDbSnapshot()`, which is called unawaited, so the failure surfaces as an unhandled async error and `databaseStream` simply never emits again — the offline dashboard is left permanently stale.

Two failure modes the reported casts don't cover, but which live on the same line:

- `jsonDecode(row['payload'] as String)` throws `FormatException`, not a cast error, when the stored payload isn't valid JSON.
- `... as Map<String, dynamic>` throws when the payload is valid JSON but decodes to an array or scalar.

**The same defect is on the sync path**, which is what actually produces the impact described in the issue. `_runSyncPass` repeats the identical unguarded construction (previously lines 229-235):

```dart
final results = await Future.wait(
  batch.map((row) => _syncSingleEvent(OfflineSyncEvent(
    eventId: row['event_id'] as String, ...
  ))),
);
```

`Iterable.map` is lazy, so the construction runs while `Future.wait` iterates it. A throw there aborts `_runSyncPass` → `_processSyncQueue` and **strands every well-formed event queued behind the bad row**. Fixing only `_loadAllEvents` would have left the more damaging instance in place, so this PR fixes both.

### Fix

Add `OfflineSyncEvent.fromRow`, which returns `null` for a row it cannot trust rather than throwing, and handle that at each call site:

| Site | Policy for an undecodable row |
|---|---|
| `_loadAllEvents` | **Skip** it — the snapshot keeps every well-formed event, so the dashboard stays live. |
| `_runSyncPass` | **Dead-letter** it via the existing `stateDeadLetter`. |

A row that cannot be decoded can never be POSTed, so it is terminal by definition — dead-lettering reuses the state the retry ceiling already uses, instead of leaving a poison row to be re-read on every connectivity change forever. The query now selects `rowid` so such a row is still addressable when `event_id` is itself the undecodable column.

Which columns are required vs. defaulted is deliberate. The issue suggests `row['event_id'] as String? ?? ''`, but defaulting the identity columns is worse than crashing:

- **Required** (`event_id`, `event_type`, `payload`, `queued_at`) — `event_id` addresses the row in every `UPDATE`/`DELETE` and doubles as the backend idempotency key, and `queued_at` is sent as `occurred_at`. An empty-string `event_id` would make the success `DELETE` match the wrong rows, and an empty payload would be POSTed as a real event. Silent data corruption beats a crash only if you don't look. These rows are dropped instead.
- **Defaulted** (`is_synced`, `synced_at`) — advisory only; they never address a row or reach the backend. They fall back to "not synced", where the worst case is a resend that the idempotency key absorbs.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:** `cd apps/driver && flutter test test/offline_sync_row_decode_test.dart`
- **Test Steps / Prerequisites:** `flutter pub get` in `packages/truxify_shared` and `apps/driver`.
- **Expected Result:** 8 tests pass. `OfflineSyncEvent.fromRow` is a pure static, so the suite needs no sqflite/Firebase platform plugin.

`test/offline_sync_row_decode_test.dart` covers the well-formed row, each required column NULL, each required column mistyped, empty identity/type, a payload that is not valid JSON and one that is a JSON array, advisory-column degradation, and a mixed result set. The last case is the regression anchor — it asserts the **pre-fix** mapping throws `TypeError` on that result set while the fixed mapping still returns the two good events.

### Proof of work

Full Flutter wasn't available locally, so I verified the decoder by running the **actual** `offline_sync_event_model.dart` (symlinked into a scratch package, checksum-matched) against a standalone Dart SDK 3.13.0, with a harness mirroring the committed test plus a side-by-side reproduction of the pre-fix mapping:

```
== 1. Reproduce the reported crash (pre-fix mapping) ==
  THROWS     event_id NULL -> _TypeError
  THROWS     event_type NULL -> _TypeError
  THROWS     payload NULL -> _TypeError
  THROWS     queued_at NULL -> _TypeError
  THROWS     is_synced NULL -> _TypeError
  THROWS     synced_at mistyped -> _TypeError
  THROWS     payload not JSON -> FormatException
  THROWS     payload JSON array -> _TypeError

== 2. Fixed decoder: same rows, no throw ==
  dropped    event_id NULL
  dropped    event_type NULL
  dropped    payload NULL
  dropped    queued_at NULL
  kept       is_synced NULL
  kept       synced_at mistyped
  dropped    payload not JSON
  dropped    payload JSON array

== 3. Assertions ==
  PASS  decodes a well-formed row
  PASS  reads sync markers when marked synced
  PASS  NULL required columns -> null
  PASS  mistyped columns -> null
  PASS  empty identity/type -> null
  PASS  payload not a JSON object -> null
  PASS  advisory columns degrade to "not synced"
  PASS  one corrupt row no longer aborts the read

8 passed, 0 failed
```

`dart analyze` reports **No issues found!** on the model. All three changed files parse cleanly.

Two things I could not run locally and am flagging honestly: `flutter analyze` and `flutter test` over the service file (it imports `package:flutter`, `sqflite` and `firebase_auth`) — CI covers both. I also deliberately did **not** run `dart format`: the repo predates the Dart 3.7+ "tall style" formatter (566 of 706 files in `apps/driver` are reformatted by it, and `lint.yml` is already failing on `main` for that reason), so the new code matches the surrounding hand-written style rather than adding unrelated churn.

### Test Environment
- [x] Unit / Integration tests (`npm test`, `flutter test`, etc.)
- [ ] Local manual testing
- [ ] Tested via Docker Compose

## Related Issues
Closes #12426

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
