### PR TITLE
fix(deviceController): remove dead deletedRows reference (closes #14257)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -179,12 +179,7 @@ export async function unregisterDeviceToken(req, res, next) {
     }
 
     // If no rows were deleted, the token was not registered for this user
-    if (!deletedRows || deletedRows.length === 0) {
-      return res.status(404).json({
-        success: false,
-        error: 'Device token not found'
-      });
-    }
+    // (RPC returns no row count; rpcError check above covers the failure case)
 
     // Query remaining device tokens for this user to fallback
     const { data: remainingDevice, error: remainingError } = await supabase


### PR DESCRIPTION
## Summary

Fixes a ReferenceError crash in `unregisterDeviceToken`. The `deletedRows` variable was referenced but never declared. The RPC call only returns `{ error }` so the `rpcError` check already covers the failure case.

## Testing

- File passes `node --check`
- Backend unit tests run successfully
