### PR TITLE
fix(customer app): guard null metric values in ml_dashboard

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -98,6 +98,7 @@ class _MLDashboardState extends State<MLDashboard> {
     results.forEach((metric, values) {
       final prod = values['production']?.toStringAsFixed(2);
       final shadow = values['shadow']?.toStringAsFixed(2);
+      if (prod == null || shadow == null) return;
       rows.add(_buildMetricRow(metric, prod, shadow, metric == 'rmse'));
     });
 


### PR DESCRIPTION
## Summary
Prevent double.parse(null) crash in the customer ML dashboard metrics card.
## Changes
Skip a metric row when its production or shadow value is missing/null.
## Impact
No more runtime TypeError when a metric result lacks production/shadow values.

Fixes #12706

GSSOC
