### PR TITLE
fix(middleware): export runWithCorrelationId and getCorrelationStore

### DIFF
--- a/backend/api/src/middleware/correlationId.js
+++ b/backend/api/src/middleware/correlationId.js
@@ -32,3 +32,19 @@ export function correlationIdMiddleware(req, res, next) {
   const store = { correlationId };
   correlationContext.run(store, next);
 }
+
+/**
+ * Run a function inside a correlation-id context, exposing the id to any
+ * nested getCorrelationStore()/correlationContext.getStore() callers.
+ */
+export function runWithCorrelationId(correlationId, fn) {
+  return correlationContext.run({ correlationId }, fn);
+}
+
+/**
+ * Return the correlation store for the current execution context, or an empty
+ * object when no correlation id has been set.
+ */
+export function getCorrelationStore() {
+  return correlationContext.getStore() ?? {};
+}


### PR DESCRIPTION
Closes #13131

## Summary
The correlation-id middleware exposed only the AsyncLocalStorage instance, so callers/tests could not scope work under a correlation id or read the current store.

## Changes
- Add runWithCorrelationId() to run a function inside a correlation-id context.
- Add getCorrelationStore() returning the current store (empty object outside any context).

## Verification
- correlationId tests: 13/13 pass (previously 11/13).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.