### PR TITLE
fix : osrm route cache key rounds coordinates to 6 decimals

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -52,7 +52,7 @@ function buildRouteUrl({ pickupLat, pickupLng, dropLat, dropLng }) {
 }
 
 function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng }) {
-  const r = (n) => Number(n.toFixed(8));
+  const r = (n) => Number(n.toFixed(6));
   return `osrm:route:v2:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
 }
 


### PR DESCRIPTION
Closes #13179.

Summary of What Has Been Done:
Changed buildCacheKey() from Number(n.toFixed(8)) to Number(n.toFixed(6)) to match the contract's expected precision and the geometry cache key.

Changes Made:
- backend/api/src/services/osrm.js: buildCacheKey() now uses toFixed(6) instead of toFixed(8).

Impact it Made:
- Consistent coordinate precision across all OSRM cache keys.
- Better cache hit rate by aligning with the contract's expected precision.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.