### PR TITLE
fix : invoke stopStaleOrderWorker in server shutdown handler

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -159,7 +159,7 @@ import {
   startDlqWorker,
   stopDlqWorker,
 } from './workers/dlqWorker.js'
-import { startStaleOrderWorker } from './workers/staleOrderWorker.js'
+import { startStaleOrderWorker, stopStaleOrderWorker } from './workers/staleOrderWorker.js'
 import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
 import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
@@ -795,7 +795,7 @@ async function shutdown(signal) {
   stopDevicePruningWorker()
   stopWithdrawalSettlementWorker()
   stopOutboxRelayWorker()
-  stopDevicePruningWorker()
+  stopStaleOrderWorker()
   fraudDetection.destroy()
   CacheManager.shutdown()
 


### PR DESCRIPTION
Closes #14485.

Summary of What Has Been Done:
The staleOrderWorker was started in the server startup block but stopStaleOrderWorker was never called during graceful shutdown. This fix imports stopStaleOrderWorker and invokes it in the shutdown handler alongside the other worker stop calls.

Changes Made:
- backend/api/src/index.js: Updated the import to include stopStaleOrderWorker alongside startStaleOrderWorker
- backend/api/src/index.js: Added stopStaleOrderWorker() call in the shutdown handler after the other worker stops

Impact it Made:
- All started workers are now stopped during graceful server shutdown
- Prevents stale-order worker from continuing to run after the server begins shutting down
- Ensures clean, predictable shutdown behavior

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown by properly stopping the stale-order background worker.
  * Helps prevent background processing from continuing after the application shuts down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->