### PR TITLE
fix: stop device pruning worker during graceful shutdown

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -160,7 +160,7 @@ import {
   stopDlqWorker,
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
-import { startDevicePruningWorker } from './workers/devicePruningWorker.js'
+import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
 import EscalationHandler from './services/blockchain/escalationHandler.js'
@@ -798,6 +798,7 @@ async function shutdown(signal) {
   stopDocumentExpiryWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
+  stopDevicePruningWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()
 


### PR DESCRIPTION
Closes #14484

## Problem
`backend/api/src/index.js` starts the device pruning worker with `startDevicePruningWorker()` (line 754) but the shutdown handler (lines 792-800) stops every other worker (escrow, reputation, DLQ, document expiry, withdrawal settlement, outbox relay) while omitting `stopDevicePruningWorker`. The pruning worker keeps running — and its interval keeps firing — after the server starts shutting down.

## Fix
Imported `stopDevicePruningWorker` and invoked it in the shutdown handler alongside the other worker stops.

GSSOC
