### PR TITLE
#22 Document-expiry worker queries wrong table (`documents` vs `driver_documents`), sends no reminders

### DIFF
--- a/backend/api/src/services/documentExpiryService.js
+++ b/backend/api/src/services/documentExpiryService.js
@@ -132,8 +132,8 @@ export async function processDocumentExpiryBatch() {
         let page = [];
         do {
           const { data, error } = await supabaseAdmin
-            .from('documents')
-            .select('id, user_id, doc_type, valid_until')
+            .from('driver_documents')
+            .select('id, driver_id, document_type, valid_until')
             .not('valid_until', 'is', null)
             .gte('valid_until', windowStart.toISOString())
             .lte('valid_until', windowEnd.toISOString())
@@ -162,18 +162,18 @@ export async function processDocumentExpiryBatch() {
       logger.info(`[document-expiry] Found ${documents.length} document(s) expiring in ${window.label} window.`);
 
       for (const doc of documents) {
-        if (!doc.user_id || !doc.id) {
-          logger.warn('[document-expiry] Skipping document with missing user_id or id:', doc.id);
+        if (!doc.driver_id || !doc.id) {
+          logger.warn('[document-expiry] Skipping document with missing driver_id or id:', doc.id);
           continue;
         }
 
-        const alreadyNotified = await hasExistingNotification(doc.user_id, doc.id, window.days);
+        const alreadyNotified = await hasExistingNotification(doc.driver_id, doc.id, window.days);
         if (alreadyNotified) {
           logger.info(`[document-expiry] Document ${doc.id} already notified for ${window.label} window, skipping.`);
           continue;
         }
 
-        const docLabel = getDocTypeLabel(doc.doc_type);
+        const docLabel = getDocTypeLabel(doc.document_type);
         const expiryDate = new Date(doc.valid_until).toLocaleDateString('en-IN', {
           day: '2-digit',
           month: 'short',
@@ -186,15 +186,15 @@ export async function processDocumentExpiryBatch() {
         const metadata = {
           type: 'document_expiry',
           documentId: doc.id,
-          documentType: doc.doc_type,
+          documentType: doc.document_type,
           daysRemaining: window.days,
           expiryDate: doc.valid_until,
         };
 
         try {
-          await sendPushNotification(doc.user_id, title, body, 'document', metadata);
+          await sendPushNotification(doc.driver_id, title, body, 'document', metadata);
           totalNotificationsSent++;
-          logger.info(`[document-expiry] Sent ${window.label} expiry alert for ${docLabel} (doc: ${doc.id}) to user ${doc.user_id}`);
+          logger.info(`[document-expiry] Sent ${window.label} expiry alert for ${docLabel} (doc: ${doc.id}) to user ${doc.driver_id}`);
         } catch (err) {
           logger.error(`[document-expiry] Failed to send notification for document ${doc.id}:`, err.message);
         }

--- a/backend/api/test/unit/documentExpiryService.test.js
+++ b/backend/api/test/unit/documentExpiryService.test.js
@@ -18,7 +18,7 @@ function makeBuilder(result) {
 }
 
 const resultsByTable = {
-  documents: { data: [{ id: 'doc-1', user_id: 'user-1', doc_type: 'rc_book', valid_until: '2099-01-01T00:00:00.000Z' }], error: null },
+  driver_documents: { data: [{ id: 'doc-1', driver_id: 'user-1', document_type: 'rc_book', valid_until: '2099-01-01T00:00:00.000Z' }], error: null },
   notifications: { data: [], error: null },
 };
 
@@ -56,7 +56,7 @@ describe('documentExpiryService', () => {
 
     await processDocumentExpiryBatch();
 
-    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('documents');
+    expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('driver_documents');
     expect(supabaseAdminBuilder.from).toHaveBeenCalledWith('notifications');
     expect(supabaseAnonBuilder.from).not.toHaveBeenCalled();
     expect(sendPushNotificationMock).toHaveBeenCalledWith(
@@ -71,17 +71,17 @@ describe('documentExpiryService', () => {
   it('pages the window sweep past the PostgREST 1000-row cap until fewer than a full page remains', async () => {
     const pageOf1000 = Array.from({ length: 1000 }, (_, i) => ({
       id: `doc-${i + 1}`,
-      user_id: 'user-1',
-      doc_type: 'rc_book',
+      driver_id: 'user-1',
+      document_type: 'rc_book',
       valid_until: '2099-01-01T00:00:00.000Z',
     }));
 
     const notificationsResult = { data: [], error: null };
-    const responses = [pageOf1000, [{ id: 'doc-tail', user_id: 'user-2', doc_type: 'insurance', valid_until: '2099-02-01T00:00:00.000Z' }]];
+    const responses = [pageOf1000, [{ id: 'doc-tail', driver_id: 'user-2', document_type: 'insurance', valid_until: '2099-02-01T00:00:00.000Z' }]];
 
     const paginatedBuilder = {
       from: vi.fn((table) => {
-        if (table === 'documents') {
+        if (table === 'driver_documents') {
           return makeBuilder({ data: responses.shift() ?? [], error: null });
         }
         return makeBuilder(notificationsResult);
@@ -101,7 +101,7 @@ describe('documentExpiryService', () => {
     const { processDocumentExpiryBatch } = await import('../../src/services/documentExpiryService.js');
     await processDocumentExpiryBatch();
 
-    const docCalls = paginatedBuilder.from.mock.calls.filter(([table]) => table === 'documents');
+    const docCalls = paginatedBuilder.from.mock.calls.filter(([table]) => table === 'driver_documents');
     expect(docCalls.length).toBeGreaterThan(1);
     expect(sendPushNotificationMock).toHaveBeenCalledWith(
       'user-2',


### PR DESCRIPTION
## Problem
#22 Document-expiry worker queries wrong table (`documents` vs `driver_documents`), sends no reminders

See issue #12333 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 backend/api/src/services/documentExpiryService.js   | 18 +++++++++---------
 backend/api/test/unit/documentExpiryService.test.js | 14 +++++++-------
 2 files changed, 16 insertions(+), 16 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #12333
