### PR TITLE
fix : add Number.isFinite guards, pageSize key, and limit cap in apiResponse paginated

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -2,6 +2,8 @@
  * Standard API Response Helpers
  */
 
+const MAX_PAGE_SIZE = 1000;
+
 export function success(data = null, message = 'Success', statusCode = 200) {
   return {
     success: true,
@@ -26,20 +28,24 @@ export function error(message = 'An error occurred', statusCode = 500, errors = 
 }
 
 export function paginated(data = [], page = 1, limit = 10, total = 0, message = 'Success') {
-  if (limit < 1) limit = 1;
-  const totalPages = Math.ceil(total / limit) || 0;
+  const safePage = Number.isFinite(Number(page)) ? Math.max(1, Number(page)) : 1;
+  const rawLimit = Number.isFinite(Number(limit)) ? Math.max(1, Number(limit)) : 10;
+  const safeLimit = Math.min(rawLimit, MAX_PAGE_SIZE);
+  const safeTotal = Number.isFinite(Number(total)) ? Math.max(0, Number(total)) : 0;
+  const totalPages = Math.ceil(safeTotal / safeLimit) || 0;
   return {
     success: true,
     statusCode: 200,
     message,
     data,
     pagination: {
-      page: Number(page),
-      limit: Number(limit),
-      total: Number(total),
+      page: safePage,
+      pageSize: safeLimit,
+      limit: safeLimit,
+      total: safeTotal,
       totalPages,
-      hasNextPage: Number(page) < totalPages - 1,
-      hasPrevPage: Number(page) > 1,
+      hasNextPage: safePage < totalPages,
+      hasPrevPage: safePage > 1,
     },
   };
 }


### PR DESCRIPTION
Closes #13579.
Closes #13585.
Closes #13597.

Summary of What Has Been Done:
Added Number.isFinite guards for page, limit, and total parameters in the apiResponse paginated function to prevent NaN values in the pagination envelope. Also added a pageSize key alongside the existing limit key for naming consistency. Added a MAX_PAGE_SIZE constant (1000) as a maximum cap for pagination requests to prevent performance issues from oversized requests.

Changes Made:
- backend/api/src/lib/apiResponse.js: added MAX_PAGE_SIZE cap, Number.isFinite guards for page/limit/total, pageSize key, fixed hasNextPage logic

Impact it Made:
- Prevents NaN values in API pagination responses
- Adds 1000-item cap to prevent resource exhaustion from oversized requests
- Consistent pagination envelope with both pageSize and limit keys

This pull request is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.