### PR TITLE
fix : added error guard in workZoneService predictWorkZoneDelays catch block

### DIFF
--- a/backend/api/src/services/workZoneService.js
+++ b/backend/api/src/services/workZoneService.js
@@ -58,7 +58,7 @@ export async function predictWorkZoneDelays(start, end, waypoints = [], departur
     };
 
   } catch (error) {
-    logger.error(`[WorkZoneService] Error predicting work-zone delays: ${error.message}`);
+    logger.error(`[WorkZoneService] Error predicting work-zone delays: ${error?.message ?? String(error)}`);
     // Fail open: assume no severe delay if predictive engine fails
     return { hasSevereDelay: false, predictedDelayMins: 0, problematicPoint: null };
   }


### PR DESCRIPTION
Closes #13444.

Summary of What Has Been Done:
The catch block in predictWorkZoneDelays accessed error.message directly, which would crash if the thrown value was not an Error. Changed to error?.message ?? String(error) for safe access.

Changes Made:
- backend/api/src/services/workZoneService.js: Guarded error.message access with optional chaining and String() fallback.

Impact it Made:
- Work zone delay prediction no longer crashes on non-Error throw values. Fail-open behavior is preserved.

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC (GirlScript Summer of Code).