### PR TITLE
refactor : remove dead SecurityAdmin export from authFailureMonitor.js

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -72,7 +72,7 @@ if (gcTimer.unref) gcTimer.unref();
 // 3. ADMIN MANAGEMENT API
 // ==========================================
 
-export const SecurityAdmin = {
+const SecurityAdmin = {
   blockIP(ip, durationMs = DEFAULT_BAN_DURATION_MS) {
     blockedIPs.set(ip, Date.now() + durationMs);
     failures.delete(ip);


### PR DESCRIPTION
Closes #14521.

Summary of What Has Been Done:
Removed the unnecessary export from SecurityAdmin in authFailureMonitor.js. The object is only used internally within the module.

Changes Made:
- backend/api/src/middleware/authFailureMonitor.js: removed 'export' from SecurityAdmin

Impact it Made:
Cleaner module with no dead exports.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.