### PR TITLE
fix : correct hasNextPage off-by-one in apiResponse paginated

### DIFF
--- a/backend/api/src/lib/apiResponse.js
+++ b/backend/api/src/lib/apiResponse.js
@@ -38,7 +38,7 @@ export function paginated(data = [], page = 1, limit = 10, total = 0, message = 
       limit: Number(limit),
       total: Number(total),
       totalPages,
-      hasNextPage: Number(page) < totalPages - 1,
+      hasNextPage: Number(page) < totalPages,
       hasPrevPage: Number(page) > 1,
     },
   };

--- a/backend/api/test/unit/apiResponse.test.js
+++ b/backend/api/test/unit/apiResponse.test.js
@@ -81,6 +81,14 @@ describe('apiResponse helpers', () => {
       expect(result.pagination.hasPrevPage).toBe(false);
     });
 
+    it('hasNextPage is true on penultimate page when total divides evenly by limit', () => {
+      // total=30, limit=10: totalPages=3, page=2 is not last, hasNextPage should be true
+      const result = paginated(['a'], 2, 10, 30);
+      expect(result.pagination.totalPages).toBe(3);
+      expect(result.pagination.hasNextPage).toBe(true);
+      expect(result.pagination.hasPrevPage).toBe(true);
+    });
+
     it('converts page and limit to numbers', () => {
       const result = paginated([], '2', '10', 30);
       expect(result.pagination.page).toBe(2);


### PR DESCRIPTION
Closes #13691.

Summary of What Has Been Done:
Fixed the hasNextPage off-by-one bug in backend/api/src/lib/apiResponse.js. When total is evenly divisible by limit (e.g. total=30, limit=10, totalPages=3), page=2 is not the last page but the formula Number(page) < totalPages - 1 incorrectly returned false (2 < 2 = false). Corrected to Number(page) < totalPages which properly returns true when there are additional pages remaining.

Changes Made:
- backend/api/src/lib/apiResponse.js: changed hasNextPage formula from Number(page) < totalPages - 1 to Number(page) < totalPages
- backend/api/test/unit/apiResponse.test.js: added test case for evenly divisible totals on the penultimate page

Impact it Made:
- Correct pagination navigation in frontend clients
- Accurate hasNextPage on full-page boundaries

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pagination indicators so the “next page” option appears accurately, including when results divide evenly across pages.

* **Tests**
  * Added coverage for pagination behavior on the penultimate page, including next and previous page indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->