### PR TITLE
fix(customer): differentiate location picker search vs resolve logs (#12492)

### DIFF
--- a/apps/customer/lib/screens/location_picker_screen.dart
+++ b/apps/customer/lib/screens/location_picker_screen.dart
@@ -95,7 +95,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         _suggestions = suggestions;
       });
     } catch (e) {
-      debugPrint('LocationPickerScreen: $e');
+      debugPrint('LocationPickerScreen searchPlaces: $e');
       if (!mounted) {
         return;
       }
@@ -135,7 +135,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         _selectedAddress = resolvedAddress;
       });
     } catch (e) {
-      debugPrint('LocationPickerScreen: $e');
+      debugPrint('LocationPickerScreen resolveAddress: $e');
       if (!mounted) {
         return;
       }


### PR DESCRIPTION
## Fixes #12492

### What changed
`apps/customer/lib/screens/location_picker_screen.dart`:

- `_searchPlaces` failure now logs `'LocationPickerScreen searchPlaces: $e'` (line ~98).
- `_resolveAddress` failure now logs `'LocationPickerScreen resolveAddress: $e'` (line ~138).

The two failure paths are now distinguishable in logs.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). Log-message string only; no behavior change.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
