### PR TITLE
fix(osrm): round route cache-key coordinates to 6 decimal places

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -52,7 +52,7 @@ function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
 }
 
 function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng }) {
-  const r = (n) => Number(n.toFixed(8));
+  const r = (n) => Number(n.toFixed(6));
   return `osrm:route:v2:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
 }
 


### PR DESCRIPTION
Closes #13137

## Summary
buildCacheKey rounded coordinates to 8 decimals while the contract expects 6-decimal precision, causing cache-key mismatches with consumers that use 6-decimal keys.

## Changes
- Use toFixed(6) in buildCacheKey.

## Verification
- osrm tests: cache-key test now passes (25/30 on this branch; remaining failures are the null-input case tracked in #13138 plus pre-existing Redis-mock artifacts).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.