### PR TITLE
chore: remove dead sanitizeLoadFilters helper in loadRoutes.js

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -63,19 +63,6 @@ import { escapeLike } from '../lib/escapeLike.js';
 
 const router = express.Router();
 
-
-// Sanitize load filter query params to prevent injection attacks
-function sanitizeLoadFilters(query) {
-  const allowed = ['min_price', 'max_price', 'distance', 'goods_type', 'weight', 'origin', 'destination', 'page', 'limit'];
-  const sanitized = {};
-  for (const key of Object.keys(query)) {
-    if (allowed.includes(key)) {
-      sanitized[key] = query[key];
-    }
-  }
-  return sanitized;
-}
-
 // ============================================================================
 // 1. GET ALL AVAILABLE LOAD OFFERS (DRIVER)
 // GET /api/loads


### PR DESCRIPTION
Closes #14482

## Problem
`backend/api/src/routes/loadRoutes.js` defines `sanitizeLoadFilters(query)` but it is never called anywhere in production code or tests — load filtering is handled inline by the route handlers. It is dead code.

## Fix
Removed the unused `sanitizeLoadFilters` function (10 lines deleted). Verified with `node --check` and `git grep` for remaining references.

GSSOC
