### PR TITLE
fix: purge non-object JSON payloads in getCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -206,8 +206,19 @@ export async function getCachedProfile(firebaseUid) {
   try {
     const raw = await redisClient.get(firebaseProfileKey(firebaseUid));
     if (raw) {
-      cacheHits++;
-      return JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        cacheHits++;
+        return parsed;
+      }
+      // Corrupt payload (not a plain object): treat as a miss and purge the key
+      cacheMisses++;
+      try {
+        await redisClient.del(firebaseProfileKey(firebaseUid));
+      } catch (delErr) {
+        // Ignore failures on background cleanup deletion
+      }
+      return null;
     }
     cacheMisses++;
     return null;


### PR DESCRIPTION
Closes #12743

## Summary
getCachedProfile() returned whatever JSON.parse(raw) produced for any truthy Redis value. Corrupt payloads that parse to a non-object — a number, a string, or an array — were served back as valid profiles.

Now only plain-object payloads count as a hit. Numeric/string/array payloads are treated as a cache miss and the corrupt key is deleted.

## Changes
- backend/api/src/lib/profileCache.js: validate the parsed payload shape in getCachedProfile(); purge non-object payloads.

## Tests
npx vitest run test/unit/profileCacheParse.test.js — 4/4 passing.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.