### PR TITLE
GAT temporal flattening with a single shared edge_index isolates most nodes — silently wrong traffic forecasts

### DIFF
--- a/backend/ml/gat/model.py
+++ b/backend/ml/gat/model.py
@@ -105,18 +105,22 @@ class SpatialTemporalGAT(nn.Module):
     ) -> torch.Tensor:
         # x shape: (batch_size, num_nodes, time_steps, features)
         batch_size, num_nodes, time_steps, features = x.shape
-        
-        # Reshape for spatial processing
-        x = x.permute(0, 2, 1, 3).contiguous()  # (batch, time, nodes, features)
-        x = x.view(batch_size * time_steps, num_nodes, features)
-        
-        # Spatial GAT
-        for spatial_layer in self.spatial_layers:
-            x = spatial_layer(x, edge_index)
-            x = F.relu(x)
-        
-        # Reshape back
-        x = x.view(batch_size, time_steps, num_nodes, -1)
+
+        if features != self.in_features:
+            raise ValueError(
+                f"Expected feature dimension {self.in_features}, got {features}"
+            )
+
+        x = x.permute(0, 2, 1, 3).contiguous()
+
+        outs = []
+        for t in range(time_steps):
+            out = x[:, t]
+            for spatial_layer in self.spatial_layers:
+                out = spatial_layer(out, edge_index)
+                out = F.relu(out)
+            outs.append(out)
+        x = torch.stack(outs, dim=1)
         
         # Temporal attention
         x = x.permute(0, 2, 1, 3).contiguous()  # (batch, nodes, time, features)

--- a/backend/ml/tests/test_gat_temporal.py
+++ b/backend/ml/tests/test_gat_temporal.py
@@ -1,0 +1,41 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from gat.model import SpatialTemporalGAT
+
+
+def _edge_index():
+    return torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+
+
+def test_forward_output_shape():
+    model = SpatialTemporalGAT(in_features=2, prediction_horizon=3)
+    x = torch.zeros(2, 5, 4, 2)
+    out = model(x, _edge_index())
+    assert out.shape == (2, 5, 3)
+
+
+def test_feature_dimension_guard():
+    model = SpatialTemporalGAT(in_features=4)
+    x = torch.zeros(1, 2, 3, 1)
+    with pytest.raises(ValueError):
+        model(x, _edge_index())
+
+
+def test_source_node_aggregated_at_every_timestep():
+    model = SpatialTemporalGAT(
+        in_features=1, hidden_features=4, out_features=2,
+        num_layers=1, time_steps=3, prediction_horizon=1,
+    )
+    edge_index = _edge_index()
+
+    def predict(source_value_ts1):
+        x = torch.zeros(1, 2, 3, 1)
+        x[0, 0, 1, 0] = source_value_ts1
+        return model(x, edge_index)[0, 1, 0].item()
+
+    low = predict(0.0)
+    high = predict(5.0)
+    assert abs(high - low) > 1e-3


### PR DESCRIPTION
## Problem
GAT temporal flattening with a single shared edge_index isolates most nodes — silently wrong traffic forecasts

See issue #13116 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 backend/ml/gat/model.py               | 28 ++++++++++++++----------
 backend/ml/tests/test_gat_temporal.py | 41 +++++++++++++++++++++++++++++++++++
 2 files changed, 57 insertions(+), 12 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13116
