### PR TITLE
fix(driver): log reverse-geocode failure in home_screen

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -660,7 +660,8 @@ class _HomeScreenState extends State<HomeScreen> {
         final displayName = (decoded['display_name'] as String?)?.trim();
         if (displayName != null && displayName.isNotEmpty) return displayName;
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[_resolveCurrentLocationAddress] reverse geocode failed: $e');
       return 'Location Unavailable';
     }
     return 'Location Unavailable';


### PR DESCRIPTION
## Summary
Logs the reverse-geocode failure in the driver `home_screen.dart` instead of silently returning `Location Unavailable`.

## Changes
- Added `debugPrint` in the catch of `_resolveCurrentLocationAddress`.

## Impact


Fixes #12523

GSSOC