### PR TITLE
fix(driver): log GPS lookup failure in delivery OTP screen (#12495)

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -140,8 +140,10 @@ class _DeliveryOtpScreenState extends State<DeliveryOtpScreen>
           _withinGeofence = d <= _geofenceRadius;
         });
       }
-    } catch (_) {
-      // GPS unavailable — silent fail
+    } catch (e) {
+      // GPS unavailable — log the reason so stale distance/geofence state is
+      // diagnosable instead of silently never updating (#12495).
+      debugPrint('DeliveryOtpScreen: GPS lookup failed: $e');
     }
   }
 


### PR DESCRIPTION
## Fixes #12495

### What changed
`apps/driver/lib/screens/delivery_otp_screen.dart`:

- The empty `catch (_) {}` around the GPS lookup (line ~143) now logs the failure reason via `debugPrint` (`'DeliveryOtpScreen: GPS lookup failed: $e'`). Drivers/support can now tell whether a stale distance/geofence indicator is due to GPS being unavailable rather than a logic bug.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). `debugPrint` is available via the already-imported `package:flutter/material.dart`; behavior unchanged (no rethrow).

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
