### PR TITLE
fix: add Number.isFinite guard for coordinates in trafficService

### DIFF
--- a/backend/api/src/services/trafficService.js
+++ b/backend/api/src/services/trafficService.js
@@ -23,6 +23,9 @@ export async function getLiveTrafficMultiplier(pickupLat, pickupLng) {
     if (pickupLat == null || pickupLng == null) {
       return 1.0;
     }
+    if (!Number.isFinite(pickupLat) || !Number.isFinite(pickupLng)) {
+      return 1.0;
+    }
 
     const apiKey = process.env.TOMTOM_API_KEY || process.env.GOOGLE_MAPS_API_KEY;
 


### PR DESCRIPTION
## Summary
Adds a Number.isFinite guard for pickupLat and pickupLng in trafficService.getLiveTrafficMultiplier, complementing the existing null check. This prevents NaN values from being passed to external API calls.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13863.
