### PR TITLE
fix : invoke stopStaleOrderWorker in server shutdown handler

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -159,7 +159,7 @@ import {
   startDlqWorker,
   stopDlqWorker,
 } from './workers/dlqWorker.js'
-import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
+import { startStaleOrderWorker, stopStaleOrderWorker } from './workers/staleOrderWorker.js'
 import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
@@ -795,6 +795,7 @@ async function shutdown(signal) {
   stopDevicePruningWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
+  stopStaleOrderWorker()
   stopDevicePruningWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()


### PR DESCRIPTION
Closes #14583.

Summary of What Has Been Done:
The staleOrderWorker was started when the server boots but was never stopped when the server shut down. This caused orphaned worker processes and potential resource leaks. Added the stopStaleOrderWorker call to the server shutdown handler.

Changes Made:
- backend/api/src/index.js: import stopStaleOrderWorker alongside startStaleOrderWorker
- backend/api/src/index.js: call stopStaleOrderWorker() in the shutdown function alongside other worker stop calls

Impact it Made:
- Clean server shutdown with no orphaned workers
- Prevents resource leaks on server restart

Note: Please assign this PR to the `tmdeveloper007` account.

This PR is submitted as part of GSSOC (GirlScript Summer of Code).