### PR TITLE
fix(mev): remove dead axios submitFlashbotsBundle duplicate

### DIFF
--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import axios from 'axios';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
 import { getMevRelayer } from './flashbots_relayer.js';
@@ -182,48 +181,6 @@ class MEVService {
     }
 
     // ============ Flashbots Integration ============
-
-    async submitFlashbotsBundle(escrowId, transactions) {
-        try {
-            // Sign transactions
-            const signedTxs = await this.signTransactions(transactions);
-            
-            // Get current block number
-            const blockNumber = await this.provider.getBlockNumber();
-            const targetBlock = blockNumber + 1;
-            
-            // Submit to Flashbots
-            const response = await axios.post(
-                `${this.flashbotsEndpoint}/eth/v1/bundle`,
-                {
-                    jsonrpc: "2.0",
-                    method: "eth_sendBundle",
-                    params: [{
-                        txs: signedTxs,
-                        blockNumber: `0x${targetBlock.toString(16)}`
-                    }],
-                    id: 1
-                }
-            );
-            
-            // Store bundle
-            await this.storeBundle({
-                escrowId,
-                bundleId: response.data.result,
-                blockNumber: targetBlock
-            });
-            
-            logger.info(`✅ Flashbots bundle submitted for escrow ${escrowId}`);
-            return {
-                success: true,
-                bundleId: response.data.result,
-                blockNumber: targetBlock
-            };
-        } catch (error) {
-            logger.error('Flashbots bundle submission failed:', error);
-            throw error;
-        }
-    }
 
     async signTransactions(transactions) {
         const signedTxs = [];


### PR DESCRIPTION
## Summary
Remove the dead axios-based submitFlashbotsBundle duplicate in mev.service.js.
## Changes
Deleted the legacy axios submission copy and its now-unused axios import; the relayer-based implementation remains.
## Impact
Single source of truth for bundle submission.

Fixes #12707

GSSOC
