### PR TITLE
fix(customer): log temp audio file delete failure in voice AI screen (#12489)

### DIFF
--- a/apps/customer/lib/screens/voice_ai_screen.dart
+++ b/apps/customer/lib/screens/voice_ai_screen.dart
@@ -186,7 +186,9 @@ class _VoiceAiScreenState extends State<VoiceAiScreen> with SingleTickerProvider
         if (await file.exists()) {
           await file.delete();
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('VoiceAIScreen: failed to delete temp audio file: $e');
+      }
     }
   }
 


### PR DESCRIPTION
## Fixes #12489

### What changed
`apps/customer/lib/screens/voice_ai_screen.dart`:

- The empty `catch (_) {}` around the temp audio file `delete()` (line ~189) now logs the failure with `debugPrint`, so leftover temp files are diagnosable and stop accumulating invisibly.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). Cleanup behavior is unchanged — the catch still swallows (no rethrow), it just logs now.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
