### PR TITLE
fix(locationServer): remove duplicate gpsTimestamp declaration (Closes #14176)

### DIFF
--- a/backend/api/src/sockets/locationServer.js
+++ b/backend/api/src/sockets/locationServer.js
@@ -233,8 +233,7 @@ export function initLocationServer(httpServer) {
         return;
       }
 
-      const gpsTimestamp = timestamp ? new Date(timestamp) : new Date();
-        const gpsTimestamp = parseGpsTimestamp(timestamp);
+      const gpsTimestamp = parseGpsTimestamp(timestamp);
 
       // 1. Buffer GPS point into the shared telemetry pipeline. Synchronous and
       //    fail-open — a slow or unavailable MongoDB must never delay the


### PR DESCRIPTION
Closes #14176

## Problem
`backend/api/src/sockets/locationServer.js` declared `const gpsTimestamp` twice in the same scope (lines 236-237), throwing `SyntaxError: Identifier 'gpsTimestamp' has already been declared` so the location WebSocket server could not load.

## Fix
Removed the raw `timestamp ? new Date(timestamp) : new Date()` declaration and kept the intended `parseGpsTimestamp(timestamp)` parser. Verified with `node --check` (exit 0).

GSSOC
