### PR TITLE
sync_engine unguarded as String on queue id aborts batch sync

### DIFF
--- a/apps/driver/lib/services/sync_engine.dart
+++ b/apps/driver/lib/services/sync_engine.dart
@@ -95,7 +95,11 @@ class SyncEngine {
       if (user == null) return;
       final token = await user.getIdToken();
 
-      final eventIds = events.map((e) => e['id'] as String).toList()..sort();
+      final eventIds = events
+          .map((e) => (e['id'] as String?) ?? '')
+          .where((id) => id.isNotEmpty)
+          .toList()
+        ..sort();
       final idempotencyKey = eventIds.join(',');
 
       final requestBody = {


### PR DESCRIPTION
﻿## Problem

`e['id'] as String` was a non-nullable cast on a local SQLite queue row. A `null` `id` threw `CastError` and aborted the whole batch sync before it was sent.

## Fix

Read the id null-safely (`as String? ?? ''`) and skip rows without a valid id before building the idempotency key.

## Files changed

apps/driver/lib/services/sync_engine.dart

## Testing

Run `flutter analyze` on `apps/driver`; unit-test the batch-sync id list with a row whose `id` is `null`.

Closes #12430
