### PR TITLE
#43 cross_dock_transfers UPDATE RLS policy has no WITH CHECK, enabling privilege escalation on handoff rows

### DIFF
--- a/supabase/migrations/20260812000000_create_cross_dock_transfers.sql
+++ b/supabase/migrations/20260812000000_create_cross_dock_transfers.sql
@@ -102,4 +102,12 @@ CREATE POLICY cross_dock_update_policy ON public.cross_dock_transfers
       SELECT 1 FROM public.profiles p
       WHERE p.id = get_profile_id() AND p.role = 'admin'
     )
+  )
+  WITH CHECK (
+    get_profile_id() = from_driver_id
+    OR get_profile_id() = to_driver_id
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = get_profile_id() AND p.role = 'admin'
+    )
   );


### PR DESCRIPTION
﻿## Problem

`cross_dock_transfers` has an INSERT policy with a `WITH CHECK`, but its UPDATE policy has only a `USING` clause and **no `WITH CHECK`**, so any authenticated user who can see a row may `UPDATE` any column on it:

```sql
-- supabase/migrations/20260812000000_create_cross_dock_transfers.sql
CREATE POLICY cross_dock_update_policy ON public.cross_dock_transfers
  FOR UPDATE TO authenticated
  USING (
    get_profile_id() = from_driver_id
    OR get_profile_id() = to_driver_id
    OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = get_profile_id() AND p.role = 'admin')
  );
  -- no WITH CHECK clause
```

The paired INSERT policy pins ownership (`WITH CHECK (get_profile_id() = from_driver_id)`), so the omission is clearly an oversight.

## Fix

Add `WITH CHECK (get_profile_id() = from_driver_id OR get_profile_id() = to_driver_id)` to the UPDATE policy (and consider column-level restrictions). Add a test asserting a `to_driver_id` cannot flip `status` to `completed` or rewrite `otp_hash`.

## Files changed

supabase/migrations/20260812000000_create_cross_dock_transfers.sql

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12550
