### PR TITLE
fix : remove double validateBody in sync-weight route handler

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1618,7 +1618,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;


### PR DESCRIPTION
Closes #13348.

Summary of What Has Been Done:
Removed the duplicate validateBody(syncWeightSchema) middleware from the POST /weigh-stations/sync-weight route. The body was being validated twice per request.

Changes Made:
- backend/api/src/routes/driverRoutes.js line 1621: removed second validateBody(syncWeightSchema) from middleware chain

Impact it Made:
- Eliminates redundant body validation overhead
- Clean middleware chain following proper Express conventions

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).