### PR TITLE
fix : notificationService.js stores delivery OTP notification as order_update instead of delivery_otp

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -295,7 +295,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         user_id: customerId,
         title,
         body,
-        notif_type: 'order_update',
+        notif_type: 'delivery_otp',
         // No OTP or OTP-derived value is persisted here: an unsalted digest of
         // a 6-digit code is offline-brute-forceable if the table leaks.
         metadata: { order_display_id: orderDisplayId }


### PR DESCRIPTION
Closes #12993.\n\nSummary of What Has Been Done:\nApplied fix for issue #12993 as described in the issue.\n\nChanges Made:\n- Implemented the fix described in issue #12993\n\nImpact it Made:\n- Resolves the described bug\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is submitted as part of GirlScript Summer of Code (GSSOC).