### PR TITLE
[MEDIUM] Supabase: `complete_trip_tx` escrow guard is fail-OPEN for `service_role`

### DIFF
--- a/backend/api/test/unit/completeTripTxFailClosed.test.js
+++ b/backend/api/test/unit/completeTripTxFailClosed.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Regression test for issue #13099: complete_trip_tx must not be fail-open on
+// service_role. The wallet-credit guard must compare the supplied release hash
+// to the recorded on-chain settlement (orders.release_tx_hash /
+// orders.blockchain_tx_hash) rather than merely testing non-null, so a random
+// non-null hash cannot credit the driver wallet.
+describe('complete_trip_tx fail-closed on unverified release hash (issue #13099)', () => {
+  const sql = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../supabase/migrations/20260812130000_complete_trip_tx_fail_closed_on_missing_wallet.sql'
+    ),
+    'utf8'
+  );
+
+  it('rejects a non-null but unverified release hash instead of trusting any non-null value', () => {
+    expect(sql).toMatch(
+      /p_release_tx_hash\s+is\s+distinct\s+from\s+coalesce\s*\(\s*v_order\.release_tx_hash\s*,\s*v_order\.blockchain_tx_hash\s*\)/i
+    );
+  });
+
+  it('still requires a release hash when escrow is not disabled and not released', () => {
+    expect(sql).toMatch(
+      /raise exception\s+'Blockchain escrow release must complete before crediting driver wallet'/i
+    );
+  });
+});

--- a/supabase/migrations/20260812130000_complete_trip_tx_fail_closed_on_missing_wallet.sql
+++ b/supabase/migrations/20260812130000_complete_trip_tx_fail_closed_on_missing_wallet.sql
@@ -105,14 +105,27 @@ begin
   end if;
 
   -- Fail closed (restored from 20260802130000_complete_trip_tx_require_funded_escrow.sql):
-  -- credit the driver wallet ONLY when the escrow was actually funded and released
-  -- on-chain (`escrow_status = 'released'` or a release tx hash is supplied), or
-  -- when the order is explicitly marked `escrow_disabled`. Any ambiguous/unfunded
-  -- state raises instead of crediting.
-  if not v_order.escrow_disabled
-     and coalesce(v_order.escrow_status, '') <> 'released'
-     and p_release_tx_hash is null then
-    raise exception 'Blockchain escrow release must complete before crediting driver wallet';
+  -- credit the driver wallet ONLY when the escrow was actually released on-chain
+  -- AND the caller-supplied release hash matches the recorded settlement. A
+  -- non-null hash is no longer sufficient — service_role (or any caller) cannot
+  -- credit the wallet with a forged or stale hash. (Fixes #13099.)
+  if not v_order.escrow_disabled then
+    if v_order.escrow_status = 'released' then
+      -- Escrow already marked released: the supplied hash must match the
+      -- on-chain settlement recorded by the deposit/verify path.
+      if p_release_tx_hash is null
+         or p_release_tx_hash is distinct from coalesce(v_order.release_tx_hash, v_order.blockchain_tx_hash) then
+        raise exception 'Blockchain escrow release hash does not match the recorded settlement';
+      end if;
+    else
+      -- Escrow not yet released: no wallet credit without a genuine release hash.
+      if p_release_tx_hash is null then
+        raise exception 'Blockchain escrow release must complete before crediting driver wallet';
+      end if;
+      if p_release_tx_hash is distinct from coalesce(v_order.release_tx_hash, v_order.blockchain_tx_hash) then
+        raise exception 'Blockchain escrow release hash does not match the recorded settlement';
+      end if;
+    end if;
   end if;
 
   -- Finalize the active trip that actually served THIS order (restored from


### PR DESCRIPTION
## Problem
[MEDIUM] Supabase: `complete_trip_tx` escrow guard is fail-OPEN for `service_role`

See issue #13099 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 .../api/test/unit/completeTripTxFailClosed.test.js | 34 ++++++++++++++++++++++
 ...plete_trip_tx_fail_closed_on_missing_wallet.sql | 29 +++++++++++++-----
 2 files changed, 55 insertions(+), 8 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13099
