### PR TITLE
dispute-resolution.json 'Is Still Unresolved?' IF relies on fragile .status equality

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -200,9 +200,21 @@
     {
       "parameters": {
         "conditions": {
+          "combinator": "or",
           "string": [
             {
               "value1": "={{$json.status}}",
+              "operation": "equals",
+              "value2": "disputed"
+            },
+            {
+              "value1": "={{$json.data.status}}",
+              "operation": "equals",
+              "value2": "disputed"
+            },
+            {
+              "value1": "={{$json.order.status}}",
+              "operation": "equals",
               "value2": "disputed"
             }
           ]


### PR DESCRIPTION
## Problem

dispute-resolution.json 'Is Still Unresolved?' IF relies on fragile .status equality

## Fix

Addresses the defect described in issue #12063 with a minimal, scoped change.

## Files changed

automation/n8n/dispute-resolution.json

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12063
