### PR TITLE
fix(tracker): remove dead GpsLog/getMongoDb block that throws ReferenceError (closes #14371)

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -1108,29 +1108,6 @@ export async function handleLocationPing(ws, data, req) {
     })();
   }
 
-  // Persist GPS log to MongoDB Atlas (GPS Logs collection) using the typed
-  // GpsLog mongoose schema. Fire-and-forget — the write must not block the
-  // WebSocket broadcast path. The bulk telemetry flush to the raw `telemetry`
-  // collection continues separately for batch analytics.
-  if (getMongoDb()) {
-    GpsLog.create({
-      bookingId: orderDisplayId || orderUUID || driver_id,
-      driverId: driver_id,
-      lat: sanitized.lat,
-      lng: sanitized.lng,
-      speed: sanitized.speed ?? 0,
-      heading: sanitized.bearing ?? 0,
-      timestamp: deviceTime || new Date(serverNow),
-      metadata: {
-        order_id: orderUUID || null,
-        order_display_id: orderDisplayId || null,
-        server_received_at: new Date(serverNow).toISOString(),
-      },
-    }).catch((err) => {
-      logger.error('[GpsLog] Failed to persist GPS coordinate to MongoDB:', err.message);
-    });
-  }
-
   const timestampIso = new Date(serverNow).toISOString();
   const broadcastPayload = buildClientLocationPayload({
     driverId: driver_id,


### PR DESCRIPTION
## Summary

Every `location_update` message handled by `backend/api/src/sockets/tracker.js` reached a "persist GPS log" block calling `getMongoDb()` and `GpsLog.create(...)` — identifiers that are **neither imported nor declared** in this file (they belong to `./telemetryBuffer.js`). This threw `ReferenceError: getMongoDb is not defined` on every valid location ping, aborting `handleLocationPing` before the local broadcast and Supabase realtime publish.

The block is leftover pre-`telemetryBuffer`-migration dead code; `telemetryBuffer.js` already handles telemetry persistence.

## Changes

- `backend/api/src/sockets/tracker.js` — delete the stale GpsLog block (previously lines 1111-1132).

## Verification

- `node --check` passes.
- `npx eslint backend/api/src/sockets/tracker.js` — this change removes one of the `no-undef` violation sources; the remaining violations are the legacy shutdown block addressed separately in #14372.

## GSSOC

**Contributor:** Akshita-2307

Closes #14371
