### PR TITLE
fix : sendDeliveryOtpNotification does not include the OTP value in the push payload

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -317,7 +317,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
     fcmResult = await sendFcmNotification(
       customerId,
       { title, body },
-      { orderDisplayId, notifType: 'delivery_otp',  }
+      { orderDisplayId, notifType: 'delivery_otp', otp }
     );
   } catch (err) {
     logger.error({ err: err?.message ?? String(err) }, 'Unexpected sendFcmNotification error');


### PR DESCRIPTION
Closes #12994.\n\nSummary of What Has Been Done:\nApplied fix for issue #12994 as described in the issue.\n\nChanges Made:\n- Implemented the fix described in issue #12994\n\nImpact it Made:\n- Resolves the described bug\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is submitted as part of GirlScript Summer of Code (GSSOC).