### PR TITLE
fix : added null-guard in validateBody and validateParams middleware

### DIFF
--- a/backend/api/src/middleware/validate.js
+++ b/backend/api/src/middleware/validate.js
@@ -30,6 +30,13 @@ export function validateArray(schema) {
 
 export function validateBody(schema) {
   return (req, res, next) => {
+    // Guard: req.body must be present before schema validation.
+    if (req.body == null) {
+      return res.status(400).json({
+        error: "Request body is required",
+      });
+    }
+
     const result = schema.safeParse(req.body);
 
     if (!result.success) {
@@ -50,6 +57,13 @@ export function validateBody(schema) {
 
 export function validateParams(schema) {
   return (req, res, next) => {
+    // Guard: req.params must be present before schema validation.
+    if (req.params == null) {
+      return res.status(400).json({
+        error: "Request params are required",
+      });
+    }
+
     const result = schema.safeParse(req.params);
 
     if (!result.success) {


### PR DESCRIPTION
Closes #14048.

Summary of What Has Been Done:
Added explicit null/undefined guards in both validateBody and validateParams middleware functions. If req.body or req.params is null/undefined, the middleware now returns a clear 400 error before attempting schema parsing, rather than relying on Zod's implicit handling.

Changes Made:
- backend/api/src/middleware/validate.js: Added if (req.body == null) check in validateBody returning 'Request body is required'
- backend/api/src/middleware/validate.js: Added if (req.params == null) check in validateParams returning 'Request params are required'

Impact it Made:
- Clearer error messages when requests arrive without body/params
- Defensive coding against malformed requests
- Consistent with the explicit null-checking pattern used in other validation middleware

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).