### PR TITLE
[HIGH] Services (Rust ZKP): verify_range_proof trusts prover flag, ignores max_allowed

### DIFF
--- a/services/zkp-verifier-rust/src/bulletproofs.rs
+++ b/services/zkp-verifier-rust/src/bulletproofs.rs
@@ -30,9 +30,49 @@ impl BulletproofsGenerator {
     }
 
     pub fn verify_range_proof(result: &BulletproofResult, max_allowed: u64) -> bool {
-        if !result.is_in_range {
+        // Never trust the prover-supplied flag. Recompute the weight from the
+        // commitment and verify it is internally consistent with the proof, then
+        // enforce the caller's range bound.
+
+        // Expected commitment format: "0xcomm_<weight_hex>_<blinding>"
+        let commitment = match result.commitment_hex.strip_prefix("0xcomm_") {
+            Some(rest) => rest,
+            None => return false,
+        };
+        let mut comm_parts = commitment.splitn(2, '_');
+        let weight_hex = match comm_parts.next() {
+            Some(w) => w,
+            None => return false,
+        };
+        let blinding = match comm_parts.next() {
+            Some(b) => b,
+            None => return false,
+        };
+        let weight_kg = match u64::from_str_radix(weight_hex, 16) {
+            Ok(w) => w,
+            Err(_) => return false,
+        };
+
+        // The proof must be consistent with the same weight and blinding.
+        let proof = match result.proof_bytes_hex.strip_prefix("0xbproof_") {
+            Some(rest) => rest,
+            None => return false,
+        };
+        let mut proof_parts = proof.splitn(2, '_');
+        let proof_weight_hex = match proof_parts.next() {
+            Some(w) => w,
+            None => return false,
+        };
+        let proof_blinding = match proof_parts.next() {
+            Some(b) => b,
+            None => return false,
+        };
+
+        if weight_hex != proof_weight_hex || blinding != proof_blinding {
             return false;
         }
-        result.proof_bytes_hex.starts_with("0xbproof_") && result.commitment_hex.starts_with("0xcomm_")
+
+        // Enforce the actual range bound the caller cares about.
+        weight_kg <= max_allowed
     }
 }


### PR DESCRIPTION
## Problem

`verify_range_proof` in `services/zkp-verifier-rust/src/bulletproofs.rs` (#13913) is an unsound verifier: it returns `false` solely when the prover-supplied `result.is_in_range` is false, otherwise it only checks that two attacker-controlled hex strings start with fixed prefixes (`0xbproof_` / `0xcomm_`). The `max_allowed` argument is never used. A client can set `is_in_range = true` with any arbitrary `proof_bytes_hex`/`commitment_hex` and the verifier returns `true` regardless of the actual weight — the range proof is fully forgeable.

## Fix

Rewrote `verify_range_proof` (`services/zkp-verifier-rust/src/bulletproofs.rs:32`) to:
- Never trust `is_in_range`; it is no longer consulted.
- Parse the weight out of the commitment (`0xcomm_<weight_hex>_<blinding>`) and reject malformed input.
- Require the proof (`0xbproof_...`) to be internally consistent with the same weight and blinding.
- Enforce the real bound `weight_kg <= max_allowed` and return `false` otherwise.

## Files changed

- services/zkp-verifier-rust/src/bulletproofs.rs

## Testing

Manual Rust review (no compiler run per instructions). Forged `is_in_range = true` input with mismatched/invalid hex or weight exceeding `max_allowed` now returns `false`; only a correctly-formed, consistent proof with `weight_kg <= max_allowed` passes.

Closes #13913
