### PR TITLE
fix : add NaN guard to parseInt calls in apiKey.js

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -6,6 +6,11 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+const safeInt = (raw, fallback) => {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+};
+
 export class AuthConfig {
   constructor() {
     this.reload();
@@ -21,16 +26,16 @@ export class AuthConfig {
     // Security Policies
     this.allowQueryParam = process.env.ALLOW_API_KEY_IN_QUERY === 'true'; // Default false (anti-pattern)
     this.requireHmac = process.env.REQUIRE_HMAC_SIGNATURE === 'true';
-    this.signatureMaxAgeMs = parseInt(process.env.SIGNATURE_MAX_AGE_MS || '300000', 10); // 5 minutes
+    this.signatureMaxAgeMs = safeInt(process.env.SIGNATURE_MAX_AGE_MS, 300000);
     this.enableRateLimiting = process.env.ENABLE_RATE_LIMITING !== 'false';
     
     // Rate Limit Defaults
-    this.defaultRateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10);
-    this.defaultRateLimitMax = parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100', 10);
+    this.defaultRateLimitWindowMs = safeInt(process.env.RATE_LIMIT_WINDOW_MS, 60000);
+    this.defaultRateLimitMax = safeInt(process.env.RATE_LIMIT_MAX_REQUESTS, 100);
 
     // Redis Configuration
     this.redisUrl = process.env.REDIS_URL || null;
-    this.cacheTtlMs = parseInt(process.env.KEY_CACHE_TTL_MS || '600000', 10); // 10 minutes
+    this.cacheTtlMs = safeInt(process.env.KEY_CACHE_TTL_MS, 600000);
 
     // Internal Store Parsing
     this.parsedKeys = this._parseRawKeys(this.validKeysRaw);


### PR DESCRIPTION
Closes #14431.

Summary of What Has Been Done:
Added a safeInt helper function and replaced all four parseInt calls for env var parsing in AuthConfig with NaN-safe equivalents. When an env var contains a non-numeric value (e.g., typo, placeholder), the fallback value is used instead of producing NaN.

Changes Made:
- backend/api/src/middleware/apiKey.js: added safeInt helper, replaced parseInt for SIGNATURE_MAX_AGE_MS, RATE_LIMIT_WINDOW_MS, RATE_LIMIT_MAX_REQUESTS, and KEY_CACHE_TTL_MS

Impact it Made:
Malformed env vars now produce sensible fallback values instead of NaN. This prevents silent security degradation (replay protection disabled, rate limiting bypassed).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.