### PR TITLE
fix : deduplicate vitest imports in requestCache.test.js

### DIFF
--- a/backend/api/test/unit/requestCache.test.js
+++ b/backend/api/test/unit/requestCache.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { RequestCache } from '../../src/lib/requestCache.js';
+import { EventEmitter } from 'node:events';
+import { RequestCache, attachResponseCleanup } from '../../src/lib/requestCache.js';
 
 describe('RequestCache', () => {
   let cache;


### PR DESCRIPTION
Closes #13482.

Summary of What Has Been Done:
Removed duplicate mid-file vitest import from requestCache.test.js and added EventEmitter and attachResponseCleanup to the top-level imports. Enables the request cache middleware tests to run.

Changes Made:
- backend/api/test/unit/requestCache.test.js: removed duplicate import and consolidated into single top-level import

Impact it Made:
- Enables previously broken unit tests to run
- Prevents module parse errors in CI

This PR was created as part of GSSOC (GirlScript Summer of Code).