### PR TITLE
PolicyEvaluator skips ownership check when resource is undefined, allowing cross-tenant access

### DIFF
--- a/backend/api/src/core/auth/PolicyEvaluator.js
+++ b/backend/api/src/core/auth/PolicyEvaluator.js
@@ -43,6 +43,14 @@ export class PolicyEvaluator {
       };
     }
 
+    if (resource === undefined && permission.ownership) {
+      return {
+        allowed: false,
+        permission: permission.toJSON(),
+        reason: 'missing_resource',
+      };
+    }
+
     if (resource !== undefined && !permission.checkOwnership(user, resource)) {
       return {
         allowed: false,


### PR DESCRIPTION
## Problem

PolicyEvaluator.authorize falls through to a default allow when no resource is supplied, skipping the ownership check. A caller that omits the resource is granted access even when the permission declares an ownership requirement, enabling a cross-tenant authorization bypass.

## Fix

In PolicyEvaluator.evaluate, when a permission declares an ownership check (permission.ownership is set) but no resource is provided, evaluation now returns `{ allowed: false, reason: 'missing_resource' }` instead of skipping the check.

## Files changed

backend/api/src/core/auth/PolicyEvaluator.js

## Testing

Reviewed the change against the ownership-evaluation flow; the ownership branch is no longer silently bypassed when resource is undefined.

Closes #12030


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ownership-based permissions are now denied when no resource is provided.
  * Denied requests include a clear `missing_resource` reason and permission details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->