### PR TITLE
fix(authFailureMonitor): route env config through parseEnvNumber to avoid NaN (closes #14378)

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -41,12 +41,12 @@ function getThresholdForPath(path) {
   for (const [route, limit] of ROUTE_THRESHOLDS.entries()) {
     if (path.startsWith(route)) return limit;
   }
-  return Number(process.env.AUTH_FAILURE_THRESHOLD || DEFAULT_THRESHOLD);
+  return parseEnvNumber(process.env.AUTH_FAILURE_THRESHOLD, DEFAULT_THRESHOLD, { min: 1 });
 }
 
 function cleanExpiredRecords() {
   const now = Date.now();
-  const windowMs = Number(process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS);
+  const windowMs = parseEnvNumber(process.env.AUTH_FAILURE_WINDOW_MS, DEFAULT_WINDOW_MS, { min: 1 });
 
   // Sweep failures
   for (const [ip, record] of failures.entries()) {
@@ -154,8 +154,8 @@ export default function authFailureMonitor(req, res, next) {
       return;
     }
 
-    const windowMs = Number(process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS);
-    const banDurationMs = Number(process.env.AUTH_BAN_DURATION_MS || DEFAULT_BAN_DURATION_MS);
+    const windowMs = parseEnvNumber(process.env.AUTH_FAILURE_WINDOW_MS, DEFAULT_WINDOW_MS, { min: 1 });
+    const banDurationMs = parseEnvNumber(process.env.AUTH_BAN_DURATION_MS, DEFAULT_BAN_DURATION_MS, { min: 1 });
     const threshold = getThresholdForPath(req.originalUrl);
 
     const existing = failures.get(ip);


### PR DESCRIPTION
## Summary

`authFailureMonitor.js` defines a `parseEnvNumber(raw, fallback, { min })` helper (line 108) but never uses it. All four environment-config reads instead call `Number(...)` directly:

- `getThresholdForPath` — `Number(process.env.AUTH_FAILURE_THRESHOLD || DEFAULT_THRESHOLD)`
- `cleanExpiredRecords` — `Number(process.env.AUTH_FAILURE_WINDOW_MS || DEFAULT_WINDOW_MS)`
- `authFailureMonitor` — `Number(process.env.AUTH_FAILURE_WINDOW_MS || ...)` and `Number(process.env.AUTH_BAN_DURATION_MS || ...)`

When an env var is malformed (e.g. `"abc"`), `Number()` yields `NaN`, which silently corrupts the security engine:

- `threshold = NaN` → `existing.count >= NaN` is always false → automatic IP bans never trigger (login brute-force protection disabled).
- `windowMs = NaN` → failure records are never expired and windows never reset → an IP stays counted forever (and, combined with a valid threshold, leads to permanent bans / unbounded in-memory tracking).
- `banDurationMs = NaN` → bans never expire.

The existing `parseEnvNumber` helper already handles exactly this: non-finite values fall back to the default, and `{ min }` clamps negative/zero values (a zero window would also disable expiry).

## Changes

- `backend/api/src/middleware/authFailureMonitor.js` — route the four env reads through `parseEnvNumber(env, DEFAULT, { min: 1 })` (rejects non-numeric and <1s/1-count values, falling back to defaults).

## Verification

- `node --check` passes; `npx eslint backend/api/src/middleware/authFailureMonitor.js` is clean.
- `npx vitest run test/unit/authFailureMonitor.test.js` → **7/7 passed**.
- `authFailureMonitorBound.test.js` and `authFailureMonitorEnv.test.js` fail 8 tests **identically before and after this change** (pre-existing: those suites blow up in `extractClientIP` with an undefined `req` before reaching the env logic, and reference behaviors the current source does not implement). No regression introduced.

## GSSOC

**Contributor:** Akshita-2307

Closes #14378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication security settings.
  * Invalid, non-finite, or values below the minimum are now safely replaced with defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->