### PR TITLE
fix(raft): loop replication in HandleCommitOrder to avoid 503 retry duplicates

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -734,6 +734,48 @@ func (rn *RaftNode) writeCommitSuccess(w http.ResponseWriter, entry LogEntry) {
 	})
 }
 
+// commitRetryTimeout bounds how long HandleCommitOrder waits for a single
+// entry to replicate to a quorum before answering 503. It is short on purpose:
+// the entry is already durable in the leader's log and will commit on a later
+// background heartbeat, so we only retry local replication rather than forcing
+// the client to retry (which, without trusting the idempotency guard, could
+// append a duplicate entry for the same OrderID).
+const commitRetryTimeout = 2 * time.Second
+
+// commitRetryInterval is the delay between replication rounds while waiting for
+// an entry to commit.
+const commitRetryInterval = 25 * time.Millisecond
+
+// waitForCommit drives background heartbeats for the entry at entryIndex and
+// returns once it is committed to a quorum, the node steps down, or the bounded
+// retry window elapses. Replication is looped (not a single round) so a slow
+// follower that misses the first heartbeat does not cause a spurious 503 and
+// does not force the client to retry-and-duplicate.
+func (rn *RaftNode) waitForCommit(entryIndex uint64) (committed bool, steppedDown bool, entry LogEntry) {
+	deadline := time.Now().Add(commitRetryTimeout)
+	for {
+		rn.sendHeartbeats()
+
+		rn.mu.Lock()
+		if rn.Role != Leader {
+			entry = rn.Log[entryIndex-1]
+			rn.mu.Unlock()
+			return false, true, entry
+		}
+		committed = rn.CommitIndex >= entryIndex
+		entry = rn.Log[entryIndex-1]
+		rn.mu.Unlock()
+
+		if committed {
+			return true, false, entry
+		}
+		if time.Now().After(deadline) {
+			return false, false, entry
+		}
+		time.Sleep(commitRetryInterval)
+	}
+}
+
 // HandleCommitOrder accepts a committed order entry on the leader.
 func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -828,13 +870,15 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 
 	rn.mu.Unlock()
 
-	// Replicate to followers and wait for a quorum acknowledgement before
-	// treating the entry as committed.
-	rn.sendHeartbeats()
+	// Replicate to followers and wait (bounded) for a quorum acknowledgement
+	// before treating the entry as committed. A single heartbeat round can miss
+	// slow followers even though the entry is durable in the leader's log, so we
+	// loop for a short bounded window instead of answering 503 after one round.
+	// The idempotency guard above (findEntryLocked) means a client that still
+	// retries never appends a duplicate entry for the same OrderID.
+	committed, steppedDown, entry := rn.waitForCommit(entryIndex)
 
-	rn.mu.Lock()
-	if rn.Role != Leader {
-		rn.mu.Unlock()
+	if steppedDown {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -844,23 +888,8 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	committed := rn.CommitIndex >= entryIndex
-	entry := rn.Log[entryIndex-1]
-	rn.mu.Unlock()
 
 	if !committed {
-		rn.mu.Lock()
-		defer rn.mu.Unlock()
-		if rn.Role != Leader {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"success":   false,
-				"error":     "stepped down while replicating entry",
-				"leader_id": rn.LeaderID,
-			})
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		json.NewEncoder(w).Encode(map[string]interface{}{


### PR DESCRIPTION
## Problem

`services/consensus-raft-go/main.go`'s `HandleCommitOrder` replicated a committed order with exactly one `sendHeartbeats()` round and then answered `503` if quorum was not yet reached (issue #13976). Because there was no idempotency on `OrderID` at the time the issue was filed, a client retrying the `503` would issue a second `HandleCommitOrder` that appended a brand-new log entry with the same `OrderID`, committing the same order twice (double dispatch). Even with the existing `findEntryLocked` idempotency guard (which now prevents the duplicate append), answering `503` after a single round still forces unnecessary client retries that the leader could have satisfied locally.

## Fix

`HandleCommitOrder` now loops replication for a bounded window instead of returning `503` after one round:

- Added `commitRetryTimeout` (2s) and `commitRetryInterval` (25ms) constants.
- Added `RaftNode.waitForCommit(entryIndex)` which drives `sendHeartbeats()` in a bounded loop, returning as soon as `CommitIndex >= entryIndex` (committed), if the node steps down (caller answers `409` conflict), or the window elapses (caller answers `503`). The already-present `findEntryLocked` idempotency guard ensures any surviving client retry reuses the same entry rather than appending a duplicate.

- `services/consensus-raft-go/main.go:737` — constants and `waitForCommit` helper.
- `services/consensus-raft-go/main.go:871` — `HandleCommitOrder` now uses `waitForCommit` (bounded retry) instead of a single `sendHeartbeats()` + immediate `503`.

## Files changed

- services/consensus-raft-go/main.go

## Testing

Go toolchain is not available in this environment, so the change was verified by careful manual review: `waitForCommit` calls `sendHeartbeats()` (which locks `rn.mu` internally) and then checks `CommitIndex`/`Role` under `rn.mu`; step-down is surfaced as the existing `409` conflict response and only a true quorum timeout yields `503`. Single-node clusters (empty `PeerURLs`) commit on the first round and return immediately. The idempotency path (`findEntryLocked`) is unchanged and still prevents duplicate appends.

Closes #13976
