### PR TITLE
fix : added null guard in circuitBreaker.execute for non-function input

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -58,6 +58,9 @@ export class CircuitBreaker {
   }
 
   async execute(fn, ...args) {
+    if (typeof fn !== 'function') {
+      throw new TypeError('circuitBreaker execute: fn must be a function');
+    }
     const currentState = this.getState();
 
     if (currentState === CircuitState.OPEN) {


### PR DESCRIPTION
Closes #12894.

Summary of What Has Been Done:
circuitBreaker.execute did not guard against non-function input for the fn parameter. Added explicit check that throws TypeError when fn is not a function.

Changes Made:
- backend/api/src/lib/circuitBreaker.js: Added typeof fn !== 'function' guard at start of execute

Impact it Made:
- Prevents confusing errors when circuit breaker is called with wrong argument types
- Clear error message for callers passing invalid fn

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).