### PR TITLE
feat: implement voice activated load booking (#11942)

### DIFF
--- a/apps/driver/lib/models/voice_booking_model.dart
+++ b/apps/driver/lib/models/voice_booking_model.dart
@@ -1,0 +1,33 @@
+class VoiceLoadOffer {
+  final String loadId;
+  final String spokenDescription;
+  final String origin;
+  final String destination;
+  final double rate;
+
+  VoiceLoadOffer({
+    required this.loadId,
+    required this.spokenDescription,
+    required this.origin,
+    required this.destination,
+    required this.rate,
+  });
+}
+
+class VoiceBookingSession {
+  final String status;
+  final bool isListening;
+  final bool isSpeaking;
+  final String transcript;
+  final VoiceLoadOffer? currentOffer;
+  final bool isBooked;
+
+  VoiceBookingSession({
+    required this.status,
+    required this.isListening,
+    required this.isSpeaking,
+    required this.transcript,
+    this.currentOffer,
+    required this.isBooked,
+  });
+}

--- a/apps/driver/lib/screens/voice_booking_screen.dart
+++ b/apps/driver/lib/screens/voice_booking_screen.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import '../models/voice_booking_model.dart';
+import '../services/voice_booking_service.dart';
+
+class VoiceBookingScreen extends StatefulWidget {
+  const VoiceBookingScreen({super.key});
+
+  @override
+  State<VoiceBookingScreen> createState() => _VoiceBookingScreenState();
+}
+
+class _VoiceBookingScreenState extends State<VoiceBookingScreen> {
+  final VoiceBookingService _service = VoiceBookingService();
+  VoiceBookingSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.voiceStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.initializeEngine();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Voice-Activated Booking'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _session?.status.contains('Inactive') == true ? () => _service.activateDriveMode() : null,
+        backgroundColor: _session?.status.contains('Inactive') == true ? Colors.indigo : Colors.grey,
+        icon: const Icon(Icons.drive_eta),
+        label: const Text('Enable Drive Mode'),
+      ),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.currentOffer != null)
+                _buildLoadCard(s.currentOffer!, s.isBooked),
+              const SizedBox(height: 24),
+              if (s.isListening || s.transcript.isNotEmpty)
+                _buildVoiceInteractionUI(s),
+              const SizedBox(height: 80), // Padding for FAB
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(VoiceBookingSession s) {
+    Color headerColor = Colors.blueGrey[800]!;
+    if (s.isListening) headerColor = Colors.blue[700]!;
+    if (s.isSpeaking) headerColor = Colors.purple[700]!;
+    if (s.isBooked) headerColor = Colors.green[700]!;
+
+    IconData icon = Icons.mic_off;
+    if (s.isListening) icon = Icons.mic;
+    if (s.isSpeaking) icon = Icons.volume_up;
+    if (s.isBooked) icon = Icons.check_circle;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: double.infinity,
+      padding: const EdgeInsets.all(32),
+      color: headerColor,
+      child: Column(
+        children: [
+          Icon(icon, color: Colors.white, size: 64),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadCard(VoiceLoadOffer offer, bool isBooked) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: isBooked ? Colors.green : Colors.transparent, width: 3),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Icon(isBooked ? Icons.check_circle : Icons.warning_amber, color: isBooked ? Colors.green : Colors.orange),
+                const SizedBox(width: 12),
+                Text(isBooked ? 'LOAD SECURED' : 'INCOMING OFFER', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: isBooked ? Colors.green : Colors.orange[800])),
+              ],
+            ),
+            const Divider(height: 32),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('ROUTE', style: TextStyle(color: Colors.grey, fontSize: 12, fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 4),
+                      Text('${offer.origin} ➔ ${offer.destination}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                    ],
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    const Text('RATE', style: TextStyle(color: Colors.grey, fontSize: 12, fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 4),
+                    Text('\$${offer.rate.toStringAsFixed(2)}', style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.indigo)),
+                  ],
+                ),
+              ],
+            ),
+            if (!isBooked) ...[
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(color: Colors.grey[100], borderRadius: BorderRadius.circular(8)),
+                child: Text('TTS: "${offer.spokenDescription}"', style: const TextStyle(fontStyle: FontStyle.italic)),
+              )
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVoiceInteractionUI(VoiceBookingSession s) {
+    return Column(
+      children: [
+        if (s.isListening)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: LinearProgressIndicator(color: Colors.blue),
+          ),
+        if (s.isListening && !s.isBooked)
+          Wrap(
+            spacing: 12,
+            children: [
+              ElevatedButton.icon(
+                onPressed: () => _service.simulateVoiceCommand('Hey Truxify, book it!'),
+                icon: const Icon(Icons.record_voice_over),
+                label: const Text('Say: "Book It"'),
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.blue, foregroundColor: Colors.white),
+              ),
+              ElevatedButton.icon(
+                onPressed: () => _service.simulateVoiceCommand('Ignore'),
+                icon: const Icon(Icons.close),
+                label: const Text('Say: "Ignore"'),
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.grey, foregroundColor: Colors.white),
+              ),
+            ],
+          ),
+        if (s.transcript.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Card(
+            color: Colors.black,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                children: [
+                  const Icon(Icons.text_snippet, color: Colors.greenAccent),
+                  const SizedBox(width: 12),
+                  Expanded(child: Text('Driver NLP Transcript: "${s.transcript}"', style: const TextStyle(color: Colors.greenAccent, fontFamily: 'monospace'))),
+                ],
+              ),
+            ),
+          )
+        ]
+      ],
+    );
+  }
+}

