### PR TITLE
fix(tflite): resolve merge conflict markers in routes.py

### DIFF
--- a/backend/tflite/routes.py
+++ b/backend/tflite/routes.py
@@ -78,56 +78,39 @@ async def predict_tflite(request: PredictRequest):
     try:
         input_array = np.array(request.input_data, dtype=np.float32)
         result = inference.predict(request.model_name, input_array)
-<<<<<<< HEAD
-        
-=======
 
         if not result.get('success'):
             raise HTTPException(status_code=400, detail=result.get('error', 'Prediction failed'))
 
->>>>>>> upstream/main
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
-<<<<<<< HEAD
-=======
     except HTTPException:
         raise
->>>>>>> upstream/main
     except Exception as e:
         logger.error(f"Prediction error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-<<<<<<< HEAD
-=======
 
->>>>>>> upstream/main
 @router.post("/predict-batch")
 async def predict_batch_tflite(request: BatchPredictRequest):
     """Run batch TFLite inference"""
     try:
         input_batch = [np.array(data, dtype=np.float32) for data in request.input_batch]
         result = inference.predict_batch(request.model_name, input_batch)
-<<<<<<< HEAD
-        
-=======
 
         if not result.get('success'):
             raise HTTPException(status_code=400, detail=result.get('error', 'Batch prediction failed'))
 
->>>>>>> upstream/main
         return {
             'success': True,
             'data': result,
             'timestamp': datetime.now().isoformat()
         }
-<<<<<<< HEAD
-=======
     except HTTPException:
         raise
->>>>>>> upstream/main
     except Exception as e:
         logger.error(f"Batch prediction error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -137,46 +120,30 @@ async def quantize_model(request: ConvertRequest):
     """Quantize model for edge deployment"""
     try:
         import tensorflow as tf
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> upstream/main
         model = tf.keras.Sequential([
             tf.keras.layers.Dense(128, activation='relu', input_shape=(784,)),
             tf.keras.layers.Dense(10, activation='softmax')
         ])
-<<<<<<< HEAD
-        
-        quantized_model = optimizer.quantize_weights(model, request.quantization)
-        
-=======
 
         result = optimizer.quantize_weights(model, request.quantization, request.name)
 
         if not result.get('success'):
             raise HTTPException(status_code=500, detail=result.get('error', 'Quantization failed'))
 
->>>>>>> upstream/main
         return {
             'success': True,
             'data': {
                 'quantization': request.quantization,
                 'model_quantized': True,
-<<<<<<< HEAD
-=======
                 'model_path': result.get('model_path'),
                 'size_bytes': result.get('size_bytes'),
->>>>>>> upstream/main
                 'timestamp': datetime.now().isoformat()
             },
             'timestamp': datetime.now().isoformat()
         }
-<<<<<<< HEAD
-=======
     except HTTPException:
         raise
->>>>>>> upstream/main
     except Exception as e:
         logger.error(f"Quantization error: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
Resolves 9 merge conflict marker sites committed into `backend/tflite/routes.py` on `main`, leaving it un-importable.

## Changes
- Removed all conflict markers and kept the upstream side at every site:
  - error paths now re-raise `HTTPException` with explicit `status_code`/`detail`
  - the `quantize` endpoint calls the 3-arg `quantize_weights(model, request.quantization, request.name)`, checks `success`, and reports `model_path`/`size_bytes`
  - consistent with the 3-arg `quantize_weights` signature in `backend/tflite/model_converter.py`.

## Impact
`python -m py_compile backend/tflite/routes.py` succeeds and the file contains zero conflict markers. Full endpoint verification requires `tensorflow`/`tflite-support`, which are not installed in this environment. Note: `model_converter.py` still contains conflict markers but is a separate file outside this issue's scope.

Fixes #12466

GSSOC
