### PR TITLE
[HIGH] Infra/k8s: public LoadBalancer selector too broad and exposes plaintext HTTP (bypasses nginx edge)

### DIFF
--- a/k8s/multi-region/global-loadbalancer.yaml
+++ b/k8s/multi-region/global-loadbalancer.yaml
@@ -13,11 +13,13 @@ spec:
   - port: 443
     targetPort: 5000
     name: https
-  - port: 80
-    targetPort: 5000
-    name: http
+  # Only the API tier is reachable through the public edge. A broad selector
+  # (app: truxify) would also route internet traffic to ml/redis/shard pods,
+  # and the removed port 80 listener previously served plaintext HTTP
+  # straight to the API, bypassing the nginx edge (TLS, rate-limit, HSTS).
   selector:
     app: truxify
+    component: api
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,6 +31,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    # The edge LB now only exposes TLS; speak HTTPS to it.
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   ingressClassName: nginx
   tls:
@@ -46,4 +50,4 @@ spec:
           service:
             name: global-lb
             port:
-              number: 80
+              number: 443


### PR DESCRIPTION
## Problem

`k8s/multi-region/global-loadbalancer.yaml` defined a public `LoadBalancer` with `selector: app: truxify` (which matches **every** workload — api, ml, redis, shard, …) and a plaintext `port: 80 -> targetPort: 5000` listener. The broad selector lets internet traffic hit non-API pods, and the plaintext listener serves HTTP straight to the API, bypassing the nginx edge (TLS termination, rate limiting, `Strict-Transport-Security`/security headers, auth routing) (refs #13917).

## Fix

- Narrowed the selector to `app: truxify, component: api` so only the API tier is behind the public LB (verified against `k8s/services/api-service.yaml`, which labels API pods `component: api`).
- Removed the plaintext `port: 80` listener; only `port: 443` (TLS) remains.
- Updated the `Ingress` backend to `port: 443` and added `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` so the ingress reference stays valid and still terminates TLS.

## Files changed

- k8s/multi-region/global-loadbalancer.yaml

## Testing

Manual YAML review; the narrowed selector matches exactly the API tier's labels (`app: truxify, component: api`). No cluster apply executed in this environment.

Closes #13917
