### PR TITLE
test(api): remove duplicate vitest import in osrm tests (#12772)

### DIFF
--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -382,7 +382,6 @@ describe('osrm - getRouteEstimate edge cases', () => {
 });
 
 // === Spec 22 test ===
-import { describe, it, expect, vi } from 'vitest';
 import { routeWithFailover } from '../../src/services/osrm.js';
 describe('routeWithFailover', () => {
   it('uses primary', async () => {


### PR DESCRIPTION
## Summary
`osrm.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 385 (an appended spec block re-imports vitest after the file already imported it at line 1). The OSRM routing tests therefore never run.

## Changes
- `backend/api/test/unit/osrm.test.js` – remove the stray duplicate vitest import in the appended `routeWithFailover` spec block, keeping the single top-level import.

## Impact
The file loads and the OSRM routing tests execute (23 of 30 pass via `vitest run`; the 7 remaining failures are pre-existing test/implementation mismatches unrelated to loading, e.g. missing global `fetch` stub, cache-key rounding, and pino-style logger call shape).

Fixes #12772

GSSOC
