### PR TITLE
fix(security): honor SECURE_HSTS_PRELOAD env for the HSTS preload flag

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -39,9 +39,11 @@ export default function securityHeaders(req, res, next) {
   // Enforce HTTPS for sensitive headers
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
     if (!res.getHeader('Strict-Transport-Security')) {
+      const hstsPreload =
+        process.env.SECURE_HSTS_PRELOAD === 'true' || process.env.SECURE_HSTS_PRELOAD === '1';
       res.setHeader(
         'Strict-Transport-Security',
-        `max-age=${resolveHstsMaxAge()}; includeSubDomains`
+        `max-age=${resolveHstsMaxAge()}; includeSubDomains${hstsPreload ? '; preload' : ''}`
       );
     }
   }


### PR DESCRIPTION
Closes #13129

## Summary
The Strict-Transport-Security header never included the preload directive because SECURE_HSTS_PRELOAD was not read from the environment.

## Changes
- Append '; preload' to the HSTS header when SECURE_HSTS_PRELOAD is 'true' or '1'.

## Verification
- securityHeadersHsts: preload test now passes (5/6; the remaining floor test belongs to #13128, fixed in PR #13143).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.