### PR TITLE
fix(apiKey): NaN-safe env parsing so replay protection and rate limits cannot be disabled (closes #14431)

### DIFF
--- a/backend/api/src/middleware/apiKey.js
+++ b/backend/api/src/middleware/apiKey.js
@@ -6,6 +6,14 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+// Environment-driven security values must never become NaN at runtime: a
+// malformed value (e.g. SIGNATURE_MAX_AGE_MS=abc) silently disables the
+// checks that consume them. Parse with a positive-integer fallback instead.
+const parseEnvInt = (raw, fallback) => {
+  const n = parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+};
+
 export class AuthConfig {
   constructor() {
     this.reload();
@@ -21,16 +29,16 @@ export class AuthConfig {
     // Security Policies
     this.allowQueryParam = process.env.ALLOW_API_KEY_IN_QUERY === 'true'; // Default false (anti-pattern)
     this.requireHmac = process.env.REQUIRE_HMAC_SIGNATURE === 'true';
-    this.signatureMaxAgeMs = parseInt(process.env.SIGNATURE_MAX_AGE_MS || '300000', 10); // 5 minutes
+    this.signatureMaxAgeMs = parseEnvInt(process.env.SIGNATURE_MAX_AGE_MS, 300000); // 5 minutes
     this.enableRateLimiting = process.env.ENABLE_RATE_LIMITING !== 'false';
     
     // Rate Limit Defaults
-    this.defaultRateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10);
-    this.defaultRateLimitMax = parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100', 10);
+    this.defaultRateLimitWindowMs = parseEnvInt(process.env.RATE_LIMIT_WINDOW_MS, 60000);
+    this.defaultRateLimitMax = parseEnvInt(process.env.RATE_LIMIT_MAX_REQUESTS, 100);
 
     // Redis Configuration
     this.redisUrl = process.env.REDIS_URL || null;
-    this.cacheTtlMs = parseInt(process.env.KEY_CACHE_TTL_MS || '600000', 10); // 10 minutes
+    this.cacheTtlMs = parseEnvInt(process.env.KEY_CACHE_TTL_MS, 600000); // 10 minutes
 
     // Internal Store Parsing
     this.parsedKeys = this._parseRawKeys(this.validKeysRaw);

--- a/backend/api/test/unit/middleware/apiKey.test.js
+++ b/backend/api/test/unit/middleware/apiKey.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { requireApiKey } from '../../../src/middleware/apiKey.js';
+import { requireApiKey, AuthConfig } from '../../../src/middleware/apiKey.js';
 
 const mockReq = (headers = {}) => ({
   headers,
@@ -111,5 +111,36 @@ describe('requireApiKey middleware', () => {
 
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthConfig env parsing', () => {
+  it('falls back to defaults when env values are malformed', () => {
+    process.env.SIGNATURE_MAX_AGE_MS = 'abc';
+    process.env.RATE_LIMIT_WINDOW_MS = 'not-a-number';
+    process.env.RATE_LIMIT_MAX_REQUESTS = '';
+    process.env.KEY_CACHE_TTL_MS = '0';
+    try {
+      const config = new AuthConfig();
+      expect(config.signatureMaxAgeMs).toBe(300000);
+      expect(config.defaultRateLimitWindowMs).toBe(60000);
+      expect(config.defaultRateLimitMax).toBe(100);
+      expect(config.cacheTtlMs).toBe(600000);
+    } finally {
+      delete process.env.SIGNATURE_MAX_AGE_MS;
+      delete process.env.RATE_LIMIT_WINDOW_MS;
+      delete process.env.RATE_LIMIT_MAX_REQUESTS;
+      delete process.env.KEY_CACHE_TTL_MS;
+    }
+  });
+
+  it('uses valid env values without coercion', () => {
+    process.env.SIGNATURE_MAX_AGE_MS = '5000';
+    try {
+      const config = new AuthConfig();
+      expect(config.signatureMaxAgeMs).toBe(5000);
+    } finally {
+      delete process.env.SIGNATURE_MAX_AGE_MS;
+    }
   });
 });


### PR DESCRIPTION
## Summary

`AuthConfig` parsed all env-driven security values with bare `parseInt` and **no NaN guard**:

```js
this.signatureMaxAgeMs = parseInt(process.env.SIGNATURE_MAX_AGE_MS || '300000', 10);
this.defaultRateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10);
this.defaultRateLimitMax = parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100', 10);
this.cacheTtlMs = parseInt(process.env.KEY_CACHE_TTL_MS || '600000', 10);
```

The `|| default` only covers the **absent** case. A malformed value (e.g. `SIGNATURE_MAX_AGE_MS=abc`) yields `NaN` with no fallback, and the checks that consume these values silently stop working:

- `signatureMaxAgeMs = NaN` → replay check at `apiKey.js:458` (`Math.abs(currentTime - clientTime) > NaN`) is always false → **HMAC replay protection disabled**.
- `defaultRateLimitWindowMs` / `defaultRateLimitMax = NaN` → sliding-window limiter never trips → **API-key rate limiting disabled**.
- `cacheTtlMs = NaN` → key-cache entries instantly expire (performance only).

## Changes

- `backend/api/src/middleware/apiKey.js` — new `parseEnvInt(raw, fallback)` helper (`Number.isInteger(n) && n > 0 ? n : fallback`) applied to all four values. Malformed, empty, or non-positive env values fall back to the documented defaults instead of becoming `NaN`.
- `backend/api/test/unit/middleware/apiKey.test.js` — two new tests: malformed env values fall back to defaults; valid values are honored.

## Verification

- `node --check` passes; `npx eslint` on both changed files is clean.
- `npx vitest run test/unit/middleware/apiKey.test.js` → 3 passed / 6 failed — the 6 failures are **identical to baseline on `main`** (verified via `git stash`); the 2 new `AuthConfig` tests pass.

## GSSOC

**Contributor:** Akshita-2307

Closes #14431
