### PR TITLE
fix(ml): only forward min_price/max_price keys when present in predictPrice

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -199,11 +199,13 @@ export async function predictPrice({
   }
 
   const adjustedPrice = initialValidation.validated.estimated_price * safeMultiplier;
+  // Only forward min_price/max_price keys when the raw response actually
+  // carried them — injecting undefined values trips the response validator.
   const revalidated = validatePricePrediction({
       ...raw,
       estimated_price: adjustedPrice,
-      min_price: typeof raw?.min_price === 'number' ? raw.min_price * safeMultiplier : undefined,
-      max_price: typeof raw?.max_price === 'number' ? raw.max_price * safeMultiplier : undefined,
+      ...(typeof raw?.min_price === 'number' ? { min_price: raw.min_price * safeMultiplier } : {}),
+      ...(typeof raw?.max_price === 'number' ? { max_price: raw.max_price * safeMultiplier } : {}),
   });
 
   if (!revalidated.ok) {


### PR DESCRIPTION
Closes #13135

## Summary
predictPrice injected min_price/max_price as undefined into the revalidated object when the raw response omitted them, tripping the response validator and rejecting valid predictions.

## Changes
- Conditionally spread min_price/max_price only when the raw response carries numeric values.

## Verification
- ml tests: 49/53 pass (baseline 44/53). The 4 remaining failures are the unrelated 'non-ok response message' tests tracked in #13136.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.