--- a/apps/driver/lib/services/voice_booking_service.dart
+++ b/apps/driver/lib/services/voice_booking_service.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import '../models/voice_booking_model.dart';
+
+class VoiceBookingService {
+  final _sessionController = StreamController<VoiceBookingSession>.broadcast();
+  
+  Stream<VoiceBookingSession> get voiceStream => _sessionController.stream;
+
+  VoiceLoadOffer? _activeOffer;
+
+  void initializeEngine() {
+    _emitState('Drive Mode Inactive', false, false, '', false);
+  }
+
+  void activateDriveMode() async {
+    _emitState('Drive Mode Active: Waiting for loads...', true, false, '', false);
+
+    await Future.delayed(const Duration(seconds: 2));
+
+    _activeOffer = VoiceLoadOffer(
+      loadId: 'L-90210',
+      origin: 'Dallas, TX',
+      destination: 'Chicago, IL',
+      rate: 3450.00,
+      spokenDescription: 'New flatbed load available. Dallas, Texas to Chicago, Illinois paying \$3,450. Say "Book It" to accept.',
+    );
+
+    _emitState('Reading Load Aloud via TTS...', false, true, '...', false);
+    
+    await Future.delayed(const Duration(seconds: 3));
+
+    _emitState('Awaiting Driver Voice Command...', true, false, '...', false);
+  }
+
+  void simulateVoiceCommand(String command) async {
+    _emitState('Processing NLP Intent...', false, false, command, false);
+
+    await Future.delayed(const Duration(seconds: 1));
+
+    if (command.toLowerCase().contains('book it') || command.toLowerCase().contains('accept')) {
+      _emitState('Load Successfully Booked via Voice!', false, false, command, true);
+    } else {
+      _emitState('Command ignored. Waiting for next load...', true, false, command, false);
+      _activeOffer = null; // Clear offer
+    }
+  }
+
+  void _emitState(String status, bool listening, bool speaking, String transcript, bool booked) {
+    _sessionController.add(VoiceBookingSession(
+      status: status,
+      isListening: listening,
+      isSpeaking: speaking,
+      transcript: transcript,
+      currentOffer: _activeOffer,
+      isBooked: booked,
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11942
Resolves #12194

This PR introduces the frontend UI and mock telemetry services for the Voice-Activated "Hands-Free" Load Booking feature. The freight market is hyper-competitive, meaning drivers often have to book loads within seconds of them being posted. If a driver is currently operating their truck at highway speeds, interacting with a mobile app to book a load is a massive safety hazard. This feature introduces a hands-free "Drive Mode". Using a simulated NLP engine, the app reads incoming high-paying loads aloud using Text-to-Speech (TTS). The driver can then simply use their voice (e.g., "Hey Truxify, book it") to secure the freight without ever taking their hands off the steering wheel or their eyes off the road.

### Changes Made:
- **`voice_booking_model.dart`**: Established the `VoiceBookingSession` schema to manage the complex state of the voice engine (`isListening`, `isSpeaking`, `transcript`), alongside the `VoiceLoadOffer` schema which includes a pre-formatted `spokenDescription` for TTS output.
- **`voice_booking_service.dart`**: Implemented a mock `Stream` simulating the Natural Language Processing (NLP) pipeline. It handles the timed progression of receiving a load, reading it aloud, opening the microphone, and processing the driver's voice command to successfully book the freight.
- **`voice_booking_screen.dart`**: Built a highly visual, distraction-free dashboard. Because the driver is operating a vehicle, the UI uses massive color-coded states (Purple for speaking, Blue for listening, Green for success) rather than relying on small text. It also renders a live transcript of the driver's voice command for debugging and trust-building.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
