### PR TITLE
Fix transaction anomaly detection can never fire (keyed by unique transaction_id)

### DIFF
--- a/backend/ml/anomaly/detector.py
+++ b/backend/ml/anomaly/detector.py
@@ -195,12 +195,22 @@ class AnomalyDetector:
         try:
             # Extract features
             features = self._extract_transaction_features(transaction)
-            
-            # Detect anomaly (window keyed per transaction)
+
+            # Detect anomaly (window keyed per stable entity, NOT the unique
+            # transaction_id). Keying per transaction_id created a fresh 1-element
+            # buffer for every tx that was front-padded into a constant sequence,
+            # so the anomaly score could never cross the threshold (issue #13900).
+            entity_id = (
+                transaction.get('account_id')
+                or transaction.get('customer_id')
+                or transaction.get('card_id')
+                or transaction.get('user_id')
+                or transaction.get('transaction_id')
+            )
             result = self.detect_anomaly(
                 'transactions',
                 features,
-                entity_key=str(transaction.get('transaction_id') or '')
+                entity_key=str(entity_id or '')
             )
             
             # Add transaction-specific info


### PR DESCRIPTION
## Problem

`backend/ml/anomaly/detector.py` keys the rolling feature buffer for transaction anomalies by the **unique** `transaction_id` (`detect_transaction_anomaly`, line ~203). Because every transaction gets its own buffer, each new transaction creates a fresh 1-element window that is front-padded by repeating that single row into a constant 30-step sequence. The LSTM autoencoder therefore sees a constant input for every transaction, reconstruction error is ~0, the anomaly score stays `< 1.0`, and `is_anomaly` is always `False`. Transaction fraud detection can **never** raise an alert — the opposite of its purpose (see #13900). Driver/GPS paths are keyed by `driver_id` and are correct.

## Fix

In `detect_transaction_anomaly` (backend/ml/anomaly/detector.py), the `entity_key` now resolves to a **stable** entity (`account_id` → `customer_id` → `card_id` → `user_id`, falling back to `transaction_id` only if no stable id is present) instead of the unique `transaction_id`. This lets each entity's buffer accumulate a real temporal sequence so the autoencoder can compute meaningful reconstruction errors and raise alerts.

## Files changed

- backend/ml/anomaly/detector.py

## Testing

Verified the file compiles with `python -m py_compile`. Manual review of the buffer/keying logic confirms the key is now stable per account/customer/card/user rather than unique per transaction.

Closes #13900
