### PR TITLE
fix : await emitSafe, use supabaseAdmin in verificationRoutes, and fix IP audit log

### DIFF
--- a/backend/api/src/core/events/EventBus.js
+++ b/backend/api/src/core/events/EventBus.js
@@ -311,7 +311,9 @@ class EventBus extends EventEmitter {
 
     const span = spanFactory.startEventPublishSpan(eventType, { source, eventId });
 
-    const consumed = this.emitSafe(eventType, enrichedEvent);
+    // Await local listeners so that the outbox relay worker can safely mark
+    // an event as published only after all listeners have finished processing.
+    const consumed = await this.emitSafe(eventType, enrichedEvent);
 
     const targetAdapters = options.adapters || null;
     let adapterAttempted = 0;

--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import rateLimit from 'express-rate-limit';
 import { verificationService } from '../core/container.js';
-import { supabase, supabaseAdmin, createUserClient } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { safeIpKeyGenerator, createStore } from '../middleware/rateLimiter.js';
 import { validateParams, validateBody } from '../middleware/validate.js';
@@ -61,8 +61,7 @@ const kycUploadLimiter = rateLimit({
 router.get('/order/:orderId', orderVerificationLimiter, authenticate, validateParams(verifyOrderParamsSchema), async (req, res) => {
   try {
     const { orderId } = req.params;
-    const userClient = createUserClient(req.token);
-    const { data: order, error: orderError } = await userClient
+    const { data: order, error: orderError } = await supabaseAdmin
       .from('orders')
       .select('id, customer_id, driver_id')
       .eq('id', orderId)

--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -249,7 +249,7 @@ class KeyRotationService {
           status,
           error_message: errorMessage,
           timestamp: new Date().toISOString(),
-          ip_address: requestIp || process.env.REQUEST_IP || 'unknown',
+          ip_address: requestIp || 'server-initiated',
         }]);
     } catch (err) {
       logger.error('[KeyRotationService] Failed to log rotation event:', err.message);


### PR DESCRIPTION
Closes #13521.
Closes #13526.
Closes #13527.

Summary of What Has Been Done:
Three independent backend fixes combined into a single PR to stay within the 20-PR budget.

Changes Made:
1. backend/api/src/core/events/EventBus.js (publishAndReport):
   - Add await to emitSafe() call so local listeners are confirmed complete before the outbox relay worker marks an event as published. This prevents race conditions where the outbox marks an event as published before async listeners finish processing.
   - The emitSafe method already returns a promise that resolves when all async listeners settle (as documented in its comment), but publishAndReport was not awaiting it.

2. backend/api/src/routes/verificationRoutes.js (GET /order/:orderId):
   - Replace userClient (RLS-gated) with supabaseAdmin for the initial order existence check. The policy.authorize() check still gates access to the response, so authorization is preserved while avoiding false 500s from RLS edge cases during verification checks.
   - Remove unused createUserClient import.

3. backend/api/src/services/security/keyRotationService.js (logKeyRotationEvent):
   - Remove misleading process.env.REQUEST_IP fallback from ip_address field. The env var contains the server IP, not the requester IP, making audit logs misleading. Now falls back to 'server-initiated' when requestIp is not provided.

Impact it Made:
- Prevents race condition in event publishing where outbox could mark events published before listeners complete
- Fixes verification route RLS-related failures
- Improves audit log accuracy for key rotation events

This PR is submitted as part of GSSOC (GirlScript Summer of Code).