### PR TITLE
refactor : removed dead sanitizeLoadFilters helper from loadRoutes.js

### DIFF
--- a/backend/api/src/routes/loadRoutes.js
+++ b/backend/api/src/routes/loadRoutes.js
@@ -64,18 +64,6 @@ import { escapeLike } from '../lib/escapeLike.js';
 const router = express.Router();
 
 
-// Sanitize load filter query params to prevent injection attacks
-function sanitizeLoadFilters(query) {
-  const allowed = ['min_price', 'max_price', 'distance', 'goods_type', 'weight', 'origin', 'destination', 'page', 'limit'];
-  const sanitized = {};
-  for (const key of Object.keys(query)) {
-    if (allowed.includes(key)) {
-      sanitized[key] = query[key];
-    }
-  }
-  return sanitized;
-}
-
 // ============================================================================
 // 1. GET ALL AVAILABLE LOAD OFFERS (DRIVER)
 // GET /api/loads


### PR DESCRIPTION
Closes #14482.

Summary of What Has Been Done:
Removed the unused sanitizeLoadFilters function from backend/api/src/routes/loadRoutes.js. The function was defined but never called anywhere in production or test code.

Changes Made:
- backend/api/src/routes/loadRoutes.js: removed sanitizeLoadFilters function and its comment

Impact it Made:
Cleaner route module with no dead code.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.