### PR TITLE
fix(truckRoutes): move export default so fuel-advisor endpoint is reachable (closes #14261)

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -755,7 +755,7 @@ router.get('/:id/number', authenticate, userLimiter, validateParams(uuidParamSch
   }
 });
 
-export default router;
+// export default moved to end
 
 // ============================================================================
 // INTELLIGENT FUEL ADVISOR
@@ -828,3 +828,5 @@ router.get('/:id/fuel-advisor', authenticate, userLimiter, validateParams(uuidPa
 });
 
 // Resolves #2053: Prevent race conditions in truck allocation
+
+export default router;


### PR DESCRIPTION
## Summary

Fixes an unreachable route bug. The fuel-advisor endpoint (GET /api/trucks/:id/fuel-advisor) was defined after `export default router;`, making it non-functional. Moved the export to end of file.

## Testing

- File passes `node --check`
- Backend unit tests run successfully
