### PR TITLE
fix(driver): log sync failures in offline_first_sync_service

### DIFF
--- a/apps/driver/lib/services/offline_first_sync_service.dart
+++ b/apps/driver/lib/services/offline_first_sync_service.dart
@@ -186,7 +186,9 @@ class OfflineFirstSyncService {
       );
 
       return response.statusCode == 200 || response.statusCode == 202;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[OfflineFirstSyncService] Sync failed for event '
+          '${event.eventId} (${event.eventType}): $e');
       return false;
     }
   }


### PR DESCRIPTION
## Summary
Logs sync failures in the driver `offline_first_sync_service.dart` empty catch.

## Changes
- Added `debugPrint` in the event-sync catch before returning false.

## Impact


Fixes #12519

GSSOC