### PR TITLE
fix(fraud): structured pino logging so error details are not dropped (Closes #13602)

### DIFF
--- a/backend/api/src/middleware/fraudMiddleware.js
+++ b/backend/api/src/middleware/fraudMiddleware.js
@@ -67,7 +67,7 @@ export const fraudDetectionMiddleware = async (req, res, next) => {
 
     next();
   } catch (error) {
-    logger.error('Fraud middleware error — failing closed:', error);
+    logger.error({ err: error }, 'Fraud middleware error — failing closed');
     return res.status(503).json({
       error: 'Fraud detection service is temporarily unavailable. Please retry.',
     });
@@ -94,7 +94,7 @@ export const networkAnalysisMiddleware = async (req, res, next) => {
     req.networkRisk = networkRisk;
     next();
   } catch (error) {
-    logger.error('Network analysis middleware error — failing closed:', error);
+    logger.error({ err: error }, 'Network analysis middleware error — failing closed');
     return res.status(503).json({
       error: 'Fraud detection service is temporarily unavailable. Please retry.',
     });


### PR DESCRIPTION
Closes #13602.

Summary of What Has Been Done:
Fixed logger.error('msg:', error) calls in ackend/api/src/middleware/fraudMiddleware.js. The logger is pino (log(obj, msg) API); a trailing error argument with no %s placeholder is silently dropped, so fail-closed error details never reached the logs. Both catch blocks now log the full error via logger.error({ err: error }, msg).

Changes Made:
- fraudMiddleware.js lines 70 and 97: logger.error('msg:', error) → logger.error({ err: error }, 'msg').

Impact it Made:
- Full error objects are serialized into the pino record; fail-closed behavior unchanged.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).