### PR TITLE
fix : declared deletedRows from unregister_device_token RPC result

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,4 +1,3 @@
-import { supabaseAdmin } from '../config/db.js';
 import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
@@ -168,7 +167,7 @@ export async function unregisterDeviceToken(req, res, next) {
       });
     }
 
-    const { error: rpcError } = await supabaseAdmin.rpc('unregister_device_token', {
+    const { error: rpcError, data: deletedRows } = await supabaseAdmin.rpc('unregister_device_token', {
       p_user_id:   userId,
       p_fcm_token: fcmToken,
     });


### PR DESCRIPTION
Closes #14211.

Summary of What Has Been Done:
Fixed `unregisterDeviceToken` in `backend/api/src/controllers/deviceController.js` by adding `data: deletedRows` to the RPC result destructuring. The `deletedRows` variable was used at line 182 but never declared.

Changes Made:
- Changed `const { error: rpcError } = await supabaseAdmin.rpc(...)` to `const { error: rpcError, data: deletedRows } = await supabaseAdmin.rpc(...)`

Impact it Made:
- Fixes ReferenceError when unregistering device tokens
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).