### PR TITLE
[HIGH] Blockchain: EIP-191 commitment signature mismatch between backend `escrow.js` and `TruxifyEscrow.sol`

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -401,8 +401,8 @@ export async function buildDepositTx (orderDisplayId, customerWalletAddress, dri
     const network = await escrowContract.runner.provider.getNetwork()
     const nonce = await escrowContract.commitmentNonces(customerWalletAddress)
     const commitment = ethers.solidityPackedKeccak256(
-      ['uint256', 'address', 'address', 'uint256', 'uint256'],
-      [network.chainId, contractAddress, customerWalletAddress, bookingId, nonce]
+      ['uint256', 'address', 'address', 'uint256', 'address', 'uint256', 'uint256'],
+      [network.chainId, contractAddress, customerWalletAddress, bookingId, driverWalletAddress, amountWei, nonce]
     )
     const signature = await relayerWallet.signMessage(ethers.getBytes(commitment))
 

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -142,26 +142,17 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     /**
      * @dev Verify the owner's EIP-191 signature over the create commitment:
-<<<<<<< HEAD
-     *      keccak256(chainId, this, customer, bookingId, commitmentNonces[customer]).
-     *      Only the contract owner (the backend relayer) can authorise a slot,
-     *      so an external party cannot claim a pending bookingId for 1 wei.
-=======
      *      keccak256(chainId, this, customer, bookingId, driver, amount,
      *      commitmentNonces[customer]). Pinning driver and amount prevents a
      *      customer from reusing a valid commitment to create a booking whose
      *      driver/amount diverge from what the backend authorised (issue #11393).
      *      Only the contract owner (the backend relayer) can authorise a slot.
->>>>>>> upstream/main
      */
     function _verifyCreateCommitment(
         address customer,
         uint256 bookingId,
-<<<<<<< HEAD
-=======
         address driver,
         uint256 amount,
->>>>>>> upstream/main
         bytes calldata signature
     ) private view returns (bool) {
         require(signature.length == 65, "TruxifyEscrow: Invalid signature length");
@@ -172,11 +163,8 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
                 address(this),
                 customer,
                 bookingId,
-<<<<<<< HEAD
-=======
                 driver,
                 amount,
->>>>>>> upstream/main
                 commitmentNonces[customer]
             )
         );
@@ -232,11 +220,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Booking already exists"
         );
         require(
-<<<<<<< HEAD
-            _verifyCreateCommitment(msg.sender, bookingId, signature),
-=======
             _verifyCreateCommitment(msg.sender, bookingId, driver, msg.value, signature),
->>>>>>> upstream/main
             "TruxifyEscrow: Invalid commitment signature"
         );
 


### PR DESCRIPTION
## Problem

[HIGH] Blockchain: EIP-191 commitment signature mismatch between backend `escrow.js` and `TruxifyEscrow.sol`

## Fix

Addresses the defect described in issue #13082 with a minimal, scoped change.

## Files changed

backend/api/src/services/escrow.js
blockchain/contracts/TruxifyEscrow.sol

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13082
