### PR TITLE
fix : added empty-buffer guard to validateDocumentBuffer

### DIFF
--- a/backend/api/src/lib/documentValidation.js
+++ b/backend/api/src/lib/documentValidation.js
@@ -56,6 +56,9 @@ export function validateDocumentBuffer(buffer, declaredMimeType) {
   if (buffer == null) {
     throw new DocumentValidationError('Document buffer is null or undefined.');
   }
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    throw new DocumentValidationError('Document buffer is empty.');
+  }
   const detected = detectDocumentMimeType(buffer);
 
   if (!detected || !ALLOWED_DOCUMENT_MIME_TYPES.includes(detected)) {


### PR DESCRIPTION
Closes #14035.

Summary of What Has Been Done:
Added an explicit empty-buffer guard in validateDocumentBuffer. When buffer is empty (length === 0), the function now throws a specific 'Document buffer is empty.' error instead of the generic 'Invalid document type: unknown.' error.

Changes Made:
- backend/api/src/lib/documentValidation.js: Added if (!Buffer.isBuffer(buffer) || buffer.length === 0) check before calling detectDocumentMimeType, providing a clear error message for empty uploads.

Impact it Made:
- Clearer error messages for users uploading empty files
- Consistent with audioValidation.js pattern which also checks buffer.length === 0

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).