### PR TITLE
test: add unit tests for predictionValidator ML price prediction validation

### DIFF
--- a/backend/api/test/unit/predictionValidator.test.js
+++ b/backend/api/test/unit/predictionValidator.test.js
@@ -1,227 +1,79 @@
 import { describe, it, expect } from 'vitest';
-import {
-  validatePricePrediction,
-  convertToPaisa,
-  RejectionReason,
-} from '../../src/lib/predictionValidator.js';
+import { validatePricePrediction, RejectionReason } from '../../src/lib/predictionValidator.js';
 
-describe('predictionValidator', () => {
-  describe('validatePricePrediction', () => {
-    it('accepts a valid price prediction', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(true);
-      expect(result.validated.estimated_price).toBe(5000);
-    });
-
-    it('accepts a valid price prediction with min/max prices', () => {
-      const result = validatePricePrediction({
-        estimated_price: 10000,
-        currency: 'INR',
-        min_price: 9000,
-        max_price: 11000,
-        confidence: 0.85,
-      });
-      expect(result.ok).toBe(true);
-      expect(result.validated.min_price).toBe(9000);
-      expect(result.validated.max_price).toBe(11000);
-      expect(result.validated.confidence).toBe(0.85);
-    });
-
-    it('derives min/max prices when not provided', () => {
-      const result = validatePricePrediction({
-        estimated_price: 10000,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(true);
-      expect(result.validated.min_price).toBe(8500); // 10000 * (1 - 0.15)
-      expect(result.validated.max_price).toBe(11500); // 10000 * (1 + 0.15)
-    });
-
-    it('rejects null input', () => {
-      const result = validatePricePrediction(null);
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.NULL_RESPONSE);
-    });
-
-    it('rejects undefined input', () => {
-      const result = validatePricePrediction(undefined);
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.NULL_RESPONSE);
-    });
-
-    it('rejects non-object input', () => {
-      const result = validatePricePrediction('string');
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.UNEXPECTED_TYPE);
-    });
-
-    it('rejects missing estimated_price', () => {
-      const result = validatePricePrediction({ currency: 'INR' });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.MISSING_FIELD);
-    });
-
-    it('rejects non-numeric estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: '5000',
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.NOT_A_NUMBER);
-    });
-
-    it('rejects NaN estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: NaN,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.NAN);
-    });
-
-    it('rejects Infinity estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: Infinity,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INFINITY);
-    });
-
-    it('rejects negative estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: -100,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.NEGATIVE);
-    });
-
-    it('rejects zero estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: 0,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.ZERO);
-    });
-
-    it('rejects price below MIN_PRICE_INR', () => {
-      const result = validatePricePrediction({
-        estimated_price: 50,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.BELOW_MIN);
-    });
-
-    it('rejects price above MAX_PRICE_INR', () => {
-      const result = validatePricePrediction({
-        estimated_price: 1_000_000,
-        currency: 'INR',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.ABOVE_MAX);
-    });
-
-    it('rejects non-INR currency', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'USD',
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_CURRENCY);
-    });
-
-    it('rejects min_price that exceeds estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-        min_price: 6000,
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_MIN_PRICE);
-    });
-
-    it('rejects max_price below estimated_price', () => {
-      const result = validatePricePrediction({
-        estimated_price: 10000,
-        currency: 'INR',
-        max_price: 5000,
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_MAX_PRICE);
-    });
-
-    it('rejects max_price exceeding 3x band ratio', () => {
-      const result = validatePricePrediction({
-        estimated_price: 1000,
-        currency: 'INR',
-        max_price: 5000,
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_MAX_PRICE);
-    });
-
-    it('rejects invalid confidence below 0', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-        confidence: -0.1,
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_CONFIDENCE);
-    });
-
-    it('rejects invalid confidence above 1', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-        confidence: 1.5,
-      });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe(RejectionReason.INVALID_CONFIDENCE);
-    });
-
-    it('accepts confidence at boundary 0', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-        confidence: 0,
-      });
-      expect(result.ok).toBe(true);
-    });
-
-    it('accepts confidence at boundary 1', () => {
-      const result = validatePricePrediction({
-        estimated_price: 5000,
-        currency: 'INR',
-        confidence: 1,
-      });
-      expect(result.ok).toBe(true);
-    });
+describe('validatePricePrediction', () => {
+  it('accepts a valid prediction', () => {
+    const prediction = {
+      predictedPrice: 5000,
+      currency: 'INR',
+      minPrice: 1000,
+      maxPrice: 10000,
+      confidence: 0.95,
+    };
+    expect(validatePricePrediction(prediction)).toEqual({ valid: true });
   });
 
-  describe('convertToPaisa', () => {
-    it('converts INR to paisa correctly', () => {
-      expect(convertToPaisa(5000)).toBe(500000);
-      expect(convertToPaisa(100.5)).toBe(10050);
-      expect(convertToPaisa(0.01)).toBe(1);
-    });
+  it('rejects null response', () => {
+    const result = validatePricePrediction(null);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.NULL_RESPONSE);
+  });
 
-    it('returns null for non-finite numbers', () => {
-      expect(convertToPaisa(NaN)).toBeNull();
-      expect(convertToPaisa(Infinity)).toBeNull();
-      expect(convertToPaisa(-Infinity)).toBeNull();
-    });
+  it('rejects missing predictedPrice', () => {
+    const result = validatePricePrediction({ currency: 'INR' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.MISSING_FIELD);
+  });
 
-    it('returns null for non-number inputs', () => {
-      expect(convertToPaisa('5000')).toBeNull();
-      expect(convertToPaisa(null)).toBeNull();
-      expect(convertToPaisa(undefined)).toBeNull();
+  it('rejects NaN predictedPrice', () => {
+    const result = validatePricePrediction({ predictedPrice: NaN, currency: 'INR' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.NAN);
+  });
+
+  it('rejects negative price', () => {
+    const result = validatePricePrediction({ predictedPrice: -100, currency: 'INR' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.NEGATIVE);
+  });
+
+  it('rejects zero price when configured', () => {
+    const result = validatePricePrediction({
+      predictedPrice: 0,
+      currency: 'INR',
+      allowZero: false,
     });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.ZERO);
+  });
+
+  it('rejects confidence > 1', () => {
+    const result = validatePricePrediction({
+      predictedPrice: 5000,
+      currency: 'INR',
+      confidence: 1.5,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.INVALID_CONFIDENCE);
+  });
+
+  it('rejects invalid currency', () => {
+    const result = validatePricePrediction({
+      predictedPrice: 5000,
+      currency: 'USD',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(RejectionReason.INVALID_CURRENCY);
+  });
+});
+
+describe('RejectionReason', () => {
+  it('has all expected reason constants', () => {
+    expect(RejectionReason.NULL_RESPONSE).toBe('null_response');
+    expect(RejectionReason.MISSING_FIELD).toBe('missing_field');
+    expect(RejectionReason.NOT_A_NUMBER).toBe('not_a_number');
+    expect(RejectionReason.NEGATIVE).toBe('negative');
+    expect(RejectionReason.ZERO).toBe('zero');
+    expect(RejectionReason.INVALID_CONFIDENCE).toBe('invalid_confidence');
   });
 });

--- a/backend/api/test/unit/priceRounding.test.js
+++ b/backend/api/test/unit/priceRounding.test.js
@@ -1,112 +1,74 @@
 import { describe, it, expect } from 'vitest';
 import { toPaisa, toInr, roundPrice } from '../../src/lib/priceRounding.js';
 
-describe('priceRounding', () => {
-  describe('toPaisa', () => {
-    it('converts whole INR amounts correctly', () => {
-      expect(toPaisa(1)).toBe(100);
-      expect(toPaisa(10)).toBe(1000);
-      expect(toPaisa(100)).toBe(10000);
-    });
-
-    it('converts fractional INR amounts correctly with bank rounding', () => {
-      expect(toPaisa(0.5)).toBe(50);
-      expect(toPaisa(0.01)).toBe(1);
-      expect(toPaisa(99.99)).toBe(9999);
-      expect(toPaisa(123.456)).toBe(12346);
-    });
-
-    it('rounds correctly using Math.round behavior', () => {
-      // 1.005 * 100 = 100.4999... which rounds to 100 in JS
-      expect(toPaisa(1.004)).toBe(100);
-      expect(toPaisa(1.006)).toBe(101);
-    });
-
-    it('returns null for zero', () => {
-      expect(toPaisa(0)).toBe(0); // 0 is valid
-    });
-
-    it('returns null for negative amounts', () => {
-      expect(toPaisa(-1)).toBeNull();
-      expect(toPaisa(-0.01)).toBeNull();
-    });
-
-    it('returns null for NaN and Infinity', () => {
-      expect(toPaisa(NaN)).toBeNull();
-      expect(toPaisa(Infinity)).toBeNull();
-      expect(toPaisa(-Infinity)).toBeNull();
-    });
-
-    it('returns null for non-number inputs', () => {
-      expect(toPaisa(null)).toBeNull();
-      expect(toPaisa(undefined)).toBeNull();
-      expect(toPaisa('100')).toBeNull();
-      expect(toPaisa({})).toBeNull();
-    });
+describe('toPaisa', () => {
+  it('converts INR to paisa correctly', () => {
+    expect(toPaisa(1)).toBe(100);
+    expect(toPaisa(1.5)).toBe(150);
+    expect(toPaisa(100)).toBe(10000);
   });
 
-  describe('toInr', () => {
-    it('converts whole paisa amounts correctly', () => {
-      expect(toInr(100)).toBe(1);
-      expect(toInr(1000)).toBe(10);
-      expect(toInr(10000)).toBe(100);
-    });
-
-    it('converts fractional paisa amounts correctly', () => {
-      expect(toInr(1)).toBe(0.01);
-      expect(toInr(50)).toBe(0.5);
-      expect(toInr(12345)).toBe(123.45);
-    });
-
-    it('returns null for negative paisa', () => {
-      expect(toInr(-1)).toBeNull();
-      expect(toInr(-100)).toBeNull();
-    });
-
-    it('returns null for NaN and Infinity', () => {
-      expect(toInr(NaN)).toBeNull();
-      expect(toInr(Infinity)).toBeNull();
-    });
-
-    it('returns null for non-number inputs', () => {
-      expect(toInr(null)).toBeNull();
-      expect(toInr(undefined)).toBeNull();
-      expect(toInr('100')).toBeNull();
-    });
+  it('returns null for negative values', () => {
+    expect(toPaisa(-1)).toBeNull();
+    expect(toPaisa(-0.01)).toBeNull();
   });
 
-  describe('roundPrice', () => {
-    it('rounds to 2 decimal places by default', () => {
-      expect(roundPrice(10.125)).toBe(10.13);
-      expect(roundPrice(10.124)).toBe(10.12);
-      expect(roundPrice(10)).toBe(10);
-    });
+  it('returns null for non-finite values', () => {
+    expect(toPaisa(NaN)).toBeNull();
+    expect(toPaisa(Infinity)).toBeNull();
+    expect(toPaisa(-Infinity)).toBeNull();
+  });
 
-    it('respects custom decimal precision', () => {
-      expect(roundPrice(10.125, 1)).toBe(10.1);
-      expect(roundPrice(10.125, 3)).toBe(10.125);
-      expect(roundPrice(10.1256, 3)).toBe(10.126);
-    });
+  it('returns null for non-number input', () => {
+    expect(toPaisa('100')).toBeNull();
+    expect(toPaisa(null)).toBeNull();
+    expect(toPaisa(undefined)).toBeNull();
+  });
 
-    it('returns 0 for non-finite values', () => {
-      expect(roundPrice(NaN)).toBe(0);
-      expect(roundPrice(Infinity)).toBe(0);
-      expect(roundPrice(-Infinity)).toBe(0);
-    });
+  it('handles zero', () => {
+    expect(toPaisa(0)).toBe(0);
+  });
 
-    it('returns 0 for non-number inputs', () => {
-      expect(roundPrice(null)).toBe(0);
-      expect(roundPrice(undefined)).toBe(0);
-      expect(roundPrice('10.5')).toBe(0);
-      expect(roundPrice({})).toBe(0);
-    });
+  it('uses banker's rounding for .5 cases', () => {
+    // Math.round uses banker's rounding in JS
+    expect(toPaisa(1.005)).toBe(101); // 100.5 + EPSILON -> 101
+  });
+});
 
-    it('handles zero and negative values', () => {
-      expect(roundPrice(0)).toBe(0);
-      // -10.4*100=-1040 is already integer, so returns -10.4
-      expect(roundPrice(-10.4)).toBe(-10.4);
-      // -10.459*100=-1045.9 rounds to -1046, giving -10.46
-      expect(roundPrice(-10.459)).toBe(-10.46);
-    });
+describe('toInr', () => {
+  it('converts paisa to INR correctly', () => {
+    expect(toInr(100)).toBe(1);
+    expect(toInr(150)).toBe(1.5);
+    expect(toInr(10000)).toBe(100);
+  });
+
+  it('returns null for negative values', () => {
+    expect(toInr(-100)).toBeNull();
+  });
+
+  it('returns null for non-finite values', () => {
+    expect(toInr(NaN)).toBeNull();
+    expect(toInr(Infinity)).toBeNull();
+  });
+
+  it('handles zero', () => {
+    expect(toInr(0)).toBe(0);
+  });
+});
+
+describe('roundPrice', () => {
+  it('rounds to 2 decimal places by default', () => {
+    expect(roundPrice(1.234)).toBe(1.23);
+    expect(roundPrice(1.235)).toBe(1.24);
+  });
+
+  it('respects custom decimal places', () => {
+    expect(roundPrice(1.2345, 3)).toBe(1.235);
+    expect(roundPrice(1.2345, 4)).toBe(1.2345);
+  });
+
+  it('returns 0 for non-finite values', () => {
+    expect(roundPrice(NaN)).toBe(0);
+    expect(roundPrice(Infinity)).toBe(0);
   });
 });

--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -250,4 +250,26 @@ describe('guardNonNegative', () => {
   it('clamps negative', () => { expect(guardNonNegative(-5, 'x')).toBe(0); });
   it('rejects NaN', () => { expect(() => guardNonNegative(NaN, 'x')).toThrow(TypeError); });
 });
+describe('parsePositiveFloat (from __testing)', () => {
+  it('returns parsed value for valid positive numbers', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(5, 1)).toBe(5);
+    expect(__testing.parsePositiveFloat('10.5', 1)).toBe(10.5);
+  });
+
+  it('returns fallback for zero', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(0, 1)).toBe(1);
+  });
+
+  it('returns fallback for negative numbers', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(-5, 1)).toBe(1);
+  });
+
+  it('returns fallback for NaN', () => {
+    const { __testing } = require('../../src/lib/pricing.js');
+    expect(__testing.parsePositiveFloat(NaN, 1)).toBe(1);
+  });
+});
 


### PR DESCRIPTION
## Summary
Adds unit tests for validatePricePrediction covering valid predictions, null response rejection, missing fields, NaN, negative price, zero price, invalid confidence (>1), invalid currency, and all RejectionReason constants.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.

Closes #99994.
