### PR TITLE
fix(api): remove dead MIN_FREIGHT_PAISa/MAX_FREIGHT_PAISa constants from pricing lib

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -25,8 +25,6 @@ export function sanitizePrice(value) {
 const EARTH_RADIUS_KM = 6371.0088;
 
 // Pricing constants (all amounts in paisa unless noted)
-const MIN_FREIGHT_PAISa = 0;
-const MAX_FREIGHT_PAISa = 10_000_000_00; // 1 crore in paisa
 const TOLL_ESCALATION_HOURS = 6;
 const DEFAULT_RATE_PER_TONNE_KM = 50; // paisa per tonne-km
 


### PR DESCRIPTION
## Summary
Removes two dead, never-referenced constants from `backend/api/src/lib/pricing.js`.

## Changes
- Deleted `MIN_FREIGHT_PAISa` and `MAX_FREIGHT_PAISa` (lines 28–29). A repo-wide search confirms they are never read or exported anywhere; the live freight bounds are `MIN_FREIGHT_PAISa_INR`/`MAX_FREIGHT_PAISa_INR`.

## Impact
No runtime behaviour change. `npx vitest run test/unit/pricing.test.js` passes.

Fixes #12476

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused pricing configuration constants with no impact on customer-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->