### PR TITLE
fix : constantTimeEqualHex validates hex format before comparison

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -46,13 +46,10 @@ export function verifyOtpHash(otp, otpRecord) {
   return false;
 }
 
-
-// === Spec 12: ===
-// === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;
+  if (!/^[0-9a-fA-F]+$/.test(a) || !/^[0-9a-fA-F]+$/.test(b)) return false;
   try { return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex')); }
   catch (_) { return false; }
 }


### PR DESCRIPTION
Closes #12831.

Summary of What Has Been Done:
Added hex format validation to constantTimeEqualHex before calling Buffer.from to prevent timingSafeEqual from returning true for equal-length invalid hex strings like zzzz vs xxxx.

Changes Made:
- backend/api/src/lib/otpHashing.js: added hex validation regex before Buffer.from

Impact it Made:
- Constant-time comparison now correctly rejects invalid hex inputs
- Maintains security properties of the OTP hash comparison

Note: This PR is submitted from GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.