### PR TITLE
fix: sign txs and actually submit Flashbots bundle via relayer (closes #13899)

### DIFF
--- a/backend/mev/flashbots_relayer.js
+++ b/backend/mev/flashbots_relayer.js
@@ -31,14 +31,41 @@ export class FlashbotsRelayerService {
   }
 
   async sendPrivateBundle(bundle) {
+    const blockHex = '0x' + BigInt(bundle.targetBlock).toString(16);
     console.log(`[MEV Relayer] Submitting private transaction bundle to ${this.flashbotsRelayUrl} for block ${bundle.targetBlock}...`);
-    // Simulated private submission response
+
+    const response = await fetch(this.flashbotsRelayUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_sendBundle',
+        params: [{
+          txs: bundle.signedBundle,
+          blockNumber: blockHex,
+        }],
+      }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (payload.error) {
+      throw new Error(`Flashbots relay rejected bundle: ${payload.error.message || JSON.stringify(payload.error)}`);
+    }
+    if (!payload.result) {
+      throw new Error('Flashbots relay returned no bundle hash');
+    }
+
     return {
       success: true,
-      bundleHash: ethers.keccak256(bundle.signedBundle[0]),
+      bundleHash: payload.result,
       targetBlock: bundle.targetBlock,
     };
   }
+}
+
+export function getMevRelayer() {
+  return mevRelayer;
 }
 
 const relayerPrivateKey = process.env.RELAYER_WALLET_PRIVATE_KEY;

--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -214,8 +214,9 @@ class MEVService {
         try {
             const relayer = getMevRelayer();
             const targetBlock = (await this.provider.getBlockNumber()) + 1;
+            const signedTxs = await this.signTransactions(transactions);
             const result = await relayer.sendPrivateBundle({
-                signedBundle: transactions,
+                signedBundle: signedTxs,
                 targetBlock
             });
             await this.storeBundle({

--- a/backend/mev/submitFlashbotsBundle.test.js
+++ b/backend/mev/submitFlashbotsBundle.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const TEST_KEY = '0x' + '1'.repeat(64);
+
+describe('submitFlashbotsBundle', () => {
+  it('signs transactions, submits to the relay, and returns a real bundleId', async () => {
+    process.env.RELAYER_WALLET_PRIVATE_KEY = TEST_KEY;
+    process.env.POLYGON_RPC_URL = 'https://polygon-rpc.com';
+
+    const mev = (await import('./mev.service.js')).default;
+
+    // Avoid real RPC / DB calls during the test.
+    mev._provider = { getBlockNumber: async () => 100 };
+    const storeBundle = vi.fn(async () => {});
+    mev.storeBundle = storeBundle;
+
+    const fetchMock = vi.fn(async () => ({
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xrealbundlehash' }),
+    }));
+    global.fetch = fetchMock;
+
+    const unsignedTx = { to: '0x' + '2'.repeat(40), value: 1, gasLimit: 21000 };
+    const result = await mev.submitFlashbotsBundle('escrow-1', [unsignedTx]);
+
+    expect(result.bundleHash).toBe('0xrealbundlehash');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    // The submitted tx must be a signed (serialized) string, not the raw object.
+    expect(typeof body.params[0].txs[0]).toBe('string');
+    expect(body.params[0].txs[0]).not.toBe(unsignedTx);
+
+    expect(storeBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ escrowId: 'escrow-1', bundleId: '0xrealbundlehash' })
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`backend/mev/mev.service.js` `submitFlashbotsBundle` was broken in two ways (refs #13899):

1. It passed the caller-supplied `transactions` straight into `signedBundle: transactions` **without signing them**, so unsigned transactions would be handed to the relay.
2. It relied on `getMevRelayer()`, which was **never exported** from `backend/mev/flashbots_relayer.js`. Calling it threw `getMevRelayer is not a function`, so the bundle was never submitted to the relay at all. The relayer's `sendPrivateBundle` also only *simulated* a response (it returned a locally computed hash) and never performed a real submission.

Net effect: bundles were never actually protected/sent to the Flashbots relay, and the real signing path was unreachable.

## Fix

- `backend/mev/flashbots_relayer.js`: exported `getMevRelayer()` returning the singleton relayer; rewrote `sendPrivateBundle` to perform a real JSON-RPC `eth_sendBundle` POST to the relay URL and return the relay-issued `bundleHash` (throwing on relay errors), instead of simulating.
- `backend/mev/mev.service.js:213`: `submitFlashbotsBundle` now signs the transactions via `this.signTransactions(...)` before submitting, so the relay receives signed transactions.
- `backend/mev/submitFlashbotsBundle.test.js`: new isolated test asserting the bundle is signed, submitted to the relay (via a mocked `fetch`), and a real `bundleId` is stored.

## Files changed

- backend/mev/flashbots_relayer.js
- backend/mev/mev.service.js
- backend/mev/submitFlashbotsBundle.test.js

## Testing

- `node --check` passes for `mev.service.js` and `flashbots_relayer.js`.
- Manual review of the relay submission path and signing flow. (Full vitest run not executed in this environment as `vitest` is not installed; the added test targets the fixed behavior.)

Closes #13899
