### PR TITLE
vector-matcher-cpp bin-packing never places boxes; reports 'fits' for geometrically impossible loads

### DIFF
--- a/services/vector-matcher-cpp/include/matcher.hpp
+++ b/services/vector-matcher-cpp/include/matcher.hpp
@@ -14,10 +14,18 @@ struct Box3D {
     float volume() const { return length * width * height; }
 };
 
+struct PlacedBox {
+    Box3D box;
+    float x;
+    float y;
+    float z;
+};
+
 struct VectorMatchResult {
     bool fits;
     float utilizationPercentage;
     size_t packedCount;
+    std::vector<PlacedBox> placementMap;
 };
 
 class VectorMatcherEngine {

--- a/services/vector-matcher-cpp/src/matcher.cpp
+++ b/services/vector-matcher-cpp/src/matcher.cpp
@@ -1,8 +1,31 @@
 #include "../include/matcher.hpp"
 #include <algorithm>
+#include <array>
 #include <numeric>
+#include <vector>
 
 namespace TruxifyMatcher {
+
+namespace {
+
+struct Placement {
+    float x, y, z;
+    float dx, dy, dz;
+};
+
+bool overlaps(const Placement& a, const Placement& b) {
+    return a.x < b.x + b.dx && b.x < a.x + a.dx &&
+           a.y < b.y + b.dy && b.y < a.y + a.dy &&
+           a.z < b.z + b.dz && b.z < a.z + a.dz;
+}
+
+bool fitsBed(const Placement& p, const Box3D& bed) {
+    return p.x + p.dx <= bed.length + 1e-4f &&
+           p.y + p.dy <= bed.width + 1e-4f &&
+           p.z + p.dz <= bed.height + 1e-4f;
+}
+
+} // namespace
 
 VectorMatchResult VectorMatcherEngine::evaluatePackingAVX(
     const Box3D& truckBed,
@@ -10,45 +33,83 @@ VectorMatchResult VectorMatcherEngine::evaluatePackingAVX(
 ) {
     float totalTruckVolume = truckBed.volume();
     if (totalTruckVolume <= 0.0f) {
-        return { false, 0.0f, 0 };
+        return { false, 0.0f, 0, {} };
     }
 
+    std::vector<Placement> placed;
     float totalCargoVolume = 0.0f;
-    size_t packed = 0;
+
+    const int permutations[6][3] = {
+        {0, 1, 2}, // (L, W, H)
+        {1, 0, 2}, // (W, L, H)
+        {0, 2, 1}, // (L, H, W)
+        {2, 1, 0}, // (H, W, L)
+        {1, 2, 0}, // (W, H, L)
+        {2, 0, 1}, // (H, L, W)
+    };
 
     for (const auto& box : cargoBoxes) {
-        // Dimension check: a box fits if any of the 6 axis permutations of its
-        // (length, width, height) fits within the bed's (length, width, height).
-        // Checking only (L,W,H), (W,L,H) and (H,W,L) wrongly rejected boxes
-        // that fit only in the (L,H,W), (W,H,L) or (H,L,W) orientations.
-        const float boxDims[3] = { box.length, box.width, box.height };
-        const int permutations[6][3] = {
-            {0, 1, 2}, // (L, W, H)
-            {1, 0, 2}, // (W, L, H)
-            {0, 2, 1}, // (L, H, W)
-            {2, 1, 0}, // (H, W, L)
-            {1, 2, 0}, // (W, H, L)
-            {2, 0, 1}, // (H, L, W)
-        };
+        const float dims[3] = { box.length, box.width, box.height };
+        bool placedBox = false;
 
-        bool fitsOrientation = false;
-        for (int i = 0; i < 6 && !fitsOrientation; ++i) {
-            fitsOrientation =
-                boxDims[permutations[i][0]] <= truckBed.length &&
-                boxDims[permutations[i][1]] <= truckBed.width &&
-                boxDims[permutations[i][2]] <= truckBed.height;
+        for (int i = 0; i < 6 && !placedBox; ++i) {
+            Placement cand;
+            cand.dx = dims[permutations[i][0]];
+            cand.dy = dims[permutations[i][1]];
+            cand.dz = dims[permutations[i][2]];
+
+            // Candidate anchor positions: the origin plus the three "positive"
+            // corners of every already-placed box (extreme-point heuristic).
+            std::vector<std::array<float, 3>> anchors;
+            anchors.push_back({ 0.0f, 0.0f, 0.0f });
+            for (const auto& p : placed) {
+                anchors.push_back({ p.x + p.dx, p.y, p.z });
+                anchors.push_back({ p.x, p.y + p.dy, p.z });
+                anchors.push_back({ p.x, p.y, p.z + p.dz });
+            }
+
+            for (const auto& a : anchors) {
+                cand.x = a[0];
+                cand.y = a[1];
+                cand.z = a[2];
+                if (!fitsBed(cand, truckBed)) {
+                    continue;
+                }
+                bool ok = true;
+                for (const auto& p : placed) {
+                    if (overlaps(cand, p)) {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (ok) {
+                    placed.push_back(cand);
+                    totalCargoVolume += box.volume();
+                    placedBox = true;
+                    break;
+                }
+            }
         }
 
-        if (fitsOrientation && (totalCargoVolume + box.volume() <= totalTruckVolume)) {
-            totalCargoVolume += box.volume();
-            packed++;
+        if (!placedBox) {
+            // This box cannot be placed without overlap: the load is infeasible.
+            return { false, 0.0f, placed.size(), {} };
         }
     }
 
     float utilization = (totalCargoVolume / totalTruckVolume) * 100.0f;
-    bool allFits = (packed == cargoBoxes.size());
+    bool allFits = (placed.size() == cargoBoxes.size());
 
-    return { allFits, utilization, packed };
+    VectorMatchResult res;
+    res.fits = allFits;
+    res.utilizationPercentage = utilization;
+    res.packedCount = placed.size();
+    res.placementMap.reserve(placed.size());
+    for (const auto& p : placed) {
+        Box3D b{ p.dx, p.dy, p.dz };
+        res.placementMap.push_back({ b, p.x, p.y, p.z });
+    }
+    return res;
 }
 
 } // namespace TruxifyMatcher


### PR DESCRIPTION
## Problem

`services/vector-matcher-cpp/src/matcher.cpp` only checked dimensional fit and a total volume sum — it never performed actual placement or overlap detection, and never produced the `placementMap` the contract/test expects (`r.placementMap`). As a result it reported `fits == true` for physically impossible loads: feeding two 7×7×7 cubes into a 10³ bed passes the per-box dimensional check (7 ≤ 10) and the volume check (686 < 1000), yet 7+7 = 14 > 10 on every axis so the cubes must overlap. The engine reported a load "fits" when it cannot be packed. Refs #13973.

## Fix

Replaced the volume-sum heuristic with an actual placement pass:
- Added a `Placement` struct and AABB `overlaps`/`fitsBed` helpers (`matcher.cpp:11`).
- `evaluatePackingAVX` now tries each box in all 6 orientations and places it at an extreme-point anchor (origin + the three positive corners of every already-placed box). A candidate is only accepted if it fits inside the bed AND does not overlap any placed box (`matcher.cpp:55`).
- A box that cannot be placed without overlap makes the whole load infeasible (`return { false, ... }`), so `fits` is true only when every box is actually placed.
- Populated `res.placementMap` with each placed box and its `(x,y,z)` position (`matcher.cpp:107`), matching the `VectorMatchResult.placementMap` contract in `matcher.hpp:28`.

## Files changed

- services/vector-matcher-cpp/src/matcher.cpp
- services/vector-matcher-cpp/include/matcher.hpp

## Testing

Manual trace of `test_overlap_rejected`: two 7×7×7 cubes in a 10³ bed — the first is placed at the origin, the second's only candidate anchors ((7,0,0),(0,7,0),(0,0,7)) all exceed the 10-unit bed, so placement fails and `fits == false` as expected. (C++ compiler not executed per task constraints.)

Closes #13973
