### PR TITLE
fix(blockchain): guard against re-entrant block scanning

### DIFF
--- a/backend/api/src/services/blockchain/blockchainMonitor.js
+++ b/backend/api/src/services/blockchain/blockchainMonitor.js
@@ -30,6 +30,7 @@ class BlockchainMonitor {
     this.provider = null;
     this.contract = null;
     this.isListening = false;
+    this.isScanning = false;
     this.lastBlockScanned = 0;
     this.eventHandlers = {};
   }
@@ -98,9 +99,15 @@ class BlockchainMonitor {
     const pollInterval = parseInt(process.env.BLOCKCHAIN_POLL_INTERVAL_MS || '12000', 10);
 
     setInterval(async () => {
+      if (this.isScanning) {
+        logger.warn('[BlockchainMonitor] Previous block scan still in progress. Skipping interval tick to avoid duplicate event processing.');
+        return;
+      }
+
       try {
         if (!this.isListening || !this.provider) return;
 
+        this.isScanning = true;
         const currentBlock = await this.provider.getBlockNumber();
         if (currentBlock > this.lastBlockScanned) {
           await this.scanBlockRange(this.lastBlockScanned + 1, currentBlock);
@@ -109,6 +116,8 @@ class BlockchainMonitor {
       } catch (err) {
         logger.error('[BlockchainMonitor] Polling error:', err.message);
         Sentry.captureException(err);
+      } finally {
+        this.isScanning = false;
       }
     }, pollInterval);
   }

--- a/backend/api/test/unit/services/blockchain/blockchainMonitor.test.js
+++ b/backend/api/test/unit/services/blockchain/blockchainMonitor.test.js
@@ -150,7 +150,7 @@ describe('BlockchainMonitor', () => {
     vi.unstubAllGlobals();
   });
 
-  it('clears isScanning in a finally block even when the scan throws', async () => {
+  it('clears isScanning in a finally block when getBlockNumber fails', async () => {
     const { monitor } = buildMonitor();
     let capturedCallback;
     vi.stubGlobal('setInterval', (cb) => {
@@ -167,6 +167,30 @@ describe('BlockchainMonitor', () => {
     await capturedCallback();
 
     expect(monitor.isScanning).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('clears isScanning in a finally block when scanBlockRange rejects', async () => {
+    const { monitor } = buildMonitor();
+    let capturedCallback;
+    vi.stubGlobal('setInterval', (cb) => {
+      capturedCallback = cb;
+      return 1;
+    });
+
+    monitor.isListening = true;
+    monitor.lastBlockScanned = 0;
+    monitor.provider = {
+      getBlockNumber: vi.fn().mockResolvedValue(5),
+    };
+    monitor.scanBlockRange = vi.fn().mockRejectedValue(new Error('range scan failed'));
+    monitor.startPollingBlocks();
+
+    await capturedCallback();
+
+    expect(monitor.isScanning).toBe(false);
+    expect(monitor.scanBlockRange).toHaveBeenCalledWith(1, 5);
 
     vi.unstubAllGlobals();
   });

--- a/backend/api/test/unit/services/blockchain/blockchainMonitor.test.js
+++ b/backend/api/test/unit/services/blockchain/blockchainMonitor.test.js
@@ -117,4 +117,57 @@ describe('BlockchainMonitor', () => {
     await monitor.stopListening();
     expect(monitor.isListening).toBe(false);
   });
+
+  it('skips interval ticks while a scan is already in progress (re-entrancy guard)', async () => {
+    const { monitor, metricsService } = buildMonitor();
+    let capturedCallback;
+    vi.stubGlobal('setInterval', (cb) => {
+      capturedCallback = cb;
+      return 1;
+    });
+
+    let resolveBlockNumber;
+    monitor.isListening = true;
+    monitor.lastBlockScanned = 0;
+    monitor.provider = {
+      getBlockNumber: vi.fn(() => new Promise((resolve) => { resolveBlockNumber = resolve; })),
+      getLogs: vi.fn().mockResolvedValue([]),
+    };
+    monitor.startPollingBlocks();
+
+    const firstTick = capturedCallback();
+    expect(monitor.isScanning).toBe(true);
+
+    await capturedCallback();
+    expect(monitor.provider.getBlockNumber).toHaveBeenCalledTimes(1);
+
+    resolveBlockNumber(5);
+    await firstTick;
+
+    expect(monitor.isScanning).toBe(false);
+    expect(metricsService.recordBlockScan).toHaveBeenCalledWith(5);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('clears isScanning in a finally block even when the scan throws', async () => {
+    const { monitor } = buildMonitor();
+    let capturedCallback;
+    vi.stubGlobal('setInterval', (cb) => {
+      capturedCallback = cb;
+      return 1;
+    });
+
+    monitor.isListening = true;
+    monitor.provider = {
+      getBlockNumber: vi.fn().mockRejectedValue(new Error('rpc down')),
+    };
+    monitor.startPollingBlocks();
+
+    await capturedCallback();
+
+    expect(monitor.isScanning).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
 });


### PR DESCRIPTION
## Description

Closes #12601

\startPollingBlocks()\ uses a bare \setInterval\ with an async callback to poll blocks every 12s. There was no re-entrancy guard: if \scanBlockRange()\ took longer than the poll interval (e.g., RPC latency spike, large block range), the next interval fired while the previous scan was still running. Both invocations read the same \	his.lastBlockScanned\, scanned the same block range, and processed the same logs — triggering duplicate \PaymentReceived\, \InsuranceClaimApproved\, and \GeofenceBreach\ event handlers. This could cause double wallet credits, duplicate insurance payouts, and false geofence alerts.

## Fix

- Added an \isScanning\ boolean guard (initialized to \alse\ in the constructor).
- Set it to \	rue\ before \scanBlockRange\ runs and reset it to \alse\ in a \inally\ block so it is always cleared, even on error.
- The interval tick now skips (with a warning log) if \isScanning\ is already \	rue\.

## Testing

- Added unit tests verifying:
  - a concurrent interval tick is skipped while a scan is in flight (\getBlockNumber\ called only once);
  - \isScanning\ is cleared in the \inally\ block even when the scan throws.
- \
px vitest run test/unit/services/blockchain test/unit/blockchainMonitorGuard.test.js\ — 42/42 passing.
- \
px eslint\ on the modified files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved blockchain monitoring to prevent overlapping scans during polling.
  - Ensured monitoring resumes correctly after successful or failed scans.

- **Tests**
  - Added coverage for overlapping polling intervals.
  - Added validation that scan status is reset after both successful and failed scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->