### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/authFailureMonitor.test.js
+++ b/backend/api/test/unit/authFailureMonitor.test.js
@@ -52,7 +52,6 @@ describe('shouldIgnoreError', () => {
 
 
 // === Spec 4 test ===
-import { describe, it, expect, vi } from 'vitest';
 import { checkBoundOrFailClosed } from '../../src/middleware/authFailureMonitor.js';
 describe('checkBoundOrFailClosed', () => {
   it('allows under limit', async () => {


### PR DESCRIPTION
Closes #12826.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError preventing the test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.