### PR TITLE
fix : added Number.isFinite guard for coordinates in trafficService

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -20,7 +20,7 @@ const SURGE_PEAK_AMPLITUDE = 1.3;
  */
 export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
   try {
-    if (!pickupLat || !pickupLng) {
+    if (!pickupLat || !pickupLng || !Number.isFinite(pickupLat) || !Number.isFinite(pickupLng)) {
       return 1.0;
     }
 


### PR DESCRIPTION
Closes #13446.

Summary of What Has Been Done:
getLiveTrafficMultiplier checked coordinates with falsy checks (!pickupLat || !pickupLng) which allowed non-numeric strings to pass. Added Number.isFinite() checks for proper validation.

Changes Made:
- backend/api/src/services/trafficService.js: Updated coordinate validation to use Number.isFinite(pickupLat) && Number.isFinite(pickupLng).

Impact it Made:
- Invalid non-numeric coordinate inputs are rejected early with 1.0 multiplier. No malformed API URLs sent to traffic providers.

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC (GirlScript Summer of Code).