### PR TITLE
#42 sanitizeTruckName is defined but never applied, allowing stored HTML/script in truck names

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -216,7 +216,7 @@ router.post('/', authenticate, requirePolicy('truck:register'), userLimiter, val
 
     const { data: truck, error: insertErr } = await supabase
       .from('trucks')
-      .insert({ name, truck_type, number_plate: normalizedNumberPlate, max_capacity_tons, driver_id: req.user.id })
+      .insert({ name: sanitizeTruckName(name), truck_type, number_plate: normalizedNumberPlate, max_capacity_tons, driver_id: req.user.id })
       .select('id, name, truck_type, number_plate, max_capacity_tons, created_at')
       .single();
 


### PR DESCRIPTION
﻿## Problem

`truckRoutes.js` defines and imports `sanitizeTruckName` (which strips `<>`, `script`, `javascript:`, `on*=`), but it is **never called**. The truck `name` is inserted verbatim while only `number_plate` is normalized:

```js
// routes/truckRoutes.js (~lines 108-115 definition; 197-221 register route)
const { name, truck_type, number_plate, max_capacity_tons } = req.body;
...
.insert({
  name,                                  // raw, unsanitized
  truck_type,
  number_plate: normalizedNumberPlate,   // sanitized
  ...
});
```

## Fix

Call `sanitizeTruckName(name)` before inserting/updating. Add a test asserting `<script>`-laden names are stripped on save.

## Files changed

backend/api/src/routes/truckRoutes.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12549
