### PR TITLE
fix(notificationService): use allowed notif_type for delivery OTP notifications (closes #14375)

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -684,7 +684,11 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         user_id: customerId,
         title,
         body,
-        notif_type: 'delivery_otp',
+        // `delivery_otp` is not in the notifications.notif_type CHECK constraint
+        // (see supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql),
+        // so use an allowed type or the insert always fails and the OTP
+        // notification is never persisted.
+        notif_type: 'order_update',
         // No OTP or OTP-derived value is persisted here: an unsalted digest of
         // a 6-digit code is offline-brute-forceable if the table leaks.
         metadata: { order_display_id: orderDisplayId }


### PR DESCRIPTION
## Summary

`sendDeliveryOtpNotification()` inserted into `notifications` with `notif_type: 'delivery_otp'`, but the `notifications.notif_type` CHECK constraint does not include that value (allowed set per `supabase/migrations/20260807000050_widen_notifications_notif_type_check.sql`: `order_update, payment, load_offer, trip_update, document, system, bid_accepted, new_bid, payment_locked, payment_released`).

Every delivery-OTP notification therefore failed its database insert with a CHECK violation, so the row was never persisted (`dbSuccess` stayed `false`). Only the FCM push succeeded.

## Changes

- `backend/api/src/services/notificationService.js` — persist delivery-OTP notifications with `notif_type: 'order_update'` (an allowed, semantically-appropriate type). The FCM payload keeps its own `notifType: 'delivery_otp'` metadata (line 713) so downstream consumers can still distinguish the notification.

This matches the existing unit test expectation in `test/unit/notificationService.test.js`:
`expect(persisted.notif_type).toBe('order_update');` (line 272).

## Verification

- `node --check` passes; `npx eslint backend/api/src/services/notificationService.js` is clean.
- The `notifications` insert now uses only values permitted by the DB CHECK constraint.

Note (pre-existing, unrelated): `test/unit/notificationService.test.js` currently fails to parse on `main` — stray mid-file `import` statements (lines 342-348) and a missing closing brace for the `it` block at line 319, so that file cannot run. It is unchanged here.

## GSSOC

**Contributor:** Akshita-2307

Closes #14375
