### PR TITLE
test(api): remove duplicate vitest import in reputation tests (#12775)

### DIFF
--- a/backend/api/test/unit/reputation.test.js
+++ b/backend/api/test/unit/reputation.test.js
@@ -238,7 +238,6 @@ describe('reputation service', () => {
 
 
 // === Spec 23 test ===
-import { describe, it, expect } from 'vitest';
 import { clampRating, aggregateRating } from '../../src/services/reputation.js';
 describe('clampRating', () => {
   it('5.5 → 5', () => { expect(clampRating(5.5)).toBe(5); });


### PR DESCRIPTION
## Summary
`reputation.test.js` fails to load because of a duplicate `import ... from 'vitest'` at line 241 (an appended spec block re-imports vitest after the file already imported it at line 18). The reputation scoring tests therefore never run.

## Changes
- `backend/api/test/unit/reputation.test.js` – remove the stray duplicate vitest import in the appended `clampRating`/`aggregateRating` spec block, keeping the single top-level import.

## Impact
The file loads and the reputation scoring tests execute (verified via `vitest run`).

Fixes #12775

GSSOC
