### PR TITLE
fix(orders): pass req.token to createUserClient in submitRating (Closes #13576)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -1412,7 +1412,7 @@ router.post('/:id/bids/:bidId/accept', authenticate, userLimiter, requirePolicy(
 router.post('/:id/ratings', authenticate, userLimiter, validateParams(paramIdSchema), validateBody(submitRatingSchema), async (req, res) => {
   try {
     const { stars, comment } = req.body;
-    const result = await orderLifecycleService.submitRating(req.params.id, req.user.id, stars, comment, createUserClient(req.user.id));
+    const result = await orderLifecycleService.submitRating(req.params.id, req.user.id, stars, comment, createUserClient(req.token));
     return res.json(result);
   } catch (err) {
     if (err instanceof DomainError) {


### PR DESCRIPTION
Closes #13576.

Summary of What Has Been Done:
Fixed POST /api/orders/:id/ratings passing a non-JWT value to createUserClient. createUserClient in src/config/db.js embeds the value in Authorization: Bearer <token> so the Supabase client carries the caller's identity (used by uth.uid() RPCs). The handler passed eq.user.id (a DB profile id, not a token), producing an invalid Bearer header and failing rating submissions. It now passes eq.token, the raw JWT captured by the uthenticate middleware.

Changes Made:
- backend/api/src/routes/orderRoutes.js (submitRating): createUserClient(req.user.id) → createUserClient(req.token).

Impact it Made:
- Rating submissions now use a valid JWT for the per-request Supabase client; no other createUserClient(req.user.*) call sites exist in the codebase.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).