### PR TITLE
fix(admin): log malformed support-ticket responses in parser (#12488)

### DIFF
--- a/apps/admin/lib/utils/support_ticket_parser.dart
+++ b/apps/admin/lib/utils/support_ticket_parser.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
+
 /// Parses the support tickets response body safely.
 ///
 /// Handles `{ "tickets": [...], "pagination": {...} }` maps, legacy direct `[...]` lists,
@@ -13,7 +15,14 @@ List<dynamic> parseSupportTicketsResponse(String responseBody) {
       List<dynamic> list => list,
       _ => <dynamic>[],
     };
-  } catch (_) {
+  } catch (e) {
+    final truncated = responseBody.length > 500
+        ? '${responseBody.substring(0, 500)}…'
+        : responseBody;
+    debugPrint(
+      'SupportTicketParser: failed to parse support tickets response: $e\n'
+      'truncated body: $truncated',
+    );
     return <dynamic>[];
   }
 }


### PR DESCRIPTION
## Fixes #12488

### What changed
`apps/admin/lib/utils/support_ticket_parser.dart`:

- The empty `catch (_) {}` in `parseSupportTicketsResponse()` now logs the exception plus a truncated (500-char) response body via `debugPrint` before returning the empty list. Malformed support-ticket API responses are no longer silently invisible.
- Added `import 'package:flutter/foundation.dart';`.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). Behavior for valid payloads is unchanged; the fallback still returns `[]`.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
