### PR TITLE
fix : use correct table/column names and remove dead CROSS_DOCK_STATUSES export in crossDockService

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -27,7 +27,7 @@ import { sendPushNotification } from '../notificationService.js';
 
 export { DomainError } from './domainError.js';
 
-export const CROSS_DOCK_STATUSES = Object.freeze({
+const CROSS_DOCK_STATUSES = Object.freeze({
   REQUESTED: 'requested',
   ACCEPTED: 'accepted',
   VERIFIED: 'verified',
@@ -140,20 +140,20 @@ export async function findHandoffCandidates({
 
     if (drivers.length === 0) {
       const { data: onlineDrivers, error: qErr } = await supabaseAdmin
-        .from('driver_location')
-        .select('driver_id, lat, lng, last_seen_at, profiles:driver_id (full_name)')
-        .eq('is_online', true)
+        .from('driver_locations')
+        .select('driver_id, latitude, longitude, last_updated_at, profiles:driver_id (full_name)')
+        .eq('is_active', true)
         .limit(limit * 4);
       if (qErr) {
-        throw new DomainError(503, { error: 'Failed to query nearby drivers.', details: qErr.message });
+        throw new new DomainError(503, { error: 'Failed to query nearby drivers.', details: qErr.message });
       }
       drivers = (onlineDrivers || [])
         .map((d) => ({
           driver_id: d.driver_id,
           name: d.profiles?.full_name,
-          lat: Number(d.lat),
-          lng: Number(d.lng),
-          last_seen_at: d.last_seen_at,
+          lat: Number(d.latitude),
+          lng: Number(d.longitude),
+          last_seen_at: d.last_updated_at,
         }))
         .filter((d) => d.driver_id !== fromDriverId)
         .map((d) => ({


### PR DESCRIPTION
Closes #14424.
Closes #14517.

Summary of What Has Been Done:
Fixed the crossDockService.js in two ways: (1) corrected the nearby-driver fallback query to use the right table (driver_locations) and column names (latitude/longitude/is_active/last_updated_at), and (2) removed the dead export from CROSS_DOCK_STATUSES.

Changes Made:
- backend/api/src/services/order/crossDockService.js: fixed fallback query table/columns and removed dead export

Impact it Made:
Cross-dock search no longer 503s when the RPC is unavailable. Also cleaned up dead exports.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.