### PR TITLE
fix: prevent N x M fan-out to Package Dispute PDF (closes #12061)

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -354,17 +354,6 @@
         ]
       ]
     },
-    "Query Supabase OTP Logs": {
-      "main": [
-        [
-          {
-            "node": "Package Dispute PDF",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
     "Package Dispute PDF": {
       "main": [
         [


### PR DESCRIPTION
## Problem

In dispute-resolution.json, both `Query MongoDB GPS Trail` and `Query Supabase OTP Logs` connect into `Package Dispute PDF`. Because a node with two incoming connections runs once per incoming item, the PDF node — and the entire downstream escalation chain (Notify Both Parties, Wait 24h, Check Dispute Resolution, Create Arbitration Record) — executes N x M times, producing duplicate PDFs, emails, and arbitration records.

## Fix

Removed the duplicate incoming connection so `Package Dispute PDF` receives a single input (from `Query MongoDB GPS Trail`). The `Query Supabase OTP Logs` node still executes (it is downstream of `Freeze Payment Contract`) and its result is still referenced by the PDF node via `$node[\"Query Supabase OTP Logs\"].json`, so the escalation chain now runs once per dispute instead of N x M.

## Files changed

automation/n8n/dispute-resolution.json

## Testing

Validated the workflow JSON parses correctly. The connection graph now has exactly one incoming edge to `Package Dispute PDF`.

Closes #12061
