### PR TITLE
fix(region-service): validate REGIONS env var at startup

### DIFF
--- a/k8s/multi-region/region-service.js
+++ b/k8s/multi-region/region-service.js
@@ -23,29 +23,44 @@ class RegionService {
     }
 
     loadRegionConfig() {
-        const config = process.env.REGIONS ? JSON.parse(process.env.REGIONS) : [
-            {
-                name: 'us-east-1',
-                endpoint: process.env.US_EAST_ENDPOINT || 'https://us-east.truxify.com',
-                cluster: 'us-east',
-                primary: true,
-                weight: 33
-            },
-            {
-                name: 'eu-west-1',
-                endpoint: process.env.EU_WEST_ENDPOINT || 'https://eu-west.truxify.com',
-                cluster: 'eu-west',
-                primary: false,
-                weight: 33
-            },
-            {
-                name: 'ap-south-1',
-                endpoint: process.env.AP_SOUTH_ENDPOINT || 'https://ap-south.truxify.com',
-                cluster: 'ap-south',
-                primary: false,
-                weight: 34
+        let config;
+        if (process.env.REGIONS) {
+            try {
+                config = JSON.parse(process.env.REGIONS);
+            } catch (err) {
+                logger.error(`Invalid REGIONS env var (must be valid JSON). Value: ${process.env.REGIONS}`);
+                logger.error(`JSON parse error: ${err.message}`);
+                process.exit(1);
             }
-        ];
+            if (!Array.isArray(config)) {
+                logger.error(`REGIONS env var must be a JSON array of region objects. Value: ${process.env.REGIONS}`);
+                process.exit(1);
+            }
+        } else {
+            config = [
+                {
+                    name: 'us-east-1',
+                    endpoint: process.env.US_EAST_ENDPOINT || 'https://us-east.truxify.com',
+                    cluster: 'us-east',
+                    primary: true,
+                    weight: 33
+                },
+                {
+                    name: 'eu-west-1',
+                    endpoint: process.env.EU_WEST_ENDPOINT || 'https://eu-west.truxify.com',
+                    cluster: 'eu-west',
+                    primary: false,
+                    weight: 33
+                },
+                {
+                    name: 'ap-south-1',
+                    endpoint: process.env.AP_SOUTH_ENDPOINT || 'https://ap-south.truxify.com',
+                    cluster: 'ap-south',
+                    primary: false,
+                    weight: 34
+                }
+            ];
+        }
 
         this.regions = config;
         this.activeRegions = config.filter(r => r.active !== false);


### PR DESCRIPTION
Closes #12755

## Summary
loadRegionConfig() ran JSON.parse(process.env.REGIONS) at module load with no guard. A single malformed value (trailing comma, non-JSON, accidental log prefix) made the process throw during import and crash-loop the pod with an opaque parse exception.

The env var is now validated at startup:
- a JSON parse failure logs a clear error naming the offending value and exits with code 1
- a valid JSON value that is not an array (which would have crashed later in filter()/find()) also fails fast with a clear message
- unset REGIONS keeps the existing default region set

## Changes
- k8s/multi-region/region-service.js: guarded, validated REGIONS parsing in loadRegionConfig().

## Verification
- node --check passes on the edited file. No test suite exists for this standalone k8s service.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.