### PR TITLE
fix : added date validation in getDisplayIdDate and constant-time comparison fix

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -50,13 +50,16 @@ export function verifyOtpHash(otp, otpRecord) {
 // === Spec 12: constant-time hex compare ===
 export function constantTimeEqualHex(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
-  if (a.length !== b.length) return false;
-  if (a.length === 0 && b.length === 0) return true;
-  // Buffer.from(value, 'hex') does not reject invalid hex: it truncates at the
-  // first invalid character and drops a trailing odd nibble. Two identical
-  // invalid inputs would decode to equal short buffers and compare "equal",
-  // so reject anything that is not well-formed hex first.
+  // Reject non-hex input before any comparison to preserve the timing
+  // guarantee for valid inputs.  Buffer.from with hex encoding silently
+  // truncates at the first invalid char, so we validate upfront.
   if (!/^[0-9a-fA-F]+$/.test(a) || !/^[0-9a-fA-F]+$/.test(b)) return false;
-  try { return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex')); }
+  // Pad the shorter string with null bytes so both buffers are the same length.
+  // This keeps the crypto.timingSafeEqual call constant-time regardless of
+  // whether the inputs differ in length.
+  const maxLen = Math.max(a.length, b.length);
+  const bufA = Buffer.from(a.padEnd(maxLen, '\0'), 'ascii');
+  const bufB = Buffer.from(b.padEnd(maxLen, '\0'), 'ascii');
+  try { return crypto.timingSafeEqual(bufA, bufB) && a.length === b.length; }
   catch (_) { return false; }
 }

--- a/backend/api/src/utils/orderDisplayIdValidation.js
+++ b/backend/api/src/utils/orderDisplayIdValidation.js
@@ -18,10 +18,27 @@ export function isValidDisplayId(displayId) {
 
 /**
  * Get the date portion of a display ID.
+ * Validates that the date portion is a real calendar date (not just 8 digits).
  * @param {string} displayId - Valid display ID
  * @returns {string|null} YYYYMMDD date string or null
  */
 export function getDisplayIdDate(displayId) {
   if (!isValidDisplayId(displayId)) return null;
-  return displayId.slice(3, 11);
+  const dateStr = displayId.slice(3, 11);
+  const year = Number(dateStr.slice(0, 4));
+  const month = Number(dateStr.slice(4, 6));
+  const day = Number(dateStr.slice(6, 8));
+
+  // Reject out-of-range values that pass the regex but are not valid dates
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  // Validate using Date constructor: invalid dates produce "Invalid Date"
+  const parsed = new Date(`${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  // Reject pre-2020 and post-2100 dates as clearly invalid
+  if (year < 2020 || year > 2100) return null;
+
+  return dateStr;
 }


### PR DESCRIPTION
Closes #14324.

Summary of What Has Been Done:
Fixed two issues in the backend API utilities: (1) getDisplayIdDate now validates that the extracted date portion is a real calendar date, rejecting invalid dates like '99999999' that pass the regex but are not valid dates; (2) constantTimeEqualHex now performs constant-time comparison even for different-length inputs, eliminating a timing side-channel.

Changes Made:
- backend/api/src/utils/orderDisplayIdValidation.js: Added date validation in getDisplayIdDate checking month 1-12, day 1-31, valid Date constructor, and year 2020-2100
- backend/api/src/lib/otpHashing.js: Padded inputs to equal length before timing-safe comparison to eliminate length-based timing leak

Impact it Made:
Both changes were verified locally with npm run test:unit. The date validation prevents invalid display IDs from being processed as valid, and the timing leak fix closes a security vulnerability in sensitive comparison logic.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for one-time-password security comparisons, including invalid and empty values.
  * Strengthened order display ID date validation by rejecting impossible dates and unsupported years.
  * Invalid values now fail safely and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->