### PR TITLE
fix(security): resolve conflict markers and duplicate default export in routes.js

### DIFF
--- a/backend/security/routes.js
+++ b/backend/security/routes.js
@@ -1,12 +1,4 @@
 import express from 'express';
-<<<<<<< HEAD
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import rateLimit from 'express-rate-limit';
-import logger from '../api/src/middleware/logger.js';
-
-const execAsync = promisify(exec);
-=======
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -56,7 +48,6 @@ async function recordAlert({ type, description, severity = 'HIGH', file, process
     return alert;
 }
 
->>>>>>> upstream/main
 const router = express.Router();
 
 // Rate limiters
@@ -66,68 +57,6 @@ const securityLimiter = rateLimit({
     message: { success: false, error: 'Too many requests' }
 });
 
-<<<<<<< HEAD
-// Get threats
-router.get('/security/threats', securityLimiter, async (req, res) => {
-    try {
-        const threats = [
-            {
-                type: 'suspicious_file',
-                file: '/etc/passwd',
-                pid: 1234,
-                timestamp: new Date().toISOString(),
-                severity: 'HIGH'
-            },
-            {
-                type: 'suspicious_process',
-                process: '/bin/sh',
-                pid: 5678,
-                timestamp: new Date().toISOString(),
-                severity: 'MEDIUM'
-            }
-        ];
-        
-        res.json({
-            success: true,
-            data: threats,
-            count: threats.length,
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('Threats error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Get alerts
-router.get('/security/alerts', securityLimiter, async (req, res) => {
-    try {
-        const { severity } = req.query;
-        
-        const alerts = [
-            {
-                id: 1,
-                type: 'file_access',
-                description: 'Sensitive file accessed',
-                file: '/etc/passwd',
-                severity: 'CRITICAL',
-                timestamp: new Date().toISOString(),
-                resolved: false
-            },
-            {
-                id: 2,
-                type: 'process_execution',
-                description: 'Suspicious process executed',
-                process: 'nc -l -p 4444',
-                severity: 'HIGH',
-                timestamp: new Date().toISOString(),
-                resolved: false
-            }
-        ];
-        
-        const filtered = severity ? alerts.filter(a => a.severity === severity) : alerts;
-        
-=======
 // Get alerts (persisted alert store)
 router.get('/security/alerts', securityLimiter, async (req, res) => {
     try {
@@ -142,7 +71,6 @@ router.get('/security/alerts', securityLimiter, async (req, res) => {
             filtered = filtered.filter((alert) => !alert.resolved);
         }
 
->>>>>>> upstream/main
         res.json({
             success: true,
             data: filtered,
@@ -155,25 +83,11 @@ router.get('/security/alerts', securityLimiter, async (req, res) => {
     }
 });
 
-<<<<<<< HEAD
-// Resolve alert
-=======
 // Resolve alert (only for a real, persisted alert)
->>>>>>> upstream/main
 router.post('/security/alerts/:alertId/resolve', securityLimiter, async (req, res) => {
     try {
         const { alertId } = req.params;
         const { resolution } = req.body;
-<<<<<<< HEAD
-        
-        res.json({
-            success: true,
-            data: {
-                alertId,
-                resolution: resolution || 'Resolved',
-                resolvedAt: new Date().toISOString()
-            },
-=======
 
         const alerts = await loadAlerts();
         const alert = alerts.find((entry) => String(entry.id) === String(alertId));
@@ -194,7 +108,6 @@ router.post('/security/alerts/:alertId/resolve', securityLimiter, async (req, re
         res.json({
             success: true,
             data: alert,
->>>>>>> upstream/main
             timestamp: new Date().toISOString()
         });
     } catch (error) {
@@ -203,92 +116,6 @@ router.post('/security/alerts/:alertId/resolve', securityLimiter, async (req, re
     }
 });
 
-<<<<<<< HEAD
-// Get file integrity
-router.get('/security/integrity', securityLimiter, async (req, res) => {
-    try {
-        const files = [
-            {
-                path: '/etc/passwd',
-                hash: 'abc123',
-                modified: false,
-                lastCheck: new Date().toISOString()
-            },
-            {
-                path: '/etc/sudoers',
-                hash: 'def456',
-                modified: false,
-                lastCheck: new Date().toISOString()
-            }
-        ];
-        
-        res.json({
-            success: true,
-            data: files,
-            count: files.length,
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('Integrity error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Start monitoring
-router.post('/security/monitor/start', securityLimiter, async (req, res) => {
-    try {
-        // In production: start eBPF monitoring
-        res.json({
-            success: true,
-            message: 'Security monitoring started',
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('Start monitoring error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Stop monitoring
-router.post('/security/monitor/stop', securityLimiter, async (req, res) => {
-    try {
-        // In production: stop eBPF monitoring
-        res.json({
-            success: true,
-            message: 'Security monitoring stopped',
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('Stop monitoring error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-// Get stats
-router.get('/security/stats', async (req, res) => {
-    try {
-        const stats = {
-            threats_detected: 42,
-            alerts_active: 5,
-            alerts_resolved: 37,
-            files_monitored: 150,
-            monitoring_active: true,
-            timestamp: new Date().toISOString()
-        };
-        
-        res.json({
-            success: true,
-            data: stats,
-            timestamp: new Date().toISOString()
-        });
-    } catch (error) {
-        logger.error('Stats error:', error);
-        res.status(500).json({ success: false, error: error.message });
-    }
-});
-
-export default router;
-=======
 // Get threats (requires a real eBPF/threat source; not implemented)
 router.get('/security/threats', securityLimiter, async (req, res) => {
     res.status(501).json({ success: false, error: 'Not implemented', message: 'Threat detection source is not wired up yet' });
@@ -316,4 +143,3 @@ router.get('/security/stats', securityLimiter, async (req, res) => {
 
 export default router;
 export { recordAlert };
->>>>>>> upstream/main


### PR DESCRIPTION
## Summary
Resolve conflict markers and the duplicate `export default router;` in backend/security/routes.js.
## Changes
Kept the upstream side in every conflict block and consolidated the two `export default router;` statements into one.
## Impact
Module exports the router exactly once.

Fixes #12701

GSSOC
