### PR TITLE
trips_screen _totalEarningsPaise unguarded 'as num' on net_earnings crashes build

### DIFF
--- a/apps/driver/lib/screens/trips_screen.dart
+++ b/apps/driver/lib/screens/trips_screen.dart
@@ -387,7 +387,7 @@ class _TripsScreenState extends State<TripsScreen> {
           final val = row['net_earnings'];
           if (val is num) return sum + val.toInt();
           if (val is String) return sum + (num.tryParse(val)?.toInt() ?? 0);
-          return sum + ((val ?? 0) as num).toInt();
+          return sum + (val is num ? val.toInt() : int.tryParse(val.toString()) ?? 0);
         },
       );
 


### PR DESCRIPTION
## Problem

trips_screen _totalEarningsPaise unguarded 'as num' on net_earnings crashes build

## Fix

Addresses the defect described in issue #12170 with a minimal, scoped change.

## Files changed

apps/driver/lib/screens/trips_screen.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12170
