### PR TITLE
fix : geofence-confirm route path and undefined id variable

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -200,7 +200,8 @@ const getOrderResource = async (req) => {
 };
 
 
-router.post('/api/deliveries/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
+router.post('/:id/geofence-confirm', authenticate, requireRole(['driver']), async (req, res) => {
+  const { id } = req.params;
   const { driver_lat, driver_lng, geofence_radius_m } = req.body;
 
   const lat = parseFloat(driver_lat);


### PR DESCRIPTION
Closes #12837.

Summary of What Has Been Done:
Changed the geofence-confirm route path from '/api/deliveries/:id/geofence-confirm' to '/:id/geofence-confirm' (making it reachable at /api/orders/:id/geofence-confirm) and added 'const { id } = req.params;' to fix the ReferenceError.

Changes Made:
- backend/api/src/routes/orderRoutes.js: fixed route path and added id scoping

Impact it Made:
- The geofence-confirm endpoint becomes reachable and functional

Note: This PR is submitted from GSSOC (GirlScript Summer of Code).
Note: Please assign this PR to the `tmdeveloper007` account.