### PR TITLE
fix : removed duplicate import of errorResponse in deviceController.js

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -2,7 +2,6 @@ import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
-import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
Closes #13026.

Summary of What Has Been Done:
Removed the duplicate import of the errorResponse function from backend/api/src/controllers/deviceController.js. The file imported errorResponse twice (at lines 3 and 5). Removed the duplicate, keeping only the single import.

Changes Made:
- backend/api/src/controllers/deviceController.js: Removed duplicate 'import { errorResponse }' at line 5

Impact it Made:
- Cleaner, more maintainable code
- All existing deviceController tests continue to pass

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.