### PR TITLE
fix : added error logging to routeWithFailover catch block in osrm.js

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -291,6 +291,7 @@ export function haversineFallbackKm(lat1, lon1, lat2, lon2) {
 export async function routeWithFailover(primary, _fb, coords) {
   try { return await primary(coords); }
   catch (err) {
+    logger.warn({ errMessage: err?.message }, '[osrm] routeWithFailover: primary call failed, falling back to haversine');
     if (!coords || !coords[0] || !coords[0][0] || !coords[0][1]) {
       return { distance: 0, source: 'haversine-fallback', error: 'No valid coordinates for haversine fallback' };
     }


### PR DESCRIPTION
Closes #12839.

Summary of What Has Been Done:
The routeWithFailover() function in backend/api/src/services/osrm.js had a catch (err) block that silently swallowed the primary route call failure without any logging. Added logger.warn to report the error before returning the haversine fallback response, enabling observability of failover events in production.

Changes Made:
- backend/api/src/services/osrm.js: Added logger.warn call in routeWithFailover catch block

Impact it Made:
- Enables observability into primary route failures and failover events
- Maintains existing failover behavior so no breaking changes for callers
- Follows the logging pattern used in the rest of the osrm.js file

Note: This PR is part of a GSSOC contribution batch.