### PR TITLE
fix(customer): read order eta field on home screen (#12734)

### DIFF
--- a/apps/customer/lib/screens/home_screen.dart
+++ b/apps/customer/lib/screens/home_screen.dart
@@ -222,7 +222,7 @@ class _HomeScreenState extends State<HomeScreen> {
     // The API returns snake_case statuses; humanize before comparing so the
     // in-transit styling/live badge actually triggers.
     final status = _formatStatus(order['status']?.toString() ?? 'pending');
-    final eta = order['estimated_arrival']?.toString() ?? 'Pending';
+    final eta = order['eta']?.toString() ?? 'Pending';
 
     return ShipmentCardData(
       route: route,


### PR DESCRIPTION
## Summary
The customer home screen reads `order['estimated_arrival']`, a key the backend never produces — the order history payload exposes the ETA under `eta`. The ETA card therefore always shows the fallback.

## Changes
- `apps/customer/lib/screens/home_screen.dart` – read `order['eta']` instead of `order['estimated_arrival']`.

## Impact
The order ETA card on the home screen now shows the real value returned by the API.

Fixes #12734

GSSOC
