### PR TITLE
fix(driver): unwrap { loads } envelope in fetchLoadOffers/fetchEnRouteLoads

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -75,8 +75,8 @@ class MarketplaceRepository {
     final path = '/api/orders/load-offers';
     try {
       final decoded = await _apiClient.get(path);
-      if (decoded is! List) throw StateError('Unexpected response type');
-      return decoded.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
+      final body = _unwrapLoads(decoded);
+      return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);
       rethrow;
@@ -100,12 +100,25 @@ class MarketplaceRepository {
     final path = '/api/orders/load-offers/en-route$query';
     try {
       final decoded = await _apiClient.get(path);
-      if (decoded is! List) throw StateError('Unexpected response type');
-      return decoded.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
+      final body = _unwrapLoads(decoded);
+      return body.cast<Map<String, dynamic>>().map(_mapLoadOffer).toList(growable: false);
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);
       rethrow;
     }
+  }
+
+  /// Extracts the list of load offers from a marketplace response, accepting
+  /// both the bare-list shape and the paginated `{ loads: [...] }` envelope
+  /// returned by `GET /api/orders/load-offers` and
+  /// `GET /api/orders/load-offers/en-route`. An envelope without a `loads`
+  /// key resolves to an empty list.
+  static List<dynamic> _unwrapLoads(dynamic decoded) {
+    if (decoded is Map<String, dynamic>) {
+      return decoded['loads'] as List? ?? const [];
+    }
+    if (decoded is List) return decoded;
+    throw StateError('Unexpected response type');
   }
 
   Future<Map<String, dynamic>> fetchDemandHeatmap() async {

--- a/apps/driver/test/marketplace_repository_test.dart
+++ b/apps/driver/test/marketplace_repository_test.dart
@@ -55,9 +55,40 @@ void main() {
       expect(offers, isEmpty);
     });
 
-    test('throws StateError on non-list response', () async {
+    test('unwraps { loads } envelope returned by the marketplace endpoint', () async {
       final client = MockClient((request) async {
-        return http.Response('{"not": "a list"}', 200);
+        expect(request.url.path, '/api/orders/load-offers');
+        return http.Response(
+          jsonEncode({
+            'page': 1,
+            'limit': 20,
+            'total': 1,
+            'loads': [_loadOfferRow],
+          }),
+          200,
+        );
+      });
+
+      final offers = await _repository(client).fetchLoadOffers();
+
+      expect(offers, hasLength(1));
+      expect(offers.first.id, 'load-1');
+      expect(offers.first.customer, 'Acme Corp');
+    });
+
+    test('returns empty list when envelope has no loads key', () async {
+      final client = MockClient((request) async {
+        return http.Response('{"total": 0}', 200);
+      });
+
+      final offers = await _repository(client).fetchLoadOffers();
+
+      expect(offers, isEmpty);
+    });
+
+    test('throws StateError on non-list non-map response', () async {
+      final client = MockClient((request) async {
+        return http.Response('"unexpected"', 200);
       });
 
       expect(
@@ -119,6 +150,27 @@ void main() {
         currentLng: 72.0,
         maxDetourKm: 120,
       );
+    });
+
+    test('unwraps { loads } envelope returned by the en-route endpoint', () async {
+      final client = MockClient((request) async {
+        expect(request.url.path, '/api/orders/load-offers/en-route');
+        return http.Response(
+          jsonEncode({
+            'loads': [_loadOfferRow],
+          }),
+          200,
+        );
+      });
+
+      final loads = await _repository(client).fetchEnRouteLoads(
+        currentLat: 19.0,
+        currentLng: 72.0,
+      );
+
+      expect(loads, hasLength(1));
+      expect(loads.first.id, 'load-1');
+      expect(loads.first.customer, 'Acme Corp');
     });
   });
 


### PR DESCRIPTION
### Description
Fixes #12817 — `fetchLoadOffers` and `fetchEnRouteLoads` in the driver app demanded a bare JSON `List`, but the marketplace endpoints return the paginated `{ loads: [...] }` envelope, so every marketplace call threw `StateError('Unexpected response type')` at runtime.

### Changes
- Added a shared `_unwrapLoads(decoded)` helper that accepts **both** shapes:
  - `{ "loads": [...] }` envelope (the real `GET /api/orders/load-offers` response) → unwraps the `loads` array
  - an envelope without a `loads` key → empty list
  - a bare `[...]` array (legacy / mock shape) → used as-is
  - anything else (string, number, etc.) → `StateError('Unexpected response type')`, preserving the original guard
- `fetchLoadOffers` and `fetchEnRouteLoads` now route their decoded payloads through `_unwrapLoads` before mapping to `LoadOffer` objects. This mirrors the tolerant parse already used by `fetchDriverBids` in the same file (which unwraps a `{ bids }` envelope with a bare-list fallback), so the marketplace screens (`available_loads_screen.dart`, `trips_screen.dart`) recover without their callers changing — they all consume `Future<List<LoadOffer>>`.

### Verification
- Updated `apps/driver/test/marketplace_repository_test.dart`:
  - `fetchLoadOffers`: added "unwraps { loads } envelope" and "empty list when envelope has no loads key" tests; replaced the old "throws StateError on non-list" test (which used a JSON object that is now a valid envelope) with a genuine non-list/non-map case (`"unexpected"` → still throws `StateError`).
  - `fetchEnRouteLoads`: added "unwraps { loads } envelope" test alongside the existing query-param tests.
- **Static verification only**: the Dart/Flutter SDK is not installed in this environment, so `flutter test` could not be executed. The changed code is a minimal, type-safe refactor mirroring the existing `fetchDriverBids` pattern (line 142) already in the repo.
- No backend changes: the `{ loads }` envelope contract is provided by the marketplace board in `loadRoutes.js` (`GET /api/loads`) and by the restored en-route route (issue #12813).

### GSSOC
- Contributor: Akshita-2307
- Issue: #12817
