### PR TITLE
fix(tokenization): fall back to wallet signer in sellFraction (#12732)

### DIFF
--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -112,7 +112,7 @@ class TokenizationService {
 
     async sellFraction(assetId, amount, userAddress, signer) {
         try {
-            const userContract = new ethers.Contract(this.tokenAddress, this.tokenABI, signer);
+            const userContract = new ethers.Contract(this.tokenAddress, this.tokenABI, signer || this.wallet);
             const tx = await userContract.sellFraction(
                 assetId,
                 ethers.parseEther(amount.toString()),


### PR DESCRIPTION
## Summary
`sellFraction` declares a `signer` parameter but the routes call it with only three arguments, so `signer` is always `undefined` and `new ethers.Contract(..., signer)` throws. Fall back to the service wallet, mirroring `purchaseFraction`.

## Changes
- `backend/tokenization/token.service.js` – `new ethers.Contract(this.tokenAddress, this.tokenABI, signer || this.wallet)` in `sellFraction`.

## Impact
Enables selling a token fraction via the wallet route without passing an explicit signer.

Fixes #12732

GSSOC
