### PR TITLE
fix(rateLimiter): remove dead adminRateLimiter export (Closes #14182)

### DIFF
--- a/backend/api/src/middleware/rateLimiter.js
+++ b/backend/api/src/middleware/rateLimiter.js
@@ -395,24 +395,6 @@ export const podUploadLimiter = rateLimit({
   },
 });
 
-const adminWindowMs =
-  Number(process.env.ADMIN_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
-const adminMaxRequests =
-  Number(process.env.ADMIN_RATE_LIMIT_MAX_REQUESTS) || 50;
-
-export const adminRateLimiter = rateLimit({
-  windowMs: adminWindowMs,
-  max: adminMaxRequests,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: userKeyGenerator,
-  store: createStore("rl:admin:"),
-  message: {
-    error: "Rate limit exceeded",
-    retryAfter: Math.ceil(adminWindowMs / 1000),
-  },
-});
-
 const VERIFY_DELIVERY_WINDOW_MS =
   Number(process.env.VERIFY_DELIVERY_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 const VERIFY_DELIVERY_MAX_REQUESTS =


### PR DESCRIPTION
Closes #14182

## Problem
`backend/api/src/middleware/rateLimiter.js` exported `adminRateLimiter` (and its `adminWindowMs`/`adminMaxRequests` helpers) with zero callers anywhere in `backend/api/src` (verified with `git grep`) — dead configuration that silently ships unreachable rate limits.

## Fix
Removed the unused `adminRateLimiter` export and its two helper constants. Verified with `node --check` (exit 0).

GSSOC
