### PR TITLE
fix : added null guard in escrow.paisaToMaticWei

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -185,6 +185,9 @@ export const ESCROW_AMOUNT_TOLERANCE_WEI = 1_000_000_000n; // 1 gwei
  * @throws {RangeError} If paisa is negative, NaN, or exceeds safety cap
  */
 export function paisaToMaticWei(paisa) {
+  if (paisa == null) {
+    throw new TypeError('paisa argument is required');
+  }
   const numeric = Number(paisa);
   if (!Number.isFinite(numeric) || numeric < 0) {
     throw new RangeError(`Invalid paisa amount: ${paisa}`);


### PR DESCRIPTION
Closes #12875.

Summary of What Has Been Done:
The escrow.paisaToMaticWei function did not guard against null/undefined input. Number(null) returns 0 which passes the isFinite check but produces 0 wei instead of an error. Added explicit null/undefined check at function entry.

Changes Made:
- backend/api/src/services/escrow.js: Added null/undefined guard at start of paisaToMaticWei that throws TypeError for invalid input

Impact it Made:
- Prevents silent 0-wei deposits from null arguments
- More descriptive errors for invalid inputs
- Safer escrow operations when called with unexpected data

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).