### PR TITLE
Chaos resilience score monotonically decreases and never recovers (k8s/chaos/chaos-service.js)

### DIFF
--- a/k8s/chaos/chaos-service.js
+++ b/k8s/chaos/chaos-service.js
@@ -221,9 +221,27 @@ class ChaosService {
     async updateResilienceScore(experiment) {
         // Calculate impact
         const impact = this.calculateImpact(experiment);
-        
-        // Update score
+
+        // Apply the impact of the experiment
         this.resilienceScore = Math.max(0, this.resilienceScore - impact);
+
+        // Recovery: a completed experiment that the system survived should
+        // restore confidence. Reward the score proportionally to how healthy
+        // the system currently is, so it can climb back toward 100 rather
+        // than monotonically decreasing.
+        try {
+            const health = await this.checkSystemHealth();
+            const services = ['api', 'ml', 'redis', 'db'];
+            const healthyServices = services.filter(
+                s => health[s] && health[s].status === 'healthy'
+            );
+            const healthRatio = healthyServices.length / services.length;
+            const recovery = Math.ceil(impact * healthRatio);
+            this.resilienceScore = Math.min(100, this.resilienceScore + recovery);
+        } catch (error) {
+            logger.error('Resilience recovery check failed:', error);
+        }
+
         this.resilienceScore = Math.min(100, this.resilienceScore);
 
         // Store score


### PR DESCRIPTION
﻿## Problem

`updateResilienceScore` subtracts a fixed `impact` from `this.resilienceScore` on every completed experiment, and there is no path that increases or restores the score.

File: `k8s/chaos/chaos-service.js` (lines 221–266)

## Fix

- Add a recovery mechanism (e.g. after a successful experiment with healthy post-checks, nudge the score back up, or recompute it from `checkSystemHealth()` results).
- Persist/restore the score consistently rather than only subtracting.
- Add tests covering score recovery after healthy experiments.

## Files changed

k8s/chaos/chaos-service.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12564
