### PR TITLE
marketplace_repository unguarded ^Gs Map cast on API bid field throws on malformed response

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -145,7 +145,11 @@ class MarketplaceRepository {
         },
       ) as Map<String, dynamic>;
       
-      return DriverBid.fromJson(Map<String, dynamic>.from(decoded['bid'] as Map));
+      final bid = decoded['bid'];
+      if (bid is! Map) {
+        throw StateError('Malformed bid response: expected a bid object');
+      }
+      return DriverBid.fromJson(Map<String, dynamic>.from(bid));
     } catch (e) {
       if (e is ApiException) throw StateError(e.message);
       rethrow;


### PR DESCRIPTION
## Problem

marketplace_repository unguarded ^Gs Map cast on API bid field throws on malformed response

## Fix

Addresses the defect described in issue #12039 with a minimal, scoped change.

## Files changed

apps/driver/lib/services/marketplace_repository.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12039
