### PR TITLE
fix : scope profile name lookup to authenticated user to prevent PII enumeration

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -230,10 +230,14 @@ router.get('/customer-stats', authenticate, userLimiter, async (req, res) => {
  */
 router.get('/:id/name', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   try {
+    // Scope to authenticated user to prevent PII enumeration via arbitrary UUIDs
+    const targetId = req.user?.id;
+    if (!targetId) return res.status(403).json({ error: 'Forbidden' });
+
     const { data: profile, error } = await supabase
       .from('profiles')
       .select('full_name')
-      .eq('id', req.params.id)
+      .eq('id', targetId)
       .maybeSingle();
 
     if (error) return res.status(500).json({ error: 'Failed to fetch profile name.', details: error.message });


### PR DESCRIPTION
Closes #12328.

Summary of What Has Been Done:
Fixed the GET /api/profile/:id/name endpoint to scope the profile lookup to the authenticated user's own ID, preventing any authenticated user from enumerating other users' full names by guessing UUIDs.

Changes Made:
- backend/api/src/routes/profileRoutes.js: Changed query to use req.user?.id instead of req.params.id, with 403 for unauthenticated requests

Impact it Made:
- Prevents PII enumeration via arbitrary UUIDs in the profile name endpoint

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).