### PR TITLE
Withdrawal payout dispatch timeout treated as failure can double-pay driver

### DIFF
--- a/backend/api/src/workers/withdrawalSettlementWorker.js
+++ b/backend/api/src/workers/withdrawalSettlementWorker.js
@@ -15,6 +15,23 @@ let intervalId = null;
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * Classifies a dispatchPayout failure as "ambiguous": the payout may already
+ * have been committed at the gateway before the request timed out/errored, so
+ * it is unsafe to assume nothing left the platform. These errors must NOT lead
+ * to restoring reserved funds (which would double-pay the driver).
+ */
+function isAmbiguousDispatchError(err) {
+  const msg = String((err && err.message) || "").toLowerCase();
+  return (
+    /timeout|timed out|etimedout|econnreset|econnrefused|enotfound|network|socket|eai_again/.test(
+      msg,
+    ) ||
+    /[^0-9]5\d\d\b/.test(msg) ||
+    /unknown error/.test(msg)
+  );
+}
+
+/**
  * Atomically claims a pending withdrawal for this worker BEFORE the payout is
  * dispatched. The update is conditioned on payout_attempted_at IS NULL, so at
  * most one concurrent sweep can win the claim; losers skip the row entirely.
@@ -166,6 +183,17 @@ export async function settlePendingWithdrawals() {
         //    in between is detected and settled (not failed) on the next sweep.
         await recordDispatchOutcome(withdrawal.id, settlementRef);
       } catch (err) {
+        if (isAmbiguousDispatchError(err)) {
+          // The payout may already have been committed at the gateway before
+          // the request errored (timeout/network/5xx/unknown). Restoring the
+          // reserved funds here would double-pay the driver, so leave the
+          // withdrawal pending for manual reconciliation / the next sweep.
+          logger.error(
+            `[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} dispatch returned ambiguous error — leaving pending for reconciliation: ${err.message}`,
+          );
+          continue;
+        }
+
         // The payout never left the platform — safe to restore the reserved
         // funds to wallet_confirmed.
         logger.error(


### PR DESCRIPTION
﻿## Problem

## Summary
In `settlePendingWithdrawals`, any failure thrown by `dispatchPayout` is treated identically as a hard failure and the reserved funds are restored to `wallet_confirmed` via `fail_withdrawal_tx`. But a dispatch failure can be ambiguous — the payout may have already been committed at the gateway before the request timed out/errored.

## Location
`backend/api/src/workers/withdrawalSettlementWorker.js`
- Dispatch + failure handling: lines ~158-189 (`catch (err)` -> `fail_withdrawal_tx`)
- Comment acknowledging ambiguity: lines 59-68

## Code
```js
try {
  const result = await dispatchPayout({ driverId: withdrawal.driver_id, withdrawal });
  settlementRef = result.settlementRef;
  await recordDispatchOutcome(withdrawal.id, settlementRef);
} catch (err) {
  // The payout never left the platform - safe to restore the reserved funds
  const { error: failErr } = await supabaseAdmin.rpc("fail_withdrawal_tx", {
    p_withdrawal_id: withdrawal.id,
    p_error: String(err.message || "Unknown error").slice(0, 1000),
  });
  ...
  continue;
}
```

## Impact
A gateway timeout / transient 5xx during `dispatchPayout` is indistinguishable from "payout never happened". The code restores `wallet_pending -> wallet_confirmed`, but if the gateway did commit the transfer, the driver is both **paid and refunded** -> direct money loss.

## Suggested fix
On an ambiguous dispatch error (timeout/unknown), do not restore funds. Mark the withdrawal for manual reconciliation (or leave it pending so the next sweep re-checks the gateway) instead of calling `fail_withdrawal_tx`.


## Fix

On an ambiguous dispatch error (timeout/unknown), do not restore funds. Mark the withdrawal for manual reconciliation (or leave it pending so the next sweep re-checks the gateway) instead of calling `fail_withdrawal_tx`.

## Files changed

backend/api/src/workers/withdrawalSettlementWorker.js

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12568
