### PR TITLE
test: add unit tests for parsePositiveFloat function in pricing

### DIFF
--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -250,4 +250,26 @@ describe('guardNonNegative', () => {
   it('clamps negative', () => { expect(guardNonNegative(-5, 'x')).toBe(0); });
   it('rejects NaN', () => { expect(() => guardNonNegative(NaN, 'x')).toThrow(TypeError); });
 });
+describe('parsePositiveFloat (from __testing)', () => {
+  it('returns parsed value for valid positive numbers', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(5, 1)).toBe(5);
+    expect(__testing.parsePositiveFloat('10.5', 1)).toBe(10.5);
+  });
+
+  it('returns fallback for zero', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(0, 1)).toBe(1);
+  });
+
+  it('returns fallback for negative numbers', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(-5, 1)).toBe(1);
+  });
+
+  it('returns fallback for NaN', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(NaN, 1)).toBe(1);
+  });
+});
 


### PR DESCRIPTION
## Summary
Expands pricing.test.js to cover parsePositiveFloat for valid positive numbers, zero (falls back), negative numbers (falls back), and NaN inputs (falls back).

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13861.
