### PR TITLE
fix(driver app): guard avatar initials against names with stray spaces

### DIFF
--- a/apps/driver/lib/screens/profile_screen.dart
+++ b/apps/driver/lib/screens/profile_screen.dart
@@ -758,6 +758,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
     );
   }
 
+  String _initials(String name) {
+    final parts = name.trim().split(' ').where((s) => s.isNotEmpty).toList();
+    if (parts.isEmpty) return 'JD';
+    return parts[0].substring(0, 1) +
+        (parts.length > 1 ? parts[1].substring(0, 1) : '');
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -794,12 +801,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     radius: 30,
                     backgroundColor: Theme.of(context).colorScheme.surface,
                     child: Text(
-                      _driverName.isNotEmpty
-                          ? _driverName.substring(0, 1) +
-                              (_driverName.contains(' ')
-                                  ? _driverName.split(' ')[1].substring(0, 1)
-                                  : '')
-                          : 'JD',
+                      _initials(_driverName),
                       style: GoogleFonts.dmSans(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
Guard avatar-initial substring against names with stray or trailing spaces.
## Changes
Added an _initials helper that trims the name and filters empty parts before taking the initials, falling back to JD.
## Impact
No RangeError for names like "John " or "John  Smith".

Fixes #12708

GSSOC
