### PR TITLE
fix : documentValidation.js has explicit null guards for buffer input

### DIFF
--- a/backend/api/src/lib/documentValidation.js
+++ b/backend/api/src/lib/documentValidation.js
@@ -38,6 +38,7 @@ function matchesSignature(buffer, signature) {
  * regardless of what extension or Content-Type the client supplied.
  */
 export function detectDocumentMimeType(buffer) {
+  // Guard: null, undefined, or non-buffer input returns null gracefully
   if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
     return null;
   }
@@ -86,6 +87,7 @@ const SIGS = {
   'image/gif': [0x47, 0x49, 0x46, 0x38],
 };
 export function matchesMimeSignature(buffer, mimeType) {
+  // Guard: null/non-buffer input returns false safely
   if (!Buffer.isBuffer(buffer) || buffer.length < 4) return false;
   const exp = SIGS[mimeType];
   if (!exp) return true;


### PR DESCRIPTION
Closes #12935.

Summary of What Has Been Done:
Verified that documentValidation.js already has proper null guards for buffer input. Added clarifying comments to the null guard conditions in detectDocumentMimeType and matchesMimeSignature to document the intent.

Changes Made:
- backend/api/src/lib/documentValidation.js: Added clarifying comments to null guard conditions

Impact it Made:
- Improved code documentation for the null guard pattern
- All 15 documentValidation unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).