### PR TITLE
fix : added null guard in trackingTokenInvalidResponse

### DIFF
--- a/backend/api/src/utils/trackingTokenStatus.js
+++ b/backend/api/src/utils/trackingTokenStatus.js
@@ -10,6 +10,9 @@ export const TRACKING_TOKEN_STATUS_MESSAGES = {
 };
 
 export function trackingTokenInvalidResponse(validation) {
+  if (!validation) {
+    return TRACKING_TOKEN_STATUS_MESSAGES['not_found'];
+  }
   const { status, message } =
     TRACKING_TOKEN_STATUS_MESSAGES[validation.reason] ||
     TRACKING_TOKEN_STATUS_MESSAGES.not_found;


### PR DESCRIPTION
Closes #13034.

Summary of What Has Been Done:
Added null/undefined guard in trackingTokenInvalidResponse to prevent TypeError when validation is null/undefined.

Changes Made:
- backend/api/src/utils/trackingTokenStatus.js: Added null check that returns not_found response as safe default

Impact it Made:
- Prevents runtime TypeError crashes
- Defensive programming

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.