### PR TITLE
past_trips_screen ^Gs num on onChainScore crashes when backend returns non-num

### DIFF
--- a/apps/driver/lib/screens/past_trips_screen.dart
+++ b/apps/driver/lib/screens/past_trips_screen.dart
@@ -168,7 +168,8 @@ class _PastTripsScreenState extends State<PastTripsScreen> {
         if (data is Map<String, dynamic>) {
           setState(() {
             _platformRating = (data['supabaseRating'] as num?)?.toDouble() ?? 0.0;
-            _onChainScore = data['onChainScore'] != null ? (data['onChainScore'] as num).toInt() : null;
+            final s = data['onChainScore'];
+            _onChainScore = s is num ? s.toInt() : int.tryParse(s?.toString() ?? '');
             _walletAddress = data['walletAddress']?.toString() ?? '';
             _isLoadingReputation = false;
           });


### PR DESCRIPTION
## Problem

past_trips_screen ^Gs num on onChainScore crashes when backend returns non-num

## Fix

Addresses the defect described in issue #12067 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/past_trips_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12067
