### PR TITLE
[HIGH] Services (CUDA): vehicleCapacity==0 division-by-zero

### DIFF
--- a/services/gpu-routing-cuda/src/cuda_vrp.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp.cu
@@ -12,6 +12,11 @@ VrpSolution CudaVrpSolver::solveParallelVRP(
     if (stops.empty()) {
         return { 0.0f, 0, true };
     }
+    // Reject zero capacity before the division below, which would otherwise be
+    // a division-by-zero (UB / SIGFPE) on this reachable, non-empty input.
+    if (vehicleCapacity == 0) {
+        return { 0.0f, 0, false };
+    }
 
     float distance = 0.0f;
     Location prev = depot;


### PR DESCRIPTION
## Problem

`services/gpu-routing-cuda/src/cuda_vrp.cu` (#13910) computes `routesNeeded = (stops.size() + vehicleCapacity - 1) / vehicleCapacity` but only guards against an empty `stops` vector, not `vehicleCapacity == 0`. When `vehicleCapacity == 0` the divisor is zero → undefined behavior / SIGFPE crash, and `isValid` is returned `true` so the invalid input is reported as a valid solution. This is reachable with non-empty input.

## Fix

Added a guard in `solveParallelVRP` (`services/gpu-routing-cuda/src/cuda_vrp.cu:12`) that rejects zero capacity before the division: `if (vehicleCapacity == 0) { return { 0.0f, 0, false }; }`. The empty-stops guard is left unchanged, so `solveParallelVRP(depot, stops, 0)` now returns `isValid = false` without crashing.

## Files changed

- services/gpu-routing-cuda/src/cuda_vrp.cu

## Testing

Manual C++ review (no compiler run per instructions). With `vehicleCapacity == 0` and non-empty `stops`, execution returns `{0.0f, 0, false}` before reaching the division, eliminating the division-by-zero.

Closes #13910
