### PR TITLE
fix+test : oracle _verifyOTP checks orders.otp_verified before querying OTP records

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -50,6 +50,16 @@ class OracleService {
 
   async _verifyOTP(orderId, otp) {
     try {
+      // Check if order is already verified — skip OTP work if so.
+      const { data: order } = await this.supabase
+        .from('orders')
+        .select('otp_verified')
+        .eq('id', orderId)
+        .maybeSingle();
+      if (order?.otp_verified === true) {
+        return { confirmed: true, provider: 'OTPVerifier', reason: 'Already verified', timestamp: new Date().toISOString() };
+      }
+
       const { data: otpRecord, error: otpErr } = await this.supabase
         .from('delivery_otps')
         .select('id, otp_hash, otp_salt, expires_at')

--- a/backend/api/test/unit/oracle/OracleService.test.js
+++ b/backend/api/test/unit/oracle/OracleService.test.js
@@ -101,8 +101,22 @@ describe('OracleService', () => {
   });
 
   describe('_verifyOTP', () => {
+    it('returns already verified when orders.otp_verified is true', async () => {
+      // First query returns order with otp_verified=true.
+      chain.orderRecord = { id: 'order-1', otp_verified: true };
+      chain.otpRecord = null;
+      const result = await service._verifyOTP('order-1', '123456');
+      expect(result.confirmed).toBe(true);
+      expect(result.reason).toBe('Already verified');
+      // Should not query delivery_otps when already verified.
+      const fromCalls = chain.from.mock.calls;
+      expect(fromCalls.length).toBe(1);
+      expect(fromCalls[0][0]).toBe('orders');
+    });
+
     it('fails when no OTP record exists', async () => {
       chain.otpRecord = null;
+      chain.orderRecord = null;
       const result = await service._verifyOTP('order-1', '123456');
       expect(result.confirmed).toBe(false);
       expect(result.reason).toContain('No OTP record');
@@ -114,6 +128,7 @@ describe('OracleService', () => {
         otp_hash: 'x',
         expires_at: new Date(Date.now() - 60000).toISOString(),
       };
+      chain.orderRecord = null;
       const result = await service._verifyOTP('order-1', '123456');
       expect(result.confirmed).toBe(false);
       expect(result.reason).toContain('expired');


### PR DESCRIPTION
Closes #13188.

Summary of What Has Been Done:
Added an early-return guard in _verifyOTP() to check if orders.otp_verified is already true before querying the delivery_otps table. If already verified, returns immediately with reason 'Already verified'. Added test case for this behavior.

Changes Made:
- backend/api/src/oracle/OracleService.js: _verifyOTP() now queries the orders table for otp_verified first, returning early if already verified.
- backend/api/test/unit/oracle/OracleService.test.js: Added test for early-return when orders.otp_verified is true.

Impact it Made:
- Reduces unnecessary database queries on re-confirmation attempts.
- Improves performance for repeated confirmDelivery calls on already-verified orders.

These Pull Requests are from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.