### PR TITLE
fix: stop stale order worker during graceful shutdown

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -159,7 +159,7 @@ import {
   startDlqWorker,
   stopDlqWorker,
 } from './workers/dlqWorker.js'
-import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
+import { startStaleOrderWorker, stopStaleOrderWorker } from './workers/staleOrderWorker.js'
 import { startDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
@@ -798,6 +798,7 @@ async function shutdown(signal) {
   stopDocumentExpiryWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
+  stopStaleOrderWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()
 


### PR DESCRIPTION
Closes #14485

## Problem
`backend/api/src/index.js` starts the stale-order worker with `startStaleOrderWorker(...)` (line 753) but the shutdown handler (lines 792-800) stops every other worker while omitting `stopStaleOrderWorker`. The stale-order worker keeps running after the server starts shutting down.

## Fix
Imported `stopStaleOrderWorker` and invoked it in the shutdown handler alongside the other worker stops.

GSSOC
