### PR TITLE
fix(reverseGeocode): fall back to 60s wait when Retry-After is an HTTP-date (Closes #13770)

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -57,7 +57,10 @@ export async function reverseGeocode(lat, lon) {
     // Handle rate-limiting with Retry-After support
     if (response.status === 429) {
       const retryAfter = response.headers.get('Retry-After');
-      const waitMs = retryAfter ? Math.min(parseInt(retryAfter, 10) * 1000, 60000) : 60000;
+      const retryAfterSecs = Number.parseInt(retryAfter, 10);
+      const waitMs = retryAfter && Number.isFinite(retryAfterSecs)
+        ? Math.min(retryAfterSecs * 1000, 60000)
+        : 60000;
       logger.warn({ waitMs, lat: roundedLat, lon: roundedLon }, '[ReverseGeocode] Rate-limited, retrying after Retry-After delay');
       await new Promise((resolve) => setTimeout(resolve, waitMs));
       response = await fetch(url, {


### PR DESCRIPTION
Closes #13770.

Summary of What Has Been Done:
Fixed everseGeocode.js retrying instantly on 429 when Nominatim returns an HTTP-date Retry-After header (backend/api/src/lib/reverseGeocode.js:60). Math.min(parseInt(retryAfter, 10) * 1000, 60000) produced NaN for an HTTP-date (e.g. Wed, 21 Oct 2015 07:28:00 GMT), and setTimeout(..., NaN) fires immediately — hammering a rate-limited API instead of backing off.

Changes Made:
- backend/api/src/lib/reverseGeocode.js: parse Retry-After with Number.parseInt and only use it when finite; otherwise fall back to the fixed 60s delay.

Impact it Made:
- Retry-After: 2 → waits 2s; Retry-After: <HTTP-date> or missing → waits 60s (before: NaN → instant retry).

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).