### PR TITLE
fix(state-channels): resolve conflict markers in test_state_channel.js

### DIFF
--- a/backend/state-channels/test_state_channel.js
+++ b/backend/state-channels/test_state_channel.js
@@ -1,28 +1,10 @@
 import { StateChannelManager } from './channel_manager.js';
 import assert from 'assert';
-<<<<<<< HEAD
-=======
 import { generateKeyPairSync } from 'crypto';
->>>>>>> upstream/main
 
 console.log('Testing StateChannelManager...');
 
 const manager = new StateChannelManager();
-<<<<<<< HEAD
-const channelId = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
-const userA = '0xUserAAddress';
-const userB = '0xUserBAddress';
-
-const state = manager.createChannelState(channelId, userA, userB, 1000, 0);
-assert.strictEqual(state.sequence, 0);
-assert.strictEqual(state.balanceA, 1000);
-
-manager.updateState(channelId, 250, userB);
-const updatedState = manager.activeChannels.get(channelId);
-assert.strictEqual(updatedState.sequence, 1);
-assert.strictEqual(updatedState.balanceA, 750);
-assert.strictEqual(updatedState.balanceB, 250);
-=======
 const channelId = 'channel-001';
 const userA = '0xAAAA';
 const userB = '0xBBBB';
@@ -68,6 +50,5 @@ assert.throws(
   () => manager.updateState(channelId, 100, userB, staleSignature, publicKeyA),
   /Invalid signature/
 );
->>>>>>> upstream/main
 
 console.log('✅ StateChannelManager tests passed successfully.');


### PR DESCRIPTION
## Summary
Resolve conflict markers in backend/state-channels/test_state_channel.js.
## Changes
Kept the upstream test code (ECDSA-signed state updates) and removed the stale HEAD side.
## Impact
Test file loads and runs against the current channel manager.

Fixes #12709

GSSOC
