### PR TITLE
feat: implement predictive maintenance cost amortization (#11950)

### DIFF
--- a/apps/driver/lib/models/maintenance_amortization_model.dart
+++ b/apps/driver/lib/models/maintenance_amortization_model.dart
@@ -1,0 +1,49 @@
+class MaintenanceItem {
+  final String componentName;
+  final double replacementCost;
+  final int lifecycleMiles;
+  final double costPerMile;
+
+  MaintenanceItem({
+    required this.componentName,
+    required this.replacementCost,
+    required this.lifecycleMiles,
+    required this.costPerMile,
+  });
+}
+
+class AmortizedLoad {
+  final String loadId;
+  final String origin;
+  final String destination;
+  final double miles;
+  final double grossRevenue;
+  final double maintenanceReserveCost;
+  final double amortizedNetProfit;
+
+  AmortizedLoad({
+    required this.loadId,
+    required this.origin,
+    required this.destination,
+    required this.miles,
+    required this.grossRevenue,
+    required this.maintenanceReserveCost,
+    required this.amortizedNetProfit,
+  });
+}
+
+class MaintenanceAmortizationSession {
+  final String status;
+  final List<MaintenanceItem> vehicleComponents;
+  final double totalMaintenanceCPM;
+  final List<AmortizedLoad> simulatedLoads;
+  final bool isCalculating;
+
+  MaintenanceAmortizationSession({
+    required this.status,
+    required this.vehicleComponents,
+    required this.totalMaintenanceCPM,
+    required this.simulatedLoads,
+    required this.isCalculating,
+  });
+}

--- a/apps/driver/lib/screens/maintenance_amortization_screen.dart
+++ b/apps/driver/lib/screens/maintenance_amortization_screen.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import '../models/maintenance_amortization_model.dart';
+import '../services/maintenance_amortization_service.dart';
+
+class MaintenanceAmortizationScreen extends StatefulWidget {
+  const MaintenanceAmortizationScreen({super.key});
+
+  @override
+  State<MaintenanceAmortizationScreen> createState() => _MaintenanceAmortizationScreenState();
+}
+
+class _MaintenanceAmortizationScreenState extends State<MaintenanceAmortizationScreen> {
+  final MaintenanceAmortizationService _service = MaintenanceAmortizationService();
+  MaintenanceAmortizationSession? _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.amortizationStream.listen((data) {
+      if (mounted) setState(() => _session = data);
+    });
+    _service.initializeDashboard();
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Maintenance Amortization Engine'),
+        backgroundColor: Colors.blueGrey[900],
+      ),
+      backgroundColor: Colors.grey[200],
+      body: _session == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildDashboard(),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _session?.isCalculating == true ? null : () => _service.runAmortizationEngine(),
+        backgroundColor: Colors.indigo,
+        icon: const Icon(Icons.calculate),
+        label: const Text('Calculate Depreciation matrix'),
+      ),
+    );
+  }
+
+  Widget _buildDashboard() {
+    final s = _session!;
+
+    return Column(
+      children: [
+        _buildStatusHeader(s),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (s.vehicleComponents.isNotEmpty) ...[
+                _buildTotalCpmCard(s.totalMaintenanceCPM),
+                const SizedBox(height: 24),
+                const Text('LOAD BOARD PROFITABILITY ADJUSTMENT', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                const SizedBox(height: 12),
+                ...s.simulatedLoads.map((load) => _buildAmortizedLoadCard(load)),
+                const SizedBox(height: 24),
+                const Text('VEHICLE COMPONENT LIFECYCLES', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+                const SizedBox(height: 12),
+                ...s.vehicleComponents.map((comp) => _buildComponentCard(comp)),
+              ] else ...[
+                const Center(child: Padding(
+                  padding: EdgeInsets.all(32.0),
+                  child: Text('Tap Calculate to run financial depreciation modeling.', style: TextStyle(color: Colors.grey)),
+                ))
+              ],
+              const SizedBox(height: 80), // Padding for FAB
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildStatusHeader(MaintenanceAmortizationSession s) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      color: s.isCalculating ? Colors.indigo[600] : Colors.blueGrey[800],
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              s.isCalculating 
+                ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: Colors.white, strokeWidth: 3))
+                : const Icon(Icons.money_off, color: Colors.white, size: 36),
+              const SizedBox(width: 12),
+              const Text('FINANCIAL ACCOUNTING ENGINE', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 1.5)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(s.status.toUpperCase(), textAlign: TextAlign.center, style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotalCpmCard(double totalCpm) {
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: Colors.orange, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.build, color: Colors.orange),
+                SizedBox(width: 12),
+                Text('Real-Time Maintenance CPM', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+              ],
+            ),
+            const Divider(height: 32),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Expanded(
+                  child: Text('You must save this amount for every single mile you drive to avoid bankruptcy when your truck breaks down.', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                ),
+                const SizedBox(width: 16),
+                Text('\$${totalCpm.toStringAsFixed(3)} / mi', style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold, color: Colors.orange[900])),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAmortizedLoadCard(AmortizedLoad load) {
+    return Card(
+      elevation: 2,
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('${load.origin} ➔ ${load.destination}', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                Text('${load.miles} mi', style: const TextStyle(color: Colors.grey, fontWeight: FontWeight.bold)),
+              ],
+            ),
+            const Divider(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Gross Revenue (Broker Offer)', style: TextStyle(color: Colors.blueGrey)),
+                Text('\$${load.grossRevenue.toStringAsFixed(2)}', style: const TextStyle(color: Colors.blueGrey, fontWeight: FontWeight.bold)),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Maintenance Reserve Deduction', style: TextStyle(color: Colors.red)),
+                Text('- \$${load.maintenanceReserveCost.toStringAsFixed(2)}', style: const TextStyle(color: Colors.red, fontWeight: FontWeight.bold)),
+              ],
+            ),
+            const Divider(height: 24),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(color: Colors.green[50], borderRadius: BorderRadius.circular(8)),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text('TRUE AMORTIZED PROFIT', style: TextStyle(color: Colors.green[900], fontWeight: FontWeight.bold)),
+                  Text('\$${load.amortizedNetProfit.toStringAsFixed(2)}', style: TextStyle(color: Colors.green[900], fontSize: 20, fontWeight: FontWeight.bold)),
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComponentCard(MaintenanceItem comp) {
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        leading: const Icon(Icons.settings, color: Colors.grey),
+        title: Text(comp.componentName, style: const TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: Text('Cost: \$${comp.replacementCost.toStringAsFixed(0)} | Lifespan: ${comp.lifecycleMiles} mi'),
+        trailing: Text('\$${comp.costPerMile.toStringAsFixed(3)} /mi', style: const TextStyle(color: Colors.orange, fontWeight: FontWeight.bold)),
+      ),
+    );
+  }
+}

--- a/apps/driver/lib/services/maintenance_amortization_service.dart
+++ b/apps/driver/lib/services/maintenance_amortization_service.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import '../models/maintenance_amortization_model.dart';
+
+class MaintenanceAmortizationService {
+  final _sessionController = StreamController<MaintenanceAmortizationSession>.broadcast();
+  
+  Stream<MaintenanceAmortizationSession> get amortizationStream => _sessionController.stream;
+
+  void initializeDashboard() {
+    _emitState('Awaiting Accounting Input', [], 0.0, [], false);
+  }
+
+  void runAmortizationEngine() async {
+    _emitState('Calculating Vehicle Depreciation Matrix...', [], 0.0, [], true);
+
+    await Future.delayed(const Duration(seconds: 1));
+    
+    _emitState('Amortizing Load Board Profitability...', [], 0.0, [], true);
+
+    await Future.delayed(const Duration(seconds: 1));
+
+    List<MaintenanceItem> components = [
+      MaintenanceItem(componentName: 'Drive Tires (x8)', replacementCost: 3200.0, lifecycleMiles: 120000, costPerMile: 0.026),
+      MaintenanceItem(componentName: 'Engine Overhaul', replacementCost: 15000.0, lifecycleMiles: 500000, costPerMile: 0.030),
+      MaintenanceItem(componentName: 'Transmission Replace', replacementCost: 8500.0, lifecycleMiles: 750000, costPerMile: 0.011),
+      MaintenanceItem(componentName: 'Oil Changes / PM', replacementCost: 450.0, lifecycleMiles: 15000, costPerMile: 0.030),
+    ];
+
+    double totalCpm = components.fold(0.0, (sum, item) => sum + item.costPerMile);
+
+    List<AmortizedLoad> loads = [
+      AmortizedLoad(
+        loadId: 'LD-922',
+        origin: 'Atlanta, GA',
+        destination: 'Dallas, TX',
+        miles: 800.0,
+        grossRevenue: 1800.0,
+        maintenanceReserveCost: 800.0 * totalCpm,
+        amortizedNetProfit: 1800.0 - (800.0 * totalCpm),
+      ),
+      AmortizedLoad(
+        loadId: 'LD-410',
+        origin: 'Chicago, IL',
+        destination: 'Denver, CO',
+        miles: 1000.0,
+        grossRevenue: 1500.0,
+        maintenanceReserveCost: 1000.0 * totalCpm,
+        amortizedNetProfit: 1500.0 - (1000.0 * totalCpm),
+      )
+    ];
+
+    _emitState('Depreciation Accounting Complete', components, totalCpm, loads, false);
+  }
+
+  void _emitState(String status, List<MaintenanceItem> components, double totalCpm, List<AmortizedLoad> loads, bool isCalculating) {
+    _sessionController.add(MaintenanceAmortizationSession(
+      status: status,
+      vehicleComponents: List.from(components),
+      totalMaintenanceCPM: totalCpm,
+      simulatedLoads: List.from(loads),
+      isCalculating: isCalculating,
+    ));
+  }
+
+  void dispose() {
+    _sessionController.close();
+  }
+}


### PR DESCRIPTION
## Description
Resolves #11950
Resolves #12202

This PR introduces the frontend UI and mock telemetry services for the Predictive Maintenance Cost Amortization feature. Owner-operators frequently miscalculate their profitability because they only look at the gross revenue a broker offers, forgetting to account for massive, long-term depreciation events (like a \$15,000 engine overhaul). This leads to bankruptcy when the truck inevitably breaks down. This feature translates complex depreciation accounting into real-time UI metrics. The software maps the replacement costs and lifecycles of major truck components to calculate a "Maintenance Cost Per Mile" (CPM). It then dynamically subtracts this amortized cost from the gross revenue of every load on the board, showing the driver their true, net profitability.

### Changes Made:
- **`maintenance_amortization_model.dart`**: Established the `MaintenanceAmortizationSession` schema to manage the accounting state, alongside the `MaintenanceItem` schema (calculating CPM) and the `AmortizedLoad` schema (calculating true net profit).
- **`maintenance_amortization_service.dart`**: Implemented a mock `Stream` simulating the financial depreciation matrix. It calculates the cumulative CPM of tires, engines, transmissions, and oil changes. It then applies that CPM to a simulated 800-mile load from Atlanta to Dallas, correctly deducting \$77.60 from the broker's \$1,800 gross offer to fund the driver's maintenance reserve.
- **`maintenance_amortization_screen.dart`**: Built a Financial Accounting Engine dashboard. The UI explicitly educates the driver, using a large orange warning card to show the exact dollar amount they must save for every mile driven. It then breaks down the simulated loads, using red text to show the maintenance deduction and green text to highlight the final, amortized net profit.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
