### PR TITLE
fix : added error logging to bare catch block in cursorPagination.js

### DIFF
--- a/backend/api/src/utils/cursorPagination.js
+++ b/backend/api/src/utils/cursorPagination.js
@@ -5,6 +5,7 @@
  */
 
 import { Buffer } from 'buffer';
+import logger from '../middleware/logger.js';
 
 /**
  * Encode opaque cursor data into a URL-safe base64 string.
@@ -26,7 +27,8 @@ export function decodeCursor(cursor) {
   try {
     const json = Buffer.from(cursor, 'base64url').toString('utf8');
     return JSON.parse(json);
-  } catch {
+  } catch (err) {
+    logger.warn({ err, cursor }, '[cursorPagination] Failed to decode cursor');
     return null;
   }
 }


### PR DESCRIPTION
Closes #12838.

Summary of What Has Been Done:
The decodeCursor() function in backend/api/src/utils/cursorPagination.js used a bare `catch {}` block that silently returned null without any error logging. This made it impossible to distinguish between invalid base64 cursors and other unexpected parsing failures in production. The fix adds `catch (err)` with a logger.warn call to log the error before returning null.

Changes Made:
- backend/api/src/utils/cursorPagination.js: Added import for logger, replaced bare catch with catch (err) + logger.warn

Impact it Made:
- Enables observability into cursor decoding failures via structured logs
- Maintains existing return value (null for invalid cursors) so no behavior change for callers
- Follows the logging pattern used throughout the codebase

Note: This PR is part of a GSSOC contribution batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid pagination cursors by safely returning no cursor results.
  * Added warning logs to help identify malformed cursor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->