### PR TITLE
fix: remove unused invalidateCachedSupabaseProfile import in profileRoutes (#13351)

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -106,7 +106,7 @@ import {
 } from '../services/profileService.js';
 import { supabase } from '../config/db.js';
 import { ProfileModel } from '../models/ProfileModel.js';
-import { invalidateCachedProfile, invalidateCachedSupabaseProfile, invalidateCachedSupabaseProfileAll } from '../lib/profileCache.js';
+import { invalidateCachedProfile, invalidateCachedSupabaseProfileAll } from '../lib/profileCache.js';
 import { auditLog } from '../middleware/auditLog.js';
 
 const router = express.Router();


### PR DESCRIPTION
Closes #13351

Removes the unused `invalidateCachedSupabaseProfile` import from `profileRoutes.js`. The file only calls `invalidateCachedProfile` and `invalidateCachedSupabaseProfileAll`.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13351.
