### PR TITLE
feat(routes): restore POST /:id/bids submit-bid route

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -798,6 +798,58 @@ router.post('/:id/confirm-deposit', authenticate, userLimiter, requirePolicy('or
 });
 
 // ============================================================================
+// 18a. SUBMIT BID FOR A LOAD (DRIVER) — POST /api/orders/:id/bids
+// ============================================================================
+/**
+ * @openapi
+ * /api/orders/{id}/bids:
+ *   post:
+ *     tags: [Orders]
+ *     summary: Submit a bid for a load offer
+ *     description: Allows an authenticated driver to submit a bid on an available load offer. Rate-limited per driver.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SubmitBidRequest'
+ *     responses:
+ *       201:
+ *         description: Bid submitted
+ *       400:
+ *         description: Validation error
+ *       403:
+ *         description: Forbidden (bidding on own load)
+ *       404:
+ *         description: Load offer not found
+ *       409:
+ *         description: Duplicate pending bid
+ *       410:
+ *         description: Load no longer available
+ */
+router.post('/:id/bids', authenticate, userLimiter, requirePolicy('bid:submit'), bidLimiter, validateParams(paramIdSchema), validateBody(submitBidSchema), async (req, res) => {
+  try {
+    const { bid_amount } = req.body;
+    const result = await orderLifecycleService.submitBid(req.params.id, req.user.id, bid_amount);
+    return res.status(201).json(result);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(err.status).json(err.payload);
+    }
+    logger.error('Failed to submit bid:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error.' });
+  }
+});
+
+// ============================================================================
 // 18. PREDICT RIDE DEMAND (CUSTOMER OR DRIVER)
 // ============================================================================
 /**

--- a/backend/api/test/unit/orderRoutesBids.test.js
+++ b/backend/api/test/unit/orderRoutesBids.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import orderRoutes from '../../src/routes/orderRoutes.js';
+
+const { svcMock } = vi.hoisted(() => ({
+  svcMock: {
+    submitBid: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/core/container.js', () => ({
+  orderRepository: {},
+  orderValidationService: {},
+  orderTimelineService: {},
+  orderMilestoneService: {},
+  orderLifecycleService: svcMock,
+  deliveryVerificationService: {},
+  buildDepositTx: vi.fn(),
+  recordDepositTx: vi.fn(),
+  submitEscrowRefund: vi.fn(),
+  confirmEscrowRefund: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => { req.user = req.user || { id: 'u1' }; next(); },
+  requireRole: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}));
+
+import { DomainError } from '../../src/services/order/domainError.js';
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  req.user = { id: 'driver-1' };
+  next();
+});
+app.use(orderRoutes);
+
+describe('POST /api/orders/:id/bids', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svcMock.submitBid.mockReset();
+  });
+
+  it('201: returns message and bid object', async () => {
+    svcMock.submitBid.mockResolvedValue({ message: 'Bid submitted successfully.', bid: { id: 'b1', bid_amount: 50000 } });
+    const res = await request(app)
+      .post('/load-bid-1/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Bid submitted successfully.');
+    expect(res.body.bid.id).toBe('b1');
+    expect(svcMock.submitBid).toHaveBeenCalledWith('load-bid-1', 'driver-1', 50000);
+  });
+
+  it('400: validation error on invalid bid_amount', async () => {
+    const res = await request(app)
+      .post('/load-bid-1/bids')
+      .send({ bid_amount: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.details).toBeDefined();
+  });
+
+  it('403: forwards DomainError from service', async () => {
+    svcMock.submitBid.mockRejectedValue(new DomainError(403, { error: 'You cannot bid on your own load offer' }));
+    const res = await request(app)
+      .post('/load-own/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('You cannot bid on your own load offer');
+  });
+
+  it('404: forwards DomainError when load missing', async () => {
+    svcMock.submitBid.mockRejectedValue(new DomainError(404, { error: 'Load offer not found.' }));
+    const res = await request(app)
+      .post('/nonexistent/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Load offer not found.');
+  });
+
+  it('409: forwards DomainError on duplicate bid', async () => {
+    svcMock.submitBid.mockRejectedValue(new DomainError(409, { error: 'You already have a pending bid for this load.' }));
+    const res = await request(app)
+      .post('/load-dupe/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('You already have a pending bid for this load.');
+  });
+
+  it('410: forwards DomainError when load no longer available', async () => {
+    svcMock.submitBid.mockRejectedValue(new DomainError(410, { error: 'Load is no longer available for bidding.' }));
+    const res = await request(app)
+      .post('/load-assigned/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe('Load is no longer available for bidding.');
+  });
+
+  it('500: server error on unexpected failure', async () => {
+    svcMock.submitBid.mockRejectedValue(new Error('boom'));
+    const res = await request(app)
+      .post('/load-bid-1/bids')
+      .send({ bid_amount: 50000 });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Internal Server Error.');
+  });
+});


### PR DESCRIPTION
### Description
Fixes #12814 — restores the driver submit-bid endpoint that commit `c4e35b092` (#6989) accidentally gutted from `orderRoutes.js` (1946 lines deleted). The issue's symptoms were exact: `POST /api/orders/:id/bids` returned 404 while `submitBidSchema` and `bidLimiter` sat unused as dead imports.

### Changes
- **`POST /api/orders/:id/bids`** (driver submits bid)
  - Middleware: `authenticate` + `userLimiter` + `requirePolicy('bid:submit')` + `bidLimiter` + `validateParams(paramIdSchema)` + `validateBody(submitBidSchema)`.
  - Delegates to the existing `orderLifecycleService.submitBid(id, userId, bidAmount)` → 201 `{ message, bid }`.
  - Service enforces: load offer exists (404), status `available` (410), not bidding on own load (403), truck assigned to driver profile (400), no duplicate pending bid (409), and a Redis lock serializes concurrent double-submits.
- Consumes the previously-dead `bidLimiter` and `submitBidSchema` imports; `bid:submit` policy already exists in `policyEngine.js`.

Note: the customer-facing `GET /api/orders/:id/bids` and `POST /api/orders/:id/bids/:bidId/accept` routes are intentionally **out of scope** here — they are tracked separately by issue #12816.

### Verification
- New unit suite `backend/api/test/unit/orderRoutesBids.test.js` — **7/7 passing**:
  - 201 happy path (returns `message` + `bid`)
  - 400 invalid `bid_amount`
  - 403 own-load, 404 missing load, 409 duplicate bid, 410 unavailable load (DomainError propagation)
  - 500 unexpected failure
- The authoritative contract suite `test/contracts/bids.contract.test.js` cannot load on main because of a standalone harness gap (`No "supabaseAdmin" export is defined on the "../../src/config/db.js" mock` — container.js:1 imports `supabaseAdmin` after #8911) and additionally mocks `buildDepositTx`/`recordDepositTx` via `../../src/services/escrow.js` which the current module tree no longer exports; the 7 route-level unit tests above cover the same behavior contract.
- Runs required the standalone prerequisite PR #13192 (duplicate `syncWeightSchema` export breaks module parsing on main); that fix is not included in this branch.

### GSSOC
- Contributor: Akshita-2307
- Issue: #12814
