### PR TITLE
fix: resolve duplicate const existingDoc in documentController (closes #13903)

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -65,16 +65,16 @@ export async function uploadDriverDocument(req, res) {
       });
     }
 
-    // Retrieve existing document of the same type for this driver
-    const { data: existingDoc, error: checkError } = await supabaseAdmin
+    // Retrieve existing document of the same type for this driver (pre-flight check)
+    const { data: existingDocPreflight, error: checkErrorPreflight } = await supabaseAdmin
       .from('driver_documents')
       .select('id, storage_path')
       .eq('driver_id', driverId)
       .eq('document_type', documentType)
       .maybeSingle();
 
-    if (checkError) {
-      logger.error('[DocumentController] Failed to query existing document:', checkError.message);
+    if (checkErrorPreflight) {
+      logger.error('[DocumentController] Failed to query existing document:', checkErrorPreflight.message);
       return res.status(500).json({ error: 'Failed to verify existing documents' });
     }
 


### PR DESCRIPTION
## Problem

`backend/api/src/controllers/documentController.js` declared the same block-scoped identifiers `existingDoc` and `checkError` twice inside `uploadDriverDocument` (line 69 and line 142). Because `const` cannot be re-declared in the same function scope, the module failed to parse with `SyntaxError: Identifier 'existingDoc' has already been declared`. This prevented the entire API process from booting, taking down all document endpoints (refs #13903).

## Fix

Renamed the unused pre-flight declaration (line 69, which queried via `supabaseAdmin`) to `existingDocPreflight` / `checkErrorPreflight` so it no longer collides with the real declaration used later in the function (line 142). No logic was changed — the pre-flight check's result was never referenced; the active code path uses the `client`-based lookup. Verified the module now parses with `node --check`.

- `backend/api/src/controllers/documentController.js:69`

## Files changed

- backend/api/src/controllers/documentController.js

## Testing

- `node --check backend/api/src/controllers/documentController.js` now exits 0 (previously threw a SyntaxError).

Closes #13903
