### PR TITLE
fix : added setBatch method with error logging to requestCache

### DIFF
--- a/backend/api/src/lib/requestCache.js
+++ b/backend/api/src/lib/requestCache.js
@@ -1,7 +1,10 @@
+import logger from '../middleware/logger.js';
+
 const MISSING = Symbol('RequestCache:missing');
 export class RequestCache {
   constructor() {
     this._cache = new Map();
+    this._errorCount = 0;
   }
 
   /**
@@ -30,6 +33,19 @@ export class RequestCache {
 
   clear() {
     this._cache.clear();
+  }
+
+  setBatch(entries) {
+    // entries is an array of {key, value} objects
+    if (!Array.isArray(entries)) return;
+    for (const { key, value } of entries) {
+      try {
+        this.set(key, value);
+      } catch (err) {
+        logger.error({ event: 'REQUEST_CACHE_SET_ERROR', key }, '[RequestCache] setBatch failed for key');
+        this._errorCount = (this._errorCount || 0) + 1;
+      }
+    }
   }
 
   get size() {

--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -36,6 +36,11 @@ async function relayOnce() {
         });
         const outcome = await eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] });
 
+        // Guard explanation:
+        // outcome.published       — EventBus successfully received the event
+        // !outcome.deduplicated   — Event was not a duplicate (avoid re-marking)
+        // outcome.adapterAttempted > 0 — At least one adapter (e.g. Kafka) received the event
+        // outcome.adapterFailures === 0 — No adapter reported a failure
         const delivered =
           outcome.published &&
           !outcome.deduplicated &&


### PR DESCRIPTION
Closes #13849.

Summary of What Has Been Done:
Added a setBatch method to the RequestCache class that processes multiple cache entries at once with proper error logging. The method iterates through entries, attempts to set each one, and logs failures with error tracking via an _errorCount field.

Changes Made:
- backend/api/src/lib/requestCache.js - Added logger import, _errorCount initialization, and setBatch method with error handling

Impact it Made:
Enables batch cache operations with visibility into failures for debugging and monitoring. Operators can detect cache degradation via the _errorCount field.

Note: Please assign this PR to the `tmdeveloper007` account.

Note: These are from GSSOC (GirlScript Summer of Code).