### PR TITLE
[MEDIUM-HIGH] Infra/nginx: add client_max_body_size & proxy timeouts, fix merge conflict

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,13 +41,20 @@ http {
     # Legacy IE6 mishandles gzip; excluded rather than risking corrupt bodies.
     gzip_disable "msie6";
 
-<<<<<<< HEAD
-    server {
-        listen 8080;
+    # ------------------------------------------------------------------
+    # Upload size & upstream timeouts
+    #
+    # Drivers upload KYC documents, POD scans and maintenance photos that can
+    # exceed nginx's 1m default body limit, which produced spurious HTTP 413
+    # responses. ML inference can run long, so upstream read/send timeouts
+    # are raised to avoid premature HTTP 504 gateway timeouts.
+    # ------------------------------------------------------------------
+    client_max_body_size 25m;
+    proxy_request_buffering off;
+    proxy_connect_timeout 10s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
 
-        # Node.js Auth Service
-        location /api/v1/auth {
-=======
     # ------------------------------------------------------------------
     # Rate limiting
     #
@@ -85,7 +92,6 @@ http {
             # Brute-force protection: throttle login attempts per client.
             limit_req zone=auth burst=10 nodelay;
 
->>>>>>> upstream/main
             rewrite ^/api/v1/auth(/.*)?$ /api/auth$1 break;
             proxy_pass http://api:5000;
             proxy_set_header Host $host;
@@ -101,10 +107,7 @@ http {
 
         # FastAPI ML Service
         location /api/v1/ml {
-<<<<<<< HEAD
-=======
             rewrite ^/api/v1/ml$ / break;
->>>>>>> upstream/main
             rewrite ^/api/v1/ml(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;
@@ -113,10 +116,7 @@ http {
 
         # FastAPI Pricing Service
         location /api/v1/pricing {
-<<<<<<< HEAD
-=======
             rewrite ^/api/v1/pricing$ / break;
->>>>>>> upstream/main
             rewrite ^/api/v1/pricing(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;


### PR DESCRIPTION
## Problem

`nginx/nginx.conf` had no `client_max_body_size` and no proxy timeouts. Driver uploads (KYC documents, POD scans, maintenance photos) exceeded the 1m default body limit, returning HTTP 413; long ML inferences were cut off by the default 60s proxy read timeout, returning HTTP 504. The file also contained unresolved merge-conflict markers (`<<<<<<< HEAD` / `>>>>>>> upstream/main`) left from a bad merge, which would make nginx fail to start. (refs #13960)

## Fix

- Resolved the merge-conflict markers, keeping the richer TLS + rate-limiting + security-headers `server` block.
- Added to the `http` block: `client_max_body_size 25m;`, `proxy_request_buffering off;`, `proxy_connect_timeout 10s;`, `proxy_send_timeout 300s;`, `proxy_read_timeout 300s;` (in `nginx/nginx.conf`).

## Files changed

- nginx/nginx.conf

## Testing

- Manual review: valid nginx config structure, conflict markers removed, body-size and proxy timeout directives present.

Closes #13960
