### PR TITLE
profileCache REDIS_CACHE_TTL non-numeric yields NaN TTL

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -32,7 +32,10 @@ async function _publishProfileInvalidation(eventOpts) {
   }
 }
 
-export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || "120", 10); // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
+const parsedTtlSeconds = parseInt(process.env.REDIS_CACHE_TTL, 10);
+export const TTL_SECONDS = Number.isFinite(parsedTtlSeconds) && parsedTtlSeconds > 0
+  ? parsedTtlSeconds
+  : 120; // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 
 let cacheHits = 0;


### PR DESCRIPTION
﻿## Problem

`TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || "120", 10)`. A non-numeric non-empty value yields `NaN`, used directly as the Redis `EX` TTL, defeating the 2-minute propagation window for role/status changes (suspension, demotion).

## Fix

Validate with `Number.isFinite` and fall back to `120` when the parsed value is not a positive finite number.

## Files changed

backend/api/src/lib/profileCache.js

## Testing

Run `npm test`; confirm `TTL_SECONDS` falls back to `120` for non-numeric/`abc` values.

Closes #12435
