### PR TITLE
fix(orderLifecycleService): map milestones to constraint-valid order statuses (closes #14423)

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -407,12 +407,12 @@ export class OrderLifecycleService {
   async updateMilestone(orderId, milestone, driverId) {
     return measureExecution('OrderLifecycleService.updateMilestone', async () => {
       const milestoneMap = {
-        'Arrived at Pickup': 'at_pickup',
+        'Truck Assigned': 'truck_assigned',
+        'En Route to Pickup': 'en_route_pickup',
+        'Arrived at Pickup': 'arrived_pickup',
         'Goods Loaded': 'picked_up',
         'In Transit': 'in_transit',
         'Arriving': 'arriving',
-        'Arrived at Drop-off': 'at_dropoff',
-        'Goods Unloaded': 'at_dropoff',
       };
 
       const { data: order, error: orderErr } = await this.orderRepository.findOrderById(orderId, '*');


### PR DESCRIPTION
## Summary

`OrderLifecycleService.updateMilestone()` mapped driver timeline milestones to order statuses that do not exist:

```js
'Arrived at Pickup': 'at_pickup',     // invalid — canonical is 'arrived_pickup'
'Arrived at Drop-off': 'at_dropoff',  // not a status at all
'Goods Unloaded': 'at_dropoff',       // not a status at all
```

The `orders_status_check` constraint (`supabase/migrations/20260811080000_add_disputed_to_orders_status_check.sql`) allows only `pending, truck_assigned, en_route_pickup, arrived_pickup, picked_up, in_transit, arriving, delivered, cancelled, payment_released, disputed`. `at_pickup` and `at_dropoff` appear in no migration.

Every time a driver tapped **"Arrived at Pickup"** (a default timeline milestone) the service passed sequence checks, marked the timeline completed, then wrote `status = 'at_pickup'` via the service-role repository → Postgres **23514 CHECK violation** → HTTP 500 with a timeline rollback. Drop-off milestones failed the same way, and the order could never progress past pickup through this endpoint.

## Changes

- `backend/api/src/services/order/orderLifecycleService.js` — align the milestone map with the canonical `OrderMilestoneService` (`orderMilestoneService.js:36-43`):
  - `'Truck Assigned' → 'truck_assigned'`
  - `'En Route to Pickup' → 'en_route_pickup'`
  - `'Arrived at Pickup' → 'arrived_pickup'`
  - `'Goods Loaded' → 'picked_up'`
  - `'In Transit' → 'in_transit'`
  - `'Arriving' → 'arriving'`
- Drop-off milestones have no valid order status (delivery is confirmed via the `/verify-delivery` OTP flow), so they now fall through to the existing `DomainError(400, 'does not map to an order status. Use the delivery verification endpoint instead.')` branch instead of attempting an invalid status write.

## Verification

- `node --check` passes; `npx eslint` on the changed file is clean.
- `npx vitest run test/unit/orderLifecycleService.test.js test/unit/services/orderLifecycleService.test.js` → 3 passed / 4 failed, **identical to baseline on `main`** (the 4 failures are stale `startOrder`/`completeOrder` tests that mock a non-existent `updateOrderWithFilter`; no regression).
- All mapped statuses are verified members of `orders_status_check`.

## GSSOC

**Contributor:** Akshita-2307

Closes #14423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated order status tracking for truck assignment, pickup travel, and pickup arrival milestones.
  * Replaced the pickup status mapping with the correct arrived-at-pickup status.
  * Removed outdated mappings for drop-off arrival and goods unloading milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->