### PR TITLE
fix : allow parsePositiveFloat to accept 0 as a valid value

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -61,7 +61,7 @@ function parsePositiveFloat(raw, fallback, label) {
     return fallback;
   }
   const n = Number(raw);
-  if (Number.isFinite(n) && n > 0) return n;
+  if (Number.isFinite(n) && n >= 0) return n;
   if (label) logger.warn(`[pricing] ${label}=${raw} is invalid — using default ${fallback}`);
   return fallback;
 }
@@ -203,7 +203,7 @@ export function convertKmToMiles(km) {
   return km * 0.621371;
 }
 
-export const __testing = { DEFAULTS, readRateCard, EARTH_RADIUS_KM };
+export const __testing = { DEFAULTS, readRateCard, EARTH_RADIUS_KM, parsePositiveFloat };
 
 
 // === Spec 10: ===


### PR DESCRIPTION
Closes #13818.

Note: This PR is submitted as part of GirlScript Summer of Code (GSSOC).

Note: Please assign this PR to the `tmdeveloper007` account.