### PR TITLE
[MEDIUM] Backend: PostgREST filter injection via unsanitized tripId (mlRoutes)

### DIFF
--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -24,6 +24,18 @@ function parseCoord(value, min, max) {
   return Number.isFinite(n) && n >= min && n <= max ? n : null;
 }
 
+// Sanitize a trip identifier before interpolating it into a PostgREST `.or()`
+// filter. The filter grammar treats `)`, `,`, quotes and whitespace as syntax,
+// so an unsanitized value could break out of the intended predicate
+// (injection / malformed query / DoS). Rejects any such characters.
+function sanitizeTripId(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  if (/[,)(\s'"]/.test(trimmed)) return null;
+  return trimmed;
+}
+
 // ============================================================================
 // GET /api/ml/eta?tripId=...&lat=...&lng=...
 // ============================================================================
@@ -34,12 +46,18 @@ router.get('/eta', authenticate, userLimiter, async (req, res) => {
       return res.status(400).json({ error: 'tripId is required.' });
     }
 
+    // Sanitize before interpolating into the PostgREST filter (see sanitizeTripId).
+    const safeTripId = sanitizeTripId(tripId);
+    if (!safeTripId) {
+      return res.status(400).json({ error: 'tripId contains invalid characters.' });
+    }
+
     // Resolve the trip by primary key or display id, then its linked order for
     // the drop coordinates that define the remaining route.
     const { data: trip, error: tripErr } = await supabaseAdmin
       .from('trips')
       .select('id, trip_display_id, order_id')
-      .or(`id.eq.${tripId},trip_display_id.eq.${tripId}`)
+      .or(`id.eq.${safeTripId},trip_display_id.eq.${safeTripId}`)
       .maybeSingle();
 
     if (tripErr) {

--- a/backend/api/test/unit/mlRoutes.test.js
+++ b/backend/api/test/unit/mlRoutes.test.js
@@ -139,6 +139,18 @@ describe('mlRoutes GET /eta', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a tripId containing PostgREST filter-breaking characters', async () => {
+    const res = await request(makeApp()).get(
+      '/api/ml/eta?tripId=00000000-0000-0000-0000-000000000000).neq.id',
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a tripId containing commas or quotes', async () => {
+    const res = await request(makeApp()).get('/api/ml/eta?tripId=abc,def');
+    expect(res.status).toBe(400);
+  });
+
   it('denies non-owners with 404', async () => {
     supabaseChain.maybeSingle
       .mockResolvedValueOnce({ data: { id: 't1', order_id: 'o1' }, error: null })


### PR DESCRIPTION
## Problem

`backend/api/src/routes/mlRoutes.js` interpolates `req.query.tripId` directly into a PostgREST `.or()` filter after only checking for emptiness. PostgREST `.or()` treats `)` as a group terminator and `,`/operators as syntax, so a crafted `tripId` (e.g. `00000000-0000-0000-0000-000000000000).neq.id`) breaks out of the intended predicate — causing malformed queries (500 / DoS) or manipulating which row `maybeSingle()` applies to. The same injection class is defended against elsewhere (`FraudDetectionService.sanitizeUserId`) but omitted here. Refs #13953.

## Fix

- `backend/api/src/routes/mlRoutes.js:22` — added `sanitizeTripId()`, which rejects `,() ' "` and whitespace and returns `null` for invalid input.
- `backend/api/src/routes/mlRoutes.js:39` — the route now sanitizes `tripId` and returns `400` when it contains invalid characters, then interpolates only the sanitized value into `.or(\`id.eq.${safeTripId},trip_display_id.eq.${safeTripId}\`)`.

This mirrors the allowlist approach used by `FraudDetectionService.sanitizeUserId` and covers the injection/DoS point.

## Files changed

- backend/api/src/routes/mlRoutes.js
- backend/api/test/unit/mlRoutes.test.js

## Testing

- Added tests in `backend/api/test/unit/mlRoutes.test.js` asserting a `tripId` containing filter-breaking characters (`)`) or commas/quotes is rejected with `400`.
- `node --check backend/api/src/routes/mlRoutes.js` passes.

Closes #13953
