### PR TITLE
fix : use userClient for ticket read in maintenancePhotoController

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -64,7 +64,7 @@ export async function uploadMaintenancePhotos(req, res) {
     }
 
     // Verify ticket exists and belongs to this driver
-    const { data: ticket, error: ticketError } = await supabase
+    const { data: ticket, error: ticketError } = await userClient
       .from('truck_maintenance_tickets')
       .select('id, driver_id, photo_urls')
       .eq('id', ticketId)


### PR DESCRIPTION
Closes #14426.

Summary of What Has Been Done:
Updated maintenancePhotoController.js to use the caller-scoped userClient for reading the truck_maintenance_tickets row instead of the anon supabase client.

Changes Made:
- backend/api/src/controllers/maintenancePhotoController.js: replaced supabase with userClient for the ticket lookup query (line 67)

Impact it Made:
Maintenance photo uploads now correctly verify ticket ownership using the caller's JWT, preventing permission denied errors on the truck_maintenance_tickets table.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.