### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -15,7 +15,6 @@ describe('redisRateLimiter Middleware', () => {
 
 
 // === Spec 2 test ===
-import { describe, it, expect, vi } from 'vitest';
 import { checkSlidingWindow } from '../../src/middleware/redisRateLimiter.js';
 describe('checkSlidingWindow', () => {
   it('allows under limit', async () => {


### PR DESCRIPTION
Closes #12819.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError because JavaScript modules do not allow duplicate top-level imports, preventing the entire test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute
- Fixes pre-existing bug introduced by a prior merge

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.