### PR TITLE
dispute-resolution.json Create Arbitration Record insert has no error handling (silent failure)

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -223,6 +223,10 @@
       "name": "Create Arbitration Record",
       "type": "n8n-nodes-base.supabase",
       "typeVersion": 1,
+      "onError": "continueErrorOutput",
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 2000,
       "position": [
         1850,
         200
@@ -417,6 +421,24 @@
             "type": "main",
             "index": 0
           },
+          {
+            "node": "Email Admin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Arbitration Record": {
+      "main": [
+        [
+          {
+            "node": "Admin Resolution Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
           {
             "node": "Email Admin",
             "type": "main",


### PR DESCRIPTION
## Problem

dispute-resolution.json Create Arbitration Record insert has no error handling (silent failure)

## Fix

Addresses the defect described in issue #12065 with a minimal, scoped change.

## Files changed

automation/n8n/dispute-resolution.json

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12065
