### PR TITLE
ZK proof G2 point Fp2 coordinate order not swapped for Solidity verifier (blockchain/scripts/generate-zk-proof.cjs)

### DIFF
--- a/blockchain/scripts/generate-zk-proof.cjs
+++ b/blockchain/scripts/generate-zk-proof.cjs
@@ -93,8 +93,8 @@ class ZKProofGenerator {
         return {
             a: [proof.pi_a[0], proof.pi_a[1]],
             b: [
-                [proof.pi_b[0][0], proof.pi_b[0][1]],
-                [proof.pi_b[1][0], proof.pi_b[1][1]]
+                [proof.pi_b[0][1], proof.pi_b[0][0]],
+                [proof.pi_b[1][1], proof.pi_b[1][0]]
             ],
             c: [proof.pi_c[0], proof.pi_c[1]],
             input: proof.publicSignals.slice(0, 2)


### PR DESCRIPTION
﻿## Problem

The script assembles the Groth16 proof `b` (a G2 point) and posts it to the on-chain verifier. snarkjs represents G2 points with Fp2 coordinates in `[c0, c1]` order, while the Solidity `Verifier.verifyProof` expects the Fp2 coordinates **swapped** (`[c1, c0]`).

File: `blockchain/scripts/generate-zk-proof.cjs` (lines ~91–102)

## Fix

- Swap the Fp2 coordinate order for the G2 `b` point before submission.
- Add a test/check that a known-good proof verifies on-chain (or against the verifier's expected encoding) after the fix.

## Files changed

blockchain/scripts/generate-zk-proof.cjs

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12557
