### PR TITLE
fix : added input validation for driverUpiId and amountPaisa in UpiPaymentService

### DIFF
--- a/backend/api/src/services/payment/UpiPaymentService.js
+++ b/backend/api/src/services/payment/UpiPaymentService.js
@@ -23,6 +23,12 @@ class UpiPaymentService {
    * Mock payout to driver UPI ID
    */
   async processDriverPayout(driverUpiId, amountPaisa) {
+    if (typeof driverUpiId !== 'string' || !driverUpiId.trim()) {
+      throw new TypeError('driverUpiId must be a non-empty string');
+    }
+    if (!Number.isFinite(amountPaisa) || amountPaisa <= 0) {
+      throw new TypeError('amountPaisa must be a positive finite number');
+    }
     logger.info(`[UPI Payout] Initiating driver payout via ${this.gatewayName} to ${driverUpiId}, amount: ${amountPaisa} paisa`);
     // Simulate payout API delay
     await new Promise(resolve => setTimeout(resolve, MOCK_PAYOUT_DELAY_MS));


### PR DESCRIPTION
Closes #13728.

Summary of What Has Been Done:
Added input validation guards to processDriverPayout in UpiPaymentService: driverUpiId is validated as a non-empty string, and amountPaisa is validated as a positive finite number. Invalid inputs now throw a TypeError instead of producing misleading log output or invalid payout records.

Changes Made:
- backend/api/src/services/payment/UpiPaymentService.js: added TypeError guards for driverUpiId (must be non-empty string) and amountPaisa (must be positive finite number)

Impact it Made:
- Prevents invalid payout records from being created with null/empty driver UPI IDs
- Prevents NaN values from appearing in payout amount fields
- Consistent with Number.isFinite guard patterns used elsewhere in the service layer

These pull requests are submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.