### PR TITLE
fix : use req.params.id in geofence-confirm handler validation

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -210,7 +210,7 @@ router.post('/api/deliveries/:id/geofence-confirm', authenticate, requireRole(['
     return res.status(400).json({ error: 'Invalid driver_lat or driver_lng' });
   }
 
-  if (!id || !id.trim()) {
+  if (!req.params.id || !req.params.id.trim()) {
     return res.status(400).json({ error: 'Invalid order id' });
   }
   let geofenceRadiusM;


### PR DESCRIPTION
Closes #13395.

Summary of What Has Been Done:
Fixed the geofence-confirm route handler to use req.params.id instead of an undefined variable id.

Changes Made:
- backend/api/src/routes/orderRoutes.js line 213: changed if (!id || !id.trim()) to if (!req.params.id || !req.params.id.trim())

Impact it Made:
- Fixes a runtime ReferenceError that would occur when the geofence-confirm route is called
- Proper validation of the order ID from the URL parameter

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).