### PR TITLE
fix: guard null analytics payload in my_truck_screen (closes #12037)

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -941,10 +941,10 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
       return Center(child: Text(_error!, style: const TextStyle(color: TruxifyColors.error)));
     }
 
-    final totalPayout = (_data!['totalPayout'] as num?)?.toDouble() ?? 0.0;
-    final estFuel = (_data!['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
-    final margin = (_data!['profitMargin'] as num?)?.toDouble() ?? 0.0;
-    final chartPoints = (_data!['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
+    final totalPayout = (_data?['totalPayout'] as num?)?.toDouble() ?? 0.0;
+    final estFuel = (_data?['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
+    final margin = (_data?['profitMargin'] as num?)?.toDouble() ?? 0.0;
+    final chartPoints = (_data?['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
 
     return RefreshIndicator(
       onRefresh: _load,


### PR DESCRIPTION
## Problem

my_truck_screen.dart dereferences `_data!` on analytics fields. When the API returns an empty/error payload that does not throw, `_data` becomes null while `_isLoading` is false, causing a "Null check operator used on a null value" crash on the next build.

## Fix

Replaced the `_data!` null-assertions with null-safe `_data?` access so a missing payload falls back to 0.0 / empty list instead of crashing. Build only guards `_isLoading` and `_error`, so this makes the analytics tab resilient to a null `_data`.

## Files changed

apps/driver/lib/screens/my_truck_screen.dart

## Testing

Verified the changed lines compile structurally; the null-safe fallback mirrors the existing `?? 0.0` / `?? const []` defaults already in place.

Closes #12037
