### PR TITLE
fix(delivery): accept 0 as a valid drop-off coordinate in assertDriverAtDropoff (Closes #13580)

### DIFF
--- a/backend/api/src/services/order/deliveryVerificationService.js
+++ b/backend/api/src/services/order/deliveryVerificationService.js
@@ -404,7 +404,7 @@ export class DeliveryVerificationService {
    *                       409 no/invalid/stale/out-of-range telemetry.
    */
   async assertDriverAtDropoff(order, radiusM) {
-    if (!order.drop_lat || !order.drop_lng) {
+    if (order.drop_lat == null || order.drop_lng == null) {
       throw new DomainError(400, {
         error: "Order is missing drop-off coordinates.",
       });


### PR DESCRIPTION
Closes #13580.

Summary of What Has Been Done:
Fixed ssertDriverAtDropoff in ackend/api/src/services/order/deliveryVerificationService.js rejecting valid  coordinates. The falsy guard !order.drop_lat || !order.drop_lng treated latitude/longitude of 0 (equator/Greenwich) as missing, throwing a 400 for legitimate orders. Now only 
ull/undefined are considered missing.

Changes Made:
- backend/api/src/services/order/deliveryVerificationService.js: !order.drop_lat || !order.drop_lng → order.drop_lat == null || order.drop_lng == null.

Impact it Made:
- Orders with a  drop-off coordinate are accepted; genuinely missing coords still throw the 400 DomainError.
- test/unit/deliveryVerificationService.test.js and deliveryVerificationGeofence.test.js: same results as clean main (no regression; 16 pre-existing mock-related failures are unrelated and present on main).

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).