### PR TITLE
Federated learning accepts unauthenticated client updates with naive averaging (model-poisoning)

### DIFF
--- a/backend/ml/federated/federated_server.py
+++ b/backend/ml/federated/federated_server.py
@@ -10,6 +10,8 @@ import hashlib
 import os
 from cryptography.fernet import Fernet
 
+from .fl_server import robust_aggregate
+
 logger = logging.getLogger(__name__)
 
 class FederatedServer:
@@ -23,6 +25,10 @@ class FederatedServer:
         self.round = 0
         self.min_clients = 3
         self.clients_per_round = 5
+        # Clients selected for the current round. Updates from any other
+        # (unregistered or unselected) client are rejected.
+        self.selected_clients = []
+        self.current_round = None
         self.encryption_key = Fernet.generate_key()
         self.cipher = Fernet(self.encryption_key)
         self.redis.setex('federated:encryption_key', 86400, self.encryption_key)
@@ -62,6 +68,8 @@ class FederatedServer:
         
         # Select clients for this round
         selected_clients = clients[:self.clients_per_round]
+        self.selected_clients = selected_clients
+        self.current_round = self.round
         
         # Broadcast global model weights
         if self.global_weights is None:
@@ -81,6 +89,21 @@ class FederatedServer:
         """Get list of available clients"""
         clients = self.redis.smembers('federated:clients')
         return [c.decode('utf-8') for c in clients]
+    
+    def _is_authorized_client(self, client_id):
+        """Return True only if ``client_id`` is registered and selected this round.
+
+        Prevents unauthenticated callers from injecting model updates: the
+        sender must both be a known/registered client and have been selected as
+        a participant in the current round (otherwise an attacker could POST
+        forged weights and poison the global model).
+        """
+        if client_id in self.client_weights:
+            # Already submitted for this round; ignore duplicate updates.
+            return False
+        registered = client_id in self._get_available_clients()
+        selected = client_id in self.selected_clients
+        return registered and selected
     
     def _send_weights_to_client(self, client_id, weights):
         """Send model weights to client"""
@@ -111,6 +134,12 @@ class FederatedServer:
     def receive_client_update(self, client_id, encrypted_weights):
         """Receive and process client model updates"""
         try:
+            # Authenticate the sender: it must be a registered client that was
+            # selected for the current round before its weights are accepted.
+            if not self._is_authorized_client(client_id):
+                logger.warning(f"🚫 Rejected update from unauthorized client {client_id}")
+                return {'success': False, 'error': 'unauthorized_client'}
+
             # Decrypt weights
             decrypted = self.cipher.decrypt(encrypted_weights)
             weights = json.loads(decrypted)
@@ -152,7 +181,10 @@ class FederatedServer:
             # Apply noisy gradients back to weights
             self.client_weights[client_id] = [gw + ng for gw, ng in zip(self.global_weights, noisy_grads)]
         
-        # Federated Averaging
+        # Robust Federated Aggregation: coordinate-wise median (byzantine-robust)
+        # instead of a naive plain mean, so a single malicious or compromised
+        # client submitting extreme weights cannot skew the global model. The
+        # per-layer delta from the previous global weights is also clipped.
         num_clients = len(self.client_weights)
         new_weights = []
         
@@ -161,9 +193,15 @@ class FederatedServer:
             for client_id in self.client_weights:
                 layer_weights.append(self.client_weights[client_id][layer_idx])
             
-            # Average weights
-            avg_weight = np.mean(layer_weights, axis=0)
-            new_weights.append(avg_weight)
+            global_layer = (
+                self.global_weights[layer_idx] if self.global_weights else None
+            )
+            agg_weight = robust_aggregate(
+                layer_weights,
+                global_layer,
+                clip_norm=self.dp_clip_norm,
+            )
+            new_weights.append(agg_weight)
         
         # Update global model
         self.global_weights = new_weights

--- a/backend/ml/federated/fl_server.py
+++ b/backend/ml/federated/fl_server.py
@@ -26,3 +26,34 @@ class FederatedAveragingServer:
         return self.global_weights
 
 fl_server = FederatedAveragingServer()
