### PR TITLE
#40 IoT telemetry authorized by raw req.user.id === loadId equality with no device-to-load provisioning check

### DIFF
--- a/backend/api/src/routes/iotRoutes.js
+++ b/backend/api/src/routes/iotRoutes.js
@@ -68,7 +68,13 @@ router.post('/telemetry/:id', telemetryHistoryLimiter, authenticate, validatePar
       let isAuthorized = false;
 
       if (req.user.role === 'iot_device') {
-        isAuthorized = req.user.id === loadId;
+        const { data: binding, error: bindErr } = await supabaseAdmin
+          .from('device_load_bindings')
+          .select('load_id')
+          .eq('device_id', req.user.id)
+          .eq('load_id', loadId)
+          .maybeSingle();
+        isAuthorized = !bindErr && Boolean(binding);
       } else {
         isAuthorized = load.customer_id === req.user.id;
         if (!isAuthorized && load.order_display_id) {


### PR DESCRIPTION
﻿## Problem

`POST /telemetry/:id` authorizes an IoT device using a raw equality between the device's user id and the load id, with no lookup of which loads the device is actually provisioned for:

```js
// routes/iotRoutes.js (~lines 67-83)
if (req.user.role !== 'admin') {
  let isAuthorized = false;
  if (req.user.role === 'iot_device') {
    isAuthorized = req.user.id === loadId;   // device user id must equal the load UUID
  } else {
    isAuthorized = load.customer_id === req.user.id;   // customers/drivers: proper ownership
    ...
  }
  if (!isAuthorized) return res.status(403)...;
}
```

For customers/drivers the code does a real ownership check (`load.customer_id === req.user.id` / assigned driver). For `iot_device` it only checks `req.user.id === loadId`. There is no `device_load_bindings` (or similar) lookup, so the binding is purely "does my user id string-equal this load id."

## Fix

Look up the device's provisioned load(s) (e.g., `device_load_bindings` where `device_id = req.user.id`) and require `loadId` to be in that set; reject otherwise. Add a test asserting a device not bound to a load is 403'd.

## Files changed

backend/api/src/routes/iotRoutes.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12547
