### PR TITLE
fix : guard against null/undefined error in wimBypass.js catch handler

### DIFF
--- a/backend/api/src/routes/wimBypass.js
+++ b/backend/api/src/routes/wimBypass.js
@@ -104,8 +104,8 @@ router.post('/request-bypass', async (req, res) => {
             wimPacket: signedPacket,
         });
     } catch (error) {
-        logger.error('[WIM] request-bypass error:', error.message);
-        return res.status(500).json({ error: error.message });
+        logger.error('[WIM] request-bypass error:', error?.message ?? String(error));
+        return res.status(500).json({ error: error?.message ?? String(error) });
     }
 });
 


### PR DESCRIPTION
Closes #14619.

Summary of What Has Been Done:
The request-bypass route in wimBypass.js caught errors and accessed error.message directly in the catch handler. If a caller threw null or a plain string, error.message would be undefined, and the 500 response would contain undefined.

Changes Made:
- backend/api/src/routes/wimBypass.js: Updated the catch handler to use error?.message ?? String(error) instead of error.message.

Impact it Made:
- Safe, consistent error responses even when non-Error values are thrown.
- Prevents undefined from appearing in API error responses.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).