### PR TITLE
config/demand.js parseNumber returns 0 instead of fallback for empty env

### DIFF
--- a/backend/api/src/config/demand.js
+++ b/backend/api/src/config/demand.js
@@ -1,4 +1,5 @@
 const parseNumber = (value, fallback) => {
+  if (value === '' || value === null || value === undefined) return fallback;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
 };


### PR DESCRIPTION
﻿## Problem

`parseNumber` uses `Number(value)`. `Number('')` is `0`, which is finite, so an empty `DEMAND_*` env var returns `0` instead of the `fallback`, zeroing surge/demand-based earnings calculations.

## Fix

Guard `''`/`null`/`undefined` before parsing so the configured fallback is used when the env var is empty or unset.

## Files changed

backend/api/src/config/demand.js

## Testing

Run `npm test`; confirm `parseNumber('', 18.5)` returns `18.5` and only `0` when `0` is passed explicitly.

Closes #12419
