### PR TITLE
fix(supportRoutes): fetch public FAQs with service-role client (closes #14430)

### DIFF
--- a/backend/api/src/routes/supportRoutes.js
+++ b/backend/api/src/routes/supportRoutes.js
@@ -216,7 +216,7 @@ router.get('/faqs', async (req, res) => {
   const appType = normalizeRequiredText(req.query.app_type);
 
   try {
-    let query = supabase
+    let query = adminDb
       .from('faqs')
       .select(FAQ_COLUMNS)
       .eq('is_active', true)


### PR DESCRIPTION
## Summary

The public `GET /api/v1/support/faqs` endpoint read `faqs` through the shared **anon** client:

```js
let query = supabase
  .from('faqs')
  .select(FAQ_COLUMNS)
  .eq('is_active', true)
  .order('sort_order', { ascending: true });
```

`faqs` has **ALL anon privileges revoked** (`supabase/migrations/revoke_anon_privileges.sql:27`), so PostgREST returned `permission denied` and the route always responded **HTTP 500 `Failed to fetch FAQs.`**. This is a public endpoint (no `authenticate` middleware) — it failed for every user, logged in or not.

## Changes

`backend/api/src/routes/supportRoutes.js` — the `/faqs` query now uses the file's own `adminDb` (`supabaseAdmin || supabase`, defined at L114), consistent with the other admin-scoped reads in this router. The route is intentionally public, so there is no caller token to scope to — the service-role client is the only option.

## Verification

- `node --check` passes; `npx eslint` on the changed file is clean.
- `npx vitest run test/unit/supportRoutes.test.js` → **35 passed**.

## GSSOC

**Contributor:** Akshita-2307

Closes #14430
