### PR TITLE
chore: stop exporting internal BROKER_COMMISSION_RATE

### DIFF
--- a/backend/api/src/services/driver/earningsSummaryService.js
+++ b/backend/api/src/services/driver/earningsSummaryService.js
@@ -11,7 +11,7 @@
  * as a fraction of gross freight value. Surfaced to drivers as the saving
  * they make by booking directly.
  */
-export const BROKER_COMMISSION_RATE = 0.35;
+const BROKER_COMMISSION_RATE = 0.35;
 
 /**
  * Upper bound on rows read for a single summary. A driver cannot complete


### PR DESCRIPTION
Closes #14519

## Problem
`backend/api/src/services/driver/earningsSummaryService.js` exports `BROKER_COMMISSION_RATE` but it is never imported anywhere else — it is only referenced within the module itself. The `export` keyword advertises a public API that does not exist.

## Fix
Dropped the `export` keyword from `BROKER_COMMISSION_RATE`; internal usages are unchanged. Verified with `git grep` and `node --check`.

GSSOC
