### PR TITLE
test(api): remove duplicate vitest import in redisRateLimiter tests (#12774)

### DIFF
--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -15,7 +15,6 @@ describe('redisRateLimiter Middleware', () => {
 
 
 // === Spec 2 test ===
-import { describe, it, expect, vi } from 'vitest';
 import { checkSlidingWindow } from '../../src/middleware/redisRateLimiter.js';
 describe('checkSlidingWindow', () => {
   it('allows under limit', async () => {


### PR DESCRIPTION
## Summary
`redisRateLimiter.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 18 (an appended spec block re-imports vitest after the file already imported it at line 1). The Redis rate-limiting tests therefore never run.

## Changes
- `backend/api/test/unit/redisRateLimiter.test.js` – remove the stray duplicate vitest import in the appended `checkSlidingWindow` spec block, keeping the single top-level import.

## Impact
The file loads and the Redis rate-limiting tests execute (verified via `vitest run`).

Fixes #12774

GSSOC
