### PR TITLE
fix(driver): surface camera failures in pod_screen

### DIFF
--- a/apps/driver/lib/screens/pod_screen.dart
+++ b/apps/driver/lib/screens/pod_screen.dart
@@ -53,9 +53,20 @@ class _ProofOfDeliveryScreenState extends State<ProofOfDeliveryScreen> {
         _cameraController = CameraController(cameras.first, ResolutionPreset.medium);
         await _cameraController!.initialize();
         if (mounted) setState(() {});
+      } else {
+        _showCameraError('No camera found on this device.');
       }
     } catch (e) {
       debugPrint('Error initializing camera: $e');
+      _showCameraError('Camera unavailable. Please check camera permissions.');
+    }
+  }
+
+  void _showCameraError(String message) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message), backgroundColor: TruxifyColors.error),
+      );
     }
   }
 
@@ -77,6 +88,14 @@ class _ProofOfDeliveryScreenState extends State<ProofOfDeliveryScreen> {
       });
     } catch (e) {
       debugPrint('Error taking photo: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to capture photo. Please try again.'),
+            backgroundColor: TruxifyColors.error,
+          ),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Gives the driver user feedback when the camera fails instead of only logging.

## Changes
- Added a SnackBar on camera init failure and on photo-capture failure, plus a "no camera found" case.

## Impact


Fixes #12529

GSSOC