### PR TITLE
fix : change default in_features from 64 to 5 in SpatialTemporalGAT

### DIFF
--- a/backend/ml/gat/model.py
+++ b/backend/ml/gat/model.py
@@ -44,7 +44,7 @@ class SpatialTemporalGAT(nn.Module):
     
     def __init__(
         self,
-        in_features: int = 64,
+        in_features: int = 5,
         hidden_features: int = 128,
         out_features: int = 32,
         num_heads: int = 8,


### PR DESCRIPTION
Closes #13979.

Summary of What Has Been Done:
Changed the default in_features parameter of SpatialTemporalGAT from 64 to 5 to match the number of node features produced by TrafficGraphBuilder.get_pytorch_data(). This fixes the dimension mismatch that caused every /gat/predict call to crash with a ValueError.

Changes Made:
- backend/ml/gat/model.py: Changed default in_features from 64 to 5 in SpatialTemporalGAT.__init__

Impact it Made:
The GAT traffic predictor no longer crashes with dimension mismatch errors on /gat/predict calls.

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).