### PR TITLE
fix : normalise MLService error message prefix to [ML]

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -747,19 +747,19 @@ class MLService {
     try {
       data = await response.json();
     } catch (_) {
-      throw new Error(`[MLService] Failed to parse JSON response from ${method} ${url} (Status: ${response.status})`);
+      throw new Error(`[ML] Failed to parse JSON response from ${method} ${url} (Status: ${response.status})`);
     }
 
     if (response.status === 401) {
-      throw new Error(`[MLService] Authentication failed: ${method} ${url} (${response.status})`);
+      throw new Error(`[ML] Authentication failed: ${method} ${url} (${response.status})`);
     }
 
     if (response.status === 403) {
-      throw new Error(`[MLService] Forbidden: ${method} ${url} (${response.status})`);
+      throw new Error(`[ML] Forbidden: ${method} ${url} (${response.status})`);
     }
 
     if (!response.ok) {
-      throw new Error(`[MLService] Request failed: ${method} ${url} ${response.status}`);
+      throw new Error(`[ML] Request failed: ${method} ${url} ${response.status}`);
     }
 
     return data;


### PR DESCRIPTION
Closes #13489.

Summary of What Has Been Done:
Changed error message prefixes in the MLService class from [MLService] to [ML] to match the rest of the ml.js service, ensuring consistent structured error messages across all ML service error paths.

Changes Made:
- backend/api/src/services/ml.js: replaced [MLService] prefix with [ML] in MLService.handleResponse error messages (4 occurrences)

Impact it Made:
- Consistent [ML] error message prefix across the entire ML service
- Easier log scanning and alerting for ML failures

This PR was created as part of GSSOC (GirlScript Summer of Code).