### PR TITLE
fix(driver): safe updatePalletPosition for unknown pallet ids

### DIFF
--- a/apps/driver/lib/services/weight_distribution_service.dart
+++ b/apps/driver/lib/services/weight_distribution_service.dart
@@ -21,9 +21,13 @@ class WeightDistributionService {
   }
 
   void updatePalletPosition(String id, double newX) {
-    final pallet = _pallets.firstWhere((p) => p.id == id);
-    pallet.positionX = newX.clamp(0.0, 1.0);
-    _calculatePhysics();
+    for (final pallet in _pallets) {
+      if (pallet.id == id) {
+        pallet.positionX = newX.clamp(0.0, 1.0);
+        _calculatePhysics();
+        return;
+      }
+    }
   }
 
   void _calculatePhysics() {

--- a/apps/driver/test/weight_distribution_service_test.dart
+++ b/apps/driver/test/weight_distribution_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truxify_driver/services/weight_distribution_service.dart';
+
+void main() {
+  group('WeightDistributionService.updatePalletPosition', () {
+    test('updates the position of a known pallet', () async {
+      final service = WeightDistributionService();
+      service.initializeSimulation();
+
+      final emitted = <double>[];
+      final sub = service.weightStream.listen((s) {
+        for (final p in s.pallets) {
+          if (p.id == 'P1 (Steel)') emitted.add(p.positionX);
+        }
+      });
+      service.updatePalletPosition('P1 (Steel)', 0.2);
+      await Future<void>.delayed(Duration.zero);
+      sub.cancel();
+      service.dispose();
+
+      expect(emitted.last, closeTo(0.2, 1e-9));
+    });
+
+    test('does not throw for an unknown pallet id', () {
+      final service = WeightDistributionService();
+      service.initializeSimulation();
+
+      expect(() => service.updatePalletPosition('NO-SUCH-PALLET', 0.9),
+          returnsNormally);
+      service.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fixes a crash in `WeightDistributionService.updatePalletPosition` when called with a pallet id that is not in the simulated load. The old `firstWhere(...)` threw `StateError: No element` for unknown ids.

## Changes
- `apps/driver/lib/services/weight_distribution_service.dart`: replaced `firstWhere` with a plain loop that updates the matching pallet and returns; unknown ids are now a safe no-op.
- Added `apps/driver/test/weight_distribution_service_test.dart` covering both a known pallet update (emits the new position) and an unknown id (no throw).

## Impact
Callers can no longer crash the simulation with a stale or invalid pallet id. `flutter test test/weight_distribution_service_test.dart` — 2/2 pass; `dart analyze` reports no new issues.

Fixes #12472

GSSOC
