### PR TITLE
fix : validate status query param in GET /scheduler/tasks endpoint

### DIFF
--- a/backend/scheduler/routes.js
+++ b/backend/scheduler/routes.js
@@ -232,9 +232,17 @@ router.get('/scheduler/task/:taskId', (req, res) => {
 });
 
 // Get tasks
+const VALID_TASK_STATUSES = new Set(['pending', 'running', 'completed', 'failed', 'cancelled']);
+
 router.get('/scheduler/tasks', (req, res) => {
     try {
         const { status } = req.query;
+        if (status !== undefined && !VALID_TASK_STATUSES.has(status)) {
+            return res.status(400).json({
+                success: false,
+                error: `Invalid status '${status}'. Valid values are: pending, running, completed, failed, cancelled.`
+            });
+        }
         const tasks = scheduler.getTasks(status);
         
         res.json({


### PR DESCRIPTION
Closes #14492.

Summary of What Has Been Done:
Added validation for the status query parameter in GET /scheduler/tasks endpoint. Invalid status values now return a 400 error with a descriptive message instead of silently returning an empty list.

Changes Made:
- backend/scheduler/routes.js: added VALID_TASK_STATUSES set and status validation

Impact it Made:
API callers can now distinguish between 'no matching tasks' and 'invalid status value'. Consistent with other scheduler endpoints that validate their inputs.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.