### PR TITLE
test: add priceRounding fractional paisa and negative value edge cases

### DIFF
--- a/backend/api/test/unit/priceRounding.test.js
+++ b/backend/api/test/unit/priceRounding.test.js
@@ -110,3 +110,20 @@ describe('priceRounding', () => {
     });
   });
 });
+
+describe('priceRounding - additional edge cases', () => {
+  it('toPaisa handles fractional paisa rounding', () => {
+    // 1.005 INR should round to 101 paisa (100.5 rounds up)
+    expect(toPaisa(1.005)).toBe(101);
+  });
+
+  it('toInr handles fractional paisa', () => {
+    expect(toInr(1)).toBe(0.01);
+    expect(toInr(150)).toBe(1.5);
+  });
+
+  it('roundPrice handles negative values', () => {
+    expect(roundPrice(-1.5)).toBe(-2); // rounds away from zero
+    expect(roundPrice(-1.234, 1)).toBe(-1.2);
+  });
+});


### PR DESCRIPTION
## Summary
Adds tests for fractional paisa rounding, paisa-to-INR conversion, and negative value handling. Merged with existing upstream test file.

## Changes Made
- Backend (Node.js) only

## GSSOC
This contribution is part of GSSOC 2026.
