### PR TITLE
[MEDIUM] Infra/nginx: client-supplied X-Forwarded-For passed through unmodified (IP spoofing)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,13 +41,6 @@ http {
     # Legacy IE6 mishandles gzip; excluded rather than risking corrupt bodies.
     gzip_disable "msie6";
 
-<<<<<<< HEAD
-    server {
-        listen 8080;
-
-        # Node.js Auth Service
-        location /api/v1/auth {
-=======
     # ------------------------------------------------------------------
     # Rate limiting
     #
@@ -85,11 +78,15 @@ http {
             # Brute-force protection: throttle login attempts per client.
             limit_req zone=auth burst=10 nodelay;
 
->>>>>>> upstream/main
             rewrite ^/api/v1/auth(/.*)?$ /api/auth$1 break;
             proxy_pass http://api:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            # Server-controlled client IP: append the real connection address
+            # and never forward a client-supplied value verbatim (prevents
+            # X-Forwarded-For IP spoofing).
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # Node.js Trips Service
@@ -97,30 +94,30 @@ http {
             proxy_pass http://api:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # FastAPI ML Service
         location /api/v1/ml {
-<<<<<<< HEAD
-=======
             rewrite ^/api/v1/ml$ / break;
->>>>>>> upstream/main
             rewrite ^/api/v1/ml(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # FastAPI Pricing Service
         location /api/v1/pricing {
-<<<<<<< HEAD
-=======
             rewrite ^/api/v1/pricing$ / break;
->>>>>>> upstream/main
             rewrite ^/api/v1/pricing(/.*)?$ $1 break;
             proxy_pass http://ml-engine:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## Problem

`nginx/nginx.conf` proxy blocks (`/api/v1/auth`, `/api/v1/trips`, `/api/v1/ml`, `/api/v1/pricing`) set `Host` and `X-Real-IP` but never set or reset `X-Forwarded-For`, so any client-supplied `X-Forwarded-For` header is forwarded unmodified. A client can spoof its IP (e.g. `X-Forwarded-For: 127.0.0.1`), defeating IP-based rate limiting, audit logging, and allow-listing that rely on XFF. The file also contained unresolved merge-conflict markers (refs #13918).

## Fix

- Resolved the leftover merge conflict to the secure TLS-terminating server block (`listen 443 ssl`).
- Added `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` and `proxy_set_header X-Forwarded-Proto $scheme;` to every `location` block so the upstream receives a server-controlled client IP and scheme rather than a client-supplied value.

## Files changed

- nginx/nginx.conf

## Testing

Manual nginx configuration review; the headers are now rewritten for all four proxy locations. No nginx build executed in this environment.

Closes #13918
