### PR TITLE
fix(profileService): read profiles and driver_details with service-role client (closes #14427)

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -1,4 +1,4 @@
-import { supabase, supabaseAdmin } from '../config/db.js';
+import { supabaseAdmin } from '../config/db.js';
 import { measureExecution } from '../core/performanceMetrics.js';
 import {
   getCachedSupabaseProfile, setCachedSupabaseProfile,
@@ -14,8 +14,8 @@ function isCacheEnabled() {
 
 export async function getProfile(userId) {
   return measureExecution('ProfileService.getProfile', async () => {
-  if (!supabase) {
-    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_ANON_KEY');
+  if (!supabaseAdmin) {
+    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY');
   }
 
   if (isCacheEnabled()) {
@@ -30,7 +30,7 @@ export async function getProfile(userId) {
     }
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await supabaseAdmin
     .from('profiles')
     .select('*')
     .eq('id', userId)
@@ -52,9 +52,9 @@ export async function getProfile(userId) {
 
 export async function getCustomerStats(userId) {
   return measureExecution('ProfileService.getCustomerStats', async () => {
-  const client = supabaseAdmin || supabase;
+  const client = supabaseAdmin;
   if (!client) {
-    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_ANON_KEY');
+    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY');
   }
 
   if (isCacheEnabled()) {
@@ -101,8 +101,8 @@ export async function getCustomerStats(userId) {
 
 export async function getDriverDetails(userId) {
   return measureExecution('ProfileService.getDriverDetails', async () => {
-  if (!supabase) {
-    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_ANON_KEY');
+  if (!supabaseAdmin) {
+    throw new Error('Supabase client not configured — check SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY');
   }
 
   if (isCacheEnabled()) {
@@ -117,7 +117,7 @@ export async function getDriverDetails(userId) {
     }
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await supabaseAdmin
     .from('driver_details')
     .select('*')
     .eq('user_id', userId)
@@ -139,8 +139,8 @@ export async function getDriverDetails(userId) {
 
 export async function createProfile(profileData) {
   return measureExecution('ProfileService.createProfile', async () => {
-  if (!supabase) throw new Error('Supabase client not configured');
-  const { data, error } = await supabase.from('profiles').insert(profileData).select().single();
+  if (!supabaseAdmin) throw new Error('Supabase client not configured');
+  const { data, error } = await supabaseAdmin.from('profiles').insert(profileData).select().single();
   if (error) { logger.error("[ProfileService] createProfile error:", error?.message || error); throw error; }
   return data;
   });
@@ -148,8 +148,8 @@ export async function createProfile(profileData) {
 
 export async function updateProfile(userId, updateData) {
   return measureExecution('ProfileService.updateProfile', async () => {
-  if (!supabase) throw new Error('Supabase client not configured');
-  const { data, error } = await supabase.from('profiles').update(updateData).eq('id', userId).select().single();
+  if (!supabaseAdmin) throw new Error('Supabase client not configured');
+  const { data, error } = await supabaseAdmin.from('profiles').update(updateData).eq('id', userId).select().single();
   if (error) { logger.error("[ProfileService] createProfile error:", error?.message || error); throw error; }
   return data;
   });

--- a/backend/api/test/unit/profileService.test.js
+++ b/backend/api/test/unit/profileService.test.js
@@ -82,8 +82,9 @@ vi.mock('../../src/config/db.js', () => ({
   get supabase() {
     return supabaseRef.current;
   },
-  // No service-role key in tests — the service falls back to the anon mock.
-  supabaseAdmin: undefined,
+  get supabaseAdmin() {
+    return supabaseRef.current;
+  },
 }));
 
 vi.mock('../../src/lib/profileCache.js', () => profileCacheRef);


### PR DESCRIPTION
## Summary

`profileService` read and wrote `profiles` / `driver_details` through the shared **anon** client, even though `supabaseAdmin` was already imported (only `getCustomerStats` used it):

- `getProfile()` — anon `profiles` read (was already the cache-seeding path)
- `getDriverDetails()` — anon `driver_details` read
- `createProfile()` / `updateProfile()` — anon `profiles` insert/update

Both tables have **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:5,6`), so PostgREST returned `permission denied` on every call. This is service-layer code with no caller token, so an ownership-scoped client isn't possible — the service-role client is the only correct choice.

## Changes

- `backend/api/src/services/profileService.js` — all four functions now use `supabaseAdmin` (guard, query, insert, update). `getCustomerStats` drops its now-unnecessary `supabaseAdmin || supabase` fallback. Error messages reference `SUPABASE_SERVICE_ROLE_KEY` instead of `SUPABASE_ANON_KEY`.
- `backend/api/test/unit/profileService.test.js` — the `db.js` mock now exposes `supabaseAdmin` as the same mock client (the tests model "service-role available"), replacing the old "falls back to anon" contract that no longer exists.

## Verification

- `node --check` passes; `npx eslint` on both changed files is clean.
- `npx vitest run test/unit/profileService.test.js` → **27 passed** (the "not configured" fail-fast paths are still covered by setting the mock client to `null`).

## GSSOC

**Contributor:** Akshita-2307

Closes #14427
