### PR TITLE
fix(services): remove dead reconciliation helpers in escrowRefundReconciliation.js

### DIFF
--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -12,20 +12,6 @@ const RECONCILIATION_EVENTS = {
   SKIPPED: 'reconciliation:skipped',
 };
 
-function logReconciliationEvent(event, details = {}) {
-  logger.info({ event, ...details }, `[escrow-reconciliation] ${event}`);
-}
-
-function createReconciliationSummary(results) {
-  return {
-    total: results.length,
-    succeeded: results.filter(r => r.success).length,
-    failed: results.filter(r => !r.success).length,
-    skipped: results.filter(r => r.skipped).length,
-    timestamp: new Date().toISOString(),
-  };
-}
-
 const DEFAULT_INTERVAL_MS = 60_000;
 const LOCK_KEY = 'escrow:reconciliation:lock';
 const LOCK_TTL_SECONDS = 120;


### PR DESCRIPTION
Closes #14549

**Problem:** `escrowRefundReconciliation.js` defines `logReconciliationEvent` and `createReconciliationSummary`, both never called anywhere.

**Fix:** Remove both dead helpers (14 lines deleted).

GSSOC
