### PR TITLE
#35 Idempotency lock released before the success-response cache write, allowing duplicate side effects

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -158,9 +158,27 @@ export function requireIdempotency(ttlSeconds = 3600) {
           });
         };
 
+        // Ensure the success response is cached BEFORE the lock is released, so
+        // a duplicate arriving after 'finish' finds the cached entry and
+        // short-circuits instead of re-acquiring the lock and re-entering the
+        // handler.
+        let pendingCache = null;
+        const finalize = async () => {
+          if (pendingCache) {
+            const cachePromise = pendingCache;
+            pendingCache = null;
+            try {
+              await cachePromise;
+            } catch (err) {
+              /* error already logged by the cache write's own .catch */
+            }
+          }
+          releaseLock();
+        };
+
         // Ensure lock is reliably released when response terminates
-        res.once('finish', releaseLock);
-        res.once('close', releaseLock);
+        res.once('finish', finalize);
+        res.once('close', finalize);
       } else {
         // Memory-only mode: use in-memory lock to prevent concurrent handler execution
         if (inFlightRequests.has(key)) {
@@ -197,7 +215,7 @@ export function requireIdempotency(ttlSeconds = 3600) {
           const cacheData = JSON.stringify({ statusCode: res.statusCode, body });
 
           if (redisClient) {
-            redisClient.set(key, cacheData, 'EX', ttlSeconds).catch(err => {
+            pendingCache = redisClient.set(key, cacheData, 'EX', ttlSeconds).catch(err => {
               logger.error({ event: 'IDEMPOTENCY_CACHE_SET_ERROR', idempotencyKey, error: err && err.message }, '[Idempotency] Failed to cache response');
             });
           } else {


### PR DESCRIPTION
﻿## Problem

The idempotency middleware releases its Redis lock on the response `finish` event, but the success-response cache write is a **fire-and-forget promise that is never awaited**. A fast duplicate request can re-acquire the lock after `finish` but before the cache SET lands, then re-enter the handler.

```js
// middleware/idempotency.js (~lines 162, 196-205)
res.once('finish', releaseLock);          // lock freed when response flushes
...
if (res.statusCode >= 200 && res.statusCode < 300) {
  const cacheData = JSON.stringify({ statusCode: res.statusCode, body });
  if (redisClient) {
    redisClient.set(key, cacheData, 'EX', ttlSeconds).catch(err => { ... }); // NOT awaited
  } else {
    setInMemory(key, cacheData, ttlMs);
  }
}
```

The whole point of the idempotency key is that a duplicate request returns the *cached* response instead of re-executing side effects. But because the lock is released before the cache is populated, a duplicate arriving in that window re-acquires the lock (cache miss) and runs the handler again.

## Fix

- `await` the cache write (or chain it) and only call `releaseLock` after it settles, or
- Populate the cache synchronously before `res.json` returns / before attaching the `finish` release.
Add a test firing two concurrent identical requests and asserting the handler runs once.

## Files changed

backend/api/src/middleware/idempotency.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12542
