### PR TITLE
fix(order-notification): structured pino logging so err details are not dropped (Closes #13601)

### DIFF
--- a/backend/api/src/services/order/orderNotificationService.js
+++ b/backend/api/src/services/order/orderNotificationService.js
@@ -49,7 +49,7 @@ async function reconcileInMemoryIntoRedis(orderId) {
       await redisClient.set(lockKey, '1', 'EX', remainingSec);
     }
   } catch (err) {
-    logger.error('[OTP] Redis error during in-memory reconciliation, keeping memory fallback:', err.message);
+    logger.error({ err }, '[OTP] Redis error during in-memory reconciliation, keeping memory fallback');
     return;
   }
   inMemoryOtpFailedAttempts.delete(orderId);
@@ -65,7 +65,7 @@ export async function checkOtpLockout(orderId) {
       const isLocked = await redisClient.get(lockKey);
       return !!isLocked;
     } catch (err) {
-      logger.error('[OTP] Redis error in checkOtpLockout, falling back to memory:', err.message);
+      logger.error({ err }, '[OTP] Redis error in checkOtpLockout, falling back to memory');
     }
   }
   const record = inMemoryOtpFailedAttempts.get(orderId);
@@ -93,7 +93,7 @@ export async function recordOtpFailure(orderId) {
       }
       return count;
     } catch (err) {
-      logger.error('[OTP] Redis error in recordOtpFailure, falling back to memory:', err.message);
+      logger.error({ err }, '[OTP] Redis error in recordOtpFailure, falling back to memory');
     }
   }
 
@@ -127,7 +127,7 @@ export async function clearOtpState(orderId) {
       inMemoryOtpFailedAttempts.delete(orderId);
       return;
     } catch (err) {
-      logger.error('[OTP] Redis error in clearOtpState, falling back to memory:', err.message);
+      logger.error({ err }, '[OTP] Redis error in clearOtpState, falling back to memory');
     }
   }
   const record = inMemoryOtpFailedAttempts.get(orderId);


### PR DESCRIPTION
Closes #13601.

Summary of What Has Been Done:
Fixed logger.error('msg:', err.message) calls in ackend/api/src/services/order/orderNotificationService.js. The logger is pino (log(obj, msg) API); a trailing string with no %s placeholder is dropped, so Redis failure details never reached the logs. All four OTP Redis fallback errors now log the full error object via logger.error({ err }, msg).

Changes Made:
- orderNotificationService.js lines 52, 68, 96, 130: logger.error('...:', err.message) → logger.error({ err }, '...').

Impact it Made:
- Full error objects are serialized into the pino record; behavior unchanged otherwise.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).