### PR TITLE
fix : phone normalization strips leading 0 after country-code check

### DIFF
--- a/backend/api/src/utils/phone.js
+++ b/backend/api/src/utils/phone.js
@@ -19,14 +19,18 @@ export function normalizePhone(phone) {
   // Handle the E.164 + prefix explicitly before stripping digits
   let digits = phone.replace(/[^\d]/g, '');
 
-  // Strip a leading trunk prefix 0 (e.g. 0919876543210 -> 919876543210)
-  if (digits.startsWith('0')) {
-    digits = digits.slice(1);
-  }
-
-  // Remove country code prefix if present (91 for India)
+  // Remove country code prefix if present (91 for India) — do this FIRST
+  // so that the trunk-prefix strip below only fires for local 10-digit numbers.
   if (digits.startsWith('91') && digits.length === 12) {
     digits = digits.slice(2);
+  }
+
+  // Strip a leading trunk prefix 0 only from remaining 11-digit sequences
+  // (10 local digits + leading 0, e.g. 091234567890 → 91234567890).
+  // This prevents 12-digit numbers (already stripped above) from being
+  // incorrectly reduced to 11 digits and rejected.
+  if (digits.startsWith('0') && digits.length === 11) {
+    digits = digits.slice(1);
   }
 
   // Validate: must be exactly 10 digits after country code removal


### PR DESCRIPTION
Closes #13173.

Summary of What Has Been Done:
Reordered the digit processing in normalizePhone() to check for the country code (91) before stripping the trunk prefix 0. Previously, leading 0 was stripped first, causing 11-digit inputs like '091234567890' to become 10 digits and be rejected.

Changes Made:
- backend/api/src/utils/phone.js: Country code (91) check now runs first. Leading-0 strip only fires for 11-digit sequences (10 local digits + leading 0).

Impact it Made:
- Correctly normalizes Indian phone numbers that include the trunk prefix 0.
- Reduces false rejections of valid phone numbers.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.