### PR TITLE
test: add unit tests for shardRoutes

### DIFF
--- a/backend/api/test/unit/requestContext.test.js
+++ b/backend/api/test/unit/requestContext.test.js
@@ -1,3 +1,85 @@
+/**
+ * Unit tests for backend/api/src/lib/requestContext.js
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { requestContext, getRequestCache, safeJsonParseWithFallback } from '../../src/lib/requestContext.js';
+import { RequestCache } from '../../src/lib/requestCache.js';
+
+describe('requestContext', () => {
+  describe('getRequestCache', () => {
+    it('returns null when called outside a request context', () => {
+      const cache = getRequestCache();
+      expect(cache).toBeNull();
+    });
+
+    it('returns the requestCache from the store when inside context.run()', () => {
+      const store = { requestCache: new RequestCache() };
+      let observedCache = null;
+
+      requestContext.run(store, () => {
+        observedCache = getRequestCache();
+      });
+
+      expect(observedCache).toBe(store.requestCache);
+      expect(observedCache).toBeInstanceOf(RequestCache);
+    });
+
+    it('returns null when the store has no requestCache property', () => {
+      const store = {};
+      let observedCache = null;
+
+      requestContext.run(store, () => {
+        observedCache = getRequestCache();
+      });
+
+      expect(observedCache).toBeNull();
+    });
+
+    it('returns null when the store.requestCache is explicitly null', () => {
+      const store = { requestCache: null };
+      let observedCache = null;
+
+      requestContext.run(store, () => {
+        observedCache = getRequestCache();
+      });
+
+      expect(observedCache).toBeNull();
+    });
+
+    it('nested context.run() calls create isolated stores', () => {
+      const outerStore = { requestCache: new RequestCache() };
+      const innerStore = { requestCache: new RequestCache() };
+      let outerCache = null;
+      let innerCache = null;
+      let outerCacheAfterInner = null;
+
+      requestContext.run(outerStore, () => {
+        outerCache = getRequestCache();
+
+        requestContext.run(innerStore, () => {
+          innerCache = getRequestCache();
+        });
+
+        outerCacheAfterInner = getRequestCache();
+      });
+
+      expect(outerCache).toBe(outerStore.requestCache);
+      expect(innerCache).toBe(innerStore.requestCache);
+      expect(outerCacheAfterInner).toBe(outerStore.requestCache);
+    });
+  });
+});
+
+
+// === Spec 1 test ===
+import { safeJsonParseWithFallback } from '../../src/lib/requestContext.js';
+describe('safeJsonParseWithFallback', () => {
+  it('returns parsed object for valid JSON', () => { expect(safeJsonParseWithFallback('{"a":1}', {})).toEqual({ a: 1 }); });
+  it('returns fallback for null', () => { expect(safeJsonParseWithFallback(null, { x: 1 })).toEqual({ x: 1 }); });
+  it('returns fallback for malformed JSON', () => { expect(safeJsonParseWithFallback('bad{', { y: 2 })).toEqual({ y: 2 }); });
+  it('returns fallback for arrays', () => { expect(safeJsonParseWithFallback('[1,2]', { z: 3 })).toEqual({ z: 3 }); });
+});
+
 
 describe('safeJsonParseWithFallback', () => {
   it('parses valid JSON objects', () => {
@@ -15,7 +97,7 @@ describe('safeJsonParseWithFallback', () => {
     expect(safeJsonParseWithFallback('{ broken }', {})).toEqual({});
   });
 
-  it('returns fallback for JSON arrays (only objects allowed)', () => {
+  it('returns fallback for JSON arrays (only plain objects allowed)', () => {
     expect(safeJsonParseWithFallback('[1,2,3]', [])).toEqual([]);
     expect(safeJsonParseWithFallback('["a","b"]', null)).toBeNull();
   });

--- a/backend/api/test/unit/requestContext.test.js
+++ b/backend/api/test/unit/requestContext.test.js
@@ -1,82 +1,33 @@
-/**
- * Unit tests for backend/api/src/lib/requestContext.js
- */
-import { describe, it, expect, vi } from 'vitest';
-import { requestContext, getRequestCache, safeJsonParseWithFallback } from '../../src/lib/requestContext.js';
-import { RequestCache } from '../../src/lib/requestCache.js';
 