+
+
+def robust_aggregate(layer_weights, global_weights=None, clip_norm=1.0):
+    """Coordinate-wise median aggregator (byzantine-robust).
+
+    Unlike a naive ``np.mean``, the median is resistant to a single malicious
+    or compromised client submitting extreme weights: one outlier cannot move
+    the median materially. When ``global_weights`` is provided, the per-layer
+    delta from the previous global weights is clipped to ``clip_norm`` so even
+    several colluding clients cannot shift the global model arbitrarily.
+
+    Parameters
+    ----------
+    layer_weights : iterable of array-like
+        Per-client weight arrays for a single layer (same shape each).
+    global_weights : array-like, optional
+        Previous global weights for this layer, used to clip the update delta.
+    clip_norm : float
+        Maximum L2 norm of the aggregated delta.
+    """
+    stacked = np.stack([np.asarray(w, dtype=float) for w in layer_weights], axis=0)
+    median = np.median(stacked, axis=0)
+
+    if global_weights is not None:
+        delta = median - np.asarray(global_weights, dtype=float)
+        norm = float(np.linalg.norm(delta))
+        if norm > clip_norm > 0:
+            delta = delta * (clip_norm / (norm + 1e-8))
+        median = np.asarray(global_weights, dtype=float) + delta
+
+    return median

--- a/backend/ml/tests/test_fl_server.py
+++ b/backend/ml/tests/test_fl_server.py
@@ -3,7 +3,38 @@
 Run with: python3 -m pytest tests/test_fl_server.py -v --no-header
 """
 import numpy as np
-from federated.fl_server import FederatedAveragingServer
+from federated.fl_server import FederatedAveragingServer, robust_aggregate
+
+
+class TestRobustAggregate:
+    """Byzantine-robust aggregation must resist a malicious outlier."""
+
+    def test_malicious_outlier_does_not_move_global_model(self):
+        """A single extreme client weight must not skew the aggregate.
+
+        With four honest clients near 1.0 and one malicious client submitting
+        an extreme value (1e6), a naive mean would land near 2e5, but the
+        coordinate-wise median must stay at ~1.0 (and the clipped delta keeps
+        it bounded).
+        """
+        honest = [np.array([1.0, 1.0]) for _ in range(4)]
+        malicious = [np.array([1e6, 1e6])]
+        global_weights = np.array([1.0, 1.0])
+
+        result = robust_aggregate(
+            honest + malicious, global_weights, clip_norm=1.0
+        )
+
+        # Median of five values with one outlier is still ~1.0 for each coord.
+        assert np.allclose(result, np.array([1.0, 1.0]), atol=1e-6)
+        # The malicious client must not move the model by more than the clip.
+        assert np.linalg.norm(result - global_weights) <= 1.0 + 1e-6
+
+    def test_single_client_returns_its_weights(self):
+        """With one client there is no outlier to resist; return its weights."""
+        result = robust_aggregate([np.array([3.0, 4.0])])
+        assert np.allclose(result, np.array([3.0, 4.0]))
+
 
 
 class TestAggregateUpdates:


### PR DESCRIPTION
## Problem

`backend/ml/federated/federated_server.py` ingested and averaged any client weights with no authentication and no byzantine-robustness: `receive_client_update` stored arbitrary `client_id` weights and `_aggregate_weights` used a plain `np.mean`. Any caller could POST weights that skew the global driver-behavior risk model — a real model-poisoning vulnerability. Ref #13969.

## Fix

- Added `_is_authorized_client` which accepts an update only when the sender is a **registered** client (`_get_available_clients`) **and** was **selected for the current round** (`selected_clients`); duplicate submissions for the same round are rejected — `federated_server.py:93-106`, enforced at `federated_server.py:134-141`.
- Replaced naive `np.mean` aggregation with `robust_aggregate` (coordinate-wise median, byzantine-robust) plus per-layer delta clipping to `dp_clip_norm` — `federated_server.py:165-204`. The robust aggregator is implemented in `backend/ml/federated/fl_server.py:31-59`.
- Added `backend/ml/tests/test_fl_server.py` with `TestRobustAggregate` asserting a single extreme (`1e6`) client weight does **not** move the aggregate away from the honest `~1.0` values (median) and the clipped delta stays within the clip bound.

## Files changed

- backend/ml/federated/federated_server.py
- backend/ml/federated/fl_server.py
- backend/ml/tests/test_fl_server.py

## Testing

Python syntax verified with `py -m py_compile`. The new `TestRobustAggregate` exercises the byzantine-robust path directly: with four honest clients at `1.0` and one malicious client at `1e6`, the aggregate remains `~1.0` and within the clip norm.

Closes #13969
