### PR TITLE
fix(api): remove duplicate outboxRelayWorker import in index.js (Closes #14174)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -168,7 +168,6 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js


### PR DESCRIPTION
Closes #14174

## Problem
`backend/api/src/index.js` imported `startOutboxRelayWorker` / `stopOutboxRelayWorker` from `./workers/outboxRelayWorker.js` twice (lines 164 and 171), throwing `SyntaxError: Identifier 'startOutboxRelayWorker' has already been declared` so the API server could not boot.

## Fix
Removed the duplicate import line. Verified with `node --check` (exit 0).

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application startup and shutdown handling for background processing.
  * No user-facing features or behavior changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->