### PR TITLE
fix : remove unused uuidParamSchema import from loadRoutes

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -57,7 +57,7 @@ import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 import { loadFilterQuerySchema, createLoadSchema } from '../validation/loadSchemas.js';
 import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
-import { paramIdSchema, uuidParamSchema } from '../validation/requestSchemas.js';
+import { paramIdSchema } from '../validation/requestSchemas.js';
 import { escapeLike } from '../lib/escapeLike.js';
 
 


### PR DESCRIPTION
Closes #13349.

Summary of What Has Been Done:
Removed unused uuidParamSchema import from loadRoutes.js. This schema was imported but never used in the file.

Changes Made:
- backend/api/src/routes/loadRoutes.js: removed uuidParamSchema from the requestSchemas import

Impact it Made:
- Clean code with only used imports
- Follows the codebase convention of no unused imports

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).