### PR TITLE
fix : removed unused EventEmitter import from requestCache.js

### DIFF
--- a/backend/api/src/lib/requestCache.js
+++ b/backend/api/src/lib/requestCache.js
@@ -32,7 +32,6 @@ export class RequestCache {
 
 // === Spec 25: ===
 // === Spec 25: event listener leak guard ===
-import { EventEmitter } from 'node:events';
 export function attachResponseCleanup(emitter, res, eventName = 'data') {
   const onData = () => {};
   emitter.on(eventName, onData);


### PR DESCRIPTION
Closes #13033.

Summary of What Has Been Done:
Removed the unused EventEmitter import from backend/api/src/lib/requestCache.js. The import at line 35 was never used as attachResponseCleanup receives emitter as a parameter.

Changes Made:
- backend/api/src/lib/requestCache.js: Removed import { EventEmitter } from 'node:events';

Impact it Made:
- Cleaner code with no unused imports

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.