### PR TITLE
fix(pricing): define missing freight constants and reject non-finite input in sanitizePrice (Closes #13573)

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -17,10 +17,15 @@
 
 import logger from '../middleware/logger.js';
 
+// Floor and ceiling for a single freight price in paisa (1 INR = 100 paisa).
+// Negative/NaN/Infinity clamp to the floor (0); the ceiling is ₹10,00,000.
+const MIN_FREIGHT_PAISa = 0;
+const MAX_FREIGHT_PAISa = 100_000_000;
+
 export function sanitizePrice(value) {
   const num = Number(value);
-  const clamped = Math.max(MIN_FREIGHT_PAISa, Math.min(MAX_FREIGHT_PAISa, num));
-  return Number.isFinite(clamped) && clamped >= 0 ? Math.round(clamped) : MIN_FREIGHT_PAISa;
+  if (!Number.isFinite(num) || num < 0) return MIN_FREIGHT_PAISa;
+  return Math.round(Math.min(MAX_FREIGHT_PAISa, num));
 }
 
 const EARTH_RADIUS_KM = 6371.0088;


### PR DESCRIPTION
Closes #13573.

Summary of What Has Been Done:
Fixed sanitizePrice in ackend/api/src/lib/pricing.js, which referenced undefined constants MIN_FREIGHT_PAISa/MAX_FREIGHT_PAISa and threw a ReferenceError on every call. Also reordered the checks so non-finite inputs are rejected before clamping (Infinity/NaN/negative now return 0 instead of being clamped to the maximum).

Changes Made:
- backend/api/src/lib/pricing.js: added MIN_FREIGHT_PAISa = 0 and MAX_FREIGHT_PAISa = 100_000_000 (₹10,00,000 in paisa), and rewrote sanitizePrice to reject non-finite/negative input first, then clamp and round.

Impact it Made:
- sanitizePrice no longer throws ReferenceError (reproduced before the fix).
- test/unit/pricing.test.js: all 31 tests pass, including the Infinity → 0 case.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).