### PR TITLE
fix : removed duplicate vitest import

### DIFF
--- a/backend/api/test/unit/auditLog.test.js
+++ b/backend/api/test/unit/auditLog.test.js
@@ -410,7 +410,6 @@ describe('auditWithState convenience', () => {
 
 
 // === Spec 20 test ===
-import { describe, it, expect } from 'vitest';
 import { maskPii } from '../../src/middleware/auditLog.js';
 describe('maskPii', () => {
   it('masks password', () => { expect(maskPii({ password: 'x' })).toEqual({ password: '***' }); });


### PR DESCRIPTION
Closes #12827.

Summary of What Has Been Done:
Removed the duplicate `import { describe, it, expect } from 'vitest'` declaration from the test file. This was causing a SyntaxError preventing the test suite from loading.

Changes Made:
- backend/api/test/unit/<file>.test.js: removed duplicate vitest import line

Impact it Made:
- Test file now loads correctly and the previously-unrun tests can execute

Note: These PRs are submitted from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.