### PR TITLE
fix(driver): never trim milestone rows when the queue has no location rows

### DIFF
--- a/apps/driver/lib/services/offline_location_queue.dart
+++ b/apps/driver/lib/services/offline_location_queue.dart
@@ -123,6 +123,10 @@ abstract class LocationQueueStore {
   /// Deletes the [count] oldest rows of any kind (last-resort trim).
   Future<int> deleteOldestRows(int count);
 
+  /// Deletes the [count] oldest non-milestone rows; milestone rows are never
+  /// dropped by capacity trimming.
+  Future<int> deleteOldestNonMilestones(int count);
+
   /// Looks up a row by its unique idempotency key (or null).
   Future<Map<String, dynamic>?> findByIdempotencyKey(String key);
 }
@@ -203,6 +207,24 @@ class SqfliteLocationQueueStore implements LocationQueueStore {
     final db = await _db;
     final rows = await db.rawQuery(
       'SELECT id FROM $table ORDER BY created_at ASC, id ASC LIMIT ?',
+      [count],
+    );
+    if (rows.isEmpty) return 0;
+    final ids = rows.map((r) => r['id']).toList();
+    return db.delete(
+      table,
+      where: 'id IN (${List.filled(ids.length, '?').join(',')})',
+      whereArgs: ids,
+    );
+  }
+
+  @override
+  Future<int> deleteOldestNonMilestones(int count) async {
+    final db = await _db;
+    final rows = await db.rawQuery(
+      'SELECT id FROM $table '
+      'WHERE kind != "milestone" '
+      'ORDER BY created_at ASC, id ASC LIMIT ?',
       [count],
     );
     if (rows.isEmpty) return 0;
@@ -498,7 +520,7 @@ class OfflineLocationQueue {
           keepNewestId: newest.id,
         );
       } else {
-        await _store.deleteOldestRows(total - maxEntries);
+        await _store.deleteOldestNonMilestones(total - maxEntries);
       }
       final after = await _store.count();
       if (after >= before) return; // nothing deleted — stop to avoid a loop

--- a/apps/driver/test/offline_location_queue_test.dart
+++ b/apps/driver/test/offline_location_queue_test.dart
@@ -94,6 +94,22 @@ class FakeLocationQueueStore implements LocationQueueStore {
   }
 
   @override
+  Future<int> deleteOldestNonMilestones(int count) async {
+    final candidates = rows
+        .where((r) => r['kind'] != 'milestone')
+        .toList()
+      ..sort((a, b) {
+        final byTime = (a['created_at'] as int).compareTo(b['created_at'] as int);
+        if (byTime != 0) return byTime;
+        return (a['id'] as int).compareTo(b['id'] as int);
+      });
+    final doomed = candidates.take(count).map((r) => r['id']).toSet();
+    final before = rows.length;
+    rows.removeWhere((r) => doomed.contains(r['id']));
+    return before - rows.length;
+  }
+
+  @override
   Future<Map<String, dynamic>?> findByIdempotencyKey(String key) async {
     for (final row in rows) {
       if (row['idempotency_key'] == key) return row;
@@ -253,6 +269,32 @@ void main() {
       expect(locations.last.payload['data']['lat'], 21.0 + 14 * 0.01);
       // Oldest location was dropped first.
       expect(locations.first.payload['data']['lat'], isNot(21.0));
+    });
+
+    test('milestone rows survive trimming when no location rows remain', () async {
+      // A long offline stretch of geofence milestones with location pings
+      // disabled leaves only milestone rows in the queue.
+      for (var i = 0; i < 15; i++) {
+        await queue.enqueueMilestone(
+          orderId: 'order-1',
+          milestone: 'Milestone $i',
+          driverId: 'driver-1',
+        );
+      }
+      expect(await queue.count(), 15);
+
+      // Trim is only reachable through enqueueLocation; the newly inserted
+      // location must not cause any milestone row to be evicted.
+      await queue.enqueueLocation(loc(lat: 21.5, lng: 72.5));
+
+      final pending = await queue.pending();
+      final milestones =
+          pending.where((i) => i.kind == QueueItemKind.milestone).toList();
+      expect(milestones, hasLength(15));
+      expect(
+        pending.where((i) => i.kind == QueueItemKind.location),
+        hasLength(1),
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #12004