### PR TITLE
crossDockService non-atomic active-transfer check converts unique-violation 409 into 500

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -277,6 +277,9 @@ export async function createTransferRequest({
       .single();
 
     if (insertErr) {
+      if (insertErr.code === '23505') {
+        throw new DomainError(409, { error: 'An active cross-dock transfer already exists for this load.' });
+      }
       throw new DomainError(500, { error: 'Failed to create cross-dock transfer.', details: insertErr.message });
     }
 


### PR DESCRIPTION
## Problem

crossDockService non-atomic active-transfer check converts unique-violation 409 into 500

## Fix

Addresses the defect described in issue #12035 with a minimal, scoped change.

## Files changed

backend/api/src/services/order/crossDockService.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12035
