### PR TITLE
[HIGH] Services (CUDA): vehicle routing uses Euclidean distance on lat/lng degrees instead of haversine meters

### DIFF
--- a/services/gpu-routing-cuda/src/cuda_vrp.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp.cu
@@ -4,6 +4,23 @@
 
 namespace TruxifyCuda {
 
+namespace {
+// Great-circle (haversine) distance in meters. `lat`/`lng` are degrees.
+// `Location.x` is longitude and `Location.y` is latitude, matching the test
+// reference (`refHaversine`) and the regression test for #11549. Using a
+// local PI constant avoids any dependency on `M_PI` portability.
+double haversineMeters(double lat1, double lng1, double lat2, double lng2) {
+    const double kPi = 3.14159265358979323846;
+    const double R = 6371000.0;
+    double dLat = (lat2 - lat1) * kPi / 180.0;
+    double dLng = (lng2 - lng1) * kPi / 180.0;
+    double a = std::sin(dLat / 2.0) * std::sin(dLat / 2.0) +
+               std::cos(lat1 * kPi / 180.0) * std::cos(lat2 * kPi / 180.0) *
+                   std::sin(dLng / 2.0) * std::sin(dLng / 2.0);
+    return 2.0 * R * std::asin(std::sqrt(a));
+}
+} // namespace
+
 VrpSolution CudaVrpSolver::solveParallelVRP(
     const Location& depot,
     const std::vector<Location>& stops,
@@ -17,16 +34,12 @@ VrpSolution CudaVrpSolver::solveParallelVRP(
     Location prev = depot;
 
     for (const auto& stop : stops) {
-        float dx = stop.x - prev.x;
-        float dy = stop.y - prev.y;
-        distance += std::sqrt(dx * dx + dy * dy);
+        distance += static_cast<float>(haversineMeters(prev.y, prev.x, stop.y, stop.x));
         prev = stop;
     }
 
     // Return to depot
-    float dx = depot.x - prev.x;
-    float dy = depot.y - prev.y;
-    distance += std::sqrt(dx * dx + dy * dy);
+    distance += static_cast<float>(haversineMeters(prev.y, prev.x, depot.y, depot.x));
 
     size_t routesNeeded = (stops.size() + vehicleCapacity - 1) / vehicleCapacity;
 


### PR DESCRIPTION
## Problem

`services/gpu-routing-cuda/src/cuda_vrp.cu` computed `totalDistance` as plain Euclidean distance on raw latitude/longitude **degrees** (`std::sqrt(dx*dx + dy*dy)` where `dx = stop.x - prev.x`, `dy = stop.y - prev.y`). With `Location.x` = longitude and `Location.y` = latitude, NY→London yields ~74.6 (degrees) instead of ~5,570,000 m — off by ~70,000×. The regression test for #11549 asserts `distance > 1.0e6f`, so the metric is fundamentally wrong and any route optimization / vehicle-count / cost calculation built on it is garbage. Refs #13908.

## Fix

Replaced the Euclidean-degree distance with a great-circle haversine in meters computed on `(lat, lng)` degrees using Earth radius `R = 6371000.0`, for both the stop loop and the return-to-depot leg:
- `services/gpu-routing-cuda/src/cuda_vrp.cu:12` added a `haversineMeters(lat1, lng1, lat2, lng2)` helper (local `kPi` avoids `M_PI` portability issues).
- `services/gpu-routing-cuda/src/cuda_vrp.cu:37` and `:42` now call `haversineMeters(prev.y, prev.x, ...)` (latitude = `y`, longitude = `x`), matching the `refHaversine` reference used by the existing regression test (`cuda_vrp_tests.cu`), which already asserts NY→London ≈ 5.57e6 m.

## Files changed

- services/gpu-routing-cuda/src/cuda_vrp.cu

## Testing

- Manual review of CUDA vs the committed `cuda_vrp_tests.cu` regression test (NY/London/Paris): the test calls `refHaversine(newYork.y, newYork.x, ...)` identically, and asserts `s.totalDistance > 1.0e6f` and `> 1000×` the Euclidean-degree value. The fix produces meters, so both assertions pass. No CUDA toolchain build available in this environment; verified by code review against the test's reference implementation.

Closes #13908
