### PR TITLE
[HIGH] Backend: public /route tracking reads orders with anon client → every request 404s

### DIFF
--- a/backend/api/src/routes/publicTrackingRoutes.js
+++ b/backend/api/src/routes/publicTrackingRoutes.js
@@ -138,21 +138,23 @@ router.get(
       }
 
       if (!validation.valid) {
-        return res.status(404).json({ error: 'Tracking link not found or invalid' });
+        const statusMessages = {
+          not_found: { status: 404, message: 'Tracking link not found or invalid' },
+          revoked: { status: 410, message: 'This tracking link has been revoked' },
+          expired: { status: 410, message: 'This tracking link has expired' },
+        };
+
+        const { status, message } = statusMessages[validation.reason] || statusMessages.not_found;
+        return res.status(status).json({ error: message });
       }
 
       const { orderDisplayId } = validation;
 
-      const { data: order, error: orderError } = await supabase
-        .from('orders')
-        .select('pickup_lat, pickup_lng, drop_lat, drop_lng, driver_id')
-        .eq('order_display_id', orderDisplayId)
-        .maybeSingle();
-
-      if (orderError) {
-        logger.error({ err: orderError, orderDisplayId }, 'Failed to fetch public route order');
-        return res.status(500).json({ error: 'Failed to load route information' });
-      }
+      // Read via the service-role client (TrackingTokenService uses
+      // supabaseAdmin). The anon `supabase` client cannot read `orders`
+      // (no anon RLS policy; anon privileges revoked) → previously every
+      // request 404'd even with a valid token (issue #13906).
+      const order = await trackingTokenService.getOrderRouteCoords(orderDisplayId);
 
       if (!order) {
         return res.status(404).json({ error: 'Order not found' });

--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -183,6 +183,34 @@ export class TrackingTokenService {
     return order;
   }
 
+  async getOrderRouteCoords(orderDisplayId) {
+    // `orders` has no anon RLS policy and anon privileges are revoked
+    // (see trackingRoutes.js), so the service-role client is required to read
+    // it — the public `/route` handler must not use the anon `supabase` client
+    // (issue #13906).
+    if (!this._supabaseAdmin) {
+      this._logger.error('getOrderRouteCoords requires service-role client');
+      throw new Error('Service-role client required for order route coordinates');
+    }
+
+    const { data: order, error: orderError } = await this._supabaseAdmin
+      .from('orders')
+      .select('pickup_lat, pickup_lng, drop_lat, drop_lng, driver_id')
+      .eq('order_display_id', orderDisplayId)
+      .maybeSingle();
+
+    if (orderError) {
+      this._logger.error({ error: orderError, orderDisplayId }, 'Failed to fetch public route order');
+      throw new Error('Failed to fetch public route order');
+    }
+
+    if (!order) {
+      return null;
+    }
+
+    return order;
+  }
+
   async getOrderTimeline(orderDisplayId) {
     const { data, error } = await this._supabase
       .from('order_timeline')


### PR DESCRIPTION
## Problem

`backend/api/src/routes/publicTrackingRoutes.js` (the `GET /api/public/tracking/:token/route` handler) read the `orders` table with the **anon** `supabase` client. Per the codebase's own comment in `trackingRoutes.js`, `orders` has no anon RLS policy and anon privileges are revoked, so the query returns nothing → `if (!order) return res.status(404)`. Every public route request 404s even with a valid token, making the customer/driver shared-route feature completely non-functional. Also, revoked/expired tokens returned 404 here instead of 410 (unlike the sibling `/tracking/:token` handler). Refs #13906.

## Fix

Read `orders` via the service-role client, mirroring the sibling handler (`TrackingTokenService.getOrderForPublicTracking` uses `supabaseAdmin`):
- Added `TrackingTokenService.getOrderRouteCoords(orderDisplayId)` (`backend/api/src/services/trackingTokenService.js:186`) which reads `pickup_lat, pickup_lng, drop_lat, drop_lng, driver_id` via `this._supabaseAdmin` (throws if the service-role client is absent), mirroring `getOrderForPublicTracking`.
- `backend/api/src/routes/publicTrackingRoutes.js:157` now calls `trackingTokenService.getOrderRouteCoords(orderDisplayId)` instead of the anon `supabase` query; the `validateToken` check is kept as-is.
- The invalid-token branch (`publicTrackingRoutes.js:140`) now returns 410 for `revoked`/`expired` (404 for `not_found`), matching the main tracking handler.

## Files changed

- backend/api/src/routes/publicTrackingRoutes.js
- backend/api/src/services/trackingTokenService.js

## Testing

- `node --check` passes on both modified JS files.
- Verified `TrackingTokenService` already stores `this._supabaseAdmin` and `this._logger` (used consistently with `getOrderForPublicTracking`), and that `validateToken` returns `reason` values `not_found`/`revoked`/`expired` (plus `validation_error`, handled earlier with 400), so the new status-message map covers all cases.
- `getOrderRouteCoords` returns `null` when no order row is found, preserving the existing 404 "Order not found" path.

Closes #13906
