### PR TITLE
fix(automation): authenticate the sentinel defensive pause and implement its missing endpoint

### DIFF
--- a/.github/workflows/n8n-automation.yml
+++ b/.github/workflows/n8n-automation.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Audit dispute-resolution escrow webhooks
         run: node automation/n8n/tests/dispute-resolution.security.test.js
+
+      - name: Audit internal control-plane call authentication
+        run: node automation/n8n/tests/internal-api-auth.security.test.js

--- a/automation/n8n/docs/sentinel_security_flow.md
+++ b/automation/n8n/docs/sentinel_security_flow.md
@@ -23,3 +23,13 @@ pause never fires (#13925).
 
 The endpoint is one-way: it only ever *opens* the escrow circuit breaker. Closing
 it is an operator action — `POST /api/internal/pause-escrow {"paused": false}`.
+
+## Payload and failure handling
+The pause node forwards `reason` (the matched heuristic and observed gas price)
+and `txHash`, which the API records on the `DEFENSIVE_PAUSE_TRIGGERED` audit
+event so an incident can be traced back to the triggering transaction.
+
+The circuit breaker is Redis-backed and `isEscrowPaused()` fails open, so when
+Redis is unreachable the pause does not take effect. The endpoint answers **503**
+in that case rather than 200 — the n8n execution fails visibly instead of the
+sentinel recording a defensive pause that never happened.

--- a/automation/n8n/docs/sentinel_security_flow.md
+++ b/automation/n8n/docs/sentinel_security_flow.md
@@ -14,3 +14,12 @@ graph TD
 - Mempool real-time WebSocket ingestion
 - High-gas anomalies detection
 - Automated frontrun pause defense triggering
+
+## Authentication
+`POST /api/internal/defensive-pause` sits behind `requireApiKey` like every other
+`/api/internal` route, so the pause node attaches the **Truxify Internal API Key**
+`httpHeaderAuth` credential. Without it the API answers 401 and the defensive
+pause never fires (#13925).
+
+The endpoint is one-way: it only ever *opens* the escrow circuit breaker. Closing
+it is an operator action — `POST /api/internal/pause-escrow {"paused": false}`.

--- a/automation/n8n/tests/internal-api-auth.security.test.js
+++ b/automation/n8n/tests/internal-api-auth.security.test.js
@@ -27,6 +27,7 @@ const HTTP_TYPE = "n8n-nodes-base.httpRequest";
 const INTERNAL_PREFIX = "/api/internal";
 const EXPECTED_CREDENTIAL = "Truxify Internal API Key";
 
+/** @returns {{file: string, workflow: object}[]} every workflow JSON in the repo. */
 function loadWorkflows() {
   return fs
     .readdirSync(WORKFLOW_DIR)
@@ -50,6 +51,14 @@ function internalApiNodes() {
 }
 
 let failures = 0;
+
+/**
+ * Runs one assertion block, recording rather than throwing on failure so a
+ * single run reports every violation instead of stopping at the first.
+ *
+ * @param {string} title
+ * @param {() => void} fn
+ */
 function test(title, fn) {
   try {
     fn();

--- a/automation/n8n/tests/internal-api-auth.security.test.js
+++ b/automation/n8n/tests/internal-api-auth.security.test.js
@@ -1,0 +1,137 @@
+"use strict";
+
+/**
+ * Security audit for n8n calls into the internal control plane (#13925).
+ *
+ * `/api/internal/*` is mounted behind `requireApiKey` in backend/api/src/index.js
+ * and fronts privileged actions — opening the escrow circuit breaker, refilling
+ * the relayer gas tank. A node that omits the `httpHeaderAuth` credential does
+ * not "call the endpoint anonymously"; the API rejects it with 401, so the
+ * automation silently never fires. For the security sentinel that means the
+ * flash-loan defensive pause is dead code: a control that appears wired up in
+ * the workflow graph and does nothing at runtime.
+ *
+ * This is a repo-wide invariant rather than a single-workflow check, because the
+ * regression is invisible in review — the node looks complete without the
+ * credential block, and there is no error until an incident.
+ *
+ * Run: node automation/n8n/tests/internal-api-auth.security.test.js
+ */
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const WORKFLOW_DIR = path.join(__dirname, "..", "workflows");
+const HTTP_TYPE = "n8n-nodes-base.httpRequest";
+const INTERNAL_PREFIX = "/api/internal";
+const EXPECTED_CREDENTIAL = "Truxify Internal API Key";
+
+function loadWorkflows() {
+  return fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({ file: f, workflow: require(path.join(WORKFLOW_DIR, f)) }));
+}
+
+/** Every httpRequest node in the repo whose URL targets /api/internal. */
+function internalApiNodes() {
+  const found = [];
+  for (const { file, workflow } of loadWorkflows()) {
+    for (const node of workflow.nodes || []) {
+      if (node.type !== HTTP_TYPE) continue;
+      const url = (node.parameters || {}).url;
+      if (typeof url === "string" && url.includes(INTERNAL_PREFIX)) {
+        found.push({ file, node });
+      }
+    }
+  }
+  return found;
+}
+
+let failures = 0;
+function test(title, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${title}`);
+  } catch (err) {
+    failures++;
+    console.error(`FAILED: ${title}\n  ${err.message}`);
+  }
+}
+
+const nodes = internalApiNodes();
+
+test("the audit actually found internal-API nodes to check", () => {
+  assert.ok(
+    nodes.length > 0,
+    "no httpRequest node targets /api/internal — the URL shape changed and this audit is no longer guarding anything",
+  );
+});
+
+test("every /api/internal node declares generic header authentication", () => {
+  for (const { file, node } of nodes) {
+    const params = node.parameters || {};
+    assert.strictEqual(
+      params.authentication,
+      "genericCredentialType",
+      `${file}: node "${node.name}" (${params.url}) has authentication=${
+        params.authentication ?? "unset"
+      }; /api/internal is behind requireApiKey, so this call is rejected with 401`,
+    );
+    assert.strictEqual(
+      params.genericAuthType,
+      "httpHeaderAuth",
+      `${file}: node "${node.name}" must use httpHeaderAuth (the x-api-key header requireApiKey reads)`,
+    );
+  }
+});
+
+test("every /api/internal node attaches the shared internal API key credential", () => {
+  for (const { file, node } of nodes) {
+    const cred = (node.credentials || {}).httpHeaderAuth;
+    assert.ok(
+      cred,
+      `${file}: node "${node.name}" declares header auth but attaches no httpHeaderAuth credential`,
+    );
+    assert.strictEqual(
+      cred.name,
+      EXPECTED_CREDENTIAL,
+      `${file}: node "${node.name}" must reference the "${EXPECTED_CREDENTIAL}" credential, got "${cred.name}"`,
+    );
+  }
+});
+
+// ─── Sentinel-specific: the pause node is the whole point of the workflow ─────
+
+test("the security sentinel still routes its detection to a defensive pause", () => {
+  const sentinel = require(path.join(WORKFLOW_DIR, "sentinel_security.json"));
+  const pause = (sentinel.nodes || []).find(
+    (n) => n.name === "Trigger Frontrun Defensive Pause",
+  );
+  assert.ok(pause, "sentinel_security.json lost its defensive pause node");
+  assert.strictEqual(
+    pause.parameters.url,
+    "http://api:5000/api/internal/defensive-pause",
+    "the defensive pause must POST to the internal defensive-pause endpoint",
+  );
+  assert.strictEqual(
+    pause.parameters.method,
+    "POST",
+    "defensive pause is a state change and must be a POST",
+  );
+
+  const targets = (sentinel.connections["Is Flash Loan Pattern?"] || {}).main || [];
+  const wired = targets.flat().some((c) => c.node === "Trigger Frontrun Defensive Pause");
+  assert.ok(wired, "the flash-loan detector is no longer wired to the pause node");
+});
+
+console.log(
+  `\n${nodes.length} internal-API node(s) audited across ${loadWorkflows().length} workflow(s).`,
+);
+
+if (failures > 0) {
+  console.error(`\n${failures} security assertion(s) failed.`);
+  process.exit(1);
+}
+console.log("All internal-API automation calls are authenticated.");

--- a/automation/n8n/tests/internal-api-auth.security.test.js
+++ b/automation/n8n/tests/internal-api-auth.security.test.js
@@ -126,6 +126,25 @@ test("the security sentinel still routes its detection to a defensive pause", ()
   assert.ok(wired, "the flash-loan detector is no longer wired to the pause node");
 });
 
+test("the defensive pause forwards detector context for incident tracing", () => {
+  const sentinel = require(path.join(WORKFLOW_DIR, "sentinel_security.json"));
+  const pause = (sentinel.nodes || []).find(
+    (n) => n.name === "Trigger Frontrun Defensive Pause",
+  );
+  const params = pause.parameters || {};
+
+  assert.strictEqual(
+    params.sendBody,
+    true,
+    "the pause node must send a body — without it the DEFENSIVE_PAUSE_TRIGGERED audit event records reason=null, txHash=null and an incident cannot be traced to a transaction",
+  );
+
+  const sent = ((params.bodyParametersUi || {}).parameter || []).map((p) => p.name);
+  for (const field of ["reason", "txHash"]) {
+    assert.ok(sent.includes(field), `the pause node must send "${field}"`);
+  }
+});
+
 console.log(
   `\n${nodes.length} internal-API node(s) audited across ${loadWorkflows().length} workflow(s).`,
 );

--- a/automation/n8n/workflows/sentinel_security.json
+++ b/automation/n8n/workflows/sentinel_security.json
@@ -61,6 +61,19 @@
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "method": "POST",
+        "sendBody": true,
+        "bodyParametersUi": {
+          "parameter": [
+            {
+              "name": "reason",
+              "value": "=flash-loan/frontrun heuristic matched: gasPrice={{ $json.gasPrice }} wei (threshold 500 gwei)"
+            },
+            {
+              "name": "txHash",
+              "value": "={{ $json.hash || ($json.params && $json.params.result ? $json.params.result.hash : '') }}"
+            }
+          ]
+        },
         "options": {}
       },
       "name": "Trigger Frontrun Defensive Pause",

--- a/automation/n8n/workflows/sentinel_security.json
+++ b/automation/n8n/workflows/sentinel_security.json
@@ -58,13 +58,21 @@
     {
       "parameters": {
         "url": "http://api:5000/api/internal/defensive-pause",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "method": "POST",
         "options": {}
       },
       "name": "Trigger Frontrun Defensive Pause",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 1,
-      "position": [850, 200]
+      "position": [850, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     }
   ],
   "connections": {

--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -566,6 +566,7 @@ app.use('/api/blockchain', (req, _res, next) => {
 // Auth-gated internal endpoints consumed by automation/n8n workflows:
 //   GET  /api/internal/escrow-velocity
 //   POST /api/internal/pause-escrow
+//   POST /api/internal/defensive-pause
 // ============================================================================
 app.use('/api/internal', requireApiKey, internalRoutes)
 

--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -691,7 +691,7 @@ export const createAdminApiRouter = () => {
     });
 
     res.status(201).json({
-      message: 'API Key created successfully. Store raw key safely - it won't be shown again.',
+      message: "API Key created successfully. Store raw key safely - it won't be shown again.",
       apiKey: rawKey,
       metadata: record,
     });

--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -1,6 +1,6 @@
 /**
- * Internal B2B API routes consumed by the n8n "Truxify Emergency Smart Contract
- * Circuit Breaker" workflow (automation/n8n/workflows/circuit_breaker.json).
+ * Internal B2B API routes consumed by the n8n automation workflows
+ * (automation/n8n/workflows/).
  *
  *   GET  /api/internal/escrow-velocity  — reports escrow event counts over a
  *                                         rolling window and whether the rate
@@ -9,10 +9,15 @@
  *                                         breaker; while open, every on-chain
  *                                         escrow submission in services/escrow.js
  *                                         is refused.
+ *   POST /api/internal/defensive-pause  — one-way emergency open of the same
+ *                                         circuit breaker, called by the
+ *                                         security sentinel workflow when it
+ *                                         matches a flash-loan/frontrun pattern
+ *                                         in the Polygon mempool.
  *
- * Both endpoints are gated by requireApiKey (x-api-key header / api_key query
- * against VALID_API_KEYS) so they are only reachable by authenticated B2B
- * callers such as the n8n workflow.
+ * Every endpoint is gated by requireApiKey (x-api-key header against
+ * VALID_API_KEYS) at the mount in index.js, so they are only reachable by
+ * authenticated B2B callers such as the n8n workflows.
  */
 
 import express from 'express';
@@ -155,6 +160,71 @@ router.post('/pause-escrow', async (req, res) => {
       '[internal] Failed to update escrow circuit breaker.'
     );
     return res.status(500).json({ error: 'Failed to update escrow circuit breaker.' });
+  }
+});
+
+/**
+ * @openapi
+ * /api/internal/defensive-pause:
+ *   post:
+ *     tags: [Internal]
+ *     summary: Emergency defensive pause (security sentinel)
+ *     description: Opens the escrow circuit breaker in response to a detected frontrun/flash-loan pattern. Unlike /pause-escrow this is one-way — it can never close the circuit — so a compromised detector cannot be replayed to re-enable escrow submissions. Closing the circuit stays an operator action via POST /api/internal/pause-escrow {"paused": false}.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               reason:
+ *                 type: string
+ *                 description: Free-text detector context recorded in the audit log.
+ *               txHash:
+ *                 type: string
+ *                 description: Mempool transaction that triggered the pause.
+ *     responses:
+ *       200:
+ *         description: Circuit breaker opened
+ *       401:
+ *         description: Missing or invalid API key
+ *       500:
+ *         description: Failed to persist pause state
+ */
+router.post('/defensive-pause', async (req, res) => {
+  const reason = typeof req.body?.reason === 'string' ? req.body.reason.slice(0, 200) : null;
+  const txHash = typeof req.body?.txHash === 'string' ? req.body.txHash.slice(0, 100) : null;
+
+  try {
+    // Deliberately ignores any `paused` in the body: this endpoint only ever
+    // opens the circuit. The sentinel is an automated detector, so giving it a
+    // close path would let a single forged call undo an emergency pause.
+    const result = await setEscrowPaused(true);
+
+    logger.warn(
+      {
+        event: 'DEFENSIVE_PAUSE_TRIGGERED',
+        source: 'security-sentinel',
+        reason,
+        txHash,
+      },
+      '[internal] Defensive pause triggered — escrow circuit breaker opened.'
+    );
+
+    return res.json({
+      paused: result.paused,
+      updatedAt: result.updatedAt,
+      persisted: result.persisted !== false,
+      source: 'security-sentinel',
+    });
+  } catch (err) {
+    logger.error(
+      { err: err && err.message, event: 'DEFENSIVE_PAUSE_ERROR', reason, txHash },
+      '[internal] Failed to apply defensive pause.'
+    );
+    return res.status(500).json({ error: 'Failed to apply defensive pause.' });
   }
 });
 

--- a/backend/api/src/routes/internalRoutes.js
+++ b/backend/api/src/routes/internalRoutes.js
@@ -187,11 +187,13 @@ router.post('/pause-escrow', async (req, res) => {
  *                 description: Mempool transaction that triggered the pause.
  *     responses:
  *       200:
- *         description: Circuit breaker opened
+ *         description: Circuit breaker opened and persisted
  *       401:
  *         description: Missing or invalid API key
  *       500:
  *         description: Failed to persist pause state
+ *       503:
+ *         description: Redis unavailable — the pause did not take effect
  */
 router.post('/defensive-pause', async (req, res) => {
   const reason = typeof req.body?.reason === 'string' ? req.body.reason.slice(0, 200) : null;
@@ -202,6 +204,23 @@ router.post('/defensive-pause', async (req, res) => {
     // opens the circuit. The sentinel is an automated detector, so giving it a
     // close path would let a single forged call undo an emergency pause.
     const result = await setEscrowPaused(true);
+
+    // setEscrowPaused resolves with persisted:false instead of throwing when
+    // Redis is down, and isEscrowPaused() fails open, so the circuit is not
+    // actually open in that case. Answering 2xx here would tell an unattended
+    // detector its defensive pause succeeded while escrow submissions keep
+    // flowing. Fail loudly so the n8n execution errors and alerts.
+    if (result.persisted === false) {
+      logger.error(
+        { event: 'DEFENSIVE_PAUSE_NOT_PERSISTED', source: 'security-sentinel', reason, txHash },
+        '[internal] Defensive pause could not be persisted — escrow is NOT paused.'
+      );
+      return res.status(503).json({
+        error: 'Defensive pause was not persisted; escrow is not paused.',
+        paused: false,
+        persisted: false,
+      });
+    }
 
     logger.warn(
       {

--- a/backend/api/test/unit/internalRoutes.test.js
+++ b/backend/api/test/unit/internalRoutes.test.js
@@ -230,6 +230,26 @@ describe('POST /api/internal/defensive-pause', () => {
     expect(res.body.error).toContain('Failed to apply defensive pause');
   });
 
+  // setEscrowPaused resolves (does not throw) with persisted:false when Redis is
+  // unavailable, and isEscrowPaused() fails open — so the circuit is not really
+  // open. A 2xx here would tell the sentinel its pause worked.
+  it('reports 503 rather than success when the pause was not persisted', async () => {
+    circuitBreakerMock.setEscrowPaused.mockResolvedValue({
+      paused: true,
+      updatedAt: '2026-08-14T00:00:00.000Z',
+      persisted: false,
+    });
+
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', VALID_KEY)
+      .send({});
+
+    expect(res.status).toBe(503);
+    expect(res.body.paused).toBe(false);
+    expect(res.body.persisted).toBe(false);
+  });
+
   it('is reachable at all — the route exists rather than falling through to 404', async () => {
     const res = await request(buildGuardedApp())
       .post('/api/internal/defensive-pause')

--- a/backend/api/test/unit/internalRoutes.test.js
+++ b/backend/api/test/unit/internalRoutes.test.js
@@ -6,6 +6,12 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
+vi.mock('@sentry/node', () => ({
+  withScope: (fn) => fn({ setTag: vi.fn(), setExtra: vi.fn() }),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
 const { velocityResults, supabaseMock, circuitBreakerMock } = vi.hoisted(() => {
   const velocityResults = {};
   return {
@@ -25,19 +31,42 @@ const { velocityResults, supabaseMock, circuitBreakerMock } = vi.hoisted(() => {
   };
 });
 
+// internalRoutes reads through supabaseAdmin (getDbClient), not the anon
+// client, so both handles must be mocked or every velocity query short-circuits
+// to the 503 "Supabase is not configured" branch.
 vi.mock('../../src/config/db.js', () => ({
   supabase: supabaseMock,
-  supabaseAdmin: null,
+  supabaseAdmin: supabaseMock,
 }));
 
 vi.mock('../../src/services/escrowCircuitBreaker.js', () => circuitBreakerMock);
 
 import internalRoutes from '../../src/routes/internalRoutes.js';
+import { requireApiKey, authConfig } from '../../src/middleware/apiKey.js';
 
 function buildApp() {
   const app = express();
   app.use(express.json());
   app.use('/api/internal', internalRoutes);
+  return app;
+}
+
+const VALID_KEY = 'internal-test-key';
+
+/**
+ * Mirrors the real mount in src/index.js:
+ *
+ *   app.use('/api/internal', requireApiKey, internalRoutes)
+ *
+ * so the auth assertions below exercise the middleware that actually guards
+ * these routes in production rather than a stand-in.
+ */
+function buildGuardedApp() {
+  process.env.VALID_API_KEYS = VALID_KEY;
+  authConfig.reload();
+  const app = express();
+  app.use(express.json());
+  app.use('/api/internal', requireApiKey, internalRoutes);
   return app;
 }
 
@@ -128,5 +157,85 @@ describe('POST /api/internal/pause-escrow', () => {
     expect(circuitBreakerMock.setEscrowPaused).toHaveBeenCalledWith(false);
     expect(res.status).toBe(200);
     expect(res.body.paused).toBe(false);
+  });
+});
+
+// #13925 — the security sentinel workflow POSTs here when it matches a
+// flash-loan/frontrun pattern in the Polygon mempool.
+describe('POST /api/internal/defensive-pause', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    circuitBreakerMock.setEscrowPaused.mockResolvedValue({
+      paused: true,
+      updatedAt: '2026-08-14T00:00:00.000Z',
+      persisted: true,
+    });
+  });
+
+  it('rejects an unauthenticated call without touching the circuit breaker', async () => {
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .send({ reason: 'attacker' });
+
+    expect(res.status).toBe(401);
+    expect(circuitBreakerMock.setEscrowPaused).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong API key without touching the circuit breaker', async () => {
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', 'not-the-key')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(circuitBreakerMock.setEscrowPaused).not.toHaveBeenCalled();
+  });
+
+  it('opens the circuit for an authenticated sentinel call', async () => {
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', VALID_KEY)
+      .send({ reason: 'gasPrice > 500 gwei', txHash: '0xabc' });
+
+    expect(res.status).toBe(200);
+    expect(circuitBreakerMock.setEscrowPaused).toHaveBeenCalledWith(true);
+    expect(res.body).toEqual({
+      paused: true,
+      updatedAt: '2026-08-14T00:00:00.000Z',
+      persisted: true,
+      source: 'security-sentinel',
+    });
+  });
+
+  it('is one-way: a paused:false body still opens the circuit', async () => {
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', VALID_KEY)
+      .send({ paused: false });
+
+    expect(circuitBreakerMock.setEscrowPaused).toHaveBeenCalledWith(true);
+    expect(res.status).toBe(200);
+    expect(res.body.paused).toBe(true);
+  });
+
+  it('returns 500 when persisting the pause state fails', async () => {
+    circuitBreakerMock.setEscrowPaused.mockRejectedValue(new Error('redis down'));
+
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', VALID_KEY)
+      .send({});
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain('Failed to apply defensive pause');
+  });
+
+  it('is reachable at all — the route exists rather than falling through to 404', async () => {
+    const res = await request(buildGuardedApp())
+      .post('/api/internal/defensive-pause')
+      .set('x-api-key', VALID_KEY)
+      .send({});
+
+    expect(res.status).not.toBe(404);
   });
 });


### PR DESCRIPTION
Fixes #13925

## Root cause

The issue is right that the node is unauthenticated, but the **impact is inverted**, and there is a second defect underneath it.

**1. The reported DoS is not reachable.** `/api/internal` is mounted with the guard in front of the router ([`backend/api/src/index.js:570`](../blob/main/backend/api/src/index.js#L570)):

```js
app.use('/api/internal', requireApiKey, internalRoutes)
```

Express runs `requireApiKey` before any handler and before the 404 fallthrough, so an unauthenticated POST to `/api/internal/defensive-pause` is already answered `401`. Nothing anonymous ever reaches the pause logic — there is no unauthenticated privileged action and no DoS.

**2. The real defect is the mirror image.** Because the *workflow* attaches no credential, **its own** call is the one rejected with `401`. The flash-loan defensive pause has never been able to fire. That is worse in practice than the reported bug: a security control that is drawn in the workflow graph, reads as wired-up in review, and does nothing at runtime — with no error until an incident.

**3. `/api/internal/defensive-pause` was never implemented.** `internalRoutes.js` declares only `/escrow-velocity` and `/pause-escrow`. Even a correctly authenticated call would `404`.

Why nobody noticed: `backend/api/scripts/check-n8n-workflow-urls.js` — the guard added for #10155 — matches a workflow URL against any mounted **prefix**:

```js
if (wc.startsWith(`${kw}/`) && kw !== '') return true;
```

`/api/internal/defensive-pause` starts with the mounted `/api/internal`, so the check passes and a missing leaf route is invisible to it.

## The fix

**Attach the credential** ([`sentinel_security.json`](../blob/main/automation/n8n/workflows/sentinel_security.json)) — the exact shape used by every other `/api/internal` caller in `circuit_breaker.json` and `gas_refiller.json`:

```json
"authentication": "genericCredentialType",
"genericAuthType": "httpHeaderAuth",
...
"credentials": { "httpHeaderAuth": { "name": "Truxify Internal API Key", "id": "" } }
```

**Implement `POST /api/internal/defensive-pause`** — it opens the same Redis-backed circuit breaker `/pause-escrow` drives (`setEscrowPaused`), so `services/escrow.js` refuses on-chain submissions, and records the detector's `reason`/`txHash` (sent by the node) under a `DEFENSIVE_PAUSE_TRIGGERED` audit event so an incident can be traced back to the mempool transaction that caused it.

It answers **503, not 200, when the pause did not persist.** `setEscrowPaused` resolves with `persisted: false` rather than throwing when Redis is down, and `isEscrowPaused()` fails open by design, so the circuit is genuinely not open in that window. A 2xx there would tell an unattended detector its defensive pause succeeded while escrow submissions keep flowing — the same silent-no-op this PR exists to remove, one layer down. n8n fails an execution on non-2xx, so it surfaces.

The endpoint is deliberately **one-way**: it ignores `paused` in the body and can only *open* the circuit. The sentinel is an unattended detector, so giving it a close path would let a single forged call undo an emergency pause. Closing stays an operator action via `POST /api/internal/pause-escrow {"paused": false}`.

No new auth code — the mount-level `requireApiKey` already covers the route, which the tests assert against the real middleware rather than a stand-in.

**A repo-wide audit instead of a one-workflow test.** `automation/n8n/tests/internal-api-auth.security.test.js` asserts that *every* httpRequest node targeting `/api/internal` declares header auth and attaches the shared credential (currently 5 nodes across 4 workflows), wired into the existing path-filtered `n8n-automation` job. Dependency-free plain node, like the dispute-resolution audit.

### Also in this PR

- **`apiKey.js` does not parse on `main`** (separate commit, cherry-pickable). [`backend/api/src/middleware/apiKey.js:694`](../blob/main/backend/api/src/middleware/apiKey.js#L694) closes a single-quoted string on the apostrophe in `won't`, from #13802. Since `requireApiKey` is exported from this file and imported by `src/index.js`, **the API does not boot** and no test touching auth can run. One-character fix. Included because the regression test here cannot execute without it.
- **Mock correction** in `internalRoutes.test.js`: the route reads through `supabaseAdmin`, but the mock set it to `null` while stubbing only `supabase`, so both escrow-velocity tests hit the 503 branch and failed on `main`. The file goes 2 failing / 5 passing → 13 passing.

## Proof of fix

Reverting only the two source fixes and keeping the new tests, on this branch:

<details open>
<summary><b>Before</b></summary>

```
$ node automation/n8n/tests/internal-api-auth.security.test.js
PASS: the audit actually found internal-API nodes to check
FAILED: every /api/internal node declares generic header authentication
  sentinel_security.json: node "Trigger Frontrun Defensive Pause"
  (http://api:5000/api/internal/defensive-pause) has authentication=unset;
  /api/internal is behind requireApiKey, so this call is rejected with 401
FAILED: every /api/internal node attaches the shared internal API key credential
  sentinel_security.json: node "Trigger Frontrun Defensive Pause" declares
  header auth but attaches no httpHeaderAuth credential
PASS: the security sentinel still routes its detection to a defensive pause

2 security assertion(s) failed.
exit=1

$ npx vitest run test/unit/internalRoutes.test.js -t 'defensive-pause'
 ✓ rejects an unauthenticated call without touching the circuit breaker
 ✓ rejects a wrong API key without touching the circuit breaker
 × opens the circuit for an authenticated sentinel call
 × is one-way: a paused:false body still opens the circuit
 × returns 500 when persisting the pause state fails
 × is reachable at all — the route exists rather than falling through to 404

AssertionError: expected 404 to be 200
AssertionError: expected "vi.fn()" to be called with arguments: [ true ]
AssertionError: expected 404 to be 500
AssertionError: expected 404 not to be 404

 Tests  4 failed | 2 passed | 7 skipped (13)
```

The two 401 tests passing here is the evidence for the root-cause correction above: the endpoint was **never** anonymously invocable. The four `404`s are the never-implemented route.

</details>

<details open>
<summary><b>After</b></summary>

```
$ node automation/n8n/tests/internal-api-auth.security.test.js
PASS: the audit actually found internal-API nodes to check
PASS: every /api/internal node declares generic header authentication
PASS: every /api/internal node attaches the shared internal API key credential
PASS: the security sentinel still routes its detection to a defensive pause

5 internal-API node(s) audited across 4 workflow(s).
All internal-API automation calls are authenticated.
exit=0

$ npx vitest run test/unit/internalRoutes.test.js
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

</details>

<details>
<summary><b>No regressions in the neighbouring checks</b></summary>

```
$ node --check backend/api/src/middleware/apiKey.js
(no output — parses)

$ for f in $(find automation/n8n -name '*.json'); do node -e "require('./$f')"; done
all parse OK

$ node automation/n8n/tests/dispute-resolution.security.test.js
PASS: every fund-moving HTTP node authenticates to the backend
PASS: every connection source and target references an existing node
All security checks passed

$ node backend/api/scripts/check-n8n-workflow-urls.js
Checked 14 workflow URL(s).
All n8n workflow URLs map to mounted routes.
```

</details>

## Review round 2

Both CodeRabbit findings were valid and are fixed in `2341d19`, each with a guard that fails without its fix:

| Finding | Fix | Guard |
|---|---|---|
| 200 returned even when the pause was not persisted | 503 + `DEFENSIVE_PAUSE_NOT_PERSISTED` error log | vitest case — returns 200 without the fix |
| Node sent no body, so `reason`/`txHash` always logged `null` | `sendBody`/`bodyParametersUi`, matching `dispute-resolution.json` | audit assertion — fails without the fix |

```
$ node automation/n8n/tests/internal-api-auth.security.test.js
PASS: the audit actually found internal-API nodes to check
PASS: every /api/internal node declares generic header authentication
PASS: every /api/internal node attaches the shared internal API key credential
PASS: the security sentinel still routes its detection to a defensive pause
PASS: the defensive pause forwards detector context for incident tracing

$ npx vitest run test/unit/internalRoutes.test.js
 Tests  14 passed (14)
```

`txHash` reads `$json.hash` with a fallback to `$json.params.result.hash`, because the workflow is already inconsistent about what shape it sees — `Is Flash Loan Pattern?` reads a flat `$json.gasPrice` while `Validate Stream Payload` checks `$json.params`. Reading both keeps the trace field populated either way. That heuristic inconsistency is pre-existing and left alone.

`/pause-escrow` deliberately keeps its current contract: it is operator-driven and the caller sees `persisted` in the response, so changing it is a separate decision.

## Follow-ups (not in this PR)

- `gas_refiller.json` targets `/api/internal/relayer-balance` and `/api/internal/refill-gas-tank`; neither is mounted. Same root cause as (3) above — happy to open a separate issue.
- `check-n8n-workflow-urls.js` should require an exact leaf-route match for `/api/internal` rather than accepting the mount prefix, which is what let both slip through.

## CI note

The pre-existing repo-wide CI failures on `main` are unrelated to this branch (`intl`/`qr` version conflicts, stale generated l10n, the npm peer conflict on `@nomicfoundation/hardhat-ignition`). Backend deps cannot be installed at the workspace root because of that last one; the runs above used an isolated install of `vitest`/`supertest`/`express` against the real source files.
