### PR TITLE
fix : setHSTSHeader reads SECURE_HSTS_PRELOAD env var

### DIFF
--- a/backend/api/src/middleware/securityHeaders.js
+++ b/backend/api/src/middleware/securityHeaders.js
@@ -59,7 +59,12 @@ export default function securityHeaders(req, res, next) {
 // === Spec 11: prevent HSTS header duplication ===
 export function setHstsHeader(res) {
   if (!res.getHeader || res.getHeader('Strict-Transport-Security')) return false;
-  res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+  const preload = process.env.SECURE_HSTS_PRELOAD;
+  const includePreload = !preload || preload === 'true' || preload === '1';
+  const header = includePreload
+    ? 'max-age=63072000; includeSubDomains; preload'
+    : 'max-age=63072000; includeSubDomains';
+  res.setHeader('Strict-Transport-Security', header);
   return true;
 }
 


### PR DESCRIPTION
Closes #13174.

Summary of What Has Been Done:
Modified setHSTSHeader() to read SECURE_HSTS_PRELOAD environment variable. Preload directive is included when the env var is unset, 'true', or '1'. Setting it to 'false' or '0' disables the preload directive.

Changes Made:
- backend/api/src/middleware/securityHeaders.js: setHSTSHeader() now conditionally adds the preload directive based on SECURE_HSTS_PRELOAD env var.

Impact it Made:
- Allows deployments to opt out of HSTS preload inclusion via environment variable.
- Aligns with the configurable HSTS pattern used for max-age.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.