### PR TITLE
test(api): remove duplicate vitest import in pricing tests (#12773)

### DIFF
--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -244,7 +244,6 @@ describe('Pricing Service Unit Tests', () => {
 
 
 // === Spec 10 test ===
-import { describe, it, expect } from 'vitest';
 import { guardNonNegative } from '../../src/lib/pricing.js';
 describe('guardNonNegative', () => {
   it('passes positive', () => { expect(guardNonNegative(10, 'x')).toBe(10); });


### PR DESCRIPTION
## Summary
`pricing.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 247 (an appended spec block re-imports vitest after the file already imported it at line 1). The price rounding tests therefore never run.

## Changes
- `backend/api/test/unit/pricing.test.js` – remove the stray duplicate vitest import in the appended `guardNonNegative` spec block, keeping the single top-level import.

## Impact
The file loads and the pricing tests execute (verified via `vitest run`).

Fixes #12773

GSSOC
