### PR TITLE
Federated round never aggregates unless >=5 clients respond (min 3, per-round 5) — global model hangs

### DIFF
--- a/backend/ml/federated/federated_server.py
+++ b/backend/ml/federated/federated_server.py
@@ -23,6 +23,12 @@ class FederatedServer:
         self.round = 0
         self.min_clients = 3
         self.clients_per_round = 5
+        # Clients selected for the current round. Aggregation triggers once a
+        # quorum of these selected clients have responded (see
+        # receive_client_update), so a round can never hang just because fewer
+        # than `clients_per_round` clients exist.
+        self.selected_clients = []
+        self.current_round = None
         self.encryption_key = Fernet.generate_key()
         self.cipher = Fernet(self.encryption_key)
         self.redis.setex('federated:encryption_key', 86400, self.encryption_key)
@@ -62,6 +68,11 @@ class FederatedServer:
         
         # Select clients for this round
         selected_clients = clients[:self.clients_per_round]
+        # Reset round state so a new round starts from a clean slate and the
+        # aggregation threshold below reflects only this round's participants.
+        self.selected_clients = selected_clients
+        self.current_round = self.round
+        self.client_weights.clear()
         
         # Broadcast global model weights
         if self.global_weights is None:
@@ -123,8 +134,14 @@ class FederatedServer:
             
             logger.info(f"📥 Received update from client {client_id}")
             
-            # Check if all clients have responded
-            if len(self.client_weights) >= self.clients_per_round:
+            # Check if a quorum of the SELECTED clients for this round have
+            # responded. Previously this required `clients_per_round` (5)
+            # responses, so with the normal 3-4 available clients the round
+            # hung forever and the global model never advanced. A quorum is
+            # ceil(half the selected set), so a round with 3 clients
+            # aggregates once 2 respond.
+            quorum = max(1, (len(self.selected_clients) + 1) // 2)
+            if len(self.client_weights) >= quorum:
                 self._aggregate_weights()
             
             return {'success': True}

--- a/backend/ml/tests/test_federated.py
+++ b/backend/ml/tests/test_federated.py
@@ -1,3 +1,6 @@
+import json
+
+import numpy as np
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -14,3 +17,37 @@ class TestFederated:
         from federated.federated_client import FederatedClient
         client = FederatedClient(client_id="client-101")
         assert client.client_id == "client-101"
+
+    @patch("redis.Redis.from_url")
+    def test_round_with_three_clients_aggregates(self, mock_redis):
+        """A round with only 3 (fewer than clients_per_round=5) clients must
+        still aggregate once a quorum of the selected clients respond."""
+        from federated.federated_server import FederatedServer
+        server = FederatedServer()
+        # Three available/registered clients; the round selects all three.
+        server.redis.smembers.return_value = {b"c1", b"c2", b"c3"}
+        round_info = server.start_round()
+        assert round_info is not None
+        assert set(server.selected_clients) == {"c1", "c2", "c3"}
+
+        # Build an encrypted weight payload the server can decrypt. Shapes
+        # mirror the driver-behavior model defined in _create_model.
+        def make_update(client_id):
+            zeros = [
+                np.zeros((10, 64)), np.zeros((64,)),
+                np.zeros((64, 32)), np.zeros((32,)),
+                np.zeros((32, 1)), np.zeros((1,)),
+            ]
+            payload = server.cipher.encrypt(
+                json.dumps([w.tolist() for w in zeros]).encode()
+            )
+            return server.receive_client_update(client_id, payload)
+
+        # Quorum for 3 selected clients is ceil(3/2) = 2 responses.
+        r1 = make_update("c1")
+        r2 = make_update("c2")
+        assert r1["success"] and r2["success"]
+        # Aggregation clears the round's client_weights and advances the model.
+        assert server.client_weights == {}
+        assert server.round == 1
+


### PR DESCRIPTION
## Problem

`backend/ml/federated/federated_server.py` set contradictory thresholds: `min_clients = 3` and `clients_per_round = 5`, and `receive_client_update` only aggregated when `len(self.client_weights) >= 5`. With the normal 3–4 available clients, `len(client_weights)` can never reach 5, so `_aggregate_weights()` is **never called** — the round hangs and the global driver-behavior risk model never advances. Ref #13968.

## Fix

- Track the actual `selected_clients` set for the round (`self.selected_clients`) and reset round state (`client_weights.clear()`) at the start of each round — `federated_server.py:25-31` (`__init__`), `federated_server.py:63-72` (`start_round`).
- Aggregate once a **quorum** of the selected clients for the round have responded, instead of requiring `clients_per_round` (5). Quorum = `ceil(selected/2)`, so a round with 3 clients aggregates once 2 respond — `federated_server.py:126-133`.
- Added `backend/ml/tests/test_federated.py::test_round_with_three_clients_aggregates` asserting a 3-client round aggregates after 2 responses (`client_weights` cleared, `round == 1`).

## Files changed

- backend/ml/federated/federated_server.py
- backend/ml/tests/test_federated.py

## Testing

Python syntax verified with `py -m py_compile`. The new test constructs a 3-client round (Redis mocked, weights encrypted with the server's own cipher) and verifies aggregation triggers after 2 of 3 clients respond, clearing `client_weights` and advancing the round.

Closes #13968
