### PR TITLE
network.rego skips network-policy check for non-template resources (bare Pods) (k8s/opa/policies/network.rego)

### DIFF
--- a/k8s/opa/policies/network.rego
+++ b/k8s/opa/policies/network.rego
@@ -13,9 +13,25 @@ deny[msg] {
     msg = "Host network is not allowed."
 }
 
-# Deny if no network policy
+# Deny if no network policy (controllers: spec.template.metadata.annotations)
 deny[msg] {
-    not input.review.object.spec.template.metadata.annotations."networking.kubernetes.io/network-policy"
+    pod_spec := object.get(input.review.object, "spec", {})
+    tmpl := object.get(pod_spec, "template", {})
+    count(tmpl) > 0
+    tmpl_meta := object.get(tmpl, "metadata", {})
+    annotations := object.get(tmpl_meta, "annotations", {})
+    not annotations["networking.kubernetes.io/network-policy"]
+    msg = "Network policy must be specified."
+}
+
+# Deny if no network policy (bare Pods: metadata.annotations)
+deny[msg] {
+    pod_spec := object.get(input.review.object, "spec", {})
+    tmpl := object.get(pod_spec, "template", {})
+    count(tmpl) == 0
+    obj_meta := object.get(input.review.object, "metadata", {})
+    annotations := object.get(obj_meta, "annotations", {})
+    not annotations["networking.kubernetes.io/network-policy"]
     msg = "Network policy must be specified."
 }
 


### PR DESCRIPTION
﻿## Problem

The network-policy admission rule only inspects `spec.template.metadata.annotations`, so it applies to Deployments/StatefulSets/DaemonSets but not to bare Pods.

File: `k8s/opa/policies/network.rego` (lines 17–20)

## Fix

- Normalize the pod spec: for controllers use `input.review.object.spec.template`, for Pods use `input.review.object` (or `input.review.object.spec`), and check the annotation on that object.
- Add rego tests for a bare Pod with no network-policy annotation (expect deny) and one with it (expect allow).

## Files changed

k8s/opa/policies/network.rego

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12565
