### PR TITLE
fix : await RPC call to get incremented retry_count before using it in outbox

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -80,12 +80,18 @@ export class OutboxService {
    * Mark an event as failed and increment retry_count.
    */
   async markFailed(eventId, errorMessage) {
+    // Await the RPC to get the incremented count before using it in the update.
+    const { data: newRetryCount, error: rpcError } = await supabase.rpc('increment', { row_id: eventId });
+    if (rpcError) {
+      logger.error('[OutboxService] Failed to increment retry_count:', rpcError.message, { eventId });
+    }
+
     const { error } = await supabase
       .from('outbox_events')
       .update({
         status: 'failed',
         last_error: String(errorMessage).slice(0, 1000),
-        retry_count: supabase.rpc('increment', { row_id: eventId }),
+        retry_count: newRetryCount ?? 0,
         last_attempted_at: new Date().toISOString(),
       })
       .eq('id', eventId);


### PR DESCRIPTION
Closes #12330.

Summary of What Has Been Done:
Fixed markFailed in OutboxService to await the RPC call that increments retry_count before using the result in the update. Previously the Promise was passed directly as the value, making the field always undefined.

Changes Made:
- backend/api/src/services/outbox/outboxService.js: Await the increment RPC first, then use newRetryCount in the update

Impact it Made:
- retry_count is now properly incremented and persisted when events fail, enabling correct backoff logic

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).