### PR TITLE
fix(automation): authenticate dispute-resolution webhooks and stop forwarding caller-supplied escrow recipient

### DIFF
--- a/.github/workflows/n8n-automation.yml
+++ b/.github/workflows/n8n-automation.yml
@@ -1,0 +1,47 @@
+name: n8n Automation
+
+# The dispute-resolution workflow fronts on-chain escrow operations, so its
+# webhook authentication and payee handling are security-critical (#13111).
+# These audits are plain-node scripts with no dependencies — they parse the
+# workflow JSON and assert invariants, so they need no n8n instance to run.
+
+on:
+  pull_request:
+    paths:
+      - "automation/n8n/**"
+      - ".github/workflows/n8n-automation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "automation/n8n/**"
+      - ".github/workflows/n8n-automation.yml"
+
+concurrency:
+  group: truxify-n8n-automation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  escrow-webhook-audit:
+    name: n8n Escrow Webhook Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate n8n workflow JSON is parseable
+        run: |
+          for f in $(find automation/n8n -name '*.json' -not -path '*/node_modules/*'); do
+            node -e "require('./$f')" || { echo "::error file=$f::invalid JSON"; exit 1; }
+          done
+
+      - name: Audit dispute-resolution escrow webhooks
+        run: node automation/n8n/tests/dispute-resolution.security.test.js

--- a/automation/n8n/README.md
+++ b/automation/n8n/README.md
@@ -51,3 +51,31 @@ http://localhost:5678
 2. Click **Workflows** → **Import from File**.
 3. Select any `.json` file from `automation/n8n/`.
 4. Configure required credentials (PostgreSQL, Email/SMTP, HTTP Header Auth) and click **Activate**.
+
+---
+
+## 🔐 Escrow Webhook Authentication
+
+`dispute-resolution.json` fronts on-chain escrow operations, so both of its webhooks
+(`POST /webhook/dispute-trigger` and `POST /webhook/admin-resolution`) use **Header Auth**
+and will reject any request that does not carry the shared secret. Before activating it,
+create an **HTTP Header Auth** credential in n8n named exactly:
+
+```text
+Truxify Internal API Key
+```
+
+Set its header to `x-api-key` and its value to one of the keys listed in the backend's
+`VALID_API_KEYS` environment variable. The same credential authenticates this workflow's
+outbound calls to the backend, which gates internal endpoints with the `requireApiKey`
+middleware (`backend/api/src/middleware/apiKey.js`).
+
+> **Escrow payee:** the release step deliberately sends only `bookingId`. `TruxifyEscrow.releasePayment(uint256 bookingId)`
+> pays `booking.driver`, which is bound when the deposit is built — a payout address must
+> never be accepted from a webhook caller.
+
+Audit the above with:
+
+```bash
+node automation/n8n/tests/dispute-resolution.security.test.js
+```

--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "dispute-trigger",
+        "authentication": "headerAuth",
         "options": {}
       },
       "id": "1d8ea83e-d9a4-4db2-a9b0-30f16f5c5315",
@@ -14,12 +15,20 @@
       "position": [
         250,
         300
-      ]
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     },
     {
       "parameters": {
         "method": "POST",
         "url": "={{$env.BACKEND_API_URL}}/api/payments/freeze",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
         "bodyParametersUi": {
           "parameter": [
@@ -39,6 +48,12 @@
         450,
         300
       ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      },
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -276,6 +291,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "admin-resolution",
+        "authentication": "headerAuth",
         "options": {}
       },
       "id": "5b23dca9-48cf-4ef2-ba2e-ffbc8601dd77",
@@ -285,22 +301,26 @@
       "position": [
         250,
         600
-      ]
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     },
     {
       "parameters": {
         "method": "POST",
         "url": "={{$env.BACKEND_API_URL}}/api/payments/release",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
         "bodyParametersUi": {
           "parameter": [
             {
               "name": "bookingId",
               "value": "={{$json.body.bookingId}}"
-            },
-            {
-              "name": "recipient",
-              "value": "={{$json.body.recipient}}"
             }
           ]
         },
@@ -314,6 +334,12 @@
         500,
         600
       ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      },
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -531,5 +557,11 @@
     }
   },
   "active": true,
-  "settings": {}
+  "settings": {},
+  "credentials": {
+    "httpHeaderAuth": {
+      "name": "Truxify Internal API Key",
+      "id": ""
+    }
+  }
 }

--- a/automation/n8n/tests/dispute-resolution.security.test.js
+++ b/automation/n8n/tests/dispute-resolution.security.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+/**
+ * Security audit for the Dispute Resolution workflow (#13111).
+ *
+ * The `dispute-trigger` and `admin-resolution` webhooks front operations that
+ * move real escrow funds on-chain (`/api/payments/freeze`, `/api/payments/release`).
+ * Two invariants must hold for this workflow to be safe to activate:
+ *
+ *   1. Neither webhook may be anonymously invocable — n8n must reject a POST
+ *      that carries no credential, before any node runs.
+ *   2. The escrow payee must never be caller-supplied. TruxifyEscrow's
+ *      `releasePayment(uint256 bookingId)` pays `booking.driver`, which is bound
+ *      at deposit time by `buildDepositTx(...)`; a `recipient` taken from the
+ *      request body is an attacker-controlled address with no legitimate consumer.
+ *
+ * Run: node automation/n8n/tests/dispute-resolution.security.test.js
+ */
+
+const assert = require("assert");
+const path = require("path");
+const workflow = require(path.join(__dirname, "..", "dispute-resolution.json"));
+
+const WEBHOOK_TYPE = "n8n-nodes-base.webhook";
+const HTTP_TYPE = "n8n-nodes-base.httpRequest";
+
+/** Endpoints in this workflow that move escrow funds on-chain. */
+const FUND_MOVING_PATHS = ["/api/payments/freeze", "/api/payments/release"];
+
+function nodeByName(name) {
+  return workflow.nodes.find((n) => n.name === name);
+}
+
+function nodesOfType(type) {
+  return workflow.nodes.filter((n) => n.type === type);
+}
+
+function bodyParameters(node) {
+  const ui = (node.parameters || {}).bodyParametersUi || {};
+  return ui.parameter || [];
+}
+
+function movesFunds(node) {
+  const url = (node.parameters || {}).url || "";
+  return FUND_MOVING_PATHS.some((p) => url.includes(p));
+}
+
+/** Serialised node, for scanning every expression regardless of nesting. */
+function nodeSource(node) {
+  return JSON.stringify(node);
+}
+
+let failures = 0;
+function test(title, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${title}`);
+  } catch (err) {
+    failures++;
+    console.error(`FAILED: ${title}\n  ${err.message}`);
+  }
+}
+
+// ─── 1. Webhooks reject unauthenticated POSTs ────────────────────────────────
+
+test("workflow still exposes the two dispute webhooks", () => {
+  const webhooks = nodesOfType(WEBHOOK_TYPE);
+  const paths = webhooks.map((n) => n.parameters.path).sort();
+  assert.deepStrictEqual(
+    paths,
+    ["admin-resolution", "dispute-trigger"],
+    "expected exactly the dispute-trigger and admin-resolution webhooks",
+  );
+});
+
+test("every webhook declares an authentication method (no anonymous POSTs)", () => {
+  for (const node of nodesOfType(WEBHOOK_TYPE)) {
+    const auth = node.parameters.authentication;
+    assert.ok(
+      auth && auth !== "none",
+      `webhook '${node.name}' (path '${node.parameters.path}') has no authentication — ` +
+        `anyone who can reach the n8n URL can trigger it`,
+    );
+  }
+});
+
+test("every webhook binds a credential for the auth method it declares", () => {
+  const credentialForAuth = {
+    headerAuth: "httpHeaderAuth",
+    basicAuth: "httpBasicAuth",
+    jwtAuth: "jwtAuth",
+  };
+  for (const node of nodesOfType(WEBHOOK_TYPE)) {
+    const auth = node.parameters.authentication;
+    const expected = credentialForAuth[auth];
+    assert.ok(expected, `webhook '${node.name}' uses unknown auth method '${auth}'`);
+    assert.ok(
+      node.credentials && node.credentials[expected],
+      `webhook '${node.name}' declares '${auth}' but binds no '${expected}' credential — ` +
+        `n8n would fail open at import time`,
+    );
+  }
+});
+
+// ─── 2. The escrow payee is never caller-supplied ────────────────────────────
+
+test("Release Escrow Payment does not forward a caller-supplied recipient", () => {
+  const release = nodeByName("Release Escrow Payment");
+  assert.ok(release, "Release Escrow Payment node must exist");
+
+  const names = bodyParameters(release).map((p) => p.name);
+  assert.ok(
+    !names.includes("recipient"),
+    `Release Escrow Payment sends a 'recipient' body parameter (${names.join(", ")}). ` +
+      `releasePayment(bookingId) pays booking.driver, bound at deposit time — ` +
+      `a request-supplied recipient can only redirect funds`,
+  );
+  assert.deepStrictEqual(
+    names,
+    ["bookingId"],
+    "escrow release must be identified by bookingId alone",
+  );
+});
+
+test("no node anywhere derives a payout address from the request body", () => {
+  const forbidden = /\$json\.body\.(recipient|payee|destination|to(?:Address)?|wallet(?:Address)?)\b/;
+  for (const node of workflow.nodes) {
+    const match = nodeSource(node).match(forbidden);
+    assert.ok(
+      !match,
+      `node '${node.name}' reads a payout address from the request body (${match && match[0]}) — ` +
+        `escrow destinations must come from the on-chain booking, not the caller`,
+    );
+  }
+});
+
+// ─── 3. Fund-moving calls authenticate to the backend ────────────────────────
+
+test("every fund-moving HTTP node authenticates to the backend", () => {
+  const moving = nodesOfType(HTTP_TYPE).filter(movesFunds);
+  assert.ok(moving.length > 0, "expected at least one fund-moving HTTP node");
+
+  for (const node of moving) {
+    assert.strictEqual(
+      node.parameters.authentication,
+      "genericCredentialType",
+      `'${node.name}' calls ${node.parameters.url} without authentication — ` +
+        `the backend cannot re-authorize an anonymous caller`,
+    );
+    assert.strictEqual(
+      node.parameters.genericAuthType,
+      "httpHeaderAuth",
+      `'${node.name}' must authenticate with the x-api-key header credential (requireApiKey)`,
+    );
+    assert.ok(
+      node.credentials && node.credentials.httpHeaderAuth,
+      `'${node.name}' declares header auth but binds no httpHeaderAuth credential`,
+    );
+  }
+});
+
+// ─── 4. Graph integrity ──────────────────────────────────────────────────────
+
+test("every connection source and target references an existing node", () => {
+  const nodeNames = new Set(workflow.nodes.map((n) => n.name));
+  for (const [source, outputs] of Object.entries(workflow.connections)) {
+    assert.ok(nodeNames.has(source), `connection source '${source}' must be a real node`);
+    for (const branch of outputs.main || []) {
+      for (const edge of branch) {
+        assert.ok(nodeNames.has(edge.node), `connection target '${edge.node}' must be a real node`);
+      }
+    }
+  }
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} security check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll security checks passed");


### PR DESCRIPTION
Fixes #13111

## Root cause

`automation/n8n/dispute-resolution.json` ships with `"active": true` and exposes two webhooks that declare **no authentication** (`options: {}`, no `authentication` key). Both front operations that move real money:

| Webhook | Forwards to |
| :--- | :--- |
| `POST /webhook/dispute-trigger` | `/api/payments/freeze` |
| `POST /webhook/admin-resolution` | `/api/payments/release` |

The release node took the payout address straight off the wire:

```json
{ "name": "bookingId", "value": "={{$json.body.bookingId}}" },
{ "name": "recipient", "value": "={{$json.body.recipient}}" }
```

Anyone who could reach the n8n URL could POST a `bookingId` plus an attacker-chosen `recipient` and divert escrowed customer funds. The outbound calls also carried **no credential at all**, so the backend had nothing to re-authorize the caller with.

### The `recipient` field is not just unauthenticated — it is unsupported

Tracing the release path end-to-end, no layer accepts a recipient:

- **Contract** — [`TruxifyEscrow.releasePayment(uint256 bookingId)`](blockchain/contracts/TruxifyEscrow.sol#L315) is `onlyOwner` and pays `address payable driver = booking.driver`. The payee is read from the booking struct.
- **Booking struct** — `booking.driver` is bound when the deposit is built, by [`buildDepositTx(orderDisplayId, customerWalletAddress, driverWalletAddress, amountWei)`](backend/api/src/services/escrow.js#L369).
- **Service** — [`escrowRelease(orderDisplayId, expectedAmountWei = null)`](backend/api/src/services/escrow.js#L599) has no recipient parameter; it calls `releasePayment(bookingId)`.

So a caller-supplied payout address has no legitimate consumer anywhere in the release path. It can only ever redirect funds. Leaving the field in place is a live trust-boundary hole for whoever implements `/api/payments/release` next — note that route does **not** exist in [`paymentRoutes.js`](backend/api/src/routes/paymentRoutes.js) today, so the workflow is wired to an endpoint whose contract is still unwritten.

## Fix

1. **Both webhooks now require a credential.** `"authentication": "headerAuth"` bound to the `Truxify Internal API Key` HTTP Header Auth credential. n8n rejects an unauthenticated POST before any node in the graph runs.
2. **`recipient` is removed from the release body.** The release is identified by `bookingId` alone; the payee stays bound on-chain where the contract already enforces it.
3. **The fund-moving calls authenticate outbound.** `freeze` and `release` send `authentication: genericCredentialType` / `genericAuthType: httpHeaderAuth` with the same credential, so the backend's [`requireApiKey`](backend/api/src/middleware/apiKey.js) (`x-api-key` vs `VALID_API_KEYS`) can re-authorize the caller.

This reuses the credential pattern already proven in [`automation/n8n/workflows/circuit_breaker.json`](automation/n8n/workflows/circuit_breaker.json), which calls the `requireApiKey`-gated `/api/internal/escrow-velocity` the same way. No new convention introduced.

## Proof

New audit: `automation/n8n/tests/dispute-resolution.security.test.js`, following the existing plain-node test style in this directory.

**Before** — against the workflow file as it exists on `main`:

```console
$ node automation/n8n/tests/dispute-resolution.security.test.js
PASS: workflow still exposes the two dispute webhooks
FAILED: every webhook declares an authentication method (no anonymous POSTs)
  webhook 'Dispute Webhook Trigger' (path 'dispute-trigger') has no authentication — anyone who can reach the n8n URL can trigger it
FAILED: every webhook binds a credential for the auth method it declares
  webhook 'Dispute Webhook Trigger' uses unknown auth method 'undefined'
FAILED: Release Escrow Payment does not forward a caller-supplied recipient
  Release Escrow Payment sends a 'recipient' body parameter (bookingId, recipient). releasePayment(bookingId) pays booking.driver, bound at deposit time — a request-supplied recipient can only redirect funds
FAILED: no node anywhere derives a payout address from the request body
  node 'Release Escrow Payment' reads a payout address from the request body ($json.body.recipient) — escrow destinations must come from the on-chain booking, not the caller
FAILED: every fund-moving HTTP node authenticates to the backend
  'Freeze Payment Contract' calls ={{$env.BACKEND_API_URL}}/api/payments/freeze without authentication — the backend cannot re-authorize an anonymous caller
PASS: every connection source and target references an existing node

5 security check(s) failed
EXIT=1
```

**After** — with this PR applied:

```console
$ node automation/n8n/tests/dispute-resolution.security.test.js
PASS: workflow still exposes the two dispute webhooks
PASS: every webhook declares an authentication method (no anonymous POSTs)
PASS: every webhook binds a credential for the auth method it declares
PASS: Release Escrow Payment does not forward a caller-supplied recipient
PASS: no node anywhere derives a payout address from the request body
PASS: every fund-moving HTTP node authenticates to the backend
PASS: every connection source and target references an existing node

All security checks passed
EXIT=0
```

The `recipient` check is written to catch the whole class, not just the one line — it scans every node for `$json.body.{recipient,payee,destination,to,toAddress,wallet,walletAddress}`, so a payout address cannot be reintroduced from the request body through a different field name or a different node.

### No regression to existing tests

`automation/n8n/tests/dispute-resolution.test.js` reports the **same 3 failures before and after** this change, so nothing here regressed it:

```
FAILED: has a Freeze Escrow Payment node with retry + onError
FAILED: Verify Escrow Release error output reaches Alert Admin — Escrow Release Failed
FAILED: every alert/escalation email routes to $env.ADMIN_ALERT_EMAIL
```

Those are pre-existing on `main` — that test expects nodes named `Freeze Escrow Payment` and `Verify Escrow Release`, which have never existed in this workflow (the node is called `Freeze Payment Contract`). Out of scope here; happy to file it separately.

### Enforced in CI

An audit nobody runs is not a guard, and nothing under `automation/n8n/` was covered by any workflow — `backend-ci.yml` runs `vitest` with `working-directory: backend/api`, collecting only `test/**/*.test.js` beneath that directory, so these plain-node scripts were never executed.

This PR adds `.github/workflows/n8n-automation.yml`, path-filtered to `automation/n8n/**`, which parses every n8n workflow JSON and runs the escrow audit. Both steps are dependency-free plain node — no n8n instance needed, finishes in seconds.

Verified the guard actually bites: restoring the workflow JSON from `main` and running the audit step exits `1`; on this branch it exits `0`. A future PR that drops webhook auth or reintroduces a body-supplied payout address fails the check.

The job deliberately runs **only** the security audit. `automation/n8n/tests/dispute-resolution.test.js` carries three failures that predate this branch (detailed above), so wiring it in here would land a permanently red job and defeat the purpose. It should be fixed and added separately.

## Operator note

This workflow now **fails closed**. Before re-activating it, create an HTTP Header Auth credential in n8n named exactly `Truxify Internal API Key`, header `x-api-key`, value = one of the backend's `VALID_API_KEYS`. Documented in `automation/n8n/README.md` under *Escrow Webhook Authentication*.

## Deliberately out of scope

- The non-money nodes in this workflow (`Package Dispute PDF`, `Notify Both Parties`, `Check Dispute Resolution`) still call the backend unauthenticated. They are reads/notifications, not fund movement, and are outside this issue — worth a follow-up.
- `automation/n8n/dispute_resolution.json` (underscore — a separate pipeline) has the same unauthenticated-webhook pattern on `POST /webhook/disputes` and `POST /webhook/manual-resolution`. Not touched here to keep this diff reviewable, but it should get the same treatment.
