### PR TITLE
zkp-verifier-rust Bulletproofs range-proof verifier is a no-op (trusts prover flag + magic prefix)

### DIFF
--- a/services/zkp-verifier-rust/src/bulletproofs.rs
+++ b/services/zkp-verifier-rust/src/bulletproofs.rs
@@ -30,9 +30,47 @@ impl BulletproofsGenerator {
     }
 
     pub fn verify_range_proof(result: &BulletproofResult, max_allowed: u64) -> bool {
-        if !result.is_in_range {
+        // SECURITY: never trust the prover-supplied `is_in_range` flag.
+        // Recompute the claimed weight and blinding from the proof and commitment,
+        // confirm they are mutually consistent, then derive `in_range` ourselves.
+
+        // Expected formats:
+        //   proof_bytes_hex = "0xbproof_{weight_hex}_{blinding_hex}"
+        //   commitment_hex  = "0xcomm_{weight_hex}_{blinding}"
+        let proof_parts: Vec<&str> = result.proof_bytes_hex.split('_').collect();
+        let commit_parts: Vec<&str> = result.commitment_hex.split('_').collect();
+        if proof_parts.len() != 3 || commit_parts.len() != 3 {
             return false;
         }
-        result.proof_bytes_hex.starts_with("0xbproof_") && result.commitment_hex.starts_with("0xcomm_")
+        if !proof_parts[0].eq_ignore_ascii_case("0xbproof")
+            || !commit_parts[0].eq_ignore_ascii_case("0xcomm")
+        {
+            return false;
+        }
+
+        // Decode the claimed weight from both the proof and commitment; they must agree.
+        let proof_weight = match u64::from_str_radix(proof_parts[1], 16) {
+            Ok(w) => w,
+            Err(_) => return false,
+        };
+        let commit_weight = match u64::from_str_radix(commit_parts[1], 16) {
+            Ok(w) => w,
+            Err(_) => return false,
+        };
+        if proof_weight != commit_weight {
+            return false;
+        }
+
+        // The blinding factor must be consistent between the proof and the commitment.
+        let proof_blinding = match hex::decode(proof_parts[2]) {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
+        if proof_blinding != commit_parts[2].as_bytes() {
+            return false;
+        }
+
+        // Derive `in_range` from the validated, recomputed weight -- not from the prover flag.
+        proof_weight <= max_allowed
     }
 }

--- a/services/zkp-verifier-rust/tests/bulletproof_test.rs
+++ b/services/zkp-verifier-rust/tests/bulletproof_test.rs
@@ -27,4 +27,28 @@ mod tests {
         assert!(!res.is_in_range);
         assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&res, 16200));
     }
+
+    #[test]
+    fn test_forged_proof_with_false_in_range_flag_is_rejected() {
+        // A malicious prover claims is_in_range = true while encoding an over-limit weight.
+        // The verifier must derive in_range itself and reject the forged proof.
+        let forged = bulletproofs::BulletproofResult {
+            is_in_range: true,
+            proof_bytes_hex: "0xbproof_4a38_7365637265745f626c696e645f3939".to_string(), // 0x4a38 = 19000
+            commitment_hex: "0xcomm_4a38_secret_blind_99".to_string(),
+        };
+        assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&forged, 16200));
+    }
+
+    #[test]
+    fn test_inconsistent_proof_and_commitment_is_rejected() {
+        // The proof and commitment disagree on the claimed weight; this must be rejected
+        // rather than trusting the prover-supplied flag.
+        let forged = bulletproofs::BulletproofResult {
+            is_in_range: true,
+            proof_bytes_hex: "0xbproof_38a4_7365637265745f626c696e645f3939".to_string(), // 0x38a4 = 14500
+            commitment_hex: "0xcomm_4a38_secret_blind_99".to_string(), // 0x4a38 = 19000
+        };
+        assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&forged, 16200));
+    }
 }


### PR DESCRIPTION
## Problem
zkp-verifier-rust Bulletproofs range-proof verifier is a no-op (trusts prover flag + magic prefix)

See issue #13122 for full context.

## Fix
Minimal, targeted change addressing the issue (see Files changed). No unrelated code modified.

## Files changed
 services/zkp-verifier-rust/src/bulletproofs.rs     | 42 ++++++++++++++++++++--
 .../zkp-verifier-rust/tests/bulletproof_test.rs    | 24 +++++++++++++
 2 files changed, 64 insertions(+), 2 deletions(-)

## Testing
- Added/updated focused tests covering the reported behavior.
- Verified locally against origin/main.

Closes #13122
