### PR TITLE
WASI network allow-list uses substring matching — SSRF / sandbox escape

### DIFF
--- a/wasi/src/Cargo.toml
+++ b/wasi/src/Cargo.toml
@@ -11,6 +11,7 @@ wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wasi = "0.11"
+url = "2"
 
 [profile.release]
 opt-level = "z"

--- a/wasi/src/lib.rs
+++ b/wasi/src/lib.rs
@@ -262,19 +262,23 @@ pub fn wasi_sleep(ms: u64) {
 }
 
 fn is_url_allowed(url: &str) -> bool {
-    // Capability-based security: only allow specific domains
-    let allowed_domains = vec![
-        "api.truxify.com",
-        "localhost",
-        "127.0.0.1",
-    ];
-    
-    for domain in allowed_domains {
-        if url.contains(domain) {
-            return true;
-        }
-    }
-    false
+    // Capability-based security: only allow specific domains.
+    // Parse the URL and compare the *host* exactly or as a proper subdomain
+    // suffix. A substring match (e.g. `url.contains("api.truxify.com")`) would
+    // also admit `http://api.truxify.com.attacker.net` or `http://127.0.0.1.evil/`.
+    let parsed = match url::Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    let host = match parsed.host_str() {
+        Some(h) => h.to_ascii_lowercase(),
+        None => return false,
+    };
+    let allowed_domains = ["api.truxify.com", "localhost", "127.0.0.1"];
+    allowed_domains.iter().any(|d| {
+        let d = d.to_ascii_lowercase();
+        host == d || host.ends_with(&format!(".{d}"))
+    })
 }
 
 // ============ Process System Calls ============
@@ -313,4 +317,40 @@ pub fn wasi_allocate_memory(size: usize) -> Result<String, String> {
     // Allocate memory (for testing)
     let vec = vec![0u8; size];
     Ok(format!("Allocated {} bytes", vec.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_exact_allowed_host() {
+        assert!(is_url_allowed("http://api.truxify.com/v1/orders"));
+        assert!(is_url_allowed("http://localhost:8080/health"));
+        assert!(is_url_allowed("http://127.0.0.1:5432/"));
+    }
+
+    #[test]
+    fn allows_subdomain_of_allowed_host() {
+        assert!(is_url_allowed("https://api.eu.api.truxify.com/x"));
+    }
+
+    #[test]
+    fn blocks_host_containing_allowed_as_suffix() {
+        // Attacker uses the allowed string as a *suffix* of their domain.
+        assert!(!is_url_allowed("http://api.truxify.com.attacker.net/x"));
+        assert!(!is_url_allowed("http://127.0.0.1.evil/"));
+    }
+
+    #[test]
+    fn blocks_host_with_allowed_string_in_query() {
+        assert!(!is_url_allowed("http://evil.com/?x=localhost"));
+    }
+
+    #[test]
+    fn blocks_unrelated_and_internal_hosts() {
+        assert!(!is_url_allowed("http://evil.com/"));
+        assert!(!is_url_allowed("http://169.254.169.254/latest/meta-data/"));
+        assert!(!is_url_allowed("not a url"));
+    }
 }


### PR DESCRIPTION
## Problem
WASI network allow-list uses substring matching — SSRF / sandbox escape

See issue #13120 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 wasi/src/Cargo.toml |  1 +
 wasi/src/lib.rs     | 66 ++++++++++++++++++++++++++++++++++++++++++-----------
 2 files changed, 54 insertions(+), 13 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13120
