### PR TITLE
#9 Location updates delivered multiple times (dual Redis Pub/Sub publish + direct + Supabase Realtime)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1284,21 +1284,12 @@ export async function handleLocationPing(ws, data, req) {
   deliverLocationToLocalSubscribers(trackingSubscriptions, broadcastPayload, orderDisplayId ?? null, driver_id);
   initRedisTrackerPubSub();
 
-  if (redisClient) {
-    const pubSubMessage = JSON.stringify({
-      orderDisplayId,
-      driver_id,
-      payload: broadcastPayload,
-    });
-    redisClient.publish(TRACKER_CHANNELS.LOCATION, pubSubMessage).catch((err) => {
-      logger.error({ err }, '[Tracker] Redis publish error for location update');
-      if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, broadcastPayload);
-      if (driver_id) deliverToLocalSubscribers(driver_id, broadcastPayload);
-    });
-  } else {
-    if (orderDisplayId) deliverToLocalSubscribers(orderDisplayId, broadcastPayload);
-    if (driver_id) deliverToLocalSubscribers(driver_id, broadcastPayload);
-  }
+  // Cross-replica fan-out is already handled by locationEventBus.publish above,
+  // which fans the update out to every replica via its own channel and lets each
+  // replica's consumer skip self-originated events. Publishing again here to the
+  // legacy TRACKER_CHANNELS.LOCATION channel caused every subscriber to receive
+  // the same update a second time (duplicate delivery), so we rely on the single
+  // bus publish and the local delivery done just above.
 
   // Publish to Supabase Realtime channel driver-location:{orderId}
   // Reuse cached channel to avoid creating a new channel per ping.


### PR DESCRIPTION
## Problem

#9 Location updates delivered multiple times (dual Redis Pub/Sub publish + direct + Supabase Realtime)

## Fix

Addresses the defect described in issue #12160 with a minimal, scoped change.

## Files changed

backend/api/src/sockets/tracker.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12160
