### PR TITLE
fix : added explicit null check in isValidCachedProfile and isValidCachedSupabaseProfile

### DIFF
--- a/backend/api/src/lib/profileCache.js
+++ b/backend/api/src/lib/profileCache.js
@@ -110,7 +110,7 @@ export function isValidCachedProfile(firebaseUid, cachedProfile) {
     return false;
   }
   if (
-    !cachedProfile ||
+    cachedProfile === null ||
     typeof cachedProfile !== "object" ||
     Array.isArray(cachedProfile)
   ) {
@@ -165,7 +165,7 @@ export function isValidCachedSupabaseProfile(userId, cachedProfile) {
     return false;
   }
   if (
-    !cachedProfile ||
+    cachedProfile === null ||
     typeof cachedProfile !== "object" ||
     Array.isArray(cachedProfile)
   ) {


### PR DESCRIPTION
Closes #13459.

Summary of What Has Been Done:
Both isValidCachedProfile and isValidCachedSupabaseProfile used typeof cachedProfile !== 'object' which is true for null (typeof null === 'object' is true but misleading). Replaced the pattern with explicit cachedProfile === null check for clarity.

Changes Made:
- backend/api/src/lib/profileCache.js: Changed !cachedProfile to cachedProfile === null in both validation functions.

Impact it Made:
- Code intent is explicit and unambiguous. The null-guard behavior is preserved with clearer logic.

Note: Please assign this PR to the `tmdeveloper007` account. This PR is submitted as part of GSSOC (GirlScript Summer of Code).