### PR TITLE
fix: read milestone_time for order timeline timestamps (#13359)

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -174,7 +174,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
 
           final parsedTimeline = timelineList.map((step) {
             final completed = step['completed'] == true;
-            final updatedAt = step['updated_at']?.toString() ?? '';
+            final updatedAt = step['milestone_time']?.toString() ?? '';
             String timeStr = '';
             if (updatedAt.isNotEmpty) {
               final parsedDate = DateTime.tryParse(updatedAt);


### PR DESCRIPTION
Closes #13359

`order_detail_screen.dart` read `step['updated_at']` for each timeline step, but `orderRepository.getTimeline` selects `milestone, milestone_time, completed, sort_order` — there is no `updated_at`, so every timeline timestamp rendered blank.

Change: read `milestone_time` instead of `updated_at`.

## GSSOC
This PR is part of my GSSoC contribution for issue #13359.
