### PR TITLE
refactor : remove dead createOrderTransactional helper in orderLifecycleService.js

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -1023,36 +1023,3 @@ export class OrderLifecycleService {
     });
   }
 }
-
-
-/**
- * Creates an order, timeline entry, and load offer in a single durable database transaction.
- */
-async function createOrderTransactional({ idempotencyKey, orderData, timelineData, loadOfferData }) {
-  if (!idempotencyKey) {
-    throw new Error('Idempotency key is required for transactional order creation.');
-  }
-
-  try {
-    const { data, error } = await supabaseAdmin.rpc('create_order_tx', {
-      p_idempotency_key: idempotencyKey,
-      p_order_data: orderData,
-      p_timeline_data: timelineData || { status: 'created', details: { note: 'Order initialized' } },
-      p_load_offer_data: loadOfferData || null
-    });
-
-    if (error) {
-      if (error.code === 'P0001' || error.message.includes('ORDER_CREATION_IN_PROGRESS')) {
-        const inProgressErr = new Error('Order creation is currently in progress for this key.');
-        inProgressErr.status = 409;
-        throw inProgressErr;
-      }
-      throw error;
-    }
-
-    return data;
-  } catch (err) {
-    logger.error({ err: err.message, key: idempotencyKey }, 'TRANSACTIONAL_ORDER_ERROR');
-    throw err;
-  }
-}


### PR DESCRIPTION
Closes #14567.

Summary of What Has Been Done:
Removed the dead createOrderTransactional function from orderLifecycleService.js. This function is never called anywhere in the codebase and is purely dead code.

Changes Made:
- backend/api/src/services/order/orderLifecycleService.js: removed dead createOrderTransactional function and its JSDoc comment

Impact it Made:
- Cleaner service module with no unused code
- Reduced code surface area

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused order-creation transaction handling.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->