### PR TITLE
feat: implement parking spot probability engine (#11947)

### DIFF
--- a/apps/driver/lib/models/parking_probability_model.dart
+++ b/apps/driver/lib/models/parking_probability_model.dart
@@ -1,0 +1,37 @@
+class RestStop {
+  final String stopName;
+  final String highwayLocation;
+  final int distanceMiles;
+  final int estimatedArrivalMinutes;
+  final int totalCapacity;
+  final int estimatedCurrentOccupancy;
+  final double probabilityScore;
+  final String status; // 'High Chance', 'Risky', 'Likely Full'
+
+  RestStop({
+    required this.stopName,
+    required this.highwayLocation,
+    required this.distanceMiles,
+    required this.estimatedArrivalMinutes,
+    required this.totalCapacity,
+    required this.estimatedCurrentOccupancy,
+    required this.probabilityScore,
+    required this.status,
+  });
+}
+
+class ParkingEngineSession {
+  final String status;
+  final String currentRoute;
+  final DateTime targetShutdownTime;
+  final List<RestStop> upcomingStops;
+  final bool isAnalyzing;
+
+  ParkingEngineSession({
+    required this.status,
+    required this.currentRoute,
+    required this.targetShutdownTime,
+    required this.upcomingStops,
+    required this.isAnalyzing,
+  });
+}

--- a/apps/driver/lib/screens/parking_probability_screen.dart
+++ b/apps/driver/lib/screens/parking_probability_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/parking_probability_model.dart';
+import '../services/parking_probability_service.dart';
+
+class ParkingProbabilityScreen extends StatefulWidget {
+  const ParkingProbabilityScreen({super.key});
+
+  @override
+  State<ParkingProbabilityScreen> createState() => _ParkingProbabilityScreenState();
+}
+
+class _ParkingProbabilityScreenState extends State<ParkingProbabilityScreen> {
+  final ParkingProbabilityService _service = ParkingProbabilityService();
+  ParkingEngineSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.engineStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.initializeEngine();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parking Probability Engine'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _session?.isAnalyzing == true ? null : () => _service.runTelemetryAnalysis(),
+        backgroundColor: Colors.indigo,
+        icon: const Icon(Icons.radar),
+        label: const Text('Scan Upcoming Rest Stops'),
+      ),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.upcomingStops.isNotEmpty) ...[
+                const Text('UPCOMING TRUCK STOPS', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                const SizedBox(height: 12),
+                ...s.upcomingStops.map((stop) => _buildStopCard(stop)),
+              ] else ...[
+                const Center(child: Padding(
+                  padding: EdgeInsets.all(32.0),
+                  child: Text('Tap Scan to analyze crowdsourced GPS telemetry.', style: TextStyle(color: Colors.grey)),
+                ))
+              ],
+              const SizedBox(height: 80), // Padding for FAB
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(ParkingEngineSession s) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: s.isAnalyzing ? Colors.indigo[600] : Colors.blueGrey[800],
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              s.isAnalyzing 
+                ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: Colors.white, strokeWidth: 3))
+                : const Icon(Icons.local_parking, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('CROWDSOURCED TELEMETRY', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStopCard(RestStop stop) {
+    Color statusColor = Colors.grey;
+    if (stop.status == 'High Chance') {
+      statusColor = Colors.green;
+    } else if (stop.status == 'Risky') {
+      statusColor = Colors.orange;
+    } else {
+      statusColor = Colors.red;
+    }
+
+    return Card(
+      elevation: 2,
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: statusColor.withOpacity(0.5), width: 2),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(stop.stopName, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                      Text(stop.highwayLocation, style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(color: statusColor, borderRadius: BorderRadius.circular(16)),
+                  child: Text('${stop.probabilityScore.toStringAsFixed(1)}%', style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
+                )
+              ],
+            ),
+            const Divider(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildMetric('Distance', '${stop.distanceMiles} mi', Colors.indigo),
+                _buildMetric('Est. Arrival', '+${stop.estimatedArrivalMinutes} min', Colors.blueGrey),
+                _buildMetric('Capacity', '${stop.estimatedCurrentOccupancy}/${stop.totalCapacity}', statusColor),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(color: statusColor.withOpacity(0.1), borderRadius: BorderRadius.circular(4)),
+              child: Text(
+                'STATUS: ${stop.status.toUpperCase()}',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: statusColor, fontWeight: FontWeight.bold, fontSize: 12, letterSpacing: 1.0),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetric(String label, String value, Color color) {
+    return Column(
+      children: [
+        Text(value, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14, color: color)),
+        const SizedBox(height: 4),
+        Text(label, style: const TextStyle(color: Colors.grey, fontSize: 10)),
+      ],
+    );
+  }
+}

--- a/apps/driver/lib/services/parking_probability_service.dart
+++ b/apps/driver/lib/services/parking_probability_service.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import '../models/parking_probability_model.dart';
+
+class ParkingProbabilityService {
+  final _sessionController = StreamController<ParkingEngineSession>.broadcast();
+  
+  Stream<ParkingEngineSession> get engineStream => _sessionController.stream;
+
+  void initializeEngine() {
+    _emitState('Awaiting Telemetry Data', 'I-80 Westbound', DateTime.now().add(const Duration(hours: 3)), [], false);
+  }
+
+  void runTelemetryAnalysis() async {
+    _emitState('Aggregating Fleet GPS Telemetry...', 'I-80 Westbound', DateTime.now().add(const Duration(hours: 3)), [], true);
+
+    await Future.delayed(const Duration(seconds: 1));
+    
+    _emitState('Calculating Rest Stop Velocity Matrices...', 'I-80 Westbound', DateTime.now().add(const Duration(hours: 3)), [], true);
+
+    await Future.delayed(const Duration(seconds: 1));
+
+    List<RestStop> stops = [
+      RestStop(
+        stopName: "Pilot Travel Center #412",
+        highwayLocation: "Exit 182, I-80 W",
+        distanceMiles: 45,
+        estimatedArrivalMinutes: 48,
+        totalCapacity: 120,
+        estimatedCurrentOccupancy: 115,
+        probabilityScore: 12.5,
+        status: 'Likely Full',
+      ),
+      RestStop(
+        stopName: "TA Truck Service / Cheyenne",
+        highwayLocation: "Exit 178, I-80 W",
+        distanceMiles: 80,
+        estimatedArrivalMinutes: 85,
+        totalCapacity: 250,
+        estimatedCurrentOccupancy: 180,
+        probabilityScore: 45.0,
+        status: 'Risky',
+      ),
+      RestStop(
+        stopName: "Wyoming State Rest Area",
+        highwayLocation: "Mile Marker 120, I-80 W",
+        distanceMiles: 140,
+        estimatedArrivalMinutes: 150,
+        totalCapacity: 45,
+        estimatedCurrentOccupancy: 10,
+        probabilityScore: 92.5,
+        status: 'High Chance',
+      )
+    ];
+
+    _emitState('Crowdsourced Parking Analysis Complete', 'I-80 Westbound', DateTime.now().add(const Duration(hours: 3)), stops, false);
+  }
+
+  void _emitState(String status, String route, DateTime targetTime, List<RestStop> stops, bool isAnalyzing) {
+    _sessionController.add(ParkingEngineSession(
+      status: status,
+      currentRoute: route,
+      targetShutdownTime: targetTime,
+      upcomingStops: List.from(stops),
+      isAnalyzing: isAnalyzing,
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11947
Resolves #12199

This PR introduces the frontend UI and mock telemetry services for the Parking Spot Probability Engine. The lack of commercial truck parking is one of the most severe crises in the logistics industry. Drivers frequently guess where they might find parking, only to arrive and find the lot full, forcing them into illegal and dangerous parking situations on highway off-ramps. This feature leverages crowdsourced GPS data. By analyzing the velocity of trucks entering and exiting geofenced rest stops, the system provides a mathematical probability score, allowing drivers to make data-driven decisions about when and where to safely shut down for the night.

### Changes Made:
- **`parking_probability_model.dart`**: Established the `ParkingEngineSession` schema to manage the telemetry aggregation state, alongside the `RestStop` schema which standardizes the capacity variables (`totalCapacity`, `estimatedCurrentOccupancy`, `probabilityScore`).
- **`parking_probability_service.dart`**: Implemented a mock `Stream` simulating the crowdsourced data engine. It analyzes a simulated route on I-80 Westbound, returning an array of three truck stops with wildly different occupancy rates. It mathematically demonstrates how a stop 45 miles away might be full (12.5% probability), while a stop 140 miles away is empty (92.5% probability).
- **`parking_probability_screen.dart`**: Built a Crowdsourced Telemetry dashboard. The UI presents the upcoming truck stops as highly readable, data-dense cards. The percentage score is heavily emphasized and color-coded (Green for High Chance, Red for Likely Full) to allow the driver to understand the risk at a quick glance while operating the vehicle.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
