### PR TITLE
fix(n8n): surface Create Arbitration Record failures with retry + admin alert

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -223,6 +223,10 @@
       "name": "Create Arbitration Record",
       "type": "n8n-nodes-base.supabase",
       "typeVersion": 1,
+      "onError": "continueErrorOutput",
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 2000,
       "position": [
         1850,
         200
@@ -417,6 +421,24 @@
             "type": "main",
             "index": 0
           },
+          {
+            "node": "Email Admin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Arbitration Record": {
+      "main": [
+        [
+          {
+            "node": "Admin Resolution Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
           {
             "node": "Email Admin",
             "type": "main",


### PR DESCRIPTION
﻿## Problem
In utomation/n8n/dispute-resolution.json, the Create Arbitration Record (Supabase insert) node had no error handling. An insert failure (permissions, network, Supabase error) was silently swallowed, so the dispute was neither resolved nor escalated and no one was alerted.

## Fix
- Added onError: "continueErrorOutput" with etryOnFail: true (maxTries 3) to the node so insert failures are retried and surfaced instead of swallowed.
- Wired the node's error output to the existing Email Admin alert node, mirroring the freeze/release paths.
- On success the record now flows to Admin Resolution Webhook.

## Files changed
- automation/n8n/dispute-resolution.json

## Testing
- Parsed the workflow JSON to confirm it remains valid (15 nodes) and the new connection/error-handling fields are present.

Closes #12065
