### PR TITLE
fix : remove duplicate crypto import in otpHashing.js

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -49,7 +49,6 @@ export function verifyOtpHash(otp, otpRecord) {
 
 // === Spec 12: ===
 // === Spec 12: constant-time hex compare ===
-import crypto from 'crypto';
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   if (a.length !== b.length) return false;


### PR DESCRIPTION
Closes #13347.

Summary of What Has Been Done:
Removed the duplicate import of crypto from otpHashing.js. The file imported crypto twice which causes a SyntaxError in ES modules.

Changes Made:
- backend/api/src/lib/otpHashing.js: removed the second import crypto from 'crypto'; (was line 52)

Impact it Made:
- Fixes the SyntaxError that prevented the module from loading
- The module now loads correctly with a single crypto import

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).