### PR TITLE
fix(snyk): guard snyk CLI output parsing with a shared helper

### DIFF
--- a/snyk/snyk.service.js
+++ b/snyk/snyk.service.js
@@ -32,6 +32,39 @@ class SnykService {
         return sanitized;
     }
 
+    // The snyk CLI can emit non-JSON lines (progress/spinner frames, warnings,
+    // plain-text summaries) around the JSON payload. Never let a bare
+    // JSON.parse turn that into a hard scan failure: try the full output, then
+    // the last JSON document found within it, and otherwise return null so the
+    // caller can report a structured failure with the raw output logged.
+    _parseJsonOutput(stdout) {
+        try {
+            return JSON.parse(stdout);
+        } catch {
+            // fall through to scan-for-JSON below
+        }
+        for (const pair of [['{', '}'], ['[', ']']]) {
+            const [open, close] = pair;
+            const start = stdout.indexOf(open);
+            if (start === -1) continue;
+            let end = -1;
+            for (let i = stdout.length - 1; i >= start; i--) {
+                if (stdout[i] === close) {
+                    end = i;
+                    break;
+                }
+            }
+            if (end === -1) continue;
+            try {
+                return JSON.parse(stdout.slice(start, end + 1));
+            } catch {
+                // keep scanning
+            }
+        }
+        logger.error('Snyk produced non-JSON output:', stdout);
+        return null;
+    }
+
     async scanDependencies(projectPath = '.') {
         try {
             const safePath = this._sanitizePath(projectPath);
@@ -43,7 +76,10 @@ class SnykService {
                 return { success: false, error: stderr };
             }
             
-            const results = JSON.parse(stdout);
+            const results = this._parseJsonOutput(stdout);
+            if (results === null) {
+                return { success: false, error: 'Snyk dependency scan produced non-JSON output (see logs)' };
+            }
             this.scanResults.push({
                 type: 'dependencies',
                 timestamp: new Date().toISOString(),
@@ -72,7 +108,10 @@ class SnykService {
                 return { success: false, error: stderr };
             }
             
-            const results = JSON.parse(stdout);
+            const results = this._parseJsonOutput(stdout);
+            if (results === null) {
+                return { success: false, error: 'Snyk container scan produced non-JSON output (see logs)' };
+            }
             this.scanResults.push({
                 type: 'container',
                 image: safeImage,
@@ -102,7 +141,10 @@ class SnykService {
                 return { success: false, error: stderr };
             }
             
-            const results = JSON.parse(stdout);
+            const results = this._parseJsonOutput(stdout);
+            if (results === null) {
+                return { success: false, error: 'Snyk IaC scan produced non-JSON output (see logs)' };
+            }
             this.scanResults.push({
                 type: 'iac',
                 path: safePath,
@@ -132,7 +174,10 @@ class SnykService {
                 return { success: false, error: stderr };
             }
             
-            const results = JSON.parse(stdout);
+            const results = this._parseJsonOutput(stdout);
+            if (results === null) {
+                return { success: false, error: 'Snyk code scan produced non-JSON output (see logs)' };
+            }
             this.scanResults.push({
                 type: 'code',
                 path: safePath,


### PR DESCRIPTION
Closes #12758

## Summary
Four scan methods (scanDependencies, scanContainer, scanIaC, scanCode) parsed the snyk CLI stdout with bare JSON.parse(). The snyk CLI frequently emits non-JSON lines — progress/spinner frames, warnings, plain-text summaries — so any such output threw mid-scan and the scanner reported a hard failure instead of a structured result.

A single _parseJsonOutput() helper now handles all four sites:
- tries JSON.parse on the full output
- on failure, extracts and parses the last JSON document ({...} or [...]) embedded in the noise
- on total failure, logs the raw output and returns null, and the caller returns a structured { success: false } scan-failed result

## Changes
- snyk/snyk.service.js: add _parseJsonOutput(); route all four JSON.parse sites through it with structured failure handling.

## Verification
- node --check passes; helper behavior verified for pure JSON, noise-prefixed JSON, JSON arrays, and non-JSON input. No test suite exists for this standalone service.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.