### PR TITLE
fix: add clarifying comment for CircuitBreaker timer declaration

### DIFF
--- a/backend/api/src/lib/circuitBreaker.js
+++ b/backend/api/src/lib/circuitBreaker.js
@@ -58,6 +58,7 @@ export class CircuitBreaker {
     this.reset();
   }
 
+  // Timer is declared at function scope so the finally block can safely clear it even if fn() throws synchronously.
   async execute(fn, ...args) {
     if (typeof fn !== 'function') {
       throw new TypeError('circuitBreaker execute: fn must be a function');


### PR DESCRIPTION
## Summary
Adds a clarifying comment documenting that the timer variable is declared at function scope so the finally block can safely clear it even if fn() throws synchronously.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13853.
