### PR TITLE
fix(eBPF): zero-init telemetry_event to stop kernel-memory leak

### DIFF
--- a/ebpf/socket_buffer_filter.c
+++ b/ebpf/socket_buffer_filter.c
@@ -14,8 +14,6 @@ struct {
     __uint(max_entries, 256 * 1024); // 256 KB Ring Buffer
 } telemetry_ringbuf SEC(".maps");
 
-<<<<<<< HEAD
-=======
 // Rate-limit map: key = connection tuple hash, value = entries in current window
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -32,7 +30,6 @@ struct {
     __type(value, __u16);
 } trusted_port_map SEC(".maps");
 
->>>>>>> upstream/main
 struct telemetry_event {
     __u32 src_ip;
     __u16 src_port;
@@ -53,9 +50,6 @@ int socket_telemetry_filter(struct __sk_buff *skb) {
     if (bpf_skb_load_bytes(skb, ETH_HLEN + sizeof(ip), &tcp, sizeof(tcp)) < 0)
         return 0;
 
-<<<<<<< HEAD
-    // Filter telemetry frames by magic header or port
-=======
     // Get trusted port from config map (default 0 = disabled, meaning all ports filtered)
     __u32 port_key = 0;
     __u16 *trusted_port = bpf_map_lookup_elem(&trusted_port_map, &port_key);
@@ -84,13 +78,16 @@ int socket_telemetry_filter(struct __sk_buff *skb) {
         return 0;
 
     // Calculate payload length
->>>>>>> upstream/main
     __u32 payload_len = skb->len - (ETH_HLEN + sizeof(ip) + (tcp.doff * 4));
     if (payload_len > 0) {
         struct telemetry_event *evt = bpf_ringbuf_reserve(&telemetry_ringbuf, sizeof(struct telemetry_event), 0);
         if (evt) {
+            // Zero the whole record (including the implicit padding hole between
+            // src_port and payload_len) so no uninitialized kernel memory is
+            // published to userspace readers of the ring buffer.
+            __builtin_memset(evt, 0, sizeof(*evt));
             evt->src_ip = ip.saddr;
-            evt->src_port = tcp.source;
+            evt->src_port = bpf_ntohs(tcp.source);
             evt->payload_len = payload_len;
             bpf_ringbuf_submit(evt, 0);
         }
@@ -99,8 +96,4 @@ int socket_telemetry_filter(struct __sk_buff *skb) {
     return skb->len; // Pass frame to socket buffer
 }
 
-<<<<<<< HEAD
 char _license[] SEC("license") = "GPL";
-=======
-char _license[] SEC("license") = "GPL";
->>>>>>> upstream/main


### PR DESCRIPTION
﻿## Problem
ebpf/socket_buffer_filter.c wrote a 	elemetry_event struct into the ring buffer that has an implicit 2-byte padding hole (src_ip(4) + src_port(2) + 2 pad + payload_len(4)). pf_ringbuf_reserve returns non-zeroed memory and only the three named fields were written, leaking up to 2 bytes of uninitialized kernel memory to userspace on every telemetry event (HIGH severity security issue, and would be rejected by stricter verifiers).

## Fix
- Resolved the merge-conflict markers in the file (kept the trusted-port / rate-limit maps and the truncated-packet guard).
- Zero the entire event with __builtin_memset(evt, 0, sizeof(*evt)) before filling fields, so the padding hole is never uninitialized.
- Convert src_port to host order with pf_ntohs(tcp.source) so userspace gets a readable port.

## Files changed
- ebpf/socket_buffer_filter.c

## Testing
- Confirmed no merge-conflict markers remain; the record is fully initialized before pf_ringbuf_submit.

Closes #13086
