### PR TITLE
fix: deactivate escrow client when validateEscrowSetup() fails

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -128,11 +128,13 @@ export async function validateEscrowSetup () {
         `[escrow] ❌ No contract deployed at ${address}. ` +
         'Check ESCROW_CONTRACT_ADDRESS in your .env.'
       )
+      escrowContract = null
       return false
     }
     logger.info(`[escrow] ✅ Bytecode confirmed at ${address} (${(code.length - 2) / 2} bytes).`)
   } catch (err) {
     logger.error({ event: 'ESCROW_BYTECODE_QUERY_ERROR', address, error: err && err.message }, `[escrow] Failed to query bytecode at ${address}`)
+    escrowContract = null
     return false
   }
 
@@ -150,6 +152,7 @@ export async function validateEscrowSetup () {
       'Check that ESCROW_CONTRACT_ADDRESS points to the active TruxifyEscrow contract, ' +
       'not the deprecated Escrow.sol.'
     )
+    escrowContract = null
     return false
   }
 


### PR DESCRIPTION
Closes #12741

## Summary
When the escrow env vars are configured but validateEscrowSetup() fails (no bytecode at ESCROW_CONTRACT_ADDRESS, or the contract does not respond to the expected ABI), the contract client stayed initialised — isEscrowEnabled() kept returning true and every operation attempted contract calls that failed at runtime.

Now a failed validation sets escrowContract = null, so:
- isEscrowEnabled() returns false
- escrow operations return { txData: null } / null immediately
- checkEscrowHealth() reports not_configured

## Changes
- backend/api/src/services/escrow.js: deactivate the client on all three validation-failure paths.

## Tests
npx vitest run test/unit/escrowValidationDisable.test.js — 3/3 passing.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.