### PR TITLE
refactor : remove dead profileCacheControl helper in profileRoutes.js

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -117,15 +117,6 @@ function sanitizeNumberPlate(plate) {
 }
 
 
-// Cache control middleware for profile endpoints
-function profileCacheControl(req, res, next) {
-  if (req.method === 'GET') {
-    res.setHeader('Cache-Control', 'private, max-age=30');
-    res.setHeader('Vary', 'Authorization');
-  }
-  next();
-}
-
 /**
  * @openapi
  * /api/profile:


### PR DESCRIPTION
Closes #14571.

Summary of What Has Been Done:
Removed the dead profileCacheControl helper function from profileRoutes.js. This function is never called anywhere in the codebase and is purely dead code.

Changes Made:
- backend/api/src/routes/profileRoutes.js: removed dead profileCacheControl function

Impact it Made:
- Cleaner profile routes module with no unused code

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).