### PR TITLE
Cross-site scripting in fleet_manager renderDrivers (apps/fleet_manager/main.js)

### DIFF
--- a/apps/fleet_manager/main.js
+++ b/apps/fleet_manager/main.js
@@ -1,5 +1,9 @@
 import './style.css';
 
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const inviteBtn = document.getElementById('inviteDriverBtn');
     const modal = document.getElementById('inviteModal');
@@ -33,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const li = document.createElement('li');
         li.innerHTML = `
             <div class="driver-info">
-                <strong>${email.split('@')[0]}</strong>
+                <strong>${escapeHtml(email.split('@')[0])}</strong>
                 <span>Invite Pending</span>
             </div>
             <div class="status resting" style="background: rgba(59, 130, 246, 0.2); color: var(--primary);">Pending</div>


### PR DESCRIPTION
﻿## Problem

`renderDrivers` builds driver card HTML with template literals and assigns it directly to `container.innerHTML`. The `email` field comes from the API response and is interpolated without any sanitization/escaping.

File: `apps/fleet_manager/main.js` (lines ~26–46)

## Fix

- Escape `email` (and any other interpolated field) before interpolation, e.g. a small `escapeHtml()` helper, or
- Build elements with `document.createElement` + `el.textContent = driver.email` instead of `innerHTML` string concatenation.
- Add a regression test that injects a payload and asserts no script executes.

## Files changed

apps/fleet_manager/main.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12553
