### PR TITLE
fix : include OTP in FCM push notification data for delivery verification

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -317,7 +317,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     fcmResult = await sendFcmNotification(
       customerId,
       { title, body },
-      { orderDisplayId, notifType: 'delivery_otp',  }
+      { orderDisplayId, notifType: 'delivery_otp', otp }
     );
   } catch (err) {
     logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');


### PR DESCRIPTION
Closes #12329.

Summary of What Has Been Done:
Fixed sendDeliveryOtpNotification to include the OTP value in the FCM push notification data payload, enabling the mobile app to display the OTP without a separate API call.

Changes Made:
- backend/api/src/services/notificationService.js: Added otp field to sendFcmNotification data argument

Impact it Made:
- Mobile app can now receive and display the delivery OTP directly from the push notification
- Reduces API call overhead during delivery verification

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).