### PR TITLE
fix : move pendingCache declaration to outer scope in idempotency middleware

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -104,6 +104,8 @@ export function requireIdempotency(ttlSeconds = 3600) {
         return res.status(cached.statusCode).json(cached.body);
       }
 
+      let pendingCache = null;
+
       if (redisClient) {
         const lockKey = `${key}:lock`;
         const lockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', LOCK_TTL_MS);
@@ -162,7 +164,6 @@ export function requireIdempotency(ttlSeconds = 3600) {
         // a duplicate arriving after 'finish' finds the cached entry and
         // short-circuits instead of re-acquiring the lock and re-entering the
         // handler.
-        let pendingCache = null;
         const finalize = async () => {
           if (pendingCache) {
             const cachePromise = pendingCache;

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -481,6 +481,8 @@ export function createSupabaseMock(initialStore = {}) {
         if (profile && profile.fcm_token === token) {
           profile.fcm_token = nextActive?.fcm_token ?? null;
           profile.fcm_token_updated_at = nowIso;
+        }
+      }
       // Simulate the append_maintenance_photos PL/pgSQL RPC (see
       // migrations/20260811000000_create_append_maintenance_photos.sql)
       if (fnName === 'append_maintenance_photos' && args?.p_ticket_id) {


### PR DESCRIPTION
## Description
`pendingCache` is declared inside the `if (redisClient)` block but referenced in the `res.json` override which is at the same scope level as the `if/else` branches. When tests run in memory-only mode (no Redis), `pendingCache` is never declared, causing `ReferenceError: pendingCache is not defined`.

## Fix
Move `let pendingCache = null;` to before the `if (redisClient)` block so it is in scope for the entire handler.

## Testing
```bash
cd backend/api && npx vitest run test/unit/idempotency.test.js
```

GSSOC