### PR TITLE
fix : allow 0 as valid value in parsePositiveFloat

### DIFF
--- a/backend/api/src/lib/pricing.js
+++ b/backend/api/src/lib/pricing.js
@@ -61,7 +61,7 @@ function parsePositiveFloat(raw, fallback, label) {
     return fallback;
   }
   const n = Number(raw);
-  if (Number.isFinite(n) && n > 0) return n;
+  if (Number.isFinite(n) && n >= 0) return n;
   if (label) logger.warn(`[pricing] ${label}=${raw} is invalid — using default ${fallback}`);
   return fallback;
 }


### PR DESCRIPTION
Change `n > 0` to `n >= 0` in `parsePositiveFloat` so that operators can set rate card multipliers (e.g. `TRUXIFY_FRAGILE_MULTIPLIER=0`) to explicitly disable surcharges instead of silently falling back to defaults.

Fixes #13818

---
**GSSOC**