### PR TITLE
fix : validatePagination.js explicitly documents NaN handling in comments

### DIFF
--- a/backend/api/src/lib/validatePagination.js
+++ b/backend/api/src/lib/validatePagination.js
@@ -4,6 +4,8 @@ const MAX_OFFSET = 1_000_000;
 export function validatePagination({ page = 1, pageSize = 20 } = {}) {
   const p = Number(page);
   const ps = Number(pageSize);
+  // Number.isFinite(NaN) = false, so non-numeric strings (parseInt('abc')) and
+  // undefined/null coerce to NaN and are caught here with a clear error.
   if (!Number.isFinite(p) || p < 1) return { error: 'page must be >= 1' };
   if (!Number.isFinite(ps) || ps < 1) return { error: 'pageSize must be >= 1' };
   if (ps > 200) return { error: 'pageSize must be <= 200' };


### PR DESCRIPTION
Closes #12937.

Summary of What Has Been Done:
Verified that validatePagination.js already handles NaN values correctly via Number.isFinite() checks. Added a clarifying comment documenting that Number.isFinite(NaN) = false, which catches non-numeric strings and undefined inputs.

Changes Made:
- backend/api/src/lib/validatePagination.js: Added clarifying comment about NaN handling

Impact it Made:
- Improved code documentation for the NaN handling behavior
- All 5 validatePagination unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).