### PR TITLE
fix : pass adapter filter as third arg to publishAndReport in outboxRelayWorker

### DIFF
--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -34,7 +34,7 @@ async function relayOnce() {
           source: EVENT_SOURCES.INTERNAL,
           category: EVENT_CATEGORIES.DOMAIN,
         });
-        const outcome = await eventBus.publishAndReport(baseEvent, { adapters: ['kafka'] });
+        const outcome = await eventBus.publishAndReport(baseEvent, undefined, { adapters: ['kafka'] });
 
         // Guard explanation:
         // outcome.published       — EventBus successfully received the event


### PR DESCRIPTION
Closes #14373.

Summary of What Has Been Done:
Fixed the outboxRelayWorker to pass the Kafka adapter filter as the third argument to eventBus.publishAndReport() instead of the second. When called with a BaseEvent instance, the second argument is treated as payload and the adapter restriction in the options object is ignored, causing all registered adapters to be attempted instead of just Kafka.

Changes Made:
- backend/api/src/workers/outboxRelayWorker.js: Changed publishAndReport(baseEvent, { adapters: ['kafka'] }) to publishAndReport(baseEvent, undefined, { adapters: ['kafka'] })

Impact it Made:
The worker now publishes to Kafka only, as intended, instead of attempting all registered adapters on every outbox relay.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).