### PR TITLE
booking_confirmation_screen uses context after await in then

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -321,6 +321,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
     });
     _controller.forward(from: 0).then((_) async {
       await Future<void>.delayed(const Duration(milliseconds: 1200));
+      if (!mounted) return;
       _exitToBookings();
     });
   }


### PR DESCRIPTION
﻿## Problem

## Summary
`_showSuccessPanel` checks `if (!mounted) return;` only before the animation. The `.then` callback runs ~1200ms later (after `await Future.delayed`) and calls `_exitToBookings()` which uses `Navigator.of(context)` — with no re-check that the widget is still mounted.

## Location
`apps/customer/lib/screens/booking_confirmation_screen.dart:322-324`

## Code
```dart
void _showSuccessPanel() {
  if (!mounted) return;
  setState(() { _showSuccess = true; _isAwaitingUpi = false; });
  _controller.forward(from: 0).then((_) async {
    await Future<void>.delayed(const Duration(milliseconds: 1200));
    _exitToBookings();   // uses Navigator.of(context)...
  });
}
```

## Impact
If the widget is popped during the 1200ms window, `_exitToBookings()` looks up a deactivated context's ancestor -> "Looking up a deactivated widget's ancestor is unsafe" crash.

## Suggested fix
Re-check `if (!mounted) return;` inside the `.then` callback before using `context`.


## Fix

Re-check `if (!mounted) return;` inside the `.then` callback before using `context`.

## Files changed

apps/customer/lib/screens/booking_confirmation_screen.dart

## Testing

Verify the changed code path; run the relevant existing unit/integration tests for the affected module and confirm the buggy behavior no longer reproduces.

Closes #12569
