### PR TITLE
fix : added error.message guard in KEDAService catch blocks

### DIFF
--- a/backend/api/src/services/kedaService.js
+++ b/backend/api/src/services/kedaService.js
@@ -51,7 +51,7 @@ class KEDAService {
             logger.error({ event: 'KEDA_METRICS_FETCH_ERROR', error: error?.message }, 'Metrics fetch failed');
             return {
                 success: false,
-                error: error.message,
+                error: error?.message ?? String(error),
                 timestamp: new Date().toISOString()
             };
         }
@@ -108,7 +108,7 @@ class KEDAService {
             logger.error({ event: 'KEDA_CPU_FETCH_ERROR', error: error?.message }, 'CPU usage fetch failed');
             return {
                 success: false,
-                error: error.message,
+                error: error?.message ?? String(error),
                 timestamp: new Date().toISOString()
             };
         }
@@ -124,7 +124,7 @@ class KEDAService {
             logger.error({ event: 'KEDA_MEMORY_FETCH_ERROR', error: error?.message }, 'Memory usage fetch failed');
             return {
                 success: false,
-                error: error.message,
+                error: error?.message ?? String(error),
                 timestamp: new Date().toISOString()
             };
         }
@@ -140,7 +140,7 @@ class KEDAService {
             logger.error({ event: 'KEDA_REPLICA_FETCH_ERROR', error: error?.message }, 'Replica count fetch failed');
             return {
                 success: false,
-                error: error.message,
+                error: error?.message ?? String(error),
                 timestamp: new Date().toISOString()
             };
         }


### PR DESCRIPTION
Closes #13445.

Summary of What Has Been Done:
Multiple catch blocks in KEDAService accessed error.message directly. Changed to error?.message ?? String(error) for safe access.

Changes Made:
- backend/api/src/services/kedaService.js: Changed error.message to error?.message ?? String(error) in all catch blocks.

Impact it Made:
- KEDA autoscaling service remains stable even when Prometheus queries fail with unexpected error types.

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC (GirlScript Summer of Code).