### PR TITLE
fix: add null guard clarifying comment in redisRateLimiter

### DIFF
--- a/backend/api/src/middleware/redisRateLimiter.js
+++ b/backend/api/src/middleware/redisRateLimiter.js
@@ -61,7 +61,9 @@ export function redisRateLimiter({ routeKey, limit, windowMs, failClosed = false
       // resolve to null when Redis is unreachable — treat that like a failed
       // ZCARD so the limiter fails open (or closed, per failClosed) instead
       // of crashing on a null dereference.
-      const zcardTuple = results ? results[1] : null;
+      // Guard: pipeline.exec() returns null when Redis is unreachable.
+  // Treat null as a failed request rather than crashing on a null dereference.
+  const zcardTuple = results ? results[1] : null;
       if (!zcardTuple || zcardTuple[0]) {
         if (failClosed) {
           logger.error({ routeKey, err: zcardTuple?.[0] }, '[RateLimiter] ZCARD failed — failing closed');


### PR DESCRIPTION
## Summary
Adds a clarifying comment documenting that pipeline.exec() can return null when Redis is unreachable, and the code correctly handles this by treating null as a failed request.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13866.
