### PR TITLE
[MEDIUM] Blockchain: per-customer commitment nonce race bricks concurrent deposits

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -49,7 +49,7 @@ import { supabaseAdmin } from '../config/db.js'
 const ESCROW_ABI = [
   'function createBooking(uint256 bookingId, address payable driver, bytes signature) external payable',
   'function lockPayment(uint256 bookingId, address payable customer, address payable driver) external payable',
-  'function commitmentNonces(address customer) external view returns (uint256)',
+  'function commitmentNonces(address customer, uint256 bookingId) external view returns (uint256)',
   'function releasePayment(uint256 bookingId) external',
   'function cancelBooking(uint256 bookingId) external',
   'function cancelWithPenalty(uint256 bookingId, uint256 driverFee) external',
@@ -399,7 +399,7 @@ export async function buildDepositTx (orderDisplayId, customerWalletAddress, dri
     // rejects createBooking, so a third party cannot front-run the slot
     // (issue #7734).
     const network = await escrowContract.runner.provider.getNetwork()
-    const nonce = await escrowContract.commitmentNonces(customerWalletAddress)
+    const nonce = await escrowContract.commitmentNonces(customerWalletAddress, bookingId)
     const commitment = ethers.solidityPackedKeccak256(
       ['uint256', 'address', 'address', 'uint256', 'address', 'uint256', 'uint256'],
       [network.chainId, contractAddress, customerWalletAddress, bookingId, driverWalletAddress, amountWei, nonce]

--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -50,11 +50,15 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     mapping(address => uint256) public pendingWithdrawals;
     mapping(address => uint256) public releaseTimestamps;
 
-    // Backend-issued commitment nonce per customer wallet. A valid createBooking
-    // requires an owner-signed EIP-191 commitment over (chain, this, customer,
-    // bookingId, nonce). The nonce is burned on success so a commitment cannot
-    // be replayed by anyone who observes a submitted deposit transaction.
-    mapping(address => uint256) public commitmentNonces;
+    // Backend-issued commitment nonce, tracked PER (customer, bookingId). A
+    // valid createBooking requires an owner-signed EIP-191 commitment over
+    // (chain, this, customer, bookingId, driver, amount, nonce). Tracking the
+    // nonce per bookingId means a customer funding several distinct bookings in
+    // quick succession each carries a distinct, currently-valid nonce — reading
+    // the nonce once no longer bricks concurrent deposits (issue #13119). The
+    // nonce is burned on success so a commitment cannot be replayed after a slot
+    // is reused (e.g. cancel + recreate the same bookingId).
+    mapping(address => mapping(uint256 => uint256)) public commitmentNonces;
     uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
     uint256 public constant DISPUTE_TIMEOUT = 7 days;
     address public trustedRelayer;
@@ -143,7 +147,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
     /**
      * @dev Verify the owner's EIP-191 signature over the create commitment:
      *      keccak256(chainId, this, customer, bookingId, driver, amount,
-     *      commitmentNonces[customer]). Pinning driver and amount prevents a
+     *      commitmentNonces[customer][bookingId]). Pinning driver and amount
      *      customer from reusing a valid commitment to create a booking whose
      *      driver/amount diverge from what the backend authorised (issue #11393).
      *      Only the contract owner (the backend relayer) can authorise a slot.
@@ -165,7 +169,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
                 bookingId,
                 driver,
                 amount,
-                commitmentNonces[customer]
+                commitmentNonces[customer][bookingId]
             )
         );
         bytes32 signedHash = keccak256(
@@ -225,7 +229,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         );
 
         // Burn the nonce so the same commitment can never be replayed.
-        commitmentNonces[msg.sender]++;
+        commitmentNonces[msg.sender][bookingId]++;
 
         bookings[bookingId] = Booking({
             customer:  payable(msg.sender),

--- a/blockchain/contracts/TruxifyEscrow.test.js
+++ b/blockchain/contracts/TruxifyEscrow.test.js
@@ -9,14 +9,15 @@ const STATUS = { Active: 0, Delivered: 1, Cancelled: 2, Disputed: 3, Resolved: 4
 
 /**
  * Mint the same EIP-191 commitment the contract verifies:
- *   keccak256(chainId, this, customer, bookingId, commitmentNonces[customer])
+ *   keccak256(chainId, this, customer, bookingId, driver, amount,
+ *   commitmentNonces[customer][bookingId])
  */
-async function signCommitment(signer, escrow, customer, bookingId) {
+async function signCommitment(signer, escrow, customer, bookingId, driver, amount) {
   const { chainId } = await ethers.provider.getNetwork();
-  const nonce = await escrow.commitmentNonces(customer);
+  const nonce = await escrow.commitmentNonces(customer, bookingId);
   const commitment = ethers.solidityPackedKeccak256(
-    ["uint256", "address", "address", "uint256", "uint256"],
-    [chainId, escrow.target, customer, bookingId, nonce]
+    ["uint256", "address", "address", "uint256", "address", "uint256", "uint256"],
+    [chainId, escrow.target, customer, bookingId, driver, amount, nonce]
   );
   return signer.signMessage(ethers.getBytes(commitment));
 }
@@ -34,7 +35,7 @@ describe("TruxifyEscrow", function () {
   describe("createBooking — owner-signed commitment (issue #7734)", function () {
     it("creates a booking with a valid owner-signed commitment", async function () {
       const bookingId = 1;
-      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId, driver.address, AMOUNT);
 
       await expect(
         escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
@@ -52,7 +53,7 @@ describe("TruxifyEscrow", function () {
 
     it("reverts when the commitment is forged by a non-owner (front-running blocked)", async function () {
       const bookingId = 1;
-      const forged = await signCommitment(attacker, escrow, customer.address, bookingId);
+      const forged = await signCommitment(attacker, escrow, customer.address, bookingId, driver.address, AMOUNT);
 
       await expect(
         escrow.connect(customer).createBooking(bookingId, driver.address, forged, { value: AMOUNT })
@@ -69,7 +70,7 @@ describe("TruxifyEscrow", function () {
 
     it("reverts when the commitment covers a different bookingId", async function () {
       const bookingId = 1;
-      const sig = await signCommitment(owner, escrow, customer.address, 99);
+      const sig = await signCommitment(owner, escrow, customer.address, 99, driver.address, AMOUNT);
 
       await expect(
         escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
@@ -78,7 +79,7 @@ describe("TruxifyEscrow", function () {
 
     it("reverts when the commitment covers a different customer wallet", async function () {
       const bookingId = 1;
-      const sig = await signCommitment(owner, escrow, otherCustomer.address, bookingId);
+      const sig = await signCommitment(owner, escrow, otherCustomer.address, bookingId, driver.address, AMOUNT);
 
       await expect(
         escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT })
@@ -87,7 +88,7 @@ describe("TruxifyEscrow", function () {
 
     it("burns the nonce — a replayed commitment reverts", async function () {
       const bookingId = 1;
-      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId, driver.address, AMOUNT);
       await escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
 
       await expect(
@@ -97,7 +98,7 @@ describe("TruxifyEscrow", function () {
 
     it("records msg.sender as the customer so the wallet funds the escrow", async function () {
       const bookingId = 1;
-      const sig = await signCommitment(owner, escrow, customer.address, bookingId);
+      const sig = await signCommitment(owner, escrow, customer.address, bookingId, driver.address, AMOUNT);
       await escrow.connect(customer).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
 
       const booking = await escrow.bookings(bookingId);
@@ -108,13 +109,13 @@ describe("TruxifyEscrow", function () {
 
   describe("slot reuse after settlement (issue #7734)", function () {
     async function createBooking(bookingId, who = customer) {
-      const sig = await signCommitment(owner, escrow, who.address, bookingId);
+      const sig = await signCommitment(owner, escrow, who.address, bookingId, driver.address, AMOUNT);
       await escrow.connect(who).createBooking(bookingId, driver.address, sig, { value: AMOUNT });
     }
 
     it("cannot re-create the slot while the original booking is active", async function () {
       await createBooking(1);
-      const sig = await signCommitment(owner, escrow, customer.address, 1);
+      const sig = await signCommitment(owner, escrow, customer.address, 1, driver.address, AMOUNT);
 
       await expect(
         escrow.connect(customer).createBooking(1, driver.address, sig, { value: AMOUNT })
@@ -164,10 +165,34 @@ describe("TruxifyEscrow", function () {
       await escrow.connect(owner).releasePayment(1);
       expect((await escrow.bookings(1)).status).to.equal(STATUS.Delivered);
 
-      const sig = await signCommitment(owner, escrow, customer.address, 1);
+      const sig = await signCommitment(owner, escrow, customer.address, 1, driver.address, AMOUNT);
       await expect(
         escrow.connect(customer).createBooking(1, driver.address, sig, { value: AMOUNT })
       ).to.be.revertedWith("TruxifyEscrow: Booking already exists");
+    });
+  });
+
+  describe("concurrent deposits do not collide on a shared nonce (issue #13119)", function () {
+    it("funds two distinct bookings built back-to-back with distinct valid nonces", async function () {
+      // Simulate two orders accepted in quick succession: the backend reads the
+      // per-(customer, bookingId) nonce for each booking independently, so both
+      // deposits embed a currently-valid nonce even though neither has mined yet.
+      const bookingIdA = 1;
+      const bookingIdB = 2;
+      const sigA = await signCommitment(owner, escrow, customer.address, bookingIdA, driver.address, AMOUNT);
+      const sigB = await signCommitment(owner, escrow, customer.address, bookingIdB, driver.address, AMOUNT);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingIdA, driver.address, sigA, { value: AMOUNT })
+      ).to.emit(escrow, "BookingCreated").withArgs(bookingIdA, customer.address, driver.address, AMOUNT);
+
+      await expect(
+        escrow.connect(customer).createBooking(bookingIdB, driver.address, sigB, { value: AMOUNT })
+      ).to.emit(escrow, "BookingCreated").withArgs(bookingIdB, customer.address, driver.address, AMOUNT);
+
+      // Each booking burned its own per-bookingId nonce.
+      expect(await escrow.commitmentNonces(customer.address, bookingIdA)).to.equal(1n);
+      expect(await escrow.commitmentNonces(customer.address, bookingIdB)).to.equal(1n);
     });
   });
 });

--- a/scripts/check-escrow-abi.sh
+++ b/scripts/check-escrow-abi.sh
@@ -34,7 +34,7 @@ echo "🔍 Checking escrow ABI compatibility..."
 declare -A EXPECTED_SELECTORS
 EXPECTED_SELECTORS["createBooking(uint256,address,bytes)"]="0bb7aa51"
 EXPECTED_SELECTORS["lockPayment(uint256,address,address)"]="044e8539"
-EXPECTED_SELECTORS["commitmentNonces(address)"]="09135335"
+EXPECTED_SELECTORS["commitmentNonces(address,uint256)"]="699ef9bb"
 EXPECTED_SELECTORS["releasePayment(uint256)"]="88685cd9"
 EXPECTED_SELECTORS["cancelBooking(uint256)"]="0dca825e"
 EXPECTED_SELECTORS["cancelWithPenalty(uint256,uint256)"]="ca9a63b1"


### PR DESCRIPTION
## Problem
[MEDIUM] Blockchain: per-customer commitment nonce race bricks concurrent deposits

See issue #13119 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 backend/api/src/services/escrow.js         |  4 +--
 blockchain/contracts/TruxifyEscrow.sol     | 20 ++++++-----
 blockchain/contracts/TruxifyEscrow.test.js | 53 ++++++++++++++++++++++--------
 scripts/check-escrow-abi.sh                |  2 +-
 4 files changed, 54 insertions(+), 25 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13119
