### PR TITLE
fix : parseWeightKgSafe returns null for invalid input instead of 0

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -44,10 +44,14 @@ function parseWeightKg(weight) {
 }
 
 function parseWeightKgSafe(weight) {
+  if (weight == null || weight === '' || Number.isNaN(Number(weight))) {
+    logger.warn(`[ML] parseWeightKgSafe received invalid weight: ${weight}`);
+    return null;
+  }
   const result = parseWeightKg(weight);
   if (Number.isNaN(result)) {
     logger.warn(`[ML] parseWeightKg received unparseable weight: ${weight}`);
-    return 0;
+    return null;
   }
   return result;
 }


### PR DESCRIPTION
Closes #12930.

Summary of What Has Been Done:
Added explicit null/undefined/empty string guard to parseWeightKgSafe that returns null for invalid input instead of 0. This makes it possible to distinguish between a valid zero-kilogram load and an invalid input.

Changes Made:
- backend/api/src/services/ml.js: parseWeightKgSafe now returns null for null/undefined/empty/NaN inputs instead of 0

Impact it Made:
- Callers can now distinguish between invalid inputs (null) and valid zero-weight loads (0)
- Explicit logging of invalid inputs

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).