### PR TITLE
chore: remove dead verifyOnChainEscrowBalance from escrow.js

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -974,16 +974,3 @@ export async function submitEscrowResolveDisputeTimeout (orderDisplayId) {
   })
 }
 export const lockPayment = escrowLockPayment;
-
-
-
-export async function verifyOnChainEscrowBalance(bookingId, expectedWei) {
-  const bookingOnChain = await escrowContract.bookings(bookingId);
-  const onChainAmountBN = BigInt(bookingOnChain.amount.toString());
-  const expectedWeiBN = BigInt(expectedWei);
-  return {
-    valid: onChainAmountBN >= expectedWeiBN,
-    onChainAmount: onChainAmountBN.toString(),
-    expectedAmount: expectedWeiBN.toString()
-  };
-}


### PR DESCRIPTION
Closes #14514

## Problem
`backend/api/src/services/escrow.js` exports `verifyOnChainEscrowBalance(bookingId, expectedWei)` but the function is never called anywhere in the codebase (no production code, no tests). Escrow verification is handled by other flows.

## Fix
Removed the dead `verifyOnChainEscrowBalance` function. Verified with `node --check` and `git grep`.

GSSOC
