### PR TITLE
fix : move fuel-advisor route before export default so endpoint is reachable

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -755,8 +755,6 @@ router.get('/:id/number', authenticate, userLimiter, validateParams(uuidParamSch
   }
 });
 
-export default router;
-
 // ============================================================================
 // INTELLIGENT FUEL ADVISOR
 // ============================================================================
@@ -827,4 +825,4 @@ router.get('/:id/fuel-advisor', authenticate, userLimiter, validateParams(uuidPa
   }
 });
 
-// Resolves #2053: Prevent race conditions in truck allocation
+export default router;


### PR DESCRIPTION
Closes #14261.

Summary of What Has Been Done:
Moved the fuel-advisor route definition from after the  statement to before it. In JavaScript modules, code after the export default statement is unreachable, so the endpoint was non-functional.

Changes Made:
- backend/api/src/routes/truckRoutes.js: Moved the entire INTELLIGENT FUEL ADVISOR section (JSDoc + router.get('/:id/fuel-advisor')) before the export default statement

Impact it Made:
GET /api/trucks/:id/fuel-advisor endpoint is now reachable and functional.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).