### PR TITLE
refactor : remove dead BROKER_COMMISSION_RATE export from earningsSummaryService.js

### DIFF
--- a/backend/api/src/services/driver/earningsSummaryService.js
+++ b/backend/api/src/services/driver/earningsSummaryService.js
@@ -11,7 +11,7 @@
  * as a fraction of gross freight value. Surfaced to drivers as the saving
  * they make by booking directly.
  */
-export const BROKER_COMMISSION_RATE = 0.35;
+const BROKER_COMMISSION_RATE = 0.35;
 
 /**
  * Upper bound on rows read for a single summary. A driver cannot complete


### PR DESCRIPTION
Closes #14519.

Summary of What Has Been Done:
Removed the unnecessary export from BROKER_COMMISSION_RATE in earningsSummaryService.js. The constant is only used internally within the module.

Changes Made:
- backend/api/src/services/driver/earningsSummaryService.js: removed 'export' from BROKER_COMMISSION_RATE

Impact it Made:
Cleaner module with no dead exports.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.