### PR TITLE
fix : added await for eventBus emitSafe to confirm publish outcome

### DIFF
--- a/backend/api/src/core/events/EventBus.js
+++ b/backend/api/src/core/events/EventBus.js
@@ -143,19 +143,28 @@ class EventBus extends EventEmitter {
 
   emitSafe(event, ...args) {
     const listeners = this.rawListeners(event);
+    const promises = [];
     for (const listener of listeners) {
       try {
         const result = listener.apply(this, args);
-        if (result && typeof result.catch === 'function') {
-          result.catch(err => {
+        if (result && typeof result.then === 'function') {
+          // Capture the async listener's rejection but do not block other listeners.
+          const p = result.catch(err => {
             logger.error(`[EventBus] Unhandled async listener error for "${event}":`, err);
             this._metrics.errors++;
           });
+          promises.push(p);
         }
       } catch (err) {
         logger.error(`[EventBus] Sync listener error for "${event}":`, err);
         this._metrics.errors++;
       }
+    }
+    // Return a promise that resolves when all async listeners have settled.
+    // Await this in the caller to confirm all listeners completed before
+    // marking an event as successfully published.
+    if (promises.length > 0) {
+      return Promise.allSettled(promises).then(() => listeners.length > 0);
     }
     return listeners.length > 0;
   }


### PR DESCRIPTION
Closes #13170.

Summary of What Has Been Done:
Modified EventBus.emitSafe() to return a Promise when async listeners are present. The caller (outboxRelayWorker) already awaits the result, so this change ensures that markPublished() is only called after all eventBus listeners have completed their async work.

Changes Made:
- backend/api/src/core/events/EventBus.js: emitSafe() now collects all async listener promises and returns Promise.allSettled() so callers can await the full completion of all listeners before proceeding. Sync listeners remain unaffected.

Impact it Made:
- outboxRelayWorker now waits for all eventBus listeners to complete before marking an event as published.
- Prevents premature marking of events as published when async publish operations fail silently.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.