### PR TITLE
PolicyEvaluator skips ownership check when resource is undefined, allowing cross-tenant access

### DIFF
--- a/backend/api/src/core/auth/PolicyEvaluator.js
+++ b/backend/api/src/core/auth/PolicyEvaluator.js
@@ -43,6 +43,14 @@ export class PolicyEvaluator {
       };
     }
 
+    if (resource === undefined && permission.ownership) {
+      return {
+        allowed: false,
+        permission: permission.toJSON(),
+        reason: 'missing_resource',
+      };
+    }
+
     if (resource !== undefined && !permission.checkOwnership(user, resource)) {
       return {
         allowed: false,


### PR DESCRIPTION
## Problem

PolicyEvaluator skips ownership check when resource is undefined, allowing cross-tenant access

## Fix

Addresses the defect described in issue #12030 with a minimal, scoped change.

## Files changed

backend/api/src/core/auth/PolicyEvaluator.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12030
