### PR TITLE
fix : corrected sort param default to desc in tripRoutes

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -519,7 +519,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
 router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const tripId = req.params.id;
   const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
-  const isAscending = sort !== 'desc';
+  const isAscending = sort === 'asc';
   const parsedPage = parsePositiveIntegerQuery(req.query.page, 1, Number.MAX_SAFE_INTEGER);
   const parsedLimit = parsePositiveIntegerQuery(req.query.limit, DEFAULT_EVENTS_LIMIT, MAX_EVENTS_LIMIT);
 


### PR DESCRIPTION
Closes #14208.

Summary of What Has Been Done:
Changed the sort parameter condition in `backend/api/src/routes/tripRoutes.js` from `sort !== desc` to `sort === asc`, so that when no sort parameter is provided, the default is descending order matching the API documentation.

Changes Made:
- Changed `const isAscending = sort !== "desc"` to `const isAscending = sort === "asc"`

Impact it Made:
- API behavior now matches documented default (descending order)
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).