### PR TITLE
fix : remove unused supabase paisaToMaticWei escrowLockPayment upiPaymentService imports from paymentRoutes

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1618,7 +1618,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;

--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -28,18 +28,15 @@ import { auditLog } from '../middleware/auditLog.js';
 import logger from '../middleware/logger.js';
 import { createStore } from '../middleware/rateLimiter.js';
 import { orderRepository, orderValidationService } from '../core/container.js';
-import { supabase, createUserClient } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 import {
   recordDepositTx,
   getEscrowBookingId,
-  paisaToMaticWei,
   isEscrowEnabled,
-  escrowLockPayment,
   resolveExpectedDepositAmount,
   submitEscrowRefund,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
-import upiPaymentService from '../services/payment/UpiPaymentService.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Closes #13352.

Summary of What Has Been Done:
Removed four unused imports from paymentRoutes.js: supabase, paisaToMaticWei, escrowLockPayment, and upiPaymentService.

Changes Made:
- backend/api/src/routes/paymentRoutes.js: removed supabase from config/db import
- backend/api/src/routes/paymentRoutes.js: removed paisaToMaticWei and escrowLockPayment from escrow import
- backend/api/src/routes/paymentRoutes.js: removed upiPaymentService import line

Impact it Made:
- Clean code with only used imports
- Follows the codebase convention of no unused imports

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).