### PR TITLE
chore: remove dead SecurityAdmin export

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -69,39 +69,6 @@ const gcTimer = setInterval(cleanExpiredRecords, GC_INTERVAL_MS);
 if (gcTimer.unref) gcTimer.unref();
 
 // ==========================================
-// 3. ADMIN MANAGEMENT API
-// ==========================================
-
-export const SecurityAdmin = {
-  blockIP(ip, durationMs = DEFAULT_BAN_DURATION_MS) {
-    blockedIPs.set(ip, Date.now() + durationMs);
-    failures.delete(ip);
-    logger.warn({ ip, durationMs }, '[Security Engine] Manual IP Ban applied');
-  },
-
-  unblockIP(ip) {
-    blockedIPs.delete(ip);
-    failures.delete(ip);
-    logger.info({ ip }, '[Security Engine] IP manually unblocked');
-  },
-
-  allowlistIP(ip) {
-    allowlistedIPs.add(ip);
-    blockedIPs.delete(ip);
-    failures.delete(ip);
-  },
-
-  getMetrics() {
-    return {
-      trackedIPCount: failures.size,
-      blockedIPCount: blockedIPs.size,
-      blockedIPs: Array.from(blockedIPs.keys()),
-      allowlistedIPs: Array.from(allowlistedIPs)
-    };
-  }
-};
-
-// ==========================================
 // 4. CORE MIDDLEWARE ENGINE
 // ==========================================
 


### PR DESCRIPTION
Closes #14521

## Problem
`backend/api/src/middleware/authFailureMonitor.js` exports `SecurityAdmin` (an object with `blockIP`, `unblockIP`, `allowlistIP`, `getMetrics`) but nothing in the codebase references it (no production code, no tests, no admin routes). The manual IP-ban admin API is dead code.

## Fix
Removed the `SecurityAdmin` export and its section header. The module's default `authFailureMonitor` middleware is unaffected. Verified with `node --check` and `git grep`.

GSSOC
