### PR TITLE
voiceRoutes builds audio_url from attacker-controlled Host header

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -62,11 +62,20 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
 
     const result = await processVoiceQuery(req.user.id, bookingId, file.buffer, safeFilename);
     
-    // Prefix the audio_url with host if relative path
-    const protocol = req.headers['x-forwarded-proto'] || req.protocol;
-    const host = req.headers.host;
+    // Prefix the audio_url with the configured public base URL. We never
+    // derive the base URL from attacker-controlled headers (Host /
+    // X-Forwarded-Proto) because that enables open-redirect / phishing URLs
+    // that are returned to and opened by the mobile client.
     if (result.audio_url && result.audio_url.startsWith('/')) {
-      const baseUrl = process.env.PUBLIC_BASE_URL || `${protocol}://${host}`;
+      const baseUrl = process.env.PUBLIC_BASE_URL;
+      if (!baseUrl) {
+        logger.error(
+          'PUBLIC_BASE_URL is not configured — refusing to build audio_url from request headers.',
+        );
+        return res.status(500).json({
+          error: 'Server misconfiguration: PUBLIC_BASE_URL is not set.',
+        });
+      }
       result.audio_url = `${baseUrl}${result.audio_url}`;
     }
     


### PR DESCRIPTION
﻿## Problem

`audio_url` was prefixed using `req.headers.host` and `x-forwarded-proto`, both attacker-controllable. With `PUBLIC_BASE_URL` unset, the returned URL was assembled from a forged Host header, enabling open-redirect / phishing URLs opened by the mobile client.

## Fix

Always derive `audio_url` from `process.env.PUBLIC_BASE_URL` and fail closed (500) when it is unset. Never trust `req.headers.host` / `x-forwarded-proto` for building returned URLs.

## Files changed

backend/api/src/routes/voiceRoutes.js

## Testing

Run `npm test`; verify a relative `audio_url` is prefixed with `PUBLIC_BASE_URL` and that the endpoint errors when `PUBLIC_BASE_URL` is unset regardless of Host header.

Closes #12420
