### PR TITLE
fix : oracle _verifyOTP checks orders.otp_verified before querying OTP records

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -50,6 +50,16 @@ class OracleService {
 
   async _verifyOTP(orderId, otp) {
     try {
+      // Check if order is already verified — skip OTP work if so.
+      const { data: order } = await this.supabase
+        .from('orders')
+        .select('otp_verified')
+        .eq('id', orderId)
+        .maybeSingle();
+      if (order?.otp_verified === true) {
+        return { confirmed: true, provider: 'OTPVerifier', reason: 'Already verified', timestamp: new Date().toISOString() };
+      }
+
       const { data: otpRecord, error: otpErr } = await this.supabase
         .from('delivery_otps')
         .select('id, otp_hash, otp_salt, expires_at')


### PR DESCRIPTION
Closes #13178.

Summary of What Has Been Done:
Added an early-return guard in _verifyOTP() to check if orders.otp_verified is already true before querying the delivery_otps table. If already verified, returns immediately with reason 'Already verified'.

Changes Made:
- backend/api/src/oracle/OracleService.js: _verifyOTP() now queries the orders table for otp_verified first, returning early if already verified.

Impact it Made:
- Reduces unnecessary database queries on re-confirmation attempts.
- Improves performance for repeated confirmDelivery calls on already-verified orders.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.