### PR TITLE
fix(driver): log skipped malformed document rows (#12496)

### DIFF
--- a/apps/driver/lib/screens/documents_screen.dart
+++ b/apps/driver/lib/screens/documents_screen.dart
@@ -651,7 +651,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         if (row is! Map) continue;
         try {
           documents.add(DriverDocument.fromMap(Map<String, dynamic>.from(row)));
-        } catch (_) {
+        } catch (e) {
+          debugPrint(
+            'DocumentsScreen: skipped malformed driver document row: $e\nrow: $row',
+          );
           continue;
         }
       }


### PR DESCRIPTION
## Fixes #12496

### What changed
`apps/driver/lib/screens/documents_screen.dart` `_fetchDocuments()`:

- The empty `catch (_) {}` around `DriverDocument.fromMap` now logs the exception and the skipped row via `debugPrint` before `continue`. Malformed document rows are now traceable instead of silently dropped.

### Verification
- Manual review (no Flutter/Dart toolchain available on this machine). `debugPrint` is available via the already-imported `package:flutter/foundation.dart`; skip behavior is unchanged.

---
**GSSOC'26**: This PR is submitted for the GSSOC'26 program. Please add the `gssoc-ext` label if available.
