### PR TITLE
fix : removed dead adminRateLimiter export from rateLimiter middleware

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -395,24 +395,6 @@ export const podUploadLimiter = rateLimit({
   },
 });
 
-const adminWindowMs =
-  Number(process.env.ADMIN_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
-const adminMaxRequests =
-  Number(process.env.ADMIN_RATE_LIMIT_MAX_REQUESTS) || 50;
-
-export const adminRateLimiter = rateLimit({
-  windowMs: adminWindowMs,
-  max: adminMaxRequests,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  store: createStore("rl:admin:"),
-  message: {
-    error: "Rate limit exceeded",
-    retryAfter: Math.ceil(adminWindowMs / 1000),
-  },
-});
-
 const VERIFY_DELIVERY_WINDOW_MS =
   Number(process.env.VERIFY_DELIVERY_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 const VERIFY_DELIVERY_MAX_REQUESTS =


### PR DESCRIPTION
Closes #14206.

Summary of What Has Been Done:
Removed the unused `adminRateLimiter` export from `backend/api/src/middleware/rateLimiter.js`. The export was verified to be unused via grep across the entire backend/api/src/ directory.

Changes Made:
- Removed `const adminWindowMs` and `const adminMaxRequests` declarations
- Removed `export const adminRateLimiter = rateLimit({...})` block

Impact it Made:
- Eliminates dead code from the rate limiter module
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).