### PR TITLE
fix : added explicit null check in errorTranslationInterceptor

### DIFF
--- a/backend/api/src/middleware/i18n.js
+++ b/backend/api/src/middleware/i18n.js
@@ -42,7 +42,7 @@ export const i18nMiddleware = middleware.handle(i18next);
 export const errorTranslationInterceptor = (req, res, next) => {
   const originalJson = res.json;
   res.json = function(body) {
-    if (body && typeof body === 'object' && typeof body.error === 'string') {
+    if (body !== null && body && typeof body === 'object' && typeof body.error === 'string') {
       // Use original English error string as key
       const translated = req.t(body.error, { defaultValue: body.error });
       body.error = translated;


### PR DESCRIPTION
Closes #14040.

Summary of What Has Been Done:
Added an explicit null check (body !== null) in the errorTranslationInterceptor condition before accessing body.error. While JavaScript's typeof null === 'object' quirk means the existing condition already handles null correctly due to short-circuit evaluation, adding the explicit check makes the intent clear and guards against future refactoring.

Changes Made:
- backend/api/src/middleware/i18n.js: Updated the if condition from body && ... to body !== null && body && ...

Impact it Made:
- Makes the null guard explicit and self-documenting
- Prevents potential edge-case bugs if the condition is refactored

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).