### PR TITLE
test : add unit tests for webrtc.js socket module

### DIFF
--- a/backend/api/test/unit/sockets/webrtc.test.js
+++ b/backend/api/test/unit/sockets/webrtc.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { signalingMock } = vi.hoisted(() => ({
+  signalingMock: { on: vi.fn(), destroy: vi.fn() },
+}));
+
+vi.mock('../../../src/services/webrtc/WebRTCSignalingServer.js', () => ({
+  default: class { constructor() { Object.assign(this, signalingMock); } },
+}));
+
+const { initWebRTCSignaling, getWebRTCSignaling, closeWebRTCSignaling } = await import('../../../src/sockets/webrtc.js');
+
+describe('webrtc socket module', () => {
+  beforeEach(() => {
+    closeWebRTCSignaling();
+    vi.clearAllMocks();
+  });
+
+  it('returns null before initialization', () => {
+    expect(getWebRTCSignaling()).toBeNull();
+  });
+
+  it('initializes the signaling server once', () => {
+    const server = {};
+    const first = initWebRTCSignaling(server);
+    const second = initWebRTCSignaling(server);
+    expect(first).toBe(second);
+  });
+
+  it('closeWebRTCSignaling clears the singleton', () => {
+    const server = { on: vi.fn() };
+    initWebRTCSignaling(server);
+    closeWebRTCSignaling();
+    expect(getWebRTCSignaling()).toBeNull();
+  });
+
+  it('closeWebRTCSignaling is idempotent', () => {
+    closeWebRTCSignaling();
+    closeWebRTCSignaling();
+    expect(getWebRTCSignaling()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #13701.

Summary of What Has Been Done:
Adds unit tests for the WebRTC socket module.

Closes #13701.

Changes Made:
- backend/api/test/unit/sockets/webrtc.test.js: Added unit tests

Impact it Made:
- Ensures untested code paths have coverage

Note: Please assign this PR to the `tmdeveloper007` account.

---

This PR is submitted as part of GirlScript Summer of Code (GSSOC).