### PR TITLE
fix : added Number.isNaN guard in reverseGeocode getTimeoutMs

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -12,7 +12,7 @@ const NOMINATIM_TIMEOUT_MS = 5000;
  */
 function getTimeoutMs() {
   const configured = Number(process.env.NOMINATIM_TIMEOUT_MS);
-  return Number.isFinite(configured) && configured > 0 ? configured : NOMINATIM_TIMEOUT_MS;
+  return Number.isFinite(configured) && configured > 0 && !Number.isNaN(configured) ? configured : NOMINATIM_TIMEOUT_MS;
 }
 
 /**


### PR DESCRIPTION
Closes #13458.

Summary of What Has Been Done:
The getTimeoutMs function checked Number.isFinite but did not guard against NaN. If NOMINATIM_TIMEOUT_MS env var is set to a non-numeric string like 'abc', Number('abc') produces NaN which passes Number.isFinite check as false. Added explicit Number.isNaN check.

Changes Made:
- backend/api/src/lib/reverseGeocode.js: Added Number.isNaN(configured) check to getTimeoutMs.

Impact it Made:
- Timeout configuration is validated correctly even for invalid numeric strings in environment variables.

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC (GirlScript Summer of Code).