### PR TITLE
fix : use supabaseAdmin for revoked-table reads in trackingTokenService

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -57,7 +57,7 @@ export class TrackingTokenService {
   async validateToken(rawToken) {
     const tokenHash = this.hashToken(rawToken);
 
-    const { data: token, error } = await this._supabase
+    const { data: token, error } = await this._supabaseAdmin
       .from('tracking_tokens')
       .select('id, order_display_id, expires_at, revoked, revoked_at')
       .eq('token_hash', tokenHash)
@@ -147,7 +147,7 @@ export class TrackingTokenService {
   }
 
   async getOrderForPublicTracking(orderDisplayId) {
-    const { data: order, error: orderError } = await this._supabase
+    const { data: order, error: orderError } = await this._supabaseAdmin
       .from('orders')
       .select(`
         order_display_id,
@@ -212,7 +212,7 @@ export class TrackingTokenService {
   }
 
   async getOrderTimeline(orderDisplayId) {
-    const { data, error } = await this._supabase
+    const { data, error } = await this._supabaseAdmin
       .from('order_timeline')
       .select('milestone, milestone_time, completed, sort_order')
       .eq('order_display_id', orderDisplayId)
@@ -235,7 +235,7 @@ export class TrackingTokenService {
       throw new Error('Service-role client required for driver location tracking');
     }
 
-    const { data: order, error: orderError } = await this._supabase
+    const { data: order, error: orderError } = await this._supabaseAdmin
       .from('orders')
       .select('driver_id')
       .eq('order_display_id', orderDisplayId)


### PR DESCRIPTION
Closes #14374.

Summary of What Has Been Done:
Changed four methods in trackingTokenService to use this._supabaseAdmin instead of this._supabase for tables that have had anon privileges revoked (tracking_tokens, orders, order_timeline). The anon client was erroring on all reads to these tables.

Changes Made:
- backend/api/src/services/trackingTokenService.js: validateToken() now uses _supabaseAdmin for tracking_tokens read
- backend/api/src/services/trackingTokenService.js: getOrderForPublicTracking() now uses _supabaseAdmin for orders read
- backend/api/src/services/trackingTokenService.js: getOrderTimeline() now uses _supabaseAdmin for order_timeline read
- backend/api/src/services/trackingTokenService.js: getDriverLocation() now uses _supabaseAdmin for orders read

Impact it Made:
Public tracking endpoints now work in real deployments instead of always failing with permission errors.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).