### PR TITLE
fix(routes): remove dead validateCapacity helper in truckRoutes.js

### DIFF
--- a/backend/api/src/routes/truckRoutes.js
+++ b/backend/api/src/routes/truckRoutes.js
@@ -114,11 +114,6 @@ function sanitizeTruckName(name) {
     .replace(/on\w+=/gi, '');
 }
 
-function validateCapacity(capacity) {
-  const num = Number(capacity);
-  return Number.isFinite(num) && num > 0 && num <= 100 ? num : null;
-}
-
 const router = express.Router();
 
 /**


### PR DESCRIPTION
Closes #14548

**Problem:** `truckRoutes.js` defines `validateCapacity(capacity)`, a local helper that is never called anywhere.

**Fix:** Remove the dead helper.

GSSOC
