### PR TITLE
security.rego denies valid 2Gi memory limit and allows limits above 2Gi (k8s/opa/policies/security.rego)

### DIFF
--- a/k8s/opa/policies/security.rego
+++ b/k8s/opa/policies/security.rego
@@ -35,11 +35,38 @@ deny[msg] {
     msg = "Resource limits must be specified."
 }
 
-# Deny if memory limit > 2GB
+# Deny if memory limit > 2Gi
 deny[msg] {
     container := input.review.object.spec.containers[_]
-    container.resources.limits.memory == "2Gi"
-    msg = "Memory limit exceeded. Max allowed: 2Gi"
+    mem := container.resources.limits.memory
+    bytes := parse_memory(mem)
+    bytes > 2147483648
+    msg = sprintf("Memory limit %v exceeds max allowed 2Gi", [mem])
+}
+
+parse_memory(qty) = bytes {
+    endswith(qty, "Gi")
+    num := to_number(replace(qty, "Gi", ""))
+    bytes := num * 1073741824
+}
+
+parse_memory(qty) = bytes {
+    endswith(qty, "Mi")
+    num := to_number(replace(qty, "Mi", ""))
+    bytes := num * 1048576
+}
+
+parse_memory(qty) = bytes {
+    endswith(qty, "Ki")
+    num := to_number(replace(qty, "Ki", ""))
+    bytes := num * 1024
+}
+
+parse_memory(qty) = bytes {
+    not endswith(qty, "Gi")
+    not endswith(qty, "Mi")
+    not endswith(qty, "Ki")
+    bytes := to_number(qty)
 }
 
 # Allow if all checks pass


### PR DESCRIPTION
﻿## Problem

The memory-limit admission rule is meant to reject containers whose memory limit exceeds 2Gi, but the comparison is wrong.

File: `k8s/opa/policies/security.rego` (lines 39–43)

## Fix

- Parse `container.resources.limits.memory` into bytes and deny when `> 2Gi` (use a helper or Rego quantity parsing).
- Add rego unit tests covering `2Gi` (allow), `1Gi` (allow), `4Gi` (deny).

## Files changed

k8s/opa/policies/security.rego

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12558
