### PR TITLE
test : add unit tests for apiKey and correlationId middleware

### DIFF
--- a/backend/api/test/unit/middleware/apiKey.test.js
+++ b/backend/api/test/unit/middleware/apiKey.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requireApiKey } from '../../../src/middleware/apiKey.js';
+
+const mockReq = (headers = {}) => ({
+  headers,
+  ip: '127.0.0.1',
+  originalUrl: '/api/test',
+});
+
+const mockRes = () => {
+  const res = {
+    statusCode: null,
+    jsonData: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.jsonData = data;
+      return this;
+    },
+  };
+  return res;
+};
+
+const mockNext = vi.fn();
+
+describe('requireApiKey middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset env to control VALID_API_KEYS
+    delete process.env.VALID_API_KEYS;
+  });
+
+  it('returns 503 when VALID_API_KEYS is not configured', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.jsonData.error).toContain('not configured');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when API key is missing', () => {
+    process.env.VALID_API_KEYS = 'valid-key-1,valid-key-2';
+    const req = mockReq({});
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when API key is invalid', () => {
+    process.env.VALID_API_KEYS = 'valid-key-1,valid-key-2';
+    const req = mockReq({ 'x-api-key': 'wrong-key' });
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next when API key is valid', () => {
+    process.env.VALID_API_KEYS = 'valid-key-1,valid-key-2';
+    const req = mockReq({ 'x-api-key': 'valid-key-1' });
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('accepts the second valid key from a comma-separated list', () => {
+    process.env.VALID_API_KEYS = 'key-one,key-two,key-three';
+    const req = mockReq({ 'x-api-key': 'key-two' });
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('trims whitespace from valid keys', () => {
+    process.env.VALID_API_KEYS = '  key-with-spaces  , another-key ';
+    const req = mockReq({ 'x-api-key': 'key-with-spaces' });
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('returns 401 when API key is an empty string', () => {
+    process.env.VALID_API_KEYS = 'valid-key';
+    const req = mockReq({ 'x-api-key': '' });
+    const res = mockRes();
+    const next = mockNext;
+
+    requireApiKey(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/api/test/unit/middleware/correlationId.test.js
+++ b/backend/api/test/unit/middleware/correlationId.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
+import { correlationIdMiddleware } from '../../../src/middleware/correlationId.js';
+
+const mockReq = (headers = {}) => ({
+  headers,
+  correlationId: null,
+  requestId: null,
+  id: null,
+});
+
+const mockRes = () => {
+  const res = {
+    headers: {},
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+  };
+  return res;
+};
+
+describe('correlationIdMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates a new random UUID when no correlation ID is in headers', () => {
+    const req = mockReq({});
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.correlationId).toBeTruthy();
+    // UUID format check
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('uses the x-correlation-id header when valid', () => {
+    const req = mockReq({ 'x-correlation-id': 'my-correlation-123' });
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.correlationId).toBe('my-correlation-123');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('uses X-Correlation-ID header (capital variant)', () => {
+    const req = mockReq({ 'X-Correlation-ID': 'capital-header-id' });
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.correlationId).toBe('capital-header-id');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects correlation IDs longer than 64 characters', () => {
+    const longId = 'a'.repeat(65);
+    const req = mockReq({ 'x-correlation-id': longId });
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    // Should fall back to randomUUID instead of accepting the long id
+    expect(req.correlationId).not.toBe(longId);
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-/);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('sets X-Correlation-ID response header', () => {
+    const req = mockReq({});
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(res.headers['X-Correlation-ID']).toBe(req.correlationId);
+  });
+
+  it('accepts correlation IDs with alphanumeric, underscore, and hyphen', () => {
+    const validId = 'valid-id_123';
+    const req = mockReq({ 'x-correlation-id': validId });
+    const res = mockRes();
+    const next = vi.fn();
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.correlationId).toBe(validId);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #13535.

Summary of What Has Been Done:
Adds comprehensive unit tests for two backend middleware files.

Changes Made:
- backend/api/test/unit/middleware/apiKey.test.js: 7 tests covering the requireApiKey middleware - unconfigured state (503), missing API key (401), invalid API key (401), valid key acceptance, comma-separated key list, whitespace trimming, and empty string rejection
- backend/api/test/unit/middleware/correlationId.test.js: 6 tests covering the correlationIdMiddleware - UUID generation fallback, x-correlation-id header propagation, X-Correlation-ID capital variant, length validation (rejects >64 chars), response header setting, and valid character set acceptance (alphanumeric, underscore, hyphen)

Impact it Made:
- Increases test coverage for two backend middleware files
- Verifies security-critical middleware (apiKey) behaves correctly under all key scenarios

This PR is submitted as part of GSSOC (GirlScript Summer of Code).