### PR TITLE
fix: remove duplicate validateBody(syncWeightSchema) in sync-weight route (#13348)

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1618,7 +1618,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;


### PR DESCRIPTION
Closes #13348

Removes the second `validateBody(syncWeightSchema)` from the `POST /weigh-stations/sync-weight` middleware chain in `driverRoutes.js`. The schema was being validated twice on every request.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13348.
