### PR TITLE
fix : remove duplicate gpsTimestamp declaration so location server loads

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -233,8 +233,7 @@ export function initLocationServer(httpServer) {
         return;
       }
 
-      const gpsTimestamp = timestamp ? new Date(timestamp) : new Date();
-        const gpsTimestamp = parseGpsTimestamp(timestamp);
+      const gpsTimestamp = parseGpsTimestamp(timestamp);
 
       // 1. Buffer GPS point into the shared telemetry pipeline. Synchronous and
       //    fail-open — a slow or unavailable MongoDB must never delay the


### PR DESCRIPTION
Closes #14176.

Summary of What Has Been Done:
Removed the duplicate const gpsTimestamp declaration at line 236 in backend/api/src/sockets/locationServer.js. The second declaration using parseGpsTimestamp(timestamp) is the intended validated parser.

Changes Made:
- backend/api/src/sockets/locationServer.js: removed duplicate gpsTimestamp declaration

Impact it Made:
Location WebSocket server can now load without throwing 'Identifier gpsTimestamp has already been declared'. Verified with node --check.

Note: Please assign this PR to the `tmdeveloper007` account.

*This PR is submitted as part of GSSOC (GirlScript Summer of Code).*