### PR TITLE
fix(tracker): enforce bearing bounds by passing the correct key to telemetry validation (Closes #13769)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1003,7 +1003,7 @@ export async function handleLocationPing(ws, data, req) {
     driverId: driver_id,
     timestamp: device_timestamp ? Date.parse(device_timestamp) || Date.now() : Date.now(),
     speed: typeof speed === 'number' ? speed : undefined,
-    heading: typeof bearing === 'number' ? bearing : undefined,
+    bearing: typeof bearing === 'number' ? bearing : undefined,
   };
 
   const normalizedValidationErrors = validateTelemetryPayload(normalizedForValidation);


### PR DESCRIPTION
Closes #13769.

Summary of What Has Been Done:
Fixed the tracker socket never enforcing the earing bounds (backend/api/src/sockets/tracker.js:1006). The telemetry schema defines earing: { min: 0, max: 360 }, but the object handed to alidateTelemetryPayload used the key heading, so the rule was never evaluated and out-of-range bearings (e.g. 9999) passed validation and were broadcast raw.

Changes Made:
- backend/api/src/sockets/tracker.js: heading: typeof bearing === 'number' ? bearing : undefined → earing: ....

Impact it Made:
- Out-of-range bearing values are now rejected by the existing schema rule before broadcast.

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).