### PR TITLE
fix(tripRoutes): sort defaults to desc per OpenAPI contract (Closes #14180)

### DIFF
--- a/backend/api/src/routes/tripRoutes.js
+++ b/backend/api/src/routes/tripRoutes.js
@@ -519,7 +519,7 @@ router.post('/events/batch', authenticate, userLimiter, validateBatchPayload(bat
 router.get('/:id/events', authenticate, userLimiter, validateParams(uuidParamSchema), async (req, res) => {
   const tripId = req.params.id;
   const { type, sort, min_lat, max_lat, min_lng, max_lng } = req.query;
-  const isAscending = sort !== 'desc';
+  const isAscending = sort === 'asc';
   const parsedPage = parsePositiveIntegerQuery(req.query.page, 1, Number.MAX_SAFE_INTEGER);
   const parsedLimit = parsePositiveIntegerQuery(req.query.limit, DEFAULT_EVENTS_LIMIT, MAX_EVENTS_LIMIT);
 


### PR DESCRIPTION
Closes #14180

## Problem
`backend/api/src/routes/tripRoutes.js` line 522 used `const isAscending = sort !== 'desc';`, so an invalid/missing `sort` value was treated as ascending — contradicting the OpenAPI schema (`enum: [asc, desc]`, `default: desc`) and silently mis-sorting on typos.

## Fix
Only an explicit `'asc'` now sorts ascending: `const isAscending = sort === 'asc';`. Verified with `node --check` (exit 0).

GSSOC
