### PR TITLE
[HIGH] Supabase: payments INSERT RLS over-permissive (broken write authorization)

### DIFF
--- a/supabase/migrations/20260811000000_drop_overpermissive_payments_insert_rls.sql
+++ b/supabase/migrations/20260811000000_drop_overpermissive_payments_insert_rls.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Fix over-permissive payments INSERT RLS (issue #13961)
+-- ============================================================================
+-- `payments` is a financial ledger. Rows must only ever be created server-side:
+-- the backend API writes via the service_role key
+-- (backend/api/src/routes/paymentRoutes.js) and escrow deposits are recorded by
+-- recordDepositTx; the GraphQL layer only reads
+-- (backend/graphql/services/order.service.js). Nothing inserts client-side.
+--
+-- The prior policy was over-permissive:
+--
+--   create policy payments_owner_insert_policy on payments
+--     for insert to authenticated
+--     with check (user_id = get_profile_id());
+--
+-- WITH CHECK only validated `user_id`, so ANY authenticated caller could INSERT
+-- rows and freely set `amount_paisa`, `status` (e.g. directly 'captured' /
+-- 'released') and `order_id` (any order) — forging ledger entries and bypassing
+-- the payment / escrow flow. That is broken write authorization on a financial
+-- table.
+--
+-- Drop the direct client INSERT capability. service_role keeps full write
+-- access, so legitimate server-side payment creation is unaffected; SELECT for
+-- the owning user is unchanged.
+
+drop policy if exists payments_owner_insert_policy on payments;


### PR DESCRIPTION
## Problem

The `payments` table (a financial ledger) was protected by an RLS policy `payments_owner_insert_policy` that allowed **any** `authenticated` user to INSERT rows. Its `WITH CHECK (user_id = get_profile_id())` only validated the row's `user_id`, so a caller could freely set `amount_paisa`, `status` (e.g. directly `'captured'`/`'released'`) and `order_id` (any order) — forging ledger entries and bypassing the payment/escrow flow. This is broken write authorization on a financial table. (refs #13961)

## Fix

- Dropped the over-permissive `payments_owner_insert_policy` in a new migration `supabase/migrations/20260811000000_drop_overpermissive_payments_insert_rls.sql` (idempotent `DROP POLICY IF EXISTS`).
- Payments are only ever created server-side via the `service_role` key (`backend/api/src/routes/paymentRoutes.js`, `recordDepositTx`), so removing the client INSERT capability does not affect legitimate flows. `service_role` keeps full write access and the owning-user SELECT policy is unchanged.

## Files changed

- supabase/migrations/20260811000000_drop_overpermissive_payments_insert_rls.sql

## Testing

- Manual review of the policy and all codebase write paths; confirmed no client-side `.from('payments').insert()` exists. The migration is additive (DROP IF EXISTS) and idempotent.

Closes #13961
