### PR TITLE
chore: remove unused i18nMiddleware export

### DIFF
--- a/backend/api/src/middleware/i18n.js
+++ b/backend/api/src/middleware/i18n.js
@@ -37,8 +37,6 @@ i18next
     }
   });
 
-export const i18nMiddleware = middleware.handle(i18next);
-
 export const errorTranslationInterceptor = (req, res, next) => {
   const originalJson = res.json;
   res.json = function(body) {


### PR DESCRIPTION
Closes #14511

## Problem
`backend/api/src/middleware/i18n.js` exports `i18nMiddleware = middleware.handle(i18next)` but nothing imports or mounts it. The module's other export `errorTranslationInterceptor` is used and tested; `i18nMiddleware` is dead code.

## Fix
Removed the unused `i18nMiddleware` export. Verified with `node --check` and `git grep`.

GSSOC
