### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -96,7 +96,6 @@ describe('fraudMiddleware', () => {
 
 
 // === Spec 13 test ===
-import { describe, it, expect } from 'vitest';
 import { clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 describe('clampRiskScore', () => {
   it('50 passes', () => { expect(clampRiskScore(50)).toBe(50); });


### PR DESCRIPTION
Closes #12822.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError because JavaScript modules do not allow duplicate top-level imports, preventing the entire test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute
- Fixes pre-existing bug introduced by a prior merge

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.