### PR TITLE
[MEDIUM-HIGH] Blockchain: `releasePayment` lacks a `started` precondition (state-machine asymmetry)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -324,6 +324,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             booking.status == BookingStatus.Active,
             "TruxifyEscrow: Booking not active"
         );
+        require(booking.started, "TruxifyEscrow: Trip not started");
         require(!booking.paid, "TruxifyEscrow: Already paid");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to release");
 


### PR DESCRIPTION
## Problem

[MEDIUM-HIGH] Blockchain: `releasePayment` lacks a `started` precondition (state-machine asymmetry)

## Fix

Addresses the defect described in issue #13083 with a minimal, scoped change.

## Files changed

blockchain/contracts/TruxifyEscrow.sol

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13083
