### PR TITLE
ai_broker_negotiation_screen calls s.history.first on empty list -> crash

### DIFF
--- a/apps/driver/lib/screens/ai_broker_negotiation_screen.dart
+++ b/apps/driver/lib/screens/ai_broker_negotiation_screen.dart
@@ -130,7 +130,7 @@ class _AIBrokerNegotiationScreenState extends State<AIBrokerNegotiationScreen> {
                 children: [
                   _buildMetric('Driver Min', '\$${s.driverMinimumUsd.toInt()}'),
                   _buildMetric('Broker Initial', '\$${s.initialBrokerOfferUsd.toInt()}'),
-                  _buildMetric('Current Offer', '\$${s.history.first.offerAmountUsd?.toInt() ?? 0}', color: Colors.deepPurple),
+                  _buildMetric('Current Offer', '\$${s.history.isNotEmpty ? s.history.first.offerAmountUsd?.toInt() ?? 0 : 0}', color: Colors.deepPurple),
                 ],
               )
             ],


### PR DESCRIPTION
## Problem

ai_broker_negotiation_screen calls s.history.first on empty list -> crash

## Fix

Addresses the defect described in issue #12036 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/ai_broker_negotiation_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12036


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Current Offer” metric now displays **$0** when no negotiation history is available, instead of producing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->