### PR TITLE
fix: add error handling to dispute PDF and notify nodes (closes #12064)

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -127,7 +127,11 @@
       "position": [
         850,
         300
-      ]
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
     },
     {
       "parameters": {
@@ -159,7 +163,11 @@
       "position": [
         1050,
         300
-      ]
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
     },
     {
       "parameters": {
@@ -306,6 +314,38 @@
         500,
         800
       ]
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Package Dispute PDF Failed for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
+        "textBody": "=CRITICAL: The Package Dispute PDF step failed after 3 retries for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}. Dispute evidence could not be packaged. Immediate manual intervention required.",
+        "options": {}
+      },
+      "id": "alert-dispute-pdf-failed",
+      "name": "Alert Admin — Dispute PDF Failed",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        850,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "toEmail": "admin@truxify.com",
+        "subject": "=Escrow Alert: Notify Both Parties Failed for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}",
+        "textBody": "=CRITICAL: The Notify Both Parties step failed after 3 retries for Booking {{$node[\"Dispute Webhook Trigger\"].json.body.bookingId}}. The disputed parties were not notified. Immediate manual intervention required.",
+        "options": {}
+      },
+      "id": "alert-notify-failed",
+      "name": "Alert Admin — Notify Parties Failed",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        500
+      ]
     }
   ],
   "connections": {
@@ -373,6 +413,13 @@
             "type": "main",
             "index": 0
           }
+        ],
+        [
+          {
+            "node": "Alert Admin — Dispute PDF Failed",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
@@ -381,6 +428,13 @@
         [
           {
             "node": "Wait 24h",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Alert Admin — Notify Parties Failed",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Problem

In dispute-resolution.json, the Package Dispute PDF and Notify Both Parties HTTP nodes on the critical path had no error handling. A transient failure halted the whole dispute flow before escalation, unlike the Freeze/Release nodes which do handle errors.

## Fix

Added retryOnFail: true, maxTries: 3, waitBetweenTries: 5000, and onError: "continueErrorOutput" to both nodes, matching the freeze/release pattern. Added two admin-alert email nodes (Dispute PDF Failed, Notify Parties Failed) and wired the error branch (output index 1) of each node to the corresponding alert.

## Files changed

automation/n8n/dispute-resolution.json

## Testing

Validated the JSON parses correctly and the new error-output connections are present. The flow now retries transient failures and alerts admins instead of stalling.

Closes #12064
