### PR TITLE
test(api): remove duplicate vitest import in fraudMiddleware tests (#12771)

### DIFF
--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -96,7 +96,6 @@ describe('fraudMiddleware', () => {
 
 
 // === Spec 13 test ===
-import { describe, it, expect } from 'vitest';
 import { clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 describe('clampRiskScore', () => {
   it('50 passes', () => { expect(clampRiskScore(50)).toBe(50); });


### PR DESCRIPTION
## Summary
`fraudMiddleware.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 99 (an appended spec block re-imports vitest after the file already imported it at line 1). The fraud-detection middleware tests therefore never run.

## Changes
- `backend/api/test/unit/fraudMiddleware.test.js` – remove the stray duplicate vitest import in the appended `clampRiskScore` spec block, keeping the single top-level import.

## Impact
The file loads and the fraud-detection tests execute (verified via `vitest run`).

Fixes #12771

GSSOC
