### PR TITLE
[HIGH] Automation: ML retraining threshold uses >= instead of ==

### DIFF
--- a/automation/n8n/ml_retraining.json
+++ b/automation/n8n/ml_retraining.json
@@ -42,6 +42,7 @@
           "number": [
             {
               "value1": "={{$json.new_booking_count}}",
+              "operator": "largerEqual",
               "value2": 100
             }
           ]


### PR DESCRIPTION
## Problem

The "New Bookings >= 100?" IF node in `automation/n8n/ml_retraining.json` (#13915) declares a `number` condition with only `value1` and `value2` and no `operator` field. In n8n v1 IF nodes, a missing operator defaults to `equal`, so the weekly retraining pipeline only fires when the new-booking count is exactly 100 — never for 101, 500, etc. Scheduled auto-retraining silently never runs under normal or high data volumes and models drift.

## Fix

Added `"operator": "largerEqual"` to the number condition in `automation/n8n/ml_retraining.json` (the `New Bookings >= 100?` IF node), so the threshold is correctly `new_booking_count >= 100`.

## Files changed

- automation/n8n/ml_retraining.json

## Testing

Validated the workflow JSON with `node -e "JSON.parse(...)"` — parses successfully. The change adds a single `operator` key to the existing condition, matching n8n v1 IF node schema.

Closes #13915
