### PR TITLE
Vitess sharding is dead — executeRead/executeWrite ignore shardKey, all CRUD hits default keyspace (k8s/vitess/vitess.service.js)

### DIFF
--- a/k8s/vitess/vitess.service.js
+++ b/k8s/vitess/vitess.service.js
@@ -83,9 +83,12 @@ class VitessService {
         }
     }
 
-    async executeRead(query, params = []) {
+    async executeRead(query, params = [], shardKey = null) {
         try {
-            const [rows] = await this.readPool.execute(query, params);
+            const connection = shardKey
+                ? await this.getShardConnection(this.getShard(shardKey))
+                : this.readPool;
+            const [rows] = await connection.execute(query, params);
             return rows;
         } catch (error) {
             logger.error('Read query failed:', error);
@@ -93,9 +96,12 @@ class VitessService {
         }
     }
 
-    async executeWrite(query, params = []) {
+    async executeWrite(query, params = [], shardKey = null) {
         try {
-            const [rows] = await this.writePool.execute(query, params);
+            const connection = shardKey
+                ? await this.getShardConnection(this.getShard(shardKey))
+                : this.writePool;
+            const [rows] = await connection.execute(query, params);
             return rows;
         } catch (error) {
             logger.error('Write query failed:', error);


### PR DESCRIPTION
﻿## Problem

The service builds per-shard connection pools and exposes `getShard(key)` / `getShardConnection(shard)`, but the CRUD methods pass a `shardKey` to `executeRead`/`executeWrite` which **ignore that third argument** and always use the default `readPool`/`writePool` (keyspace `truxify_main`).

File: `k8s/vitess/vitess.service.js`
- `executeRead(query, params=[])` / `executeWrite(query, params=[])` — signatures drop `shardKey` (lines ~86, 96).
- Callers pass it anyway: `insertOrder(..., shardKey)` → `executeWrite(query, params, shardKey)` (line 152), `getOrder`/`getOrdersByCustomer`/`getDriver`/`updateOrderStatus` similarly (lines 158, 165, 171, 189, 195, 202, 221).

## Fix

- Change signatures to `executeRead(query, params, shardKey=null)` / `executeWrite(query, params, shardKey=null)` and select the connection via `shardKey ? await this.getShardConnection(this.getShard(shardKey)) : this.readPool/this.writePool`.
- Add tests asserting a row written with `shardKey="X"` lands on shard `getShard("X")` (e.g. via a mock/inspectable pool).

## Files changed

k8s/vitess/vitess.service.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12563
