### PR TITLE
#34 Load-offer cache global version bump is never read, leaving a stale load board

### DIFF
--- a/backend/api/src/services/order/loadOfferCacheService.js
+++ b/backend/api/src/services/order/loadOfferCacheService.js
@@ -20,8 +20,14 @@ export class LoadOfferCacheService {
   static async getVersion(region) {
     if (!redisClient) return null;
     try {
-      const version = await redisClient.get(`version:load_offers:region:${region}`);
-      return version || null;
+      const [regionVersion, globalVersion] = await Promise.all([
+        redisClient.get(`version:load_offers:region:${region}`),
+        redisClient.get(`version:load_offers:region:global`),
+      ]);
+      const regionNum = regionVersion ? Number(regionVersion) : 0;
+      const globalNum = globalVersion ? Number(globalVersion) : 0;
+      const max = Math.max(regionNum, globalNum);
+      return max > 0 ? String(max) : null;
     } catch (err) {
       logger.warn('[LoadOfferCache] Redis error getting version:', err.message);
       return null;
@@ -36,9 +42,6 @@ export class LoadOfferCacheService {
     try {
       const region = this.getRegion(lat, lng);
       await redisClient.incr(`version:load_offers:region:${region}`);
-      if (region !== 'global') {
-        await redisClient.incr(`version:load_offers:region:global`);
-      }
     } catch (err) {
       logger.warn('[LoadOfferCache] Redis error invalidating cache:', err.message);
     }


### PR DESCRIPTION
﻿## Problem

The load-offer cache uses a per-region version key plus a `global` key, but the read path never consults the `global` key, and the invalidation logic bumps `global` in a case where no client reads it — so offers can go stale.

```js
// loadOfferCacheService.js (~lines 20-45)
static async getVersion(region) {
  return redisClient.get(`version:load_offers:region:${region}`); // only region, never 'global'
}
static async invalidateRegion(lat, lng) {
  const region = this.getRegion(lat, lng);
  await redisClient.incr(`version:load_offers:region:${region}`);
  if (region !== 'global') await redisClient.incr(`version:load_offers:region:global`); // bumped but never read
}
```

When `getRegion` returns `'global'` (e.g., missing/invalid coords), `invalidateRegion` bumps only `global` — which `getVersion` never reads — so the per-region caches that actually serve the offer are never invalidated. Conversely, a deliberate cross-region invalidation (bumping `global`) has no effect because clients only check their own region key.

## Fix

- Have `getVersion` read `max(region, global)` version, or
- Make `invalidateRegion` bump the concrete region derived from the offer's coordinates (not `global`), and only bump `global` when a true full flush is intended and the reader honors it.
Add a test asserting an offer change invalidates the correct region cache.

## Files changed

backend/api/src/services/order/loadOfferCacheService.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12541
