### PR TITLE
fix : use allowed notif_type order_update instead of delivery_otp in notificationService

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -684,7 +684,7 @@ export async function sendDeliveryOtpNotification(customerId, orderDisplayId, ot
         user_id: customerId,
         title,
         body,
-        notif_type: 'delivery_otp',
+        notif_type: 'order_update',
         // No OTP or OTP-derived value is persisted here: an unsalted digest of
         // a 6-digit code is offline-brute-forceable if the table leaks.
         metadata: { order_display_id: orderDisplayId }


### PR DESCRIPTION
Closes #14375.

Summary of What Has Been Done:
Changed the notif_type value in sendDeliveryOtpNotification from 'delivery_otp' to 'order_update', which is a value permitted by the notifications.notif_type CHECK constraint. The previous value always violated the constraint and caused the notification row to be silently dropped.

Changes Made:
- backend/api/src/services/notificationService.js: Changed notif_type: 'delivery_otp' to notif_type: 'order_update' in the database insert within sendDeliveryOtpNotification

Impact it Made:
OTP notification rows are now successfully persisted to the database instead of being silently dropped due to a CHECK constraint violation.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).