### PR TITLE
fix(customer): log JSON decode failures in cache_manager _safeDecode

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
@@ -45,7 +46,8 @@ class CacheManager {
   dynamic _safeDecode(String json) {
     try {
       return jsonDecode(json);
-    } catch (_) {
+    } catch (e) {
+      developer.log('CacheManager: failed to JSON-decode cached value: $e');
       return null;
     }
   }


### PR DESCRIPTION
## Summary
Adds logging to `CacheManager._safeDecode` so JSON decode failures on cached values are no longer silent.

## Changes
- Added `dart:developer` import.

## Impact


Fixes #12513

GSSOC