### PR TITLE
fix(security): HSTS floor check must require strictly greater than the minimum

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -14,7 +14,7 @@ const MAX_HSTS_MAX_AGE = 63072000; // 2 years
 // the value to 0, a negative number, or an unbounded one.
 function resolveHstsMaxAge() {
   const raw = Number(process.env.SECURE_HSTS_MAX_AGE);
-  if (Number.isFinite(raw) && raw >= MIN_HSTS_MAX_AGE && raw <= MAX_HSTS_MAX_AGE) {
+  if (Number.isFinite(raw) && raw > MIN_HSTS_MAX_AGE && raw <= MAX_HSTS_MAX_AGE) {
     return Math.floor(raw);
   }
   return DEFAULT_HSTS_MAX_AGE;


### PR DESCRIPTION
Closes #13128

## Summary
resolveHstsMaxAge used >= MIN_HSTS_MAX_AGE, so an override exactly equal to the 60-second floor passed even though the floor should require strictly greater values.

## Changes
- Use a strict greater-than comparison for the minimum floor.

## Verification
- securityHeadersHsts: floor-fallback test now passes (5/6; remaining failure is the unrelated preload test tracked in #13129).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.