### PR TITLE
fix(driver): coerce amount_inr number from confirm-otp to String (Resolves #12811)

### DIFF
--- a/apps/driver/lib/screens/delivery_otp_screen.dart
+++ b/apps/driver/lib/screens/delivery_otp_screen.dart
@@ -70,6 +70,15 @@ class _DeliveryOtpScreenState extends State<DeliveryOtpScreen>
 
   static const _geofenceRadius = 500.0; // metres
 
+  /// Normalises the `amount_inr` value returned by the confirm-otp endpoint
+  /// into a displayable string. The API sends a number (rupees), but older
+  /// responses may carry a string. Returns null when the API omits the field.
+  static String? _amountInr(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toStringAsFixed(value % 1 == 0 ? 0 : 2);
+    return value.toString();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -182,7 +191,7 @@ class _DeliveryOtpScreenState extends State<DeliveryOtpScreen>
         body: {'otp': _otp},
       );
 
-      final amount = body is Map ? (body['amount_inr'] as String?) : null;
+      final amount = body is Map ? _amountInr(body['amount_inr']) : null;
       final reconciliationRequired =
           body is Map && body['reconciliation_required'] == true;
       if (reconciliationRequired) {


### PR DESCRIPTION
### Description
Fixes #12811 — `DeliveryOtpScreen` crashes on every successful OTP verification. The confirm-otp endpoint returns `amount_inr` as a **number** (rupees) or null (`backend/api/src/routes/orderRoutes.js:335-356` — `Math.round(total_amount / 100)`), but the app cast it with `(body['amount_inr'] as String?)`, which throws a `TypeError` (cast error) on every real response and aborts the whole success path.

### Changes
- Replaced the unsafe `as String?` cast at `apps/driver/lib/screens/delivery_otp_screen.dart:185` with a `_amountInr(dynamic)` helper that normalises the field for display:
  - `num` → fixed-point string (e.g. `1500` → `"1500"`, `1500.5` → `"1500.50"`)
  - `String` → used as-is (older/legacy responses)
  - `null` → `null` (falls back to `widget.amountInr` at the call site, unchanged)
- No behaviour change on the display path: `'₹$_releasedAmount credited'` now receives `"1500"` instead of crashing.

### Verification
- Only one `amount_inr` read exists in the driver app (`grep`), and the cast site is the only one changed.
- The existing source-gate test `apps/driver/test/delivery_otp_screen_regression_test.dart` (exactly-one `_apiClient.post`, `body: {'otp': _otp}`) is unaffected — the confirm-otp call shape is untouched.
- **Static verification only**: the Dart/Flutter SDK is not installed in this environment, so `flutter test`/`dart analyze` could not be executed. The change is a minimal, side-effect-free type coercion replacing a known-bad cast, matching the API's documented number/null contract.

### GSSOC
- Contributor: Akshita-2307
- Issue: #12811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery OTP confirmation handling for payment amounts.
  * Amounts are now displayed consistently in rupees, including whole and two-decimal values.
  * Prevented confirmation errors when the payment amount is returned as a number or is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->