### PR TITLE
fix(driver): surface truck update failure to user in driver_profile_screen

### DIFF
--- a/apps/driver/lib/screens/driver_profile_screen.dart
+++ b/apps/driver/lib/screens/driver_profile_screen.dart
@@ -288,6 +288,14 @@ class _DriverProfileScreenState extends State<DriverProfileScreen> {
                       );
                     } catch (e) {
                       debugPrint('Failed to update truck: $e');
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: const Text('Failed to update truck details. Please try again.'),
+                            backgroundColor: TruxifyColors.error,
+                          ),
+                        );
+                      }
                     } finally {
                       apiClient.close();
                     }


### PR DESCRIPTION
## Summary
Surfaces truck-update failures to the driver instead of only `debugPrint`ing them.

## Changes
- Added a failure SnackBar (`TruxifyColors.error`) in the catch of the truck update handler; the bottom sheet stays open so the driver can retry.

## Impact


Fixes #12526

GSSOC