### PR TITLE
fix(road-condition): structured pino logging so error details are not dropped (Closes #13600)

### DIFF
--- a/backend/api/src/controllers/roadConditionController.js
+++ b/backend/api/src/controllers/roadConditionController.js
@@ -22,13 +22,13 @@ export const reportGripData = async (req, res) => {
       });
 
     if (insertErr) {
-      logger.error('Failed to insert road grip report:', insertErr);
+      logger.error({ err: insertErr }, 'Failed to insert road grip report');
       return res.status(500).json({ error: 'Database error' });
     }
 
     return res.status(201).json({ success: true, message: 'Grip data reported successfully' });
   } catch (err) {
-    logger.error('Internal server error in reportGripData:', err);
+    logger.error({ err }, 'Internal server error in reportGripData');
     return res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -86,13 +86,13 @@ export const getNearbyGripData = async (req, res) => {
       .limit(100);
 
     if (error) {
-      logger.error('Failed to fetch nearby grip data:', error);
+      logger.error({ err: error }, 'Failed to fetch nearby grip data');
       return res.status(500).json({ error: 'Database error' });
     }
 
     return res.json({ success: true, data });
   } catch (err) {
-    logger.error('Internal server error in getNearbyGripData:', err);
+    logger.error({ err }, 'Internal server error in getNearbyGripData');
     return res.status(500).json({ error: 'Internal server error' });
   }
 };


### PR DESCRIPTION
Closes #13600.

Summary of What Has Been Done:
Fixed logger.error('msg:', err) calls in ackend/api/src/controllers/roadConditionController.js. The logger is pino, whose API is log(obj, msg) / log(msg); a trailing err argument with no %s placeholder is silently dropped, so error details never reached the logs. Changed all four call sites to structured logger.error({ err }, msg) form.

Changes Made:
- roadConditionController.js lines 25, 31, 89, 95: logger.error('msg:', err) → logger.error({ err: ... }, 'msg').

Impact it Made:
- Error objects (message, stack, etc.) are now serialized into the pino record instead of being dropped.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).