### PR TITLE
fix(idempotency): hoist pendingCache so Redis mode caches responses (closes #14369)

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -162,7 +162,6 @@ export function requireIdempotency(ttlSeconds = 3600) {
         // a duplicate arriving after 'finish' finds the cached entry and
         // short-circuits instead of re-acquiring the lock and re-entering the
         // handler.
-        let pendingCache = null;
         const finalize = async () => {
           if (pendingCache) {
             const cachePromise = pendingCache;
@@ -204,6 +203,7 @@ export function requireIdempotency(ttlSeconds = 3600) {
         res.once('close', releaseMemoryLock);
       }
 
+      let pendingCache = null;
       let responded = false;
 
       const originalJson = res.json.bind(res);


### PR DESCRIPTION
## Summary

`let pendingCache = null;` was declared **inside** the `if (redisClient) { ... } else { ... }` block of `requireIdempotency`, but the `res.json` response-cache override **outside** that block assigned `pendingCache = redisClient.set(...)`. In strict/ESM mode this threw `ReferenceError: pendingCache is not defined` on every 2xx idempotent response whenever Redis was enabled, so callers got a 500 instead of the actual response.

The fix hoists the declaration to the shared scope (next to `let responded = false;`), so the Redis response cache is written before the lock is released, as intended.

## Changes

- `backend/api/src/middleware/idempotency.js` — hoist `pendingCache` out of the `if (redisClient)` block.

## Verification

- `npx vitest run test/unit/idempotency.test.js test/unit/idempotency-lock-order.test.js` → **25 passed / 2 failed**.
- Baseline on clean `main` for the same files: **17 passed / 9 failed** — the 7 newly-passing tests are the Redis-mode response-cache tests this fix addresses.
- The 2 remaining failures are pre-existing `vi.useFakeTimers()` timeout hangs unrelated to this change.

## GSSOC

**Contributor:** Akshita-2307

Closes #14369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request processing consistency when completing operations and serializing responses.
  * Reduced the risk of duplicate or incomplete results during repeated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->