### PR TITLE
test(api): remove duplicate vitest import in documentValidation tests (#12769)

### DIFF
--- a/backend/api/test/unit/documentValidation.test.js
+++ b/backend/api/test/unit/documentValidation.test.js
@@ -73,7 +73,6 @@ describe('validateDocumentBuffer', () => {
 
 
 // === Spec 7 test ===
-import { describe, it, expect } from 'vitest';
 import { matchesMimeSignature } from '../../src/lib/documentValidation.js';
 describe('matchesMimeSignature', () => {
   it('matches PNG', () => {


### PR DESCRIPTION
## Summary
`documentValidation.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 76 (an appended spec block re-imports vitest after the file already imported it at line 1). The document upload validation tests therefore never run.

## Changes
- `backend/api/test/unit/documentValidation.test.js` – remove the stray duplicate vitest import in the appended `matchesMimeSignature` spec block, keeping the single top-level import.

## Impact
The file loads and the `matchesMimeSignature` tests execute (verified via `vitest run`).

Fixes #12769

GSSOC
