### PR TITLE
fix(customer): log corrupt cached profile decode failure (#12491)

### DIFF
--- a/apps/customer/lib/services/profile_service.dart
+++ b/apps/customer/lib/services/profile_service.dart
@@ -21,7 +21,8 @@ class ProfileService {
     try {
       final decoded = jsonDecode(cached);
       if (decoded is Map<String, dynamic>) return decoded;
-    } catch (_) {
+    } catch (e) {
+      developer.log('Discarding corrupt cached profile: $e');
       // Invalid cache entries are cleared so future fallbacks do not crash.
     }
     await _secureStorage.delete(key: _profileCacheKey);


### PR DESCRIPTION
## Fixes #12491

### What changed
`apps/customer/lib/services/profile_service.dart` `_readCachedProfile()`:

- The empty `catch (_) {}` around `jsonDecode` now logs the failure via the already-imported `developer.log` before the corrupt cache entry is deleted. Cache corruption incidents are now visible while the safe fallback (clearing the bad cache) is preserved.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). `dart:developer` is already imported and used elsewhere in this file.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
