### PR TITLE
[MEDIUM] Flutter (customer): ml_dashboard crashes on non-numeric / missing ML metric values

### DIFF
--- a/cutomer_app/lib/screens/ml_dashboard.dart
+++ b/cutomer_app/lib/screens/ml_dashboard.dart
@@ -92,12 +92,31 @@ class _MLDashboardState extends State<MLDashboard> {
     );
   }
 
+  /// Safely coerce a metric value (num, or a JSON string such as "0.95")
+  /// into a double. Returns null when the value is missing or unparsable so
+  /// the dashboard can skip it instead of crashing.
+  double? _toDouble(dynamic value) {
+    if (value is num) return value.toDouble();
+    if (value == null) return null;
+    return double.tryParse(value.toString());
+  }
+
   Widget _buildMetricsCard() {
-    final results = metrics?['results'] as Map<String, dynamic>? ?? {};
+    final rawResults = metrics?['results'];
+    final Map<String, dynamic> results;
+    if (rawResults is Map) {
+      results = Map<String, dynamic>.from(rawResults);
+    } else {
+      // `results` may arrive as a list (or any other shape) on some
+      // responses; treat anything that is not a map as "no metrics".
+      results = {};
+    }
+
     final rows = <Widget>[];
     results.forEach((metric, values) {
-      final prod = values['production']?.toStringAsFixed(2);
-      final shadow = values['shadow']?.toStringAsFixed(2);
+      if (values is! Map) return;
+      final prod = _toDouble(values['production'])?.toStringAsFixed(2);
+      final shadow = _toDouble(values['shadow'])?.toStringAsFixed(2);
       if (prod == null || shadow == null) return;
       rows.add(_buildMetricRow(metric, prod, shadow, metric == 'rmse'));
     });
@@ -122,9 +141,11 @@ class _MLDashboardState extends State<MLDashboard> {
   }
 
   Widget _buildMetricRow(String metric, String prod, String shadow, bool lowerBetter) {
-    final isBetter = lowerBetter 
-        ? double.parse(shadow) < double.parse(prod)
-        : double.parse(shadow) > double.parse(prod);
+    final prodVal = double.tryParse(prod);
+    final shadowVal = double.tryParse(shadow);
+    final isBetter = prodVal != null && shadowVal != null
+        ? (lowerBetter ? shadowVal < prodVal : shadowVal > prodVal)
+        : false;
     
     return Padding(
       padding: EdgeInsets.symmetric(vertical: 4),


### PR DESCRIPTION
## Problem

`cutomer_app/lib/screens/ml_dashboard.dart` (`_buildMetricsCard`, lines ~96-127) assumed ML metric values are `num` and that `metrics['results']` is always a `Map<String, dynamic>`. When the backend serializes floats as strings, `values['production']?.toStringAsFixed(2)` throws `NoSuchMethodError`; when `results` arrives as a JSON list, the `as Map<String, dynamic>` cast throws. Either way the whole ML dashboard widget fails to render, leaving the customer with a blank/crashed screen (refs #13919).

## Fix

- Added a `_toDouble(dynamic)` helper that safely coerces a `num` or a numeric `String` (and returns `null` otherwise).
- `_buildMetricsCard` now casts `results` defensively (`Map<String, dynamic>.from` when it is a `Map`, otherwise treated as empty) so a `List`/non-map `results` no longer crashes, and uses `_toDouble(...)` for the production/shadow values.
- `_buildMetricRow` now parses with `double.tryParse` and guards against null, so missing/unparsable values are rendered without throwing.

## Files changed

- cutomer_app/lib/screens/ml_dashboard.dart

## Testing

Careful manual Dart review of the coercion paths (num, numeric String, null, List results). No Flutter build executed in this environment.

Closes #13919
