### PR TITLE
test : added unit tests for cursorPagination, PolicyRegistry, and BasePolicy

### DIFF
--- a/backend/api/test/unit/BasePolicy.test.js
+++ b/backend/api/test/unit/BasePolicy.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { BasePolicy } from '../../src/core/auth/BasePolicy.js';
+import { Permission } from '../../src/core/auth/Permission.js';
+
+describe('BasePolicy', () => {
+  describe('constructor', () => {
+    it('creates a policy with a given namespace', () => {
+      const policy = new BasePolicy('order');
+      expect(policy.namespace).toBe('order');
+    });
+
+    it('throws when namespace is not a non-empty string', () => {
+      expect(() => new BasePolicy()).toThrow('BasePolicy requires a non-empty namespace string.');
+      expect(() => new BasePolicy('')).toThrow('BasePolicy requires a non-empty namespace string.');
+      expect(() => new BasePolicy(null)).toThrow('BasePolicy requires a non-empty namespace string.');
+      expect(() => new BasePolicy(123)).toThrow('BasePolicy requires a non-empty namespace string.');
+    });
+  });
+
+  describe('define', () => {
+    it('adds a permission to the policy', () => {
+      const policy = new BasePolicy('order');
+      const perm = policy.define({ action: 'order:view', roles: ['driver'] });
+      expect(perm).toBeInstanceOf(Permission);
+      expect(perm.action).toBe('order:view');
+    });
+
+    it('returns the defined permission', () => {
+      const policy = new BasePolicy('order');
+      const perm = policy.define({ action: 'order:delete', roles: ['admin'] });
+      expect(perm.action).toBe('order:delete');
+    });
+  });
+
+  describe('getPermissions', () => {
+    it('returns all defined permissions', () => {
+      const policy = new BasePolicy('order');
+      policy.define({ action: 'order:view', roles: ['driver'] });
+      policy.define({ action: 'order:delete', roles: ['admin'] });
+      const perms = policy.getPermissions();
+      expect(perms).toHaveLength(2);
+    });
+
+    it('returns a copy of the permissions array', () => {
+      const policy = new BasePolicy('order');
+      policy.define({ action: 'order:view', roles: ['driver'] });
+      const perms1 = policy.getPermissions();
+      const perms2 = policy.getPermissions();
+      expect(perms1).not.toBe(perms2);
+      expect(perms1).toEqual(perms2);
+    });
+  });
+
+  describe('toMap', () => {
+    it('returns a Map of action to Permission', () => {
+      const policy = new BasePolicy('order');
+      policy.define({ action: 'order:view', roles: ['driver'] });
+      policy.define({ action: 'order:delete', roles: ['admin'] });
+      const map = policy.toMap();
+      expect(map).toBeInstanceOf(Map);
+      expect(map.get('order:view')).toBeDefined();
+      expect(map.get('order:delete')).toBeDefined();
+      expect(map.get('order:view').action).toBe('order:view');
+    });
+
+    it('returns an empty Map when no permissions defined', () => {
+      const policy = new BasePolicy('order');
+      const map = policy.toMap();
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe('multiple define calls', () => {
+    it('accumulates permissions correctly', () => {
+      const policy = new BasePolicy('driver');
+      policy.define({ action: 'driver:view', roles: ['driver'] });
+      policy.define({ action: 'driver:update', roles: ['driver'] });
+      policy.define({ action: 'driver:delete', roles: ['admin'] });
+      expect(policy.getPermissions()).toHaveLength(3);
+      expect(policy.toMap().size).toBe(3);
+    });
+  });
+});

--- a/backend/api/test/unit/PolicyRegistry.test.js
+++ b/backend/api/test/unit/PolicyRegistry.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { PolicyRegistry } from '../../src/core/auth/PolicyRegistry.js';
+import { Permission } from '../../src/core/auth/Permission.js';
+
+describe('PolicyRegistry', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new PolicyRegistry();
+  });
+
+  describe('register', () => {
+    it('registers a permission and returns it', () => {
+      const perm = new Permission({ action: 'order:view', roles: ['driver'] });
+      const result = registry.register(perm);
+      expect(result).toBe(perm);
+    });
+
+    it('registers a permission from an object', () => {
+      const result = registry.register({ action: 'order:view', roles: ['driver'] });
+      expect(registry.get('order:view')).toBeDefined();
+      expect(registry.get('order:view').action).toBe('order:view');
+    });
+
+    it('throws when action is already registered', () => {
+      registry.register({ action: 'order:view', roles: ['driver'] });
+      expect(() => {
+        registry.register({ action: 'order:view', roles: ['admin'] });
+      }).toThrow('Permission already registered for action: order:view');
+    });
+  });
+
+  describe('registerAll', () => {
+    it('registers multiple permissions', () => {
+      registry.registerAll([
+        { action: 'order:view', roles: ['driver'] },
+        { action: 'order:delete', roles: ['admin'] },
+      ]);
+      expect(registry.size).toBe(2);
+      expect(registry.has('order:view')).toBe(true);
+      expect(registry.has('order:delete')).toBe(true);
+    });
+
+    it('throws on duplicate within registerAll', () => {
+      expect(() => {
+        registry.registerAll([
+          { action: 'order:view', roles: ['driver'] },
+          { action: 'order:view', roles: ['admin'] },
+        ]);
+      }).toThrow('Permission already registered for action: order:view');
+    });
+  });
+
+  describe('get', () => {
+    it('returns the correct permission', () => {
+      registry.register({ action: 'order:view', roles: ['driver'] });
+      const perm = registry.get('order:view');
+      expect(perm).toBeDefined();
+      expect(perm.action).toBe('order:view');
+    });
+
+    it('returns undefined for unknown action', () => {
+      expect(registry.get('order:view')).toBeUndefined();
+    });
+  });
+
+  describe('has', () => {
+    it('returns true for registered action', () => {
+      registry.register({ action: 'order:view', roles: ['driver'] });
+      expect(registry.has('order:view')).toBe(true);
+    });
+
+    it('returns false for unregistered action', () => {
+      expect(registry.has('order:view')).toBe(false);
+    });
+  });
+
+  describe('listActions', () => {
+    it('returns sorted action names', () => {
+      registry.registerAll([
+        { action: 'order:delete', roles: ['admin'] },
+        { action: 'order:view', roles: ['driver'] },
+        { action: 'order:update', roles: ['driver'] },
+      ]);
+      const actions = registry.listActions();
+      expect(actions).toEqual(['order:delete', 'order:update', 'order:view']);
+    });
+
+    it('returns empty array when no permissions registered', () => {
+      expect(registry.listActions()).toEqual([]);
+    });
+  });
+
+  describe('listPermissions', () => {
+    it('returns all permission objects', () => {
+      registry.registerAll([
+        { action: 'order:view', roles: ['driver'] },
+        { action: 'order:delete', roles: ['admin'] },
+      ]);
+      const perms = registry.listPermissions();
+      expect(perms).toHaveLength(2);
+      expect(perms.map(p => p.action).sort()).toEqual(['order:delete', 'order:view']);
+    });
+  });
+
+  describe('size', () => {
+    it('returns the correct count', () => {
+      expect(registry.size).toBe(0);
+      registry.register({ action: 'order:view', roles: ['driver'] });
+      expect(registry.size).toBe(1);
+      registry.register({ action: 'order:delete', roles: ['admin'] });
+      expect(registry.size).toBe(2);
+    });
+  });
+
+  describe('snapshot', () => {
+    it('produces a valid JSON object with correct count', () => {
+      registry.registerAll([
+        { action: 'order:view', roles: ['driver'] },
+        { action: 'order:delete', roles: ['admin'] },
+      ]);
+      const snap = registry.snapshot();
+      expect(snap.totalPermissions).toBe(2);
+      expect(snap.policies['order:view']).toBeDefined();
+      expect(snap.policies['order:delete']).toBeDefined();
+    });
+  });
+});

--- a/backend/api/test/unit/cursorPagination.test.js
+++ b/backend/api/test/unit/cursorPagination.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { encodeCursor, decodeCursor, isValidCursor } from '../../src/utils/cursorPagination.js';
+
+describe('cursorPagination', () => {
+  describe('encodeCursor', () => {
+    it('encodes a cursor object to base64url', () => {
+      const cursor = { id: '123', createdAt: '2026-01-01T00:00:00Z' };
+      const encoded = encodeCursor(cursor);
+      expect(typeof encoded).toBe('string');
+      expect(encoded.length).toBeGreaterThan(0);
+      // base64url should not contain + or /
+      expect(encoded).not.toMatch(/[+/=]/);
+    });
+
+    it('encodes empty object', () => {
+      const encoded = encodeCursor({});
+      expect(typeof encoded).toBe('string');
+      expect(encoded.length).toBeGreaterThan(0);
+    });
+
+    it('encodes nested objects', () => {
+      const cursor = { id: 'abc', filter: { status: 'active' }, page: 1 };
+      const encoded = encodeCursor(cursor);
+      expect(typeof encoded).toBe('string');
+      const decoded = decodeCursor(encoded);
+      expect(decoded).toEqual(cursor);
+    });
+  });
+
+  describe('decodeCursor', () => {
+    it('round-trips encoded cursors correctly', () => {
+      const original = { id: '123', createdAt: '2026-01-01T00:00:00Z' };
+      const encoded = encodeCursor(original);
+      const decoded = decodeCursor(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it('returns null for null input', () => {
+      expect(decodeCursor(null)).toBeNull();
+    });
+
+    it('returns null for undefined input', () => {
+      expect(decodeCursor(undefined)).toBeNull();
+    });
+
+    it('returns null for non-string input', () => {
+      expect(decodeCursor(123)).toBeNull();
+      expect(decodeCursor({})).toBeNull();
+      expect(decodeCursor([])).toBeNull();
+    });
+
+    it('returns null for malformed base64', () => {
+      expect(decodeCursor('not-valid-base64!!!')).toBeNull();
+    });
+
+    it('returns null for valid base64 that is not JSON', () => {
+      // A valid base64 string that decodes to non-JSON text
+      const encoded = Buffer.from('this is not json').toString('base64url');
+      expect(decodeCursor(encoded)).toBeNull();
+    });
+
+    it('returns null for arrays (must be object)', () => {
+      const encoded = encodeCursor([1, 2, 3]);
+      expect(decodeCursor(encoded)).toBeNull();
+    });
+
+    it('returns null for primitives (must be object)', () => {
+      expect(decodeCursor(encodeCursor('string'))).toBeNull();
+      expect(decodeCursor(encodeCursor(42))).toBeNull();
+    });
+  });
+
+  describe('isValidCursor', () => {
+    it('returns true for valid cursors', () => {
+      const cursor = { id: '123' };
+      expect(isValidCursor(encodeCursor(cursor))).toBe(true);
+    });
+
+    it('returns false for invalid cursors', () => {
+      expect(isValidCursor(null)).toBe(false);
+      expect(isValidCursor('not-a-valid-cursor')).toBe(false);
+      expect(isValidCursor(encodeCursor([1, 2]))).toBe(false);
+    });
+
+    it('returns false for tampered cursors', () => {
+      const cursor = { id: '123' };
+      const encoded = encodeCursor(cursor);
+      const tampered = encoded.slice(0, -1) + 'X';
+      expect(isValidCursor(tampered)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #14326.

Summary of What Has Been Done:
Added comprehensive unit tests for three previously untested modules in the backend API: cursorPagination (encode/decode/validate functions), PolicyRegistry (register, get, has, list, snapshot), and BasePolicy (constructor, define, getPermissions, toMap).

Changes Made:
- backend/api/test/unit/cursorPagination.test.js: Added 14 tests covering encoding, decoding, validation, and tamper-resistance for cursor-based pagination
- backend/api/test/unit/PolicyRegistry.test.js: Added 14 tests covering registration, lookup, enumeration, and snapshot functionality
- backend/api/test/unit/BasePolicy.test.js: Added 9 tests covering constructor validation, permission definition, and enumeration

Impact it Made:
All tests verified locally with npm run test:unit. Test files follow the existing vitest convention (2-space indent, single quotes, ESM).

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).