### PR TITLE
fix(auth): return 403 for inactive Firebase profiles instead of ReferenceError (closes #14370)

### DIFF
--- a/backend/api/src/middleware/auth.js
+++ b/backend/api/src/middleware/auth.js
@@ -477,7 +477,6 @@ export async function authenticate(req, res, next) {
           TOMBSTONE_TTL_SECONDS,
         ).catch((err) => logger.error({ err }, "Cache set failed"));
 
-      if (profileIsDeactivated) {
         return res.status(403).json({
           error: "User profile is inactive.",
           hint: "Contact support to reactivate your account.",
@@ -498,7 +497,6 @@ export async function authenticate(req, res, next) {
       );
 
       return next();
-    }
     }
   } catch (error) {
     logger.error(


### PR DESCRIPTION
## Summary

In the Firebase auth flow of `backend/api/src/middleware/auth.js`, the code referenced `profileIsDeactivated`, which is never declared anywhere. Consequences:

- **Inactive Firebase users**: `ReferenceError: profileIsDeactivated is not defined` → swallowed by the outer catch → user gets `401 Invalid or expired authentication token.` instead of the intended `403 User profile is inactive.`
- **Active Firebase users**: the whole `if (!profile.is_active)` block was skipped, so `req.user` was never set and `next()` was never called — the request hung until client timeout.

The fix mirrors the (correct) Supabase branch: return 403 directly inside the `if (!profile.is_active)` block, and run the `req.user`/`setCachedProfile`/`return next()` sequence **outside** it.

## Changes

- `backend/api/src/middleware/auth.js` — remove the bogus `if (profileIsDeactivated) { ... }` wrapper and restructure the Firebase inactive-profile branch to match the Supabase branch.

## Verification

- `node --check` passes; `npx eslint backend/api/src/middleware/auth.js` is clean.
- `npx vitest run test/unit/auth.test.js` → **19 passed / 9 failed**, identical to the baseline on clean `main` (the 9 failures are pre-existing mock issues: missing `redisClient` export, missing `maybeSingle`, `invalid token`, unrelated to this change).

## GSSOC

**Contributor:** Akshita-2307

Closes #14370
