### PR TITLE
fix(admin): replace print() with debugPrint() in memory reclaimer (#12487)

### DIFF
--- a/apps/admin/lib/services/memory_reclaimer.dart
+++ b/apps/admin/lib/services/memory_reclaimer.dart
@@ -1,4 +1,6 @@
 /// Active WebGL & Canvas Memory Reclaimer for Flutter Admin Web App
+import 'package:flutter/foundation.dart';
+
 class WebGLMemoryReclaimerService {
   static final WebGLMemoryReclaimerService _instance = WebGLMemoryReclaimerService._internal();
   factory WebGLMemoryReclaimerService() => _instance;
@@ -9,7 +11,7 @@ class WebGLMemoryReclaimerService {
   void purgeOffscreenCanvasMemory() {
     _reclaimedFrameCount++;
     if (_reclaimedFrameCount % 50 == 0) {
-      print('[Memory Reclaimer] Purging off-screen canvas objects & triggering WebGL garbage collection...');
+      debugPrint('[Memory Reclaimer] Purging off-screen canvas objects & triggering WebGL garbage collection...');
     }
   }
 }


### PR DESCRIPTION
## Fixes #12487

### What changed
`apps/admin/lib/services/memory_reclaimer.dart`:

- Replaced `print('[Memory Reclaimer] ...')` with `debugPrint(...)` and added `import 'package:flutter/foundation.dart';`, matching the rest of the codebase and satisfying the `avoid_print` lint rule.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine to run `flutter analyze`). Change is a 1:1 `print` → `debugPrint` swap plus its required import.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-reclamation logging to better support Flutter applications.
  * Reduced the risk of excessive or disruptive console output during periodic cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->