### PR TITLE
fix(documentController): use declared existingDoc variable in upload flow (closes #14376)

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -66,7 +66,7 @@ export async function uploadDriverDocument(req, res) {
     }
 
     // Retrieve existing document of the same type for this driver (pre-flight check)
-    const { data: existingDocPreflight, error: checkErrorPreflight } = await supabaseAdmin
+    const { data: existingDoc, error: checkErrorPreflight } = await supabaseAdmin
       .from('driver_documents')
       .select('id, storage_path')
       .eq('driver_id', driverId)


### PR DESCRIPTION
## Summary

`uploadDriverDocument()` destructures the pre-flight query result as `existingDocPreflight` (`documentController.js:69`), but every subsequent use refers to `existingDoc` (lines 165, 175, 216, 219, 225). Since `existingDoc` is undeclared, referencing it in the `if (existingDoc)` branch at line 165 throws a `ReferenceError` on **every** document upload (both new documents and re-uploads), which is caught by the outer handler and returns a 500 "An unexpected error occurred".

This also means the supersede/update path (re-upload) could never actually run, and the orphaned-file cleanup for superseded documents was dead code.

## Changes

- `backend/api/src/controllers/documentController.js` — rename the pre-flight destructure from `existingDocPreflight` to `existingDoc`, matching all five call sites.

## Verification

- `node --check` passes; `npx eslint backend/api/src/controllers/documentController.js` is clean (the undeclared identifier would have been flagged as `no-undef` before the fix).
- `npx vitest run test/unit/documentRoutes.test.js` → 1 passed (import smoke test).

## GSSOC

**Contributor:** Akshita-2307

Closes #14376
