### PR TITLE
fix(auditRoutes): avoid TypeError when err is nullish in audit-logs error handler (closes #14377)

### DIFF
--- a/backend/api/src/routes/auditRoutes.js
+++ b/backend/api/src/routes/auditRoutes.js
@@ -201,7 +201,7 @@ router.get('/', authenticate, userLimiter, requirePolicy('admin:view-audit-logs'
     res.json(result);
   } catch (err) {
     logger.error({ requestId: req.requestId }, "[AuditRoutes] Error:", err?.message || err);
-    res.status(500).json({ error: "Failed to fetch audit logs.", details: err?.message || err.message });
+    res.status(500).json({ error: "Failed to fetch audit logs.", details: err?.message ?? String(err) });
   }
 });
 


### PR DESCRIPTION
## Summary

The admin `GET /api/v1/admin/audit-logs` error handler computed the error detail as:

```js
err?.message || err.message
```

When `err` is nullish/undefined, `err?.message` is `undefined` (falsy), so the expression falls through to `err.message` — which throws a `TypeError: Cannot read properties of undefined (reading 'message')` inside the catch block. Instead of a 500 JSON response, the client receives an unhandled exception (the response is never sent).

## Changes

- `backend/api/src/routes/auditRoutes.js:204` — use `err?.message ?? String(err)` (matches the idiom already used elsewhere, e.g. `notificationService.js`).

## Verification

- `node --check` passes; `npx eslint backend/api/src/routes/auditRoutes.js` is clean.
- `npx vitest run test/unit/auditRoutes.test.js test/unit/auditRoutes.moduleLoad.test.js` → **6/6 passed**.

## GSSOC

**Contributor:** Akshita-2307

Closes #14377
