### PR TITLE
fix : removed dead updateDocumentStatusSchema and otpSendSchema exports

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -277,11 +277,6 @@ export const earningsSummarySchema = z.object({
   period: z.enum(['weekly', 'monthly']).optional(),
 }).strict();
 
-export const updateDocumentStatusSchema = z.object({
-  status: z.enum(['Approved', 'Rejected', 'Pending']),
-  rejection_reason: z.string().optional()
-});
-
 export const syncWeightSchema = z.object({
   truck_id: z.string().min(1, "Truck ID is required"),
   axles: z.array(z.object({
@@ -293,12 +288,6 @@ export const syncWeightSchema = z.object({
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
 // e.g. MH12AB1234 or DL01C1234
 const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;
-
-export const otpSendSchema = z.object({
-  phone: z.string().trim().min(10).max(20).refine(isValidPhone, {
-    message: 'Phone must be a valid number (digits, optional +, spaces/dashes/parens)',
-  }),
-}).strict();
 
 export const registerTruckSchema = z.object({
   name: z.string()


### PR DESCRIPTION
Closes #14205.

Summary of What Has Been Done:
Removed two validation schemas (`updateDocumentStatusSchema` and `otpSendSchema`) from `backend/api/src/validation/requestSchemas.js` that were exported but never imported or used anywhere in the codebase.

Changes Made:
- Removed `export const updateDocumentStatusSchema` (lines 280-283)
- Removed `export const otpSendSchema` (lines 297-301)

Impact it Made:
- Cleaner codebase with no dead exports
- Verified: Node.js syntax check passed on the modified file

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed two obsolete request validation rules.
  * Existing request validation behavior remains unchanged for all other supported requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->