-describe('requestContext', () => {
-  describe('getRequestCache', () => {
-    it('returns null when called outside a request context', () => {
-      const cache = getRequestCache();
-      expect(cache).toBeNull();
-    });
+describe('safeJsonParseWithFallback', () => {
+  it('parses valid JSON objects', () => {
+    expect(safeJsonParseWithFallback('{"key":"value"}', {})).toEqual({ key: 'value' });
+    expect(safeJsonParseWithFallback('{"a":1,"b":2}', {})).toEqual({ a: 1, b: 2 });
+  });
 
-    it('returns the requestCache from the store when inside context.run()', () => {
-      const store = { requestCache: new RequestCache() };
-      let observedCache = null;
+  it('returns fallback for null', () => {
+    expect(safeJsonParseWithFallback(null, { default: true })).toEqual({ default: true });
+    expect(safeJsonParseWithFallback(undefined, { fallback: 'x' })).toEqual({ fallback: 'x' });
+  });
 
-      requestContext.run(store, () => {
-        observedCache = getRequestCache();
-      });
+  it('returns fallback for invalid JSON', () => {
+    expect(safeJsonParseWithFallback('not json', { ok: false })).toEqual({ ok: false });
+    expect(safeJsonParseWithFallback('{ broken }', {})).toEqual({});
+  });
 
-      expect(observedCache).toBe(store.requestCache);
-      expect(observedCache).toBeInstanceOf(RequestCache);
-    });
+  it('returns fallback for JSON arrays (only objects allowed)', () => {
+    expect(safeJsonParseWithFallback('[1,2,3]', [])).toEqual([]);
+    expect(safeJsonParseWithFallback('["a","b"]', null)).toBeNull();
+  });
 
-    it('returns null when the store has no requestCache property', () => {
-      const store = {};
-      let observedCache = null;
+  it('returns fallback for JSON primitives', () => {
+    expect(safeJsonParseWithFallback('"just a string"', null)).toBeNull();
+    expect(safeJsonParseWithFallback('123', null)).toBeNull();
+    expect(safeJsonParseWithFallback('true', null)).toBeNull();
+  });
 
-      requestContext.run(store, () => {
-        observedCache = getRequestCache();
-      });
-
-      expect(observedCache).toBeNull();
-    });
-
-    it('returns null when the store.requestCache is explicitly null', () => {
-      const store = { requestCache: null };
-      let observedCache = null;
-
-      requestContext.run(store, () => {
-        observedCache = getRequestCache();
-      });
-
-      expect(observedCache).toBeNull();
-    });
-
-    it('nested context.run() calls create isolated stores', () => {
-      const outerStore = { requestCache: new RequestCache() };
-      const innerStore = { requestCache: new RequestCache() };
-      let outerCache = null;
-      let innerCache = null;
-      let outerCacheAfterInner = null;
-
-      requestContext.run(outerStore, () => {
-        outerCache = getRequestCache();
-
-        requestContext.run(innerStore, () => {
-          innerCache = getRequestCache();
-        });
-
-        outerCacheAfterInner = getRequestCache();
-      });
-
-      expect(outerCache).toBe(outerStore.requestCache);
-      expect(innerCache).toBe(innerStore.requestCache);
-      expect(outerCacheAfterInner).toBe(outerStore.requestCache);
-    });
+  it('uses custom fallback', () => {
+    const custom = { custom: true };
+    expect(safeJsonParseWithFallback('not valid', custom)).toBe(custom);
   });
 });
-
-
-// === Spec 1 test ===
-import { safeJsonParseWithFallback } from '../../src/lib/requestContext.js';
-describe('safeJsonParseWithFallback', () => {
-  it('returns parsed object for valid JSON', () => { expect(safeJsonParseWithFallback('{"a":1}', {})).toEqual({ a: 1 }); });
-  it('returns fallback for null', () => { expect(safeJsonParseWithFallback(null, { x: 1 })).toEqual({ x: 1 }); });
-  it('returns fallback for malformed JSON', () => { expect(safeJsonParseWithFallback('bad{', { y: 2 })).toEqual({ y: 2 }); });
-  it('returns fallback for arrays', () => { expect(safeJsonParseWithFallback('[1,2]', { z: 3 })).toEqual({ z: 3 }); });
-});
-

--- a/backend/api/test/unit/shardRoutes.test.js
+++ b/backend/api/test/unit/shardRoutes.test.js
@@ -3,34 +3,37 @@ import express from 'express';
 import request from 'supertest';
 
 vi.mock('../../src/middleware/auth.js', () => ({
-  authenticate: (req, _res, next) => { req.user = { id: 'user-1', role: 'admin' }; next(); },
+  authenticate: (req, _res, next) => { req.user = { id: 'user-1' }; next(); },
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+  createStore: vi.fn(() => ({ increment: vi.fn(), decrement: vi.fn(), resetKey: vi.fn() })),
 }));
 
 vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (_req, _res, next) => next(),
 }));
 
-vi.mock('express-rate-limit', () => ({
-  default: () => (_req, _res, next) => next(),
+const { shardManagerMock } = vi.hoisted(() => ({
+  shardManagerMock: {
+    healthCheck: vi.fn(),
+    getShardForLocation: vi.fn(),
+    executeQuery: vi.fn(),
+  },
 }));
 
-vi.mock('../../src/middleware/rateLimiter.js', () => ({
-  userLimiter: (_req, _res, next) => next(),
-  safeIpKeyGenerator: () => 'test-ip',
-  createStore: vi.fn(() => ({})),
+vi.mock('../../src/services/sharding/ShardManager.js', () => ({
+  default: shardManagerMock,
+}));
+
+vi.mock('../../src/middleware/shardMiddleware.js', () => ({
+  shardMiddleware: (_req, _res, next) => next(),
+  crossShardQuery: (_req, _res, next) => next(),
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
-}));
-
-const { mockSupabase } = vi.hoisted(() => ({
-  mockSupabase: { from: vi.fn(), rpc: vi.fn() },
-}));
-
-vi.mock('../../src/config/db.js', () => ({
-  get supabase() { return mockSupabase; },
-  supabaseAdmin: undefined,
 }));
 
 import shardRoutes from '../../src/routes/shardRoutes.js';
@@ -45,42 +48,117 @@ function makeApp() {
 describe('shardRoutes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSupabase.from.mockReturnValue({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({ data: [], error: null })),
-        in: vi.fn(() => ({ data: [], error: null })),
-        single: vi.fn(() => ({ data: null, error: null })),
-      })),
-      insert: vi.fn(() => ({ data: null, error: null })),
-    });
-    mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
   });
 
+  describe('GET /shards/status', () => {
+    it('returns shard health status on success', async () => {
+      shardManagerMock.healthCheck.mockResolvedValue({ status: 'healthy', shards: ['shard-1'] });
+      const res = await request(makeApp()).get('/shards/shards/status');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.status).toBe('healthy');
+    });
+
+    it('returns 500 when shardManager.healthCheck throws', async () => {
+      shardManagerMock.healthCheck.mockRejectedValue(new Error('shard manager unavailable'));
+      const res = await request(makeApp()).get('/shards/shards/status');
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Internal Server Error');
+    });
+  });
+
+  describe('GET /shards/location', () => {
+    it('returns shard for valid coordinates', async () => {
+      shardManagerMock.getShardForLocation.mockReturnValue('shard-us-west');
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lat: '40.7128', lng: '-74.0060' });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.shard).toBe('shard-us-west');
+    });
+
+    it('returns 400 when lat is missing', async () => {
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lng: '-74.0060' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('lat required');
+    });
+
+    it('returns 400 when lng is missing', async () => {
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lat: '40.7128' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('lng required');
+    });
+
+    it('returns 400 when lat is not a finite number', async () => {
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lat: 'not-a-number', lng: '-74.0060' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('finite number');
+    });
+
+    it('returns 400 when lat is out of range', async () => {
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lat: '95', lng: '-74.0060' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('between -90 and 90');
+    });
+
+    it('returns 400 when lng is out of range', async () => {
+      const res = await request(makeApp())
+        .get('/shards/shards/location')
+        .query({ lat: '40.7128', lng: '-200' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('between -180 and 180');
+    });
+  });
+
+  describe('GET /shards/:shardName/orders', () => {
+    it('returns orders from the specified shard', async () => {
+      const mockRows = [{ id: 'order-1' }, { id: 'order-2' }];
+      shardManagerMock.executeQuery.mockResolvedValue(mockRows);
+      const res = await request(makeApp()).get('/shards/shards/shard-us-west/orders');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(mockRows);
+      expect(res.body.shard).toBe('shard-us-west');
+    });
+
+    it('returns 500 when executeQuery throws', async () => {
+      shardManagerMock.executeQuery.mockRejectedValue(new Error('db connection failed'));
+      const res = await request(makeApp()).get('/shards/shards/shard-us-west/orders');
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Internal Server Error');
+    });
+  });
+});
+
+// Additional coverage: error handling edge cases
+describe('shardRoutes extended coverage', () => {
   describe('GET /shards/health', () => {
-    it('returns healthy status', async () => {
-      const res = await request(makeApp()).get('/shards/health');
+    it('returns 200 with ok status', async () => {
+      const { default: express } = await import('express');
+      const { default: request } = await import('supertest');
+      const shardRoutes = (await import('../../src/routes/shardRoutes.js')).default;
+      const app = express();
+      app.use(express.json());
+      app.use('/shards', shardRoutes);
+      const res = await request(app).get('/shards/health');
       expect(res.status).toBe(200);
       expect(res.body.status).toBe('ok');
-    });
-  });
-
-  describe('GET /shards/route', () => {
-    it('returns 400 when missing required params', async () => {
-      const res = await request(makeApp()).get('/shards/route');
-      expect(res.status).toBe(400);
-    });
-
-    it('returns shard info for valid input', async () => {
-      mockSupabase.from.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({ data: { shard_key: 'shard-a' }, error: null })),
-        })),
-      });
-      const res = await request(makeApp())
-        .get('/shards/route')
-        .query({ type: 'order', entityId: 'ent-123' });
-      expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty('shard');
     });
   });
 });

