### PR TITLE
orders_screen TabController listener never removed in dispose (leak)

### DIFF
--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -102,11 +102,7 @@ class _OrdersScreenState extends State<OrdersScreen>
 
     _orderService = widget.orderService ?? OrderService();
     _tabController = TabController(length: 2, vsync: this);
-    _tabController.addListener(() {
-      if (!_tabController.indexIsChanging) {
-        _controller?.setOrdersTab(_tabController.index);
-      }
-    });
+    _tabController.addListener(_onTabChanged);
     _loadOrders();
     _subscribeToOrdersListUpdates();
   }
@@ -343,8 +339,15 @@ class _OrdersScreenState extends State<OrdersScreen>
         .subscribe();
   }
 
+  void _onTabChanged() {
+    if (!_tabController.indexIsChanging) {
+      _controller?.setOrdersTab(_tabController.index);
+    }
+  }
+
   @override
   void dispose() {
+    _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
     _searchController.dispose();
     if (SupabaseConfig.isConfigured && _ordersChannel != null) {


### PR DESCRIPTION
## Problem

orders_screen TabController listener never removed in dispose (leak)

## Fix

Addresses the defect described in issue #12038 with a minimal, scoped change.

## Files changed

apps/customer/lib/screens/orders_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12038
