### PR TITLE
fix(ml): resolve merge conflict markers in test_transformers.py

### DIFF
--- a/backend/ml/tests/test_transformers.py
+++ b/backend/ml/tests/test_transformers.py
@@ -1,31 +1,9 @@
 import pytest
 import torch
-<<<<<<< HEAD
 from transformers.model import TimeSeriesTransformer
-=======
-from fastapi import HTTPException
-from transformers.model import TimeSeriesTransformer
-from routes.transformer_routes import (
-    ForecastRequest,
-    _validate_horizon,
-)
->>>>>>> upstream/main
 
 class TestTimeSeriesTransformer:
     def test_transformer_init(self):
         model = TimeSeriesTransformer(seq_len=60, pred_len=12, d_model=64)
         assert model is not None
         assert hasattr(model, 'forward')
-<<<<<<< HEAD
-=======
-
-
-class TestHorizonValidation:
-    def test_matching_horizon_passes(self):
-        _validate_horizon(ForecastRequest(data=[[1.0]], horizon=24), 24)
-
-    def test_mismatched_horizon_rejected(self):
-        with pytest.raises(HTTPException) as exc_info:
-            _validate_horizon(ForecastRequest(data=[[1.0]], horizon=48), 24)
-        assert exc_info.value.status_code == 422
->>>>>>> upstream/main


### PR DESCRIPTION
## Summary
Resolves merge conflict markers (`<<<<<<<`/`=======`/`>>>>>>>`) that were committed into `backend/ml/tests/test_transformers.py` on `main`, leaving the file un-runnable.

## Changes
- Removed the conflict markers and the conflicting block.
- Kept the working `TestTimeSeriesTransformer` suite (HEAD side). Dropped the upstream-side `TestHorizonValidation` block because it references `_validate_horizon`, which was removed from `backend/ml/routes/transformer_routes.py` in commit `ea533a2f9` (#11850) — keeping it would have failed at import time.

## Impact
`python -m py_compile backend/ml/tests/test_transformers.py` succeeds and the file contains zero conflict markers. Full test execution requires `transformers`/`torch`, which are not installed in this environment.

Fixes #12471

GSSOC
