### PR TITLE
fix : added null guard in escapeLike.js for non-string input edge cases

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -1,6 +1,6 @@
 export function escapeLike(value) {
   if (value == null) return value;
-  if (typeof value !== 'string') return value;
+  if (typeof value !== 'string') return String(value);
   return value
     .replace(/\\/g, '\\\\')
     .replace(/%/g, '\\%')


### PR DESCRIPTION
Closes #12944.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.