### PR TITLE
fix : remove duplicate vitest import in requestCache.test.js

### DIFF
--- a/backend/api/test/unit/requestCache.test.js
+++ b/backend/api/test/unit/requestCache.test.js
@@ -59,7 +59,6 @@ describe('RequestCache', () => {
 
 
 // === Spec 25 test ===
-import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { attachResponseCleanup } from '../../src/lib/requestCache.js';
 describe('attachResponseCleanup', () => {


### PR DESCRIPTION
Closes #13337.

Summary of What Has Been Done:
Removed the duplicate vitest import from fix : remove duplicate vitest import in requestCache.test.js. This fixes the SyntaxError caused by importing the same vitest symbols twice in the same ES module scope.

Changes Made:
- backend/api/test/unit/requestCache: Removed duplicate import line

Impact it Made:
- The affected unit tests can now be loaded and run by vitest.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).