### PR TITLE
chore: stop exporting internal CROSS_DOCK_STATUSES

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -27,7 +27,7 @@ import { sendPushNotification } from '../notificationService.js';
 
 export { DomainError } from './domainError.js';
 
-export const CROSS_DOCK_STATUSES = Object.freeze({
+const CROSS_DOCK_STATUSES = Object.freeze({
   REQUESTED: 'requested',
   ACCEPTED: 'accepted',
   VERIFIED: 'verified',


### PR DESCRIPTION
Closes #14517

## Problem
`backend/api/src/services/order/crossDockService.js` exports `CROSS_DOCK_STATUSES` but it is never imported anywhere else — it is only referenced within the module itself. The `export` keyword advertises a public API that does not exist.

## Fix
Dropped the `export` keyword from `CROSS_DOCK_STATUSES`; internal usages are unchanged. Verified with `git grep` and `node --check`.

GSSOC
