### PR TITLE
fix(ml): emit structured [ML] Request failed (status) message

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -92,7 +92,7 @@ async function handleResponse(response, url = '', method = 'GET') {
         throw new Error(`[ML] Authentication failed (${response.status}): ${method} ${url} - ${text}`);
     }
     if (!response.ok) {
-        throw new Error(`[ML] Request failed: ${method} ${url} ${response.status} - ${text}`);
+        throw new Error(`[ML] Request failed (${response.status}): ${method} ${url} - ${text}`);
     }
 
     try {


### PR DESCRIPTION
Closes #13136

## Summary
Non-OK ML responses threw '[ML] Request failed: ...' without the status in parentheses, breaking the structured error contract and degrading logs/caller messaging.

## Changes
- Format non-OK errors as '[ML] Request failed ()'.

## Verification
- ml tests: 48/53 pass on this branch; the 4 'non-ok response' tests now pass. The 5 remaining failures are the predictPrice min/max tests fixed in PR #13150 (#13135).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.