### PR TITLE
fix : added null guard before destructuring in getRouteEstimate

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -56,7 +56,9 @@ function buildCacheKey({ pickupLat, pickupLng, dropLat, dropLng }) {
   return `osrm:route:v2:${r(pickupLat)}:${r(pickupLng)}:${r(dropLat)}:${r(dropLng)}`;
 }
 
-export async function getRouteEstimate({ pickupLat, pickupLng, dropLat, dropLng } = {}) {
+export async function getRouteEstimate(params) {
+  if (!params || typeof params !== 'object') return null;
+  const { pickupLat, pickupLng, dropLat, dropLng } = params;
   return measureExecution('OSRMService.getRouteEstimate', async () => {
   if (
     !Number.isFinite(pickupLat) || !Number.isFinite(pickupLng) ||


### PR DESCRIPTION
Closes #13487.

Summary of What Has Been Done:
Added a null/undefined guard at the top of getRouteEstimate() that returns null immediately when the parameter is not an object. This prevents the TypeError that occurred when getRouteEstimate was called with null, which tried to destructure null as an object.

Changes Made:
- backend/api/src/services/osrm.js: changed function signature from destructuring default  to named  parameter with explicit null guard before destructuring

Impact it Made:
- Prevents TypeError on null input
- Maintains same return behavior for valid calls
- Verified locally that the null guard is placed before any async/destructuring operations

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC contributions.