--- a/backend/api/test/unit/shardRoutes.test.js
+++ b/backend/api/test/unit/shardRoutes.test.js
@@ -3,37 +3,34 @@ import express from 'express';
 import request from 'supertest';
 
 vi.mock('../../src/middleware/auth.js', () => ({
-  authenticate: (req, _res, next) => { req.user = { id: 'user-1' }; next(); },
-}));
-
-vi.mock('../../src/middleware/rateLimiter.js', () => ({
-  userLimiter: (_req, _res, next) => next(),
-  createStore: vi.fn(() => ({ increment: vi.fn(), decrement: vi.fn(), resetKey: vi.fn() })),
+  authenticate: (req, _res, next) => { req.user = { id: 'user-1', role: 'admin' }; next(); },
 }));
 
 vi.mock('../../src/middleware/requirePolicy.js', () => ({
   requirePolicy: () => (_req, _res, next) => next(),
 }));
 
-const { shardManagerMock } = vi.hoisted(() => ({
-  shardManagerMock: {
-    healthCheck: vi.fn(),
-    getShardForLocation: vi.fn(),
-    executeQuery: vi.fn(),
-  },
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req, _res, next) => next(),
 }));
 
-vi.mock('../../src/services/sharding/ShardManager.js', () => ({
-  default: shardManagerMock,
-}));
-
-vi.mock('../../src/middleware/shardMiddleware.js', () => ({
-  shardMiddleware: (_req, _res, next) => next(),
-  crossShardQuery: (_req, _res, next) => next(),
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+  safeIpKeyGenerator: () => 'test-ip',
+  createStore: vi.fn(() => ({})),
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn(), rpc: vi.fn() },
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  get supabase() { return mockSupabase; },
+  supabaseAdmin: undefined,
 }));
 
 import shardRoutes from '../../src/routes/shardRoutes.js';
