### PR TITLE
fix(geocode-service): autocomplete catch references undefined 'point'; return [] not null (Closes #13772)

### DIFF
--- a/apps/driver/lib/services/geocode_service.dart
+++ b/apps/driver/lib/services/geocode_service.dart
@@ -156,9 +156,8 @@ class GeocodeService {
           .where((s) => s.isNotEmpty)
           .toList();
     } catch (e) {
-      debugPrint('[GeocodeService] reverseGeocode failed for '
-          '${point.latitude},${point.longitude}: $e');
-      return null;
+      debugPrint('[GeocodeService] autocomplete failed for "$query": $e');
+      return [];
     }
   }
 


### PR DESCRIPTION
Closes #13772.

Summary of What Has Been Done:
Fixed two compile errors in utocomplete() (apps/driver/lib/services/geocode_service.dart:158-162): the catch block referenced point.latitude/point.longitude (a variable that only exists in the sibling everseGeocode() function), and eturn null from a Future<List<String>> function.

Changes Made:
- apps/driver/lib/services/geocode_service.dart: log the query instead of point; return [] instead of 
ull.

Impact it Made:
- dart analyze lib/services/geocode_service.dart → No issues found (before: 3 errors — undefined point x2 and eturn_of_invalid_type).

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).