### PR TITLE
fix(driver): log earnings export deferred cleanup failure (#12493)

### DIFF
--- a/apps/driver/lib/services/earnings_export_service.dart
+++ b/apps/driver/lib/services/earnings_export_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
@@ -101,7 +102,9 @@ class EarningsExportService {
         if (await file.exists()) {
           await file.delete();
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('EarningsExportService: deferred file cleanup failed: $e');
+      }
     });
   }
 


### PR DESCRIPTION
## Fixes #12493

### What changed
`apps/driver/lib/services/earnings_export_service.dart` `_scheduleFileCleanup()`:

- The empty `catch (_) {}` around the deferred shared-file `delete()` now logs the failure via `debugPrint`. Leftover exported CSV files are now visible in logs instead of silently accumulating in app documents.
- Added `import 'package:flutter/foundation.dart';`.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). The deferred delete still swallows the error (no rethrow); test `F. Cleanup failure does not break successful sharing` in `apps/driver/test/earnings_export_service_test.dart` remains valid since behavior is unchanged.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
