### PR TITLE
#8 KYC upload stores empty OCR number as NULL `kyc_doc_number`, bypassing identity binding

### DIFF
--- a/backend/api/src/routes/verificationRoutes.js
+++ b/backend/api/src/routes/verificationRoutes.js
@@ -266,15 +266,28 @@ router.post('/kyc/upload', kycUploadLimiter, upload.single('image'), authenticat
     const ocrData = await mlResponse.json();
 
     if (ocrData.verified) {
-      const { error: verifyError } = await supabaseAdmin
-        .from('driver_details')
-        .update({ 
-          kyc_status: 'Verified',
-          kyc_doc_number: ocrData.extracted_number
-        })
-        .eq('user_id', userId);
+      const docNumber = typeof ocrData.extracted_number === 'string'
+        ? ocrData.extracted_number.trim().toUpperCase()
+        : '';
 
-      if (verifyError) throw verifyError;
+      if (!docNumber) {
+        const { error: verifyError } = await supabaseAdmin
+          .from('driver_details')
+          .update({ kyc_status: 'Rejected' })
+          .eq('user_id', userId);
+
+        if (verifyError) throw verifyError;
+      } else {
+        const { error: verifyError } = await supabaseAdmin
+          .from('driver_details')
+          .update({
+            kyc_status: 'Verified',
+            kyc_doc_number: docNumber,
+          })
+          .eq('user_id', userId);
+
+        if (verifyError) throw verifyError;
+      }
     } else {
        const { error: rejectError } = await supabaseAdmin
         .from('driver_details')


### PR DESCRIPTION
## Problem

#8 KYC upload stores empty OCR number as NULL `kyc_doc_number`, bypassing identity binding

## Fix

Addresses the defect described in issue #12159 with a minimal, scoped change.

## Files changed

backend/api/src/routes/verificationRoutes.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12159
