### PR TITLE
config/compression.js non-numeric env yields NaN threshold/level

### DIFF
--- a/backend/api/src/config/compression.js
+++ b/backend/api/src/config/compression.js
@@ -18,16 +18,20 @@ import compression from 'compression';
  * CPU cost is not repaid, and very small payloads can grow once the gzip
  * header and trailer are added.
  */
-export const COMPRESSION_THRESHOLD_BYTES = Number(
-  process.env.COMPRESSION_THRESHOLD_BYTES || 1024
-);
+const parsedCompressionThreshold = Number(process.env.COMPRESSION_THRESHOLD_BYTES);
+export const COMPRESSION_THRESHOLD_BYTES = Number.isFinite(parsedCompressionThreshold)
+  ? parsedCompressionThreshold
+  : 1024;
 
 /**
  * zlib level, 1 (fastest) to 9 (smallest). 6 is zlib's default and sits at
  * the knee of the curve: levels above it cost noticeably more CPU for very
  * little additional saving on JSON.
  */
-export const COMPRESSION_LEVEL = Number(process.env.COMPRESSION_LEVEL || 6);
+const parsedCompressionLevel = Number(process.env.COMPRESSION_LEVEL);
+export const COMPRESSION_LEVEL = Number.isFinite(parsedCompressionLevel)
+  ? parsedCompressionLevel
+  : 6;
 
 /**
  * Content types that are already compressed. Re-compressing them burns CPU


### PR DESCRIPTION
﻿## Problem

`COMPRESSION_THRESHOLD_BYTES` and `COMPRESSION_LEVEL` were `Number(process.env.X || default)`. A non-numeric non-empty value yields `NaN` and the `|| default` does not apply, degrading the data-cost guarantee for drivers on metered 3G/4G.

## Fix

Validate the parse with `Number.isFinite` and fall back to the safe default (`1024` / `6`) on any non-finite value.

## Files changed

backend/api/src/config/compression.js

## Testing

Run `npm test`; confirm `COMPRESSION_THRESHOLD_BYTES`/`COMPRESSION_LEVEL` fall back to defaults for non-numeric env values.

Closes #12428
