### PR TITLE
fix : add length validation for meshId URL parameter in WebRTCSignalingServer

### DIFF
--- a/backend/api/src/services/webrtc/WebRTCSignalingServer.js
+++ b/backend/api/src/services/webrtc/WebRTCSignalingServer.js
@@ -50,7 +50,13 @@ class WebRTCSignalingServer {
       }
 
       const peerId = this.generatePeerId();
-      const meshId = url.searchParams.get('meshId') || this.getOrCreateMesh();
+      const rawMeshId = url.searchParams.get('meshId');
+      const MAX_MESH_ID_LENGTH = 64;
+      if (rawMeshId != null && rawMeshId.length > MAX_MESH_ID_LENGTH) {
+        ws.close(4001, 'meshId exceeds maximum length');
+        return;
+      }
+      const meshId = rawMeshId || this.getOrCreateMesh();
 
       // Store peer with authenticated user info
       this.peers.set(peerId, {


### PR DESCRIPTION
Closes #14620.

Summary of What Has Been Done:
The WebRTCSignalingServer.js accepted meshId from a URL query parameter and used it directly as a Map key without any length or character validation. This fix adds a length check: connections with meshId longer than 64 characters are rejected with a 4001 close code.

Changes Made:
- backend/api/src/services/webrtc/WebRTCSignalingServer.js: Added MAX_MESH_ID_LENGTH constant (64) and a guard that rejects connections with meshId exceeding this limit.

Impact it Made:
- Prevents potential abuse via excessively long meshId values.
- Ensures mesh isolation logic cannot be bypassed with crafted input.
- Aligns with the security-first design of other WebSocket connection parameters.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).