### PR TITLE
fix: remove duplicate crypto import in otpHashing (#13347)

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -49,7 +49,6 @@ export function verifyOtpHash(otp, otpRecord) {
 
 // === Spec 12: ===
 // === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;


### PR DESCRIPTION
Closes #13347

Removes the duplicate `import crypto from 'crypto'` at line 52 of `otpHashing.js` (line 1 already imports it). The duplicate default-import binding is an ES-module SyntaxError, so the module failed to load.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13347.
