### PR TITLE
fix : clamped limit to positive value in paginated helper

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -26,6 +26,7 @@ export function error(message = 'An error occurred', statusCode = 500, errors = 
 }
 
 export function paginated(data = [], page = 1, limit = 10, total = 0, message = 'Success') {
+  if (limit < 1) limit = 1;
   const totalPages = Math.ceil(total / limit) || 0;
   return {
     success: true,


### PR DESCRIPTION
Closes #13041.

Summary of What Has Been Done:
Added guard in paginated function to clamp limit to at least 1, preventing Infinity values for totalPages when limit is 0.

Changes Made:
- backend/api/src/lib/apiResponse.js: Added if (limit < 1) limit = 1; guard

Impact it Made:
- Prevents Infinity values in pagination metadata
- Fixes hasNextPage always being true when limit is 0

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR was created as part of GSSOC (GirlScript Summer of Code) contributions from tmdeveloper007.