### PR TITLE
fix: remove unused otpSendSchema import in authRoutes (#13350)

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -173,7 +173,6 @@ router.get("/session", authenticate, userLimiter, (req, res) => {
 });
 
 import crypto from "crypto";
-import { otpSendSchema } from "../validation/requestSchemas.js";
 import { z } from "zod";
 import { verifyOtpHash } from "../lib/otpHashing.js";
 


### PR DESCRIPTION
Closes #13350

Removes the unused `otpSendSchema` import from `authRoutes.js`.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13350.
