### PR TITLE
fix(driver): log route-generation exception in home_screen

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -2132,7 +2132,8 @@ class _HomeScreenState extends State<HomeScreen> {
           SnackBar(content: Text(AppLocalizations.of(context)!.unableToOpenGoogleMaps)),
         );
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[_openGoogleMapsRoute] route generation/launch failed: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.failedToGenerateRoute)),


### PR DESCRIPTION
## Summary
Logs the route-generation/launch exception in the driver `home_screen.dart` that was previously only shown to the user.

## Changes
- Added `debugPrint` in the catch of `_openGoogleMapsRoute`; the existing failure SnackBar is unchanged.

## Impact


Fixes #12524

GSSOC