### PR TITLE
fix(escapeLike): coerce non-string input to string in escapeSqlLike (Closes #13592)

### DIFF
--- a/backend/api/src/lib/escapeLike.js
+++ b/backend/api/src/lib/escapeLike.js
@@ -13,8 +13,7 @@ export function escapeLike(value) {
 const W = ['\\', '%', '_', '[', ']'];
 export function escapeSqlLike(value) {
   if (value == null) return value;
-  if (typeof value !== 'string') return value;
-  if (value === '') return value;
+  if (typeof value !== 'string') return String(value);
   let out = value;
   for (const ch of W) out = out.split(ch).join('\\' + ch);
   return out;


### PR DESCRIPTION
Closes #13592.

Summary of What Has Been Done:
Made escapeSqlLike consistent with escapeLike in ackend/api/src/lib/escapeLike.js. The two siblings had diverged: escapeLike coerces non-string input with String(value), but escapeSqlLike returned the raw non-string value (e.g. a number stays a number), and also carried a dead alue === '' early-return that was unreachable once the value is guaranteed to be a string.

Changes Made:
- backend/api/src/lib/escapeLike.js: escapeSqlLike now returns String(value) for non-string input; removed the unreachable empty-string branch.

Impact it Made:
- escapeLike(5) and escapeSqlLike(5) both return the string "5"; escaping behavior for %, _, \, [, ] is unchanged (verified with node). Null/undefined still pass through untouched.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).