### PR TITLE
fix(ml) : use Y-width for row_height in bin packing shelf placement

### DIFF
--- a/backend/ml/app/models/bin_packing.py
+++ b/backend/ml/app/models/bin_packing.py
@@ -93,7 +93,7 @@ class _Shelf:
         if self.cursor_x + l <= self.max_length and self.cursor_y + w <= self.max_width:
             pos = {"x": self.cursor_x, "y": self.cursor_y, "z": self.z_bottom}
             self.cursor_x += l
-            self.row_height = max(self.row_height, h)
+            self.row_height = max(self.row_height, w)
             self.shelf_height = max(self.shelf_height, h)
             self.items.append({"pos": pos, "rotated": rotated})
             return {**pos, "rotated": rotated}
@@ -103,7 +103,7 @@ class _Shelf:
         if new_y + w <= self.max_width and l <= self.max_length:
             self.cursor_x = l
             self.cursor_y = new_y
-            self.row_height = h
+            self.row_height = w
             self.shelf_height = max(self.shelf_height, h)
             pos = {"x": 0.0, "y": new_y, "z": self.z_bottom}
             self.items.append({"pos": pos, "rotated": rotated})


### PR DESCRIPTION
Closes #12334.

Summary of What Has Been Done:
Fixed _Shelf.place() in bin packing to use the Y-dimension (width) for row_height instead of the Z-dimension (height). The row_height tracks the Y-axis extent of items in a row, not their vertical height.

Changes Made:
- backend/ml/app/models/bin_packing.py: Changed row_height assignment from h to w in both placement paths

Impact it Made:
- Correct row tracking prevents incorrect shelf overflow detection and cargo overlap
- Fixes phantom 'not enough shelf space' errors during packing

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).