### PR TITLE
#45 T-GCN speed forecast crashes on default config (GCN weights length 3 vs num_nodes=5 broadcast mismatch)

### DIFF
--- a/backend/ml/gnn/tgcn_speed.py
+++ b/backend/ml/gnn/tgcn_speed.py
@@ -7,7 +7,8 @@ class TemporalGcnSpeedPredictor:
     def __init__(self, num_nodes: int = 5):
         self.num_nodes = num_nodes
         # Simulated GCN spatial weights & GRU hidden state weights
-        self.gcn_weights = np.array([0.4, 0.35, 0.25])
+        base = [0.4, 0.35, 0.25]
+        self.gcn_weights = np.array((base + [0.3] * (self.num_nodes - len(base)))[:self.num_nodes], dtype=float)
         self.gru_weights = 0.85
 
     def predict_speed_forecast(self, time_series_node_speeds: np.ndarray) -> dict:


### PR DESCRIPTION
﻿## Problem

`TGCN` speed forecasting crashes on its default configuration due to a shape mismatch between the GCN weight vector and the number of nodes:

```python
# backend/ml/gnn/tgcn_speed.py (~lines 10, 17-18)
self.num_nodes = 5                      # default
self.gcn_weights = np.array([0.4, 0.35, 0.25])   # length 3
...
recent_speeds = np.mean(time_series_node_speeds, axis=1)   # length = num_nodes (5)
spatial_convolved = recent_speeds * self.gcn_weights[:len(recent_speeds)]   # (5,) * (3,) -> broadcast error
```

`gcn_weights[:5]` is still length 3, so multiplying a `(5,)` array by a `(3,)` array raises `ValueError: operands could not be broadcast together`.

## Fix

Size `gcn_weights` from `num_nodes`, e.g. `self.gcn_weights = np.array([...])[:self.num_nodes]` padded to length `self.num_nodes`, or build a `(num_nodes,)` weight vector in `__init__`. Add a test with `num_nodes=5` asserting no broadcast error and a valid output shape.

## Files changed

backend/ml/gnn/tgcn_speed.py

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12552
