### PR TITLE
bug: backend/smpc/smpc_node.py Shamir secret sharing uses prime=2087 and the non-CSPRNG random module

### DIFF
--- a/backend/smpc/smpc_node.py
+++ b/backend/smpc/smpc_node.py
@@ -1,17 +1,22 @@
-import random
+import secrets
 import numpy as np
+
+# Field used across the SMPC stack (matches smpc_service.SecretSharing). A
+# 127-bit Mersenne prime keeps secret values and share coordinates out of any
+# brute-force range.
+DEFAULT_PRIME = 2**127 - 1
 
 class ShamirSmpcEngine:
     """
     Shamir's Secret Sharing (k, n) Threshold Engine for SMPC Joint Fleet Analytics.
     Splits fleet earnings secrets into polynomial shares without raw revenue disclosure.
     """
-    def __init__(self, prime: int = 2087):
+    def __init__(self, prime: int = DEFAULT_PRIME):
         self.prime = prime
 
     def split_secret(self, secret: int, k: int = 3, n: int = 5) -> list:
         """Splits integer secret into n polynomial shares with threshold k."""
-        coeffs = [secret] + [random.randint(1, self.prime - 1) for _ in range(k - 1)]
+        coeffs = [secret] + [secrets.randbelow(self.prime - 1) + 1 for _ in range(k - 1)]
         shares = []
         for x in range(1, n + 1):
             y = sum(c * (x ** i) for i, c in enumerate(coeffs)) % self.prime

--- a/backend/smpc/test_smpc.py
+++ b/backend/smpc/test_smpc.py
@@ -15,5 +15,21 @@ class TestSmpc(unittest.TestCase):
         reconstructed = self.engine.reconstruct_secret(subset)
         self.assertEqual(reconstructed, revenue_secret)
 
+class TestSmpcFieldStrength(unittest.TestCase):
+    def test_default_field_is_cryptographically_large(self):
+        engine = ShamirSmpcEngine()
+        # Field must be far larger than any brute-force range.
+        self.assertGreater(engine.prime.bit_length(), 64)
+
+    def test_t_minus_1_shares_do_not_reveal_secret(self):
+        engine = ShamirSmpcEngine()
+        secret = 12345678901234567890123456789
+        shares = engine.split_secret(secret, k=3, n=5)
+
+        # An attacker holding only t-1 = 2 shares must not recover the secret.
+        attacker_shares = shares[:2]
+        reconstructed = engine.reconstruct_secret(attacker_shares)
+        self.assertNotEqual(reconstructed, secret)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

bug: backend/smpc/smpc_node.py Shamir secret sharing uses prime=2087 and the non-CSPRNG random module

## Fix

Addresses the defect described in issue #13075 with a minimal, scoped change.

## Files changed

backend/smpc/smpc_node.py
backend/smpc/test_smpc.py

## Testing

Reviewed the changed code path; change is minimal and limited to the issue scope.

Closes #13075
