### PR TITLE
fix : added stopDevicePruningWorker to server shutdown handler

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -160,7 +160,7 @@ import {
   stopDlqWorker,
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
-import { startDevicePruningWorker } from './workers/devicePruningWorker.js'
+import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
 import EscalationHandler from './services/blockchain/escalationHandler.js'
@@ -796,6 +796,7 @@ async function shutdown(signal) {
   stopReputationReconciliation()
   stopDlqWorker()
   stopDocumentExpiryWorker()
+  stopDevicePruningWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
   fraudDetection.destroy()


### PR DESCRIPTION
Closes #14484.

Summary of What Has Been Done:
Added the missing stopDevicePruningWorker() import and call to the graceful shutdown handler in backend/api/src/index.js, matching the pattern used for all other background workers.

Changes Made:
- backend/api/src/index.js: updated import to include stopDevicePruningWorker
- backend/api/src/index.js: added stopDevicePruningWorker() call in shutdown handler alongside other worker stops

Impact it Made:
All background workers are now properly stopped during graceful server shutdown, preventing the device pruning cron job from continuing to fire after the server has initiated shutdown.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.