### PR TITLE
fix(customer): log unexpected upload errors in sync_engine empty catches

### DIFF
--- a/apps/customer/lib/core/offline/sync/sync_engine.dart
+++ b/apps/customer/lib/core/offline/sync/sync_engine.dart
@@ -127,7 +127,8 @@ class SyncEngine {
     final SyncUploadOutcome uploadOutcome;
     try {
       uploadOutcome = await _uploadBatch(resolved);
-    } catch (_) {
+    } catch (e) {
+      developer.log('[SyncEngine] Unexpected error during batch upload: $e');
       // An unexpected error during upload must never leave events stuck in the
       // transient `syncing` state; fall through to failure handling below so
       // they are re-queued on a later sync pass.
@@ -209,7 +210,8 @@ class SyncEngine {
       }
 
       return SyncUploadOutcome.retryableFailure;
-    } catch (_) {
+    } catch (e) {
+      developer.log('[SyncEngine] Batch upload threw: $e');
       await Future<void>.delayed(_backoffDelay(_maxRetryCount(events)));
       return SyncUploadOutcome.retryableFailure;
     }


### PR DESCRIPTION
## Summary
Adds logging to the empty `catch` blocks around offline event batch uploads in the customer `sync_engine.dart`.

## Changes
- Logs unexpected batch-upload errors before falling through to the existing retryable-failure handling.

## Impact


Fixes #12514

GSSOC