### PR TITLE
fix(store): resolve conflict markers in GlobalStore.js

### DIFF
--- a/backend/store/GlobalStore.js
+++ b/backend/store/GlobalStore.js
@@ -21,10 +21,7 @@ class StoreTransaction {
         
         this.snapshot = this.store.createSnapshot();
         this.isActive = true;
-<<<<<<< HEAD
-=======
         this.txStartIndex = this.store.historyIndex;
->>>>>>> upstream/main
         this.startTime = Date.now();
         this.store.emit('transactionStarted', { id: this.id });
         logger.debug(`Transaction ${this.id} started`);
@@ -64,9 +61,6 @@ class StoreTransaction {
         
         this.endTime = Date.now();
         this.isActive = false;
-<<<<<<< HEAD
-        
-=======
 
         // Record the transaction's net effect as a single undo entry so that
         // one undo reverts the whole transaction, not an intermediate step.
@@ -74,7 +68,6 @@ class StoreTransaction {
             this.store.saveHistory();
         }
 
->>>>>>> upstream/main
         this.store.emit('transactionCommitted', {
             id: this.id,
             duration: this.endTime - this.startTime,
@@ -99,15 +92,12 @@ class StoreTransaction {
             this.store.restoreSnapshot(this.snapshot);
         }
         
-<<<<<<< HEAD
-=======
         // Restore the undo history cursor to the pre-transaction point so the
         // pointer does not diverge from the restored state.
         if (this.txStartIndex !== undefined && this.txStartIndex !== null) {
             this.store.historyIndex = this.txStartIndex;
         }
         
->>>>>>> upstream/main
         this.endTime = Date.now();
         this.isActive = false;
         
@@ -158,16 +148,11 @@ class GlobalStore extends EventEmitter {
             return;
         }
         
-<<<<<<< HEAD
-        // Save history for undo
-        this.saveHistory();
-=======
         // Save history for undo (skip while a transaction is active so that
         // intermediate mutations do not pollute the undo history).
         if (!this.activeTransaction) {
             this.saveHistory();
         }
->>>>>>> upstream/main
         
         const oldValue = this.state[key];
         this.state[key] = value;
@@ -184,15 +169,11 @@ class GlobalStore extends EventEmitter {
             return;
         }
         
-<<<<<<< HEAD
-        this.saveHistory();
-=======
         // Skip while a transaction is active so intermediate mutations do not
         // pollute the undo history.
         if (!this.activeTransaction) {
             this.saveHistory();
         }
->>>>>>> upstream/main
         const oldState = { ...this.state };
         Object.assign(this.state, updates);
         
@@ -295,11 +276,7 @@ class GlobalStore extends EventEmitter {
     
     createSnapshot() {
         return {
-<<<<<<< HEAD
-            state: { ...this.state },
-=======
             state: structuredClone(this.state),
->>>>>>> upstream/main
             timestamp: Date.now(),
             id: `snapshot_${Date.now()}`
         };
@@ -311,14 +288,9 @@ class GlobalStore extends EventEmitter {
         }
         
         const oldState = { ...this.state };
-<<<<<<< HEAD
-        this.state = { ...snapshot.state };
-        
-=======
         this.state = structuredClone(snapshot.state);
         
         this.notifyStateDiff(oldState, this.state);
->>>>>>> upstream/main
         this.emit('snapshotRestored', { oldState, newState: this.state });
         logger.debug(`Snapshot restored: ${snapshot.id}`);
     }
@@ -335,10 +307,7 @@ class GlobalStore extends EventEmitter {
         const oldState = { ...this.state };
         this.state = { ...this.history[this.historyIndex] };
         
-<<<<<<< HEAD
-=======
         this.notifyStateDiff(oldState, this.state);
->>>>>>> upstream/main
         this.emit('undo', { oldState, newState: this.state });
         logger.debug('Undo performed');
         
@@ -355,10 +324,7 @@ class GlobalStore extends EventEmitter {
         const oldState = { ...this.state };
         this.state = { ...this.history[this.historyIndex] };
         
-<<<<<<< HEAD
-=======
         this.notifyStateDiff(oldState, this.state);
->>>>>>> upstream/main
         this.emit('redo', { oldState, newState: this.state });
         logger.debug('Redo performed');
         
@@ -405,8 +371,6 @@ class GlobalStore extends EventEmitter {
             }
         }
     }
-<<<<<<< HEAD
-=======
 
     // Notify subscribers of every key whose value changed between two states.
     // Used by undo/redo/restoreSnapshot/atomic, which mutate the whole state
@@ -419,7 +383,6 @@ class GlobalStore extends EventEmitter {
             }
         }
     }
->>>>>>> upstream/main
     
     // ============ Atomic Updates ============
     
@@ -429,10 +392,7 @@ class GlobalStore extends EventEmitter {
         
         try {
             Object.assign(this.state, updates);
-<<<<<<< HEAD
-=======
             this.notifyStateDiff(oldState, this.state);
->>>>>>> upstream/main
             this.emit('atomicUpdate', { oldState, newState: this.state });
             logger.debug(`Atomic update: ${Object.keys(updates).join(', ')}`);
         } catch (error) {


### PR DESCRIPTION
## Summary
Resolve leftover Git conflict markers in backend/store/GlobalStore.js that break the module.
## Changes
Removed 11 conflict blocks, keeping the upstream side so the file matches its clean pre-squash state.
## Impact
GlobalStore.js parses and loads cleanly.

Fixes #12698

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction handling so grouped changes create a single undo history entry.
  * Rolling back a transaction now correctly restores the previous history position.
  * Undo, redo, restoration, and atomic updates now reliably notify subscribers of affected state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->