### PR TITLE
refactor : removed dead ML helper exports from ml.js

### DIFF
--- a/backend/api/src/services/ml.js
+++ b/backend/api/src/services/ml.js
@@ -297,22 +297,6 @@ export async function predictEta({
  * @returns {Promise<{assignments: Array, unmatched_loads: Array, unmatched_drivers: Array}>}
  * @throws {Error} if ML_API_KEY is missing or HTTP fails
  */
-export async function matchBilateral({ loads, drivers }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/match/bilateral`;
-
-  const payload = { loads, drivers };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
-  });
-
-  return handleResponse(response, url, 'POST');
-}
-
 /**
  * Predicts driver profit for a given route using ML model.
  *
@@ -387,26 +371,6 @@ export async function predictDriverProfit({
  * @returns {Promise<{packing_arrangement: Array, unpacked_packages: Array, stop_sequence: Array, utilization_pct: number}>}
  * @throws {Error} if ML_API_KEY is missing or HTTP fails
  */
-export async function optimisePacking({ packages, truck, deliveryAddresses }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/optimise/packing`;
-
-  const payload = {
-    packages,
-    truck,
-    delivery_addresses: deliveryAddresses,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_HEAVY),
-  });
-
-  return handleResponse(response, url, 'POST');
-}
-
 /**
  * Recommends available loads for a user based on collaborative filtering.
  *
@@ -418,27 +382,6 @@ export async function optimisePacking({ packages, truck, deliveryAddresses }) {
  * @returns {Promise<{recommendations: Array}>}
  * @throws {Error} if ML_API_KEY is missing or HTTP fails
  */
-export async function recommendLoads({ userId, bookingHistory = [], ratedDrivers = [], topN = 5 }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/recommend/loads`;
-
-  const payload = {
-    user_id: userId,
-    booking_history: bookingHistory,
-    rated_drivers: ratedDrivers,
-    top_n: topN,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-
-  return handleResponse(response);
-}
-
 /**
  * Recommends suitable trucks for a user based on collaborative filtering.
  *
@@ -450,27 +393,6 @@ export async function recommendLoads({ userId, bookingHistory = [], ratedDrivers
  * @returns {Promise<{recommendations: Array}>}
  * @throws {Error} if ML_API_KEY is missing or HTTP fails
  */
-export async function recommendTrucks({ userId, bookingHistory = [], ratedLoads = [], topN = 5 }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/recommend/trucks`;
-
-  const payload = {
-    user_id: userId,
-    booking_history: bookingHistory,
-    rated_loads: ratedLoads,
-    top_n: topN,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-
-  return handleResponse(response);
-}
-
 /**
  * Computes a trust score for a driver or customer based on behavioral metrics.
  *
@@ -483,28 +405,6 @@ export async function recommendTrucks({ userId, bookingHistory = [], ratedLoads 
  * @returns {Promise<{trust_score: number, risk_category: string}>}
  * @throws {Error} if ML_API_KEY is missing or HTTP fails
  */
-export async function scoreTrust({ cancellationRate, onTimePct, avgRating, disputeCount, isVerified }) {
-  guardMlApiKey();
-  const url = `${getBaseUrl()}/score/trust`;
-
-  const payload = {
-    cancellation_rate: cancellationRate,
-    on_time_pct: onTimePct,
-    avg_rating: avgRating,
-    dispute_count: disputeCount,
-    is_verified: isVerified,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-
-  return handleResponse(response);
-}
-
 /**
  * Finds deadhead (return-trip) loads for a truck to avoid empty backhauls.
  * @param {object} params
@@ -537,71 +437,6 @@ export async function matchDeadhead({ driverDestination, truckSpecs, arrivalTime
  * @param {object} routeData - { current_location, destination, fuel_level, hours_driven }
  * @returns {Promise<{adjustments: Array, fuel_saving: number}>}
  */
-export async function optimiseMidTrip(routeData) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/optimise/mid-trip`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify(routeData),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Triggers retraining of the demand prediction model.
- * @param {boolean} [force=false] - Force retrain even if model is current
- * @returns {Promise<{status: string, model_version: string}>}
- */
-export async function trainDemandModel(force = false) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/train/demand`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({ force }),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Triggers retraining of the price prediction model.
- * @param {boolean} [force=false] - Force retrain even if model is current
- * @returns {Promise<{status: string, model_version: string}>}
- */
-export async function trainPriceModel(force = false) {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/train/price`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({ force }),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS_LONG),
-  });
-  return handleResponse(response);
-}
-
-/**
- * Lists all available ML models and their versions.
- * @returns {Promise<{models: Array}>}
- */
-export async function listModels() {
-  guardMlApiKey();
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/models`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: getHeaders(),
-    signal: AbortSignal.timeout(ML_HTTP_TIMEOUT_MS),
-  });
-  return handleResponse(response);
-}
-
 /**
  * Finds en-route load opportunities for an active driver using the Deadhead
  * Eliminator ML model. When the ML engine is unavailable (no ML_API_KEY,


### PR DESCRIPTION
Closes #14481.

Summary of What Has Been Done:
Removed 9 dead exported ML helper functions from backend/api/src/services/ml.js that are never imported or called anywhere in production code or tests: matchBilateral, optimisePacking, recommendLoads, recommendTrucks, scoreTrust, optimiseMidTrip, trainDemandModel, trainPriceModel, and listModels.

Changes Made:
- backend/api/src/services/ml.js: removed dead exported functions (165 lines deleted)

Impact it Made:
Cleaner ML service module with no unused exports. The remaining functions (predictDemand, predictPrice, predictEta, matchDeadhead, matchEnRouteLoads, predictDriverProfit) are actively used.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.