### PR TITLE
TripsController.totalEarningsPaise unguarded 'as num' on net_earnings

### DIFF
--- a/apps/driver/lib/controllers/trips_controller.dart
+++ b/apps/driver/lib/controllers/trips_controller.dart
@@ -49,7 +49,7 @@ class TripsController extends ChangeNotifier {
           final val = row['net_earnings'];
           if (val is num) return sum + val.toInt();
           if (val is String) return sum + (num.tryParse(val)?.toInt() ?? 0);
-          return sum + ((val ?? 0) as num).toInt();
+          return sum + (val is num ? val.toInt() : int.tryParse(val.toString()) ?? 0);
         },
       );
 


### PR DESCRIPTION
## Problem

TripsController.totalEarningsPaise unguarded 'as num' on net_earnings

## Fix

Addresses the defect described in issue #12171 with a minimal, scoped change.

## Files changed

apps/driver/lib/controllers/trips_controller.dart

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #12171
