### PR TITLE
fix(pqc): resolve merge conflict markers in kyber_relayer.py

### DIFF
--- a/backend/pqc/kyber_relayer.py
+++ b/backend/pqc/kyber_relayer.py
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-import os
-import hashlib
-=======
 """
 Real ML-KEM-1024 (CRYSTALS-Kyber) key-encapsulation relayer service.
 
@@ -16,7 +12,6 @@ only the holder of the secret key can decapsulate the shared secret.
 from mlkem.ml_kem import ML_KEM
 from mlkem.parameter_set import ML_KEM_1024
 
->>>>>>> upstream/main
 
 class Kyber1024Relayer:
     """
@@ -29,43 +24,6 @@ class Kyber1024Relayer:
         self.secret_key_len = 3168
         self.ciphertext_len = 1568
         self.shared_secret_len = 32
-<<<<<<< HEAD
-
-    @staticmethod
-    def _expand(material: bytes, length: int) -> bytes:
-        """SHA3-512 expansion of ``material`` to exactly ``length`` bytes."""
-        out = b""
-        counter = 0
-        while len(out) < length:
-            out += hashlib.sha3_512(material + counter.to_bytes(4, 'big')).digest()
-            counter += 1
-        return out[:length]
-
-    def generate_keypair(self):
-        """Generates a Kyber1024 public/private keypair."""
-        seed = os.urandom(64)
-        # The seed is embedded at the front of the secret key so decapsulate can
-        # reconstruct the public key from the private key and recover the
-        # encapsulated secret.
-        sk = seed + self._expand(seed + b"KYBER_SK_TAG", self.secret_key_len - 64)
-        pk = self._expand(seed + b"KYBER_PK_TAG", self.public_key_len)
-        return pk, sk
-
-    def encapsulate(self, public_key: bytes):
-        """Encapsulates a random 256-bit shared secret using the recipient's Kyber public key."""
-        if len(public_key) != self.public_key_len:
-            raise ValueError(f"Invalid Kyber1024 public key length: {len(public_key)} bytes required.")
-
-        # Random message encapsulated for the recipient
-        message = os.urandom(self.shared_secret_len)
-        shared_secret = hashlib.sha3_512(public_key + message).digest()[:self.shared_secret_len]
-        # Encrypt the message under a key derived from the public key; only the
-        # holder of the secret key (who can reconstruct the public key) can
-        # recover it.
-        enc_key = hashlib.sha3_512(public_key).digest()
-        ct_blob = bytes(a ^ b for a, b in zip(message, enc_key[:self.shared_secret_len]))
-        ciphertext = (ct_blob * ((self.ciphertext_len + self.shared_secret_len - 1) // self.shared_secret_len))[:self.ciphertext_len]
-=======
         self._kem = ML_KEM(ML_KEM_1024)
 
     def generate_keypair(self):
@@ -83,7 +41,6 @@ class Kyber1024Relayer:
             raise ValueError(f"Invalid Kyber1024 public key length: {len(public_key)} bytes required.")
 
         shared_secret, ciphertext = self._kem.encaps(public_key)
->>>>>>> upstream/main
         return ciphertext, shared_secret
 
     def decapsulate(self, ciphertext: bytes, secret_key: bytes):
@@ -93,19 +50,7 @@ class Kyber1024Relayer:
         if len(secret_key) != self.secret_key_len:
             raise ValueError(f"Invalid secret key length: {len(secret_key)} bytes required.")
 
-<<<<<<< HEAD
-        # Reconstruct the public key from the seed embedded in the secret key
-        seed = secret_key[:64]
-        public_key = self._expand(seed + b"KYBER_PK_TAG", self.public_key_len)
-
-        # Recover the encapsulated message and re-derive the shared secret
-        enc_key = hashlib.sha3_512(public_key).digest()
-        ct_blob = ciphertext[:self.shared_secret_len]
-        message = bytes(a ^ b for a, b in zip(ct_blob, enc_key[:self.shared_secret_len]))
-        return hashlib.sha3_512(public_key + message).digest()[:self.shared_secret_len]
-=======
         return self._kem.decaps(secret_key, ciphertext)
 
->>>>>>> upstream/main
 
 relayer_service = Kyber1024Relayer()


### PR DESCRIPTION
## Summary
Resolves merge conflict markers committed into `backend/pqc/kyber_relayer.py` on `main`, leaving it un-importable.

## Changes
- Removed the conflict markers and kept the upstream side: a real ML-KEM-1024 implementation on the `mlkem` package —
  - `from mlkem.ml_kem import ML_KEM; from mlkem.parameter_set import ML_KEM_1024`
  - `Kyber1024Relayer` with `public_key_len = 1568`, `secret_key_len = 3168`, `ciphertext_len = 1568`, `shared_secret_len = 32`
  - `generate_keypair`/`encapsulate`/`decapsulate` delegating to `key_gen`/`encaps`/`decaps`
  - module-level `relayer_service` singleton.

## Impact
`python -m py_compile backend/pqc/kyber_relayer.py` succeeds and the file contains zero conflict markers. The API matches the published `mlkem` package exactly (verified against its source distribution: `ML_KEM(parameters=ML_KEM_1024)`, `key_gen() -> (pk, sk)`, `encaps(ek) -> (shared_secret, ciphertext)`, `decaps(dk, c)`). The `mlkem` wheel does not build on Python 3.14/Windows, so functional execution must happen on CI/Linux.

Fixes #12467

GSSOC
