### PR TITLE
fix : redisRateLimiter checkSlidingWindow guards against null/invalid key

### DIFF
--- a/backend/api/src/middleware/redisRateLimiter.js
+++ b/backend/api/src/middleware/redisRateLimiter.js
@@ -123,6 +123,9 @@ return {1, count + 1}
 `;
 
 export async function checkSlidingWindow(redis, key, nowMs, windowMs, limit, member) {
+  if (!key || typeof key !== 'string') {
+    throw new Error('[RateLimiter] checkSlidingWindow: key must be a non-empty string');
+  }
   const result = await redis.eval(SLIDING_WINDOW_LUA, 1, key, nowMs, windowMs, limit, member);
   return { allowed: result[0] === 1, count: result[1] };
 }


### PR DESCRIPTION
Closes #12934.

Summary of What Has Been Done:
Added a null/invalid key guard at the top of checkSlidingWindow that throws if the key parameter is not a non-empty string. This prevents null/undefined keys from being passed to Redis eval operations where they would be coerced to invalid string values.

Changes Made:
- backend/api/src/middleware/redisRateLimiter.js: Added key validation guard in checkSlidingWindow

Impact it Made:
- Prevents Redis operations with invalid/null keys
- All 3 redisRateLimiter unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).