### PR TITLE
fix : added null-guard for missing req.headers in headerSizeMonitor middleware

### DIFF
--- a/backend/api/src/middleware/headerSizeMonitor.js
+++ b/backend/api/src/middleware/headerSizeMonitor.js
@@ -7,6 +7,11 @@ export default function headerSizeMonitor(req, res, next) {
   const parsedLimit = Number(rawLimit);
   const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_LIMIT;
 
+  // Guard: req.headers must be defined before iterating over it.
+  if (req.headers == null) {
+    return next();
+  }
+
   let totalSize = 0;
 
   for (const [name, value] of Object.entries(req.headers)) {


### PR DESCRIPTION
Closes #14032.

Summary of What Has Been Done:
Added a null/undefined guard for req.headers at the top of the headerSizeMonitor middleware function. If req.headers is null or undefined, the middleware now returns next() early instead of attempting to iterate over it with Object.entries().

Changes Made:
- backend/api/src/middleware/headerSizeMonitor.js: Added if (req.headers == null) return next(); guard before the Object.entries() call.

Impact it Made:
- Prevents TypeError crash on malformed requests that arrive without headers
- Makes the middleware defensive and testable without needing fully-formed req mocks
- Verified by running npm run test:unit in the backend/api directory

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).