### PR TITLE
fix(customer): log silent search date/time parse failures in find_trucks_screen

### DIFF
--- a/apps/customer/lib/screens/find_trucks_screen.dart
+++ b/apps/customer/lib/screens/find_trucks_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
@@ -241,7 +243,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     } else {
       try {
         date = DateFormat('dd MMM yyyy').parseStrict(parts.first.trim());
-      } catch (_) {
+      } catch (e) {
+        developer.log('Failed to parse pickup date "${parts.first.trim()}": $e');
         return null;
       }
     }
@@ -249,7 +252,8 @@ class _FindTrucksScreenState extends State<FindTrucksScreen> {
     DateTime parsedTime;
     try {
       parsedTime = DateFormat('h:mm a').parseStrict(timePart.toUpperCase());
-    } catch (_) {
+    } catch (e) {
+      developer.log('Failed to parse pickup time "$timePart": $e');
       return null;
     }
 


### PR DESCRIPTION
## Summary
Adds logging when the search date/time label cannot be parsed in `find_trucks_screen.dart`.

## Changes
- Added `dart:developer` import.

## Impact


Fixes #12515

GSSOC