### PR TITLE
fix: sign and verify trusted subgraph identity headers (closes #13898)

### DIFF
--- a/backend/graphql/gateway/index.js
+++ b/backend/graphql/gateway/index.js
@@ -5,6 +5,7 @@ import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
 import logger from '../../api/src/middleware/logger.js';
 import { supabase } from '../../api/src/config/db.js';
 import { resolveUserContext, DEFAULT_ROLE } from './authContext.js';
+import { computeTrustedSignature } from '../shared/trustedIdentity.js';
 
 class GraphQLGateway {
     constructor() {
@@ -49,10 +50,19 @@ class GraphQLGateway {
                         // forged x-user-id/x-user-role on the raw client request.
                         request.http.headers.delete('x-user-id');
                         request.http.headers.delete('x-user-role');
+                        request.http.headers.delete('x-gateway-signature');
 
                         if (context?.user?.id) {
-                            request.http.headers.set('x-user-id', context.user.id);
-                            request.http.headers.set('x-user-role', context.user.role || DEFAULT_ROLE);
+                            const userId = context.user.id;
+                            const role = context.user.role || DEFAULT_ROLE;
+                            request.http.headers.set('x-user-id', userId);
+                            request.http.headers.set('x-user-role', role);
+                            // Sign the trusted identity so subgraphs can verify it
+                            // originated from the gateway and was not forged.
+                            request.http.headers.set(
+                                'x-gateway-signature',
+                                computeTrustedSignature(userId, role)
+                            );
                         }
 
                         logger.debug(`GraphQL ${name} request sent`);

--- a/backend/graphql/services/driver.service.js
+++ b/backend/graphql/services/driver.service.js
@@ -4,6 +4,7 @@ import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
 import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
+import { resolveUserFromTrustedHeaders } from '../shared/trustedIdentity.js';
 
 const DISPATCH_ROLES = new Set(['ADMIN', 'admin', 'DISPATCHER', 'dispatcher']);
 
@@ -209,7 +210,13 @@ async function startDriverService() {
     });
 
     const { url } = await startStandaloneServer(server, {
-        listen: { port: 4002 }
+        listen: { port: 4002 },
+        context: async ({ req }) => {
+            // Identity is derived only from gateway-signed trusted headers;
+            // forged x-user-id/x-user-role reaching the subgraph directly are
+            // rejected (no IDOR / privilege escalation).
+            return { user: resolveUserFromTrustedHeaders(req.headers) };
+        }
     });
 
     logger.info(`OK Driver GraphQL service running at ${url}`);

--- a/backend/graphql/services/order.service.js
+++ b/backend/graphql/services/order.service.js
@@ -4,6 +4,7 @@ import { buildSubgraphSchema } from '@apollo/federation';
 import { gql } from 'graphql-tag';
 import { supabase } from '../../api/src/config/db.js';
 import logger from '../../api/src/middleware/logger.js';
+import { resolveUserFromTrustedHeaders } from '../shared/trustedIdentity.js';
 import { generateOrderDisplayId } from '../../api/src/lib/orderDisplayId.js';
 import { createLoaders } from '../gateway/authContext.js';
 
@@ -326,10 +327,13 @@ async function startOrderService() {
     const { url } = await startStandaloneServer(server, {
         listen: { port: 4001 },
         context: async ({ req }) => {
-            const id = req.headers['x-user-id'];
-            const role = req.headers['x-user-role'];
-            const user = id ? { id, role } : null;
-            
+            // Identity is derived only from gateway-signed trusted headers.
+            // Requests that reach the subgraph directly, or with forged
+            // x-user-id/x-user-role not bearing a valid gateway signature,
+            // resolve to an unauthenticated user and are rejected by
+            // requireUser/isAdmin in the resolvers (no IDOR / privilege escalation).
+            const user = resolveUserFromTrustedHeaders(req.headers);
+
             return {
                 user,
                 loaders: createLoaders(supabase)

--- a/backend/graphql/shared/trustedIdentity.js
+++ b/backend/graphql/shared/trustedIdentity.js
@@ -1,0 +1,62 @@
+import crypto from 'crypto';
+import logger from '../../api/src/middleware/logger.js';
+
+/**
+ * Binds subgraph identity to the gateway.
+ *
+ * Subgraphs (order/driver/etc.) previously trusted `x-user-id` / `x-user-role`
+ * headers verbatim. Because subgraphs are reachable on their own ports, any
+ * client could forge those headers and impersonate another user or an admin
+ * (IDOR / privilege escalation). The gateway now signs the trusted headers with
+ * an HMAC over `SUBGRAPH_SHARED_SECRET`; subgraphs verify the signature and
+ * reject any request that lacks a valid one.
+ */
+
+const SIGNATURE_HEADER = 'x-gateway-signature';
+
+function getSecret() {
+  const secret = process.env.SUBGRAPH_SHARED_SECRET;
+  if (!secret) {
+    logger.warn(
+      '[trustedIdentity] SUBGRAPH_SHARED_SECRET is not set; trusted subgraph ' +
+      'identity headers will not be signed/verified. Set it on both the ' +
+      'gateway and subgraphs to enable protection.'
+    );
+  }
+  return secret || '';
+}
+
+export function computeTrustedSignature(userId, role) {
+  const secret = getSecret();
+  if (!secret) return '';
+  const payload = `${userId || ''}:${role || ''}`;
+  return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+export function resolveUserFromTrustedHeaders(reqHeaders) {
+  const userId = reqHeaders['x-user-id'];
+  const role = reqHeaders['x-user-role'];
+  const signature = reqHeaders[SIGNATURE_HEADER];
+
+  // No identity supplied -> unauthenticated. This also rejects requests that
+  // arrive at a subgraph directly with forged x-user-id/x-user-role but no
+  // gateway-produced signature.
+  if (!userId || !signature) {
+    return null;
+  }
+
+  const secret = process.env.SUBGRAPH_SHARED_SECRET;
+  if (!secret) {
+    // Misconfigured: we cannot verify, so refuse to trust the identity.
+    return null;
+  }
+
+  const expected = crypto.createHmac('sha256', secret).update(`${userId}:${role || ''}`).digest('hex');
+  const a = Buffer.from(expected);
+  const b = Buffer.from(String(signature));
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    return null;
+  }
+
+  return { id: userId, role };
+}


### PR DESCRIPTION
## Problem

GraphQL subgraphs trusted `x-user-id` / `x-user-role` headers verbatim to establish identity/authorization. The gateway (`graphql/gateway/index.js`) already stripped and re-stamped these headers from the verified JWT, but the **subgraphs performed no validation** of them (`backend/graphql/services/order.service.js:328-337` built `user = { id: req.headers['x-user-id'], role: req.headers['x-user-role'] }` with no verification). `requireUser`/`isAdmin` in `order.service.js` (and `driver.service.js`) then relied entirely on that identity.

Because subgraphs listen on their own ports (4001-4004), any client that could reach one directly could send `x-user-id: <victim>` / `x-user-role: ADMIN` and impersonate that user or an admin — a full IDOR / privilege-escalation hole. There was no shared secret or message integrity binding the gateway to the subgraphs (refs #13898).

## Fix

Introduced an HMAC-signed trusted-identity header so only the gateway can assert subgraph identity:

- `backend/graphql/shared/trustedIdentity.js` (new): `computeTrustedSignature(userId, role)` and `resolveUserFromTrustedHeaders(reqHeaders)`. The latter returns a user only when a valid HMAC (`SUBGRAPH_SHARED_SECRET`) over `x-user-id:x-user-role` is present; forged/missing signatures resolve to `null` (rejected by `requireUser`/`isAdmin`). Comparison uses `crypto.timingSafeEqual`.
- `backend/graphql/gateway/index.js`: `willSendRequest` now deletes any client-supplied `x-gateway-signature` and stamps a fresh HMAC signature over the gateway-verified `x-user-id`/`x-user-role`.
- `backend/graphql/services/order.service.js`: context now derives `user` via `resolveUserFromTrustedHeaders` instead of trusting raw headers.
- `backend/graphql/services/driver.service.js`: added a secure context builder (previously missing entirely, so its resolvers never received a user) that uses `resolveUserFromTrustedHeaders`.

Requires `SUBGRAPH_SHARED_SECRET` to be set identically on the gateway and subgraphs; without it, identity is never trusted (fail-closed).

## Files changed

- backend/graphql/shared/trustedIdentity.js
- backend/graphql/gateway/index.js
- backend/graphql/services/order.service.js
- backend/graphql/services/driver.service.js

## Testing

- `node --check` passes for all four changed files.
- Manual review: forged `x-user-id`/`x-user-role` without a valid `x-gateway-signature` now yield an unauthenticated `user` (rejected by resolvers); only the gateway (which knows `SUBGRAPH_SHARED_SECRET`) can produce a valid signature.

Closes #13898


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added signed identity verification for requests between gateway services.
  - Prevents client-provided identity information from being trusted without validation.
  - Invalid, missing, or tampered identity data is rejected and handled through existing authentication and authorization checks.

- **Authentication**
  - Consistently carries verified user identity and role information across gateway and backend services.
  - Standalone services now apply the same authenticated request context as gateway-routed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->