### PR TITLE
fix : close if block in supabaseMock.js to fix parse error

### DIFF
--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -481,6 +481,8 @@ export function createSupabaseMock(initialStore = {}) {
         if (profile && profile.fcm_token === token) {
           profile.fcm_token = nextActive?.fcm_token ?? null;
           profile.fcm_token_updated_at = nowIso;
+        }
+      }
       // Simulate the append_maintenance_photos PL/pgSQL RPC (see
       // migrations/20260811000000_create_append_maintenance_photos.sql)
       if (fnName === 'append_maintenance_photos' && args?.p_ticket_id) {


### PR DESCRIPTION
## Description
Closes the `if (profile && profile.fcm_token === token)` block inside `unregister_device_token` handler and the outer `if (fnName === 'unregister_device_token')` block in `test/helpers/supabaseMock.js`. Without these closing braces, the `rpc` function body never closes, causing a SyntaxError at the `storage` property.

## Changes
- Added `}` to close `if (profile && profile.fcm_token === token)` block (line ~484)
- Added `}` to close `if (fnName === 'unregister_device_token')` block (line ~485)

## Testing
Run `node --check test/helpers/supabaseMock.js` to confirm the fix.

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the device token removal test mock to correctly handle fallback token updates.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->