### PR TITLE
index.js TRUST_PROXY misparse can set NaN trust proxy

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -332,7 +332,18 @@ app.use(headerSizeMonitor);
 //   - Production (behind Nginx/ALB/Cloudflare) → 1 (default)
 //   - Docker Compose (no proxy)                 → 0
 //   - Multiple proxy hops (e.g. Cloudflare→Nginx) → 2
-const trustProxy = process.env.TRUST_PROXY !== undefined ? Number(process.env.TRUST_PROXY) : 1
+let trustProxy = 1;
+if (process.env.TRUST_PROXY !== undefined) {
+  const rawTrustProxy = String(process.env.TRUST_PROXY).trim().toLowerCase();
+  if (rawTrustProxy === 'true') {
+    trustProxy = true;
+  } else if (rawTrustProxy === 'false') {
+    trustProxy = false;
+  } else {
+    const parsedTrustProxy = Number(process.env.TRUST_PROXY);
+    trustProxy = Number.isFinite(parsedTrustProxy) ? parsedTrustProxy : 1;
+  }
+}
 app.set('trust proxy', trustProxy)
 
 // ============================================================================


### PR DESCRIPTION
﻿## Problem

`TRUST_PROXY` was `Number(process.env.TRUST_PROXY)`. `Number('false')`/`Number('true')`/`Number('abc')` are `NaN`, and `app.set('trust proxy', NaN)` is an invalid Express setting, misconfiguring `req.ip`, `req.secure` and rate-limiter/client-key derivation behind a proxy.

## Fix

Parse with a guard accepting only valid proxy values (`true`/`false`/number), falling back to `1` on any invalid input.

## Files changed

backend/api/src/index.js

## Testing

Run `npm test`; verify `TRUST_PROXY=false`/`true`/typo resolve to the correct Express trust-proxy setting.

Closes #12429
