### PR TITLE
fix(crossDockService): query driver_locations fallback with real table and columns (closes #14424)

### DIFF
--- a/backend/api/src/services/order/crossDockService.js
+++ b/backend/api/src/services/order/crossDockService.js
@@ -140,9 +140,9 @@ export async function findHandoffCandidates({
 
     if (drivers.length === 0) {
       const { data: onlineDrivers, error: qErr } = await supabaseAdmin
-        .from('driver_location')
-        .select('driver_id, lat, lng, last_seen_at, profiles:driver_id (full_name)')
-        .eq('is_online', true)
+        .from('driver_locations')
+        .select('driver_id, latitude, longitude, last_updated_at, profiles:driver_id (full_name)')
+        .eq('is_active', true)
         .limit(limit * 4);
       if (qErr) {
         throw new DomainError(503, { error: 'Failed to query nearby drivers.', details: qErr.message });
@@ -151,9 +151,9 @@ export async function findHandoffCandidates({
         .map((d) => ({
           driver_id: d.driver_id,
           name: d.profiles?.full_name,
-          lat: Number(d.lat),
-          lng: Number(d.lng),
-          last_seen_at: d.last_seen_at,
+          lat: Number(d.latitude),
+          lng: Number(d.longitude),
+          last_seen_at: d.last_updated_at,
         }))
         .filter((d) => d.driver_id !== fromDriverId)
         .map((d) => ({


### PR DESCRIPTION
## Summary

The nearby-driver fallback in `findHandoffCandidates()` queried a non-existent table with non-existent columns:

```js
.from('driver_location')                       // table is driver_locations
.select('driver_id, lat, lng, last_seen_at, ...')
.eq('is_online', true)                         // column is is_active
```

The fallback runs whenever the `get_nearby_active_drivers` RPC errors **or returns zero rows**. In the "no nearby drivers" case, PostgREST failed with `relation "driver_location" does not exist` → the handler threw `DomainError(503, 'Failed to query nearby drivers.')`. A legitimate empty result was surfaced as a 503 instead of an empty candidate list, and the client-side distance fallback never worked.

## Changes

`backend/api/src/services/order/crossDockService.js` — corrected the fallback query against the real schema (`docs/supabase_setup.sql:835`):

- `.from('driver_locations')`
- `.select('driver_id, latitude, longitude, last_updated_at, profiles:driver_id (full_name)')` — the embedded `profiles` join works because `driver_locations.driver_id` has an FK to `profiles(id)` (supabase_setup.sql:837)
- `.eq('is_active', true)`
- updated the row mapping to `d.latitude` / `d.longitude` / `d.last_updated_at`

## Verification

- `node --check` passes; `npx eslint` on the changed file is clean.
- `npx vitest run test/unit/crossDockService.test.js test/unit/crossDockRoutes.test.js` → 49 passed / 6 failed, **identical to baseline on `main`** (the 6 failures are pre-existing `createTransferRequest` tests; no regression).
- `driver_locations` is the only table name used anywhere else in `src` (`tracker.js`, `trackingTokenService.js`).

## GSSOC

**Contributor:** Akshita-2307

Closes #14424
