### PR TITLE
test : added unit tests for KafkaHealth and PostgresHealth

### DIFF
--- a/backend/api/test/unit/kafkaHealth.test.js
+++ b/backend/api/test/unit/kafkaHealth.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HealthStatus } from '../../src/core/health/HealthCheck.js';
+
+vi.mock('../../src/config/db.js', () => ({
+  pgPool: null,
+}));
+
+describe('kafkaHealth', () => {
+  it('returns DEGRADED when KAFKA_BROKERS is not set', async () => {
+    const original = process.env.KAFKA_BROKERS;
+    const originalEnabled = process.env.KAFKA_ENABLED;
+    delete process.env.KAFKA_BROKERS;
+    delete process.env.KAFKA_ENABLED;
+
+    vi.resetModules();
+    const { default: kafkaHealth } = await import('../../src/core/health/checks/kafkaHealth.js');
+    const result = await kafkaHealth();
+
+    process.env.KAFKA_BROKERS = original || '';
+    process.env.KAFKA_ENABLED = originalEnabled || '';
+    expect(result.status).toBe(HealthStatus.DEGRADED);
+  });
+});

--- a/backend/api/test/unit/postgresHealth.test.js
+++ b/backend/api/test/unit/postgresHealth.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HealthStatus } from '../../src/core/health/HealthCheck.js';
+
+describe('postgresHealth', () => {
+  it('returns UNHEALTHY when pgPool is not configured', async () => {
+    vi.resetModules();
+    vi.mock('../../src/config/db.js', () => ({
+      pgPool: null,
+    }));
+    const { default: postgresHealth } = await import('../../src/core/health/checks/postgresHealth.js');
+    const result = await postgresHealth();
+    expect(result.status).toBe(HealthStatus.UNHEALTHY);
+  });
+});


### PR DESCRIPTION
Closes #12912, #12913.

Summary of What Has Been Done:
Added unit tests for KafkaHealth and PostgresHealth modules.

Changes Made:
- backend/api/test/unit/kafkaHealth.test.js: Tests Kafka health check returns DEGRADED when not configured
- backend/api/test/unit/postgresHealth.test.js: Tests Postgres health check returns UNHEALTHY when pgPool is not configured

Impact it Made:
- Regression protection for health check modules
- 2 new tests added

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).