### PR TITLE
fix(mev): use top-level ESM ethers import in recoverSender

### DIFF
--- a/backend/mev/routes.js
+++ b/backend/mev/routes.js
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import express from 'express';
 import mevService from './mev.service.js';
 import logger from '../api/src/middleware/logger.js';
@@ -123,7 +124,6 @@ export default router;
 // === Spec 43: recover sender ===
 export function recoverSender(msg, sig) {
   try {
-    const { ethers } = require('ethers');
     return ethers.verifyMessage(msg, sig);
   } catch (_) { return null; }
 }


### PR DESCRIPTION
## Summary
Fix recoverSender using require(ethers) inside an ESM module, which always failed and returned null.
## Changes
Imported ethers at module top level (v6) and removed the in-function require.
## Impact
recoverSender returns the recovered address for valid signatures.

Fixes #12704

GSSOC
