### PR TITLE
fix : removed duplicate import of crypto in otpHashing.js

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -49,7 +49,6 @@ export function verifyOtpHash(otp, otpRecord) {
 
 // === Spec 12: ===
 // === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;


### PR DESCRIPTION
Closes #13025.

Summary of What Has Been Done:
Removed the duplicate import of the crypto module from backend/api/src/lib/otpHashing.js. The file imported crypto twice (at line 1 and line 52). Since ESM hoists all imports, both work but having duplicate imports is redundant and confusing. The duplicate at line 52 was removed, keeping only the single import at the top of the file.

Changes Made:
- backend/api/src/lib/otpHashing.js: Removed duplicate 'import crypto from crypto;' at line 52

Impact it Made:
- Cleaner, more maintainable code
- Follows ESM best practice of having a single import per module
- All existing otpHashing tests continue to pass

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a redundant internal import without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->