### PR TITLE
#10 `assertServerVerified` trusts client-supplied license number and is a no-op when `kyc_doc_number` is NULL

### DIFF
--- a/backend/api/src/services/zkp/zkp.service.js
+++ b/backend/api/src/services/zkp/zkp.service.js
@@ -205,13 +205,11 @@ class ZKPService {
     if (data.kyc_status !== 'Verified') {
       return { ok: false, error: `KYC is not server-verified (status: ${data.kyc_status || 'Unverified'}). Complete document verification (OCR/DigiLocker) before requesting a ZK proof.` };
     }
-    if (data.kyc_doc_number) {
-      const normalize = (value) => String(value || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
-      const serverDocNumber = normalize(data.kyc_doc_number);
-      const claimedLicenseNumber = normalize(driverData.licenseNumber);
-      if (!serverDocNumber || claimedLicenseNumber !== serverDocNumber) {
-        return { ok: false, error: 'License number does not match the server-verified document. Proofs are generated only over verified document data.' };
-      }
+    const normalize = (value) => String(value || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
+    const serverDocNumber = normalize(data.kyc_doc_number);
+    const claimedLicenseNumber = normalize(driverData.licenseNumber);
+    if (!serverDocNumber || claimedLicenseNumber !== serverDocNumber) {
+      return { ok: false, error: 'License number does not match the server-verified document. Proofs are generated only over verified document data.' };
     }
     return { ok: true };
   }


### PR DESCRIPTION
## Problem

#10 `assertServerVerified` trusts client-supplied license number and is a no-op when `kyc_doc_number` is NULL

## Fix

Addresses the defect described in issue #12161 with a minimal, scoped change.

## Files changed

backend/api/src/services/zkp/zkp.service.js

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12161
