### PR TITLE
voice_assistant_sheet setState after await without mounted guard

### DIFF
--- a/apps/driver/lib/features/voice_ai/presentation/voice_assistant_sheet.dart
+++ b/apps/driver/lib/features/voice_ai/presentation/voice_assistant_sheet.dart
@@ -40,10 +40,12 @@ class _VoiceAssistantSheetState extends State<VoiceAssistantSheet> {
           const RecordConfig(encoder: AudioEncoder.aacLc),
           path: path,
         );
-        setState(() {
-          _isRecording = true;
-          _recordedFilePath = path;
-        });
+        if (mounted) {
+          setState(() {
+            _isRecording = true;
+            _recordedFilePath = path;
+          });
+        }
       }
     } catch (e) {
       debugPrint("Recording Error: $e");
@@ -53,17 +55,21 @@ class _VoiceAssistantSheetState extends State<VoiceAssistantSheet> {
   Future<void> _stopRecordingAndSend() async {
     try {
       final path = await _record.stop();
-      setState(() {
-        _isRecording = false;
-        _isLoading = true;
-      });
+      if (mounted) {
+        setState(() {
+          _isRecording = false;
+          _isLoading = true;
+        });
+      }
 
       if (path != null) {
         await _sendAudioToBackend(path);
       }
     } catch (e) {
       debugPrint("Stop Recording Error: $e");
-      setState(() => _isLoading = false);
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 
@@ -100,9 +106,11 @@ class _VoiceAssistantSheetState extends State<VoiceAssistantSheet> {
     } catch (e) {
       debugPrint("Network Error: $e");
     } finally {
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
﻿## Problem

`setState` was called after `await` (`_record.start`, `_record.stop`, network send) without a `mounted` guard in the dismissible BottomSheet. Dismissing the sheet while a recording/network await was pending fired `setState` on a disposed `State`.

## Fix

Guard every post-await `setState` with `if (mounted)` (including the `finally` block).

## Files changed

apps/driver/lib/features/voice_ai/presentation/voice_assistant_sheet.dart

## Testing

Run `flutter analyze` on `apps/driver`; verify dismissing the sheet during recording/playback no longer throws `setState() called after dispose`.

Closes #12422
