### PR TITLE
[HIGH] Infra/k8s: route Istio traffic to api-service port 5000 (fixes 503 outage, closes #13957)

### DIFF
--- a/k8s/istio/gateway.yaml
+++ b/k8s/istio/gateway.yaml
@@ -48,7 +48,7 @@ spec:
     - destination:
         host: api-service
         port:
-          number: 80
+          number: 5000
   - match:
     - uri:
         prefix: /docs
@@ -56,4 +56,4 @@ spec:
     - destination:
         host: api-service
         port:
-          number: 80
+          number: 5000

--- a/k8s/istio/virtual-service.yaml
+++ b/k8s/istio/virtual-service.yaml
@@ -14,7 +14,7 @@ spec:
     - destination:
         host: api-service
         port:
-          number: 80
+          number: 5000
       weight: 100
     retries:
       attempts: 3
@@ -36,7 +36,7 @@ spec:
     - destination:
         host: api-service
         port:
-          number: 80
+          number: 5000
       weight: 100
   - match:
     - uri:
@@ -45,4 +45,4 @@ spec:
     - destination:
         host: api-service
         port:
-          number: 80
+          number: 5000


### PR DESCRIPTION
## Problem

`k8s/istio/virtual-service.yaml` (and identically `k8s/istio/gateway.yaml`) routes mesh traffic to `api-service` on port `80`:

```yaml
    route:
    - destination:
        host: api-service
        port:
          number: 80
```

But `api-service` only publishes `port: 5000` / `targetPort: 5000` (no port `80`). Envoy therefore has no healthy upstream on `:80`, so every Istio-ingressed `/api/` and `/docs` request returns 503 — a complete API outage through the mesh. (refs #13957)

## Fix

Changed `number: 80` → `number: 5000` on every route destination that points at `api-service`, aligning with the port the Service actually exposes:

- `k8s/istio/virtual-service.yaml` — 3 route destinations (lines ~17, ~39, ~48).
- `k8s/istio/gateway.yaml` — 2 route destinations (lines ~50, ~58).

## Files changed

- k8s/istio/virtual-service.yaml
- k8s/istio/gateway.yaml

## Testing

Manual YAML review confirming the destination port now matches `api-service`'s published port `5000` in all 5 route entries. No `kubectl`/istioctl apply performed (infra-only change).

Closes #13957
