### PR TITLE
fix(fraud): fall back on corrupt cached behavior profile

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -104,7 +104,13 @@ class FraudDetectionService {
     // Check Redis cache
     const cached = this.redis ? await this.redis.get(`behavior:${userId}`) : null;
     if (cached) {
-      return JSON.parse(cached);
+      try {
+        return JSON.parse(cached);
+      } catch (err) {
+        // Corrupt cache entry — log and fall through to the in-memory / DB
+        // paths so a single bad entry cannot 500 the fraud check.
+        logger.error(`[FraudDetection] Corrupt cached behavior profile for user ${userId}: ${err.message}`);
+      }
     }
 
     // Check in-memory cache (written by trackBehavior during Redis outages)


### PR DESCRIPTION
Closes #12753

## Summary
getOrCreateProfile() parsed the cached behavior: Redis value with a bare JSON.parse(). A corrupt cache entry (partial write, schema migration, non-JSON) threw, and the fraud-check request returned HTTP 500 instead of continuing with a default profile — a single bad entry took down fraud scoring for that customer until expiry.

The parse is now wrapped in try/catch: on corruption the error is logged and the method falls through to the in-memory cache / database paths.

## Changes
- backend/api/src/services/fraud/FraudDetectionService.js: guard JSON.parse of the cached behavior profile.

## Tests
- ESLint: no new issues (2 pre-existing no-useless-assignment at other lines, verified on main). Existing fraud test files fail 9/10 on clean main (pre-existing), unchanged by this PR.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.