### PR TITLE
[MEDIUM] Supabase: wallet_transactions.amount and payments.amount_paisa are 32-bit int (overflow)

### DIFF
--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -685,7 +685,7 @@ create table if not exists wallet_transactions (
   driver_id        uuid not null,                             -- profiles.id
   order_display_id text,                                      -- orders.order_display_id
   trip_display_id  text,                                      -- trips.trip_display_id
-  amount           int not null,                              -- paisa (always positive)
+   amount           numeric(20,0) not null check (amount >= 0), -- paisa (always non-negative)
   txn_type         text not null
                    check (txn_type in ('credit','debit','withdrawal','refund')),
   status           text not null default 'confirmed'

--- a/supabase/migrations/20260805000030_create_payments_table.sql
+++ b/supabase/migrations/20260805000030_create_payments_table.sql
@@ -8,7 +8,7 @@ create table if not exists payments (
   id              uuid primary key default gen_random_uuid(),
   order_id        uuid not null,
   user_id         uuid not null,
-  amount_paisa    int  not null default 0,
+  amount_paisa    numeric(20,0) not null default 0 check (amount_paisa >= 0),
   status          text not null default 'pending'
                   check (status in ('pending', 'initiated', 'captured', 'released', 'refunded', 'failed', 'cancelled')),
   payment_method  text not null default 'upi'

--- a/supabase/migrations/20260814000000_widen_financial_amount_columns.sql
+++ b/supabase/migrations/20260814000000_widen_financial_amount_columns.sql
@@ -1,0 +1,24 @@
+-- Fix integer-overflow on financial amount columns (issue #13963).
+-- High-value freight payments / payouts (and cross-border / MEV values) exceed
+-- the 2,147,483,647 paisa (≈ ₹21.47L) ceiling of a 32-bit int, causing insert
+-- failures or silent wraparound that corrupts balance accounting.
+
+-- wallet_transactions.amount (paisa)
+alter table if exists wallet_transactions
+  alter column amount type numeric(20,0);
+
+alter table if exists wallet_transactions
+  drop constraint if exists wallet_transactions_amount_nonneg;
+
+alter table if exists wallet_transactions
+  add constraint wallet_transactions_amount_nonneg check (amount >= 0);
+
+-- payments.amount_paisa (paisa)
+alter table if exists payments
+  alter column amount_paisa type numeric(20,0);
+
+alter table if exists payments
+  drop constraint if exists payments_amount_paisa_nonneg;
+
+alter table if exists payments
+  add constraint payments_amount_paisa_nonneg check (amount_paisa >= 0);


### PR DESCRIPTION
## Problem

Financial amount columns were declared as 32-bit `int`:
- `wallet_transactions.amount` (`docs/supabase_setup.sql`)
- `payments.amount_paisa` (`supabase/migrations/20260805000030_create_payments_table.sql`)

Max 32-bit `int` = 2,147,483,647 paisa ≈ **₹21.47L**. A single high-value freight payment/payout (easily exceeding ₹21L; MEV/cross-border values are far larger) overflows `int`, causing insert failure or silent wraparound. `wallet_transactions.amount` feeds the settlement/double-payout logic, so an overflow there corrupts balance accounting. Refs #13963.

## Fix

- Added migration `supabase/migrations/20260814000000_widen_financial_amount_columns.sql` that `ALTER`s both columns to `numeric(20,0)` and adds `CHECK (amount >= 0)` / `CHECK (amount_paisa >= 0)` (idempotent with `IF EXISTS` / `DROP CONSTRAINT IF EXISTS`).
- Updated the canonical DDL in `docs/supabase_setup.sql` (`amount numeric(20,0) not null check (amount >= 0)`).
- Updated the `payments` table DDL in `supabase/migrations/20260805000030_create_payments_table.sql` to `numeric(20,0) not null default 0 check (amount_paisa >= 0)`.

## Files changed

- supabase/migrations/20260814000000_widen_financial_amount_columns.sql (new)
- docs/supabase_setup.sql
- supabase/migrations/20260805000030_create_payments_table.sql

## Testing

Manual SQL review; `numeric(20,0)` accommodates values far beyond ₹21L (e.g. 10,000,000,000 paisa = ₹10Cr) without overflow, and the non-negative checks reject corrupt negative amounts. No live DB migration run performed.

Closes #13963
