### PR TITLE
offline_first_sync_service unguarded as casts crash queue load

### DIFF
--- a/apps/driver/lib/services/offline_first_sync_service.dart
+++ b/apps/driver/lib/services/offline_first_sync_service.dart
@@ -136,13 +136,13 @@ class OfflineFirstSyncService {
 
     final rows = await db.query('sync_events', orderBy: 'queued_at ASC');
     return rows.map((row) => OfflineSyncEvent(
-      eventId: row['event_id'] as String,
-      eventType: row['event_type'] as String,
-      payload: jsonDecode(row['payload'] as String) as Map<String, dynamic>,
-      queuedAt: DateTime.fromMillisecondsSinceEpoch(row['queued_at'] as int),
-      isSynced: (row['is_synced'] as int) == 1,
-      syncedAt: row['synced_at'] != null
-          ? DateTime.fromMillisecondsSinceEpoch(row['synced_at'] as int)
+      eventId: (row['event_id'] as String?) ?? '',
+      eventType: (row['event_type'] as String?) ?? '',
+      payload: jsonDecode((row['payload'] as String?) ?? '{}') as Map<String, dynamic>,
+      queuedAt: DateTime.fromMillisecondsSinceEpoch((row['queued_at'] as int?) ?? 0),
+      isSynced: (row['is_synced'] as int?) == 1,
+      syncedAt: (row['synced_at'] as int?) != null
+          ? DateTime.fromMillisecondsSinceEpoch((row['synced_at'] as int?) ?? 0)
           : null,
     )).toList();
   }


### PR DESCRIPTION
﻿## Problem

`_loadAllEvents` used non-nullable `as` casts on SQLite columns (`event_id`, `payload`, `queued_at`, `is_synced`, `synced_at`). A `NULL` column (partial write / schema drift / interrupted migration) threw `CastError` and aborted offline-sync queue processing for all events.

## Fix

Read the columns null-safely with fallbacks (`as String? ?? ''`, `as int? ?? 0`, etc.) so a single bad row does not abort the queue load.

## Files changed

apps/driver/lib/services/offline_first_sync_service.dart

## Testing

Run `flutter analyze` on `apps/driver`; unit-test `_loadAllEvents` with rows containing NULL columns.

Closes #12426
