### PR TITLE
fix : FraudDetectionService.trackBehavior guards against null userId

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -38,6 +38,7 @@ class FraudDetectionService {
 
   // ============ Behavioral Fingerprinting ============
   async trackBehavior(userId, eventData) {
+    if (!userId) return null;
     try {
       if (!supabaseAdmin) return null;
       const profile = await this.getOrCreateProfile(userId);


### PR DESCRIPTION
Closes #12931.

Summary of What Has Been Done:
Added an early return guard in FraudDetectionService.trackBehavior that returns null immediately when userId is falsy (null/undefined/empty). This prevents null from being used as a Map key and avoids potential TypeErrors in downstream calls.

Changes Made:
- backend/api/src/services/fraud/FraudDetectionService.js: Added  at the start of trackBehavior

Impact it Made:
- Prevents null-key entries in behavioral profile Maps
- Clear early-exit behavior for invalid inputs

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).