### PR TITLE
fix(pricing): accept handlingFee of 0 as valid free-handling config (Closes #13768)

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -131,7 +131,7 @@ export function computeOrderPricing(input, rateCard = readRateCard()) {
   if (!rateCard.ratePerTonneKm || rateCard.ratePerTonneKm <= 0) {
     throw new RangeError(`ratePerTonneKm must be > 0, got ${rateCard.ratePerTonneKm}`);
   }
-  if (!rateCard.handlingFee || rateCard.handlingFee < 0) {
+  if (rateCard.handlingFee == null || rateCard.handlingFee < 0) {
     throw new RangeError(`handlingFee must be >= 0, got ${rateCard.handlingFee}`);
   }
 


### PR DESCRIPTION
Closes #13768.

Summary of What Has Been Done:
Fixed computeOrderPricing rejecting a valid handlingFee of 0 in ackend/api/src/lib/pricing.js:134. The guard !rateCard.handlingFee || rateCard.handlingFee < 0 treats a  handling fee (free handling) as invalid and throws RangeError: handlingFee must be >= 0, got 0 on every pricing call with such a rate card.

Changes Made:
- backend/api/src/lib/pricing.js: !rateCard.handlingFee → ateCard.handlingFee == null.

Impact it Made:
- computeOrderPricing with handlingFee: 0 now succeeds (before: RangeError). Null/undefined or negative fees still throw as intended. The 4 sanitizePrice test failures in this run are pre-existing on main (undefined MIN/MAX_FREIGHT_PAISa, addressed in a separate PR) and unrelated to this change.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).