### PR TITLE
[CRITICAL] Automation: `dispute-resolution` n8n webhook is unauthenticated and releases escrow to an arbitrary recipient

### DIFF
--- a/automation/n8n/dispute-resolution.json
+++ b/automation/n8n/dispute-resolution.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "dispute-trigger",
+        "authentication": "basicAuth",
         "options": {}
       },
       "id": "1d8ea83e-d9a4-4db2-a9b0-30f16f5c5315",
@@ -276,6 +277,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "admin-resolution",
+        "authentication": "basicAuth",
         "options": {}
       },
       "id": "5b23dca9-48cf-4ef2-ba2e-ffbc8601dd77",

--- a/automation/n8n/tests/dispute-resolution.test.js
+++ b/automation/n8n/tests/dispute-resolution.test.js
@@ -100,6 +100,24 @@ test("Release Escrow Payment error output reaches Alert Admin — Escrow Release
   );
 });
 
+test("both webhook triggers require authentication (no open escrow endpoints)", () => {
+  const webhooks = workflow.nodes.filter((n) => n.type === "n8n-nodes-base.webhook");
+  assert.ok(webhooks.length >= 2, "workflow must expose at least two webhook triggers");
+  for (const webhook of webhooks) {
+    const auth = webhook.parameters && webhook.parameters.authentication;
+    assert.notStrictEqual(
+      auth,
+      undefined,
+      `${webhook.name} must declare an authentication method`,
+    );
+    assert.notStrictEqual(
+      auth,
+      "none",
+      `${webhook.name} must not be unauthenticated (found '${auth}')`,
+    );
+  }
+});
+
 test("every connection source and target references an existing node", () => {
   const nodeNames = new Set(workflow.nodes.map((n) => n.name));
   for (const [source, outputs] of Object.entries(workflow.connections)) {


### PR DESCRIPTION
## Problem
[CRITICAL] Automation: `dispute-resolution` n8n webhook is unauthenticated and releases escrow to an arbitrary recipient

See issue #13111 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 automation/n8n/dispute-resolution.json          |  2 ++
 automation/n8n/tests/dispute-resolution.test.js | 18 ++++++++++++++++++
 2 files changed, 20 insertions(+)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13111
