### PR TITLE
refactor: dedupe validateCoordinateRange between shardMiddleware and shardRoutes

### DIFF
--- a/backend/api/src/middleware/shardMiddleware.js
+++ b/backend/api/src/middleware/shardMiddleware.js
@@ -1,5 +1,6 @@
 import shardManager from '../services/sharding/ShardManager.js';
 import logger from './logger.js';
+import { validateCoordinateRange } from '../utils/coordinates.js';
 
 function firstDefined(...values) {
   return values.find(value => value !== undefined && value !== null && value !== '');
@@ -11,12 +12,6 @@ function parseCoordinate(value) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return { error: 'coordinate must be a finite number' };
   return { value: parsed };
-}
-
-function validateCoordinateRange(lat, lng) {
-  if (lat < -90 || lat > 90) return 'lat must be between -90 and 90';
-  if (lng < -180 || lng > 180) return 'lng must be between -180 and 180';
-  return null;
 }
 
 export const shardMiddleware = async (req, res, next) => {

--- a/backend/api/src/routes/shardRoutes.js
+++ b/backend/api/src/routes/shardRoutes.js
@@ -5,6 +5,7 @@ import { shardMiddleware, crossShardQuery } from '../middleware/shardMiddleware.
 import { authenticate } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
+import { validateCoordinateRange } from '../utils/coordinates.js';
 
 const router = express.Router();
 
@@ -20,12 +21,6 @@ function parseCoordinate(value, field) {
     return { error: `${field} must be a finite number` };
   }
   return { value: parsed };
-}
-
-function validateCoordinateRange(lat, lng) {
-  if (lat < -90 || lat > 90) return 'lat must be between -90 and 90';
-  if (lng < -180 || lng > 180) return 'lng must be between -180 and 180';
-  return null;
 }
 
 // Get shard status

--- a/backend/api/src/utils/coordinates.js
+++ b/backend/api/src/utils/coordinates.js
@@ -1,0 +1,8 @@
+/**
+ * Returns an error message if the lat/lng pair is out of bounds, or null when valid.
+ */
+export function validateCoordinateRange(lat, lng) {
+  if (lat < -90 || lat > 90) return 'lat must be between -90 and 90';
+  if (lng < -180 || lng > 180) return 'lng must be between -180 and 180';
+  return null;
+}


### PR DESCRIPTION
Closes #14552

**Problem:** The identical `validateCoordinateRange(lat, lng)` helper is duplicated in `shardMiddleware.js` and `shardRoutes.js`, forcing any coordinate-range change to be applied in two places.

**Fix:** Extract the helper into a shared `backend/api/src/utils/coordinates.js` and import it from both files, removing the local copies.

GSSOC
