### PR TITLE
fix : use user-scoped client for profile read in escortWalletController

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -1,7 +1,7 @@
 import didService from '../../../did/did.service.js';
 import logger from '../middleware/logger.js';
 import { AppError } from '../utils/errors.js';
-import { supabase } from '../config/db.js';
+import { supabase, createUserClient } from '../config/db.js';
 
 /**
  * Resolve the resource for the 'escort:issue-credential' ownership check:
@@ -11,7 +11,8 @@ import { supabase } from '../config/db.js';
  * wallet address/DID.
  */
 export const resolveCredentialSubject = async (req) => {
-    const { data: profile, error } = await supabase
+    const userClient = createUserClient(req.token);
+    const { data: profile, error } = await userClient
         .from('profiles')
         .select('polygon_wallet_address')
         .eq('id', req.user.id)


### PR DESCRIPTION
Closes #14425.

Summary of What Has Been Done:
Updated escortWalletController.js to use the caller-scoped userClient for reading the profile instead of the anon supabase client. This lets the caller's RLS ownership policy apply.

Changes Made:
- backend/api/src/controllers/escortWalletController.js: imported createUserClient, used userClient for profile read in resolveCredentialSubject

Impact it Made:
Credential issuance now correctly reads the profile using the caller's JWT, preventing permission denied errors on the profiles table.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.