### PR TITLE
fix(sharding): guard JSON.parse of cached order location

### DIFF
--- a/backend/api/src/services/sharding/ShardManager.js
+++ b/backend/api/src/services/sharding/ShardManager.js
@@ -209,7 +209,13 @@ class ShardManager {
     // Check cache first
     const cached = await this.redis.get(`order:${orderId}:location`);
     if (cached) {
-      return JSON.parse(cached);
+      try {
+        return JSON.parse(cached);
+      } catch (err) {
+        // Corrupt cache entry — fall through to the authoritative lookup
+        // instead of throwing (issue #12751).
+        logger.warn(`[ShardManager] Corrupt cached location for order ${orderId}, falling back to database: ${err.message}`);
+      }
     }
     // Resolve the real pickup location from the authoritative orders table when
     // a primary PostgreSQL connection is configured. This prevents every


### PR DESCRIPTION
Closes #12751

## Summary
getOrderLocation() parsed the cached Redis value with a bare JSON.parse(cached). A corrupt cache entry (partial write, non-JSON value) threw instead of falling through to the authoritative lookup, taking down shard routing for that order.

The parse is now guarded: on a corrupt entry the method logs a warning and falls through to the existing pickup_lat/pickup_lng database lookup / configurable default-state path, so shard selection degrades gracefully instead of crashing.

Note: the hard-coded New Delhi fallback portion of the issue is already resolved on main (issue #11394 introduced the database lookup + configurable default state); this PR closes the remaining unguarded parse.

## Changes
- backend/api/src/services/sharding/ShardManager.js: try/catch around JSON.parse of the cached order location.

## Tests
- target function covered by existing suite; test/unit/ShardManager.test.js fails 10/10 on clean main (unrelated import/API drift), verified unchanged by this PR.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.