### PR TITLE
refactor : removed dead export from computeStateDiff in auditLog.js

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -93,7 +93,7 @@ export function sanitizePayload(data, maxDepth = 5, currentDepth = 0) {
 /**
  * Computes structural differences between beforeState and afterState.
  */
-export function computeStateDiff(before, after) {
+function computeStateDiff(before, after) {
   if (!before && !after) return null;
   if (!before) return { added: sanitizePayload(after) };
   if (!after) return { removed: sanitizePayload(before) };


### PR DESCRIPTION
Closes #14483.

Summary of What Has Been Done:
Removed the unnecessary export from the computeStateDiff function in backend/api/src/middleware/auditLog.js. The function is used internally within the file but never imported externally.

Changes Made:
- backend/api/src/middleware/auditLog.js: removed 'export' keyword from computeStateDiff function

Impact it Made:
Cleaner module with no unused exports. Internal function still works correctly.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.