### PR TITLE
MAML inner-loop `param.data -=` detaches the graph — the meta-model never trains

### DIFF
--- a/backend/ml/meta/model.py
+++ b/backend/ml/meta/model.py
@@ -9,6 +9,34 @@ import copy
 
 logger = logging.getLogger(__name__)
 
+try:
+    from torch.func import functional_call as _functional_call
+except AttributeError:  # older torch
+    from torch.nn.utils.stateless import functional_call as _functional_call
+
+
+class _AdaptedModel:
+    """Thin wrapper holding graph-tracking adapted parameters.
+
+    Forwarding goes through ``functional_call`` so the computation graph
+    stays connected back to the original (meta) model parameters, allowing
+    second-order gradients to flow into ``self.model`` during meta-updates.
+    """
+
+    def __init__(self, base_model: nn.Module, params: Dict[str, torch.Tensor]):
+        self.base_model = base_model
+        self.params = params
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        return _functional_call(self.base_model, self.params, (x,))
+
+    def eval(self) -> "_AdaptedModel":
+        return self
+
+    def train(self, mode: bool = True) -> "_AdaptedModel":
+        return self
+
+
 class MAMLModel(nn.Module):
     """Model-Agnostic Meta-Learning (MAML)"""
     
@@ -82,23 +110,26 @@ class MAML:
         
         logger.info(f"✅ MAML initialized on {self.device}")
     
-    def inner_update(self, model: MAMLModel, support_x: torch.Tensor, support_y: torch.Tensor) -> MAMLModel:
-        """Perform inner loop update (task-specific adaptation)"""
-        # Clone model for inner update
-        adapted_model = model.clone()
-        
-        # Compute gradients on support set
-        pred = adapted_model(support_x)
+    def inner_update(self, model: MAMLModel, support_x: torch.Tensor, support_y: torch.Tensor) -> _AdaptedModel:
+        """Perform inner loop update (task-specific adaptation).
+
+        Uses differentiable (graph-preserving) parameter updates so that the
+        query loss computed through the adapted parameters back-propagates
+        through the inner step into ``self.model`` parameters.
+        """
+        adapted = {name: p.clone() for name, p in model.named_parameters()}
+
+        pred = _functional_call(model, adapted, (support_x,))
         loss = self.criterion(pred, support_y)
-        
-        # Compute gradients
-        grads = torch.autograd.grad(loss, adapted_model.parameters(), create_graph=True)
-        
-        # Update parameters
-        for param, grad in zip(adapted_model.parameters(), grads):
-            param.data -= self.inner_lr * grad
-        
-        return adapted_model
+
+        grads = torch.autograd.grad(loss, list(adapted.values()), create_graph=True)
+
+        adapted = {
+            name: param - self.inner_lr * grad
+            for (name, param), grad in zip(adapted.items(), grads)
+        }
+
+        return _AdaptedModel(model, adapted)
     
     def outer_update(self, meta_loss: torch.Tensor):
         """Perform outer loop update (meta-optimization)"""
@@ -118,8 +149,8 @@ class MAML:
         for support_x, support_y, query_x, query_y in tasks:
             # Inner adaptation on support set
             adapted_model = self.inner_update(self.model, support_x, support_y)
-            
-            # Compute loss on query set
+
+            # Compute loss on query set (graph flows back into self.model)
             pred = adapted_model(query_x)
             task_loss = self.criterion(pred, query_y)
             meta_loss += task_loss
@@ -158,20 +189,22 @@ class MAML:
             'final_loss': losses[-1]
         }
     
-    def adapt(self, support_x: torch.Tensor, support_y: torch.Tensor, steps: int = 5) -> MAMLModel:
-        """Adapt model to new task"""
-        adapted_model = self.model.clone()
-        
+    def adapt(self, support_x: torch.Tensor, support_y: torch.Tensor, steps: int = 5) -> _AdaptedModel:
+        """Adapt model to new task using graph-preserving inner updates."""
+        adapted = {name: p.clone() for name, p in self.model.named_parameters()}
+
         for _ in range(steps):
-            pred = adapted_model(support_x)
+            pred = _functional_call(self.model, adapted, (support_x,))
             loss = self.criterion(pred, support_y)
-            
-            grads = torch.autograd.grad(loss, adapted_model.parameters(), create_graph=True)
-            
-            for param, grad in zip(adapted_model.parameters(), grads):
-                param.data -= self.inner_lr * grad
-        
-        return adapted_model
+
+            grads = torch.autograd.grad(loss, list(adapted.values()), create_graph=True)
+
+            adapted = {
+                name: param - self.inner_lr * grad
+                for (name, param), grad in zip(adapted.items(), grads)
+            }
+
+        return _AdaptedModel(self.model, adapted)
     
     def predict(self, model: MAMLModel, x: torch.Tensor) -> torch.Tensor:
         """Make prediction with adapted model"""

--- a/backend/ml/tests/test_meta.py
+++ b/backend/ml/tests/test_meta.py
@@ -1,9 +1,47 @@
 import pytest
 import torch
-from meta.model import MAMLModel
+from meta.model import MAML, MAMLModel
+
+
+def _make_task(input_dim=8):
+    w = torch.randn(input_dim, 1)
+    b = torch.randn(1)
+    support_x = torch.randn(5, input_dim)
+    support_y = support_x @ w + b
+    query_x = torch.randn(5, input_dim)
+    query_y = query_x @ w + b
+    return support_x, support_y, query_x, query_y
+
 
 class TestMetaModel:
     def test_maml_init(self):
         model = MAMLModel(input_dim=10, output_dim=1)
         assert model is not None
         assert hasattr(model, 'adapt')
+
+    def test_meta_train_step_backprops_to_meta_params(self):
+        """Regression test for #13118: the inner-loop update must not detach
+        the graph; meta-model parameters must receive a non-None gradient."""
+        torch.manual_seed(0)
+        model = MAMLModel(input_dim=8, hidden_dim=16, output_dim=1, num_layers=2)
+        maml = MAML(model, inner_lr=0.1, outer_lr=0.1)
+
+        tasks = [_make_task(8) for _ in range(4)]
+        maml.meta_train_step(tasks)
+
+        grads = [p.grad for p in maml.model.parameters()]
+        assert all(g is not None for g in grads), "meta params received no gradient (graph detached)"
+        assert all(g.abs().sum() > 0 for g in grads), "meta gradients are all zero"
+
+    def test_meta_loss_decreases(self):
+        """Regression test for #13118: with a working meta-gradient the
+        meta-loss should decrease across training steps."""
+        torch.manual_seed(0)
+        model = MAMLModel(input_dim=8, hidden_dim=16, output_dim=1, num_layers=2)
+        maml = MAML(model, inner_lr=0.1, outer_lr=0.1)
+
+        losses = []
+        for _ in range(5):
+            losses.append(maml.meta_train_step([_make_task(8) for _ in range(4)]))
+
+        assert losses[-1] < losses[0], "meta-loss did not decrease (model not training)"


### PR DESCRIPTION
## Problem
MAML inner-loop `param.data -=` detaches the graph — the meta-model never trains

See issue #13118 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 backend/ml/meta/model.py      | 93 +++++++++++++++++++++++++++++--------------
 backend/ml/tests/test_meta.py | 40 ++++++++++++++++++-
 2 files changed, 102 insertions(+), 31 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13118