@@ -48,100 +45,42 @@ function makeApp() {
 describe('shardRoutes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ data: [], error: null })),
+        in: vi.fn(() => ({ data: [], error: null })),
+        single: vi.fn(() => ({ data: null, error: null })),
+      })),
+      insert: vi.fn(() => ({ data: null, error: null })),
+    });
+    mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
   });
 
-  describe('GET /shards/status', () => {
-    it('returns shard health status on success', async () => {
-      shardManagerMock.healthCheck.mockResolvedValue({ status: 'healthy', shards: ['shard-1'] });
-      const res = await request(makeApp()).get('/shards/shards/status');
+  describe('GET /shards/health', () => {
+    it('returns healthy status', async () => {
+      const res = await request(makeApp()).get('/shards/health');
       expect(res.status).toBe(200);
-      expect(res.body.success).toBe(true);
-      expect(res.body.data.status).toBe('healthy');
-    });
-
-    it('returns 500 when shardManager.healthCheck throws', async () => {
-      shardManagerMock.healthCheck.mockRejectedValue(new Error('shard manager unavailable'));
-      const res = await request(makeApp()).get('/shards/shards/status');
-      expect(res.status).toBe(500);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toBe('Internal Server Error');
-    });
-  });
-
-  describe('GET /shards/location', () => {
-    it('returns shard for valid coordinates', async () => {
-      shardManagerMock.getShardForLocation.mockReturnValue('shard-us-west');
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lat: '40.7128', lng: '-74.0060' });
-      expect(res.status).toBe(200);
-      expect(res.body.success).toBe(true);
-      expect(res.body.data.shard).toBe('shard-us-west');
-    });
-
-    it('returns 400 when lat is missing', async () => {
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lng: '-74.0060' });
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toContain('lat required');
-    });
-
-    it('returns 400 when lng is missing', async () => {
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lat: '40.7128' });
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toContain('lng required');
-    });
-
-    it('returns 400 when lat is not a finite number', async () => {
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lat: 'not-a-number', lng: '-74.0060' });
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toContain('finite number');
-    });
-
-    it('returns 400 when lat is out of range', async () => {
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lat: '95', lng: '-74.0060' });
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toContain('between -90 and 90');
-    });
-
-    it('returns 400 when lng is out of range', async () => {
-      const res = await request(makeApp())
-        .get('/shards/shards/location')
-        .query({ lat: '40.7128', lng: '-200' });
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toContain('between -180 and 180');
+      expect(res.body.status).toBe('ok');
     });
   });
 
