### PR TITLE
refactor(services): reuse haversineKm from lib/pricing in crossDockService

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -70,7 +70,8 @@ function hoursAhead(hours) {
   return new Date(Date.now() + hours * 60 * 60 * 1000);
 }
 
-export { haversineKm } from '../../lib/pricing.js';
+import { haversineKm } from '../../lib/pricing.js';
+export { haversineKm };
 
 /**
  * Find candidate drivers near a cross-dock point who can take the load onward.

--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -70,21 +70,7 @@ function hoursAhead(hours) {
   return new Date(Date.now() + hours * 60 * 60 * 1000);
 }
 
-/**
- * Haversine distance in km between two lat/lng points. Used for ranking
- * candidate handoff drivers and for sanity-checking the requested cross-dock
- * point; not authoritative for routing.
- */
-export function haversineKm(lat1, lng1, lat2, lng2) {
-  const toRad = (d) => (d * Math.PI) / 180;
-  const R = 6371;
-  const dLat = toRad(lat2 - lat1);
-  const dLng = toRad(lng2 - lng1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
-  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
-}
+export { haversineKm } from '../../lib/pricing.js';
 
 /**
  * Find candidate drivers near a cross-dock point who can take the load onward.


### PR DESCRIPTION
Closes #14553

**Problem:** `crossDockService.js` maintains its own copy of `haversineKm` even though the canonical implementation already exists in `lib/pricing.js` (and is already imported by `deliveryVerificationService.js`). The two copies can drift apart.

**Fix:** Replace the duplicated implementation with `export { haversineKm } from "../../lib/pricing.js";`, keeping the same export surface for callers and tests.

GSSOC
