### PR TITLE
fix(api): resolve pre-existing ESLint errors across backend

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -151,6 +151,14 @@ export async function authenticate(req, res, next) {
 
   // Support local development bypass mode
   if (bypassAuth) {
+    // Default development identity used by the DEV_ACCESS_TOKEN bypass path.
+    // Overridable via env so local dev can impersonate a specific user.
+    const devIdentity = {
+      id: process.env.DEV_USER_ID || "00000000-0000-0000-0000-000000000000",
+      role: process.env.DEV_USER_ROLE || "admin",
+      name: process.env.DEV_USER_NAME || "Dev User",
+    };
+
     if (process.env.NODE_ENV === "production") {
       return res.status(503).json({
         error:

--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -281,6 +281,7 @@ let telemetryFlushTimeout = null;
 let wsServer = null;
 let wsHeartbeatInterval = null;
 let telemetryMonitorInterval = null;
+let wsUpgradeLimitsCleanupInterval = null;
 const HEARTBEAT_INTERVAL_MS = parseInt(process.env.WS_HEARTBEAT_INTERVAL_MS, 10) || 180000; // 3 minutes
 
 // Observability counters


### PR DESCRIPTION
﻿## Problem

Pre-existing ESLint errors blocked all PRs. `wsUpgradeLimitsCleanupInterval` was assigned without a declaration (no-undef) and `devIdentity` was used in the auth dev-bypass path without being defined (ReferenceError).

## Fix

Declare `wsUpgradeLimitsCleanupInterval` at module scope alongside its sibling interval handles; define `devIdentity` before the `DEV_ACCESS_TOKEN` bypass path uses it. (The vitest globals declaration in `eslint.config.js` and the logger / `attachResponseCleanup` imports referenced by the issue are already present on `main`.)

## Files changed

backend/api/src/sockets/tracker.js, backend/api/src/middleware/auth.js

## Testing

Run `npm run lint` (eslint . --max-warnings=0) -- the referenced no-undef errors are resolved.

Closes #12438
