### PR TITLE
fix(telemetry): guard allowPing against sweeper eviction of in-flight rate entry

### DIFF
--- a/services/telemetry-ingestion/main.go
+++ b/services/telemetry-ingestion/main.go
@@ -530,6 +530,16 @@ func allowPing(driverID string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	// Re-check that this entry is still the one mapped to the driver. The
+	// reference count held by acquireRateEntry (inUse) already prevents the
+	// background sweeper from evicting an in-flight entry, so this is a
+	// belt-and-suspenders guard: if the entry were ever replaced or retired
+	// out from under us, mutating it would be lost and the ping would not be
+	// counted, letting the driver burst past maxPingsPerSec.
+	if cur, ok := pingRateLimit.Load(driverID); !ok || cur.(*rateEntry) != e {
+		return false
+	}
+
 	cutoff := time.Now().Add(-time.Second)
 	kept := e.stamps[:0]
 	for _, t := range e.stamps {


### PR DESCRIPTION
## Problem

`services/telemetry-ingestion/main.go` had a data race between `allowPing` and the `sweepDrivers` ticker (issue #13977). `allowPing` obtained a `*rateEntry` and mutated its sliding-window timestamps, but the background sweeper could delete that key from `pingRateLimit` before the request finished counting. Once the entry was orphaned, the appended timestamp was lost and the driver's 1-second window was never enforced, letting a driver exceed `maxPingsPerSec` (rate-limit bypass / burst above cap).

## Fix

The reference-counting in `acquireRateEntry` (the `inUse`/`retired` deferred-delete mechanism) already prevents the sweeper from evicting an entry that a request holds, so the entry is never orphaned. To make the alive-check explicit and robust against any future change to that contract, `allowPing` now re-checks map membership under the entry lock after acquiring `e.mu` and rejects (counts as limited) if the entry is no longer the mapped one — exactly the first option in the issue's Proposed Fix (re-`Load` the key and compare the returned pointer to `e`).

- `services/telemetry-ingestion/main.go:530` — added membership re-check in `allowPing` before mutating `e.stamps`.

## Files changed

- services/telemetry-ingestion/main.go

## Testing

Go toolchain is not available in this environment, so the change was verified by careful manual review of the concurrency contract: `acquireRateEntry` holds `e.mu` while bumping `inUse`, and `retireStalePingEntry`/`evictGeofenceOverflow` refuse to delete an entry with `inUse > 0`; the new re-check is a redundant safe guard that can only deny (never bypass) if it ever triggers. The diff is localized to `allowPing` and adds no new imports or dependencies.

Closes #13977
