### PR TITLE
refactor : remove dead exports and duplicate JSDoc from various modules

### DIFF
--- a/backend/api/src/middleware/i18n.js
+++ b/backend/api/src/middleware/i18n.js
@@ -37,7 +37,7 @@ i18next
     }
   });
 
-export const i18nMiddleware = middleware.handle(i18next);
+const i18nMiddleware = middleware.handle(i18next);
 
 export const errorTranslationInterceptor = (req, res, next) => {
   const originalJson = res.json;

--- a/backend/api/src/routes/userRoutes.js
+++ b/backend/api/src/routes/userRoutes.js
@@ -52,22 +52,6 @@ const fcmTokenSchema = z.object({
 // ============================================================================
 
 /**
- * @fileoverview userRoutes.js
- *
- * This module handles user-specific endpoints that do not fit other route modules.
- *
- * PRIMARY ENDPOINT: POST /api/users/fcm-token
- *   Updates the Firebase Cloud Messaging (FCM) push token for the authenticated user.
- *   This endpoint is kept separate from deviceRoutes.js to maintain clear authorization
- *   scoping: the FCM token is a user-profile attribute (users own their notification
- *   tokens), while deviceRoutes.js handles device-level registration (platform,
- *   model, OS version). Splitting them prevents device operations from needing
- *   user-level write access to profiles.
- *
- * @module routes/userRoutes
- */
-
-/**
  * @openapi
  * /api/users/fcm-token:
  *   post:

--- a/backend/api/src/services/osrm.js
+++ b/backend/api/src/services/osrm.js
@@ -3,7 +3,7 @@ import logger from '../middleware/logger.js';
 import CircuitBreaker from 'opossum';
 import { measureExecution } from '../core/performanceMetrics.js';
 
-export const osrmBreaker = new CircuitBreaker(async (url, options) => {
+const osrmBreaker = new CircuitBreaker(async (url, options) => {
   const response = await fetch(url, options);
   if (response.status >= 500) {
     await response.text().catch(err => logger.warn('[OSRM] Failed to read error body:', err?.message));
@@ -281,7 +281,7 @@ export const __testing = {
 
 // === Spec 22: ===
 // === Spec 22: OSRM failover ===
-export function haversineFallbackKm(lat1, lon1, lat2, lon2) {
+function haversineFallbackKm(lat1, lon1, lat2, lon2) {
   const nLat1 = Number(lat1);
   const nLon1 = Number(lon1);
   const nLat2 = Number(lat2);

--- a/backend/api/src/services/reputation.js
+++ b/backend/api/src/services/reputation.js
@@ -30,7 +30,7 @@ import { measureExecution } from "../core/performanceMetrics.js";
 /** @type {number} Must match Reputation.sol MAX_REPUTATION constant */
 const MAX_REPUTATION = 10000;
 
-export function clampReputation(value) {
+function clampReputation(value) {
   return Math.max(0, Math.min(MAX_REPUTATION, Number(value) || 0));
 }
 


### PR DESCRIPTION
Closes #14511.
Closes #14510.
Closes #14494.
Closes #14493.

Summary of What Has Been Done:
Removed dead exports and duplicate JSDoc from multiple modules:
- i18n.js: removed unused i18nMiddleware export
- reputation.js: removed dead clampReputation export
- osrm.js: removed dead osrmBreaker and haversineFallbackKm exports
- userRoutes.js: removed duplicate fileoverview JSDoc block

Changes Made:
- backend/api/src/middleware/i18n.js
- backend/api/src/services/reputation.js
- backend/api/src/services/osrm.js
- backend/api/src/routes/userRoutes.js

Impact it Made:
Cleaner modules with no dead exports. Less redundant documentation.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.