### PR TITLE
fix: impossible-travel speed guard against zero/negative time deltas

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -249,7 +249,8 @@ class FraudDetectionService {
           locations[i].lat, locations[i].lng
         );
         const hours = (locations[i].timestamp - locations[i-1].timestamp) / 3_600_000;
-        const speedKmh = hours > 0 ? dist / hours : Infinity;
+        if (hours <= 0) continue;
+        const speedKmh = dist / hours;
         if (speedKmh > maxSpeedKmh) {
           maxSpeedKmh = speedKmh;
         }


### PR DESCRIPTION
## Problem

`FraudDetectionService` computes travel speed as `dist / hours` where `hours` can be 0 (equal/duplicate timestamps) or negative (out-of-order pings). When `hours === 0`, speed becomes `Infinity`, which trips the `> 150` impossible-travel threshold as a permanent false positive.

## Fix

Skip the location pair when the time delta is zero or negative (`hours <= 0`) instead of falling back to `Infinity`, so duplicate or out-of-order pings cannot inflate the fraud risk score.

## Files changed

backend/api/src/services/fraud/FraudDetectionService.js

## Testing

Read the code path; the defensive `continue` removes the `Infinity` branch. No new false-positive on equal timestamps.

Closes #12033
