### PR TITLE
fix : remove duplicate vitest import in profileCache.test.js

### DIFF
--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -37,7 +37,6 @@ describe('profileCache stats', () => {
 
 
 // === Spec 8 test ===
-import { describe, it, expect } from 'vitest';
 import { isValidProfile } from '../../src/lib/profileCache.js';
 describe('isValidProfile', () => {
   it('accepts valid profile with required fields', () => {


### PR DESCRIPTION
Closes #13335.

Summary of What Has Been Done:
Removed the duplicate vitest import at line 40 of profileCache.test.js. The file was importing describe, it, and expect from 'vitest' twice (at lines 1 and 40), causing a SyntaxError in Node.js ESM that made the test file unparseable. The redundant import has been removed.

Changes Made:
- backend/api/test/unit/profileCache.test.js: Removed duplicate import line

Impact it Made:
- profileCache unit tests can now be loaded and run by vitest, restoring test coverage for the profileCache module.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).