### PR TITLE
fix : add timeout to VoiceAiService ElevenLabs axios.post call

### DIFF
--- a/backend/api/src/services/voice/VoiceAiService.js
+++ b/backend/api/src/services/voice/VoiceAiService.js
@@ -85,6 +85,7 @@ class VoiceAiService {
             'Content-Type': 'application/json',
           },
           responseType: 'stream',
+          timeout: 15000,
         }
       );
 


### PR DESCRIPTION
Closes #12828.

Summary of What Has Been Done:
Added timeout: 15000 (15 seconds) to the axios.post options for the ElevenLabs TTS API call in VoiceAiService.js. This prevents indefinite hangs on slow or unresponsive network conditions.

Changes Made:
- backend/api/src/services/voice/VoiceAiService.js: added timeout: 15000 to axios.post options

Impact it Made:
- Prevents indefinite hangs from degrading the Node.js event loop
- Improves service resilience under adverse network conditions

Note: This PR is submitted from GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.