### PR TITLE
driver_profile_screen unvalidated double.parse silently fails truck update

### DIFF
--- a/apps/driver/lib/screens/driver_profile_screen.dart
+++ b/apps/driver/lib/screens/driver_profile_screen.dart
@@ -271,11 +271,24 @@ class _DriverProfileScreenState extends State<DriverProfileScreen> {
                 onPressed: () async {
                   if (formKey.currentState?.validate() ?? false) {
                     final apiClient = ApiClient();
+                    final weight = double.tryParse(weightController.text);
+                    final volume = double.tryParse(volumeController.text);
+                    if (weight == null || volume == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                            'Capacity weight and volume must be valid numbers.',
+                          ),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                      return;
+                    }
                     try {
                       await apiClient.put('/api/driver/truck', body: {
                         'type': typeController.text.trim(),
-                        'capacityWeight': double.parse(weightController.text),
-                        'capacityVolume': double.parse(volumeController.text),
+                        'capacityWeight': weight,
+                        'capacityVolume': volume,
                         'registrationNumber': regController.text.trim().toUpperCase(),
                       });
                       Navigator.of(context).pop();


### PR DESCRIPTION
﻿## Problem

`capacityWeight`/`capacityVolume` were parsed with `double.parse` directly from unvalidated text fields. A non-numeric value threw `FormatException`, caught by a `catch` that only `debugPrint`s, so the update failed silently with no error shown.

## Fix

Use `double.tryParse` and surface a validation error snackbar when the weight/volume values are not valid numbers before sending the request.

## Files changed

apps/driver/lib/screens/driver_profile_screen.dart

## Testing

Run `flutter analyze` on `apps/driver`; manual test entering a non-numeric capacity value shows a validation error instead of a silent failure.

Closes #12421
