### PR TITLE
test : added unit tests for WIM config helpers

### DIFF
--- a/backend/api/test/unit/wim.test.js
+++ b/backend/api/test/unit/wim.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('wim config', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('getWimSigningSecret throws when WIM_SIGNING_SECRET is missing', async () => {
+    delete process.env.WIM_SIGNING_SECRET;
+    const { getWimSigningSecret } = await import('../../../../src/config/wim.js');
+    expect(() => getWimSigningSecret()).toThrow('WIM_SIGNING_SECRET environment variable is required');
+  });
+
+  it('getWimSigningSecret throws when WIM_SIGNING_SECRET is empty', async () => {
+    process.env.WIM_SIGNING_SECRET = '';
+    const { getWimSigningSecret } = await import('../../../../src/config/wim.js');
+    expect(() => getWimSigningSecret()).toThrow('WIM_SIGNING_SECRET environment variable is required');
+  });
+
+  it('getWimSigningSecret throws when secret is too short', async () => {
+    process.env.WIM_SIGNING_SECRET = 'tooshort';
+    const { getWimSigningSecret } = await import('../../../../src/config/wim.js');
+    expect(() => getWimSigningSecret()).toThrow();
+  });
+
+  it('getWimSigningSecret returns trimmed secret when valid', async () => {
+    process.env.WIM_SIGNING_SECRET = '   a_valid_secret_key_that_is_at_least_32_chars!   ';
+    const { getWimSigningSecret } = await import('../../../../src/config/wim.js');
+    expect(getWimSigningSecret()).toBe('a_valid_secret_key_that_is_at_least_32_chars!');
+  });
+
+  it('getWimCredentialTtlMs returns default when not set', async () => {
+    delete process.env.WIM_CREDENTIAL_TTL_MS;
+    const { getWimCredentialTtlMs } = await import('../../../../src/config/wim.js');
+    expect(getWimCredentialTtlMs()).toBe(15 * 60 * 1000);
+  });
+
+  it('getWimCredentialTtlMs returns configured value', async () => {
+    process.env.WIM_CREDENTIAL_TTL_MS = '600000';
+    const { getWimCredentialTtlMs } = await import('../../../../src/config/wim.js');
+    expect(getWimCredentialTtlMs()).toBe(600000);
+  });
+
+  it('isWimEnabled returns false when not configured', async () => {
+    delete process.env.WIM_ENABLED;
+    const { isWimEnabled } = await import('../../../../src/config/wim.js');
+    expect(isWimEnabled()).toBe(false);
+  });
+
+  it('isWimEnabled returns true when WIM_ENABLED=true', async () => {
+    process.env.WIM_ENABLED = 'true';
+    const { isWimEnabled } = await import('../../../../src/config/wim.js');
+    expect(isWimEnabled()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #14217.

Summary of What Has Been Done:
Added unit tests for `backend/api/src/config/wim.js` covering getWimSigningSecret (throws when missing/empty/too short, returns trimmed secret when valid), getWimCredentialTtlMs (default and configured), and isWimEnabled (true/false).

Changes Made:
- Added `backend/api/test/unit/wim.test.js`
- Tests for fail-closed signing secret contract
- Tests for TTL and enabled flag configuration

Impact it Made:
- Test coverage for WIM bypass security configuration

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).