### PR TITLE
fix : paginated hasPrevPage fixes for invalid page values

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -38,7 +38,7 @@ export function paginated(data = [], page = 1, limit = 10, total = 0, message = 
       total: Number(total),
       totalPages,
       hasNextPage: Number(page) < totalPages,
-      hasPrevPage: Number(page) > 1,
+      hasPrevPage: Number(page) > 1 && Number(page) <= totalPages,
     },
   };
 }


### PR DESCRIPTION
Closes #12835.

Summary of What Has Been Done:
Fixed hasPrevPage calculation to be false for page values outside the valid range.

Changes Made:
- backend/api/src/lib/apiResponse.js: changed hasPrevPage from Number(page) > 1 to Number(page) > 1 && Number(page) <= totalPages

Impact it Made:
- Consistent pagination metadata for all page values

Note: This PR is submitted from GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.