### PR TITLE
test : add unit tests for lruCache and otpHashing lib utilities

### DIFF
--- a/backend/api/test/unit/lib/lruCache.test.js
+++ b/backend/api/test/unit/lib/lruCache.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { clampMaxKeys } from '../../../src/lib/lruCache.js';
+
+describe('clampMaxKeys', () => {
+  it('returns fallback for non-finite inputs', () => {
+    expect(clampMaxKeys(NaN)).toBe(1000);
+    expect(clampMaxKeys(Infinity)).toBe(1000);
+    expect(clampMaxKeys(-Infinity)).toBe(1000);
+    expect(clampMaxKeys('abc')).toBe(1000);
+    expect(clampMaxKeys(undefined)).toBe(1000);
+  });
+
+  it('treats null as 0 (finite) and clamps to MIN_KEYS', () => {
+    // Number(null) === 0, which is finite but below MIN_KEYS (10)
+    expect(clampMaxKeys(null)).toBe(10);
+  });
+
+  it('returns custom fallback when provided', () => {
+    expect(clampMaxKeys(NaN, 500)).toBe(500);
+    expect(clampMaxKeys(Infinity, 0)).toBe(0);
+  });
+
+  it('clamps values below MIN_KEYS (10) to 10', () => {
+    expect(clampMaxKeys(-100)).toBe(10);
+    expect(clampMaxKeys(0)).toBe(10);
+    expect(clampMaxKeys(5)).toBe(10);
+    expect(clampMaxKeys(9)).toBe(10);
+    expect(clampMaxKeys(9.9)).toBe(10);
+  });
+
+  it('clamps values above MAX_KEYS (100000) to 100000', () => {
+    expect(clampMaxKeys(100001)).toBe(100000);
+    expect(clampMaxKeys(500000)).toBe(100000);
+    expect(clampMaxKeys(1e9)).toBe(100000);
+  });
+
+  it('returns the value unchanged when within [10, 100000]', () => {
+    expect(clampMaxKeys(10)).toBe(10);
+    expect(clampMaxKeys(1000)).toBe(1000);
+    expect(clampMaxKeys(50000)).toBe(50000);
+    expect(clampMaxKeys(100000)).toBe(100000);
+  });
+
+  it('handles floating point numbers within range', () => {
+    expect(clampMaxKeys(10.5)).toBe(10.5);
+    expect(clampMaxKeys(99999.9)).toBe(99999.9);
+  });
+});

