### PR TITLE
feat(routes): restore GET /api/orders/load-offers/en-route via matchEnRouteLoads

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -161,7 +161,7 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { validateDocumentBuffer } from '../lib/documentValidation.js';
 import { scanDocument } from '../lib/malwareScanner.js';
-import { validateBody, validateParams } from '../middleware/validate.js';
+import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
 import { z } from 'zod';
 import {
   createOrderSchema, submitBidSchema, submitRatingSchema, paramIdSchema, acceptBidParamsSchema,
@@ -290,6 +290,94 @@ router.post('/', authenticate, userLimiter, requirePolicy('order:create'), valid
       return res.status(err.status).json(err.payload);
     }
     logger.error('Create order exception:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+// ============================================================================
+// 13b. FETCH EN-ROUTE LOAD OFFERS (DRIVER) — GET /api/orders/load-offers/en-route
+// ============================================================================
+/**
+ * @openapi
+ * /api/orders/load-offers/en-route:
+ *   get:
+ *     tags: [Orders]
+ *     summary: List en-route / deadhead load opportunities
+ *     description: Returns available load offers ranked for an en-route (deadhead) match using the Deadhead Eliminator ML model, falling back to a haversine-distance ranking when the ML engine is unavailable.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: current_lat
+ *         schema:
+ *           type: number
+ *       - in: query
+ *         name: current_lng
+ *         schema:
+ *           type: number
+ *       - in: query
+ *         name: max_detour_km
+ *         schema:
+ *           type: number
+ *           default: 50
+ *     responses:
+ *       200:
+ *         description: En-route load offers
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 loads:
+ *                   type: array
+ */
+router.get('/load-offers/en-route', authenticate, userLimiter, requirePolicy('load-offer:browse'), validateQuery(z.object({
+  current_lat: z.coerce.number().optional(),
+  current_lng: z.coerce.number().optional(),
+  max_detour_km: z.coerce.number().positive('max_detour_km must be a positive number').optional(),
+})), async (req, res) => {
+  try {
+    const { current_lat, current_lng, max_detour_km } = req.query;
+
+    // load_offers is RLS-protected with all anon privileges revoked, so the
+    // marketplace board must read through the service-role client.
+    let query = supabaseAdmin
+      .from('load_offers')
+      .select('*', { count: 'exact' })
+      .eq('status', 'available');
+
+    query = query.order('created_at', { ascending: false });
+
+    const { data: offers, error } = await query;
+    if (error) {
+      logger.error('Failed to fetch en-route load offers:', error);
+      return res.status(500).json({ error: 'Failed to fetch en-route load offers.' });
+    }
+
+    const formattedOffers = (offers || []).map(offer => ({
+      ...offer,
+      pickup: offer.pickup_address,
+      destination: offer.drop_address,
+      estimated_price: offer.freight_value / 100,
+      vehicle_type: 'Truck',
+    }));
+
+    let loads = formattedOffers;
+
+    // Rank the offers for an en-route match only when the driver's current
+    // position is provided; otherwise return all available offers unsorted.
+    if (current_lat !== undefined && current_lng !== undefined) {
+      loads = await matchEnRouteLoads({
+        currentLat: Number(current_lat),
+        currentLng: Number(current_lng),
+        offers: formattedOffers,
+        maxDetourKm: max_detour_km !== undefined ? Number(max_detour_km) : 50,
+      });
+    }
+
+    return res.json({ loads });
+  } catch (err) {
+    logger.error('Internal Server Error in GET /api/orders/load-offers/en-route:', err.message);
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 });

--- a/backend/api/test/unit/orderRoutesEnRoute.test.js
+++ b/backend/api/test/unit/orderRoutesEnRoute.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import orderRoutes from '../../src/routes/orderRoutes.js';
+
+vi.mock('../../src/core/container.js', () => ({
+  orderRepository: {},
+  orderValidationService: {},
+  orderTimelineService: {},
+  orderMilestoneService: {},
+  orderLifecycleService: {},
+  deliveryVerificationService: {},
+  buildDepositTx: vi.fn(),
+  recordDepositTx: vi.fn(),
+  submitEscrowRefund: vi.fn(),
+  confirmEscrowRefund: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => { req.user = req.user || { id: 'u1' }; next(); },
+  requireRole: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}));
+
+const { dbMock, mlMock } = vi.hoisted(() => ({
+  dbMock: { supabaseAdmin: { from: vi.fn() } },
+  mlMock: { matchEnRouteLoads: vi.fn() },
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  supabaseAdmin: dbMock.supabaseAdmin,
+  supabase: {},
+  mongoDb: {},
+  redisClient: {},
+  createUserClient: () => ({}),
+}));
+
+vi.mock('../../src/services/ml.js', () => ({
+  predictDemand: vi.fn(),
+  predictPrice: vi.fn(),
+  matchEnRouteLoads: mlMock.matchEnRouteLoads,
+}));
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  req.user = { id: 'driver-1' };
+  next();
+});
+app.use(orderRoutes);
+
+function chain(result) {
+  const q = {
+    then: (onFulfilled) => Promise.resolve(result).then(onFulfilled),
+    select: vi.fn(() => q),
+    eq: vi.fn(() => q),
+    ilike: vi.fn(() => q),
+    gte: vi.fn(() => q),
+    lte: vi.fn(() => q),
+    or: vi.fn(() => q),
+    order: vi.fn(() => q),
+    range: vi.fn(() => q),
+    in: vi.fn(() => q),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+  };
+  return q;
+}
+
+describe('GET /api/orders/load-offers/en-route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.supabaseAdmin.from.mockReset();
+    mlMock.matchEnRouteLoads.mockReset();
+  });
+
+  it('returns all available offers when no coordinates are provided', async () => {
+    const q = chain({ data: [{ id: 'l1', pickup_address: 'A', drop_address: 'B', freight_value: 10000 }], error: null });
+    dbMock.supabaseAdmin.from.mockReturnValue(q);
+    const res = await request(app).get('/load-offers/en-route');
+    expect(res.status).toBe(200);
+    expect(res.body.loads).toHaveLength(1);
+    expect(res.body.loads[0].pickup).toBe('A');
+    expect(res.body.loads[0].estimated_price).toBe(100);
+    expect(dbMock.supabaseAdmin.from).toHaveBeenCalledWith('load_offers');
+    expect(mlMock.matchEnRouteLoads).not.toHaveBeenCalled();
+  });
+
+  it('ranks offers through matchEnRouteLoads when coordinates are provided', async () => {
+    const q = chain({ data: [{ id: 'l1', pickup_address: 'A', drop_address: 'B', freight_value: 10000 }], error: null });
+    dbMock.supabaseAdmin.from.mockReturnValue(q);
+    mlMock.matchEnRouteLoads.mockResolvedValue([{ id: 'l1', detour_km: 4.2, match_score: 0.9 }]);
+    const res = await request(app)
+      .get('/load-offers/en-route')
+      .query({ current_lat: '19.076', current_lng: '72.877', max_detour_km: '50' });
+    expect(res.status).toBe(200);
+    expect(mlMock.matchEnRouteLoads).toHaveBeenCalledWith({
+      currentLat: 19.076,
+      currentLng: 72.877,
+      offers: [{ id: 'l1', pickup_address: 'A', drop_address: 'B', freight_value: 10000, pickup: 'A', destination: 'B', estimated_price: 100, vehicle_type: 'Truck' }],
+      maxDetourKm: 50,
+    });
+    expect(res.body.loads[0].match_score).toBe(0.9);
+  });
+
+  it('returns 400 when max_detour_km is not positive', async () => {
+    const res = await request(app)
+      .get('/load-offers/en-route')
+      .query({ current_lat: '19.076', current_lng: '72.877', max_detour_km: '-5' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('returns 500 when the database query fails', async () => {
+    const q = chain({ data: null, error: { message: 'db down' } });
+    dbMock.supabaseAdmin.from.mockReturnValue(q);
+    const res = await request(app).get('/load-offers/en-route');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to fetch en-route load offers.');
+  });
+});


### PR DESCRIPTION
### Description
Fixes #12813 — restores the driver app's deadhead / en-route load-offers endpoint.

Commit `ea533a2f9` (#11850, ML cross-dock work) dropped the `GET /api/orders/load-offers/en-route` route from `orderRoutes.js`, leaving the driver app's `fetchEnRouteLoads` (`apps/driver/lib/services/marketplace_repository.dart:86`) pointing at a 404.

This PR restores the route and wires it to the still-existing `matchEnRouteLoads` service (`backend/api/src/services/ml.js:613`), so the ML-driven en-route match (Deadhead Eliminator) is reachable again without touching the client.

### Changes
- Re-added `GET /api/orders/load-offers/en-route` on the orders router, mounted as `/api/orders/load-offers/en-route`:
  - Auth + `userLimiter` + `load-offer:browse` policy + query validation (`current_lat`, `current_lng`, `max_detour_km`) via the existing `validateQuery` middleware.
  - Reads `status = 'available'` offers from the RLS-protected `load_offers` table through `supabaseAdmin` (same as the marketplace board in `loadRoutes.js`).
  - Formats offers into the same shape the marketplace returns (`pickup`, `destination`, `estimated_price`, `vehicle_type`) so the driver app's `_mapLoadOffer` handles them identically.
  - Returns the `{ loads: [...] }` envelope consistent with `GET /api/loads` — the driver app parses the same shape for both boards.
  - When `current_lat` / `current_lng` are provided, ranks offers through `matchEnRouteLoads({ currentLat, currentLng, offers, maxDetourKm })` (enriches with `detour_km`, `extra_earnings`, `match_score`, `extra_distance_km`, `ml_used`; haversine fallback when ML is unavailable). Without coordinates it returns the available offers unsorted.

Note: the historical `is_en_route` column filter is gone from the codebase (`is_en_route` has no matches under `backend/api/src`), so the endpoint no longer filters on it — `matchEnRouteLoads` ranks purely on deadhead distance, which matches how the service was already written.

### Verification
- New unit suite `backend/api/test/unit/orderRoutesEnRoute.test.js` — **4/4 passing**:
  - returns all available offers when no coordinates are provided
  - ranks offers through `matchEnRouteLoads` when coordinates are provided
  - returns 400 for non-positive `max_detour_km`
  - returns 500 on DB query failure
- Runs required the local merge of the standalone prerequisite PR #13192 (duplicate `syncWeightSchema` export breaks module parsing on main) — that fix is out of scope here and not included in this branch.

### GSSOC
- Contributor: Akshita-2307
- Issue: #12813
