### PR TITLE
fix : removed duplicate outboxRelayWorker import in api index.js

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -168,7 +168,6 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js


### PR DESCRIPTION
Closes #14214.

Summary of What Has Been Done:
Removed the duplicate import of `startOutboxRelayWorker` and `stopOutboxRelayWorker` from `./workers/outboxRelayWorker.js` in `backend/api/src/index.js`. The import was declared twice (lines 164 and 171) causing a SyntaxError.

Changes Made:
- Removed the duplicate import line

Impact it Made:
- API can boot without duplicate import errors
- Verified: Node.js syntax check passed

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).