### PR TITLE
fix : use parseEnvNumber helper in authFailureMonitor for robust env parsing

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -41,12 +41,12 @@ function getThresholdForPath(path) {
   for (const [route, limit] of ROUTE_THRESHOLDS.entries()) {
     if (path.startsWith(route)) return limit;
   }
-  return Number(process.env.AUTH_FAILURE_THRESHOLD || DEFAULT_THRESHOLD);
+  return parseEnvNumber(process.env.AUTH_FAILURE_THRESHOLD, DEFAULT_THRESHOLD, { min: 1 });
 }
 
 function cleanExpiredRecords() {
   const now = Date.now();
-  const windowMs = Number(process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS);
+  const windowMs = parseEnvNumber(process.env.AUTH_FAILURE_WINDOW_MS, DEFAULT_WINDOW_MS, { min: 1 });
 
   // Sweep failures
   for (const [ip, record] of failures.entries()) {
@@ -154,8 +154,8 @@ export default function authFailureMonitor(req, res, next) {
       return;
     }
 
-    const windowMs = Number(process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS);
-    const banDurationMs = Number(process.env.AUTH_BAN_DURATION_MS || DEFAULT_BAN_DURATION_MS);
+    const windowMs = parseEnvNumber(process.env.AUTH_FAILURE_WINDOW_MS, DEFAULT_WINDOW_MS, { min: 1 });
+    const banDurationMs = parseEnvNumber(process.env.AUTH_BAN_DURATION_MS, DEFAULT_BAN_DURATION_MS, { min: 1 });
     const threshold = getThresholdForPath(req.originalUrl);
 
     const existing = failures.get(ip);


### PR DESCRIPTION
Closes #14378.

Summary of What Has Been Done:
Replaced three bare Number() conversions of AUTH_FAILURE_WINDOW_MS, AUTH_BAN_DURATION_MS, and AUTH_FAILURE_THRESHOLD env vars with the existing parseEnvNumber() helper to ensure malformed env values fall back to defaults instead of producing NaN that silently breaks window expiry, auto-ban, and threshold logic.

Changes Made:
- backend/api/src/middleware/authFailureMonitor.js: getThresholdForPath() now calls parseEnvNumber(env, DEFAULT, { min: 1 }) instead of Number(env || default)
- backend/api/src/middleware/authFailureMonitor.js: cleanExpiredRecords() uses parseEnvNumber for windowMs
- backend/api/src/middleware/authFailureMonitor.js: res.on('finish') handler uses parseEnvNumber for windowMs and banDurationMs

Impact it Made:
Malformed env vars (e.g. empty string, typo, '1h') now fall back to safe defaults instead of producing NaN. The parseEnvNumber helper (previously dead code) is now the single code path for env parsing in this module.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication security settings when environment values are invalid or below the minimum allowed value.
  * Ensured safe fallback values are used for failure limits, monitoring windows, and ban durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->