### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/escapeLike.test.js
+++ b/backend/api/test/unit/escapeLike.test.js
@@ -46,7 +46,6 @@ describe('escapeLike', () => {
 
 
 // === Spec 17 test ===
-import { describe, it, expect } from 'vitest';
 import { escapeSqlLike } from '../../src/lib/escapeLike.js';
 describe('escapeSqlLike', () => {
   it('escapes %', () => { expect(escapeSqlLike('100%')).toBe('100\\%'); });


### PR DESCRIPTION
Closes #12823.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError preventing the test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.