### PR TITLE
test : add unit tests for hppProtection middleware and cursorPagination utility

### DIFF
--- a/backend/api/test/unit/lib/cursorPagination.test.js
+++ b/backend/api/test/unit/lib/cursorPagination.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { encodeCursor, decodeCursor, isValidCursor } from '../../../src/utils/cursorPagination.js';
+
+describe('encodeCursor', () => {
+  it('encodes simple object to base64url string', () => {
+    const encoded = encodeCursor({ id: '123' });
+    expect(typeof encoded).toBe('string');
+    expect(encoded.length).toBeGreaterThan(0);
+    // base64url uses A-Z, a-z, 0-9, -, _
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('encodes nested object', () => {
+    const data = { id: 'abc', nested: { key: 'value' }, arr: [1, 2, 3] };
+    const encoded = encodeCursor(data);
+    expect(typeof encoded).toBe('string');
+  });
+
+  it('encodes empty object', () => {
+    const encoded = encodeCursor({});
+    expect(typeof encoded).toBe('string');
+    // base64url encoding omits padding: {} → JSON → base64 → 'e30=' → 'e30'
+    expect(encoded).toBe('e30');
+  });
+
+  it('round-trips correctly', () => {
+    const original = { id: 'order-123', createdAt: '2026-08-14T10:00:00Z' };
+    const encoded = encodeCursor(original);
+    const decoded = decodeCursor(encoded);
+    expect(decoded).toEqual(original);
+  });
+});
+
+describe('decodeCursor', () => {
+  it('returns null for null input', () => {
+    expect(decodeCursor(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(decodeCursor(undefined)).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(decodeCursor(123)).toBeNull();
+    expect(decodeCursor({})).toBeNull();
+    expect(decodeCursor([])).toBeNull();
+  });
+
+  it('decodes valid base64url cursor', () => {
+    const data = encodeCursor({ page: 2 });
+    const decoded = decodeCursor(data);
+    expect(decoded).toEqual({ page: 2 });
+  });
+
+  it('returns null for invalid base64 string', () => {
+    expect(decodeCursor('!!!invalid!!!')).toBeNull();
+  });
+
+  it('returns null for valid base64 that is not JSON', () => {
+    // base64url of 'not json at all'
+    const raw = Buffer.from('not json at all').toString('base64url');
+    expect(decodeCursor(raw)).toBeNull();
+  });
+
+  it('handles unicode in cursor data', () => {
+    const data = encodeCursor({ name: 'John Doe' });
+    const decoded = decodeCursor(data);
+    expect(decoded.name).toBe('John Doe');
+  });
+
+  it('handles special characters', () => {
+    const data = encodeCursor({ key: 'a/b+c=d' });
+    const decoded = decodeCursor(data);
+    expect(decoded.key).toBe('a/b+c=d');
+  });
+});
+
+describe('isValidCursor', () => {
+  it('returns true for valid cursor', () => {
+    const valid = encodeCursor({ id: '123' });
+    expect(isValidCursor(valid)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isValidCursor(null)).toBe(false);
+  });
+
+  it('returns false for invalid cursor string', () => {
+    expect(isValidCursor('!!!invalid!!!')).toBe(false);
+  });
+
+  it('returns false for non-string', () => {
+    expect(isValidCursor(12345)).toBe(false);
+  });
+});

--- a/backend/api/test/unit/middleware/hppProtection.test.js
+++ b/backend/api/test/unit/middleware/hppProtection.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import hppProtection from '../../../src/middleware/hppProtection.js';
+
+const mockReq = (query = {}) => ({
+  query,
+  requestId: 'req-123',
+  ip: '127.0.0.1',
+  originalUrl: '/api/test',
+});
+const mockRes = () => ({
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(data) {
+    this.jsonData = data;
+    return this;
+  },
+});
+
+describe('hppProtection middleware', () => {
+  let next;
+
+  beforeEach(() => {
+    next = vi.fn();
+  });
+
+  it('always calls next() for non-duplicate parameters', () => {
+    const req = mockReq({ name: 'Alice', age: '30' });
+    const res = mockRes();
+    hppProtection(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('normalizes duplicate parameters to the first value', () => {
+    const req = mockReq({ tag: ['a', 'b', 'c'] });
+    const res = mockRes();
+    hppProtection(req, res, next);
+    expect(req.query.tag).toBe('a');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('normalizes duplicate parameters even when allowDuplicates option exists', () => {
+    // The default hppProtection does not take an options argument
+    const req = mockReq({ id: ['1', '2'] });
+    const res = mockRes();
+    hppProtection(req, res, next);
+    expect(req.query.id).toBe('1');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('handles empty query object', () => {
+    const req = mockReq({});
+    const res = mockRes();
+    hppProtection(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('normalizes single-element array to scalar', () => {
+    const req = mockReq({ single: ['only'] });
+    const res = mockRes();
+    hppProtection(req, res, next);
+    expect(req.query.single).toBe('only');
+    expect(next).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Summary of What Has Been Done:
Adds unit tests for HTTP Parameter Pollution protection middleware and cursor-based pagination utilities.

Changes Made:
- backend/api/test/unit/middleware/hppProtection.test.js: 5 tests covering hppProtection middleware - non-duplicate parameters pass-through, duplicate parameter normalization to first value, single-element array normalization, empty query handling
- backend/api/test/unit/lib/cursorPagination.test.js: 16 tests covering encodeCursor (simple/nested/empty object encoding, round-trip fidelity), decodeCursor (null/non-string/invalid base64/invalid JSON rejection, unicode/special character handling), and isValidCursor (valid cursor, null, invalid string, non-string)

Impact it Made:
- Increases test coverage for HTTP Parameter Pollution protection middleware
- Verifies cursor-based pagination encoding/decoding utilities

This PR is submitted as part of GSSOC (GirlScript Summer of Code).