### PR TITLE
profile_screen wallet save setState before mounted check

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -542,10 +542,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           'wallet_address': address,
                         },
                       );
+                      if (!context.mounted) return;
                       setState(() {
                         _walletAddress = address;
                       });
-                      if (!context.mounted) return;
                       Navigator.of(context).pop();
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(


### PR DESCRIPTION
﻿## Problem

In the wallet-address save handler `setState` ran after `await apiClient.put(...)` while the `if (!context.mounted) return;` guard came afterwards. Dismissing the sheet during the network call executed `setState` on a disposed widget.

## Fix

Move the `if (!context.mounted) return;` check before the `setState` so the widget is validated before any state update.

## Files changed

apps/driver/lib/screens/profile_screen.dart

## Testing

Run `flutter analyze` on `apps/driver`; verify dismissing the sheet during the wallet save no longer throws `setState() called after dispose`.

Closes #12425
