### PR TITLE
fix : added null guard for pipeline.exec result in redisRateLimiter

### DIFF
--- a/backend/api/src/middleware/redisRateLimiter.js
+++ b/backend/api/src/middleware/redisRateLimiter.js
@@ -54,6 +54,18 @@ export function redisRateLimiter({ routeKey, limit, windowMs, failClosed = false
       const results = await pipeline.exec();
 
       // Validate ZCARD result tuple [error, value].
+      // Guard against null (transient Redis failures can return null from pipeline.exec).
+      if (!results) {
+        if (failClosed) {
+          logger.error({ routeKey }, '[RateLimiter] pipeline.exec returned null — failing closed');
+          return res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable. Please try again shortly.',
+          });
+        }
+        logger.warn({ routeKey }, '[RateLimiter] pipeline.exec returned null — failing open');
+        return next();
+      }
       const zcardTuple = results[1];
       if (!zcardTuple || zcardTuple[0]) {
         if (failClosed) {


### PR DESCRIPTION
Closes #13169.

Summary of What Has Been Done:
Added a null check for the return value of Redis pipeline.exec() in the redisRateLimiter middleware. When Redis returns null during transient failures, the function now falls through to the existing failClosed/failOpen path instead of crashing with a TypeError.

Changes Made:
- backend/api/src/middleware/redisRateLimiter.js: Added null guard before accessing results[1] from pipeline.exec(). Logs warning/error and returns appropriate HTTP response based on failClosed setting.

Impact it Made:
- Prevents crashes during Redis transient failures on rate-limited routes.
- Existing fail-open/fail-closed semantics are preserved.
- Verified with unit tests (3 existing tests pass).

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.