### PR TITLE
fix(api): include truck_number in order history select (#12735)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -216,7 +216,7 @@ export class OrderLifecycleService {
     return measureExecution('OrderLifecycleService.getOrderHistory', async () => {
       const { data: history, error, count } = await this.orderRepository.findOrdersWithCount(
         customerId,
-        'id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, driver_id, eta, created_at',
+        'id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, goods_type, driver_id, eta, truck_number, created_at',
         { page, limit }
       );
 


### PR DESCRIPTION
## Summary
`getOrderHistory` selects a fixed column list that omits `truck_number`, so the customer order-history and order-detail screens (which read `order['truck_number']`) always show it as null.

## Changes
- `backend/api/src/services/order/orderLifecycleService.js` – add `truck_number` to the `select` list of the order-history query.

## Impact
Customer screens can now display the assigned truck for past orders instead of a blank value.

Fixes #12735

GSSOC
