### PR TITLE
fix : deduplicate vitest imports in securityHeaders.test.js

### DIFF
--- a/backend/api/test/unit/securityHeaders.test.js
+++ b/backend/api/test/unit/securityHeaders.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
-import securityHeaders from '../../src/middleware/securityHeaders.js';
+import securityHeaders, { setHstsHeader } from '../../src/middleware/securityHeaders.js';
 
 function createApp(preset = {}) {
   const app = express();


### PR DESCRIPTION
Closes #13479.

Summary of What Has Been Done:
Removed duplicate top-level vitest import from securityHeaders.test.js and added setHstsHeader to the existing securityHeaders import. Enables the security headers middleware tests to run.

Changes Made:
- backend/api/test/unit/securityHeaders.test.js: removed duplicate import and consolidated into single top-level import

Impact it Made:
- Enables previously broken unit tests to run
- Prevents module parse errors in CI

This PR was created as part of GSSOC (GirlScript Summer of Code).