### PR TITLE
fix(api): remove duplicate 408 branch in retry isTransientHttpStatus

### DIFF
--- a/backend/api/src/core/retry.js
+++ b/backend/api/src/core/retry.js
@@ -22,7 +22,7 @@ function isTransientHttpStatus(status) {
   if (status === null) return false;
   if (status === 408) return true;
   if (status >= 500 && status <= 599) return true;
-  if (status === 429 || status === 408) return true;
+  if (status === 429) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
Removes a duplicate `408` status check in `isTransientHttpStatus` inside `backend/api/src/core/retry.js`.

## Changes
- Line 25: `if (status === 429 || status === 408)` → `if (status === 429)`. The `408` transient branch is already handled on the line above, so the second check was unreachable duplication.

## Impact
No behaviour change. `npx vitest run test/unit/retry.test.js` passes.

Fixes #12474

GSSOC
