### PR TITLE
bug: backend/ai/causal_inference.py CausalImpact is fit on post-intervention data with inverted args

### DIFF
--- a/backend/ai/causal_inference.py
+++ b/backend/ai/causal_inference.py
@@ -208,8 +208,12 @@ class CausalImpact:
         """Measure impact of intervention"""
         # The causalimpact library expects a single full data series with
         # period indices that point into it, so the pre- and post-intervention
-        # arrays are combined into one series before analysis.
+        # arrays are combined into one series before analysis. Wrap it in a
+        # DataFrame with a default (integer) index so the pre_period /
+        # post_period positions line up exactly and the model is fit on the
+        # pre-intervention baseline.
         data = np.concatenate([pre_data, post_data])
+        series = pd.DataFrame({'value': data})
 
         # Reject intervention points outside the combined pre/post series so
         # callers get an explicit error instead of a silently-null result.
@@ -227,7 +231,7 @@ class CausalImpact:
             # Calculate counterfactual
             from causalimpact import CausalImpact
             
-            impact = CausalImpact(data, pre_period, post_period)
+            impact = CausalImpact(series, pre_period, post_period)
             impact.run()
             
             summary = impact.summary()

--- a/backend/ai/test_causal_inference.py
+++ b/backend/ai/test_causal_inference.py
@@ -1,0 +1,41 @@
+import unittest
+import numpy as np
+
+try:
+    from causalimpact import CausalImpact  # noqa: F401
+    from causal_inference import CausalImpact as CausalImpactMeasurer
+    HAVE_DEPS = True
+except Exception:
+    HAVE_DEPS = False
+
+
+@unittest.skipUnless(HAVE_DEPS, "causalimpact / causal_inference dependencies not available")
+class TestCausalImpactStepRecovery(unittest.TestCase):
+    def test_recovers_injected_step_on_post_period(self):
+        measurer = CausalImpactMeasurer()
+
+        # Pre-intervention baseline with mild noise.
+        rng = np.random.default_rng(0)
+        baseline = 10.0 + rng.normal(0, 0.1, 30)
+        # Post-intervention series: a clear +5 step change.
+        step = 5.0
+        post = (10.0 + step) + rng.normal(0, 0.1, 30)
+
+        pre_data = baseline.astype(float)
+        post_data = post.astype(float)
+        intervention_point = len(pre_data)
+
+        result = measurer.measure_impact(pre_data, post_data, intervention_point)
+
+        self.assertIsNotNone(result, "measure_impact should fit on the pre-period baseline")
+        self.assertIn("absolute_effect", result)
+
+        # The estimator must recover a positive effect with the same sign as
+        # the injected step, never the ~0 / inverted result produced when the
+        # model is fit on the post-intervention window.
+        absolute_effect = result["absolute_effect"]
+        self.assertGreater(absolute_effect, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

bug: backend/ai/causal_inference.py CausalImpact is fit on post-intervention data with inverted args

## Fix

Addresses the defect described in issue #13073 with a minimal, scoped change.

## Files changed

backend/ai/causal_inference.py
backend/ai/test_causal_inference.py

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13073
