### PR TITLE
fix : add TTL clamp to setCachedProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -238,6 +238,8 @@ export async function setCachedProfile(
 ) {
   const redisClient = getRedisClient();
   if (!redisClient || !firebaseUid || !profile) return;
+  if (ttlSeconds < 1) ttlSeconds = 1;
+  if (ttlSeconds > 86400) ttlSeconds = 86400;
   try {
     await redisClient.set(
       firebaseProfileKey(firebaseUid),


### PR DESCRIPTION
Closes #12829.

Summary of What Has Been Done:
Added TTL clamping to [1, 86400] seconds in setCachedProfile to match the pattern used by setCachedSupabaseProfile and setCachedCustomerStats in the same file.

Changes Made:
- backend/api/src/lib/profileCache.js: added TTL clamping logic

Impact it Made:
- Consistent TTL handling across all profile cache setters
- Prevents Redis from storing keys with TTL=0 or unreasonably large values

Note: This PR is submitted from GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.