### PR TITLE
fix(schemas): remove duplicate syncWeightSchema export in requestSchemas.js

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -435,16 +435,8 @@ export const reportGripDataSchema = z.object({
   ).optional().default(0),
 }).strict();
 
-
 /**
- * Schema for POST /api/driver/weigh-stations/sync-weight
+ * Schema for POST /api/driver/weigh-stations/sync-weight.
+ * NOTE: defined once above (truck_id + string axle position); the driver
+ * route reads truck_id/axles from req.body, so keep this single export.
  */
-export const syncWeightSchema = z.object({
-  vehicleId: z.string().min(1, 'vehicleId is required'),
-  truckId: z.string().min(1, 'truckId is required'),
-  axles: z.array(z.object({
-    position: z.number().int().min(0),
-    pressure_psi: z.number().positive('pressure_psi must be a positive number'),
-  })).min(1, 'At least one axle is required'),
-  timestamp: z.string().datetime({ message: 'timestamp must be ISO 8601' }).optional(),
-});


### PR DESCRIPTION
Fixes a boot-blocking duplicate named export re-added by the cross-dock PR (#11365): requestSchemas.js now parses again, unblocking the server and the contract/integration test suites.

## Verification
- node ESM import of requestSchemas.js succeeds (42 exports); syncWeightSchema still validates the driver sync-weight payload (truck_id + string axle position) used by POST /api/driver/weigh-stations/sync-weight.
- driverWim integration suite loads and passes 4/5 (the BYPASS test needs a real WIM provider and is environmental).
- Unblocks all contract suites (bids/orders/delivery/timeline) which previously failed at transform time.

## GSSOC'24
This PR is part of my GSSoC'24 contribution.