### PR TITLE
fix : add coordinate range validation and NaN guard in haversineFallbackKm

### DIFF
--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -282,11 +282,23 @@ export const __testing = {
 // === Spec 22: ===
 // === Spec 22: OSRM failover ===
 export function haversineFallbackKm(lat1, lon1, lat2, lon2) {
+  const nLat1 = Number(lat1);
+  const nLon1 = Number(lon1);
+  const nLat2 = Number(lat2);
+  const nLon2 = Number(lon2);
+  if (!Number.isFinite(nLat1) || !Number.isFinite(nLon1) ||
+      !Number.isFinite(nLat2) || !Number.isFinite(nLon2)) {
+    return 0;
+  }
+  if (nLat1 < -90 || nLat1 > 90 || nLat2 < -90 || nLat2 > 90 ||
+      nLon1 < -180 || nLon1 > 180 || nLon2 < -180 || nLon2 > 180) {
+    return 0;
+  }
   const R = 6371.0088;
   const t = (d) => (d * Math.PI) / 180;
-  const dLat = t(lat2 - lat1);
-  const dLon = t(lon2 - lon1);
-  const a = Math.sin(dLat/2)**2 + Math.cos(t(lat1))*Math.cos(t(lat2))*Math.sin(dLon/2)**2;
+  const dLat = t(nLat2 - nLat1);
+  const dLon = t(nLon2 - nLon1);
+  const a = Math.sin(dLat/2)**2 + Math.cos(t(nLat1))*Math.cos(t(nLat2))*Math.sin(dLon/2)**2;
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 export async function routeWithFailover(primary, _fb, coords) {


### PR DESCRIPTION
Closes #13588.

Summary of What Has Been Done:
Added coordinate range validation and NaN guards to the haversineFallbackKm function in osrm.js. The function now converts all lat/lon values with Number() and checks Number.isFinite before using them. Out-of-range coordinates (lat outside -90 to 90, lon outside -180 to 180) return 0 instead of computing incorrect distances.

Changes Made:
- backend/api/src/services/osrm.js: added Number.isFinite guards and coordinate range validation in haversineFallbackKm

Impact it Made:
- Prevents NaN/Infinity from haversine calculations with invalid coordinates
- Returns 0 for out-of-range coordinates instead of computing incorrect values
- Improves reliability of OSRM failover path

This pull request is submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.