### PR TITLE
[MEDIUM] Supabase: silent integer truncation of monetary values in `create_order_tx`

### DIFF
--- a/supabase/migrations/20260810000001_fix_create_order_tx_columns.sql
+++ b/supabase/migrations/20260810000001_fix_create_order_tx_columns.sql
@@ -92,11 +92,11 @@ BEGIN
         CASE WHEN jsonb_typeof(p_order_data->'special_requirements') = 'array'
              THEN (p_order_data->'special_requirements')::TEXT[]
              ELSE NULL END,
-        (p_order_data->>'base_freight')::INTEGER,
-        (p_order_data->>'toll_estimate')::INTEGER,
-        (p_order_data->>'platform_fee')::INTEGER,
-        (p_order_data->>'total_amount')::INTEGER,
-        (p_order_data->>'estimated_price')::INTEGER,
+        round((p_order_data->>'base_freight')::NUMERIC)::INTEGER,
+        round((p_order_data->>'toll_estimate')::NUMERIC)::INTEGER,
+        round((p_order_data->>'platform_fee')::NUMERIC)::INTEGER,
+        round((p_order_data->>'total_amount')::NUMERIC)::INTEGER,
+        round((p_order_data->>'estimated_price')::NUMERIC)::INTEGER,
         (p_order_data->>'payment_method_id')::UUID,
         p_order_data->>'upi_id'
     )


### PR DESCRIPTION
## Problem

[MEDIUM] Supabase: silent integer truncation of monetary values in `create_order_tx`

## Fix

Addresses the defect described in issue #13098 with a minimal, scoped change.

## Files changed

supabase/migrations/20260810000001_fix_create_order_tx_columns.sql

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13098
