### PR TITLE
fix: remove unused imports in paymentRoutes (#13352)

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -28,18 +28,15 @@ import { auditLog } from '../middleware/auditLog.js';
 import logger from '../middleware/logger.js';
 import { createStore } from '../middleware/rateLimiter.js';
 import { orderRepository, orderValidationService } from '../core/container.js';
-import { supabase, createUserClient } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 import {
   recordDepositTx,
   getEscrowBookingId,
-  paisaToMaticWei,
   isEscrowEnabled,
-  escrowLockPayment,
   resolveExpectedDepositAmount,
   submitEscrowRefund,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
-import upiPaymentService from '../services/payment/UpiPaymentService.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Closes #13352

Removes four unused imports from `paymentRoutes.js`: `supabase`, `paisaToMaticWei`, `escrowLockPayment` and `upiPaymentService`. Verified each remaining symbol is still referenced in the file.

Verified with `node --check`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13352.
