### PR TITLE
fix: remove unused uuidParamSchema import in loadRoutes (#13349)

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -57,7 +57,7 @@ import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 import { loadFilterQuerySchema, createLoadSchema } from '../validation/loadSchemas.js';
 import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
-import { paramIdSchema, uuidParamSchema } from '../validation/requestSchemas.js';
+import { paramIdSchema } from '../validation/requestSchemas.js';
 import { escapeLike } from '../lib/escapeLike.js';
 
 


### PR DESCRIPTION
Closes #13349

Removes the unused `uuidParamSchema` import from `loadRoutes.js` (only `paramIdSchema` is used in this file).

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13349.
