### PR TITLE
fix(api-client): use defaultTargetPlatform instead of undefined Platform (Closes #13773)

### DIFF
--- a/packages/truxify_shared/lib/src/services/api_client.dart
+++ b/packages/truxify_shared/lib/src/services/api_client.dart
@@ -121,7 +121,7 @@ class ApiClient {
     if (kReleaseMode) throw StateError('TRUXIFY_API_BASE_URL must be set in release mode');
     
     if (kIsWeb) return 'http://localhost:5000';
-    if (Platform.isAndroid) return 'http://10.0.2.2:5000';
+    if (defaultTargetPlatform == TargetPlatform.android) return 'http://10.0.2.2:5000';
     return 'http://localhost:5000';
   }
 


### PR DESCRIPTION
Closes #13773.

Summary of What Has Been Done:
Fixed defaultBaseUrl in packages/truxify_shared/lib/src/services/api_client.dart:124 referencing Platform.isAndroid without importing dart:io. Platform is undefined in this file, and both the customer and driver apps re-export this client, so both failed to compile.

Changes Made:
- packages/truxify_shared/lib/src/services/api_client.dart: Platform.isAndroid → defaultTargetPlatform == TargetPlatform.android (foundation is already imported; the kIsWeb check above still short-circuits web).

Impact it Made:
- dart analyze --packages=apps/customer/.dart_tool/package_config.json .../api_client.dart → No issues found (before: Undefined name 'Platform').

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).