### PR TITLE
fix(trackingTokenService): read public tracking data via service-role client (closes #14374)

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -55,9 +55,18 @@ export class TrackingTokenService {
   }
 
   async validateToken(rawToken) {
+    // `tracking_tokens` has no anon RLS policy and anon privileges are revoked,
+    // so the service-role client is required to look up the hash — the public
+    // `/tracking` handlers must not use the anon `supabase` client
+    // (issue #13906).
+    if (!this._supabaseAdmin) {
+      this._logger.error('validateToken requires service-role client');
+      throw new Error('Service-role client required for tracking token validation');
+    }
+
     const tokenHash = this.hashToken(rawToken);
 
-    const { data: token, error } = await this._supabase
+    const { data: token, error } = await this._supabaseAdmin
       .from('tracking_tokens')
       .select('id, order_display_id, expires_at, revoked, revoked_at')
       .eq('token_hash', tokenHash)
@@ -147,7 +156,14 @@ export class TrackingTokenService {
   }
 
   async getOrderForPublicTracking(orderDisplayId) {
-    const { data: order, error: orderError } = await this._supabase
+    // `orders` has no anon RLS policy and anon privileges are revoked, so the
+    // service-role client is required to read it (issue #13906).
+    if (!this._supabaseAdmin) {
+      this._logger.error('getOrderForPublicTracking requires service-role client');
+      throw new Error('Service-role client required for public tracking order');
+    }
+
+    const { data: order, error: orderError } = await this._supabaseAdmin
       .from('orders')
       .select(`
         order_display_id,
@@ -212,7 +228,14 @@ export class TrackingTokenService {
   }
 
   async getOrderTimeline(orderDisplayId) {
-    const { data, error } = await this._supabase
+    // `order_timeline` has no anon RLS policy and anon privileges are revoked,
+    // so the service-role client is required to read it (issue #13906).
+    if (!this._supabaseAdmin) {
+      this._logger.error('getOrderTimeline requires service-role client');
+      throw new Error('Service-role client required for public tracking timeline');
+    }
+
+    const { data, error } = await this._supabaseAdmin
       .from('order_timeline')
       .select('milestone, milestone_time, completed, sort_order')
       .eq('order_display_id', orderDisplayId)
@@ -235,7 +258,7 @@ export class TrackingTokenService {
       throw new Error('Service-role client required for driver location tracking');
     }
 
-    const { data: order, error: orderError } = await this._supabase
+    const { data: order, error: orderError } = await this._supabaseAdmin
       .from('orders')
       .select('driver_id')
       .eq('order_display_id', orderDisplayId)

--- a/backend/api/test/unit/trackingTokenService.test.js
+++ b/backend/api/test/unit/trackingTokenService.test.js
@@ -298,11 +298,12 @@ describe('TrackingTokenService', () => {
     });
 
     it('prefers the service-role client over the anon client', async () => {
-      mockData.store.orders.push({
+      const adminMock = createMockSupabase();
+      adminMock.store.orders = [];
+      adminMock.store.orders.push({
         order_display_id: '#FF20241205',
         driver_id: 'driver-uuid-456',
       });
-      const adminMock = createMockSupabase();
       adminMock.store.driver_locations = [];
       adminMock.store.driver_locations.push({
         driver_id: 'driver-uuid-456',


### PR DESCRIPTION
## Summary

`TrackingTokenService` ran its public-tracking reads with the **anon** Supabase client (`this._supabase`), but anon privileges are revoked and there is no anon RLS policy on the tables it reads:

- `tracking_tokens` — `REVOKE ALL ... FROM anon` (`supabase/migrations/revoke_anon_privileges.sql`); RLS policies exist only for `service_role` and `authenticated` (`supabase/migrations/20260716000000_add_public_tracking_tokens.sql`)
- `orders`, `order_timeline` — `REVOKE ALL ... FROM anon`

Affected methods (all used only by `backend/api/src/routes/publicTrackingRoutes.js`, whose `TrackingTokenService` instance **does** receive `supabaseAdmin`):

- `validateToken()` — read of `tracking_tokens` always errored → `{ valid: false, reason: 'validation_error' }` → both public endpoints returned 400
- `getOrderForPublicTracking()` — read of `orders` always errored → null → 404 "Order not found"
- `getOrderTimeline()` — read of `order_timeline` always errored
- `getDriverLocation()` — read of `orders` used the anon client (already guarded to require `supabaseAdmin`, yet still read orders via `this._supabase`)

This is the same root cause already fixed for `getOrderRouteCoords()` in issue #13906; the remaining methods are updated to match.

## Changes

- `backend/api/src/services/trackingTokenService.js` — use `this._supabaseAdmin` for the `tracking_tokens`/`orders`/`order_timeline` reads in `validateToken`, `getOrderForPublicTracking`, `getOrderTimeline`, and `getDriverLocation`, each with the same service-role-required guard used by `getOrderRouteCoords`.
- `backend/api/test/unit/trackingTokenService.test.js` — update `getDriverLocation > prefers the service-role client` to seed the order row in the admin mock's store (the order lookup now uses the service-role client).

## Verification

- `npx vitest run test/unit/trackingTokenService.test.js test/unit/trackingTokenStatus.test.js` → **25/25 passed**.
- `publicTrackingRoutes.test.js` → 4 passed / 2 failed, identical to baseline on clean `main` (pre-existing `/route` mock failures).
- `node --check` passes; `npx eslint` on the changed files is clean.

## GSSOC

**Contributor:** Akshita-2307

Closes #14374
