### PR TITLE
fix(driver): use valid grey swatch in IFTA jurisdiction screen (#12738)

### DIFF
--- a/apps/driver/lib/screens/automated_ifta_jurisdiction_screen.dart
+++ b/apps/driver/lib/screens/automated_ifta_jurisdiction_screen.dart
@@ -104,7 +104,7 @@ class _AutomatedIftaJurisdictionScreenState extends State<AutomatedIftaJurisdict
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.assessment, size: 80, color: Colors.grey[350]),
+          Icon(Icons.assessment, size: 80, color: Colors.grey[300]),
           const SizedBox(height: 16),
           Text('No report generated yet.', style: TextStyle(color: Colors.grey[600])),
         ],


### PR DESCRIPTION
## Summary
`Colors.grey[350]` is not a valid Material swatch key and resolves to null at runtime. Replace it with a valid one.

## Changes
- `apps/driver/lib/screens/automated_ifta_jurisdiction_screen.dart` – `Colors.grey[350]` → `Colors.grey[300]`.

## Impact
Fixes the invalid colour lookup on the automated IFTA jurisdiction screen.

Fixes #12738

GSSOC
