### PR TITLE
fix: validate request userId in POST /zkp/verify

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -47,7 +47,13 @@ const zkpVerifyLimiter = redisRateLimiter({
  */
 router.post('/verify', authenticate, zkpVerifyLimiter, async (req, res) => {
   try {
-    const userId = req.user.id;
+    const { userId } = req.body;
+    if (!userId || typeof userId !== 'string' || !userId.trim()) {
+      return res.status(400).json({ success: false, error: 'userId is required' });
+    }
+    if (userId !== req.user.id) {
+      return res.status(403).json({ success: false, error: 'Forbidden' });
+    }
     const {
       name,
       licenseNumber,


### PR DESCRIPTION
Closes #12745

## Summary
POST /zkp/verify never validated the userId from the request body — it always used req.user.id from the auth token, silently ignoring req.body.userId. This was inconsistent with GET /zkp/status/:userId, which enforces ownership.

The endpoint now:
- returns 400 with error 'userId is required' when userId is missing from the body
- returns 403 with error 'Forbidden' when the body userId does not match the authenticated user
- verifies the body userId against the authenticated identity

## Changes
- backend/api/src/routes/zkp.routes.js: require and validate userId in POST /zkp/verify.

## Tests
npx vitest run test/unit/zkpRoutes.test.js — 7/7 passing.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.