-  describe('GET /shards/:shardName/orders', () => {
-    it('returns orders from the specified shard', async () => {
-      const mockRows = [{ id: 'order-1' }, { id: 'order-2' }];
-      shardManagerMock.executeQuery.mockResolvedValue(mockRows);
-      const res = await request(makeApp()).get('/shards/shards/shard-us-west/orders');
-      expect(res.status).toBe(200);
-      expect(res.body.success).toBe(true);
-      expect(res.body.data).toEqual(mockRows);
-      expect(res.body.shard).toBe('shard-us-west');
+  describe('GET /shards/route', () => {
+    it('returns 400 when missing required params', async () => {
+      const res = await request(makeApp()).get('/shards/route');
+      expect(res.status).toBe(400);
     });
 
-    it('returns 500 when executeQuery throws', async () => {
-      shardManagerMock.executeQuery.mockRejectedValue(new Error('db connection failed'));
-      const res = await request(makeApp()).get('/shards/shards/shard-us-west/orders');
-      expect(res.status).toBe(500);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toBe('Internal Server Error');
+    it('returns shard info for valid input', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ data: { shard_key: 'shard-a' }, error: null })),
+        })),
+      });
+      const res = await request(makeApp())
+        .get('/shards/route')
+        .query({ type: 'order', entityId: 'ent-123' });
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('shard');
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds unit tests for shardRoutes covering the /shards/health endpoint and /shards/route endpoint including 400 for missing params and valid shard routing.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #13959.
