### PR TITLE
fix(routes): remove dead profileCacheControl helper in profileRoutes.js

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -117,15 +117,6 @@ function sanitizeNumberPlate(plate) {
 }
 
 
-// Cache control middleware for profile endpoints
-function profileCacheControl(req, res, next) {
-  if (req.method === 'GET') {
-    res.setHeader('Cache-Control', 'private, max-age=30');
-    res.setHeader('Vary', 'Authorization');
-  }
-  next();
-}
-
 /**
  * @openapi
  * /api/profile:


### PR DESCRIPTION
Closes #14547

**Problem:** `profileRoutes.js` defines `profileCacheControl`, a middleware helper that no route registers and no module imports.

**Fix:** Remove the dead helper (9 lines deleted).

GSSOC
