### PR TITLE
test : added null-pipeline guard tests for redisRateLimiter

### DIFF
--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { correlationIdMiddleware, correlationContext } from '../../src/middleware/correlationId.js';
+import { correlationIdMiddleware, correlationContext, runWithCorrelationId, getCorrelationStore } from '../../src/middleware/correlationId.js';
 
 function makeReq(headers = {}) {
   return {
@@ -67,7 +67,6 @@ describe('correlationIdMiddleware', () => {
     correlationContext.run({ correlationId: 'context-test-id' }, () => {
       storedId = correlationContext.getStore()?.correlationId;
     });
-    // The middleware stores the ID in the context before calling next
     expect(req.correlationId).toBe('context-test-id');
   });
 
@@ -128,13 +127,36 @@ describe('correlationIdMiddleware', () => {
 });
 
 
-// === Spec 14 test ===
-import { describe, it, expect } from 'vitest';
-import { runWithCorrelationId, getCorrelationStore } from '../../src/middleware/correlationId.js';
-describe('correlationId', () => {
-  it('stores in run()', () => {
-    runWithCorrelationId('cid-1', () => { expect(getCorrelationStore().correlationId).toBe('cid-1'); });
+// === Spec 14 test: runWithCorrelationId and getCorrelationStore ===
+describe('runWithCorrelationId and getCorrelationStore', () => {
+  it('runWithCorrelationId stores the ID and getCorrelationStore retrieves it', () => {
+    runWithCorrelationId('cid-1', () => {
+      expect(getCorrelationStore()?.correlationId).toBe('cid-1');
+    });
   });
-  it('empty outside', () => { expect(getCorrelationStore().correlationId).toBeUndefined(); });
-});
 
+  it('getCorrelationStore returns undefined outside any correlation context', () => {
+    expect(getCorrelationStore()).toBeUndefined();
+  });
+
+  it('runWithCorrelationId uses the shared correlationContext AsyncLocalStorage', () => {
+    runWithCorrelationId('shared-cid', () => {
+      const store = correlationContext.getStore();
+      expect(store?.correlationId).toBe('shared-cid');
+      expect(getCorrelationStore()?.correlationId).toBe('shared-cid');
+    });
+  });
+
+  it('multiple nested calls maintain separate contexts', () => {
+    let outerId = null;
+    let innerId = null;
+    runWithCorrelationId('outer-id', () => {
+      outerId = getCorrelationStore()?.correlationId;
+      runWithCorrelationId('inner-id', () => {
+        innerId = getCorrelationStore()?.correlationId;
+      });
+    });
+    expect(outerId).toBe('outer-id');
+    expect(innerId).toBe('inner-id');
+  });
+});

--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { redisRateLimiter } from '../../src/middleware/redisRateLimiter.js';
 
 describe('redisRateLimiter Middleware', () => {
@@ -28,3 +28,43 @@ describe('checkSlidingWindow', () => {
   });
 });
 
+
+// === Spec 1 test: null pipeline guard ===
+describe('redisRateLimiter null-pipeline guard', () => {
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let mockPipeline;
+  let mockRedisClient;
+
+  beforeEach(() => {
+    mockNext = vi.fn();
+    mockPipeline = {
+      zremrangebyscore: vi.fn().mockReturnThis(),
+      zcard: vi.fn().mockReturnThis(),
+      exec: vi.fn(),
+    };
+    mockRedisClient = { pipeline: vi.fn(() => mockPipeline) };
+    mockReq = { ip: '127.0.0.1' };
+    mockRes = {
+      status: vi.fn(() => mockRes),
+      json: vi.fn(),
+    };
+  });
+
+  it('allows request when pipeline.exec() returns null (connection closed)', async () => {
+    mockPipeline.exec.mockResolvedValue(null);
+    const middleware = redisRateLimiter({ routeKey: 'test', limit: 10, windowMs: 60000 });
+    middleware.client = mockRedisClient;
+    await middleware(mockReq, mockRes, mockNext);
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('allows request when pipeline.exec() results have null second element', async () => {
+    mockPipeline.exec.mockResolvedValue([null, null]);
+    const middleware = redisRateLimiter({ routeKey: 'test', limit: 10, windowMs: 60000 });
+    middleware.client = mockRedisClient;
+    await middleware(mockReq, mockRes, mockNext);
+    expect(mockNext).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #13183.

Summary of What Has Been Done:
Added two test cases for the null-pipeline guard in redisRateLimiter: (1) when pipeline.exec() returns null, (2) when pipeline.exec() results have null second element.

Changes Made:
- backend/api/test/unit/redisRateLimiter.test.js: Added test cases for null pipeline results.
- backend/api/test/unit/correlationId.test.js: Enhanced runWithCorrelationId/getCorrelationStore tests with shared context, nested contexts, and undefined outside context assertions.

Impact it Made:
- Documents the expected behavior when Redis pipeline returns null or invalid results.
- Guards against regressions in the null guard logic.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.