### PR TITLE
chore: stop exporting internal resolve helpers in auditLog

### DIFF
--- a/backend/api/src/middleware/auditLog.js
+++ b/backend/api/src/middleware/auditLog.js
@@ -122,7 +122,7 @@ export function computeStateDiff(before, after) {
 /**
  * Resolves the resource type from policy action or URI pattern.
  */
-export function resolveResourceType(action, req) {
+function resolveResourceType(action, req) {
   const mapping = ACTION_RESOURCE_MAP[action];
   if (mapping) return mapping.resourceType;
 
@@ -137,7 +137,7 @@ export function resolveResourceType(action, req) {
 /**
  * Resolves the target resource identifier from request params or body.
  */
-export function resolveResourceId(req) {
+function resolveResourceId(req) {
   return (
     req.params?.id ||
     req.params?.orderId ||


### PR DESCRIPTION
Closes #14523

## Problem
`backend/api/src/middleware/auditLog.js` exports `resolveResourceType` and `resolveResourceId`, but neither is imported anywhere else — both are only used internally by the module. The `export` keywords advertise a public API that does not exist.

## Fix
Dropped the `export` keyword from both functions; internal usages are unchanged. Verified with `git grep` (no external imports) and `node --check`.

GSSOC
