### PR TITLE
test(api): fix authFailureMonitor test loading (#12767)

### DIFF
--- a/backend/api/test/unit/authFailureMonitor.test.js
+++ b/backend/api/test/unit/authFailureMonitor.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import logger from '../../middleware/logger.js';
+import logger from '../../src/middleware/logger.js';
 
-vi.mock('../../middleware/logger.js', () => ({
+vi.mock('../../src/middleware/logger.js', () => ({
   default: {
     warn: vi.fn(),
     info: vi.fn(),
@@ -52,7 +52,6 @@ describe('shouldIgnoreError', () => {
 
 
 // === Spec 4 test ===
-import { describe, it, expect, vi } from 'vitest';
 import { checkBoundOrFailClosed } from '../../src/middleware/authFailureMonitor.js';
 describe('checkBoundOrFailClosed', () => {
   it('allows under limit', async () => {


### PR DESCRIPTION
## Summary
`authFailureMonitor.test.js` fails to load for two reasons: a duplicate `import ... from 'vitest'` at line 55, and a wrong import path for the logger mock (`../../middleware/logger.js` does not exist; the middleware lives under `src/middleware/`). The fail-closed auth-failure monitoring tests therefore never run.

## Changes
- `backend/api/test/unit/authFailureMonitor.test.js` – remove the duplicate vitest import in the appended `checkBoundOrFailClosed` spec block, and fix the logger import/mock path from `../../middleware/logger.js` to `../../src/middleware/logger.js`.

## Impact
The file loads and all 7 tests execute and pass (verified via `vitest run`).

Fixes #12767

GSSOC
