### PR TITLE
ZKPrivacy.processSTARKTransaction pays arbitrary caller-chosen amounts with no deposit/nullifier binding

### DIFF
--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -241,14 +241,28 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         uint[2][2] memory b,
         uint[2] memory c,
         uint[] memory publicInputs,
+        bytes32 nullifier,
+        bytes32 commitment,
         address recipient,
         uint256 amount
     ) external nonReentrant whenNotPaused {
         require(recipient != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be > 0");
-        require(publicInputs.length >= 2, "Invalid proof public inputs length");
-        require(publicInputs[0] == uint256(uint160(recipient)), "Recipient mismatch in proof input");
-        require(publicInputs[1] == amount, "Amount mismatch in proof input");
+
+        // Bind the withdrawal to a real on-chain deposit ledger and consume a
+        // one-time nullifier so the same proof cannot be replayed to drain the
+        // contract. Without these checks the caller-chosen `amount` is paid
+        // straight out of the contract balance regardless of any deposit.
+        require(!nullifiers[nullifier], "Nullifier already used");
+        require(commitments[commitment], "Commitment does not exist");
+        require(!spentCommitments[commitment], "Commitment already spent");
+        require(commitmentAmounts[commitment] >= amount, "Insufficient deposit amount");
+
+        require(publicInputs.length >= 4, "Invalid proof public inputs length");
+        require(publicInputs[0] == uint256(nullifier), "Nullifier mismatch in proof input");
+        require(publicInputs[1] == uint256(commitment), "Commitment mismatch in proof input");
+        require(publicInputs[2] == uint256(uint160(recipient)), "Recipient mismatch in proof input");
+        require(publicInputs[3] == amount, "Amount mismatch in proof input");
 
         // Verify zk-STARK proof
         bool isValid = verifySTARK(a, b, c, publicInputs);
@@ -258,7 +272,23 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         (bool success, ) = recipient.call{value: amount}("");
         require(success, "Transfer failed");
 
-        emit TransactionProcessed(bytes32(0), recipient, amount);
+        // Record the withdrawal against the deposit ledger.
+        transactionCounter++;
+        bytes32 txId = keccak256(abi.encodePacked(block.timestamp, transactionCounter));
+
+        transactions[txId] = PrivateTransaction({
+            commitment: commitment,
+            nullifier: nullifier,
+            recipient: recipient,
+            amount: amount,
+            timestamp: block.timestamp,
+            spent: false
+        });
+
+        nullifiers[nullifier] = true;
+        spentCommitments[commitment] = true;
+
+        emit TransactionProcessed(nullifier, recipient, amount);
     }
 
     // ============ Privacy-Preserving ============

--- a/blockchain/test/ZKPrivacy.starkWithdrawal.test.cjs
+++ b/blockchain/test/ZKPrivacy.starkWithdrawal.test.cjs
@@ -26,9 +26,14 @@ async function expectRevert(promise, expectedMessage) {
 describe("ZKPrivacy STARK withdrawal", function () {
   let zkPrivacy, verifier;
   let owner, recipient;
+  let commitment, nullifier;
 
-  const PROGRAM_INPUTS = (recipient, amount) => [
-    BigInt(recipient),
+  // The STARK public inputs must bind the withdrawal to a one-time nullifier,
+  // the deposit commitment, the recipient and the amount, in that order.
+  const PROGRAM_INPUTS = (n, c, r, amount) => [
+    BigInt(n),
+    BigInt(c),
+    BigInt(r),
     amount,
   ];
   const PROOF_A = [1, 2];
@@ -38,6 +43,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
   beforeEach(async function () {
     [owner, recipient] = await ethers.getSigners();
 
+    commitment = ethers.keccak256(ethers.toUtf8Bytes("stark-commitment"));
+    nullifier = ethers.keccak256(ethers.toUtf8Bytes("stark-nullifier"));
+
     const MockVerifier = await ethers.getContractFactory("MockZKPrivacyVerifier");
     verifier = await MockVerifier.deploy();
     await verifier.waitForDeployment();
@@ -46,12 +54,10 @@ describe("ZKPrivacy STARK withdrawal", function () {
     zkPrivacy = await ZKPrivacy.deploy(await verifier.getAddress());
     await zkPrivacy.waitForDeployment();
 
-    // Fund the contract so withdrawals can be paid out.
+    // Fund the contract with a real deposit that the withdrawal is bound to.
     await zkPrivacy
       .connect(owner)
-      .deposit(ethers.keccak256(ethers.toUtf8Bytes("escrow-funds")), {
-        value: ethers.parseEther("3"),
-      });
+      .deposit(commitment, { value: ethers.parseEther("3") });
   });
 
   it("reverts when no verifier is wired in (issue #10795)", async function () {
@@ -67,7 +73,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
           PROOF_A,
           PROOF_B,
           PROOF_C,
-          PROGRAM_INPUTS(recipient.address, amount),
+          PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+          nullifier,
+          commitment,
           recipient.address,
           amount
         ),
@@ -78,7 +86,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
   it("transfers the value to the recipient after verification (issue #10795)", async function () {
     await verifier.setShouldVerify(true);
     const amount = ethers.parseEther("1");
-    await verifier.setExpectedInput(PROGRAM_INPUTS(recipient.address, amount));
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
 
     const before = await ethers.provider.getBalance(recipient.address);
 
@@ -89,7 +99,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
           PROOF_A,
           PROOF_B,
           PROOF_C,
-          PROGRAM_INPUTS(recipient.address, amount),
+          PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+          nullifier,
+          commitment,
           recipient.address,
           amount
         )
@@ -103,7 +115,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
     await verifier.setShouldVerify(true);
     const [other] = await ethers.getSigners();
     const amount = ethers.parseEther("1");
-    await verifier.setExpectedInput(PROGRAM_INPUTS(recipient.address, amount));
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
 
     await expectRevert(
       zkPrivacy
@@ -112,7 +126,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
           PROOF_A,
           PROOF_B,
           PROOF_C,
-          PROGRAM_INPUTS(other.address, amount),
+          PROGRAM_INPUTS(nullifier, commitment, other.address, amount),
+          nullifier,
+          commitment,
           recipient.address,
           amount
         ),
@@ -123,7 +139,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
   it("rejects a proof whose public inputs do not bind the amount", async function () {
     await verifier.setShouldVerify(true);
     const amount = ethers.parseEther("1");
-    await verifier.setExpectedInput(PROGRAM_INPUTS(recipient.address, amount));
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
 
     await expectRevert(
       zkPrivacy
@@ -132,7 +150,14 @@ describe("ZKPrivacy STARK withdrawal", function () {
           PROOF_A,
           PROOF_B,
           PROOF_C,
-          PROGRAM_INPUTS(recipient.address, ethers.parseEther("2")),
+          PROGRAM_INPUTS(
+            nullifier,
+            commitment,
+            recipient.address,
+            ethers.parseEther("2")
+          ),
+          nullifier,
+          commitment,
           recipient.address,
           amount
         ),
@@ -143,7 +168,9 @@ describe("ZKPrivacy STARK withdrawal", function () {
   it("rejects a proof the verifier does not accept", async function () {
     await verifier.setShouldVerify(false);
     const amount = ethers.parseEther("1");
-    await verifier.setExpectedInput(PROGRAM_INPUTS(recipient.address, amount));
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
 
     await expectRevert(
       zkPrivacy
@@ -152,11 +179,105 @@ describe("ZKPrivacy STARK withdrawal", function () {
           PROOF_A,
           PROOF_B,
           PROOF_C,
-          PROGRAM_INPUTS(recipient.address, amount),
+          PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+          nullifier,
+          commitment,
           recipient.address,
           amount
         ),
       "Invalid STARK proof"
+    );
+  });
+
+  it("rejects a withdrawal against a commitment that was never deposited", async function () {
+    await verifier.setShouldVerify(true);
+    const amount = ethers.parseEther("1");
+    const missingCommitment = ethers.keccak256(
+      ethers.toUtf8Bytes("missing-commitment")
+    );
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, missingCommitment, recipient.address, amount)
+    );
+
+    await expectRevert(
+      zkPrivacy
+        .connect(owner)
+        .processSTARKTransaction(
+          PROOF_A,
+          PROOF_B,
+          PROOF_C,
+          PROGRAM_INPUTS(nullifier, missingCommitment, recipient.address, amount),
+          nullifier,
+          missingCommitment,
+          recipient.address,
+          amount
+        ),
+      "Commitment does not exist"
+    );
+  });
+
+  it("rejects an amount greater than the deposited balance", async function () {
+    await verifier.setShouldVerify(true);
+    const amount = ethers.parseEther("5");
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
+
+    await expectRevert(
+      zkPrivacy
+        .connect(owner)
+        .processSTARKTransaction(
+          PROOF_A,
+          PROOF_B,
+          PROOF_C,
+          PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+          nullifier,
+          commitment,
+          recipient.address,
+          amount
+        ),
+      "Insufficient deposit amount"
+    );
+  });
+
+  it("rejects replay of a consumed nullifier (issue #13110)", async function () {
+    await verifier.setShouldVerify(true);
+    const amount = ethers.parseEther("1");
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
+
+    await zkPrivacy
+      .connect(owner)
+      .processSTARKTransaction(
+        PROOF_A,
+        PROOF_B,
+        PROOF_C,
+        PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+        nullifier,
+        commitment,
+        recipient.address,
+        amount
+      );
+
+    await verifier.setExpectedInput(
+      PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount)
+    );
+
+    await expectRevert(
+      zkPrivacy
+        .connect(owner)
+        .processSTARKTransaction(
+          PROOF_A,
+          PROOF_B,
+          PROOF_C,
+          PROGRAM_INPUTS(nullifier, commitment, recipient.address, amount),
+          nullifier,
+          commitment,
+          recipient.address,
+          amount
+        ),
+      "Nullifier already used"
     );
   });
 
@@ -167,6 +288,8 @@ describe("ZKPrivacy STARK withdrawal", function () {
 
     await expectRevert(
       noVerifier.verifySTARK(PROOF_A, PROOF_B, PROOF_C, [
+        BigInt(nullifier),
+        BigInt(commitment),
         BigInt(recipient.address),
         1,
       ]),


### PR DESCRIPTION
## Problem
ZKPrivacy.processSTARKTransaction pays arbitrary caller-chosen amounts with no deposit/nullifier binding

See issue #13110 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 blockchain/contracts/ZKPrivacy.sol                 |  38 ++++-
 blockchain/test/ZKPrivacy.starkWithdrawal.test.cjs | 153 +++++++++++++++++++--
 2 files changed, 172 insertions(+), 19 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13110
