### PR TITLE
fix(outboxRelayWorker): pass kafka adapter filter as options arg to publishAndReport (closes #14373)

### DIFF
--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -34,7 +34,7 @@ async function relayOnce() {
           source: EVENT_SOURCES.INTERNAL,
           category: EVENT_CATEGORIES.DOMAIN,
         });
-        const outcome = await eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] });
+        const outcome = await eventBus.publishAndReport(baseEvent, undefined, { adapters: ['kafka'] });
 
         // Guard explanation:
         // outcome.published       — EventBus successfully received the event

--- a/backend/api/test/unit/outboxRelayWorker.test.js
+++ b/backend/api/test/unit/outboxRelayWorker.test.js
@@ -73,7 +73,7 @@ describe('outboxRelayWorker', () => {
       expect(mockEventBus.publishAndReport).toHaveBeenCalled();
     });
 
-    expect(mockEventBus.publishAndReport).toHaveBeenCalledWith(expect.any(Object), { adapters: ['kafka'] });
+    expect(mockEventBus.publishAndReport).toHaveBeenCalledWith(expect.any(Object), undefined, { adapters: ['kafka'] });
     expect(mockOutboxService.markPublished).toHaveBeenCalledWith('evt-1');
     worker.stopOutboxRelayWorker();
   });


### PR DESCRIPTION
## Summary

`backend/api/src/workers/outboxRelayWorker.js` called:

```js
eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] })
```

but `EventBus.publishAndReport(eventOrType, payloadOrOptions, options = {})` (`backend/api/src/core/events/EventBus.js:263`) only reads the adapter filter from the **third** parameter (`const targetAdapters = options.adapters || null;`, line 316). When the first argument is a `BaseEvent`, `payloadOrOptions` is ignored entirely, so `targetAdapters` was `null` and **every** registered adapter was attempted instead of only Kafka — violating the worker's intent (its comments and the `adapterAttempted > 0 && adapterFailures === 0` outcome check) and risking duplicate delivery / false failures when more than one adapter is registered.

## Changes

- `backend/api/src/workers/outboxRelayWorker.js` — pass the adapter filter as the third argument: `eventBus.publishAndReport(baseEvent, undefined, { adapters: ['kafka'] })`.
- `backend/api/test/unit/outboxRelayWorker.test.js` — update the assertion to the corrected 3-argument contract.

## Verification

- `npx vitest run test/unit/outboxRelayWorker.test.js` → **4/4 passed** (the updated assertion verifies the adapter filter now reaches the third argument).
- `npx eslint` on both changed files is clean; `node --check` passes.
- `EventBus.test.js` failures are pre-existing and identical on clean `main` (9/9).

## GSSOC

**Contributor:** Akshita-2307

Closes #14373
