### PR TITLE
fix : remove unused createStore/uuidSchema/uuidParamSchema imports from driverRoutes

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -146,12 +146,12 @@ import {
   sumEarnings,
   toDateKey,
 } from '../services/driver/earningsReportService.js';
-import { userLimiter, createStore } from '../middleware/rateLimiter.js';
+import { userLimiter } from '../middleware/rateLimiter.js';
 import { checkBypassEligibility, syncAndTransmitInternalWeights } from '../services/weighStationService.js';
 import { isPayoutProviderConfigured } from '../services/wallet/payoutProvider.js';
 
 import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
-import { driverOnlineSchema, withdrawSchema, uuidParamSchema, paramIdSchema, predictDriverProfitSchema, uuidSchema, driverIdParamSchema, driverStatementSchema, syncWeightSchema } from '../validation/requestSchemas.js';
+import { driverOnlineSchema, withdrawSchema, paramIdSchema, predictDriverProfitSchema, driverIdParamSchema, driverStatementSchema, syncWeightSchema } from '../validation/requestSchemas.js';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import logger from '../middleware/logger.js';


### PR DESCRIPTION
Closes #13415.

Summary of What Has Been Done:
Removed three unused imports from backend/api/src/routes/driverRoutes.js — createStore from the rateLimiter import and uuidSchema/uuidParamSchema from the requestSchemas import. These imports were in the file but never referenced in the route handler code.

Changes Made:
- backend/api/src/routes/driverRoutes.js: Removed createStore from import at line 149
- backend/api/src/routes/driverRoutes.js: Removed uuidParamSchema and uuidSchema from import at line 154

Impact it Made:
- Removes dead code that increased module parse time
- Makes linting more accurate
- No functional impact — imports were genuinely unused

Note: Please assign this PR to the `tmdeveloper007` account.

These Pull Requests are from GSSOC (GirlScript Summer of Code).