### PR TITLE
fix(driver): use valid grey swatch in drone trailer locator screen (#12737)

### DIFF
--- a/apps/driver/lib/screens/drone_trailer_locator_screen.dart
+++ b/apps/driver/lib/screens/drone_trailer_locator_screen.dart
@@ -154,7 +154,7 @@ class _DroneTrailerLocatorScreenState extends State<DroneTrailerLocatorScreen> {
 
   Widget _buildPinCard(TrailerLocation t) {
     return Card(
-      color: Colors.grey[850],
+      color: Colors.grey[800],
       elevation: 4,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),


### PR DESCRIPTION
## Summary
`Colors.grey[850]` is not a valid Material swatch key and resolves to null at runtime. Replace it with a valid one.

## Changes
- `apps/driver/lib/screens/drone_trailer_locator_screen.dart` – `Colors.grey[850]` → `Colors.grey[800]`.

## Impact
Fixes the invalid colour lookup on the drone trailer locator screen.

Fixes #12737

GSSOC
