### PR TITLE
fix(middleware): remove dead parseEnvNumber helper in authFailureMonitor.js

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -105,13 +105,6 @@ export const SecurityAdmin = {
 // 4. CORE MIDDLEWARE ENGINE
 // ==========================================
 
-function parseEnvNumber(raw, fallback, { min } = {}) {
-  const n = Number(raw);
-  if (!Number.isFinite(n)) return fallback;
-  if (min !== undefined && n < min) return fallback;
-  return n;
-}
-
 export default function authFailureMonitor(req, res, next) {
   const ip = extractClientIP(req);
 


### PR DESCRIPTION
Closes #14543

**Problem:** `authFailureMonitor.js` defines `parseEnvNumber`, a local helper that is never called anywhere.

**Fix:** Remove the dead helper (7 lines deleted).

GSSOC
