### PR TITLE
fix(api): keep in-flight dedup entry until shared lookup resolves

### DIFF
--- a/backend/api/src/routes/lookupRoutes.js
+++ b/backend/api/src/routes/lookupRoutes.js
@@ -22,7 +22,17 @@ function setL1(key, data, expiresAt) {
 
 async function getCachedOrFetch(key, fetchFn) {
   const existing = inflight.get(key);
-  if (existing) return existing;
+  if (existing) {
+    existing.waiters += 1;
+    try {
+      return await existing.promise;
+    } finally {
+      existing.waiters -= 1;
+      if (existing.waiters === 0) {
+        inflight.delete(key);
+      }
+    }
+  }
 
   const fetchPromise = (async () => {
     const now = Date.now();
@@ -76,13 +86,18 @@ async function getCachedOrFetch(key, fetchFn) {
     return data;
   })();
 
-  // Atomic check-and-set: only first caller wins
-  const actual = inflight.get(key) || inflight.set(key, fetchPromise).get(key);
+  // Only the first caller creates the shared promise; keep the entry in the
+  // map until every waiter (including this one) is done awaiting it.
+  const entry = { promise: fetchPromise, waiters: 1 };
+  inflight.set(key, entry);
   setTimeout(() => inflight.delete(key), 30000);
   try {
-    return await actual;
+    return await entry.promise;
   } finally {
-    inflight.delete(key);
+    entry.waiters -= 1;
+    if (entry.waiters === 0) {
+      inflight.delete(key);
+    }
   }
 }
 

--- a/backend/api/test/unit/lookupRoutes.test.js
+++ b/backend/api/test/unit/lookupRoutes.test.js
@@ -71,4 +71,51 @@ describe('lookupRoutes', () => {
       expect(res.body.error).toBe('Failed to fetch regions');
     });
   });
+
+  describe('in-flight de-duplication', () => {
+    it('coalesces concurrent requests for the same key into one fetch', async () => {
+      let resolveFetch;
+      dbMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockImplementation(
+          () => new Promise((resolve) => { resolveFetch = resolve; }),
+        ),
+      });
+
+      const app = await makeApp();
+      const p1 = request(app).get('/lookup/vehicle-types');
+      const p2 = request(app).get('/lookup/vehicle-types');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      resolveFetch({ data: [{ id: 1, name: 'Truck' }], error: null });
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(dbMock.supabase.from).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the in-flight entry on rejection so retries can occur', async () => {
+      let rejectFetch;
+      dbMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockImplementation(
+          () => new Promise((_, reject) => { rejectFetch = reject; }),
+        ),
+      });
+
+      const app = await makeApp();
+      const p1 = request(app).get('/lookup/vehicle-types');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      rejectFetch(new Error('db down'));
+      const r1 = await p1;
+      expect(r1.status).toBe(500);
+
+      dbMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockResolvedValue({ data: [{ id: 1, name: 'Truck' }], error: null }),
+      });
+      const r2 = await request(app).get('/lookup/vehicle-types');
+      expect(r2.status).toBe(200);
+      expect(dbMock.supabase.from).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #11979