### PR TITLE
getReplicationLag always returns empty — last_sync key never written (k8s/multi-region/region-service.js)

### DIFF
--- a/k8s/multi-region/region-service.js
+++ b/k8s/multi-region/region-service.js
@@ -216,6 +216,7 @@ class RegionService {
     async replicateToRegion(region, data) {
         try {
             await axios.post(`${region.endpoint}/api/replication/receive`, data);
+            await this.redis.set(`replication:${region.name}:last_sync`, Date.now());
         } catch (error) {
             logger.error(`Failed to replicate to ${region.name}:`, error);
         }


### PR DESCRIPTION
﻿## Problem

`getReplicationLag` reports per-region replication lag by reading a Redis key `replication:${region.name}:last_sync`, but nothing in the service ever writes that key.

File: `k8s/multi-region/region-service.js` (lines 269–280, and the replication path ~186–222)

## Fix

- In `replicateToRegion`, on success do `await this.redis.set(\`replication:${region.name}:last_sync\`, Date.now())`.
- Add a test that replicates then asserts `getReplicationLag` returns a non-empty, sensible value.

## Files changed

k8s/multi-region/region-service.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12561
