### PR TITLE
fix(driver): log silent language preference failures in app_controller

### DIFF
--- a/apps/driver/lib/controllers/app_controller.dart
+++ b/apps/driver/lib/controllers/app_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -63,8 +65,8 @@ class TruxifyController extends ChangeNotifier {
       final savedCode = prefs.getString(_languageKey) ?? 'en';
       _locale = Locale(savedCode);
       notifyListeners();
-    } catch (_) {
-      // Ignore shared preferences loading errors, fallback to English
+    } catch (e) {
+      developer.log('Failed to load language preference, falling back to English: $e');
     }
   }
 
@@ -76,8 +78,8 @@ class TruxifyController extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_languageKey, languageCode);
-    } catch (_) {
-      // Ignore shared preferences errors
+    } catch (e) {
+      developer.log('Failed to save language preference: $e');
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds logging to the silent language-preference load/save paths in the driver `app_controller.dart`.

## Changes
- Added `dart:developer` import.

## Impact


Fixes #12516

GSSOC