### PR TITLE
fix(customer): surface payment method save failure to the user (#12490)

### DIFF
--- a/apps/customer/lib/screens/payment_methods_screen.dart
+++ b/apps/customer/lib/screens/payment_methods_screen.dart
@@ -365,8 +365,14 @@ class _AddPaymentSheetState extends State<_AddPaymentSheet> {
       );
 
       Navigator.of(context).pop(method);
-    } catch (_) {
-      if (mounted) setState(() => _saving = false);
+    } catch (e) {
+      debugPrint('PaymentMethodsScreen: failed to save payment method: $e');
+      if (mounted) {
+        setState(() => _saving = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not save payment method')),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Fixes #12490

### What changed
`apps/customer/lib/screens/payment_methods_screen.dart` `_submit()`:

- The empty `catch (_) {}` now captures the exception (`catch (e)`), logs it via `debugPrint`, and — when `mounted` — resets `_saving` and shows a `SnackBar` ("Could not save payment method"). If `SupabaseService.requireUserId()` or `PaymentMethod` construction throws, the user now sees clear feedback instead of a silent no-op.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). Success path is unchanged (`Navigator.pop(method)`).

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
