### PR TITLE
test : added unit tests for documentController

### DIFF
--- a/backend/api/test/unit/documentController.test.js
+++ b/backend/api/test/unit/documentController.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../../../src/config/db.js', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => Promise.resolve({ data: [], error: null })),
+    })),
+  },
+}));
+
+vi.mock('../../../../src/middleware/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../../../../src/utils/apiResponse.js', () => ({
+  errorResponse: vi.fn(),
+}));
+
+import * as documentController from '../../../../src/controllers/documentController.js';
+
+describe('documentController', () => {
+  it('has reportGripData exported', () => {
+    expect(typeof documentController.reportGripData).toBe('function');
+  });
+
+  it('has getNearbyGripData exported', () => {
+    expect(typeof documentController.getNearbyGripData).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #14221.

Summary of What Has Been Done:
Added unit tests for `backend/api/src/controllers/documentController.js` verifying exported functions.

Changes Made:
- Added `backend/api/test/unit/documentController.test.js`
- Tests that reportGripData and getNearbyGripData are properly exported

Impact it Made:
- Basic test coverage for document controller exports

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GirlScript Summer of Code (GSSOC).