### PR TITLE
fix(sockets): remove Supabase location channels on driver disconnect (leak fix)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -138,6 +138,12 @@ const locationChannels = new Map();
 // subscriber for a display ID disconnects.
 const displayIdToLocationChannelKeys = new Map();
 
+// Reverse index from driverId to the set of orderUUID keys it is actively
+// publishing location channels for. Used to tear down channels when the
+// publishing driver disconnects, so driver-only / unsubscribed orders do not
+// leak a Supabase Realtime channel for the process lifetime.
+const driverToLocationChannels = new Map();
+
 // Redis Pub/Sub fan-out bus that distributes location events across API
 // replicas so a driver connected to Replica A reaches a customer connected to
 // Replica B. Local subscribers are still stored only in `trackingSubscriptions`;
@@ -736,6 +742,7 @@ export function initWebSocketServer(server, orderRepository) {
       logger.info('WebSocket connection closed');
       void (async () => {
         await removeClientFromAllSubscriptions(ws);
+        if (ws.driverId) await removeDriverLocationChannels(ws.driverId);
       })();
     });
 
@@ -743,6 +750,7 @@ export function initWebSocketServer(server, orderRepository) {
       logger.error({ err }, 'WebSocket client error');
       void (async () => {
         await removeClientFromAllSubscriptions(ws);
+        if (ws.driverId) await removeDriverLocationChannels(ws.driverId);
       })();
     });
 
@@ -1285,6 +1293,12 @@ export async function handleLocationPing(ws, data, req) {
       const channel = supabase.channel(`driver-location:${orderUUID}`);
       channel.subscribe();
       locationChannels.set(orderUUID, channel);
+      if (driver_id) {
+        if (!driverToLocationChannels.has(driver_id)) {
+          driverToLocationChannels.set(driver_id, new Set());
+        }
+        driverToLocationChannels.get(driver_id).add(orderUUID);
+      }
       if (orderDisplayId) {
         if (!displayIdToLocationChannelKeys.has(orderDisplayId)) {
           displayIdToLocationChannelKeys.set(orderDisplayId, new Set());
@@ -1755,6 +1769,28 @@ async function removeClientFromAllSubscriptions(ws) {
       }
     }
   }
+}
+
+async function removeDriverLocationChannels(driverId) {
+  if (!driverId) return;
+  const channelKeys = driverToLocationChannels.get(driverId);
+  if (!channelKeys) return;
+  for (const uuidKey of channelKeys) {
+    const channel = locationChannels.get(uuidKey);
+    if (channel) {
+      if (supabase) {
+        supabase.removeChannel(channel);
+      }
+      locationChannels.delete(uuidKey);
+    }
+    // Also drop the orderUUID from the displayId reverse index.
+    displayIdToLocationChannelKeys.forEach((set, displayId) => {
+      if (set.delete(uuidKey) && set.size === 0) {
+        displayIdToLocationChannelKeys.delete(displayId);
+      }
+    });
+  }
+  driverToLocationChannels.delete(driverId);
 }
 
 async function restoreSubscriptions(ws) {


### PR DESCRIPTION
﻿## Problem
sockets/tracker.js caches one Supabase Realtime channel per order in locationChannels, but only removed it during the displayId-last-subscriber disconnect path. For driver-only / mismatched-mapping orders (no subscriber disconnect), the channel was never removed, leaking a persistent Realtime socket + Map entry for the process lifetime and exhausting connections/memory.

## Fix
- Added a driverToLocationChannels reverse index mapping driverId -> set of orderUUID channels it publishes.
- Registered each published orderUUID under the driver when a channel is created.
- Added emoveDriverLocationChannels(driverId) which calls supabase.removeChannel(channel), deletes the entry, and cleans the displayId reverse index.
- Invoked it from the WebSocket close/error handlers so channels are torn down when the publishing driver disconnects, independent of subscriber state.

## Files changed
- backend/api/src/sockets/tracker.js

## Testing
- 
ode --check passes; confirmed no merge-conflict markers remain. Channel map is now reference-cleaned for driver disconnects.

Closes #12163
