### PR TITLE
[HIGH] Services (Rust ZKP): integer overflow on Content-Length DoS

### DIFF
--- a/services/zkp-verifier-rust/src/main.rs
+++ b/services/zkp-verifier-rust/src/main.rs
@@ -9,6 +9,10 @@ use tokio::net::{TcpListener, TcpStream};
 /// Address the verification microservice listens on (matches `EXPOSE 8087`).
 const BIND_ADDR: &str = "0.0.0.0:8087";
 
+/// Hard cap on the request body length, mirroring the ~1 MiB header cap.
+/// An attacker-controlled `Content-Length` larger than this is rejected.
+const MAX_BODY: usize = 1 * 1024 * 1024;
+
 /// Dev-only Ed25519 verifying public key (hex-encoded).
 ///
 /// A verification key is public material: it is safe to ship inside the
@@ -191,8 +195,18 @@ async fn handle_connection(mut stream: TcpStream) {
     let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
     let content_length = parse_content_length(&head);
 
+    // Reject unreasonably large or overflowing body lengths from an untrusted
+    // Content-Length header before performing any pointer arithmetic.
+    if content_length > MAX_BODY {
+        return;
+    }
+    let body_end = match header_end.checked_add(content_length) {
+        Some(end) => end,
+        None => return,
+    };
+
     // Read the remaining body bytes.
-    while buf.len() < header_end + content_length {
+    while buf.len() < body_end {
         let n = match stream.read(&mut chunk).await {
             Ok(0) => return,
             Ok(n) => n,
@@ -203,7 +217,7 @@ async fn handle_connection(mut stream: TcpStream) {
 
     let (method, path) = parse_request_line(&head);
     let body =
-        String::from_utf8_lossy(&buf[header_end..header_end + content_length]).to_string();
+        String::from_utf8_lossy(&buf[header_end..body_end]).to_string();
     let (status, payload) = route(&method, &path, &body);
 
     let _ = stream.write_all(&http_response(status, &payload)).await;


### PR DESCRIPTION
## Problem

`services/zkp-verifier-rust/src/main.rs` (#13911) uses an attacker-controlled `Content-Length` header in pointer arithmetic without bounds checking. `parse_content_length` does `value.trim().parse().unwrap_or(0)`, so `18446744073709551615` (`usize::MAX`) parses successfully. Then `header_end + content_length` overflows `usize` → panic in debug (and an out-of-bounds slice at the body read in release). Any unauthenticated client can crash the verifier with a single request. The body read loop also has no size cap (unbounded buffering DoS).

## Fix

In `handle_connection` (`services/zkp-verifier-rust/src/main.rs`):
- Added a hard `MAX_BODY` cap (1 MiB, mirroring the existing header cap) and reject requests whose `Content-Length` exceeds it before any arithmetic.
- Replaced `header_end + content_length` with `header_end.checked_add(content_length)`, returning early on overflow.
- Used the bounded `body_end` for both the read loop and the body slice.

## Files changed

- services/zkp-verifier-rust/src/main.rs

## Testing

Manual Rust review (no compiler run per instructions). With `Content-Length: 18446744073709551615`, `content_length > MAX_BODY` now causes an early return instead of overflow; `checked_add` guards any residual overflow. Body reads/slice are now bounded by `MAX_BODY`.

Closes #13911
