### PR TITLE
fix : replaced non-structured logger.error calls in healthRoutes.js

### DIFF
--- a/backend/api/src/routes/healthRoutes.js
+++ b/backend/api/src/routes/healthRoutes.js
@@ -94,7 +94,7 @@ async function checkSupabase() {
     );
     return error ? 'failed' : 'connected';
   } catch (err) {
-    logger.error('[health] Supabase check failed:', err.message);
+    logger.error({ err }, '[health] Supabase check failed');
     return 'failed';
   }
 }
@@ -105,7 +105,7 @@ async function checkMongo() {
     await withTimeout(mongoDb.admin().ping());
     return 'connected';
   } catch (err) {
-    logger.error('[health] MongoDB check failed:', err.message);
+    logger.error({ err }, '[health] MongoDB check failed');
     return 'failed';
   }
 }
@@ -116,7 +116,7 @@ async function checkRedis() {
     const reply = await withTimeout(redisClient.ping());
     return reply === 'PONG' ? 'connected' : 'failed';
   } catch (err) {
-    logger.error('[health] Redis check failed:', err.message);
+    logger.error({ err }, '[health] Redis check failed');
     return 'failed';
   }
 }
@@ -130,7 +130,7 @@ async function checkEscrow() {
     const result = await checkEscrowHealth();
     return result.status;
   } catch (err) {
-    logger.error('[Health] checkEscrow failed:', err?.message || err);
+    logger.error({ err }, '[Health] checkEscrow failed');
     return 'failed';
   }
 }

--- a/backend/api/test/integration/healthRoutes.test.js
+++ b/backend/api/test/integration/healthRoutes.test.js
@@ -94,8 +94,8 @@ describe('GET /api/health', () => {
     expect(res.body.status).toBe('degraded');
     expect(res.body.services.supabase).toBe('failed');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
-      '[health] Supabase check failed:',
-      'Supabase network error'
+      { err: expect.any(Error) },
+      '[health] Supabase check failed'
     );
   });
 
@@ -130,8 +130,8 @@ describe('GET /api/health', () => {
     expect(res.body.status).toBe('degraded');
     expect(res.body.services.mongodb).toBe('failed');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
-      '[health] MongoDB check failed:',
-      'MongoDB timeout'
+      { err: expect.any(Error) },
+      '[health] MongoDB check failed'
     );
   });
 
@@ -144,8 +144,8 @@ describe('GET /api/health', () => {
     expect(res.body.status).toBe('ok');
     expect(res.body.services.redis).toBe('failed');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
-      '[health] Redis check failed:',
-      'Redis connection refused'
+      { err: expect.any(Error) },
+      '[health] Redis check failed'
     );
   });
 


### PR DESCRIPTION
Closes #12928.

Summary of What Has Been Done:
Replaced all non-structured logger.error() calls in healthRoutes.js with the standard structured format: logger.error({ err }, 'message'). Updated the corresponding integration tests to expect the new format.

Changes Made:
- backend/api/src/routes/healthRoutes.js: Changed 4 logger.error() calls from positional to structured format
- backend/api/test/integration/healthRoutes.test.js: Updated 3 test assertions to expect structured logging format

Impact it Made:
- Consistent structured logging across the backend health check routes
- All 11 health routes integration tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).