### PR TITLE
fix(escortWalletController): use caller-scoped client for credential subject lookup (closes #14425)

### DIFF
--- a/backend/api/src/controllers/escortWalletController.js
+++ b/backend/api/src/controllers/escortWalletController.js
@@ -1,7 +1,7 @@
 import didService from '../../../did/did.service.js';
 import logger from '../middleware/logger.js';
 import { AppError } from '../utils/errors.js';
-import { supabase } from '../config/db.js';
+import { createUserClient } from '../config/db.js';
 
 /**
  * Resolve the resource for the 'escort:issue-credential' ownership check:
@@ -11,7 +11,7 @@ import { supabase } from '../config/db.js';
  * wallet address/DID.
  */
 export const resolveCredentialSubject = async (req) => {
-    const { data: profile, error } = await supabase
+    const { data: profile, error } = await createUserClient(req.token)
         .from('profiles')
         .select('polygon_wallet_address')
         .eq('id', req.user.id)


### PR DESCRIPTION
## Summary

`resolveCredentialSubject()` — the ownership pre-check for credential issuance — read `profiles` through the shared **anon** client:

```js
const { data: profile, error } = await supabase
    .from('profiles')
    .select('polygon_wallet_address')
    .eq('id', req.user.id)
    .maybeSingle();
```

`profiles` has **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:5`), so PostgREST denies the read regardless of RLS. Every credential issuance request — `POST /escort-wallet/issue-credential` for the driver's own wallet — hit `error` and returned **HTTP 500 `Failed to load profile`**. Drivers could never obtain escrow credentials.

## Changes

`backend/api/src/controllers/escortWalletController.js` — use the caller-scoped client:

- `createUserClient(req.token)` instead of the shared `supabase` anon client.
- The caller's RLS ownership policy (`Profiles select own profile`) scopes the read to `req.user.id`, so the ownership check still resolves the *authenticated driver's* wallet address.

## Verification

- `node --check` passes; `npx eslint` on the changed file is clean.
- `npx vitest run test/unit/escortWalletController.test.js` → **6 passed** (same as baseline).
- Pattern matches the rest of the codebase (`createUserClient(req.token)` is the standard for per-caller DB access in authenticated controllers).

## GSSOC

**Contributor:** Akshita-2307

Closes #14425
