### PR TITLE
fix(VerificationService): default DB client to service-role instead of anon (closes #14429)

### DIFF
--- a/backend/api/src/services/verification/VerificationService.js
+++ b/backend/api/src/services/verification/VerificationService.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../config/db.js';
+import { supabaseAdmin } from '../../config/db.js';
 import OracleService from '../../oracle/OracleService.js';
 import logger from '../../middleware/logger.js';
 
@@ -19,7 +19,7 @@ class VerificationService {
   constructor(deps = {}) {
     this.orderRepository = deps.orderRepository || null;
     this.oracleService = deps.oracleService || new OracleService();
-    this.supabase = deps.supabase || supabase;
+    this.supabase = deps.supabase || supabaseAdmin;
   }
 
   async verifyOrder(orderId) {

--- a/backend/api/test/unit/VerificationService.test.js
+++ b/backend/api/test/unit/VerificationService.test.js
@@ -7,6 +7,7 @@ const { mockFrom } = vi.hoisted(() => {
 
 vi.mock('../../src/config/db.js', () => ({
   supabase: { from: mockFrom },
+  supabaseAdmin: { from: mockFrom },
 }));
 
 vi.mock('../../src/middleware/logger.js', () => ({

--- a/backend/api/test/unit/services/verificationService.test.js
+++ b/backend/api/test/unit/services/verificationService.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../src/config/db.js', () => ({
   supabase: null,
+  supabaseAdmin: null,
   firebaseAdmin: null,
   redisClient: null,
   mongoDb: null,


### PR DESCRIPTION
## Summary

`VerificationService` defaulted its Supabase client to the shared **anon** client, and `container.js` never overrides it:

```js
this.supabase = deps.supabase || supabase;   // before
```

The service reads `profiles` (`VerificationService.js:102`) and `driver_documents` (`VerificationService.js:146`) through that client. Both tables have **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:5,33`), so every `verifyOrder()` run hit `permission denied`:

- `_verifyDriver` → profile lookup fails → `driverActive: false` even for active drivers.
- `checkDocumentIntegrity` → documents query fails → integrity check always errors instead of reporting document statuses.

## Changes

- `backend/api/src/services/verification/VerificationService.js` — default DB client is now `supabaseAdmin` (`deps.supabase || supabaseAdmin`). The `deps.supabase` override stays for callers who want to inject a client.
- Test mocks updated to expose `supabaseAdmin`:
  - `test/unit/VerificationService.test.js` — `supabaseAdmin: { from: mockFrom }`
  - `test/unit/services/verificationService.test.js` — `supabaseAdmin: null` (mirrors the existing `supabase: null` contract for the no-deps construction path)

## Verification

- `node --check` passes; `npx eslint` on all three changed files is clean.
- `npx vitest run test/unit/VerificationService.test.js test/unit/services/verificationService.test.js` → **23 passed** (baseline parity; the injection- and null-client paths are still covered).

## GSSOC

**Contributor:** Akshita-2307

Closes #14429
