### PR TITLE
Store '/store/transaction' custom op passes an undefined function (broken branch + code-injection-by-name vector)

### DIFF
--- a/backend/store/routes.js
+++ b/backend/store/routes.js
@@ -101,6 +101,17 @@ router.post('/store/atomic', (req, res) => {
 
 // ============ Transaction Routes ============
 
+// Server-defined, allowlisted custom operations. Clients request a registered
+// `name`; the callable is resolved server-side so a client can never supply
+// executable code from the request body. Unknown names are rejected with 400.
+const OP_REGISTRY = {
+    incrementCounter: (op) => {
+        const key = op.key;
+        const current = store.get(key) || 0;
+        store.set(key, current + (typeof op.amount === 'number' ? op.amount : 1));
+    },
+};
+
 // Execute transaction
 router.post('/store/transaction', async (req, res) => {
     try {
@@ -119,7 +130,13 @@ router.post('/store/transaction', async (req, res) => {
                 } else if (op.type === 'update') {
                     tx.addOperation(() => store.update(op.updates));
                 } else if (op.type === 'custom') {
-                    tx.addOperation(op.fn);
+                    const handler = OP_REGISTRY[op.name];
+                    if (!handler) {
+                        return res
+                            .status(400)
+                            .json({ success: false, error: 'unknown custom op' });
+                    }
+                    tx.addOperation(() => handler(op));
                 }
             }
             return tx.execute();


### PR DESCRIPTION
## Problem

`backend/store/routes.js:121-122` handled the `custom` transaction operation by calling `tx.addOperation(op.fn)`, queuing a function taken **straight from the request body**. JSON cannot serialize functions, so `op.fn` is always `undefined` when parsed from a request — every `custom` transaction throws at `tx.execute()` time (the branch is dead). Conceptually it also lets a client nominate which callable the server runs, an unvalidated "execute this named thing" design with no registry/allowlist. Ref #13967.

## Fix

- Added a server-side `OP_REGISTRY` mapping a safe `name` to a server-defined handler. Clients may only request a registered name; the callable is resolved server-side, so executable code is **never** accepted from the client — `routes.js:105-118`.
- The `custom` branch now looks up `OP_REGISTRY[op.name]` and rejects unknown names with `400` (`unknown custom op`); only registered handlers are enqueued via `tx.addOperation(() => handler(op))` — `routes.js:121-129`.

## Files changed

- backend/store/routes.js

## Testing

JavaScript syntax verified with `node --check backend/store/routes.js`. Confirmed the `custom` branch no longer references client-supplied `op.fn` and that unknown op names return HTTP 400 instead of enqueueing undefined code.

Closes #13967
