### PR TITLE
fix(driver): log corrupt-row quarantine failures in offline_location_queue

### DIFF
--- a/apps/driver/lib/services/offline_location_queue.dart
+++ b/apps/driver/lib/services/offline_location_queue.dart
@@ -510,7 +510,9 @@ class OfflineLocationQueue {
     if (id is! int) return;
     try {
       await _store.deleteWhereId(id);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[OfflineLocationQueue] Failed to quarantine corrupt '
+          'queue row $id: $e');
       // Never let a corrupt row block the queue.
     }
   }


### PR DESCRIPTION
## Summary
Logs corrupt-row quarantine failures in `offline_location_queue.dart`.

## Changes
- Added `debugPrint` in the quarantine catch; rows are still never allowed to block the queue.

## Impact


Fixes #12520

GSSOC