### PR TITLE
#39 Cold-chain IoT alert never fires: current frame inserted before the previous-frame lookup

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -87,6 +87,35 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       }
     }
 
+    // Check if out of range
+    const isOutOfRange = (load.target_temperature_min !== null && temperature < load.target_temperature_min) ||
+                         (load.target_temperature_max !== null && temperature > load.target_temperature_max);
+
+    // Resolve the previous (pre-insert) frame BEFORE writing the current one,
+    // so the transition check compares the new reading against the true prior
+    // reading rather than the row we are about to insert. Otherwise the
+    // previous-frame lookup returns the just-inserted row and the alert never
+    // fires on the out-of-range transition.
+    let prevOutOfRange = false;
+    let prevErr = null;
+    if (isOutOfRange) {
+      logger.warn(`Cold chain violation on load ${loadId}: temp ${temperature}°C out of range [${load.target_temperature_min}, ${load.target_temperature_max}]`);
+
+      const { data: prevTelemetry, error: pErr } = await supabaseAdmin
+        .from('temperature_telemetry')
+        .select('temperature')
+        .eq('load_id', loadId)
+        .order('recorded_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      prevErr = pErr;
+
+      const prevTemp = prevTelemetry?.temperature;
+      prevOutOfRange = prevTemp !== undefined && prevTemp !== null &&
+        ((load.target_temperature_min !== null && prevTemp < load.target_temperature_min) ||
+         (load.target_temperature_max !== null && prevTemp > load.target_temperature_max));
+    }
+
     // Insert telemetry (service-role client: RLS only permits service_role to
     // write temperature_telemetry, so the backend must use supabaseAdmin).
     const { error: insertErr } = await supabaseAdmin
@@ -101,47 +130,23 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       return res.status(500).json({ error: 'Database error' });
     }
 
-    // Check if out of range
-    const isOutOfRange = (load.target_temperature_min !== null && temperature < load.target_temperature_min) ||
-                         (load.target_temperature_max !== null && temperature > load.target_temperature_max);
-
-    if (isOutOfRange) {
-      logger.warn(`Cold chain violation on load ${loadId}: temp ${temperature}°C out of range [${load.target_temperature_min}, ${load.target_temperature_max}]`);
-
-      // Deduplicate alerts per excursion: only notify on the out-of-range
-      // transition, i.e. when the previous frame was in range or there is no
-      // prior frame. Continuing out-of-range frames are skipped, so a single
-      // excursion produces one notification instead of one per frame. The
-      // alert state resets automatically once a reading returns to range.
-      const { data: prevTelemetry, error: prevErr } = await supabaseAdmin
-        .from('temperature_telemetry')
-        .select('temperature')
-        .eq('load_id', loadId)
-        .order('recorded_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (!prevErr) {
-        const prevTemp = prevTelemetry?.temperature;
-        const prevOutOfRange = prevTemp !== undefined && prevTemp !== null &&
-          ((load.target_temperature_min !== null && prevTemp < load.target_temperature_min) ||
-           (load.target_temperature_max !== null && prevTemp > load.target_temperature_max));
-
-        if (!prevOutOfRange) {
-          await supabaseAdmin.from('notifications').insert({
-            user_id: load.customer_id,
-            title: 'Temperature Alert',
-            body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
-            notif_type: 'system',
-            metadata: {
-              load_id: loadId,
-              temperature,
-              target_temperature_min: load.target_temperature_min,
-              target_temperature_max: load.target_temperature_max
-            }
-          }).catch(err => logger.error({ event: 'IOT_NOTIFICATION_ERROR', requestId: req.requestId || req.id, error: err && (err.message || String(err)) }, 'Failed to send temperature alert notification'));
+    // Notify only on the out-of-range transition: the previous frame was in
+    // range (or absent) and the new frame is out of range. Continuing
+    // out-of-range frames are skipped, so a single excursion produces one
+    // notification instead of one per frame.
+    if (isOutOfRange && !prevErr && !prevOutOfRange) {
+      await supabaseAdmin.from('notifications').insert({
+        user_id: load.customer_id,
+        title: 'Temperature Alert',
+        body: `Your cargo (Load ${loadId}) is out of the safe temperature range. Current temp: ${temperature}°C.`,
+        notif_type: 'system',
+        metadata: {
+          load_id: loadId,
+          temperature,
+          target_temperature_min: load.target_temperature_min,
+          target_temperature_max: load.target_temperature_max
         }
-      }
+      }).catch(err => logger.error({ event: 'IOT_NOTIFICATION_ERROR', requestId: req.requestId || req.id, error: err && (err.message || String(err)) }, 'Failed to send temperature alert notification'));
     }
 
     return res.status(201).json({ success: true, message: 'Telemetry recorded' });


### PR DESCRIPTION
﻿## Problem

In `POST /telemetry/:id` (cold-chain monitoring), the current temperature frame is **inserted before** the previous-frame lookup that decides whether to fire an alert. Because the lookup orders by `recorded_at DESC LIMIT 1`, it returns the just-inserted row, so "previous out of range" equals the current value and the transition check never triggers.

```js
// routes/iotRoutes.js (~lines 92-130)
const { error: insertErr } = await supabaseAdmin
  .from('temperature_telemetry').insert({ load_id: loadId, temperature });  // insert FIRST
...
const isOutOfRange = (temperature < min) || (temperature > max);
if (isOutOfRange) {
  const { data: prevTelemetry } = await supabaseAdmin
    .from('temperature_telemetry').select('temperature')
    .eq('load_id', loadId).order('recorded_at', { ascending: false }).limit(1).maybeSingle(); // returns the row we just inserted
  const prevOutOfRange = ...; // === isOutOfRange (true on a violation)
  if (!prevOutOfRange) { await supabaseAdmin.from('notifications').insert({ ... }); } // never reached on a violation
}
```

## Fix

Perform the previous-frame lookup *before* inserting the current frame (or exclude the current row via `recorded_at < now()` / a stable id), then compare. Add a test: insert an in-range then an out-of-range reading and assert exactly one alert is sent.

## Files changed

backend/api/src/routes/iotRoutes.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12546
