### PR TITLE
docs: remove duplicate fileoverview JSDoc in userRoutes.js

### DIFF
--- a/backend/api/src/routes/userRoutes.js
+++ b/backend/api/src/routes/userRoutes.js
@@ -52,22 +52,6 @@ const fcmTokenSchema = z.object({
 // ============================================================================
 
 /**
- * @fileoverview userRoutes.js
- *
- * This module handles user-specific endpoints that do not fit other route modules.
- *
- * PRIMARY ENDPOINT: POST /api/users/fcm-token
- *   Updates the Firebase Cloud Messaging (FCM) push token for the authenticated user.
- *   This endpoint is kept separate from deviceRoutes.js to maintain clear authorization
- *   scoping: the FCM token is a user-profile attribute (users own their notification
- *   tokens), while deviceRoutes.js handles device-level registration (platform,
- *   model, OS version). Splitting them prevents device operations from needing
- *   user-level write access to profiles.
- *
- * @module routes/userRoutes
- */
-
-/**
  * @openapi
  * /api/users/fcm-token:
  *   post:


### PR DESCRIPTION
Closes #14493

## Problem
`backend/api/src/routes/userRoutes.js` contains the module documentation header (`@fileoverview userRoutes.js`, `@module routes/userRoutes`) twice — once at the top of the file and again mid-file before the FCM token endpoint. The duplicated block is redundant.

## Fix
Removed the duplicated mid-file `@fileoverview`/`@module` JSDoc block and kept the single header at the top of the file, plus the endpoint-specific `@openapi` block. Verified with `node --check`.

GSSOC
