### PR TITLE
fix: remove merged double-handler from GET /:id/driver-location route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -860,10 +860,7 @@ router.post('/predict-demand', authenticate, userLimiter, requirePolicy('order:p
  *             schema:
  *               $ref: '#/components/schemas/DriverLocationResponse'
  */
-router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-driver-location', async (req) => {
-  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id');
-  return { order };
-}), validateParams(paramIdSchema), async (req, res) => {
+router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-driver-location'), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, customer_id, driver_id, status');


### PR DESCRIPTION
Closes #12742

## Summary
GET /api/orders/:id/driver-location contained a malformed, merged double-handler (issue #6662 pattern): the requirePolicy middleware was invoked with a duplicated fragment handler as its second argument, so the middleware chain no longer matched the intended form.

The route is now a single balanced router.get call:
- requirePolicy('order:view-driver-location') as plain middleware
- validateParams(paramIdSchema)
- exactly one async (req, res) handler

## Changes
- backend/api/src/routes/orderRoutes.js: removed the stray handler fragment from the requirePolicy(...) call.

## Tests
npx vitest run test/unit/orderRoutesDriverLocationSyntax.test.js — 3/3 passing.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.