### PR TITLE
test : add unit tests for lib/validatePagination.js and lib/priceRounding.js

### DIFF
--- a/backend/api/test/unit/lib/priceRounding.test.js
+++ b/backend/api/test/unit/lib/priceRounding.test.js
@@ -1,38 +1,119 @@
 import { describe, it, expect } from 'vitest';
-function paisaToMatic(p) {
-  if (p==null) return null; const n=Number(p);
-  if (!Number.isFinite(n)) return null;
-  return Math.round(n/100000);
-}
-function maticToPaisa(m) {
-  if (m==null) return null; const n=Number(m);
-  if (!Number.isFinite(n)) return null;
-  return Math.round(n*100000);
-}
-function roundPrice(v, d=2) {
-  if (v==null) return null; const n=Number(v);
-  if (!Number.isFinite(n)) return null;
-  return Math.round(n*Math.pow(10,d))/Math.pow(10,d);
-}
-describe('priceRounding', () => {
-  describe('paisaToMatic', () => {
-    it('converts correctly', () => { expect(paisaToMatic(100000)).toBe(1); expect(paisaToMatic(500000)).toBe(5); });
-    it('rounds to nearest integer', () => { expect(paisaToMatic(150000)).toBe(2); expect(paisaToMatic(149999)).toBe(1); });
-    it('handles zero', () => expect(paisaToMatic(0)).toBe(0));
-    it('returns null for null', () => { expect(paisaToMatic(null)).toBeNull(); expect(paisaToMatic(undefined)).toBeNull(); });
-    it('returns null for non-finite', () => { expect(paisaToMatic(NaN)).toBeNull(); expect(paisaToMatic(Infinity)).toBeNull(); });
+import { toPaisa, toInr, roundPrice } from '../../../src/lib/priceRounding.js';
+
+describe('toPaisa', () => {
+  it('converts whole INR to paisa correctly', () => {
+    expect(toPaisa(100)).toBe(10000);
+    expect(toPaisa(1)).toBe(100);
+    expect(toPaisa(0)).toBe(0);
   });
-  describe('maticToPaisa', () => {
-    it('converts correctly', () => { expect(maticToPaisa(1)).toBe(100000); expect(maticToPaisa(5)).toBe(500000); expect(maticToPaisa(0.5)).toBe(50000); });
-    it('handles zero', () => expect(maticToPaisa(0)).toBe(0));
-    it('returns null for null', () => expect(maticToPaisa(null)).toBeNull());
-    it('returns null for non-finite', () => expect(maticToPaisa(NaN)).toBeNull());
+
+  it('converts fractional INR to paisa correctly', () => {
+    expect(toPaisa(10.5)).toBe(1050);
+    expect(toPaisa(99.99)).toBe(9999);
+    expect(toPaisa(0.01)).toBe(1);
   });
-  describe('roundPrice', () => {
-    it('rounds to 2dp by default', () => { expect(roundPrice(1.234)).toBe(1.23); expect(roundPrice(1.235)).toBe(1.24); });
-    it('respects custom decimals', () => expect(roundPrice(1.2345,3)).toBe(1.235));
-    it('returns null for null', () => expect(roundPrice(null)).toBeNull());
-    it('returns null for non-finite', () => { expect(roundPrice(NaN)).toBeNull(); expect(roundPrice(Infinity)).toBeNull(); });
-    it('handles zero and negatives', () => { expect(roundPrice(0)).toBe(0); expect(roundPrice(-1.234)).toBe(-1.23); });
+
+  it('uses banker\'s rounding for edge cases', () => {
+    // 1.235 rounds to 123.5 -> 124 with EPSILON adjustment
+    expect(toPaisa(1.235)).toBe(124);
+    // 1.225 should round to 122 or 123 depending on JS behavior
+    const result = toPaisa(1.225);
+    expect([122, 123]).toContain(result);
+  });
+
+  it('returns null for negative values', () => {
+    expect(toPaisa(-1)).toBeNull();
+    expect(toPaisa(-0.01)).toBeNull();
+  });
+
+  it('returns null for non-number inputs', () => {
+    expect(toPaisa('100')).toBeNull();
+    expect(toPaisa(null)).toBeNull();
+    expect(toPaisa(undefined)).toBeNull();
+  });
+
+  it('returns null for NaN', () => {
+    expect(toPaisa(NaN)).toBeNull();
+  });
+
+  it('returns null for Infinity', () => {
+    expect(toPaisa(Infinity)).toBeNull();
+    expect(toPaisa(-Infinity)).toBeNull();
+  });
+
+  it('handles zero', () => {
+    expect(toPaisa(0)).toBe(0);
+  });
+});
+
+describe('toInr', () => {
+  it('converts whole paisa to INR correctly', () => {
+    expect(toInr(10000)).toBe(100);
+    expect(toInr(100)).toBe(1);
+    expect(toInr(0)).toBe(0);
+  });
+
+  it('converts fractional paisa to INR correctly', () => {
+    expect(toInr(1050)).toBe(10.5);
+    expect(toInr(1)).toBe(0.01);
+  });
+
+  it('returns null for negative values', () => {
+    expect(toInr(-100)).toBeNull();
+    expect(toInr(-1)).toBeNull();
+  });
+
+  it('returns null for non-number inputs', () => {
+    expect(toInr('100')).toBeNull();
+    expect(toInr(null)).toBeNull();
+    expect(toInr(undefined)).toBeNull();
+  });
+
+  it('returns null for NaN', () => {
+    expect(toInr(NaN)).toBeNull();
+  });
+
+  it('returns null for Infinity', () => {
+    expect(toInr(Infinity)).toBeNull();
+    expect(toInr(-Infinity)).toBeNull();
+  });
+});
+
+describe('roundPrice', () => {
+  it('rounds to 2 decimal places by default', () => {
+    expect(roundPrice(10.555)).toBe(10.56);
+    expect(roundPrice(10.554)).toBe(10.55);
+    expect(roundPrice(10.5)).toBe(10.5);
+  });
+
+  it('rounds to specified decimal places', () => {
+    expect(roundPrice(10.5555, 3)).toBe(10.556);
+    expect(roundPrice(10.5555, 1)).toBe(10.6);
+    expect(roundPrice(10.5555, 0)).toBe(11);
+  });
+
+  it('handles zero correctly', () => {
+    expect(roundPrice(0)).toBe(0);
+  });
+
+  it('returns 0 for non-number inputs', () => {
+    expect(roundPrice('10.5')).toBe(0);
+    expect(roundPrice(null)).toBe(0);
+    expect(roundPrice(undefined)).toBe(0);
+  });
+
+  it('returns 0 for NaN', () => {
+    expect(roundPrice(NaN)).toBe(0);
+  });
+
+  it('returns 0 for Infinity', () => {
+    expect(roundPrice(Infinity)).toBe(0);
+    expect(roundPrice(-Infinity)).toBe(0);
+  });
+
+  it('handles negative values', () => {
+    expect(roundPrice(-10.556)).toBe(-10.56);
+    expect(roundPrice(-10.554)).toBe(-10.55);
   });
 });

--- a/backend/api/test/unit/lib/validatePagination.test.js
+++ b/backend/api/test/unit/lib/validatePagination.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { validatePagination } from '../../../src/lib/validatePagination.js';
+
+describe('validatePagination', () => {
+  it('returns correct pagination for valid inputs', () => {
+    const result = validatePagination({ page: 1, pageSize: 20 });
+    expect(result).toEqual({ page: 1, pageSize: 20, offset: 0, limit: 20 });
+  });
+
+  it('returns correct offset for page 2', () => {
+    const result = validatePagination({ page: 2, pageSize: 20 });
+    expect(result).toEqual({ page: 2, pageSize: 20, offset: 20, limit: 20 });
+  });
+
+  it('returns correct offset for page 5 with 10 items per page', () => {
+    const result = validatePagination({ page: 5, pageSize: 10 });
+    expect(result).toEqual({ page: 5, pageSize: 10, offset: 40, limit: 10 });
+  });
+
+  it('handles string page and pageSize inputs', () => {
+    const result = validatePagination({ page: '3', pageSize: '25' });
+    expect(result).toEqual({ page: 3, pageSize: 25, offset: 50, limit: 25 });
+  });
+
+  it('handles undefined inputs with defaults', () => {
+    const result = validatePagination({});
+    expect(result).toEqual({ page: 1, pageSize: 20, offset: 0, limit: 20 });
+  });
+
+  it('handles null/undefined individual inputs', () => {
+    const r1 = validatePagination({ page: null, pageSize: 20 });
+    expect(r1.error).toBe('page must be >= 1');
+
+    const r2 = validatePagination({ page: 1, pageSize: null });
+    expect(r2.error).toBe('pageSize must be >= 1');
+  });
+
+  it('returns error for page less than 1', () => {
+    const result = validatePagination({ page: 0, pageSize: 20 });
+    expect(result.error).toBe('page must be >= 1');
+  });
+
+  it('returns error for page less than 1 (negative)', () => {
+    const result = validatePagination({ page: -1, pageSize: 20 });
+    expect(result.error).toBe('page must be >= 1');
+  });
+
+  it('returns error for pageSize less than 1', () => {
+    const result = validatePagination({ page: 1, pageSize: 0 });
+    expect(result.error).toBe('pageSize must be >= 1');
+  });
+
+  it('returns error for pageSize greater than 200', () => {
+    const result = validatePagination({ page: 1, pageSize: 201 });
+    expect(result.error).toBe('pageSize must be <= 200');
+  });
+
+  it('allows pageSize of 200', () => {
+    const result = validatePagination({ page: 1, pageSize: 200 });
+    expect(result).toEqual({ page: 1, pageSize: 200, offset: 0, limit: 200 });
+  });
+
+  it('returns error when offset exceeds MAX_OFFSET', () => {
+    // (50001-1)*20 = 1000000 which equals MAX_OFFSET, not exceeds
+    // (50002-1)*20 = 1000020 which exceeds MAX_OFFSET
+    const result = validatePagination({ page: 50002, pageSize: 20 });
+    expect(result.error).toContain('exceeds MAX_OFFSET');
+    expect(result.status).toBe(400);
+  });
+
+  it('does not error at exactly MAX_OFFSET boundary', () => {
+    // (50001-1)*20 = 1000000 which equals MAX_OFFSET
+    const result = validatePagination({ page: 50001, pageSize: 20 });
+    expect(result.error).toBeUndefined();
+    expect(result.page).toBe(50001);
+  });
+
+  it('returns error for NaN page', () => {
+    const result = validatePagination({ page: NaN, pageSize: 20 });
+    expect(result.error).toBe('page must be >= 1');
+  });
+
+  it('returns error for NaN pageSize', () => {
+    const result = validatePagination({ page: 1, pageSize: NaN });
+    expect(result.error).toBe('pageSize must be >= 1');
+  });
+
+  it('returns error for non-numeric string page', () => {
+    const result = validatePagination({ page: 'abc', pageSize: 20 });
+    expect(result.error).toBe('page must be >= 1');
+  });
+
+  it('returns error for non-numeric string pageSize', () => {
+    const result = validatePagination({ page: 1, pageSize: 'xyz' });
+    expect(result.error).toBe('pageSize must be >= 1');
+  });
+
+  it('handles floating point page values (does not coerce to integer)', () => {
+    // Number(2.7) = 2.7, and 2.7 < 1 is false, so it passes the >= 1 check
+    const result = validatePagination({ page: 2.7, pageSize: 10 });
+    // page 2.7 with pageSize 10 gives offset = (2.7-1)*10 = 17
+    expect(result.error).toBeUndefined();
+    expect(result.page).toBe(2.7);
+    expect(result.offset).toBe(17);
+  });
+});


### PR DESCRIPTION
Closes #13522.
Closes #13523.

Summary of What Has Been Done:
Added comprehensive unit tests for two backend lib helpers.

Changes Made:
- backend/api/test/unit/lib/validatePagination.test.js: 18 test cases covering valid pagination, string coercion, defaults, error cases for page/pageSize, MAX_OFFSET guard, NaN handling, and floating-point page values
- backend/api/test/unit/lib/priceRounding.test.js: 21 test cases covering toPaisa/toInr/roundPrice with valid inputs, edge cases, null, NaN, and Infinity handling

Impact it Made:
- Tests will catch regressions in pagination validation and price rounding logic
- Increases coverage for commonly used financial and pagination utilities

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).