### PR TITLE
fix : added immutability fix in errorFormatter formatError

### DIFF
--- a/backend/api/src/utils/errorFormatter.js
+++ b/backend/api/src/utils/errorFormatter.js
@@ -1,5 +1,5 @@
 export function formatError(code, message, details = undefined) {
-  const error = {
+  const err = {
     success: false,
     error: {
       code,
@@ -8,8 +8,8 @@ export function formatError(code, message, details = undefined) {
   };
 
   if (process.env.NODE_ENV !== "production" && details) {
-    error.error.details = details;
+    err.error = { ...err.error, details };
   }
 
-  return error;
+  return err;
 }


### PR DESCRIPTION
Closes #14050.

Summary of What Has Been Done:
Fixed the formatError function to avoid mutating the returned error object's nested properties. The original code directly assigned details to the inner error object. Now it creates a new inner object using spread syntax.

Changes Made:
- backend/api/src/utils/errorFormatter.js: Changed error.error.details = details to err.error = { ...err.error, details }

Impact it Made:
- Prevents accidental mutation of returned error objects
- Makes the function behavior more predictable and consistent with immutability principles

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).