### PR TITLE
fix : use named export for deliveryVerificationService in test file

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -104,6 +104,8 @@ export function requireIdempotency(ttlSeconds = 3600) {
         return res.status(cached.statusCode).json(cached.body);
       }
 
+      let pendingCache = null;
+
       if (redisClient) {
         const lockKey = `${key}:lock`;
         const lockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', LOCK_TTL_MS);
@@ -162,7 +164,6 @@ export function requireIdempotency(ttlSeconds = 3600) {
         // a duplicate arriving after 'finish' finds the cached entry and
         // short-circuits instead of re-acquiring the lock and re-entering the
         // handler.
-        let pendingCache = null;
         const finalize = async () => {
           if (pendingCache) {
             const cachePromise = pendingCache;

--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -481,6 +481,8 @@ export function createSupabaseMock(initialStore = {}) {
         if (profile && profile.fcm_token === token) {
           profile.fcm_token = nextActive?.fcm_token ?? null;
           profile.fcm_token_updated_at = nowIso;
+        }
+      }
       // Simulate the append_maintenance_photos PL/pgSQL RPC (see
       // migrations/20260811000000_create_append_maintenance_photos.sql)
       if (fnName === 'append_maintenance_photos' && args?.p_ticket_id) {

--- a/backend/api/test/unit/deliveryVerificationService.test.js
+++ b/backend/api/test/unit/deliveryVerificationService.test.js
@@ -15,7 +15,7 @@ describe('deliveryVerificationService', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    deliveryVerificationService = (await import('../../src/services/order/deliveryVerificationService.js')).default;
+    deliveryVerificationService = (await import('../../src/services/order/deliveryVerificationService.js')).DeliveryVerificationService;
   });
 
   describe('verifyDelivery', () => {


### PR DESCRIPTION
## Description
The test file `test/unit/deliveryVerificationService.test.js` imports the service as `.default`, but the source `src/services/order/deliveryVerificationService.js` exports a named `export class DeliveryVerificationService`. This causes the test to receive `undefined` instead of the class.

## Fix
Change the import from `.default` to a named import `.DeliveryVerificationService`.

## Testing
```bash
cd backend/api && npx vitest run test/unit/deliveryVerificationService.test.js
```

GSSOC