### PR TITLE
fix : added error parameter to bare catch in cursorPagination.js

### DIFF
--- a/backend/api/src/utils/cursorPagination.js
+++ b/backend/api/src/utils/cursorPagination.js
@@ -26,7 +26,7 @@ export function decodeCursor(cursor) {
   try {
     const json = Buffer.from(cursor, 'base64url').toString('utf8');
     return JSON.parse(json);
-  } catch {
+  } catch (_) {
     return null;
   }
 }


### PR DESCRIPTION
Closes #13394.

Summary of What Has Been Done:
Changed the bare catch block in the decodeCursor function to use a named error parameter, following the codebase convention for all catch blocks.

Changes Made:
- backend/api/src/utils/cursorPagination.js line 29: changed catch { to catch (_)

Impact it Made:
- Consistent with the rest of the codebase which uses named catch parameters
- Properly names the error parameter even though it is intentionally ignored

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).