### PR TITLE
fix : use correct table and column names in crossDockService fallback query

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -140,9 +140,9 @@ export async function findHandoffCandidates({
 
     if (drivers.length === 0) {
       const { data: onlineDrivers, error: qErr } = await supabaseAdmin
-        .from('driver_location')
-        .select('driver_id, lat, lng, last_seen_at, profiles:driver_id (full_name)')
-        .eq('is_online', true)
+        .from('driver_locations')
+        .select('driver_id, latitude, longitude, last_updated_at, profiles:driver_id (full_name)')
+        .eq('is_active', true)
         .limit(limit * 4);
       if (qErr) {
         throw new DomainError(503, { error: 'Failed to query nearby drivers.', details: qErr.message });
@@ -151,9 +151,9 @@ export async function findHandoffCandidates({
         .map((d) => ({
           driver_id: d.driver_id,
           name: d.profiles?.full_name,
-          lat: Number(d.lat),
-          lng: Number(d.lng),
-          last_seen_at: d.last_seen_at,
+          lat: Number(d.latitude),
+          lng: Number(d.longitude),
+          last_seen_at: d.last_updated_at,
         }))
         .filter((d) => d.driver_id !== fromDriverId)
         .map((d) => ({


### PR DESCRIPTION
Closes #14424.

Summary of What Has Been Done:
Fixed the nearby-driver fallback query in crossDockService.js to use the correct table name (driver_locations instead of driver_location) and correct column names (latitude/longitude instead of lat/lng, is_active instead of is_online, last_updated_at instead of last_seen_at).

Changes Made:
- backend/api/src/services/order/crossDockService.js: updated fallback query to use correct table and column names

Impact it Made:
The cross-dock search no longer returns 503 errors when the RPC is unavailable. The fallback query correctly reads from the driver_locations table.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback driver matching by using the latest available location and activity information.
  * Corrected location data handling so nearby driver results are more accurate and reliable.
  * Updated driver visibility timestamps to better reflect when a driver was last detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->