### PR TITLE
[HIGH] Blockchain: cancelWithPenalty rejects started bookings

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -417,7 +417,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
      *      refunding the remaining escrow to the customer. The backend chooses
      *      the penalty only after validating the off-chain trip state.
      */
-    function cancelWithPenalty(uint256 bookingId, uint256 driverFee)
+        function cancelWithPenalty(uint256 bookingId, uint256 driverFee)
         external
         onlyOwner
         nonReentrant
@@ -430,7 +430,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             "TruxifyEscrow: Cannot cancel - booking not active"
         );
         require(!booking.paid, "TruxifyEscrow: Already paid");
-        require(!booking.started, "TruxifyEscrow: Trip already started");
+        require(booking.started, "TruxifyEscrow: Trip not started");
         require(booking.amount > 0, "TruxifyEscrow: Nothing to refund");
         require(driverFee <= booking.amount, "TruxifyEscrow: Penalty exceeds escrow");
 


### PR DESCRIPTION
## Problem

In `blockchain/contracts/TruxifyEscrow.sol` (#13914), `cancelWithPenalty` requires `!booking.started`. But `cancelBooking` already rejects started trips (documented: "A started trip must be cancelled through `cancelWithPenalty`"). Once `markBookingStarted` sets `started = true`, BOTH paths revert, so a started trip is uncancellable except via dispute — escrow funds are stuck. The normal "cancel after pickup" flow is broken.

## Fix

Changed the guard in `cancelWithPenalty` from `require(!booking.started, "TruxifyEscrow: Trip already started")` to `require(booking.started, "TruxifyEscrow: Trip not started")` at `blockchain/contracts/TruxifyEscrow.sol:433`. This matches the documented design: started trips are cancelled (with driver compensation) through `cancelWithPenalty`, while non-started trips remain cancellable via `cancelBooking`.

## Files changed

- blockchain/contracts/TruxifyEscrow.sol

## Testing

Manual review of the surrounding control flow (`cancelBooking` requires `!booking.started`; `cancelWithPenalty` now requires `booking.started`). The two paths are now mutually exclusive and together cover all started/non-started cases.

Closes #13914
