### PR TITLE
fix : added notif_type to delivery_otp alignment for delivery OTP notifications

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -295,7 +295,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         user_id: customerId,
         title,
         body,
-        notif_type: 'order_update',
+        notif_type: 'delivery_otp',
         // No OTP or OTP-derived value is persisted here: an unsalted digest of
         // a 6-digit code is offline-brute-forceable if the table leaks.
         metadata: { order_display_id: orderDisplayId }


### PR DESCRIPTION
Closes #12867.

Summary of What Has Been Done:
The sendDeliveryOtpNotification function persisted delivery OTP notifications with notif_type 'order_update' instead of 'delivery_otp', which caused inconsistency between the database persistence and push notification channels. This fix aligns the notif_type with the notifType used in the FCM push.

Changes Made:
- backend/api/src/services/notificationService.js: Changed notif_type from 'order_update' to 'delivery_otp' in sendDeliveryOtpNotification

Impact it Made:
- Consistent notification typing across persistence and push channels
- Accurate filtering in notification dashboards and analytics
- Correct alerting based on notif_type classification

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delivery OTP notifications are now correctly categorized as delivery OTP notifications instead of order updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->