### PR TITLE
chore: stop exporting internal computeStateDiff in auditLog.js

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -93,7 +93,7 @@ export function sanitizePayload(data, maxDepth = 5, currentDepth = 0) {
 /**
  * Computes structural differences between beforeState and afterState.
  */
-export function computeStateDiff(before, after) {
+function computeStateDiff(before, after) {
   if (!before && !after) return null;
   if (!before) return { added: sanitizePayload(after) };
   if (!after) return { removed: sanitizePayload(before) };


### PR DESCRIPTION
Closes #14483

## Problem
`backend/api/src/middleware/auditLog.js` exports `computeStateDiff`, but nothing imports it — it is only used internally (line 271). The `export` keyword advertises a public API that does not exist.

## Fix
Dropped the `export` keyword; `computeStateDiff` remains a private module function and the internal call site is unchanged. Verified with `git grep` (no external imports) and `node --check`.

GSSOC
