### PR TITLE
fix(rate-limit): guard a null pipeline.exec result in redisRateLimiter

### DIFF
--- a/backend/api/src/middleware/redisRateLimiter.js
+++ b/backend/api/src/middleware/redisRateLimiter.js
@@ -53,8 +53,11 @@ export function redisRateLimiter({ routeKey, limit, windowMs, failClosed = false
       pipeline.zcard(key);
       const results = await pipeline.exec();
 
-      // Validate ZCARD result tuple [error, value].
-      const zcardTuple = results[1];
+      // Validate ZCARD result tuple [error, value]. pipeline.exec can also
+      // resolve to null when Redis is unreachable — treat that like a failed
+      // ZCARD so the limiter fails open (or closed, per failClosed) instead
+      // of crashing on a null dereference.
+      const zcardTuple = results ? results[1] : null;
       if (!zcardTuple || zcardTuple[0]) {
         if (failClosed) {
           logger.error({ routeKey, err: zcardTuple?.[0] }, '[RateLimiter] ZCARD failed — failing closed');


### PR DESCRIPTION
Closes #13134

## Summary
When pipeline.exec() resolves to null (Redis unreachable), results[1] threw a TypeError instead of failing open/closed gracefully.

## Changes
- Guard the null result before indexing so the ZCARD failure path handles it like any other failed read.

## Verification
- redisRateLimiterPipeline tests: 3/3 pass (previously 2/3).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.