### PR TITLE
fix : correct TomTom traffic surge multiplier inversion in trafficService

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -35,7 +35,7 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
         if (!response.ok) throw new Error(`TomTom API error: ${response.status}`);
         const data = await response.json();
         const speedDiff = data.flowSegmentData?.speedDiffPercent || 0;
-        multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, 1.0 + Math.max(0, speedDiff / 100)));
+        multiplier = Math.min(MAX_SURGE_MULTIPLIER, Math.max(1.0, 1.0 + Math.max(0, -speedDiff / 100)));
       } else {
         const origin = `${pickupLat},${pickupLng}`;
         const destination = `${pickupLat + 0.01},${pickupLng + 0.01}`;


### PR DESCRIPTION
Closes #13426.

Summary of What Has Been Done:
Fixed the TomTom traffic surge multiplier calculation in backend/api/src/services/trafficService.js. TomTom speedDiffPercent is negative under congestion (slower than free-flow baseline) and positive under free-flow conditions. The old code used Math.max(0, speedDiff) which clamped all congested cases to 1.0x and inflated free-flow prices. Changed to Math.max(0, -speedDiff) to correctly apply surge under congestion.

Before: multiplier = Math.max(1.0, 1.0 + Math.max(0, speedDiff / 100))
After:  multiplier = Math.max(1.0, 1.0 + Math.max(0, -speedDiff / 100))

Changes Made:
- backend/api/src/services/trafficService.js: Fixed sign in TomTom branch

Impact it Made:
- Congestion now correctly increases pricing multiplier (higher price for harder conditions)
- Free-flow conditions now correctly return 1.0x (no surge)
- Fixes live-traffic pricing accuracy for driver earnings

Note: Please assign this PR to the `tmdeveloper007` account.

These Pull Requests are from GSSOC (GirlScript Summer of Code).