### PR TITLE
fix(deviceController): remove duplicate supabaseAdmin import (Closes #14175)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -1,4 +1,3 @@
-import { supabaseAdmin } from '../config/db.js';
 import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { errorResponse } from '../utils/apiResponse.js';


### PR DESCRIPTION
Closes #14175

## Problem
`backend/api/src/controllers/deviceController.js` imported `supabaseAdmin` twice (lines 1-2), throwing `SyntaxError: Identifier 'supabaseAdmin' has already been declared` so the controller (and API server) could not load.

## Fix
Removed the first import line; `import { supabase, supabaseAdmin } from '../config/db.js'` already provides both bindings. Verified with `node --check` (exit 0).

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated backend service configuration to support both standard and administrative database operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->