### PR TITLE
fix(shared): resolve merge conflict markers in shared services (#12731)

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -518,13 +518,8 @@ Future<http.Response> _execute(
     if (response.statusCode == 429) {
         final retryAfterHeader = response.headers['retry-after'];
 
-<<<<<<< HEAD
-        final retryAfterSeconds =
-            int.tryParse(retryAfterHeader ?? '') ?? 0;
-=======
         final rawRetryAfterSeconds = int.tryParse(retryAfterHeader ?? '') ?? 1;
         final retryAfterSeconds = rawRetryAfterSeconds.clamp(1, 30);
->>>>>>> upstream/main
 
         throw RateLimitException(
             response.statusCode,

--- a/packages/truxify_shared/lib/src/services/auth_service.dart
+++ b/packages/truxify_shared/lib/src/services/auth_service.dart
@@ -104,13 +104,6 @@ class AuthService {
   Future<UserCredential> verifyOtp(
       String verificationId, String smsCode) async {
     if (_auth == null) throw Exception('Firebase Auth is not available');
-<<<<<<< HEAD
-    final credential = PhoneAuthProvider.credential(
-      verificationId: verificationId,
-      smsCode: smsCode,
-    );
-    return _auth.signInWithCredential(credential);
-=======
     if (!_validateOtp(smsCode)) {
       throw ArgumentError(_lastAuthError ?? 'Invalid OTP');
     }
@@ -124,7 +117,6 @@ class AuthService {
     } finally {
       _isAuthenticating = false;
     }
->>>>>>> upstream/main
   }
 
   /// Sign out the current user.

--- a/packages/truxify_shared/lib/src/services/fcm_service.dart
+++ b/packages/truxify_shared/lib/src/services/fcm_service.dart
@@ -3,10 +3,7 @@ import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
-<<<<<<< HEAD
-=======
 import 'package:supabase_flutter/supabase_flutter.dart';
->>>>>>> upstream/main
 
 import 'api_client.dart';
 import 'notification_router.dart';
@@ -201,12 +198,8 @@ class FcmService {
     ApiClient? apiClient,
   }) async {
     final firebaseUser = FirebaseAuth.instance.currentUser;
-<<<<<<< HEAD
-    if (firebaseUser == null) {
-=======
     final supabaseUser = _currentSupabaseUser();
     if (firebaseUser == null && supabaseUser == null) {
->>>>>>> upstream/main
       debugPrint('[FCM] No authenticated user, skipping token unregister.');
       return;
     }
@@ -218,10 +211,7 @@ class FcmService {
         '/api/devices/unregister',
         body: <String, dynamic>{
           'fcmToken': token,
-<<<<<<< HEAD
-=======
           'userId': firebaseUser?.uid ?? supabaseUser?.id,
->>>>>>> upstream/main
         },
       );
       debugPrint('[FCM] Device token unregistered successfully.');
@@ -232,8 +222,6 @@ class FcmService {
     }
   }
 
-<<<<<<< HEAD
-=======
   /// Returns the currently signed-in Supabase user, or null if Supabase is
   /// not configured/initialized or no user is signed in.
   static User? _currentSupabaseUser() {
@@ -244,7 +232,6 @@ class FcmService {
     }
   }
 
->>>>>>> upstream/main
   static Future<void> clearToken({ApiClient? apiClient}) async {
     try {
       await _sendTokenToBackend(null, apiClient: apiClient);
@@ -258,12 +245,8 @@ class FcmService {
     ApiClient? apiClient,
   }) async {
     final firebaseUser = FirebaseAuth.instance.currentUser;
-<<<<<<< HEAD
-    if (firebaseUser == null) {
-=======
     final supabaseUser = _currentSupabaseUser();
     if (firebaseUser == null && supabaseUser == null) {
->>>>>>> upstream/main
       debugPrint('[FCM] No authenticated user, skipping token upload.');
       return;
     }
@@ -275,10 +258,7 @@ class FcmService {
         '/api/profile/fcm-token',
         body: <String, dynamic>{
           'fcmToken': token,
-<<<<<<< HEAD
-=======
           'userId': firebaseUser?.uid ?? supabaseUser?.id,
->>>>>>> upstream/main
         },
       );
       debugPrint('[FCM] Token updated successfully on backend.');

--- a/packages/truxify_shared/lib/src/services/notification_router.dart
+++ b/packages/truxify_shared/lib/src/services/notification_router.dart
@@ -57,8 +57,6 @@ enum NotificationTarget {
   unknown,
 }
 
-<<<<<<< HEAD
-=======
 /// Single source of truth mapping a notification type to the in-app
 /// [NotificationTarget] used for badge/consumption tracking.
 ///
@@ -82,7 +80,6 @@ const Map<String, NotificationTarget> _targetByType = {
   'general_notification': NotificationTarget.notifications,
 };
 
->>>>>>> upstream/main
 /// Signature for the app-specific navigation callback.
 ///
 /// The callback receives the resolved [target] and the raw [data] map so it
@@ -143,18 +140,9 @@ class NotificationRouter {
         return const NavigateToNotificationsList();
 
       case 'payment_released':
-<<<<<<< HEAD
-        switch (appType) {
-          case NotificationAppType.customer:
-            return const NavigateToWallet();
-          case NotificationAppType.driver:
-            return const NavigateToEarnings();
-        }
-=======
         return appType == NotificationAppType.customer
             ? const NavigateToWallet()
             : const NavigateToEarnings();
->>>>>>> upstream/main
 
       case 'support_ticket':
         if (payload.supportTicketId != null) {
@@ -193,30 +181,6 @@ class NotificationRouter {
 
   /// Resolves the [NotificationTarget] from a raw data map (FCM data payload
   /// or [NotificationItem.metadata]).
-<<<<<<< HEAD
-  static NotificationTarget resolveTarget(Map<String, dynamic> data) {
-    final type = _extractNotifType(data);
-    switch (type) {
-      case 'order_update':
-      case 'delivery_otp':
-        return NotificationTarget.orderDetail;
-      case 'trip_update':
-      case 'trip_completed':
-        return NotificationTarget.tripDetail;
-      case 'payment':
-      case 'payment_released':
-        return NotificationTarget.earnings;
-      case 'load_offer':
-        return NotificationTarget.loadDetail;
-      case 'system':
-      case 'document':
-        return NotificationTarget.notifications;
-      case 'document_expiry':
-        return NotificationTarget.documents;
-      default:
-        return NotificationTarget.unknown;
-    }
-=======
   ///
   /// The mapping is centralized in [_targetByType] so it stays in sync with the
   /// deep-link route produced by [resolve].
@@ -244,7 +208,6 @@ class NotificationRouter {
       return NotificationTarget.notifications;
     }
     return NotificationTarget.unknown;
->>>>>>> upstream/main
   }
 
   /// Extracts the order display ID from the data map.

--- a/packages/truxify_shared/lib/src/services/resilient_websocket.dart
+++ b/packages/truxify_shared/lib/src/services/resilient_websocket.dart
@@ -135,10 +135,6 @@ class ResilientWebSocket {
     try {
       final targetUrl = urlFactory != null ? urlFactory!() : url;
       _channel = WebSocketChannel.connect(Uri.parse(targetUrl));
-<<<<<<< HEAD
-      // Wait for the TCP/TLS handshake to complete before proceeding.
-      await _channel!.ready;
-=======
       // Wait for the TCP/TLS handshake to complete before proceeding. Bound the
       // wait so a stalled upgrade (proxy silently holds the connection open,
       // flaky mobile network) cannot hang the wrapper in `connecting` forever —
@@ -147,7 +143,6 @@ class ResilientWebSocket {
         const Duration(seconds: 10),
         onTimeout: () => throw TimeoutException('WS handshake timed out'),
       );
->>>>>>> upstream/main
       _subscription = _channel!.stream.listen(
         (message) {
           _controller.add(message);


### PR DESCRIPTION
## Summary
Removes unresolved git merge-conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>> upstream/main`) left in five shared services under `packages/truxify_shared/lib/src/services/`. The conflict blocks made the package unparseable for both the customer and driver apps, breaking compilation.

## Changes
- `packages/truxify_shared/lib/src/services/api_client.dart` – drop stray conflict block in the retry-handling path.
- `packages/truxify_shared/lib/src/services/auth_service.dart` – resolve conflict block in `signInWithOtp`; keep the phone-credential flow.
- `packages/truxify_shared/lib/src/services/fcm_service.dart` – resolve six conflict blocks in the FCM token/firebase-user guards.
- `packages/truxify_shared/lib/src/services/notification_router.dart` – resolve conflict blocks in `resolveTarget`/navigation mapping.
- `packages/truxify_shared/lib/src/services/resilient_websocket.dart` – resolve conflict in the handshake wait; keep the upstream timeout-bounded `ready` (which preserves the outbound-queue flush landed in #11576).

## Impact
Restores parsing/compilation of `truxify_shared` for both apps. No behavior change beyond taking the intended upstream/main side of each conflict.

Fixes #12731

GSSOC
