### PR TITLE
my_truck_screen uses _data! null-assertion when analytics response is null -> crash

### DIFF
--- a/apps/driver/lib/screens/my_truck_screen.dart
+++ b/apps/driver/lib/screens/my_truck_screen.dart
@@ -941,10 +941,10 @@ class _FuelAnalyticsTabState extends State<_FuelAnalyticsTab> {
       return Center(child: Text(_error!, style: const TextStyle(color: TruxifyColors.error)));
     }
 
-    final totalPayout = (_data!['totalPayout'] as num?)?.toDouble() ?? 0.0;
-    final estFuel = (_data!['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
-    final margin = (_data!['profitMargin'] as num?)?.toDouble() ?? 0.0;
-    final chartPoints = (_data!['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
+    final totalPayout = (_data?['totalPayout'] as num?)?.toDouble() ?? 0.0;
+    final estFuel = (_data?['estimatedFuelCost'] as num?)?.toDouble() ?? 0.0;
+    final margin = (_data?['profitMargin'] as num?)?.toDouble() ?? 0.0;
+    final chartPoints = (_data?['chartPoints'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
 
     return RefreshIndicator(
       onRefresh: _load,


### PR DESCRIPTION
## Problem

my_truck_screen uses _data! null-assertion when analytics response is null -> crash

## Fix

Addresses the defect described in issue #12037 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/my_truck_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12037
