### PR TITLE
fix : removed dead mock constants and duplicated JSDoc in weighStationService

### DIFF
--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -25,16 +25,6 @@ const checkBypassEligibility = async (driverId, lat, lng) => {
   };
 };
 
-const MAX_GROSS_WEIGHT_LBS = 80000;
-const MAX_SINGLE_AXLE_LBS = 20000;
-const MAX_TANDEM_AXLE_LBS = 34000;
-const PSI_TO_LBS_FACTOR = 250; // Mock calibration factor
-const BASE_AXLE_WEIGHT_LBS = 5000; // Unsprung weight
-
-/**
- * Syncs highly accurate internal air suspension weights with DOT enforcement software.
- * Bypasses random pull-in probability if weights are completely legal.
- */
 /**
  * Syncs highly accurate internal air suspension weights with DOT enforcement software.
  * Returns an UNSUPPORTED response until a real WIM provider (Drivewyze/PrePass) API is integrated.


### PR DESCRIPTION
Closes #14207.

Summary of What Has Been Done:
Removed five unused mock constants (`MAX_GROSS_WEIGHT_LBS`, `MAX_SINGLE_AXLE_LBS`, `MAX_TANDEM_AXLE_LBS`, `PSI_TO_LBS_FACTOR`, `BASE_AXLE_WEIGHT_LBS`) and the duplicated JSDoc comment block from `backend/api/src/services/weighStationService.js`.

Changes Made:
- Removed 5 dead mock constant declarations
- Removed one of two identical JSDoc comment blocks

Impact it Made:
- Cleaner service file with no dead constants
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).