### PR TITLE
fix: AssetToken buy/sell rounding asymmetry leaks value to contract (#13980)

### DIFF
--- a/blockchain/contracts/AssetToken.sol
+++ b/blockchain/contracts/AssetToken.sol
@@ -172,7 +172,14 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         require(asset.availableTokens >= amount, "Insufficient tokens");
         require(issuedTokens[assetId] + amount <= asset.totalTokens, "Supply cap exceeded");
 
-        uint256 totalCost = (amount * asset.tokenPrice + 1e18 - 1) / 1e18;
+        // Buy and sell MUST round identically. We use floor (truncation) on
+        // both sides so a round-trip (buy then sell the same amount) is
+        // value-neutral modulo no hidden spread. The previous code rounded
+        // buys UP (ceiling) and sells DOWN (floor) against the same
+        // asset.tokenPrice, silently leaking up to ~1 token of value per trade
+        // into the contract. With symmetric floor rounding the contract can
+        // never extract more than the exact proportional value.
+        uint256 totalCost = (amount * asset.tokenPrice) / 1e18;
         require(msg.value >= totalCost, "Insufficient payment");
 
         // Update asset
@@ -217,6 +224,9 @@ contract AssetToken is ERC20, ERC20Burnable, Ownable, Pausable, ReentrancyGuard 
         require(ownership.backedTokens >= amount, "Tokens not backed");
 
         Asset storage asset = assets[assetId];
+        // Symmetric floor rounding with purchaseFraction (see above): a
+        // round-trip pays out exactly what was paid in for the same amount,
+        // so there is no hidden spread leaking value to the contract.
         uint256 payout = (amount * asset.tokenPrice) / 1e18;
 
         // Burn tokens

--- a/blockchain/test/AssetToken.test.js
+++ b/blockchain/test/AssetToken.test.js
@@ -587,4 +587,30 @@ describe("AssetToken", function () {
     assert.equal(order.isActive, false);
     assert.equal(order.buyer, buyer2.address);
   });
+
+  it("should keep buy/sell rounding symmetric so a round-trip is value-neutral (no contract leakage)", async function () {
+    const { assetToken, owner, buyer1 } = await deployAssetToken();
+    // totalTokens=3, totalValue=100 ETH => tokenPrice = 100/3 ETH (non-integer),
+    // so any rounding asymmetry would leak a whole token to the contract.
+    await assetToken.connect(owner).createAsset(
+      "Truck 1",
+      "Volvo FH16",
+      "truck",
+      ethers.parseEther("100"),
+      ethers.parseEther("3"),
+      "ipfs://..."
+    );
+
+    const amount = ethers.parseEther("1");
+    // Buy 1 token. Cost = floor(1 * 100/3) = 33 ETH.
+    await assetToken.connect(buyer1).purchaseFraction(1, amount, {
+      value: ethers.parseEther("34")
+    });
+    // Sell the same 1 token back. Payout = floor(1 * 100/3) = 33 ETH (== cost).
+    await assetToken.connect(buyer1).sellFraction(1, amount);
+    await assetToken.connect(buyer1).claimPayout();
+
+    // Round-trip is value-neutral: the contract cannot skim a fractional token.
+    assert.equal(await ethers.provider.getBalance(assetToken.target), 0n);
+  });
 });


### PR DESCRIPTION
## Problem

`blockchain/contracts/AssetToken.sol` priced buys with a **ceiling** and sells with a **floor** against the same `asset.tokenPrice`:

- `purchaseFraction` (line ~175): `totalCost = (amount * asset.tokenPrice + 1e18 - 1) / 1e18;` (rounds up)
- `sellFraction` (line ~220): `payout = (amount * asset.tokenPrice) / 1e18;` (rounds down)

Because buy rounded up and sell rounded down, every round-trip (buy then sell the same amount) lost up to ~1 token of value to the contract — systematic, volume-scaled value leakage from sellers (and buyers on the way in). The asymmetry was undocumented and not bounded relative to `tokenPrice` (#13980).

## Fix

Made buy and sell use the **same rounding direction (floor / truncation)** against `asset.tokenPrice`:

- `blockchain/contracts/AssetToken.sol:182` — `purchaseFraction` now computes `totalCost = (amount * asset.tokenPrice) / 1e18;` (floor), matching `sellFraction`.
- `blockchain/contracts/AssetToken.sol:223` — `sellFraction` already used floor; added a comment documenting the symmetric rounding so the round-trip is value-neutral with no hidden spread.

A round-trip now pays out exactly what was paid in for the same amount, so the contract can never extract more than the exact proportional value.

Added a regression test `blockchain/test/AssetToken.test.js` that uses a non-integer `tokenPrice` (100 ETH / 3 tokens) and asserts a buy-then-sell round-trip leaves the contract with zero leftover ETH (this would fail under the old ceiling/floor asymmetry).

## Files changed

- blockchain/contracts/AssetToken.sol
- blockchain/test/AssetToken.test.js

## Testing

- `node --check blockchain/test/AssetToken.test.js` passes (syntax).
- Added regression test asserting symmetric rounding → value-neutral round-trip.
- Manual review of the pricing math: with floor on both sides, `totalCost == payout` for equal buy/sell amounts.

Closes #13980
