### PR TITLE
fix : correct sort param to default to desc in tripRoutes events endpoint

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -519,7 +519,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
 router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const tripId = req.params.id;
   const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
-  const isAscending = sort !== 'desc';
+  const isAscending = sort === 'asc';
   const parsedPage = parsePositiveIntegerQuery(req.query.page, 1, Number.MAX_SAFE_INTEGER);
   const parsedLimit = parsePositiveIntegerQuery(req.query.limit, DEFAULT_EVENTS_LIMIT, MAX_EVENTS_LIMIT);
 


### PR DESCRIPTION
Closes #14259.

Summary of What Has Been Done:
Changed the sort parameter default in GET /trips/:id/events from ascending (sort !== 'desc') to descending (sort === 'asc') to match the OpenAPI-documented default of desc.

Changes Made:
- backend/api/src/routes/tripRoutes.js: Changed const isAscending = sort !== 'desc' to const isAscending = sort === 'asc'

Impact it Made:
Events endpoint now defaults to descending order as documented, instead of ascending. Invalid sort values are treated as non-ascending (desc).

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).