### PR TITLE
fix(pqc): resolve merge conflict markers in test_kyber.py

### DIFF
--- a/backend/pqc/test_kyber.py
+++ b/backend/pqc/test_kyber.py
@@ -1,9 +1,6 @@
 import unittest
-<<<<<<< HEAD
-=======
 import hashlib
 
->>>>>>> upstream/main
 from kyber_relayer import Kyber1024Relayer
 
 class TestKyber1024Relayer(unittest.TestCase):
@@ -25,8 +22,6 @@ class TestKyber1024Relayer(unittest.TestCase):
         self.assertEqual(len(ss2), 32)
         self.assertEqual(ss1, ss2)
 
-<<<<<<< HEAD
-=======
     def test_shared_secret_not_derivable_from_public_key_alone(self):
         pk, sk = self.relayer.generate_keypair()
         ct, ss = self.relayer.encapsulate(pk)
@@ -65,6 +60,5 @@ class TestKyber1024Relayer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.relayer.decapsulate(b"bad", b"bad")
 
->>>>>>> upstream/main
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Resolves merge conflict markers committed into `backend/pqc/test_kyber.py` on `main`, leaving it un-runnable.

## Changes
- Removed the conflict markers and kept the upstream side: the test imports `hashlib` and includes the full security suite — `test_shared_secret_not_derivable_from_public_key_alone`, `test_old_xor_ciphertext_attack_no_longer_recovers_shared_secret`, `test_decapsulation_with_wrong_secret_key_fails`, `test_invalid_lengths_raise`, and the `unittest.main()` guard.

## Impact
`python -m py_compile backend/pqc/test_kyber.py` succeeds and the file contains zero conflict markers. Functional verification is blocked locally because the `mlkem` wheel does not build on Python 3.14/Windows, but the API contract used by the tests matches the `mlkem` package (`ML_KEM(ML_KEM_1024)` → key_gen/encaps/decaps, 1568/3168/1568/32 byte lengths).

Fixes #12468

GSSOC
