### PR TITLE
home_screen active trip uses ^Gs String on API field, crashes when trip_display_id is null

### DIFF
--- a/apps/driver/lib/screens/home_screen.dart
+++ b/apps/driver/lib/screens/home_screen.dart
@@ -706,8 +706,10 @@ class _HomeScreenState extends State<HomeScreen> {
       final trips = await _tripService.fetchTrips(status: 'active');
       if (trips.isNotEmpty) {
         final activeTrip = trips.first;
-        final tripId = activeTrip['trip_display_id'] as String;
-        final stops = await _tripService.fetchTripStops(tripId);
+        final tripId = activeTrip['trip_display_id'] as String? ?? '';
+        final stops = tripId.isNotEmpty
+            ? await _tripService.fetchTripStops(tripId)
+            : <Map<String, dynamic>>[];
         if (!mounted) return;
 
         final truckPlate = (activeTrip['truck_plate'] as String?) ?? '';


### PR DESCRIPTION
## Problem

home_screen active trip uses ^Gs String on API field, crashes when trip_display_id is null

## Fix

Addresses the defect described in issue #12055 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/home_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12055
