### PR TITLE
fix: remove TabController listener in dispose (orders_screen leak)

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -102,11 +102,7 @@ class _OrdersScreenState extends State<OrdersScreen>
 
     _orderService = widget.orderService ?? OrderService();
     _tabController = TabController(length: 2, vsync: this);
-    _tabController.addListener(() {
-      if (!_tabController.indexIsChanging) {
-        _controller?.setOrdersTab(_tabController.index);
-      }
-    });
+    _tabController.addListener(_onTabChanged);
     _loadOrders();
     _subscribeToOrdersListUpdates();
   }
@@ -343,8 +339,15 @@ class _OrdersScreenState extends State<OrdersScreen>
         .subscribe();
   }
 
+  void _onTabChanged() {
+    if (!_tabController.indexIsChanging) {
+      _controller?.setOrdersTab(_tabController.index);
+    }
+  }
+
   @override
   void dispose() {
+    _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
     _searchController.dispose();
     if (SupabaseConfig.isConfigured && _ordersChannel != null) {


### PR DESCRIPTION
## Problem

orders_screen.dart registers a TabController listener via addListener but never removes it in dispose(). TabController.dispose() does not remove ChangeNotifier listeners, so the closure capturing `this` leaks and can fire against a disposed widget.

## Fix

Extracted the anonymous listener into a named method `_onTabChanged` and call `_tabController.removeListener(_onTabChanged)` in `dispose()` before `_tabController.dispose()`.

## Files changed

apps/customer/lib/screens/orders_screen.dart

## Testing

Verified the listener is added and removed symmetrically; static review of initState/dispose paired calls.

Closes #12038
