### PR TITLE
fix : remove duplicate errorResponse import in deviceController.js

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -2,7 +2,6 @@ import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
 import { AppError, UnauthorizedError, ValidationError } from '../utils/errors.js';
-import { errorResponse } from '../utils/apiResponse.js';
 
 const VALID_PLATFORMS = ['android', 'ios', 'web'];
 


### PR DESCRIPTION
Closes #13346.

Summary of What Has Been Done:
Removed the duplicate import of errorResponse from deviceController.js. The file imported errorResponse twice which causes a SyntaxError in ES modules.

Changes Made:
- backend/api/src/controllers/deviceController.js: removed the second import { errorResponse } from '../utils/apiResponse.js';

Impact it Made:
- Fixes the SyntaxError that prevented the module from loading
- Clean code following proper ES module conventions

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).