### PR TITLE
chore: remove dead ML helper exports in ml.js

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -289,31 +289,6 @@ export async function predictEta({
 }
 
 /**
- * Matches shipments for bilateral load consolidation.
- *
- * @param {object} params
- * @param {Array}  params.loads   - Array of load objects with origin/dest lat/lng, dimensions, deadline
- * @param {Array}  params.drivers - Array of driver objects with current location, capacity, rating
- * @returns {Promise<{assignments: Array, unmatched_loads: Array, unmatched_drivers: Array}>}
- * @throws {Error} if ML_API_KEY is missing or HTTP fails
- */
-export async function matchBilateral({ loads, drivers }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/match/bilateral`;
-
-  const payload = { loads, drivers };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
-  });
-
-  return handleResponse(response, url, 'POST');
-}
-
-/**
  * Predicts driver profit for a given route using ML model.
  *
  * @param {object} params
@@ -375,36 +350,6 @@ export async function predictDriverProfit({
     },
     currency: 'INR',
   };
-}
-
-/**
- * Optimises packing of packages into a truck with delivery routing.
- *
- * @param {object} params
- * @param {Array<{length: number, width: number, height: number, weight: number}>} params.packages - Packages to pack
- * @param {{length: number, width: number, height: number, max_weight: number}} params.truck - Truck dimensions
- * @param {Array<{lat: number, lng: number}>} params.deliveryAddresses - Delivery stop coordinates
- * @returns {Promise<{packing_arrangement: Array, unpacked_packages: Array, stop_sequence: Array, utilization_pct: number}>}
- * @throws {Error} if ML_API_KEY is missing or HTTP fails
- */
-export async function optimisePacking({ packages, truck, deliveryAddresses }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/optimise/packing`;
-
-  const payload = {
-    packages,
-    truck,
-    delivery_addresses: deliveryAddresses,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
-  });
-
-  return handleResponse(response, url, 'POST');
 }
 
 /**
@@ -472,40 +417,6 @@ export async function recommendTrucks({ userId, bookingHistory = [], ratedLoads 
 }
 
 /**
- * Computes a trust score for a driver or customer based on behavioral metrics.
- *
- * @param {object} params
- * @param {number} params.cancellationRate - Cancellation rate (0-1)
- * @param {number} params.onTimePct        - On-time delivery percentage (0-100)
- * @param {number} params.avgRating        - Average rating (1-5)
- * @param {number} params.disputeCount     - Number of disputes (>= 0)
- * @param {boolean} params.isVerified      - Whether the user is verified
- * @returns {Promise<{trust_score: number, risk_category: string}>}
- * @throws {Error} if ML_API_KEY is missing or HTTP fails
- */
-export async function scoreTrust({ cancellationRate, onTimePct, avgRating, disputeCount, isVerified }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/score/trust`;
-
-  const payload = {
-    cancellation_rate: cancellationRate,
-    on_time_pct: onTimePct,
-    avg_rating: avgRating,
-    dispute_count: disputeCount,
-    is_verified: isVerified,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-
-  return handleResponse(response);
-}
-
-/**
  * Finds deadhead (return-trip) loads for a truck to avoid empty backhauls.
  * @param {object} params
  * @param {object} params.driverDestination - { lat, lng }
@@ -528,76 +439,6 @@ export async function matchDeadhead({ driverDestination, truckSpecs, arrivalTime
       available_loads: availableLoads,
     }),
     signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Optimises a mid-trip route based on real-time conditions.
- * @param {object} routeData - { current_location, destination, fuel_level, hours_driven }
- * @returns {Promise<{adjustments: Array, fuel_saving: number}>}
- */
-export async function optimiseMidTrip(routeData) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/optimise/mid-trip`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(routeData),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Triggers retraining of the demand prediction model.
- * @param {boolean} [force=false] - Force retrain even if model is current
- * @returns {Promise<{status: string, model_version: string}>}
- */
-export async function trainDemandModel(force = false) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/train/demand`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({ force }),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Triggers retraining of the price prediction model.
- * @param {boolean} [force=false] - Force retrain even if model is current
- * @returns {Promise<{status: string, model_version: string}>}
- */
-export async function trainPriceModel(force = false) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/train/price`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({ force }),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Lists all available ML models and their versions.
- * @returns {Promise<{models: Array}>}
- */
-export async function listModels() {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/models`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: getHeaders(),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
   });
   return handleResponse(response);
 }


### PR DESCRIPTION
Closes #14481

## Problem
`backend/api/src/services/ml.js` exports 7 helper functions that are never imported anywhere in the codebase (no production code, route, app, or test references them): `matchBilateral`, `optimisePacking`, `scoreTrust`, `optimiseMidTrip`, `trainDemandModel`, `trainPriceModel`, `listModels`. `mlRoutes.js` only imports `predictEta`.

## Fix
Removed all 7 dead exports (159 lines deleted). The `__testing` block still references only live symbols (`demandCache`, `priceCache`, `_haversineKm`, `parseWeightKg`). Verified with `node --check` and `git grep` for remaining references.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed several machine-learning-powered capabilities, including bilateral matching, packing optimization, driver trust scoring, mid-trip optimization, model retraining, and model listing.
  * All remaining machine-learning functionality continues to operate unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->