### PR TITLE
fix : replaced bare catch in decodeCursor with error variable

### DIFF
--- a/backend/api/src/utils/cursorPagination.js
+++ b/backend/api/src/utils/cursorPagination.js
@@ -26,7 +26,7 @@ export function decodeCursor(cursor) {
   try {
     const json = Buffer.from(cursor, 'base64url').toString('utf8');
     return JSON.parse(json);
-  } catch {
+  } catch (_) {
     return null;
   }
 }


### PR DESCRIPTION
Closes #12868.

Summary of What Has Been Done:
The decodeCursor function in cursorPagination.js used a bare catch {} block that silently swallowed decode errors. Replaced with catch (_) for consistency with the codebase conventions.

Changes Made:
- backend/api/src/utils/cursorPagination.js: Replaced bare catch {} with catch (_) in decodeCursor function

Impact it Made:
- Consistent error variable naming across the codebase
- Easier debugging when lint rules are added for bare catch detection
- No functional change since null is returned either way

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).