### PR TITLE
fix : compression.js NaN threshold and level values when env vars are non-numeric

### DIFF
--- a/backend/api/src/config/compression.js
+++ b/backend/api/src/config/compression.js
@@ -18,16 +18,20 @@ import compression from 'compression';
  * CPU cost is not repaid, and very small payloads can grow once the gzip
  * header and trailer are added.
  */
-export const COMPRESSION_THRESHOLD_BYTES = Number(
-  process.env.COMPRESSION_THRESHOLD_BYTES || 1024
-);
+export const COMPRESSION_THRESHOLD_BYTES = (() => {
+  const raw = Number(process.env.COMPRESSION_THRESHOLD_BYTES);
+  return Number.isFinite(raw) ? Math.max(1, Math.floor(raw)) : 1024;
+})();
 
 /**
  * zlib level, 1 (fastest) to 9 (smallest). 6 is zlib's default and sits at
  * the knee of the curve: levels above it cost noticeably more CPU for very
  * little additional saving on JSON.
  */
-export const COMPRESSION_LEVEL = Number(process.env.COMPRESSION_LEVEL || 6);
+export const COMPRESSION_LEVEL = (() => {
+  const raw = Number(process.env.COMPRESSION_LEVEL);
+  return Number.isFinite(raw) ? Math.max(1, Math.min(9, Math.floor(raw))) : 6;
+})();
 
 /**
  * Content types that are already compressed. Re-compressing them burns CPU


### PR DESCRIPTION
Closes #12995.\n\nSummary of What Has Been Done:\nApplied fix for issue #12995 as described in the issue.\n\nChanges Made:\n- Implemented the fix described in issue #12995\n\nImpact it Made:\n- Resolves the described bug\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is submitted as part of GirlScript Summer of Code (GSSOC).