### PR TITLE
fix : guard against null/undefined error in kedaRoutes.js catch handlers

### DIFF
--- a/backend/api/src/routes/kedaRoutes.js
+++ b/backend/api/src/routes/kedaRoutes.js
@@ -11,7 +11,7 @@ router.get('/keda/metrics/requests', async (_req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Requests error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -22,7 +22,7 @@ router.get('/keda/metrics/latency', async (_req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Latency error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -40,7 +40,7 @@ router.get('/keda/metrics/cpu', async (req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('CPU error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -58,7 +58,7 @@ router.get('/keda/metrics/memory', async (req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Memory error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -78,7 +78,7 @@ router.get('/keda/metrics/kafka-lag', async (req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Kafka lag error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -98,7 +98,7 @@ router.get('/keda/metrics/autoscale', async (req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Autoscale metrics error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -118,7 +118,7 @@ router.get('/keda/scale/recommend', async (req, res) => {
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Scale recommendation error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 
@@ -128,7 +128,7 @@ router.get('/keda/stats', async (_req, res) => {
         res.json({ success: true, data: stats });
     } catch (error) {
         logger.error('Stats error:', error);
-        res.status(500).json({ success: false, error: error.message });
+        res.status(500).json({ success: false, error: error?.message ?? String(error) });
     }
 });
 


### PR DESCRIPTION
Closes #14618.

Summary of What Has Been Done:
All catch handlers in kedaRoutes.js accessed error.message directly without guarding against non-Error thrown values. If a caller throws a string, null, or undefined, error.message would be undefined, making the 500 response body contain undefined instead of a meaningful message.

Changes Made:
- backend/api/src/routes/kedaRoutes.js: Updated all catch handler error responses to use error?.message ?? String(error) instead of error.message directly (8 occurrences across all endpoint handlers).

Impact it Made:
- Consistent, safe error handling across all kedaRoutes endpoints.
- 500 responses will always contain a meaningful error string, even if a non-Error value is thrown.
- Prevents undefined values leaking into API responses.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).