### PR TITLE
fix(index): hoist outbox relay worker imports out of function bodies (Closes #13774)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -166,6 +166,7 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
+import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -746,7 +747,6 @@ server.listen(PORT, () => {
   startStaleOrderWorker(escrowReconciliationOrderRepository)
   startDocumentExpiryWorker()
   startWithdrawalSettlementWorker()
-  import { startOutboxRelayWorker } from './workers/outboxRelayWorker.js'
   startOutboxRelayWorker()
 
   // Register worker states for health aggregation
@@ -789,7 +789,6 @@ async function shutdown(signal) {
   stopDlqWorker()
   stopDocumentExpiryWorker()
   stopWithdrawalSettlementWorker()
-  import { stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
   stopOutboxRelayWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()


### PR DESCRIPTION
Closes #13774.

Summary of What Has Been Done:
Fixed ackend/api/src/index.js containing ESM import statements inside function bodies. import { startOutboxRelayWorker } ... sat inside the server.listen() callback and import { stopOutboxRelayWorker } ... inside shutdown(). Since the file is "type": "module", imports inside a function are a SyntaxError, so 
ode --check failed and the server could not boot.

Changes Made:
- backend/api/src/index.js: hoisted both imports into the single import { startOutboxRelayWorker, stopOutboxRelayWorker } line at the top of the file with the other imports; the call sites now just invoke the already-imported functions.

Impact it Made:
- 
ode --check src/index.js → exit 0 (before: SyntaxError: Unexpected token '{' at line 749).

Note: This PR is submitted as part of GSSOC (GirlScript Summer of Code).