### PR TITLE
fix(utils): only strip leading 0 for the 13-digit country-code form

### DIFF
--- a/backend/api/src/utils/phone.js
+++ b/backend/api/src/utils/phone.js
@@ -19,8 +19,11 @@ export function normalizePhone(phone) {
   // Handle the E.164 + prefix explicitly before stripping digits
   let digits = phone.replace(/[^\d]/g, '');
 
-  // Strip a leading trunk prefix 0 (e.g. 0919876543210 -> 919876543210)
-  if (digits.startsWith('0')) {
+  // Strip a leading trunk prefix 0 only for the country-code form
+  // (e.g. 0919876543210 -> 919876543210). A bare 0-prefixed local number is
+  // not a valid trunk form and is left alone so it fails the 10-digit
+  // validation below instead of being silently corrupted.
+  if (digits.startsWith('0') && digits.length === 13) {
     digits = digits.slice(1);
   }
 


### PR DESCRIPTION
Closes #13130

## Summary
normalizePhone stripped a leading 0 unconditionally, so a 0-prefixed 11-digit local number (09876543210) was silently converted into a valid 10-digit number instead of being rejected.

## Changes
- Strip the leading 0 only when the input is the 13-digit trunk-prefixed country-code form (e.g. 0919876543210).

## Verification
- phone tests: 10/10 pass (previously 9/10).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.