### PR TITLE
chore: stop exporting internal sanitizePayload

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -63,7 +63,7 @@ const ACTION_RESOURCE_MAP = Object.freeze({
 /**
  * Recursively sanitizes sensitive parameters, arrays, and nested structures.
  */
-export function sanitizePayload(data, maxDepth = 5, currentDepth = 0) {
+function sanitizePayload(data, maxDepth = 5, currentDepth = 0) {
   if (data === null || data === undefined) return data;
   if (currentDepth > maxDepth) return '[Max Depth Exceeded]';
 


### PR DESCRIPTION
Closes #14522

## Problem
`backend/api/src/middleware/auditLog.js` exports `sanitizePayload` but it is never imported anywhere else — it is only used internally by the module. The `export` keyword advertises a public API that does not exist.

## Fix
Dropped the `export` keyword from `sanitizePayload`; internal usages are unchanged. Verified with `git grep` (no external imports) and `node --check`.

GSSOC
