### PR TITLE
fix : removed redundant early amount guard in recordDepositTx

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -481,11 +481,6 @@ export async function recordDepositTx (bookingId, txHash, expectedSenderAddress 
     return { error: 'Transaction destination is not the Escrow contract' }
   }
 
-  // Critical Security Check: Verify tx.value (deposit amount)
-  if (expectedAmountWei && BigInt(tx.value) < BigInt(expectedAmountWei)) {
-    return { error: `Transaction value ${tx.value} wei is less than expected ${expectedAmountWei} wei` }
-  }
-
   let decoded
   try {
     decoded = escrowContract.interface.parseTransaction({ data: tx.data, value: tx.value })


### PR DESCRIPTION
Closes #13177.

Summary of What Has Been Done:
Removed the redundant early guard in recordDepositTx() that only checked for underpayment (tx.value < expectedAmountWei). The comprehensive check at the end of the function uses exact equality (!==) and handles both under- and over-payments with appropriate error codes and messages.

Changes Made:
- backend/api/src/services/escrow.js: Removed the early amount guard block from recordDepositTx(). The later check handles all amount mismatches.

Impact it Made:
- Removes redundant check and prevents inconsistent error messages.
- Cleaner, more maintainable escrow verification logic.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.