### PR TITLE
fix : added error variable to bare catch block in decodeCursor

### DIFF
--- a/backend/api/src/utils/cursorPagination.js
+++ b/backend/api/src/utils/cursorPagination.js
@@ -26,7 +26,7 @@ export function decodeCursor(cursor) {
   try {
     const json = Buffer.from(cursor, 'base64url').toString('utf8');
     return JSON.parse(json);
-  } catch {
+  } catch (_) {
     return null;
   }
 }


### PR DESCRIPTION
Closes #13175.

Summary of What Has Been Done:
Changed bare catch {} to catch (_) in the decodeCursor function to explicitly name the ignored error variable.

Changes Made:
- backend/api/src/utils/cursorPagination.js: Changed `catch {` to `catch (_)` in decodeCursor.

Impact it Made:
- Consistent error handling with the rest of the codebase.
- Makes the ignored error explicit using the _ convention.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.