### PR TITLE
fix(maintenancePhotoController): read ticket with caller-scoped client (closes #14426)

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -64,7 +64,7 @@ export async function uploadMaintenancePhotos(req, res) {
     }
 
     // Verify ticket exists and belongs to this driver
-    const { data: ticket, error: ticketError } = await supabase
+    const { data: ticket, error: ticketError } = await userClient
       .from('truck_maintenance_tickets')
       .select('id, driver_id, photo_urls')
       .eq('id', ticketId)

--- a/backend/api/test/unit/maintenancePhotoController.test.js
+++ b/backend/api/test/unit/maintenancePhotoController.test.js
@@ -8,6 +8,7 @@ const { dbMock, docMock, scanMock } = vi.hoisted(() => ({
 
 vi.mock('../../src/config/db.js', () => ({
   get supabase() { return dbMock.supabase; },
+  createUserClient: vi.fn(() => dbMock.supabase),
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({


### PR DESCRIPTION
## Summary

`uploadMaintenancePhotos()` read the maintenance ticket through the shared **anon** client even though a caller-scoped client was already built:

```js
const userClient = createUserClient(req.token);        // L49 — already available
...
const { data: ticket, error: ticketError } = await supabase   // L67 — anon
```

`truck_maintenance_tickets` has **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:8`), so PostgREST denies the read → `ticketError` → **HTTP 500 on every maintenance photo upload**, including the success path.

## Changes

- `backend/api/src/controllers/maintenancePhotoController.js` — the ticket ownership check now uses the existing `userClient` (`createUserClient(req.token)`), so the caller's RLS ownership policy applies instead of the privilege-revoked anon role.
- `backend/api/test/unit/maintenancePhotoController.test.js` — added `createUserClient: vi.fn(() => dbMock.supabase)` to the `db.js` mock so the controller's new call path is exercised (keeps the existing `from` mocks working).

## Verification

- `node --check` passes; `npx eslint` on both changed files is clean.
- `npx vitest run test/unit/maintenancePhotoController.test.js` → 1 passed / 6 failed, **identical failure set to baseline on `main`** (verified via `git stash`; the 6 failures are pre-existing and unrelated to the ticket read change).

## GSSOC

**Contributor:** Akshita-2307

Closes #14426
