### PR TITLE
[HIGH] Blockchain: resolveDisputeTimeout refunds customer in full even when trip already started (driver uncompensated)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -572,19 +572,33 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         require(!booking.paid, "TruxifyEscrow: Already paid");
 
         // ── EFFECTS: Default to refunding customer ──────────────────────────
-        uint256 refundAmount = booking.amount;
+        uint256 escrowAmount = booking.amount;
         address payable customer = booking.customer;
+        address payable driver = booking.driver;
 
         booking.amount = 0;
         booking.paid = true;
         booking.status = BookingStatus.Cancelled;
 
         // ── INTERACTIONS ──────────────────────────────────────────────────
-        pendingWithdrawals[customer] += refundAmount;
-        releaseTimestamps[customer] = block.timestamp + WITHDRAWAL_TIMEOUT;
+        uint256 newDeadline = block.timestamp + WITHDRAWAL_TIMEOUT;
 
-        emit WithdrawalReady(bookingId, customer, refundAmount);
-        emit BookingCancelled(bookingId, customer, refundAmount);
+        if (booking.started) {
+            // Trip already started: the driver performed work, so the staleness
+            // fallback must compensate the driver instead of refunding the
+            // customer in full (issue #13964).
+            pendingWithdrawals[driver] += escrowAmount;
+            if (releaseTimestamps[driver] == 0 || newDeadline > releaseTimestamps[driver]) {
+                releaseTimestamps[driver] = newDeadline;
+            }
+            emit WithdrawalReady(bookingId, driver, escrowAmount);
+            emit BookingCancelled(bookingId, customer, 0);
+        } else {
+            pendingWithdrawals[customer] += escrowAmount;
+            releaseTimestamps[customer] = newDeadline;
+            emit WithdrawalReady(bookingId, customer, escrowAmount);
+            emit BookingCancelled(bookingId, customer, escrowAmount);
+        }
 
         // Release the slot so a retried/regenerated order can re-use the id.
         _releaseBookingSlot(bookingId);


### PR DESCRIPTION
## Problem

`resolveDisputeTimeout` in `blockchain/contracts/TruxifyEscrow.sol` always refunded the **customer in full**, even when the trip had already started. Because the driver had already performed work, refunding the customer completely left the driver uncompensated for a started trip (and effectively transferred the escrow to the customer). Refs #13964.

## Fix

- In `resolveDisputeTimeout`, after marking the booking cancelled, branch on `booking.started`:
  - If `booking.started` is true, credit the full escrow (`escrowAmount`) to the **driver**'s `pendingWithdrawals` with the withdrawal deadline, and emit `WithdrawalReady(bookingId, driver, escrowAmount)` and `BookingCancelled(bookingId, customer, 0)`.
  - Otherwise keep the existing behaviour: credit the customer.
- `releaseTimestamps` is only advanced (never decreased) so an existing later deadline is preserved.

## Files changed

- blockchain/contracts/TruxifyEscrow.sol

## Testing

Manual Solidity review of the dispute-timeout path; confirmed started trips now route the escrow to the driver while untouched behaviour is preserved for not-started trips. No full build/compile performed.

Closes #13964
