### PR TITLE
[MEDIUM] Blockchain: MEV release-window guard is a dead no-op (blockMin == creation block)

### DIFF
--- a/blockchain/contracts/MEVProtectedEscrow.sol
+++ b/blockchain/contracts/MEVProtectedEscrow.sol
@@ -25,6 +25,12 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
 
     uint256 public constant REFUND_WINDOW = 5760;
 
+    /// @dev MEV protection window: releases via the private relayer are gated
+    /// until this many blocks after the deposit is created, so a release can
+    /// never succeed in the same block as the deposit (thwarts same-block
+    /// front-running / sandwich attacks).
+    uint256 public constant RELEASE_DELAY_BLOCKS = 20;
+
     event DepositCreated(uint256 indexed depositId, address indexed shipper, address indexed driver, uint256 amount);
     event DepositReleasedMEV(uint256 indexed depositId, address indexed driver, uint256 amount);
     event DepositRefunded(uint256 indexed depositId, address indexed shipper, uint256 amount);
@@ -61,7 +67,7 @@ contract MEVProtectedEscrow is ReentrancyGuard, Ownable {
             driver: _driver,
             amount: msg.value,
             released: false,
-            blockMin: block.number,
+            blockMin: block.number + RELEASE_DELAY_BLOCKS,
             secretHash: _secretHash
         });
 

--- a/blockchain/test/MEVProtectedEscrow.releaseWindow.test.js
+++ b/blockchain/test/MEVProtectedEscrow.releaseWindow.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import hre from "hardhat";
+const { ethers } = hre;
+
+async function assertRejectsWith(promise, message) {
+  await assert.rejects(promise, (error) => error.message.includes(message));
+}
+
+describe("MEVProtectedEscrow release window", function () {
+  async function deployEscrow() {
+    const [owner, shipper, driver] = await ethers.getSigners();
+    const Escrow = await ethers.getContractFactory("MEVProtectedEscrow");
+    const escrow = await Escrow.deploy(owner.address);
+    await escrow.waitForDeployment();
+    return { escrow, owner, shipper, driver };
+  }
+
+  it("rejects release before the MEV release delay elapses", async function () {
+    const { escrow, owner, shipper, driver } = await deployEscrow();
+    const secret = ethers.id("mev-release-secret");
+    const secretHash = ethers.keccak256(ethers.solidityPacked(["bytes32"], [secret]));
+    const amount = ethers.parseEther("1");
+
+    await escrow.connect(shipper).createProtectedDeposit(driver.address, secretHash, { value: amount });
+
+    // The deposit was just created; blockMin is now creation block + RELEASE_DELAY_BLOCKS,
+    // so a same-block release must be rejected (the guard is no longer a no-op).
+    await assertRejectsWith(
+      escrow.connect(owner).releaseDepositPrivate(1, secret),
+      "Release window not open"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`blockchain/contracts/MEVProtectedEscrow.sol` sets `blockMin = block.number` at deposit creation, so the release guard `require(block.number >= dep.blockMin, "Release window not open")` is satisfied in the very same block the deposit is created. The MEV deadline is a dead no-op, allowing a release in the same block as the deposit and defeating the stated anti-front-running protection (refs #13924).

## Fix

- Added `uint256 public constant RELEASE_DELAY_BLOCKS = 20;` (`blockchain/contracts/MEVProtectedEscrow.sol:32`) and set `blockMin = block.number + RELEASE_DELAY_BLOCKS` (`blockchain/contracts/MEVProtectedEscrow.sol:70`) so private-relayer releases are gated until 20 blocks after creation.
- Added a regression test `blockchain/test/MEVProtectedEscrow.releaseWindow.test.js` asserting release is rejected before the delay elapses.

## Files changed

- blockchain/contracts/MEVProtectedEscrow.sol
- blockchain/test/MEVProtectedEscrow.releaseWindow.test.js

## Testing

Manual Solidity review of the guard semantics; the new test asserts `releaseDepositPrivate` reverts with "Release window not open" when called in the deposit block. (No contract build executed in this environment.)

Closes #13924
