### PR TITLE
fix(xdp): track per-flow sequence numbers instead of blanket src-IP drop

### DIFF
--- a/ebpf/xdp_anti_replay.c
+++ b/ebpf/xdp_anti_replay.c
@@ -1,6 +1,8 @@
 /*
  * eBPF XDP Packet Replay Defender & Anti-DDoS Telemetry Filter
  * Drops replayed and duplicate GPS packets directly in the kernel network driver stack.
+ * Replay state is keyed per-flow (src IP + src port) with a sliding window of payload
+ * sequence numbers, so legitimate in-window bursts from one IP are never blanket-dropped.
  */
 
 #include <linux/bpf.h>
@@ -9,11 +11,18 @@
 #include <linux/udp.h>
 #include <bpf/bpf_helpers.h>
 
+#define REPLAY_WINDOW_SIZE 64
+
+struct anti_replay_entry {
+    __u32 last_seq; // Highest payload sequence number seen for this flow
+    __u64 window;   // Bitmap of recently seen sequence numbers below last_seq
+};
+
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 10000);
-    __type(key, __u32);   // Client source IP address
-    __type(value, __u64); // Last seen sequence counter timestamp
+    __type(key, __u64); // Flow key: src_ip (upper 32 bits) | src_port (lower 16 bits)
+    __type(value, struct anti_replay_entry);
 } seq_tracking_map SEC(".maps");
 
 SEC("xdp")
@@ -39,19 +48,44 @@ int xdp_anti_replay_filter(struct xdp_md *ctx) {
     if ((void *)(udp + 1) > data_end)
         return XDP_PASS;
 
-    __u32 src_ip = ip->saddr;
-    __u64 current_time = bpf_ktime_get_ns();
+    // Per-flow key keeps the full (src_ip, src_port) tuple in a 64-bit key so that
+    // distinct flows behind one NAT or from one GPS device never collide.
+    __u64 flow_key = ((__u64)ip->saddr << 16) | udp->source;
 
-    // Check sliding window/replay stamp
-    __u64 *last_seen = bpf_map_lookup_elem(&seq_tracking_map, &src_ip);
-    if (last_seen) {
-        // Drop packet if sequence timestamp interval is impossibly low (< 5ms)
-        if (current_time - *last_seen < 5000000) {
-            return XDP_DROP; // Drop replayed packet flood
-        }
+    // Sequence number is the first 4 bytes of the UDP payload (network order).
+    __u32 *seq_ptr = (void *)(udp + 1);
+    if ((void *)(seq_ptr + 1) > data_end)
+        return XDP_PASS; // Truncated frame: nothing to evaluate
+
+    __u32 seq = __builtin_bswap32(*seq_ptr);
+
+    struct anti_replay_entry *entry = bpf_map_lookup_elem(&seq_tracking_map, &flow_key);
+    if (!entry) {
+        struct anti_replay_entry new_entry = {
+            .last_seq = seq,
+            .window = 1,
+        };
+        bpf_map_update_elem(&seq_tracking_map, &flow_key, &new_entry, BPF_ANY);
+        return XDP_PASS;
     }
 
-    bpf_map_update_elem(&seq_tracking_map, &src_ip, &current_time, BPF_ANY);
+    if (seq <= entry->last_seq) {
+        __u32 diff = entry->last_seq - seq;
+        if (diff >= REPLAY_WINDOW_SIZE)
+            return XDP_DROP; // Stale: outside the replay window
+        if (entry->window & (1ULL << diff))
+            return XDP_DROP; // Duplicate: sequence already seen
+        entry->window |= (1ULL << diff); // Out-of-order but in-window: accept
+    } else {
+        __u64 shift = (__u64)(seq - entry->last_seq);
+        if (shift >= REPLAY_WINDOW_SIZE)
+            entry->window = 0;
+        else
+            entry->window <<= shift;
+        entry->window |= 1ULL;
+        entry->last_seq = seq;
+    }
+
     return XDP_PASS;
 }
 


### PR DESCRIPTION
Fixes #11985