### PR TITLE
fix : CacheManager.js uses structured logging with named error fields

### DIFF
--- a/backend/api/src/cache/CacheManager.js
+++ b/backend/api/src/cache/CacheManager.js
@@ -51,6 +51,7 @@ export async function get(namespace, entityId, subKey) {
     return null;
   } catch (err) {
     stats.errors++;
+    // Structured logging: pass err as a named field for log aggregation
     logger.error({ err, key }, '[CacheManager] GET error');
     return null;
   }
@@ -72,6 +73,7 @@ export async function set(namespace, entityId, value, opts = {}) {
     return true;
   } catch (err) {
     stats.errors++;
+    // Structured logging: pass err as a named field for log aggregation
     logger.error({ err, key }, '[CacheManager] SET error');
     return false;
   }
@@ -102,6 +104,7 @@ export async function invalidateBatch(namespace, entityIds, opts = {}) {
     }
   } catch (err) {
     stats.errors++;
+    // Structured logging: pass err as a named field for log aggregation
     logger.error({ err, namespace }, '[CacheManager] Batch invalidation error');
   }
 }


### PR DESCRIPTION
Closes #12933.

Summary of What Has Been Done:
Verified that CacheManager.js already uses structured logging format (logger.error({ err, key }, 'message')) for all catch blocks. Added clarifying comments explaining the structured logging pattern.

Changes Made:
- backend/api/src/cache/CacheManager.js: Added clarifying comments to 3 catch blocks

Impact it Made:
- Improved code documentation for the error handling pattern

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).