### PR TITLE
fix: map cross-dock unique-violation to 409 instead of 500 (closes #12035)

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -277,6 +277,9 @@ export async function createTransferRequest({
       .single();
 
     if (insertErr) {
+      if (insertErr.code === '23505') {
+        throw new DomainError(409, { error: 'An active cross-dock transfer already exists for this load.' });
+      }
       throw new DomainError(500, { error: 'Failed to create cross-dock transfer.', details: insertErr.message });
     }
 


### PR DESCRIPTION
## Problem

crossDockService.createTransferRequest performs a non-atomic active-transfer check followed by an insert. Under concurrency the second request passes the check but hits the unique constraint and is converted into a generic 500 instead of the intended 409 conflict.

## Fix

Detect the Postgres unique-violation error code (23505) on insert and throw a DomainError(409) with the same message as the up-front check, instead of a 500. The existing pre-check remains the clean fast-path 409; the race window now returns a correct 409 rather than a 500.

## Files changed

backend/api/src/services/order/crossDockService.js

## Testing

Code path reviewed against the codebase convention of mapping code === '23505' to a conflict (see dlqService.js, truckRoutes.js, profileRoutes.js).

Closes #12035
