### PR TITLE
fix(routes): authenticate before multer on /kyc/upload

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -202,7 +202,7 @@ const upload = multer({
   },
 });
 
-router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticate, async (req, res) => {
+router.post('/kyc/upload', kycUploadLimiter, authenticate, upload.single('image'), async (req, res) => {
   try {
     const userId = req.user.id;
     if (!req.file) {


### PR DESCRIPTION
﻿## Problem
erificationRoutes.js /kyc/upload ran upload.single('image') (10 MB in-memory buffer + magic-byte + malware scan) before uthenticate. Any unauthenticated client could force the server to buffer a 10 MB multipart body and run the malware scanner before auth rejected, enabling cheap DoS / resource abuse.

## Fix
- Reordered the middleware so uthenticate (and the existing kycUploadLimiter) run before upload.single('image'), matching the ordering used in documentRoutes.js and maintenancePhotoRoutes.js.

## Files changed
- backend/api/src/routes/verificationRoutes.js

## Testing
- 
ode --check passes. Unauthenticated requests now fail at uthenticate before Multer buffers the upload body.

Closes #12177
