### PR TITLE
fix: clamp TTL in setCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -238,6 +238,8 @@ export async function setCachedProfile(
 ) {
   const redisClient = getRedisClient();
   if (!redisClient || !firebaseUid || !profile) return;
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       firebaseProfileKey(firebaseUid),


### PR DESCRIPTION
Closes #12744

## Summary
setCachedProfile() wrote the caller's ttlSeconds straight to Redis via SET ... EX <ttl>, unlike its siblings (setCachedSupabaseProfile, setCachedCustomerStats, setCachedDriverDetails) which clamp to [1, 86400]. A 0 or non-finite TTL could expire the key immediately or store an invalid TTL.

Now the TTL is clamped:
- below 1 second -> 1
- above 86400 -> 86400
- non-finite (NaN) -> 1

## Changes
- backend/api/src/lib/profileCache.js: clamp ttlSeconds in setCachedProfile().

## Tests
npx vitest run test/unit/profileCacheTtl.test.js — 4/4 passing.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.