### PR TITLE
fix(digilockerService): read and write profiles and driver_documents with service-role client (closes #14428)

### DIFF
--- a/backend/api/src/services/digilockerService.js
+++ b/backend/api/src/services/digilockerService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import crypto from 'crypto';
 import { ethers } from 'ethers';
-import { supabase } from '../config/db.js';
+import { supabase, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 
 const DIGILOCKER_TIMEOUT_MS = 10000;
@@ -165,7 +165,7 @@ class DigilockerService {
     const serialized = JSON.stringify({ dlData, rcData, insuranceData });
     const documentHash = '0x' + crypto.createHash('sha256').update(serialized).digest('hex');
 
-    const { data: profile, error: profileErr } = await supabase
+    const { data: profile, error: profileErr } = await supabaseAdmin
       .from('profiles')
       .select('polygon_wallet_address')
       .eq('id', userId)
@@ -191,7 +191,7 @@ class DigilockerService {
       logger.info(`[DigilockerService] KYC verifier contract address/private key not set. Mocking on-chain hash submission.`);
     }
 
-    const { error: updateError } = await supabase
+    const { error: updateError } = await supabaseAdmin
       .from('profiles')
       .update({ is_digilocker_verified: true })
       .eq('id', userId);
@@ -292,7 +292,7 @@ class DigilockerService {
     for (const doc of documents) {
       const docHash = '0x' + crypto.createHash('sha256').update(doc.data).digest('hex');
 
-      const { data: profile } = await supabase
+      const { data: profile } = await supabaseAdmin
         .from('profiles')
         .select('polygon_wallet_address')
         .eq('id', driverId)
@@ -347,7 +347,7 @@ class DigilockerService {
         updated_at: new Date().toISOString()
       };
 
-      const { data: existing, error: findError } = await supabase
+      const { data: existing, error: findError } = await supabaseAdmin
         .from('driver_documents')
         .select('id')
         .eq('driver_id', driverId)
@@ -361,13 +361,13 @@ class DigilockerService {
       }
 
       const { data: docRecord, error: dbErr } = existing
-        ? await supabase
+        ? await supabaseAdmin
             .from('driver_documents')
             .update(docPayload)
             .eq('id', existing.id)
             .select()
             .single()
-        : await supabase
+        : await supabaseAdmin
             .from('driver_documents')
             .insert(docPayload)
             .select()


### PR DESCRIPTION
## Summary

`DigilockerService` read and wrote `profiles` and `driver_documents` through the shared **anon** client:

- `verifyKyc()` — `profiles` read (polygon wallet) + `profiles` update (`is_digilocker_verified`)
- `syncDocuments()` — `profiles` read (polygon wallet), plus `driver_documents` select/update/insert

Both tables have **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:5,33`), so PostgREST returned `permission denied`:

- `verifyKyc()` → `Profile lookup failed: permission denied` → KYC verification always errors out.
- `syncDocuments()` → `Find driver_documents failed: permission denied` → every document lands in `syncErrors` and verification never persists.

The service methods have no caller token (they're invoked by controllers and, in the case of the webhook, server-side), so the service-role client is the correct choice.

## Changes

`backend/api/src/services/digilockerService.js`:

- All five DB call sites (`profiles` select x2, `profiles` update, `driver_documents` select/update/insert) now use `supabaseAdmin`.
- Storage uploads (`supabase.storage.from('driver-documents')`) are unchanged — the anon-privilege revocation only affects table access, not buckets.

## Verification

- `node --check` passes.
- `npx eslint src/services/digilockerService.js` → 1 pre-existing `preserve-caught-error` warning at L188, **identical on `main`** (verified via `git stash`); my diff introduces no new lint issues.
- `npx vitest run test/unit/digilockerService.test.js` → **10 passed**.

## GSSOC

**Contributor:** Akshita-2307

Closes #14428
