### PR TITLE
fix(otp): constantTimeEqualHex must reject invalid hex

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -47,12 +47,15 @@ export function verifyOtpHash(otp, otpRecord) {
 }
 
 
-// === Spec 12: ===
 // === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;
+  // Buffer.from(value, 'hex') does not reject invalid hex: it truncates at the
+  // first invalid character and drops a trailing odd nibble. Two identical
+  // invalid inputs would decode to equal short buffers and compare "equal",
+  // so reject anything that is not well-formed hex first.
+  if (!/^[0-9a-fA-F]+$/.test(a) || !/^[0-9a-fA-F]+$/.test(b)) return false;
   try { return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex')); }
   catch (_) { return false; }
 }


### PR DESCRIPTION
## What

`constantTimeEqualHex(a, b)` in `backend/api/src/lib/otpHashing.js` returned `true` for equal-length **invalid** hex inputs.

`Buffer.from(value, 'hex')` does not throw on invalid hex — it silently truncates at the first invalid character and drops a trailing odd nibble. Two identical invalid inputs (e.g. `'xyz'` and `'xyz'`) both decode to the same short buffer, so `crypto.timingSafeEqual` compared equal and returned `true`.

This PR:
- validates both inputs are well-formed hex (`/^[0-9a-fA-F]+$/`) before comparing, and
- removes a stray duplicate `import crypto from 'crypto';` left in the middle of the file.

## Verification

```
npx vitest run test/unit/otpHashing.test.js   # 17/17 pass
```

The previously-failing case now holds: `constantTimeEqualHex('xyz', 'xyz') === false`.

## GSSOC

This PR is submitted as part of **GSSOC'24** — it fixes issue **#12715**.
