### PR TITLE
fix(driverRoutes): remove duplicate validateBody(syncWeightSchema) on sync-weight

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1618,7 +1618,7 @@ router.get('/weigh-stations/bypass-status', authenticate, requireDriverRole, asy
  *       400:
  *         description: Invalid payload
  */
-router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, validateBody(syncWeightSchema), async (req, res) => {
+router.post('/weigh-stations/sync-weight', validateBody(syncWeightSchema), authenticate, requirePolicy('driver:view-stats'), userLimiter, async (req, res) => {
   try {
     const driverId = req.user.id;
     const { truck_id, axles } = req.body;


### PR DESCRIPTION
## What changed

In `backend/api/src/routes/driverRoutes.js`, the `POST /weigh-stations/sync-weight` route registered `validateBody(syncWeightSchema)` **twice** in its middleware chain (once before `authenticate` and again right before the route handler). This validated the request body twice per request, which is wasteful and can double-report validation errors.

### Fix
Keep only the first `validateBody(syncWeightSchema)` and remove the duplicate.



Closes #13348

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate request validation for weight synchronization, ensuring the operation is validated once while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->