### PR TITLE
bug: fix profileCache REDIS_CACHE_TTL NaN fallback

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -32,7 +32,10 @@ async function _publishProfileInvalidation(eventOpts) {
   }
 }
 
-export const TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL || "120", 10); // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
+const parsedTtlSeconds = parseInt(process.env.REDIS_CACHE_TTL, 10);
+export const TTL_SECONDS = Number.isFinite(parsedTtlSeconds) && parsedTtlSeconds > 0
+  ? parsedTtlSeconds
+  : 120; // 2 minutes default so role/status changes (suspension, demotion) propagate quickly
 export const TOMBSTONE_TTL_SECONDS = 30; // 30 seconds
 
 let cacheHits = 0;


### PR DESCRIPTION
﻿## Problem

`REDIS_CACHE_TTL` is parsed with `parseInt` at module initialisation. When set to a non-numeric string (empty or misconfigured), `parseInt` returns `NaN`, exported as `TTL_SECONDS` and used as the Redis SET TTL, caching profiles forever instead of the intended short TTL.

## Fix

Guard the `TTL_SECONDS` export with a `Number.isFinite` check, falling back to `120` when the parsed value is not a positive finite number.

## Files changed

backend/api/src/lib/profileCache.js

## Testing

Run `npm test`; confirm `TTL_SECONDS` falls back to `120` for non-numeric/`abc` values.

Closes #12439
