### PR TITLE
fix(index.js): remove duplicate blockchainMonitoringRoutes mount (closes #14258)

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -658,9 +658,6 @@ app.get('/api/fraud/health', (req, res) => {
 // ============================================================================
 app.use('/api/zkp', zkpRoutes)
 
-// 🆕 BLOCKCHAIN MONITORING ROUTES
-app.use('/api/blockchain', blockchainMonitoringRoutes)
-
 // 🆕 ZK-Proof Health Check Endpoint
 app.get('/api/zkp/health', (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary

Fixes a route shadowing bug where a second mount of blockchainMonitoringRoutes (without the supabaseAdmin middleware) overrode the first mount, breaking all /api/blockchain/* routes that rely on req.supabase.

## Testing

- File passes `node --check`
- Backend unit tests run successfully
