### PR TITLE
fix(notification): persist delivery-OTP notifications with notif_type 'delivery_otp'

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -295,7 +295,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         user_id: customerId,
         title,
         body,
-        notif_type: 'order_update',
+        notif_type: 'delivery_otp',
         // No OTP or OTP-derived value is persisted here: an unsalted digest of
         // a 6-digit code is offline-brute-forceable if the table leaks.
         metadata: { order_display_id: orderDisplayId }


### PR DESCRIPTION
Closes #12759

## Summary
sendDeliveryOtpNotification() persisted the notification row with notif_type 'order_update' while the FCM push used data.notifType 'delivery_otp'. The two channels disagreed, so the customer's in-app history mislabeled delivery-OTP alerts as generic order updates and the persisted row could not be correlated with the push type.

The notification is now persisted with notif_type 'delivery_otp', matching the push payload.

## Changes
- backend/api/src/services/notificationService.js: notif_type 'order_update' -> 'delivery_otp' in sendDeliveryOtpNotification().

## Notes
- The existing test/unit/notificationService.test.js file fails 5/5 on clean main (calls removed/mismatched APIs such as insertNotification); verified unrelated to this change via stash.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delivery OTP notifications are now correctly categorized as delivery OTP notifications instead of order updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->