### PR TITLE
fix : clamped bounding-box latitude to [-90, 90] in getNearbyGripData

### DIFF
--- a/backend/api/src/controllers/roadConditionController.js
+++ b/backend/api/src/controllers/roadConditionController.js
@@ -59,8 +59,8 @@ export const getNearbyGripData = async (req, res) => {
 
     // Approximate bounding box (1 degree is roughly 69 miles)
     const radiusDeg = radiusMiles / 69.0;
-    const minLat = latitude - radiusDeg;
-    const maxLat = latitude + radiusDeg;
+    const minLat = Math.max(-90, latitude - radiusDeg);
+    const maxLat = Math.min(90, latitude + radiusDeg);
     // Longitude degree distance varies by latitude; clamp the cos term so that
     // latitudes near ±90 cannot produce an infinite lng span.
     const latRad = latitude * (Math.PI / 180);


### PR DESCRIPTION
Closes #13187.

Summary of What Has Been Done:
Added Math.max(-90, ...) and Math.min(90, ...) clamping to minLat and maxLat computation in getNearbyGripData to ensure bounding box coordinates never exceed the valid latitude range.

Changes Made:
- backend/api/src/controllers/roadConditionController.js: Clamp minLat/maxLat to [-90, 90] after computing from input latitude and radius.

Impact it Made:
- Prevents out-of-range latitude values from being used in Supabase queries.
- Improves correctness for queries with large radius values.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.