### PR TITLE
lidar_scanner_screen setState after delay without mounted guard

### DIFF
--- a/apps/driver/lib/screens/lidar_scanner_screen.dart
+++ b/apps/driver/lib/screens/lidar_scanner_screen.dart
@@ -22,10 +22,14 @@ class _LidarScannerScreenState extends State<LidarScannerScreen> {
     });
     
     await Future.delayed(const Duration(seconds: 1));
-    setState(() => _scanProgressText = 'Mapping Point Cloud...');
-    
+    if (mounted) {
+      setState(() => _scanProgressText = 'Mapping Point Cloud...');
+    }
+
     await Future.delayed(const Duration(seconds: 1));
-    setState(() => _scanProgressText = 'Calculating Bounding Box...');
+    if (mounted) {
+      setState(() => _scanProgressText = 'Calculating Bounding Box...');
+    }
 
     final result = await _lidarService.perform3DScan();
     


### PR DESCRIPTION
﻿## Problem

Two `setState` calls followed `await Future.delayed(...)` with no `mounted` guard. The AppBar back button is active during the delays, so tapping back disposed the screen and the pending `setState` threw `setState() called after dispose`.

## Fix

Guard both post-delay `setState` calls with `if (mounted)`.

## Files changed

apps/driver/lib/screens/lidar_scanner_screen.dart

## Testing

Run `flutter analyze` on `apps/driver`; verify tapping back during the scan delays no longer throws.

Closes #12424
