### PR TITLE
test(api): fix correlationId test loading (#12768)

### DIFF
--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -129,12 +129,15 @@ describe('correlationIdMiddleware', () => {
 
 
 // === Spec 14 test ===
-import { describe, it, expect } from 'vitest';
-import { runWithCorrelationId, getCorrelationStore } from '../../src/middleware/correlationId.js';
-describe('correlationId', () => {
+import { correlationContext } from '../../src/middleware/correlationId.js';
+describe('correlationId context', () => {
   it('stores in run()', () => {
-    runWithCorrelationId('cid-1', () => { expect(getCorrelationStore().correlationId).toBe('cid-1'); });
+    correlationContext.run({ correlationId: 'cid-1' }, () => {
+      expect(correlationContext.getStore()?.correlationId).toBe('cid-1');
+    });
   });
-  it('empty outside', () => { expect(getCorrelationStore().correlationId).toBeUndefined(); });
+  it('empty outside', () => {
+    expect(correlationContext.getStore()?.correlationId).toBeUndefined();
+  });
 });
 


### PR DESCRIPTION
## Summary
`correlationId.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 132. Additionally, the appended spec block imports `runWithCorrelationId` / `getCorrelationStore`, which are not exported by the middleware (it exposes `correlationContext`, an `AsyncLocalStorage`), so those two tests would fail even after loading.

## Changes
- `backend/api/test/unit/correlationId.test.js` – remove the duplicate vitest import and rewrite the appended `correlationId` spec block to use the module's actual `correlationContext` export.

## Impact
The file loads and all 13 tests execute and pass (verified via `vitest run`).

Fixes #12768

GSSOC
