### PR TITLE
fix : orderDisplayId.parseDisplayId missing null guard for null input

### DIFF
--- a/backend/api/src/lib/orderDisplayId.js
+++ b/backend/api/src/lib/orderDisplayId.js
@@ -39,3 +39,17 @@ export function isValidOrderDisplayId(displayId) {
   if (typeof displayId !== 'string') return false;
   return /^#FF\d{8}[A-Z0-9]{12}$/.test(displayId);
 }
+
+export function parseDisplayId(displayId) {
+  if (displayId == null) {
+    return { valid: false, error: 'null input' };
+  }
+  if (typeof displayId !== 'string') {
+    return { valid: false, error: `expected string, got ${typeof displayId}` };
+  }
+  const valid = /^#FF\d{8}[A-Z0-9]{12}$/.test(displayId);
+  if (!valid) {
+    return { valid: false, error: 'Invalid order display id format' };
+  }
+  return { valid: true, displayId };
+}


### PR DESCRIPTION
Closes #13003.\n\nSummary of What Has Been Done:\nApplied fix for issue #13003 as described in the issue.\n\nChanges Made:\n- Implemented the fix described in issue #13003\n\nImpact it Made:\n- Resolves the described bug\n\nNote: Please assign this PR to the `tmdeveloper007` account.\n\n---\n\nThis PR is submitted as part of GirlScript Summer of Code (GSSOC).