### PR TITLE
[HIGH] Blockchain: verifyKyberRelayerSignature missing EIP-191 prefix (relayer gate broken)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -678,6 +678,14 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         require(trustedRelayer != address(0), "Relayer not configured");
         require(signature.length == 65, "Invalid signature length");
         bytes32 combinedHash = keccak256(abi.encodePacked(messageHash, kyberSharedSecretHash));
+
+        // EIP-191 prefix: relayer signatures are produced with a standard
+        // wallet sign (personal_sign / signMessage) which prepends
+        // "\x19Ethereum Signed Message:\n32". Recovering over the raw hash
+        // would never match a standard-signed relayer signature (issue #13965).
+        bytes32 signedHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", combinedHash)
+        );
         
         bytes32 r;
         bytes32 s;
@@ -688,7 +696,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
             v := byte(0, mload(add(signature, 96)))
         }
         
-        address signer = ecrecover(combinedHash, v, r, s);
+        address signer = ecrecover(signedHash, v, r, s);
         return (signer == trustedRelayer);
     }
 }


### PR DESCRIPTION
## Problem

`verifyKyberRelayerSignature` in `blockchain/contracts/TruxifyEscrow.sol` recovered the relayer address over the **raw** `combinedHash`. Relayer signatures are produced with a standard wallet sign (`personal_sign` / `signMessage`), which prepends the EIP-191 prefix `"\x19Ethereum Signed Message:\n32"`. Recovering over the raw hash therefore never matched the trusted relayer, leaving the relayer gate effectively broken (any relayer-protected path could be bypassed or never pass). Refs #13965.

## Fix

- Compute the EIP-191 prefixed digest before `ecrecover` in `verifyKyberRelayerSignature` (`blockchain/contracts/TruxifyEscrow.sol`, inside the function): `signedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", combinedHash))`, and recover over `signedHash`. This matches how standard-signed relayer signatures are produced.

## Files changed

- blockchain/contracts/TruxifyEscrow.sol

## Testing

Manual Solidity review of the signature recovery path; confirmed the prefixed digest matches the message format used by standard wallet signing. No full build/compile performed.

Closes #13965
