### PR TITLE
fix: guard corrupt behavioral profile cache parse in FraudDetectionService

### DIFF
--- a/backend/api/src/services/fraud/FraudDetectionService.js
+++ b/backend/api/src/services/fraud/FraudDetectionService.js
@@ -104,7 +104,15 @@ class FraudDetectionService {
     // Check Redis cache
     const cached = this.redis ? await this.redis.get(`behavior:${userId}`) : null;
     if (cached) {
-      return JSON.parse(cached);
+      try {
+        return JSON.parse(cached);
+      } catch (parseError) {
+        logger.warn(`Corrupt behavioral profile cache for ${userId}, rebuilding from DB`, parseError);
+        if (this.redis) {
+          await this.redis.del(`behavior:${userId}`).catch(() => {});
+        }
+        // Fall through to rebuild the profile from the DB / defaults below.
+      }
     }
 
     // Check in-memory cache (written by trackBehavior during Redis outages)


### PR DESCRIPTION
﻿## Problem

`getOrCreateProfile` performs an unguarded `JSON.parse` on a cached behavioral profile. A corrupt Redis entry throws, and the caller's try/catch swallows it, returning `riskLevel: 'unknown'` so fraud scoring is silently disabled for that user.

## Fix

Wrapped the cache parse in a try/catch. On parse failure the corrupt key is evicted and the method falls through to rebuild the profile from the DB (or defaults) instead of returning a parse error to the caller.

## Files changed

backend/api/src/services/fraud/FraudDetectionService.js

## Testing

Static review of the parse path; the corrupt-cache branch now evicts and rebuilds rather than throwing.

Closes #12032
