### PR TITLE
[MEDIUM] Backend: driverEarningsService.js unit inconsistency — avg_earning_per_km is INR/km while gross/net are paisa

### DIFF
--- a/backend/api/src/services/driverEarningsService.js
+++ b/backend/api/src/services/driverEarningsService.js
@@ -91,7 +91,11 @@ export const calculateEarningsAggregation = (trips, allCompletedTrips, lifetimeT
     weekly_chart: weeklyChart,
     cumulative_stats: {
       total_km: totalKm,
-      avg_earning_per_km: (Number.isFinite(totalKm) && totalKm > 0 && Number.isFinite(totalNetEarnings)) ? (totalNetEarnings / 100.0) / totalKm : 0,
+      // Unit: paisa/km. This matches `gross_earnings`/`net_earnings`, which are
+      // sums of the paisa-valued `trip.total_earnings`/`trip.net_earnings`
+      // columns. Dropping the `/100` keeps every earnings field in paisa so the
+      // aggregation is uniformly unit-consistent (do not convert to INR here).
+      avg_earning_per_km: (Number.isFinite(totalKm) && totalKm > 0 && Number.isFinite(totalNetEarnings)) ? totalNetEarnings / totalKm : 0,
       lifetime_trips: lifetimeTrips !== null ? lifetimeTrips : null
     },
     deadhead_trips_saved: deadheadTripsSaved


### PR DESCRIPTION
## Problem

`backend/api/src/services/driverEarningsService.js` computed `avg_earning_per_km` by dividing `totalNetEarnings` by 100 (`totalNetEarnings / 100.0 / totalKm`), making it **INR/km**, while `gross_earnings`/`net_earnings` are sums of the paisa-valued `trip.total_earnings`/`trip.net_earnings` columns. The aggregation therefore mixes units: any client/UI treating the aggregation as uniformly paisa shows `avg_earning_per_km` 100× too small (or, if it assumes INR, gross/net 100× too large). Silent money/analytics misreporting. Refs #13907.

## Fix

Made the earnings aggregation uniformly paisa/km by dropping the erroneous `/100`, and documented the unit explicitly:
- `backend/api/src/services/driverEarningsService.js:94` now computes `avg_earning_per_km` as `totalNetEarnings / totalKm` (paisa/km), with a comment stating the unit matches `gross_earnings`/`net_earnings` (both paisa).

## Files changed

- backend/api/src/services/driverEarningsService.js

## Testing

- `node --check backend/api/src/services/driverEarningsService.js` passes. Logic review confirms `gross_earnings`/`net_earnings` are paisa sums, so `avg_earning_per_km` is now consistently paisa/km. Unit test coverage for the unit alignment should be added downstream per the issue recommendation.

Closes #13907
