### PR TITLE
fix : add stopStaleOrderWorker to shutdown handler and remove dead code

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -159,8 +159,8 @@ import {
   startDlqWorker,
   stopDlqWorker,
 } from './workers/dlqWorker.js'
-import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
-import { startDevicePruningWorker } from './workers/devicePruningWorker.js'
+import { startStaleOrderWorker, stopStaleOrderWorker } from './workers/staleOrderWorker.js'
+import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
 import EscalationHandler from './services/blockchain/escalationHandler.js'
@@ -168,7 +168,6 @@ import {
   startWithdrawalSettlementWorker,
   stopWithdrawalSettlementWorker
 } from './workers/withdrawalSettlementWorker.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import './subscribers/reputationSubscriber.js'
 
 // Configuration load from root folder is handled in db.js
@@ -796,6 +795,8 @@ async function shutdown(signal) {
   stopReputationReconciliation()
   stopDlqWorker()
   stopDocumentExpiryWorker()
+  stopDevicePruningWorker()
+  stopStaleOrderWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
   fraudDetection.destroy()

--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -4,20 +4,9 @@ import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
 import { predictEta } from '../services/ml.js';
+import { haversineKm } from '../lib/pricing.js';
 
 const router = express.Router();
-
-function haversineKm(lat1, lng1, lat2, lng2) {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLng = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLng / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
 
 function parseCoord(value, min, max) {
   const n = Number(value);

--- a/backend/scheduler/RenderScheduler.js
+++ b/backend/scheduler/RenderScheduler.js
@@ -493,7 +493,7 @@ class RenderScheduler extends EventEmitter {
             queued: this.getQueueLength(),
             maxConcurrent: this.maxConcurrent,
             queues: this.getQueueStats(),
-            uptime: Date.now() - this.stats.startTime || 0
+            uptime: Date.now() - this.stats.startTime
         };
     }
     


### PR DESCRIPTION
Closes #14489.
Closes #14486.
Closes #14485.

Summary of What Has Been Done:
- Added stopStaleOrderWorker() to the graceful shutdown handler in index.js (matching the pattern of other worker stop calls)
- Added stopDevicePruningWorker() to the shutdown handler
- Removed duplicate outboxRelayWorker import
- Removed dead haversineKm local function from mlRoutes.js (imported from pricing.js instead)
- Removed dead || 0 fallback from RenderScheduler.js uptime calculation

Changes Made:
- backend/api/src/index.js: added worker stop calls, removed duplicate import
- backend/api/src/routes/mlRoutes.js: use haversineKm from pricing.js
- backend/scheduler/RenderScheduler.js: removed dead fallback

Impact it Made:
All background workers are now properly stopped during graceful shutdown. Cleaner modules with DRY imports.

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.