### PR TITLE
dispute-resolution.json 24h Check Dispute Resolution GET has no error handling -> escalation never runs

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -187,7 +187,11 @@
       "position": [
         1450,
         300
-      ]
+      ],
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 5000,
+      "onError": "continueErrorOutput"
     },
     {
       "parameters": {


### PR DESCRIPTION
## Problem

dispute-resolution.json 24h Check Dispute Resolution GET has no error handling -> escalation never runs

## Fix

Addresses the defect described in issue #12062 with a minimal, scoped change.

## Files changed

automation/n8n/dispute-resolution.json

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12062
