### PR TITLE
fix(customer): do not proceed as logged out when backend logout fails

### DIFF
--- a/apps/customer/lib/screens/profile_screen.dart
+++ b/apps/customer/lib/screens/profile_screen.dart
@@ -299,13 +299,19 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   void _logout(BuildContext context) async {
-    try {
-      await _profileService.logout();
-    } catch (e) {
-      debugPrint('Logout error: $e');
-    }
+    final ok = await _profileService.logout();
 
     if (!context.mounted) return;
+
+    if (!ok) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Logout failed. Check your connection and try again.'),
+          backgroundColor: TruxifyColors.errorRed,
+        ),
+      );
+      return;
+    }
 
     await _cacheManager.open();
     await _cacheManager.cacheProfile({});

--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -89,14 +89,19 @@ class ProfileService {
     );
   }
 
-  Future<void> logout() async {
+  /// Logs the user out of the backend and locally. Returns `false` if the
+  /// backend logout call failed, so callers can decide whether to keep the
+  /// user signed in (issue #12531).
+  Future<bool> logout() async {
     final userId = FirebaseAuth.instance.currentUser?.uid ?? SupabaseService.client.auth.currentUser?.id;
 
+    var backendOk = true;
     if (userId != null) {
       try {
         await _apiClient.post('/api/auth/logout');
       } catch (e) {
         developer.log('Backend logout failed: $e');
+        backendOk = false;
       }
     }
 
@@ -117,6 +122,8 @@ class ProfileService {
       _safeSignOut(() => FirebaseAuth.instance.signOut(), 'Firebase'),
       _safeSignOut(() => SupabaseService.client.auth.signOut(), 'Supabase'),
     ]);
+
+    return backendOk;
   }
 
   Future<void> _safeSignOut(


### PR DESCRIPTION
## Summary
Stops the customer app from proceeding as logged out when the backend logout call fails.

## Changes
- `ProfileService.logout()` now returns whether the backend logout succeeded.

## Impact


Fixes #12531

GSSOC