### PR TITLE
fix(middleware): normalize and truncate user-agent in suspicious-request logs

### DIFF
--- a/backend/api/src/middleware/suspiciousRequests.js
+++ b/backend/api/src/middleware/suspiciousRequests.js
@@ -41,7 +41,12 @@ export default function suspiciousRequests(req, res, next) {
   const body = JSON.stringify(req.body || {});
   const query = JSON.stringify(req.query || {});
   const url = req.originalUrl || "";
-  const ua = req.headers["user-agent"] || "";
+  // Node lowercases header names; some runtimes/clients send the user-agent as
+  // a repeated array header — take the first value. Truncate to the 256-char
+  // log limit so an oversized header cannot bloat the warning payload.
+  const rawUa = req.headers["user-agent"];
+  const ua = (Array.isArray(rawUa) ? rawUa[0] : rawUa) || "";
+  const userAgent = ua.length > 256 ? ua.slice(0, 256) : ua;
 
   const findings = [];
 
@@ -54,7 +59,7 @@ export default function suspiciousRequests(req, res, next) {
   if (matches(PATH_TRAVERSAL_PATTERNS, url))
     findings.push("Path Traversal");
 
-  if (matches(SUSPICIOUS_UA, ua))
+  if (matches(SUSPICIOUS_UA, userAgent))
     findings.push("Suspicious User Agent");
 
   if (findings.length) {
@@ -67,7 +72,7 @@ export default function suspiciousRequests(req, res, next) {
       method: req.method,
       path: req.originalUrl,
       findings,
-      userAgent: ua,
+      userAgent,
     }, "Suspicious request detected");
 
     const blocking = findings.filter(f =>


### PR DESCRIPTION
Closes #13127

## Summary
The suspicious-request middleware logged the user-agent header raw: a repeated-array header was passed through unnormalized and a long string exceeded the 256-char log limit.

## Changes
- Take the first value when user-agent arrives as an array header.
- Truncate to 256 chars before matching and logging.

## Verification
- suspiciousRequestsUserAgent tests: 2/2 pass (previously 0/2).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.