### PR TITLE
fix(scheduler): reject invalid priority in DELETE /scheduler/tasks (Closes #14179)

### DIFF
--- a/backend/scheduler/routes.js
+++ b/backend/scheduler/routes.js
@@ -81,6 +81,12 @@ router.delete('/scheduler/tasks', (req, res) => {
                 'IDLE': Priority.IDLE
             };
             priorityValue = prioMap[priority.toUpperCase()];
+            if (priorityValue === undefined) {
+                return res.status(400).json({
+                    success: false,
+                    error: `Invalid priority '${priority}'. Must be one of: CRITICAL, HIGH, MEDIUM, LOW, IDLE`
+                });
+            }
         }
         
         const count = scheduler.cancelAll(priorityValue);


### PR DESCRIPTION
Closes #14179

## Problem
`DELETE /scheduler/tasks?priority=...` looked up the priority via `prioMap[priority.toUpperCase()]`; an unknown value produced `undefined`, which was passed to `scheduler.cancelAll(undefined)`. `RenderScheduler.cancelAll(priority = null)` treats `null`/`undefined` as no filter, so a typo'd priority silently cancelled **all** scheduled tasks.

## Fix
Returned `400 Bad Request` with an explicit message when the priority is provided but not one of `CRITICAL, HIGH, MEDIUM, LOW, IDLE`. Verified with `node --check` (exit 0).

GSSOC
