### PR TITLE
fix : paginated helper clamps negative and NaN page values to 1

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -26,6 +26,7 @@ export function error(message = 'An error occurred', statusCode = 500, errors = 
 }
 
 export function paginated(data = [], page = 1, limit = 10, total = 0, message = 'Success') {
+  const clampedPage = Number.isFinite(page) && page >= 1 ? page : 1;
   const totalPages = Math.ceil(total / limit) || 0;
   return {
     success: true,
@@ -33,12 +34,12 @@ export function paginated(data = [], page = 1, limit = 10, total = 0, message = 
     message,
     data,
     pagination: {
-      page: Number(page),
+      page: Number(clampedPage),
       limit: Number(limit),
       total: Number(total),
       totalPages,
-      hasNextPage: Number(page) < totalPages,
-      hasPrevPage: Number(page) > 1,
+      hasNextPage: Number(clampedPage) < totalPages,
+      hasPrevPage: Number(clampedPage) > 1,
     },
   };
 }

--- a/backend/api/test/unit/apiResponse.test.js
+++ b/backend/api/test/unit/apiResponse.test.js
@@ -116,7 +116,8 @@ describe('apiResponse helpers', () => {
 describe('paginated edge cases', () => {
   it('handles page 0 gracefully', () => {
     const result = paginated([{ id: 1 }], 0, 10, 1);
-    expect(result.pagination.page).toBe(0);
+    // page 0 is clamped to 1 since page numbers start at 1
+    expect(result.pagination.page).toBe(1);
     expect(result.pagination.totalPages).toBe(1);
     expect(result.pagination.hasPrevPage).toBe(false);
     expect(result.pagination.hasNextPage).toBe(false);
@@ -134,6 +135,21 @@ describe('paginated edge cases', () => {
     const result = paginated([], 1, 10, 0);
     expect(result.pagination.totalPages).toBe(0);
     expect(result.pagination.hasNextPage).toBe(false);
+    expect(result.pagination.hasPrevPage).toBe(false);
+  });
+
+  it('clamps negative page values to 1', () => {
+    const result = paginated([], -5, 10, 0);
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.hasNextPage).toBe(false);
+    expect(result.pagination.hasPrevPage).toBe(false);
+  });
+
+  it('clamps NaN page values to 1', () => {
+    const result = paginated([], NaN, 10, 50);
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.totalPages).toBe(5);
+    expect(result.pagination.hasNextPage).toBe(true);
     expect(result.pagination.hasPrevPage).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #12929.

Summary of What Has Been Done:
Added page value clamping in the paginated helper function. When page is negative or NaN, it is clamped to 1. This ensures hasNextPage and hasPrevPage are always correct. Updated existing test to reflect correct behavior and added two new tests for negative and NaN page values.

Changes Made:
- backend/api/src/lib/apiResponse.js: Added clampedPage variable that clamps page to >= 1
- backend/api/test/unit/apiResponse.test.js: Updated page=0 test, added negative and NaN page tests

Impact it Made:
- Correct pagination metadata for all edge case page values
- All 14 apiResponse unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).