### PR TITLE
fix: clamp scheduler uptime with Math.max in getStats

### DIFF
--- a/backend/scheduler/RenderScheduler.js
+++ b/backend/scheduler/RenderScheduler.js
@@ -493,7 +493,7 @@ class RenderScheduler extends EventEmitter {
             queued: this.getQueueLength(),
             maxConcurrent: this.maxConcurrent,
             queues: this.getQueueStats(),
-            uptime: Date.now() - this.stats.startTime || 0
+            uptime: Math.max(0, Date.now() - this.stats.startTime)
         };
     }
     


### PR DESCRIPTION
Closes #14489

## Problem
In `backend/scheduler/RenderScheduler.js`, `uptime: Date.now() - this.stats.startTime || 0` — `startTime` is always set to `Date.now()` in the constructor and on reset, so the subtraction is always a large positive number and the `|| 0` fallback never triggers. It is dead, misleading logic, and would still not guard against a future (clock-skewed) `startTime`.

## Fix
Replaced the dead fallback with a defensive clamp: `Math.max(0, Date.now() - this.stats.startTime)`.

GSSOC
