### PR TITLE
fix(route): clamp road-condition latitude bounding box to [-90, 90]

### DIFF
--- a/backend/api/src/controllers/roadConditionController.js
+++ b/backend/api/src/controllers/roadConditionController.js
@@ -59,8 +59,10 @@ export const getNearbyGripData = async (req, res) => {
 
     // Approximate bounding box (1 degree is roughly 69 miles)
     const radiusDeg = radiusMiles / 69.0;
-    const minLat = latitude - radiusDeg;
-    const maxLat = latitude + radiusDeg;
+    // Clamp the latitude bounds to the valid range so that coordinates near the
+    // poles cannot produce an inverted or out-of-range bounding box.
+    const minLat = Math.max(-90, latitude - radiusDeg);
+    const maxLat = Math.min(90, latitude + radiusDeg);
     // Longitude degree distance varies by latitude; clamp the cos term so that
     // latitudes near ±90 cannot produce an infinite lng span.
     const latRad = latitude * (Math.PI / 180);


### PR DESCRIPTION
Closes #13126

## Summary
getNearbyGripData computed the latitude bounding box as latitude +/- radiusDeg without clamping. Near the poles the box could exceed [-90, 90], producing inverted or invalid map queries.

## Changes
- Clamp minLat/maxLat to the valid range before building the query.

## Verification
- roadConditionController tests: 8/8 pass (previously 7/8).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nearby road-condition searches by preventing invalid latitude ranges near the poles.
  * Ensured geographic bounding boxes remain within valid coordinate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->