### PR TITLE
fix : remove duplicate vitest import in requestContext.test.js

### DIFF
--- a/backend/api/test/unit/requestContext.test.js
+++ b/backend/api/test/unit/requestContext.test.js
@@ -72,7 +72,6 @@ describe('requestContext', () => {
 
 
 // === Spec 1 test ===
-import { describe, it, expect } from 'vitest';
 import { safeJsonParseWithFallback } from '../../src/lib/requestContext.js';
 describe('safeJsonParseWithFallback', () => {
   it('returns parsed object for valid JSON', () => { expect(safeJsonParseWithFallback('{"a":1}', {})).toEqual({ a: 1 }); });


### PR DESCRIPTION
Closes #13338.

Summary of What Has Been Done:
Removed the duplicate vitest import from fix : remove duplicate vitest import in requestContext.test.js. This fixes the SyntaxError caused by importing the same vitest symbols twice in the same ES module scope.

Changes Made:
- backend/api/test/unit/requestContext: Removed duplicate import line

Impact it Made:
- The affected unit tests can now be loaded and run by vitest.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).