### PR TITLE
[HIGH] ML: `base.py` uses unsafe `pickle.load` with no integrity verification (RCE + silent corruption)

### DIFF
--- a/backend/ml/app/models/base.py
+++ b/backend/ml/app/models/base.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pickle
+import hashlib
 import logging
 import asyncio
 from typing import Any, Optional
@@ -33,6 +34,55 @@ def get_previous_meta_path(model_name: str) -> str:
     os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
     return os.path.join(MODEL_STORAGE_DIR, f"{model_name}_previous_meta.json")
 
+def get_model_hash_path(model_name: str) -> str:
+    os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
+    return os.path.join(MODEL_STORAGE_DIR, f"{model_name}.sha256")
+
+def get_previous_model_hash_path(model_name: str) -> str:
+    os.makedirs(MODEL_STORAGE_DIR, exist_ok=True)
+    return os.path.join(MODEL_STORAGE_DIR, f"{model_name}_previous.sha256")
+
+def _compute_model_hash(model_name: str) -> str:
+    path = get_model_path(model_name)
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def _save_model_hash(model_name: str) -> None:
+    with open(get_model_hash_path(model_name), "w") as f:
+        f.write(_compute_model_hash(model_name))
+
+def _model_hash_exists(model_name: str) -> bool:
+    return os.path.exists(get_model_hash_path(model_name))
+
+def _verify_model_hash(model_name: str) -> bool:
+    """Return True only if the persisted .pkl matches its sha256 sidecar.
+
+    A missing or mismatched hash means the artifact was tampered with or
+    silently corrupted and must NOT be unpickled (prevents RCE, #13095).
+    """
+    if not _model_hash_exists(model_name):
+        return False
+    expected = ""
+    with open(get_model_hash_path(model_name), "r") as f:
+        expected = f.read().strip()
+    return _compute_model_hash(model_name) == expected
+
+def _verify_previous_model_hash(model_name: str) -> bool:
+    """Validate the *_previous.pkl artifact against its sha256 sidecar."""
+    prev_path = get_previous_model_path(model_name)
+    prev_hash_path = get_previous_model_hash_path(model_name)
+    if not os.path.exists(prev_path) or not os.path.exists(prev_hash_path):
+        return False
+    h = hashlib.sha256()
+    with open(prev_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    expected = open(prev_hash_path).read().strip()
+    return h.hexdigest() == expected
+
 def save_model(model: Any, model_name: str, metrics: Optional[dict] = None, training_meta: Optional[dict] = None) -> None:
     """Persist *model* as the production version for *model_name*.
 
@@ -54,11 +104,14 @@ def save_model(model: Any, model_name: str, metrics: Optional[dict] = None, trai
         os.replace(path, get_previous_model_path(model_name))
     if os.path.exists(meta_path):
         os.replace(meta_path, get_previous_meta_path(model_name))
+    if os.path.exists(get_model_hash_path(model_name)):
+        os.replace(get_model_hash_path(model_name), get_previous_model_hash_path(model_name))
 
     tmp_path = path + ".tmp"
     with open(tmp_path, "wb") as f:
         pickle.dump(model, f)
     os.replace(tmp_path, path)
+    _save_model_hash(model_name)
 
     meta = {
         "model_name": model_name,
@@ -83,12 +136,23 @@ def restore_previous_model(model_name: str) -> bool:
     """
     prev_path = get_previous_model_path(model_name)
     prev_meta_path = get_previous_meta_path(model_name)
+    prev_hash_path = get_previous_model_hash_path(model_name)
     if not os.path.exists(prev_path):
         logger.warning("No previous version of model '%s' to restore", model_name)
         return False
 
+    # Refuse to restore a tampered/corrupted previous artifact. A missing or
+    # mismatched hash means the rollback source cannot be trusted (RCE/#13095).
+    if not _verify_previous_model_hash(model_name):
+        logger.error(
+            "Refusing to restore model '%s': previous artifact failed integrity check",
+            model_name,
+        )
+        return False
+
     path = get_model_path(model_name)
     meta_path = get_meta_path(model_name)
+    hash_path = get_model_hash_path(model_name)
 
     # Swap current <-> previous so the rollback itself is also reversible.
     # Uses a ".swap" suffix (not ".tmp") since these files are only ever
@@ -106,6 +170,13 @@ def restore_previous_model(model_name: str) -> bool:
     if os.path.exists(meta_path + ".swap"):
         os.replace(meta_path + ".swap", prev_meta_path)
 
+    if os.path.exists(hash_path):
+        os.replace(hash_path, hash_path + ".swap")
+    if os.path.exists(prev_hash_path):
+        os.replace(prev_hash_path, hash_path)
+    if os.path.exists(hash_path + ".swap"):
+        os.replace(hash_path + ".swap", prev_hash_path)
+
     logger.warning("Model '%s' rolled back to previous version", model_name)
     return True
 
@@ -113,6 +184,13 @@ def load_model(model_name: str) -> Optional[Any]:
     path = get_model_path(model_name)
     if not os.path.exists(path):
         logger.warning("Model '%s' not found at %s", model_name, path)
+        return None
+    if not _verify_model_hash(model_name):
+        logger.error(
+            "Refusing to load model '%s': integrity check failed (missing or "
+            "mismatched sha256). Artifact may be tampered or corrupted.",
+            model_name,
+        )
         return None
     with open(path, "rb") as f:
         return pickle.load(f)

--- a/backend/ml/tests/test_base.py
+++ b/backend/ml/tests/test_base.py
@@ -380,3 +380,34 @@ class TestRestorePreviousModel:
         assert restore_previous_model("test_reversible") is True
         assert load_model("test_reversible") == model_b
 
+
+class TestModelIntegrity:
+    def test_save_writes_sha256_sidecar(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        save_model({"data": 1}, "hash_test")
+        assert (tmp_path / "hash_test.sha256").exists()
+
+    def test_load_rejects_tampered_pkl(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        save_model({"data": 42}, "integrity_test")
+        # Tamper with the persisted artifact without updating its hash.
+        pkl = tmp_path / "integrity_test.pkl"
+        with open(pkl, "ab") as f:
+            f.write(b"malicious")
+        # Integrity check must refuse to unpickle the tampered artifact (#13095).
+        assert load_model("integrity_test") is None
+
+    def test_restore_rejects_tampered_previous(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.models.base.MODEL_STORAGE_DIR", str(tmp_path))
+        save_model({"version": "A"}, "restore_integrity")
+        save_model({"version": "B"}, "restore_integrity")
+
+        # Tamper with the previous artifact that would be restored.
+        prev = get_previous_model_path("restore_integrity")
+        with open(prev, "ab") as f:
+            f.write(b"tampered")
+
+        assert restore_previous_model("restore_integrity") is False
+        # Production artifact stays intact and loadable.
+        assert load_model("restore_integrity") == {"version": "B"}
+


### PR DESCRIPTION
## Problem
[HIGH] ML: `base.py` uses unsafe `pickle.load` with no integrity verification (RCE + silent corruption)

See issue #13095 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 backend/ml/app/models/base.py | 78 +++++++++++++++++++++++++++++++++++++++++++
 backend/ml/tests/test_base.py | 31 +++++++++++++++++
 2 files changed, 109 insertions(+)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13095
