### PR TITLE
fix(osrm): return null for null/undefined input in getRouteEstimate

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -56,7 +56,8 @@ function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng }) {
   return `osrm:route:v2:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
 }
 
-export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng } = {}) {
+export async function getRouteEstimate(input = {}) {
+  const { pickupLat, pickupLng, dropLat, dropLng } = input ?? {};
   return measureExecution('OSRMService.getRouteEstimate', async () => {
   if (
     !Number.isFinite(pickupLat) || !Number.isFinite(pickupLng) ||


### PR DESCRIPTION
Closes #13138

## Summary
getRouteEstimate destructured its argument directly, so a null input threw a TypeError instead of returning null.

## Changes
- Accept the input object and coalesce null/undefined to {} before destructuring.

## Verification
- osrm tests: 'returns null for null input' now passes. Remaining failures are the cache-key test (fixed in #13152 / #13137) and pre-existing Redis-mock artifacts.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.