### PR TITLE
fix : remove duplicate vitest import in securityHeaders.test.js

### DIFF
--- a/backend/api/test/unit/securityHeaders.test.js
+++ b/backend/api/test/unit/securityHeaders.test.js
@@ -144,7 +144,6 @@ describe('securityHeaders', () => {
 
 
 // === Spec 11 test ===
-import { describe, it, expect } from 'vitest';
 import { setHstsHeader } from '../../src/middleware/securityHeaders.js';
 describe('setHstsHeader', () => {
   it('sets when missing', () => {


### PR DESCRIPTION
Closes #13340.

Summary of What Has Been Done:
Removed the duplicate vitest import from fix : remove duplicate vitest import in securityHeaders.test.js. This fixes the SyntaxError caused by importing the same vitest symbols twice in the same ES module scope.

Changes Made:
- backend/api/test/unit/securityHeaders: Removed duplicate import line

Impact it Made:
- The affected unit tests can now be loaded and run by vitest.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).