### PR TITLE
fix : ml predictPrice conditionally includes min_price/max_price in revalidation

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -199,12 +199,20 @@ export async function predictPrice({
   }
 
   const adjustedPrice = initialValidation.validated.estimated_price * safeMultiplier;
-  const revalidated = validatePricePrediction({
+  const revalidatedInput = {
       ...raw,
       estimated_price: adjustedPrice,
-      min_price: typeof raw?.min_price === 'number' ? raw.min_price * safeMultiplier : undefined,
-      max_price: typeof raw?.max_price === 'number' ? raw.max_price * safeMultiplier : undefined,
-  });
+  };
+  // Only include min_price/max_price in the revalidation input when the
+  // original response contained valid finite numbers — avoids injecting
+  // undefined which the validator rejects as invalid.
+  if (typeof raw?.min_price === 'number' && Number.isFinite(raw.min_price)) {
+      revalidatedInput.min_price = raw.min_price * safeMultiplier;
+  }
+  if (typeof raw?.max_price === 'number' && Number.isFinite(raw.max_price)) {
+      revalidatedInput.max_price = raw.max_price * safeMultiplier;
+  }
+  const revalidated = validatePricePrediction(revalidatedInput);
 
   if (!revalidated.ok) {
       logger.warn({


### PR DESCRIPTION
Closes #13181.

Summary of What Has Been Done:
Modified predictPrice() to only include min_price/max_price in the revalidation input when the original raw response contains valid finite numbers. This prevents undefined from being spread into the revalidation object, which caused the validator to reject predictions where the ML service omitted price bounds.

Changes Made:
- backend/api/src/services/ml.js: predictPrice() now conditionally adds min_price/max_price to revalidatedInput only when raw.min_price/raw.max_price are finite numbers.

Impact it Made:
- Correctly handles ML responses that omit min_price/max_price.
- Prevents NaN from being injected into validated price responses.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.