### PR TITLE
fix(requestSchemas): remove dead updateDocumentStatusSchema and otpSendSchema (Closes #14183)

### DIFF
--- a/backend/api/src/validation/requestSchemas.js
+++ b/backend/api/src/validation/requestSchemas.js
@@ -277,11 +277,6 @@ export const earningsSummarySchema = z.object({
   period: z.enum(['weekly', 'monthly']).optional(),
 }).strict();
 
-export const updateDocumentStatusSchema = z.object({
-  status: z.enum(['Approved', 'Rejected', 'Pending']),
-  rejection_reason: z.string().optional()
-});
-
 export const syncWeightSchema = z.object({
   truck_id: z.string().min(1, "Truck ID is required"),
   axles: z.array(z.object({
@@ -293,12 +288,6 @@ export const syncWeightSchema = z.object({
 // Indian vehicle registration plate: 2 letters, 2 digits, up to 3 letters, up to 4 digits
 // e.g. MH12AB1234 or DL01C1234
 const numberPlateRegex = /^[A-Z]{2}\d{2}[A-Z]{1,3}\d{1,4}$/;
-
-export const otpSendSchema = z.object({
-  phone: z.string().trim().min(10).max(20).refine(isValidPhone, {
-    message: 'Phone must be a valid number (digits, optional +, spaces/dashes/parens)',
-  }),
-}).strict();
 
 export const registerTruckSchema = z.object({
   name: z.string()


### PR DESCRIPTION
Closes #14183

## Problem
`backend/api/src/validation/requestSchemas.js` exported `updateDocumentStatusSchema` and `otpSendSchema`, but neither was referenced anywhere in `backend/api/src` (verified with `git grep`) — dead schemas that were never wired into any route.

## Fix
Removed the two unused schema exports. `isValidPhone` is still used by `syncWeightSchema`-adjacent schemas, so nothing else changed. Verified with `node --check` (exit 0).

GSSOC
