### PR TITLE
fix : remove duplicate supabaseAdmin import so deviceController loads

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,4 +1,3 @@
-import { supabaseAdmin } from '../config/db.js';
 import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';


### PR DESCRIPTION
Closes #14175.

Summary of What Has Been Done:
Removed the duplicate supabaseAdmin import on line 1 of backend/api/src/controllers/deviceController.js. Line 2 already imports both supabase and supabaseAdmin from the same module, making the first import redundant.

Changes Made:
- backend/api/src/controllers/deviceController.js: removed duplicate supabaseAdmin import line

Impact it Made:
Controller can now load without throwing 'Identifier supabaseAdmin has already been declared'. Verified with node --check.

Note: Please assign this PR to the `tmdeveloper007` account.

*This PR is submitted as part of GSSOC (GirlScript Summer of Code).*