### PR TITLE
Raft node persists no state (term/votedFor/log) — committed entries can be lost and logs diverge across restarts

### DIFF
--- a/services/consensus-raft-go/main.go
+++ b/services/consensus-raft-go/main.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -160,12 +161,95 @@ type RaftNode struct {
 	// is also dropped from liveAck whenever a heartbeat fails or is rejected, so
 	// liveness reflects recent contact instead of a once-set flag.
 	liveAck            map[string]bool
+	persister          *persister
 	httpClient         *http.Client
 	// rng is this node's own source of randomness for election timeouts. It is
 	// only accessed while holding mu, so a per-node Rand is safe for concurrent
 	// use across election goroutines of different nodes.
-	rng *rand.Rand
+		rng *rand.Rand
 }
+
+// persister durably stores the Raft stable state (currentTerm, votedFor, and
+// the log) so a restarted node does not lose committed entries or re-vote in a
+// term it already voted in (Raft §5.1 / §5.4.2). State is written atomically to
+// a JSON file on every mutation ("persist then respond"): SaveState is called
+// when the term or vote changes, and SaveLog when the log changes. load() is
+// invoked at startup so CurrentTerm/VotedFor/Log survive restarts.
+type persister struct {
+	path     string
+	mu       sync.Mutex
+	term     uint64
+	votedFor string
+	log      []LogEntry
+}
+
+func newPersister(id string) *persister {
+	dir := os.Getenv("RAFT_STATE_DIR")
+	if dir == "" {
+		dir = "."
+	}
+	_ = os.MkdirAll(dir, 0o755)
+	return &persister{path: filepath.Join(dir, "raft-state-"+id+".json")}
+}
+
+// load reads the persisted snapshot. It returns zero values if no state file
+// exists or it is unreadable, so a first boot starts from a clean slate.
+func (p *persister) load() (uint64, string, []LogEntry) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	data, err := os.ReadFile(p.path)
+	if err != nil {
+		return 0, "", nil
+	}
+	var s struct {
+		Term     uint64     `json:"current_term"`
+		VotedFor string     `json:"voted_for"`
+		Log      []LogEntry `json:"log"`
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return 0, "", nil
+	}
+	p.term = s.Term
+	p.votedFor = s.VotedFor
+	p.log = s.Log
+	return s.Term, s.VotedFor, s.Log
+}
+
+func (p *persister) write() error {
+	s := struct {
+		Term     uint64     `json:"current_term"`
+		VotedFor string     `json:"voted_for"`
+		Log      []LogEntry `json:"log"`
+	}{p.term, p.votedFor, p.log}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	tmp := p.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p.path)
+}
+
+// SaveState persists the current term and the candidate this node voted for.
+func (p *persister) SaveState(term uint64, votedFor string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.term = term
+	p.votedFor = votedFor
+	return p.write()
+}
+
+// SaveLog persists the full replicated log after it is mutated.
+func (p *persister) SaveLog(log []LogEntry) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.log = make([]LogEntry, len(log))
+	copy(p.log, log)
+	return p.write()
+}
+
 
 func NewRaftNode(id string, peers []string, peerURLs []string) *RaftNode {
 	heartbeatMs := envInt("RAFT_HEARTBEAT_MS", 100)
@@ -175,11 +259,16 @@ func NewRaftNode(id string, peers []string, peerURLs []string) *RaftNode {
 		electionMaxMs = electionMinMs
 	}
 
+	p := newPersister(id)
+	term, votedFor, log := p.load()
+
 	return &RaftNode{
 		NodeID:             id,
-		CurrentTerm:        0,
+		CurrentTerm:        term,
+		VotedFor:           votedFor,
 		Role:               Follower,
-		Log:                make([]LogEntry, 0),
+		Log:                log,
+		persister:          p,
 		Peers:              peers,
 		PeerURLs:           peerURLs,
 		LeaderID:           "",
@@ -224,6 +313,11 @@ func (rn *RaftNode) stepDownLocked(term uint64) {
 	}
 	rn.CurrentTerm = term
 	rn.VotedFor = ""
+	// Durably record the higher term before any response so a restart cannot
+	// re-enter a term it already observed (Raft §5.1).
+	if err := rn.persister.SaveState(rn.CurrentTerm, rn.VotedFor); err != nil {
+		log.Printf("raft persist error: %v", err)
+	}
 	rn.LeaderID = ""
 	if rn.Role != Follower {
 		rn.Role = Follower
@@ -239,6 +333,11 @@ func (rn *RaftNode) startElection() {
 	rn.CurrentTerm++
 	term := rn.CurrentTerm
 	rn.VotedFor = rn.NodeID
+	// Persist the new term and self-vote before soliciting votes (Raft §5.1: a
+	// candidate must durably record its term before sending RequestVote).
+	if err := rn.persister.SaveState(rn.CurrentTerm, rn.VotedFor); err != nil {
+		log.Printf("raft persist error: %v", err)
+	}
 	rn.LeaderID = ""
 	rn.electionStarted = time.Now()
 	rn.electionTimeout = rn.randomElectionTimeout()
@@ -616,6 +715,9 @@ func (rn *RaftNode) HandleVote(w http.ResponseWriter, r *http.Request) {
 		(rn.VotedFor == "" || rn.VotedFor == req.CandidateID) &&
 		rn.isLogUpToDate(req.LastLogIndex, req.LastLogTerm) {
 		rn.VotedFor = req.CandidateID
+		if err := rn.persister.SaveState(rn.CurrentTerm, rn.VotedFor); err != nil {
+			log.Printf("raft persist error: %v", err)
+		}
 		rn.lastLeaderSeen = time.Now()
 		resp.VoteGranted = true
 	}
@@ -666,6 +768,9 @@ func (rn *RaftNode) HandleAppend(w http.ResponseWriter, r *http.Request) {
 		if rn.VotedFor == "" || rn.VotedFor == req.LeaderID {
 			rn.VotedFor = req.LeaderID
 		}
+		if err := rn.persister.SaveState(rn.CurrentTerm, rn.VotedFor); err != nil {
+			log.Printf("raft persist error: %v", err)
+		}
 		rn.lastLeaderSeen = time.Now()
 
 		if rn.appendLogFromLeaderLocked(req) {
@@ -712,10 +817,16 @@ func (rn *RaftNode) appendLogFromLeaderLocked(req AppendEntriesRequest) bool {
 			if rn.Log[idx-1].Term != e.Term {
 				rn.Log = rn.Log[:idx-1]
 				rn.Log = append(rn.Log, req.Entries[i:]...)
+				if err := rn.persister.SaveLog(rn.Log); err != nil {
+					log.Printf("raft persist error: %v", err)
+				}
 				return true
 			}
 		} else {
 			rn.Log = append(rn.Log, req.Entries[i:]...)
+			if err := rn.persister.SaveLog(rn.Log); err != nil {
+				log.Printf("raft persist error: %v", err)
+			}
 			return true
 		}
 	}
@@ -815,6 +926,9 @@ func (rn *RaftNode) HandleCommitOrder(w http.ResponseWriter, r *http.Request) {
 		// Append to the local log first. CommitIndex is NOT advanced here: the
 		// entry must first be replicated to a quorum of followers (Raft §5.3).
 		rn.Log = append(rn.Log, entry)
+		if err := rn.persister.SaveLog(rn.Log); err != nil {
+			log.Printf("raft persist error: %v", err)
+		}
 		entryIndex = entry.Index
 	}
 


### PR DESCRIPTION
## Problem

`services/consensus-raft-go/main.go` kept `CurrentTerm`, `VotedFor`, `Log`, and `CommitIndex` as plain in-memory fields. `HandleVote`/`HandleAppend` mutated `CurrentTerm`/`VotedFor` and `HandleCommitOrder`/`appendLogFromLeaderLocked` appended to `rn.Log` with no write to stable storage before responding, and there was no load-on-startup. Per Raft §5.1/§5.4.2 this is unsafe: a node that crashes after voting in term T and restarts can vote again in the same term for a less-up-to-date candidate; a restarted leader/follower loses already-committed entries and can re-accept an overwriting log from a newer leader, causing log divergence and loss of committed orders. Refs #13974.

## Fix

Added a file-backed `persister` and applied the standard "persist then respond" rule:
- New `persister` type (`main.go:178`) atomically writes `{current_term, voted_for, log}` as JSON to `raft-state-<id>.json` (under `RAFT_STATE_DIR` or cwd), with `SaveState(term, votedFor)` and `SaveLog(log)` plus a `load()` used at startup.
- `NewRaftNode` (`main.go:260`) creates the persister and initializes `CurrentTerm`/`VotedFor`/`Log` from `load()`, so committed state survives restarts.
- `SaveState` is called in `startElection` (after bumping term + self-vote), in `stepDownLocked` (after recording a higher term), and in `HandleVote` (on vote grant) and `HandleAppend` (on recording the leader vote).
- `SaveLog` is called in `HandleCommitOrder` (before returning after `rn.Log = append(...)`), and in `appendLogFromLeaderLocked` after every log mutation (append/truncate), so each entry is durable before it is applied/replicated. Persist errors are logged but do not block the in-memory path.

## Files changed

- services/consensus-raft-go/main.go

## Testing

Manual review of all term/votedFor/log mutation sites to ensure each is preceded by a persist call, and of `load()` initialization in `NewRaftNode`. (Go toolchain not available in this environment, so the build was not executed per task constraints; changes are confined to added durability calls and a self-contained persister.)

Closes #13974
