### PR TITLE
refactor: reuse shared haversineKm in mlRoutes.js

### DIFF
--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -4,20 +4,9 @@ import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 import { predictEta } from '../services/ml.js';
+import { haversineKm } from '../lib/pricing.js';
 
 const router = express.Router();
-
-function haversineKm(lat1, lng1, lat2, lng2) {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLng = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLng / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
 
 function parseCoord(value, min, max) {
   const n = Number(value);


### PR DESCRIPTION
Closes #14486

## Problem
`backend/api/src/routes/mlRoutes.js` defines a local `haversineKm` helper, but an equivalent great-circle distance helper already exists as `haversineKm` in `backend/api/src/lib/pricing.js` (same formula and semantics, plus a guard for non-finite inputs). This duplicates logic the repo convention (DRY) asks to avoid.

## Fix
Removed the local copy and imported the shared `haversineKm` from `../lib/pricing.js`. Verified with `node --check`.

GSSOC
