### PR TITLE
chore: remove dead clampReputation from reputation.js

### DIFF
--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -24,15 +24,6 @@ import logger from "../middleware/logger.js";
 import { measureExecution } from "../core/performanceMetrics.js";
 
 // Safe math utilities for reputation calculations.
-// Boundary clamping (0–MAX_REPUTATION) is handled by clampReputation.
-
-
-/** @type {number} Must match Reputation.sol MAX_REPUTATION constant */
-const MAX_REPUTATION = 10000;
-
-export function clampReputation(value) {
-  return Math.max(0, Math.min(MAX_REPUTATION, Number(value) || 0));
-}
 
 // Minimal ABI — only the subset the backend needs to call.
 const REPUTATION_ABI = [


### PR DESCRIPTION
Closes #14510

## Problem
`backend/api/src/services/reputation.js` exports `clampReputation(value)` but the function is never called anywhere in the codebase (no production code, no tests). Its only other mention was a stale comment. `MAX_REPUTATION` was only used by that function.

## Fix
Removed `clampReputation`, the now-unused `MAX_REPUTATION` constant, and the stale boundary-clamping comment. Verified with `node --check` and `git grep`.

GSSOC
