### PR TITLE
#33 submitBid push notification renders bid_amount (paisa) as rupees, showing 100x the amount

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -334,7 +334,7 @@ export class OrderLifecycleService {
         sendPushNotification(
           offer.customer_id,
           'New Bid Received',
-          `A driver has submitted a bid of ₹${bidAmount} for your order.`,
+          `A driver has submitted a bid of ₹${(bidAmount / 100).toFixed(2)} for your order.`,
           'order_update',
           { loadOfferId, bidId: bid.id }
         ).catch(err => logger.error(`[FCM] Failed to notify customer of new bid: ${err.message}`));


### PR DESCRIPTION
﻿## Problem

When a driver submits a bid, the customer is notified with the bid amount rendered directly as rupees, but `bid_amount` is stored in **paisa** (1 rupee = 100 paisa). The notification therefore shows a value 100× too large.

```js
// orderLifecycleService.js (~lines 334-340)
sendPushNotification(
  offer.customer_id,
  'New Bid Received',
  `A driver has submitted a bid of ₹${bidAmount} for your order.`,   // bidAmount is paisa
  ...
);
```

The route schema and the escrow code confirm the unit: `paisaToMaticWei(bid.bid_amount)` is used for deposits. So a ₹5,000 bid (`bid_amount = 500000`) is shown to the customer as "₹500000".

## Fix

```js
`A driver has submitted a bid of ₹${(bidAmount / 100).toFixed(2)} for your order.`
```
Add a unit test asserting the notification string divides paisa by 100.

## Files changed

backend/api/src/services/order/orderLifecycleService.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12540
