### PR TITLE
fix : removed duplicate gpsTimestamp declaration in locationServer

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -234,7 +234,6 @@ export function initLocationServer(httpServer) {
       }
 
       const gpsTimestamp = timestamp ? new Date(timestamp) : new Date();
-        const gpsTimestamp = parseGpsTimestamp(timestamp);
 
       // 1. Buffer GPS point into the shared telemetry pipeline. Synchronous and
       //    fail-open — a slow or unavailable MongoDB must never delay the


### PR DESCRIPTION
Closes #14212.

Summary of What Has Been Done:
Removed the duplicate `const gpsTimestamp` declaration in `backend/api/src/sockets/locationServer.js`. The variable was declared twice in the same scope (lines 236-237) causing a SyntaxError at load time.

Changes Made:
- Removed the duplicate `const gpsTimestamp = parseGpsTimestamp(timestamp)` declaration

Impact it Made:
- Location server can boot without syntax errors
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).