### PR TITLE
fix : remove duplicate vitest import in redisLock.test.js

### DIFF
--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -23,7 +23,6 @@ describe('redisLock', () => {
 
 
 // === Spec 15 test ===
-import { describe, it, expect } from 'vitest';
 import { LockState } from '../../src/lib/redisLock.js';
 describe('LockState', () => {
   it('acquires once', () => { const l = new LockState(); expect(l.acquire()).toBe(true); expect(l.acquire()).toBe(false); });


### PR DESCRIPTION
Closes #13336.

Summary of What Has Been Done:
Removed the duplicate vitest import from fix : remove duplicate vitest import in redisLock.test.js. This fixes the SyntaxError caused by importing the same vitest symbols twice in the same ES module scope.

Changes Made:
- backend/api/test/unit/redisLock: Removed duplicate import line

Impact it Made:
- The affected unit tests can now be loaded and run by vitest.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).