### PR TITLE
fix(driver): log silent prediction failure in profit_estimate_card

### DIFF
--- a/apps/driver/lib/widgets/profit_estimate_card.dart
+++ b/apps/driver/lib/widgets/profit_estimate_card.dart
@@ -54,7 +54,8 @@ class _ProfitEstimateCardState extends State<ProfitEstimateCard> {
       } finally {
         repo.dispose();
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[ProfitEstimateCard] Profit prediction failed: $e');
       if (mounted) setState(() { _isLoading = false; _error = 'Prediction unavailable'; });
     }
   }


### PR DESCRIPTION
## Summary
Logs the silent prediction failure in `profit_estimate_card.dart` empty catch.

## Changes
- Added `debugPrint` before setting the unavailable fallback state.

## Impact


Fixes #12521

GSSOC