### PR TITLE
[HIGH] Automation: authenticate security-sentinel defensive-pause POST (closes #13925)

### DIFF
--- a/automation/n8n/workflows/sentinel_security.json
+++ b/automation/n8n/workflows/sentinel_security.json
@@ -58,13 +58,21 @@
     {
       "parameters": {
         "url": "http://api:5000/api/internal/defensive-pause",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "method": "POST",
         "options": {}
       },
       "name": "Trigger Frontrun Defensive Pause",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 1,
-      "position": [850, 200]
+      "position": [850, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "Truxify Internal API Key",
+          "id": ""
+        }
+      }
     }
   ],
   "connections": {


### PR DESCRIPTION
## Problem

In `automation/n8n/workflows/sentinel_security.json`, the "Trigger Frontrun Defensive Pause" HTTP node POSTs to the privileged internal endpoint `http://api:5000/api/internal/defensive-pause` with no authentication (no `authentication`/`credentials` block). This is a system-wide, privileged control-plane action that any actor able to reach `api:5000` within the cluster can invoke — an unauthenticated pause → control-plane DoS. Sibling nodes (`circuit_breaker.json`, `gas_refiller.json`) attach the `httpHeaderAuth` ("Truxify Internal API Key") credential. (#13925)

## Fix

- Added `authentication: "genericCredentialType"` and `genericAuthType: "httpHeaderAuth"` to the node `parameters`, and attached the `"httpHeaderAuth"` credential (`name: "Truxify Internal API Key"`) at the node level — matching the pattern used by sibling internal API nodes.
- File: `automation/n8n/workflows/sentinel_security.json:58-72`

Note for backend: the upstream `/api/internal/defensive-pause` should additionally validate the internal API key header; this fix ensures the sentinel now sends the expected credential so that validation can reject unauthenticated callers.

## Files changed

- automation/n8n/workflows/sentinel_security.json

## Testing

- Validated the workflow JSON parses correctly (`JSON.parse`).
- Confirmed the credential block matches the structure of sibling authenticated nodes via grep.

Closes #13925
