### PR TITLE
test: add safeJsonParseWithFallback and adminRoutes error-case unit tests

### DIFF
--- a/backend/api/test/unit/adminRoutes.test.js
+++ b/backend/api/test/unit/adminRoutes.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (req, _res, next) => next(),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/rateLimiter.js', () => ({
+  userLimiter: (_req, _res, next) => next(),
+  safeIpKeyGenerator: () => 'test-ip',
+  createStore: vi.fn(() => ({})),
+}));
+
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn() },
+}));
+
+vi.mock('../../src/config/db.js', () => ({
+  get supabase() { return mockSupabase; },
+  supabaseAdmin: undefined,
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/middleware/requirePolicy.js', () => ({
+  requirePolicy: () => (_req, _res, next) => next(),
+}));
+
+vi.mock('../../src/middleware/auditLog.js', () => ({
+  auditLog: () => (_req, _res, next) => next(),
+}));
+
+import adminRoutes from '../../src/routes/adminRoutes.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/admin', adminRoutes);
+  return app;
+}
+
+describe('adminRoutes - additional cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /admin/dashboard - error handling', () => {
+    it('returns 500 when the pending_orders query errors', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ eq: vi.fn(async () => ({ count: 5, error: null })) })),
+        })),
+      });
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(async () => ({ count: null, error: { message: 'orders table down' } })),
+        })),
+      });
+      const res = await request(makeApp()).get('/admin/dashboard');
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Failed to fetch pending orders.');
+    });
+
+    it('returns 500 when the revenue query errors', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ eq: vi.fn(async () => ({ count: 5, error: null })) })),
+        })),
+      });
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(async () => ({ count: 3, error: null })),
+        })),
+      });
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          gte: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: null, error: { message: 'revenue query failed' } })),
+          })),
+        })),
+      });
+      const res = await request(makeApp()).get('/admin/dashboard');
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Failed to fetch revenue.');
+    });
+  });
+});

--- a/backend/api/test/unit/requestContext.test.js
+++ b/backend/api/test/unit/requestContext.test.js
@@ -80,3 +80,36 @@ describe('safeJsonParseWithFallback', () => {
   it('returns fallback for arrays', () => { expect(safeJsonParseWithFallback('[1,2]', { z: 3 })).toEqual({ z: 3 }); });
 });
 
+
+describe('safeJsonParseWithFallback', () => {
+  it('parses valid JSON objects', () => {
+    expect(safeJsonParseWithFallback('{"key":"value"}', {})).toEqual({ key: 'value' });
+    expect(safeJsonParseWithFallback('{"a":1,"b":2}', {})).toEqual({ a: 1, b: 2 });
+  });
+
+  it('returns fallback for null', () => {
+    expect(safeJsonParseWithFallback(null, { default: true })).toEqual({ default: true });
+    expect(safeJsonParseWithFallback(undefined, { fallback: 'x' })).toEqual({ fallback: 'x' });
+  });
+
+  it('returns fallback for invalid JSON', () => {
+    expect(safeJsonParseWithFallback('not json', { ok: false })).toEqual({ ok: false });
+    expect(safeJsonParseWithFallback('{ broken }', {})).toEqual({});
+  });
+
+  it('returns fallback for JSON arrays (only plain objects allowed)', () => {
+    expect(safeJsonParseWithFallback('[1,2,3]', [])).toEqual([]);
+    expect(safeJsonParseWithFallback('["a","b"]', null)).toBeNull();
+  });
+
+  it('returns fallback for JSON primitives', () => {
+    expect(safeJsonParseWithFallback('"just a string"', null)).toBeNull();
+    expect(safeJsonParseWithFallback('123', null)).toBeNull();
+    expect(safeJsonParseWithFallback('true', null)).toBeNull();
+  });
+
+  it('uses custom fallback', () => {
+    const custom = { custom: true };
+    expect(safeJsonParseWithFallback('not valid', custom)).toBe(custom);
+  });
+});


### PR DESCRIPTION
## Summary
Adds two test improvements:
1. Unit tests for `safeJsonParseWithFallback` covering valid JSON objects, null/undefined fallback, invalid JSON, JSON arrays rejection, JSON primitives rejection, and custom fallback parameter.
2. Unit tests for adminRoutes dashboard error handling: 500 when pending_orders query fails and 500 when revenue query fails.

Both test files merge with existing upstream test files where applicable.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.
