### PR TITLE
fix : use supabaseAdmin for revoked tables in profileRoutes

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -104,7 +104,7 @@ import {
   getCustomerStats,
   getDriverDetails
 } from '../services/profileService.js';
-import { supabase, createUserClient } from '../config/db.js';
+import { supabase, supabaseAdmin, createUserClient } from '../config/db.js';
 import { ProfileModel } from '../models/ProfileModel.js';
 import { invalidateCachedProfile, invalidateCachedSupabaseProfileAll } from '../lib/profileCache.js';
 import { auditLog } from '../middleware/auditLog.js';
@@ -290,7 +290,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
   }
 
   try {
-    const { data: existing, error: checkErr } = await supabase
+    const { data: existing, error: checkErr } = await supabaseAdmin
       .from('profiles')
       .select('polygon_wallet_address')
       .eq('id', userId)
@@ -299,7 +299,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
     if (checkErr) return res.status(500).json({ error: 'Failed to fetch profile.', details: checkErr.message });
     if (!existing) return res.status(404).json({ error: 'Profile not found.' });
 
-    const { error: updateErr } = await supabase
+    const { error: updateErr } = await supabaseAdmin
       .from('profiles')
       .update({
         polygon_wallet_address: normalized,
@@ -314,7 +314,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
     }
 
     if (req.user.role === 'driver') {
-      const { error: driverDetailsErr } = await supabase
+      const { error: driverDetailsErr } = await supabaseAdmin
         .from('driver_details')
         .upsert({ user_id: userId, polygon_wallet_address: normalized }, { onConflict: 'user_id' });
 
@@ -378,7 +378,7 @@ router.put('/', authenticate, userLimiter, validateBody(updateProfileSchema), as
     if (phone !== undefined) profileUpdate.phone = phone;
     if (email !== undefined) profileUpdate.email = email;
 
-    const { data, error } = await supabase
+    const { data, error } = await supabaseAdmin
       .from('profiles')
       .update(profileUpdate)
       .eq('id', userId)
@@ -388,7 +388,7 @@ router.put('/', authenticate, userLimiter, validateBody(updateProfileSchema), as
     if (error) throw error;
     if (role === 'driver') {
       if (typeof is_online === 'boolean') {
-        const { error: driverError } = await supabase
+        const { error: driverError } = await supabaseAdmin
         .from('driver_details')
         .update({
           is_online
@@ -400,7 +400,7 @@ router.put('/', authenticate, userLimiter, validateBody(updateProfileSchema), as
 
       if (number_plate !== undefined) {
         const normalizedPlate = sanitizeNumberPlate(number_plate);
-        const { error: truckError } = await supabase
+        const { error: truckError } = await supabaseAdmin
           .from('trucks')
           .update({
             number_plate: normalizedPlate
@@ -476,7 +476,7 @@ router.put('/fcm-token', authenticate, userLimiter, validateBody(updateFcmTokenS
     const { fcmToken } = req.body;
     const trimmedToken = fcmToken?.trim();
 
-    const { error } = await supabase
+    const { error } = await supabaseAdmin
       .from('profiles')
       .update({
         fcm_token: trimmedToken,
@@ -556,7 +556,7 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
     const trips = [];
 
     while (true) {
-      let pageQuery = supabase
+      let pageQuery = supabaseAdmin
         .from('orders')
         .select('id, order_display_id, status, pickup_address, drop_address, pickup_date, total_amount, base_freight, toll_estimate, platform_fee, created_at')
         .eq('driver_id', userId)
@@ -588,7 +588,7 @@ router.get('/driver/statement', authenticate, requirePolicy('profile:view-statem
 
     // Fetch the driver's name/phone so the statement PDF shows the real driver
     // instead of the app-side 'Driver' fallback.
-    const { data: profile, error: profileError } = await supabase
+    const { data: profile, error: profileError } = await supabaseAdmin
       .from('profiles')
       .select('full_name, phone')
       .eq('id', userId)
@@ -719,7 +719,7 @@ router.delete('/admin/cache/:userId', authenticate, userLimiter, requirePolicy('
     let profileError = null;
 
     if (uuidRegex.test(targetUserId)) {
-      const result = await supabase
+      const result = await supabaseAdmin
         .from('profiles')
         .select('id, firebase_uid')
         .eq('id', targetUserId)
@@ -729,7 +729,7 @@ router.delete('/admin/cache/:userId', authenticate, userLimiter, requirePolicy('
     }
 
     if (!profile && !profileError) {
-      const firebaseLookup = await supabase
+      const firebaseLookup = await supabaseAdmin
         .from('profiles')
         .select('id, firebase_uid')
         .eq('firebase_uid', targetUserId)
@@ -769,7 +769,7 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
     // metrics below are derived from the data that actually exists: trips for
     // distance, the ratings table for the average rating, and the delivered
     // order set for the on-time percentage.
-    const { data: orders, error } = await supabase
+    const { data: orders, error } = await supabaseAdmin
       .from('orders')
       .select('id, order_display_id, base_freight, created_at, status, updated_at')
       .eq('driver_id', userId)
@@ -779,7 +779,7 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
       return res.status(500).json({ error: 'Failed to fetch performance stats.', details: error.message });
     }
 
-    const { data: tripRows, error: tripsError } = await supabase
+    const { data: tripRows, error: tripsError } = await supabaseAdmin
       .from('trips')
       .select('distance')
       .eq('driver_id', userId)
@@ -789,7 +789,7 @@ router.get('/driver/performance-stats', authenticate, requirePolicy('profile:vie
       return res.status(500).json({ error: 'Failed to fetch performance stats.', details: tripsError.message });
     }
 
-    const { data: ratingRows, error: ratingsError } = await supabase
+    const { data: ratingRows, error: ratingsError } = await supabaseAdmin
       .from('ratings')
       .select('stars')
       .eq('driver_id', userId);


### PR DESCRIPTION
Closes #14432.

Summary of What Has Been Done:
Updated profileRoutes.js to use supabaseAdmin for all queries to profiles, driver_details, trucks, orders, trips, and ratings tables. The anon client had no access to these tables due to revoked privileges.

Changes Made:
- backend/api/src/routes/profileRoutes.js: replaced all supabase (anon) calls with supabaseAdmin for RLS-protected tables

Impact it Made:
Profile routes now correctly query the database for all user operations (wallet updates, FCM tokens, driver details, trucks, orders, trips, ratings, and performance stats).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.