### PR TITLE
fix(order-display-id): remove import of non-exported constants (ESM link error) (Closes #13767)

### DIFF
--- a/backend/api/src/utils/orderDisplayIdValidation.js
+++ b/backend/api/src/utils/orderDisplayIdValidation.js
@@ -4,8 +4,6 @@
  * @module orderDisplayIdValidation
  */
 
-import { DISPLAY_ID_PREFIX, DISPLAY_ID_RANDOM_LENGTH } from '../lib/orderDisplayId.js';
-
 const DISPLAY_ID_PATTERN = /^#FF\d{8}[A-Z0-9]{12}$/;
 
 /**


### PR DESCRIPTION
Closes #13767.

Summary of What Has Been Done:
Removed a broken ESM import from ackend/api/src/utils/orderDisplayIdValidation.js. The file imported { DISPLAY_ID_PREFIX, DISPLAY_ID_RANDOM_LENGTH } from ../lib/orderDisplayId.js, but those constants are declared with const and never exported. In Node ESM this is a link-time failure — importing orderDisplayIdValidation.js crashes the process and cannot be caught. The imported names were unused anyway.

Changes Made:
- backend/api/src/utils/orderDisplayIdValidation.js: deleted the unused import line.

Impact it Made:
- import('./src/utils/orderDisplayIdValidation.js') now resolves (before: The requested module '../lib/orderDisplayId.js' does not provide an export named 'DISPLAY_ID_PREFIX').

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).