### PR TITLE
fix: remove duplicate errorResponse import in deviceController (#13346)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -2,7 +2,6 @@ import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
-import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
Closes #13346

Removes the duplicate `errorResponse` import in `deviceController.js` (lines 3/5). A duplicate named import is an ES-module SyntaxError, so the module and every route importing it failed to load.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13346.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a duplicate internal import from device handling code.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->