### PR TITLE
fix(auth-monitor): validate env threshold/window and fall back to defaults (Closes #13599)

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -5,6 +5,13 @@ const failures = new Map();
 const DEFAULT_THRESHOLD = 5;
 const DEFAULT_WINDOW_MS = 60_000;
 
+function parseEnvNumber(raw, fallback, { min } = {}) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  if (min !== undefined && n < min) return fallback;
+  return n;
+}
+
 export default function authFailureMonitor(req, res, next) {
   if (
     process.env.NODE_ENV === 'production' &&
@@ -18,12 +25,16 @@ export default function authFailureMonitor(req, res, next) {
       return;
     }
 
-    const threshold = Number(
-      process.env.AUTH_FAILURE_THRESHOLD || DEFAULT_THRESHOLD
+    const threshold = parseEnvNumber(
+      process.env.AUTH_FAILURE_THRESHOLD,
+      DEFAULT_THRESHOLD,
+      { min: 1 }
     );
 
-    const windowMs = Number(
-      process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS
+    const windowMs = parseEnvNumber(
+      process.env.AUTH_FAILURE_WINDOW_MS,
+      DEFAULT_WINDOW_MS,
+      { min: 1000 }
     );
 
     const ip = req.ip || req.socket?.remoteAddress || 'unknown';


### PR DESCRIPTION
Closes #13599.

Summary of What Has Been Done:
Fixed uthFailureMonitor (backend/api/src/middleware/authFailureMonitor.js) treating non-numeric env vars as valid config. Number('abc') produces NaN, so with a truthy-but-invalid AUTH_FAILURE_THRESHOLD the comparison count >= NaN was always false and the monitor never fired; a NaN AUTH_FAILURE_WINDOW_MS also broke the window reset check. Both now validate the parsed value and fall back to the documented defaults.

Changes Made:
- backend/api/src/middleware/authFailureMonitor.js: added parseEnvNumber(raw, fallback, { min }) and used it for AUTH_FAILURE_THRESHOLD (min 1) and AUTH_FAILURE_WINDOW_MS (min 1000 ms), replacing the raw Number(env || default) calls.

Impact it Made:
- AUTH_FAILURE_THRESHOLD=0/bc and AUTH_FAILURE_WINDOW_MS=100 now fall back to defaults (5 / 60 s) instead of producing NaN.
- test/unit/authFailureMonitorEnv.test.js "uses the default threshold when env is not a number" now passes (was failing on clean main); monitor test totals improved from 12/15 to 13/15 passing. The two remaining failures ("skips monitoring in test env", "includes requestId in payload") are pre-existing and unrelated.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).