### PR TITLE
#27 Traffic pipeline computes `congestion` with inverted sign, returning negative under real jams

### DIFF
--- a/backend/ml/services/traffic_pipeline.py
+++ b/backend/ml/services/traffic_pipeline.py
@@ -213,7 +213,7 @@ class TrafficPipeline:
                     return {
                         'duration': duration,
                         'speed': route.get('distance', {}).get('value', 0) / duration if duration > 0 else 50,
-                        'congestion': (1 - normal_duration / duration) if duration > 0 else 0
+                        'congestion': (duration / normal_duration - 1.0) if normal_duration > 0 else 0
                     }
         return {}
     


### PR DESCRIPTION
## Problem

#27 Traffic pipeline computes `congestion` with inverted sign, returning negative under real jams

## Fix

Addresses the defect described in issue #12338 with a minimal, scoped change.

## Files changed

backend/ml/services/traffic_pipeline.py

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12338
