### PR TITLE
fix(profile-cache): log Redis del failures instead of swallowing them

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -368,7 +368,9 @@ export async function getCachedCustomerStats(userId) {
     logCacheError("getCachedCustomerStats", err);
     try {
       await redisClient.del(customerStatsKey(userId));
-    } catch (_) {}
+    } catch (delErr) {
+      logCacheError("getCachedCustomerStats.del", delErr);
+    }
     return null;
   }
 }
@@ -418,7 +420,9 @@ export async function getCachedDriverDetails(userId) {
     logCacheError("getCachedDriverDetails", err);
     try {
       await redisClient.del(driverDetailsKey(userId));
-    } catch (_) {}
+    } catch (delErr) {
+      logCacheError("getCachedDriverDetails.del", delErr);
+    }
     return null;
   }
 }


### PR DESCRIPTION
Closes #12752

## Summary
getCachedCustomerStats() and getCachedDriverDetails() swallowed the Redis del() error in empty catch (_) {} blocks when purging a corrupt cache entry. A failed deletion was invisible, so stale profiles kept serving old roles/permissions until natural TTL expiry with no diagnostic trail.

Both delete paths now log the failure through the existing throttled logCacheError() helper, making cache-invalidation failures visible in production.

## Changes
- backend/api/src/lib/profileCache.js: log del failures in getCachedCustomerStats() and getCachedDriverDetails() corrupt-key cleanup.

## Tests
- ESLint clean. profileCache suite unchanged (existing profileCacheTtl/Parse failures are the separate #12743/#12744 issues); profileService 26/27 with the 1 failure pre-existing on main (verified via stash).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.