### PR TITLE
fix(driver): use valid grey swatch in reefer precool screen (#12736)

### DIFF
--- a/apps/driver/lib/screens/automated_reefer_precool_screen.dart
+++ b/apps/driver/lib/screens/automated_reefer_precool_screen.dart
@@ -65,7 +65,7 @@ class _AutomatedReeferPrecoolScreenState extends State<AutomatedReeferPrecoolScr
 
   Widget _buildWeatherEtaCard(ReeferTelemetry t) {
     return Card(
-      color: Colors.grey[850],
+      color: Colors.grey[800],
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -171,7 +171,7 @@ class _AutomatedReeferPrecoolScreenState extends State<AutomatedReeferPrecoolScr
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(color: Colors.grey[850], borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(color: Colors.grey[800], borderRadius: BorderRadius.circular(12)),
       child: const Text('REEFER OFF', textAlign: TextAlign.center, style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold, fontSize: 18)),
     );
   }
@@ -189,7 +189,7 @@ class _AutomatedReeferPrecoolScreenState extends State<AutomatedReeferPrecoolScr
   Widget _buildMetricCard(String title, String value, IconData icon) {
     return Container(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(color: Colors.grey[850], borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(color: Colors.grey[800], borderRadius: BorderRadius.circular(12)),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
## Summary
`Colors.grey[850]` does not exist in the Material `Colors` palette; the named swatch lookup returns null at runtime. Replace it with a valid swatch.

## Changes
- `apps/driver/lib/screens/automated_reefer_precool_screen.dart` – `Colors.grey[850]` → `Colors.grey[800]` in the weather ETA card and the reefer-off container.

## Impact
Fixes the invalid colour lookup (previously resolved to null) on the automated reefer precool screen.

Fixes #12736

GSSOC
