### PR TITLE
fix : added nullish coalescing for SENTRY_TRACES_SAMPLE_RATE in TransactionMonitor

### DIFF
--- a/backend/api/src/services/monitoring/transactionMonitor.js
+++ b/backend/api/src/services/monitoring/transactionMonitor.js
@@ -23,7 +23,7 @@ class TransactionMonitor {
       dsn,
       environment: process.env.NODE_ENV || 'development',
       release: process.env.APP_VERSION || '1.0.0',
-      tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0.1,
+      tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE) ?? 0.1,
       profilesSampleRate: 0.1,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),


### PR DESCRIPTION
Closes #13731.

Summary of What Has Been Done:
Changed the SENTRY_TRACES_SAMPLE_RATE parsing in TransactionMonitor.initialize() from parseFloat(env) || 0.1 to parseFloat(env) ?? 0.1. This allows a legitimately configured SENTRY_TRACES_SAMPLE_RATE=0 to be respected.

Changes Made:
- backend/api/src/services/monitoring/transactionMonitor.js: replaced || with ?? for tracesSampleRate fallback

Impact it Made:
- Zero-sampling configuration is now respected for Sentry tracing
- Consistent with the FRAUD_THRESHOLD nullish coalescing fix pattern

These pull requests are submitted as part of GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.