### PR TITLE
fix : remove deletedRows check and fix duplicate import in deviceController

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,4 +1,3 @@
-import { supabaseAdmin } from '../config/db.js';
 import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';
@@ -176,14 +175,6 @@ export async function unregisterDeviceToken(req, res, next) {
     if (rpcError) {
       logger.error('[DeviceController] Failed to unregister device token from database:', rpcError.message);
       return next(new AppError('Failed to unregister device', 500));
-    }
-
-    // If no rows were deleted, the token was not registered for this user
-    if (!deletedRows || deletedRows.length === 0) {
-      return res.status(404).json({
-        success: false,
-        error: 'Device token not found'
-      });
     }
 
     // Query remaining device tokens for this user to fallback


### PR DESCRIPTION
Closes #14257.

Summary of What Has Been Done:
Removed the reference to the undeclared `deletedRows` variable in `unregisterDeviceToken`. Since the Supabase RPC returns no row count, the `rpcError` check already covers all failure cases. Also fixed the duplicate `supabaseAdmin` import (issue #14175) which was preventing the module from loading.

Changes Made:
- backend/api/src/controllers/deviceController.js: Removed the if (!deletedRows || deletedRows.length === 0) check and its associated 404 response; rpcError already covers all failure cases
- backend/api/src/controllers/deviceController.js: Removed duplicate import { supabaseAdmin } statement (kept the combined import)

Impact it Made:
The unregisterDeviceToken endpoint now loads and runs without ReferenceError. The RPC error check covers all failure cases.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).