### PR TITLE
fix : remove unused otpSendSchema import from authRoutes

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -173,7 +173,6 @@ router.get("/session", authenticate, userLimiter, (req, res) => {
 });
 
 import crypto from "crypto";
-import { otpSendSchema } from "../validation/requestSchemas.js";
 import { z } from "zod";
 import { verifyOtpHash } from "../lib/otpHashing.js";
 


### PR DESCRIPTION
Closes #13350.

Summary of What Has Been Done:
Removed unused otpSendSchema import from authRoutes.js. This schema was imported but never used in the file.

Changes Made:
- backend/api/src/routes/authRoutes.js: removed import { otpSendSchema } from ../validation/requestSchemas.js;

Impact it Made:
- Clean code with only used imports
- Follows the codebase convention of no unused imports

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).