### PR TITLE
fix(deviceController): declare deletedRows from unregister_device_token result (Closes #14177)

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -168,7 +168,7 @@ export async function unregisterDeviceToken(req, res, next) {
       });
     }
 
-    const { error: rpcError } = await supabaseAdmin.rpc('unregister_device_token', {
+    const { data: rpcResult, error: rpcError } = await supabaseAdmin.rpc('unregister_device_token', {
       p_user_id:   userId,
       p_fcm_token: fcmToken,
     });
@@ -179,7 +179,12 @@ export async function unregisterDeviceToken(req, res, next) {
     }
 
     // If no rows were deleted, the token was not registered for this user
-    if (!deletedRows || deletedRows.length === 0) {
+    const deletedRows = Array.isArray(rpcResult)
+      ? rpcResult.length
+      : rpcResult && typeof rpcResult === 'object'
+        ? 1
+        : Number(rpcResult ?? 0);
+    if (!deletedRows || deletedRows === 0) {
       return res.status(404).json({
         success: false,
         error: 'Device token not found'


### PR DESCRIPTION
Closes #14177

## Problem
`unregisterDeviceToken` destructured only `{ error: rpcError }` from `supabaseAdmin.rpc('unregister_device_token', ...)` but then referenced `deletedRows` (which was never declared) for the 404 check — `ReferenceError` whenever the RPC succeeds.

## Fix
Captured the RPC result as `data: rpcResult` and derived a `deletedRows` count that handles array, object, and scalar-count return shapes, so the "Device token not found" 404 path works and the endpoint stops 500ing. Verified the change parses (`node --check` exit 0, with the pre-existing duplicate `supabaseAdmin` import excluded — that is fixed separately in #14413).

GSSOC
