### PR TITLE
fix: add clarifying comment that requireApiKey does not accept query string API keys

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -8,6 +8,9 @@ import * as Sentry from '@sentry/node';
  * variable (comma-separated) to allow for zero-downtime key rotation.
  */
 export const requireApiKey = (req, res, next) => {
+  // Note: Query string API keys (?api_key=...) are intentionally not accepted.
+  // Passing credentials in URLs exposes them in logs, browser history, and proxies.
+  // Only x-api-key header is supported.
   // Only the x-api-key header authenticates. Accepting api_key from the query
   // string leaks the shared credential into access logs, CDN/proxy logs,
   // browser history and Referer headers, so it is intentionally ignored.


### PR DESCRIPTION
## Summary
Adds a comment documenting that requireApiKey intentionally does not accept query string API keys (?api_key=...) because passing credentials in URLs exposes them in logs, browser history, and proxies.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13864.
