### PR TITLE
fix(voice-ai): add timeout to the ElevenLabs TTS request

### DIFF
--- a/backend/api/src/services/voice/VoiceAiService.js
+++ b/backend/api/src/services/voice/VoiceAiService.js
@@ -85,6 +85,7 @@ class VoiceAiService {
             'Content-Type': 'application/json',
           },
           responseType: 'stream',
+          timeout: 30000,
         }
       );
 


### PR DESCRIPTION
Closes #12754

## Summary
The ElevenLabs TTS call used axios.post(url, data, { headers, responseType }) with no timeout — axios defaults to timeout: 0 (no timeout), so a stalled upstream connection left the request hanging forever, holding the worker/request thread.

A 30s timeout is now set on the request. A stalled or timed-out upstream aborts via ECONNABORTED, which the existing catch block logs ('Voice AI Pipeline Error: ...') before rethrowing to the caller.

## Changes
- backend/api/src/services/voice/VoiceAiService.js: timeout: 30000 on the ElevenLabs axios.post config.

## Tests
- ESLint clean. test/unit/VoiceAiService.test.js fails 4/4 on clean main (pre-existing openai client setup), unchanged by this PR.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.