### PR TITLE
fix(oracleRoutes): return live oracle config instead of hardcoded values (closes #14260)

### DIFF
--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -49,8 +49,12 @@ router.get('/status', authenticate, async (req, res) => {
     res.status(200).json({
       success: true,
       data: {
-        providers: 3,
-        threshold: 2,
+        providers: [
+          process.env.CHAINLINK_ENABLED === 'true',
+          true, // customVerifier always enabled
+          process.env.BACKUP_ORACLE_ENABLED === 'true',
+        ].filter(Boolean).length,
+        threshold: Number(process.env.ORACLE_CONSENSUS_THRESHOLD) || 2,
         timestamp: new Date().toISOString()
       }
     });


### PR DESCRIPTION
## Summary

Fixes GET /oracle/status to read CHAINLINK_ENABLED, BACKUP_ORACLE_ENABLED, and ORACLE_CONSENSUS_THRESHOLD from environment instead of returning hardcoded {providers:3, threshold:2}.

## Testing

- File passes `node --check`
- Backend unit tests run successfully
