### PR TITLE
test : added unit tests for errorResponse in utils/apiResponse.js

### DIFF
--- a/backend/api/test/unit/apiResponseError.test.js
+++ b/backend/api/test/unit/apiResponseError.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { errorResponse } from '../../src/utils/apiResponse.js';
+
+describe('apiResponse errorResponse', () => {
+  let env;
+
+  beforeEach(() => {
+    env = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = env;
+  });
+
+  it('returns correct structure with code and message', () => {
+    const result = errorResponse('ERR_CODE', 'Error message');
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'ERR_CODE',
+        message: 'Error message',
+      },
+    });
+  });
+
+  it('includes details in non-production environments', () => {
+    process.env.NODE_ENV = 'development';
+    const result = errorResponse('ERR', 'Error', { extra: 'data' });
+    expect(result.error.details).toEqual({ extra: 'data' });
+  });
+
+  it('omits details in production', () => {
+    process.env.NODE_ENV = 'production';
+    const result = errorResponse('ERR', 'Error', { extra: 'data' });
+    expect(result.error).not.toHaveProperty('details');
+  });
+
+  it('omits details when not provided', () => {
+    process.env.NODE_ENV = 'development';
+    const result = errorResponse('ERR', 'Error');
+    expect(result.error).not.toHaveProperty('details');
+  });
+});


### PR DESCRIPTION
Closes #13039.

Summary of What Has Been Done:
Added unit tests for the errorResponse function in utils/apiResponse.js covering code/message/details combinations and NODE_ENV-sensitive details behavior.

Changes Made:
- backend/api/test/unit/apiResponseError.test.js: New test file with 4 tests

Impact it Made:
- Prevents regressions in error response formatting
- Documents expected behavior

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.