### PR TITLE
test(verification): use active/terminal statuses for deliveryVerified semantics

### DIFF
--- a/backend/api/test/unit/services/verificationService.test.js
+++ b/backend/api/test/unit/services/verificationService.test.js
@@ -84,11 +84,13 @@ describe('VerificationService', () => {
       expect(result.error).toBe('Order not found');
     });
 
-    it('returns full verification result for a valid delivered order', async () => {
+    it('returns full verification result for a valid active delivery', async () => {
       const order = {
         id: VALID_ORDER_ID,
         order_display_id: 'ORD-001',
-        status: 'payment_released',
+        // confirmDelivery runs before the order is marked delivered, so
+        // deliveryVerified requires an active status (picked_up/in_transit/arriving).
+        status: 'in_transit',
         customer_id: 'customer-1',
         driver_id: VALID_DRIVER_ID,
         truck_id: VALID_TRUCK_ID,
@@ -121,10 +123,10 @@ describe('VerificationService', () => {
       expect(result.timestamp).toBeDefined();
     });
 
-    it('marks deliveryVerified as false when order status is not delivered', async () => {
+    it('marks deliveryVerified as false when order status is terminal', async () => {
       const order = {
         id: VALID_ORDER_ID,
-        status: 'in_transit',
+        status: 'payment_released',
         driver_id: VALID_DRIVER_ID,
         truck_id: VALID_TRUCK_ID,
         blockchain_tx_hash: null,


### PR DESCRIPTION
## What

Two `verifyOrder` tests in `backend/api/test/unit/services/verificationService.test.js` asserted stale "delivered-only" semantics.

`VerificationService` deliberately sets `deliveryVerified` while the order is still in an **active** status (`picked_up` / `in_transit` / `arriving`) because `confirmDelivery` runs *before* the order is marked `delivered`/`payment_released` (see the comment in `src/services/verification/VerificationService.js`). Requiring a terminal status would make `deliveryVerified` unreachable.

The failing tests used the wrong fixtures:

- "returns full verification result for a valid delivered order" used `status: 'payment_released'` (terminal → `deliveryVerified: false`) but expected `true`.
- "marks deliveryVerified as false when order status is not delivered" used `status: 'in_transit'` (active → `deliveryVerified: true`) but expected `false`.

This PR swaps the fixture statuses to the intended semantics and renames the tests accordingly.

## Verification

```
npx vitest run test/unit/services/verificationService.test.js   # 15/15 pass
```

## GSSOC

This PR is submitted as part of **GSSOC'24** — it fixes issue **#12718**.
