### PR TITLE
fix(weighStationService): remove dead mock constants and duplicated JSDoc (Closes #14181)

### DIFF
--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -6,9 +6,6 @@
 
 import logger from '../middleware/logger.js';
 
-const SIMULATED_NETWORK_DELAY_MS = 800;
-const STATION_ID_RANGE = 1000;
-
 const checkBypassEligibility = async (driverId, lat, lng) => {
   // No real WIM/bypass provider (Drivewyze/PrePass) is integrated. The
   // previous implementation returned a Math.random() coin-flip presented as a
@@ -25,16 +22,6 @@ const checkBypassEligibility = async (driverId, lat, lng) => {
   };
 };
 
-const MAX_GROSS_WEIGHT_LBS = 80000;
-const MAX_SINGLE_AXLE_LBS = 20000;
-const MAX_TANDEM_AXLE_LBS = 34000;
-const PSI_TO_LBS_FACTOR = 250; // Mock calibration factor
-const BASE_AXLE_WEIGHT_LBS = 5000; // Unsprung weight
-
-/**
- * Syncs highly accurate internal air suspension weights with DOT enforcement software.
- * Bypasses random pull-in probability if weights are completely legal.
- */
 /**
  * Syncs highly accurate internal air suspension weights with DOT enforcement software.
  * Returns an UNSUPPORTED response until a real WIM provider (Drivewyze/PrePass) API is integrated.


### PR DESCRIPTION
Closes #14181

## Problem
`backend/api/src/services/weighStationService.js` contained dead mock-simulation leftovers never referenced anywhere in the repo (verified with `git grep`):
- `SIMULATED_NETWORK_DELAY_MS`, `STATION_ID_RANGE`
- `MAX_GROSS_WEIGHT_LBS`, `MAX_SINGLE_AXLE_LBS`, `MAX_TANDEM_AXLE_LBS`, `PSI_TO_LBS_FACTOR` ("Mock calibration factor"), `BASE_AXLE_WEIGHT_LBS`
- A duplicated verbatim JSDoc block above `syncAndTransmitInternalWeights`.

## Fix
Removed the unused constants and the duplicated JSDoc. The module still exports `checkBypassEligibility` and `syncAndTransmitInternalWeights` unchanged. Verified with `node --check` (exit 0).

GSSOC
