### PR TITLE
fix(tokenization): export tokenCostWei and extractEventArg helpers (#12733)

### DIFF
--- a/backend/tokenization/token.service.js
+++ b/backend/tokenization/token.service.js
@@ -2,6 +2,58 @@ import { ethers } from 'ethers';
 import logger from '../api/src/middleware/logger.js';
 import { supabase } from '../api/src/config/db.js';
 
+const WEI_UNIT = 10n ** 18n;
+
+/**
+ * Compute the exact wei cost of an amount of tokens at a given price.
+ *
+ * Both inputs are decimal strings (e.g. "0.1" ETH/token and "3" tokens). The
+ * contract multiplies the two wei values and divides by 1e18, so we replicate
+ * that with integer math only — no `parseFloat` — which avoids the float
+ * drift that previously lost wei (e.g. 0.1 * 3 rounded to 0.30000000000000004).
+ *
+ * @param {string|number} price   price per token in ether units
+ * @param {string|number} amount  number of tokens in ether units
+ * @param {boolean} roundUp       match the contract's ceiling (purchase) vs floor (trade)
+ * @returns {bigint} total cost in wei
+ */
+export function tokenCostWei(price, amount, roundUp = true) {
+    const priceWei = ethers.parseEther(price.toString());
+    const amountWei = ethers.parseEther(amount.toString());
+    const product = priceWei * amountWei;
+    return roundUp ? (product + WEI_UNIT - 1n) / WEI_UNIT : product / WEI_UNIT;
+}
+
+/**
+ * Extract an argument from the first matching event in a transaction receipt.
+ *
+ * The on-chain asset/trade IDs are assigned inside the same transaction that
+ * performs the mint/order, so reading them from the emitted event is
+ * race-free. This replaces the previous `getTotalAssets()` / `getTotalTradeOrders()`
+ * counters, which were a TOCTOU: after the tx was mined but before the count
+ * was read, a concurrent create could shift the value and produce a wrong ID.
+ *
+ * @param {object} receipt  ethers v6 transaction receipt with `.logs`
+ * @param {object} contract ethers Contract (or object exposing `.interface`)
+ * @param {string} eventName
+ * @param {number} argIndex
+ * @returns {any} the requested event argument, or null if not found
+ */
+export function extractEventArg(receipt, contract, eventName, argIndex = 0) {
+    if (!receipt || !contract || !contract.interface) return null;
+    for (const log of receipt.logs || []) {
+        try {
+            const parsed = contract.interface.parseLog(log);
+            if (parsed && parsed.name === eventName) {
+                return parsed.args[argIndex];
+            }
+        } catch {
+            // log emitted by a different contract / not decodable here
+        }
+    }
+    return null;
+}
+
 class TokenizationService {
     constructor() {
         this.provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL);


### PR DESCRIPTION
## Summary
The unit tests in `backend/api/test/unit/tokenization.test.ts` import `tokenCostWei` and `extractEventArg` as named exports from `token.service.js`, but the refactor that removed the conflict-marker block in this file also dropped those helpers. Re-add and export them.

## Changes
- `backend/tokenization/token.service.js` – export `tokenCostWei` (integer wei math via `parseEther`, no float drift) and `extractEventArg` (parse `receipt.logs` for the first matching event and return the requested argument), plus the `WEI_UNIT` constant.

## Impact
Un-breaks `tokenization.test.ts` loading and restores exact wei cost / event-argument logic used by the token mint/order flow.

Fixes #12733

GSSOC
