### PR TITLE
[MEDIUM-HIGH] Flutter: fix unsafe 'as String?' casts crashing UPI payment flow (closes #13956)

### DIFF
--- a/apps/customer/lib/screens/booking_confirmation_screen.dart
+++ b/apps/customer/lib/screens/booking_confirmation_screen.dart
@@ -205,9 +205,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       );
       if (body is Map<String, dynamic>) {
         setState(() {
-          _upiDeepLink = body['deep_link'] as String?;
-          _amountInr = body['amount_inr'] as String?;
-          _createdOrderDisplayId = body['order_ref'] as String?;
+          _upiDeepLink = body['deep_link']?.toString();
+          _amountInr = body['amount_inr']?.toString();
+          _createdOrderDisplayId = body['order_ref']?.toString();
           _isAwaitingUpi = true;
         });
       }


### PR DESCRIPTION
## Problem

`apps/customer/lib/screens/booking_confirmation_screen.dart` (lines ~208-210) casts server response fields with `as String?`:

```dart
_upiDeepLink = body['deep_link'] as String?;
_amountInr = body['amount_inr'] as String?;
_createdOrderDisplayId = body['order_ref'] as String?;
```

The sibling `delivery_otp_screen.dart` explicitly supports a **numeric** `amount_inr` (`if (value is num) ...`). When `/api/payments/upi-intent` returns `amount_inr: 1200.00` (a `num`), `as String?` throws `CastError: int/double is not a subtype of String?`, crashing the UPI payment step. `order_ref`/`deep_link` non-strings crash identically. (refs #13956)

## Fix

Replaced the unsafe casts with null-safe `?.toString()` (mirroring `delivery_otp_screen._amountInr`):

- `apps/customer/lib/screens/booking_confirmation_screen.dart:208-210`
  - `_upiDeepLink = body['deep_link']?.toString();`
  - `_amountInr = body['amount_inr']?.toString();`
  - `_createdOrderDisplayId = body['order_ref']?.toString();`

## Files changed

- apps/customer/lib/screens/booking_confirmation_screen.dart

## Testing

Manual Dart/type review: `?.toString()` coerces num/string/null without throwing and matches the existing handling in `delivery_otp_screen.dart`. No Flutter build run (per task constraints).

Closes #13956
