### PR TITLE
fix(middleware): remove dead isCacheable helper in idempotency.js

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -1,8 +1,6 @@
 import { redisClient } from '../config/db.js';
 import logger from './logger.js';
 
-const CACHEABLE_STATUS = new Set([200, 201, 202, 204]);
-
 const inMemoryStore = new Map();
 const inFlightRequests = new Map(); // In-memory lock for memory-only mode
 const IN_MEMORY_TTL_MS = 86400_000;
@@ -49,10 +47,6 @@ function setInMemory(key, data, ttlMs) {
     }
   }
   inMemoryStore.set(key, { data, expiresAt: Date.now() + ttlMs });
-}
-
-function isCacheable(statusCode) {
-  return CACHEABLE_STATUS.has(statusCode);
 }
 
 function cacheKey(req, idempotencyKey) {


### PR DESCRIPTION
Closes #14546

**Problem:** `idempotency.js` defines `isCacheable(statusCode)`, a local helper that is never called anywhere. Its only dependency, `CACHEABLE_STATUS`, is likewise unused outside it.

**Fix:** Remove the dead helper and the now-unused `CACHEABLE_STATUS` constant.

GSSOC
