### PR TITLE
fix(scheduler): resolve conflict markers in RenderScheduler.js

### DIFF
--- a/backend/scheduler/RenderScheduler.js
+++ b/backend/scheduler/RenderScheduler.js
@@ -114,8 +114,6 @@ class RenderScheduler extends EventEmitter {
             const index = queue.indexOf(task);
             if (index !== -1) {
                 queue.splice(index, 1);
-<<<<<<< HEAD
-=======
                 // Unlink this task from any dependents so they are not
                 // permanently deadlocked by a dependency that will never
                 // complete. Removing the edge lets a dependent with no other
@@ -127,16 +125,12 @@ class RenderScheduler extends EventEmitter {
                         this.emit('dependentUnblocked', { taskId: depId, dependencyId: taskId });
                     }
                 }
->>>>>>> upstream/main
                 task.status = 'cancelled';
                 this.stats.cancelledTasks++;
                 this.emit('taskCancelled', { taskId });
                 this.taskMap.delete(taskId);
                 logger.debug(`Task ${taskId} cancelled`);
-<<<<<<< HEAD
-=======
                 this.pruneTaskMap();
->>>>>>> upstream/main
                 return true;
             }
         }
@@ -333,10 +327,7 @@ class RenderScheduler extends EventEmitter {
             
             // Process dependents
             this.processDependents(task);
-<<<<<<< HEAD
-=======
             this.pruneTaskMap();
->>>>>>> upstream/main
             
         } catch (error) {
             // Handle error
@@ -358,10 +349,7 @@ class RenderScheduler extends EventEmitter {
                 this.stats.failedTasks++;
                 this.emit('taskFailed', { taskId: task.id, error: error.message });
                 logger.error(`Task ${task.id} failed: ${error.message}`);
-<<<<<<< HEAD
-=======
                 this.pruneTaskMap();
->>>>>>> upstream/main
             }
         }
     }
@@ -385,8 +373,6 @@ class RenderScheduler extends EventEmitter {
             }
         }
     }
-<<<<<<< HEAD
-=======
 
     // Completed/failed tasks are kept in this.taskMap forever, so a long-lived
     // scheduler accumulates one entry per scheduled task (unbounded memory).
@@ -429,7 +415,6 @@ class RenderScheduler extends EventEmitter {
             }
         }
     }
->>>>>>> upstream/main
     
     sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
Resolve leftover conflict markers in backend/scheduler/RenderScheduler.js.
## Changes
Removed 5 conflict blocks keeping the upstream implementation (dependency unlink, taskMap cleanup).
## Impact
RenderScheduler.js loads cleanly.

Fixes #12699

GSSOC
