### PR TITLE
test(api): remove duplicate vitest import in auditLog tests (#12766)

### DIFF
--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -410,7 +410,6 @@ describe('auditWithState convenience', () => {
 
 
 // === Spec 20 test ===
-import { describe, it, expect } from 'vitest';
 import { maskPii } from '../../src/middleware/auditLog.js';
 describe('maskPii', () => {
   it('masks password', () => { expect(maskPii({ password: 'x' })).toEqual({ password: '***' }); });


### PR DESCRIPTION
## Summary
`auditLog.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 413 (an appended spec block re-imports vitest after the file already imported it at line 1). The PII-masking/audit middleware tests therefore never run.

## Changes
- `backend/api/test/unit/auditLog.test.js` – remove the stray duplicate vitest import in the appended `maskPii` spec block, keeping the single top-level import.

## Impact
The file loads and the `maskPii` tests execute (verified via `vitest run`).

Fixes #12766

GSSOC