--- a/backend/api/test/unit/lib/otpHashing.test.js
+++ b/backend/api/test/unit/lib/otpHashing.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { hashOtp, verifyOtpHash, constantTimeEqualHex } from '../../../src/lib/otpHashing.js';
+
+describe('hashOtp', () => {
+  it('throws TypeError for null OTP', () => {
+    expect(() => hashOtp(null)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for undefined OTP', () => {
+    expect(() => hashOtp(undefined)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for empty string OTP', () => {
+    expect(() => hashOtp('')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for whitespace-only OTP', () => {
+    expect(() => hashOtp('   ')).toThrow(TypeError);
+  });
+
+  it('returns an object with hash and salt properties', () => {
+    const result = hashOtp('123456');
+    expect(result).toHaveProperty('hash');
+    expect(result).toHaveProperty('salt');
+    expect(typeof result.hash).toBe('string');
+    expect(typeof result.salt).toBe('string');
+  });
+
+  it('returns a 128-character hex hash (scrypt 64 bytes)', () => {
+    const { hash } = hashOtp('123456');
+    expect(hash).toMatch(/^[a-f0-9]{128}$/);
+  });
+
+  it('returns a 32-character hex salt (16 bytes)', () => {
+    const { salt } = hashOtp('123456');
+    expect(salt).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('uses provided salt when given', () => {
+    const { hash, salt } = hashOtp('123456', 'abcd1234abcd1234abcd1234abcd1234');
+    expect(salt).toBe('abcd1234abcd1234abcd1234abcd1234');
+    expect(hash).toMatch(/^[a-f0-9]{128}$/);
+  });
+
+  it('produces consistent hash for same OTP and salt', () => {
+    const salt = 'abcd1234abcd1234abcd1234abcd1234';
+    const hash1 = hashOtp('123456', salt);
+    const hash2 = hashOtp('123456', salt);
+    expect(hash1.hash).toBe(hash2.hash);
+  });
+
+  it('produces different hash for different OTPs with same salt', () => {
+    const salt = 'abcd1234abcd1234abcd1234abcd1234';
+    const hash1 = hashOtp('123456', salt);
+    const hash2 = hashOtp('654321', salt);
+    expect(hash1.hash).not.toBe(hash2.hash);
+  });
+
+  it('accepts numeric OTP input', () => {
+    const result = hashOtp(123456);
+    expect(result.hash).toMatch(/^[a-f0-9]{128}$/);
+  });
+});
+
+describe('verifyOtpHash', () => {
+  it('returns false when otpRecord is null', () => {
+    expect(verifyOtpHash('123456', null)).toBe(false);
+  });
+
+  it('returns false when otpRecord is undefined', () => {
+    expect(verifyOtpHash('123456', undefined)).toBe(false);
+  });
+
+  it('returns false for scrypt record with invalid hash format', () => {
+    expect(verifyOtpHash('123456', { otp_hash: 'not-hex', otp_salt: 'abcd1234abcd1234abcd1234abcd1234' })).toBe(false);
+  });
+
+  it('returns false for pre-migration record with invalid hash format', () => {
+    expect(verifyOtpHash('123456', { otp_hash: 'invalid' })).toBe(false);
+  });
+
+  it('returns false for non-matching OTP (scrypt record)', () => {
+    const { hash, salt } = hashOtp('123456');
+    expect(verifyOtpHash('654321', { otp_hash: hash, otp_salt: salt })).toBe(false);
+  });
+
+  it('returns true for matching OTP (scrypt record)', () => {
+    const { hash, salt } = hashOtp('123456');
+    expect(verifyOtpHash('123456', { otp_hash: hash, otp_salt: salt })).toBe(true);
+  });
+
+  it('returns true for matching OTP (pre-migration SHA-256 record)', async () => {
+    const { createHash } = await import('crypto');
+    const hash = createHash('sha256').update('123456').digest('hex');
+    expect(verifyOtpHash('123456', { otp_hash: hash })).toBe(true);
+  });
+
+  it('returns false for non-matching OTP (pre-migration record)', async () => {
+    const { createHash } = await import('crypto');
+    const hash = createHash('sha256').update('123456').digest('hex');
+    expect(verifyOtpHash('654321', { otp_hash: hash })).toBe(false);
+  });
+
+  it('returns false when record has no valid hash fields', () => {
+    expect(verifyOtpHash('123456', {})).toBe(false);
+    expect(verifyOtpHash('123456', { random: 'value' })).toBe(false);
+  });
+});
+
+describe('constantTimeEqualHex', () => {
+  it('returns false for non-string inputs', () => {
+    expect(constantTimeEqualHex(null, 'abc')).toBe(false);
+    expect(constantTimeEqualHex('abc', null)).toBe(false);
+    expect(constantTimeEqualHex(123, 'abc')).toBe(false);
+    expect(constantTimeEqualHex('abc', 123)).toBe(false);
+  });
+
+  it('returns false when lengths differ', () => {
+    expect(constantTimeEqualHex('abc', 'abcd')).toBe(false);
+    expect(constantTimeEqualHex('abcd', 'abc')).toBe(false);
+  });
+
+  it('returns false for non-hex strings', () => {
+    expect(constantTimeEqualHex('xyz123', 'xyz123')).toBe(false);
+  });
+
+  it('returns true for equal hex strings', () => {
+    expect(constantTimeEqualHex('deadbeef', 'deadbeef')).toBe(true);
+  });
+
+  it('returns false for unequal hex strings of same length', () => {
+    expect(constantTimeEqualHex('deadbeef', 'feedbeef')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #13537.

Summary of What Has Been Done:
Adds comprehensive unit tests for two backend lib utility files.

Changes Made:
- backend/api/test/unit/lib/lruCache.test.js: 7 tests for clampMaxKeys covering non-finite inputs (NaN, Infinity), custom fallback, clamping below MIN_KEYS (10), clamping above MAX_KEYS (100000), valid range, null treated as 0 (clamped to MIN_KEYS)
- backend/api/test/unit/lib/otpHashing.test.js: 25 tests covering hashOtp (TypeError for null/empty/whitespace OTP, 128-char hex hash, 32-char salt, deterministic hashing with salt, numeric input support), verifyOtpHash (null record, invalid hash format, scrypt verification with salt, pre-migration SHA-256 verification, mismatch cases), and constantTimeEqualHex (non-string rejection, length mismatch, invalid hex rejection)

Impact it Made:
- Increases test coverage for two backend lib utility files
- Verifies security-critical OTP hashing functions

This PR is submitted as part of GSSOC (GirlScript Summer of Code).