### PR TITLE
fix(anomaly): accumulate withdrawal average with exact integer math

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -26,6 +26,23 @@ const ANOMALY_SEVERITY = {
   CRITICAL: 'CRITICAL',
 };
 
+// Withdrawal amounts are stored as MATIC strings. Float summation of values
+// like '0.1' drifts (ten 0.1 rows sum to 0.9999999999999999), so the baseline
+// is accumulated as exact integer minor units on a fixed 18-decimal scale and
+// converted back to a plain number only once at the end (#11498).
+const DECIMAL_SCALE = 10n ** 18n;
+
+function amountToMinorUnits(amount) {
+  const s = String(amount ?? '').trim();
+  if (!s || !Number.isFinite(Number(s))) return 0n;
+  const negative = s.startsWith('-');
+  const abs = negative ? s.slice(1) : s;
+  const [intPart, fracPart = ''] = abs.split('.');
+  const frac = (fracPart + '000000000000000000').slice(0, 18);
+  let units = BigInt(intPart || '0') * DECIMAL_SCALE + BigInt(frac || '0');
+  return negative ? -units : units;
+}
+
 class AnomalyDetectionService {
   constructor(deps = {}) {
     this.alertRouter = deps.alertRouter;
@@ -123,8 +140,8 @@ class AnomalyDetectionService {
         return ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 2;
       }
 
-      const total = data.reduce((sum, t) => sum + (parseFloat(t.amount) || 0), 0);
-      return total / data.length;
+      const totalUnits = data.reduce((sum, t) => sum + amountToMinorUnits(t.amount), 0n);
+      return Number(totalUnits) / data.length / 1e18;
     } catch (err) {
       logger.warn('[AnomalyDetectionService] Failed to calculate average withdrawal:', err.message);
       return ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL / 2;


### PR DESCRIPTION
## What

`AnomalyDetectionService.getUserAverageWithdrawal` summed withdrawal amounts as floats (`parseFloat` + `reduce`), so ten `0.1` MATIC withdrawals summed to `0.9999999999999999` and the average came back as `0.09999999999999999`. That drifted average is the baseline used to z-score large-withdrawal decisions in `detectLargeWithdrawal`.

This PR accumulates the baseline with **exact integer math**: amounts are parsed into integer minor units on a fixed 18-decimal scale (BigInt, no per-row float drift) and converted back to a plain number only once at the end.

## Verification

```
npx vitest run test/unit/security/anomalyAmountMath.test.js        # 5/5 pass
npx vitest run test/unit/anomalyDetectionService.test.js           # pass
npx vitest run test/unit/security/anomalyDetectionService.test.js  # pass
npx vitest run test/unit/internalRoutes.test.js                    # pass
```

All previously-failing exact-arithmetic cases now pass:

- average of ten `0.1` withdrawals is exactly `0.1`
- `avg * 10 === 1.0` (strict, no float drift)

## GSSOC

This PR is submitted as part of **GSSOC'24** — it fixes issue **#12714**.
