### PR TITLE
fix : read backend truck fields in driver_profile_screen.dart

### DIFF
--- a/apps/driver/lib/screens/driver_profile_screen.dart
+++ b/apps/driver/lib/screens/driver_profile_screen.dart
@@ -88,9 +88,14 @@ class _DriverProfileScreenState extends State<DriverProfileScreen> {
           _kycStatus = details['kyc_status']?.toString() ?? details['kycStatus']?.toString() ?? 'Unverified';
 
           _truckType = truck['truck_type']?.toString() ?? truck['type']?.toString();
-          _capacityWeight = (truck['capacity_weight_tonnes'] as num?)?.toDouble() ?? (truck['capacityWeight'] as num?)?.toDouble() ?? 0.0;
+          _capacityWeight = (truck['max_capacity_tons'] as num?)?.toDouble()
+              ?? (truck['capacity_weight_tonnes'] as num?)?.toDouble()
+              ?? (truck['capacityWeight'] as num?)?.toDouble()
+              ?? 0.0;
           _capacityVolume = (truck['capacity_volume_m3'] as num?)?.toDouble() ?? (truck['capacityVolume'] as num?)?.toDouble() ?? 0.0;
-          _registrationNumber = truck['registration_number']?.toString() ?? truck['registrationNumber']?.toString();
+          _registrationNumber = truck['number_plate']?.toString()
+              ?? truck['registration_number']?.toString()
+              ?? truck['registrationNumber']?.toString();
 
           final parsedBadges = details['badges'] as List<dynamic>? ?? [];
           _badges = parsedBadges.map((e) => Map<String, dynamic>.from(e as Map)).toList();


### PR DESCRIPTION
Closes #13509.

Summary of What Has Been Done:
Fixed the driver profile screen to correctly read truck data from the backend by adding the correct backend field names as fallbacks.

Changes Made:
- apps/driver/lib/screens/driver_profile_screen.dart: Added max_capacity_tons as the primary field (with capacity_weight_tonnes and capacityWeight as fallbacks) when reading truck capacity weight. Added number_plate as a fallback for registration_number. This ensures the driver sees their actual truck capacity from the backend instead of always 0.0 Tonnes.

Impact it Made:
- Driver truck profile will now display actual capacity and registration from backend
- Properly handles both snake_case and camelCase field variations for robustness

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).