### PR TITLE
fix(escort-wallet): structured pino logging so error details are not dropped (Closes #13603)

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -77,7 +77,7 @@ export const loadCredential = async (req, res, next) => {
 
         throw new AppError('Failed to issue credential', 500);
     } catch (error) {
-        logger.error('Error in loadCredential:', error);
+        logger.error({ err: error }, 'Error in loadCredential');
         next(error);
     }
 };
@@ -146,7 +146,7 @@ export const handshake = async (req, res, next) => {
             convoy: complianceStatus
         });
     } catch (error) {
-        logger.error('Error in handshake:', error);
+        logger.error({ err: error }, 'Error in handshake');
         next(error);
     }
 };


### PR DESCRIPTION
Closes #13603.

Summary of What Has Been Done:
Fixed logger.error('msg:', error) calls in ackend/api/src/controllers/escortWalletController.js. The logger is pino (log(obj, msg) API); a trailing error argument with no %s placeholder is silently dropped, so credential/handshake failure details never reached the logs. Both catch blocks now log the full error via logger.error({ err: error }, msg).

Changes Made:
- escortWalletController.js lines 80 and 149: logger.error('msg:', error) → logger.error({ err: error }, 'msg').

Impact it Made:
- Full error objects are serialized into the pino record; controller behavior and error forwarding to 
ext(error) unchanged.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).