### PR TITLE
fix(escrow): remove redundant early value guard in recordDepositTx

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -481,10 +481,10 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
     return { error: 'Transaction destination is not the Escrow contract' }
   }
 
-  // Critical Security Check: Verify tx.value (deposit amount)
-  if (expectedAmountWei && BigInt(tx.value) < BigInt(expectedAmountWei)) {
-    return { error: `Transaction value ${tx.value} wei is less than expected ${expectedAmountWei} wei` }
-  }
+  // Critical Security Check: Verify tx.value (deposit amount). The exact
+  // equality check below (expectedAmountWei !== null) is the authoritative
+  // gate — a redundant less-than guard here would shadow the booking-id,
+  // sender, and driver checks for under-funded deposits.
 
   let decoded
   try {


### PR DESCRIPTION
Closes #13140

## Summary
A redundant early tx.value guard in recordDepositTx short-circuited before the booking-id, sender, and driver equality checks, so an under-funded deposit from the wrong driver was reported as an amount error instead of a driver mismatch.

## Changes
- Remove the early less-than guard; the existing exact-equality check (with DEPOSIT_AMOUNT_MISMATCH code) remains the authoritative gate.

## Verification
- escrowSenderVerification tests: 11/11 pass (previously 8/11).

## GSSOC'24
This PR is part of my GSSoC'24 contribution.