### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/documentValidation.test.js
+++ b/backend/api/test/unit/documentValidation.test.js
@@ -73,7 +73,6 @@ describe('validateDocumentBuffer', () => {
 
 
 // === Spec 7 test ===
-import { describe, it, expect } from 'vitest';
 import { matchesMimeSignature } from '../../src/lib/documentValidation.js';
 describe('matchesMimeSignature', () => {
   it('matches PNG', () => {


### PR DESCRIPTION
Closes #12824.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError preventing the test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.