### PR TITLE
#11 ZKP verification lock TTL (120s) is shorter than on-chain confirmation time, allowing duplicate `verifyKYC`

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -9,7 +9,7 @@ import { acquireLock, releaseLock, LockAcquisitionError } from '../../lib/redisL
  * Must be long enough to cover proof generation + blockchain tx confirmation.
  * Configurable via ZKP_LOCK_TTL_MS env var.
  */
-const ZKP_LOCK_TTL_MS = Number(process.env.ZKP_LOCK_TTL_MS) || 120_000;
+const ZKP_LOCK_TTL_MS = Number(process.env.ZKP_LOCK_TTL_MS) || 600_000;
 
 class ZKPService {
   constructor() {


### PR DESCRIPTION
## Problem

#11 ZKP verification lock TTL (120s) is shorter than on-chain confirmation time, allowing duplicate `verifyKYC`

## Fix

Addresses the defect described in issue #12162 with a minimal, scoped change.

## Files changed

backend/api/src/services/zkp/zkp.service.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12162
