### PR TITLE
fix : require supabaseAdmin for getDriverLocation to access driver_locations table

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -197,6 +197,11 @@ export class TrackingTokenService {
   }
 
   async getDriverLocation(orderDisplayId) {
+    if (!this._supabaseAdmin) {
+      this._logger.error('getDriverLocation requires service-role client');
+      throw new Error('Service-role client required for driver location tracking');
+    }
+
     const { data: order, error: orderError } = await this._supabase
       .from('orders')
       .select('driver_id')
@@ -209,8 +214,7 @@ export class TrackingTokenService {
 
     // `driver_locations` has no anon RLS policy, so the service-role client is
     // required to read the rows written by the tracker (issue #8932).
-    const db = this._supabaseAdmin ?? this._supabase;
-    const { data: location, error: locationError } = await db
+    const { data: location, error: locationError } = await this._supabaseAdmin
       .from('driver_locations')
       .select('latitude, longitude, last_updated_at')
       .eq('driver_id', order.driver_id)

--- a/backend/api/test/unit/trackingTokenService.test.js
+++ b/backend/api/test/unit/trackingTokenService.test.js
@@ -93,6 +93,7 @@ describe('TrackingTokenService', () => {
     mockData = createMockSupabase();
     service = new TrackingTokenService({
       supabase: mockData.supabase,
+      supabaseAdmin: mockData.supabase,
       logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
     });
   });
@@ -323,23 +324,15 @@ describe('TrackingTokenService', () => {
       expect(location.longitude).toBe(56.78);
     });
 
-    it('falls back to the anon client when no admin client is configured', async () => {
-      mockData.store.orders.push({
-        order_display_id: '#FF20241205',
-        driver_id: 'driver-uuid-456',
-      });
-      mockData.store.driver_locations.push({
-        driver_id: 'driver-uuid-456',
-        latitude: 21.21,
-        longitude: 72.88,
-        last_updated_at: new Date().toISOString(),
-        is_active: true,
+    it('throws when no admin client is configured (driver_locations requires service-role)', async () => {
+      const noAdminService = new TrackingTokenService({
+        supabase: mockData.supabase,
+        logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
       });
 
-      const location = await service.getDriverLocation('#FF20241205');
-
-      expect(location.latitude).toBe(21.21);
-      expect(location.longitude).toBe(72.88);
+      await expect(noAdminService.getDriverLocation('#FF20241205')).rejects.toThrow(
+        'Service-role client required for driver location tracking'
+      );
     });
   });
 


### PR DESCRIPTION
Closes #12331.

Summary of What Has Been Done:
Fixed TrackingTokenService.getDriverLocation to require the service-role client instead of falling back to the anon client. Since driver_locations has no anon RLS policy, the anon client would always fail. Added a guard that throws if supabaseAdmin is not configured.

Changes Made:
- backend/api/src/services/trackingTokenService.js: Added guard requiring supabaseAdmin; removed fallback to anon client
- backend/api/test/unit/trackingTokenService.test.js: Updated tests to provide supabaseAdmin; changed fallback test to expect an error

Impact it Made:
- getDriverLocation now correctly reads from driver_locations which requires service-role access

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).