### PR TITLE
fix : added error logging to routeWithFailover catch block in osrm.js

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -291,6 +291,7 @@ export function haversineFallbackKm(lat1, lon1, lat2, lon2) {
 export async function routeWithFailover(primary, _fb, coords) {
   try { return await primary(coords); }
   catch (err) {
+    logger.warn({ err, coords }, '[osrm] routeWithFailover primary route failed, falling back to haversine');
     if (!coords || !coords[0] || !coords[0][0] || !coords[0][1]) {
       return { distance: 0, source: 'haversine-fallback', error: 'No valid coordinates for haversine fallback' };
     }


### PR DESCRIPTION
Closes #12927.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.