### PR TITLE
bug: backend/pqc/kyber.py KyberKEM.decapsulate ignores the secret key

### DIFF
--- a/backend/pqc/kyber.py
+++ b/backend/pqc/kyber.py
@@ -163,44 +163,54 @@ class KyberKEM:
         for i in range(self.k):
             v = (v + self._negacyclic_convolve(t_decompressed[i], r[i], self.n, self.q)) % self.q
         v = (v + e2) % self.q
-        
+
+        # Embed a random 256-bit message as one bit per coefficient (encoded at
+        # q/2). The holder of the secret key recovers this message on
+        # decapsulation; it is never derivable from the public key and ciphertext
+        # alone, so the shared secret is bound to the key owner.
+        message = (np.frombuffer(secrets.token_bytes(self.n), dtype=np.uint8) & 1).astype(np.int64)
+        v = (v + message * (self.q // 2)) % self.q
+
         # Compress ciphertext
         u_compressed = self._compress(u, 10)
         v_compressed = self._compress(v, 4)
-        
-        # Derive shared secret from the compressed ciphertext so it matches
-        # decapsulate, which hashes the compressed u/v transmitted in the ciphertext
-        shared_secret = hashlib.sha256(
-            np.concatenate([u_compressed.flatten(), v_compressed.flatten()]).tobytes()
-        ).digest()
-        
+
+        # Shared secret is bound to the encapsulated message, which is only
+        # recoverable with the secret key during decapsulation.
+        shared_secret = hashlib.sha256(message.tobytes()).digest()
+
         ciphertext = {
             'u': u_compressed,
             'v': v_compressed
         }
-        
+
         return ciphertext, shared_secret
     
     def decapsulate(self, ciphertext: Dict, secret_key: Dict) -> bytes:
-        """Decapsulate shared secret"""
+        """Decapsulate shared secret using the recipient's secret key."""
         u = ciphertext['u']
         v = ciphertext['v']
         s = secret_key['s']
-        
+
         # Decompress ciphertext
         u_decompressed = self._decompress(u, 10)
         v_decompressed = self._decompress(v, 4)
-        
-        # Compute v - s^T * u
+
+        # Recover the encapsulated message: v - s^T * u strips the public
+        # masking, leaving the secret-key-dependent message plus lattice noise.
+        # Without the secret key this term cannot be reconstructed.
         result = v_decompressed.copy()
         for i in range(self.k):
             result = (result - self._negacyclic_convolve(s[i], u_decompressed[i], self.n, self.q)) % self.q
-        
-        # Derive shared secret
-        shared_secret = hashlib.sha256(
-            np.concatenate([u.flatten(), v.flatten()]).tobytes()
-        ).digest()
-        
+
+        # Decode each coefficient back to a message bit: values near q/2 encode a
+        # 1, values near 0/q encode a 0. This depends on the secret key.
+        message = (np.minimum(result, self.q - result) > (self.q // 4)).astype(np.int64)
+
+        # Derive the shared secret from the recovered message so it matches the
+        # value produced at encapsulation time, and only for the correct key.
+        shared_secret = hashlib.sha256(message.tobytes()).digest()
+
         return shared_secret
 
 class DilithiumSignature:

--- a/backend/pqc/test_kyber_kem.py
+++ b/backend/pqc/test_kyber_kem.py
@@ -1,0 +1,36 @@
+import unittest
+
+from kyber import KyberKEM
+
+
+class TestKyberKEMDecapsulateUsesSecretKey(unittest.TestCase):
+    def setUp(self):
+        self.kem = KyberKEM()
+
+    def test_decapsulate_recovers_encapsulated_shared_secret(self):
+        pk, sk = self.kem.keygen()
+        ciphertext, shared_secret = self.kem.encapsulate(pk)
+        self.assertEqual(self.kem.decapsulate(ciphertext, sk), shared_secret)
+
+    def test_decapsulate_with_wrong_secret_key_differs(self):
+        pk, sk = self.kem.keygen()
+        ciphertext, shared_secret = self.kem.encapsulate(pk)
+
+        _, sk_other = self.kem.keygen()
+        self.assertNotEqual(self.kem.decapsulate(ciphertext, sk_other), shared_secret)
+
+    def test_shared_secret_not_derivable_from_public_key_and_ciphertext(self):
+        # A holder of only the public key and ciphertext must not be able to
+        # derive the shared secret, since decapsulation requires the secret key.
+        import hashlib
+        pk, sk = self.kem.keygen()
+        ct, shared_secret = self.kem.encapsulate(pk)
+        ct_bytes = hashlib.sha256(
+            b"".join(int(x).to_bytes(8, 'little', signed=True) for x in ct['u'].flatten())
+            + b"".join(int(x).to_bytes(8, 'little', signed=True) for x in ct['v'].flatten())
+        ).digest()
+        self.assertNotEqual(shared_secret, hashlib.sha256(pk['rho'] + ct_bytes).digest()[:32])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

bug: backend/pqc/kyber.py KyberKEM.decapsulate ignores the secret key

## Fix

Addresses the defect described in issue #13071 with a minimal, scoped change.

## Files changed

backend/pqc/kyber.py
backend/pqc/test_kyber_kem.py

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13071
