### PR TITLE
fix(driver): log and fall back when no route is recommended (#12494)

### DIFF
--- a/apps/driver/lib/screens/toll_route_optimizer_screen.dart
+++ b/apps/driver/lib/screens/toll_route_optimizer_screen.dart
@@ -28,11 +28,22 @@ class _TollRouteOptimizerScreenState extends State<TollRouteOptimizerScreen> {
       setState(() {
         _routes = routes;
         _isLoading = false;
-        // Fall back to the first route when none is flagged as recommended,
-        // instead of letting firstWhere throw StateError on an empty/no-match list.
-        _selectedRouteId = routes.isNotEmpty
-            ? routes.firstWhere((r) => r.isRecommended, orElse: () => routes.first).routeId
-            : null;
+        // Never throw StateError when no route is flagged recommended: log the
+        // fallback and select the first route so the optimizer still behaves
+        // predictably (#12494).
+        if (routes.isNotEmpty) {
+          final recommended = routes.where((r) => r.isRecommended).toList();
+          if (recommended.isNotEmpty) {
+            _selectedRouteId = recommended.first.routeId;
+          } else {
+            debugPrint(
+              'TollRouteOptimizer: no recommended route, falling back to first route',
+            );
+            _selectedRouteId = routes.first.routeId;
+          }
+        } else {
+          _selectedRouteId = null;
+        }
       });
     }
   }


### PR DESCRIPTION
## Fixes #12494

### What changed
`apps/driver/lib/screens/toll_route_optimizer_screen.dart` `_loadRoutes()`:

- Route selection is rewritten to never throw `StateError`: if recommended routes exist, the first one is selected; otherwise the fallback to `routes.first.routeId` is **logged** via `debugPrint` (`'TollRouteOptimizer: no recommended route, falling back to first route'`); on an empty list `_selectedRouteId` stays `null`.

### Note
The core fallback (`orElse: () => routes.first`) already landed in #12093; this change keeps that behavior and adds the visible logging the issue asks for, replacing the `firstWhere`+`orElse` with an explicit, logged selection path.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). `debugPrint` is available via `package:flutter/material.dart`, which is already imported.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
