### PR TITLE
DAO quadratic-voting releaseVotes over-refunds (squares the sum instead of per-call cost) — pool drain

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -23,6 +23,7 @@ contract DAO is Ownable {
     mapping(address => bytes32) public voterIdentity;
     mapping(bytes32 => address) public identityOwner;
     mapping(uint256 => mapping(address => bool)) public votesReleased;
+    mapping(uint256 => mapping(address => uint256)) public tokensHeld;
 
     event ProposalCreated(uint256 indexed proposalId, string description, uint256 deadline);
     event VotedQuadratic(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 tokenCost);
@@ -75,8 +76,25 @@ contract DAO is Ownable {
         require(governanceToken.transferFrom(msg.sender, address(this), tokenCost), "Token transfer failed");
 
         votesCast[_proposalId][msg.sender] += _votes;
+        tokensHeld[_proposalId][msg.sender] += tokenCost;
         proposal.voteCount += _votes;
 
         emit VotedQuadratic(_proposalId, msg.sender, _votes, tokenCost);
+    }
+
+    /**
+     * @dev Releases the escrowed governance tokens for a voter on a proposal.
+     * Refunds the exact sum of per-call quadratic costs (tokensHeld), never the
+     * square of the accumulated vote total, so the shared pool cannot be drained.
+     */
+    function releaseVotes(uint256 _proposalId) external {
+        uint256 held = tokensHeld[_proposalId][msg.sender];
+        require(held > 0, "No votes to release");
+        require(!votesReleased[_proposalId][msg.sender], "Already released");
+
+        votesReleased[_proposalId][msg.sender] = true;
+        require(governanceToken.transfer(msg.sender, held), "Token transfer failed");
+
+        emit VotesReleased(_proposalId, msg.sender, held);
     }
 }

--- a/blockchain/test/DAO.quadraticVoting.test.cjs
+++ b/blockchain/test/DAO.quadraticVoting.test.cjs
@@ -102,6 +102,33 @@ describe("DAO Quadratic Voting", function () {
     await expectRevert(dao.connect(voter).voteQuadratic(0, 0), "Votes must be > 0");
   });
 
+  it("refunds the sum of per-call quadratic costs, not (Σvotes)^2", async function () {
+    const balanceBefore = await token.balanceOf(voter.address);
+
+    // Split 5 votes across calls: 3 then 2 → deposit 9 + 4 = 13 tokens.
+    await dao.connect(voter).voteQuadratic(0, 3); // cost 9
+    await dao.connect(voter).voteQuadratic(0, 2); // cost 4
+
+    expect(await token.balanceOf(voter.address)).to.equal(balanceBefore - 13n);
+
+    await dao.connect(voter).releaseVotes(0);
+
+    // Must refund exactly 13 (Σ vᵢ²), NOT (3+2)² = 25.
+    expect(await token.balanceOf(voter.address)).to.equal(balanceBefore);
+    expect(await dao.tokensHeld(0, voter.address)).to.equal(13n);
+  });
+
+  it("reverts when releasing votes that were never cast", async function () {
+    await expectRevert(dao.connect(voter).releaseVotes(0), "No votes to release");
+  });
+
+  it("reverts when releasing the same votes twice", async function () {
+    await dao.connect(voter).voteQuadratic(0, 4); // cost 16
+    await dao.connect(voter).releaseVotes(0);
+
+    await expectRevert(dao.connect(voter).releaseVotes(0), "Already released");
+  });
+
   it("reverts when an unregistered address tries to vote", async function () {
     const [, , attacker] = await ethers.getSigners();
 


### PR DESCRIPTION
## Problem
DAO quadratic-voting releaseVotes over-refunds (squares the sum instead of per-call cost) — pool drain

See issue #13112 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 blockchain/contracts/DAO.sol                 | 18 ++++++++++++++++++
 blockchain/test/DAO.quadraticVoting.test.cjs | 27 +++++++++++++++++++++++++++
 2 files changed, 45 insertions(+)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13112
