### PR TITLE
weight_distribution_service firstWhere without orElse throws

### DIFF
--- a/apps/driver/lib/services/weight_distribution_service.dart
+++ b/apps/driver/lib/services/weight_distribution_service.dart
@@ -21,7 +21,16 @@ class WeightDistributionService {
   }
 
   void updatePalletPosition(String id, double newX) {
-    final pallet = _pallets.firstWhere((p) => p.id == id);
+    final pallet = _pallets.firstWhere(
+      (p) => p.id == id,
+      orElse: () => Pallet(id: id, weightLbs: 0, positionX: 0),
+    );
+    // firstWhere returns a transient dummy when the id is unknown (stale /
+    // out-of-sync UI); only mutate and recompute when it is a real pallet.
+    if (!_pallets.contains(pallet)) {
+      debugPrint('updatePalletPosition: unknown pallet id "$id" — ignoring');
+      return;
+    }
     pallet.positionX = newX.clamp(0.0, 1.0);
     _calculatePhysics();
   }


### PR DESCRIPTION
﻿## Problem

`updatePalletPosition` used `_pallets.firstWhere((p) => p.id == id)` with no `orElse`. A stale/out-of-sync UI id threw `StateError`, crashing the weight-distribution simulation update.

## Fix

Use `firstWhere` with `orElse` and skip the update (with a debug log) when the id is not present in `_pallets`.

## Files changed

apps/driver/lib/services/weight_distribution_service.dart

## Testing

Run `flutter analyze` on `apps/driver`; verify calling `updatePalletPosition` with an unknown id no longer throws.

Closes #12434
