### PR TITLE
fix: validate status filter in GET /scheduler/tasks

### DIFF
--- a/backend/scheduler/routes.js
+++ b/backend/scheduler/routes.js
@@ -235,6 +235,15 @@ router.get('/scheduler/task/:taskId', (req, res) => {
 router.get('/scheduler/tasks', (req, res) => {
     try {
         const { status } = req.query;
+
+        const validStatuses = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+        if (status !== undefined && !validStatuses.includes(status)) {
+            return res.status(400).json({
+                success: false,
+                error: `Invalid status. Must be one of: ${validStatuses.join(', ')}`
+            });
+        }
+
         const tasks = scheduler.getTasks(status);
         
         res.json({


### PR DESCRIPTION
Closes #14492

## Problem
`GET /scheduler/tasks?status=...` in `backend/scheduler/routes.js` forwards `status` straight to `RenderScheduler.getTasks(status)`, which filters `tasks.filter(t => t.status === status)`. An invalid/unknown status silently returns an empty list with 200 — the caller cannot distinguish "no matching tasks" from "you typed a bogus status". This is inconsistent with the other scheduler endpoints, which validate inputs (e.g. `POST /scheduler/task/:taskId/priority` returns 400 for invalid priorities).

## Fix
Validated `status` against the known task statuses (`pending`, `running`, `completed`, `failed`, `cancelled`) and return 400 with the valid list for unknown values.

GSSOC
