### PR TITLE
fix(driver): log auth-token fallback in background_sync_service

### DIFF
--- a/apps/driver/lib/services/background_sync_service.dart
+++ b/apps/driver/lib/services/background_sync_service.dart
@@ -83,10 +83,12 @@ class BackgroundSyncService {
         } else {
           token = Supabase.instance.client.auth.currentSession?.accessToken;
         }
-      } catch (_) {
+      } catch (e) {
         // Firebase/Supabase are not initialized in the background isolate.
         // Fall back to the auth token persisted by the main isolate in
         // OS-backed secure storage (issue #5739) — never SharedPreferences.
+        debugPrint('[BackgroundSyncService] Auth token fetch failed, '
+            'falling back to secure storage: $e');
         token = await AuthTokenStore.read();
       }
 


### PR DESCRIPTION
## Summary
Logs the auth-token fetch failure in `background_sync_service.dart` before falling back to secure storage.

## Changes
- Added `debugPrint` in the empty catch; the secure-storage fallback behaviour is unchanged.

## Impact


Fixes #12517

GSSOC