### PR TITLE
fix(notification): include delivery OTP in the FCM data payload

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -317,7 +317,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     fcmResult = await sendFcmNotification(
       customerId,
       { title, body },
-      { orderDisplayId, notifType: 'delivery_otp',  }
+      { orderDisplayId, notifType: 'delivery_otp', otp }
     );
   } catch (err) {
     logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');


### PR DESCRIPTION
Closes #12750

## Summary
sendDeliveryOtpNotification() accepted the raw OTP but never placed it in the FCM data payload — the push contained only { orderDisplayId, notifType } — so the customer had no way to read the OTP digits. The OTP value is now included in the FCM data payload, so a client with a delivery_otp handler can surface it.

The persisted notifications row intentionally still stores no OTP (an unsalted digest of a 6-digit code is offline-brute-forceable if the table leaks), so the FCM data payload is the delivery channel for the code.

## Changes
- backend/api/src/services/notificationService.js: include otp in the FCM data payload of sendDeliveryOtpNotification().

## Follow-up (out of scope)
The customer app (apps/customer) currently has no notifType-based push handler; a delivery_otp branch that renders the OTP is the app-side follow-up.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.