### PR TITLE
fix : validate priority in DELETE /scheduler/tasks endpoint

### DIFF
--- a/backend/scheduler/routes.js
+++ b/backend/scheduler/routes.js
@@ -81,8 +81,14 @@ router.delete('/scheduler/tasks', (req, res) => {
                 'IDLE': Priority.IDLE
             };
             priorityValue = prioMap[priority.toUpperCase()];
+            if (priorityValue === undefined) {
+                return res.status(400).json({
+                    success: false,
+                    error: `Invalid priority: '${priority}'. Valid values are: CRITICAL, HIGH, MEDIUM, LOW, IDLE`,
+                });
+            }
         }
-        
+
         const count = scheduler.cancelAll(priorityValue);
         
         res.json({


### PR DESCRIPTION
Closes #14209.

Summary of What Has Been Done:
Added validation for the `priority` query parameter in `DELETE /scheduler/tasks` in `backend/scheduler/routes.js`. When an invalid priority value is provided, the endpoint now returns `400 Bad Request` instead of silently cancelling all queues.

Changes Made:
- Added check for undefined priorityValue after lookup
- Return 400 with descriptive error when priority is invalid

Impact it Made:
- Prevents accidental cancellation of all queues from typos or invalid input
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).