### PR TITLE
earnings_screen ^Gs Map<String,dynamic> on statement export crashes on non-Map response

### DIFF
--- a/apps/driver/lib/screens/earnings_screen.dart
+++ b/apps/driver/lib/screens/earnings_screen.dart
@@ -402,6 +402,11 @@ class _EarningsScreenState extends State<EarningsScreen> {
 
       if (!mounted) return;
 
+      if (json is! Map<String, dynamic>) {
+        _showSnackBar('Unable to load statement', TruxifyColors.error);
+        return;
+      }
+
       final statement = EarningsStatementModel.fromJson(
         json as Map<String, dynamic>,
       );


### PR DESCRIPTION
## Problem

earnings_screen ^Gs Map<String,dynamic> on statement export crashes on non-Map response

## Fix

Addresses the defect described in issue #12060 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/earnings_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12060
