### PR TITLE
#44 NeRF positional encoding missing the pi factor, degrading radiance-field reconstruction

### DIFF
--- a/backend/ml/nerf/model.py
+++ b/backend/ml/nerf/model.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -18,7 +19,7 @@ class PositionalEncoding(nn.Module):
         # x: (..., 3) for positions or (..., 2) for directions
         encoding = [x]
         for i in range(self.num_frequencies):
-            freq = 2 ** i
+            freq = (2 ** i) * math.pi
             encoding.append(torch.sin(freq * x))
             encoding.append(torch.cos(freq * x))
         return torch.cat(encoding, dim=-1)


### PR DESCRIPTION
﻿## Problem

NeRF positional encoding in `backend/ml/nerf/model.py` is missing the standard `π` factor. Standard NeRF (Mildenhall et al.) uses frequencies `2^i · π · x`, but here:

```python
# backend/ml/nerf/model.py (~lines 20-23)
for i in range(self.num_frequencies):
    freq = 2 ** i                      # should be (2 ** i) * math.pi
    encoding.append(torch.sin(freq * x))
    encoding.append(torch.cos(freq * x))
```

## Fix

```python
import math
...
freq = (2 ** i) * math.pi
encoding.append(torch.sin(freq * x))
encoding.append(torch.cos(freq * x))
```
Add a test asserting the generated frequencies equal `2^i·π` and that reconstruction error improves on a held-out view.

## Files changed

backend/ml/nerf/model.py

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12551
