### PR TITLE
fix : guard against null/undefined error in oracleRoutes.js catch handlers

### DIFF
--- a/backend/api/src/routes/oracleRoutes.js
+++ b/backend/api/src/routes/oracleRoutes.js
@@ -79,7 +79,7 @@ router.post('/confirm', oracleVerificationLimiter, authenticate, validateBody(or
     if (error instanceof PolicyError || error.status) {
       return res.status(error.status || 403).json({
         success: false,
-        error: error.message
+        error: error?.message ?? String(error)
       });
     }
 
@@ -106,7 +106,7 @@ router.post('/verify-crosschain', oracleVerificationLimiter, authenticate, valid
     if (error instanceof PolicyError || error.status) {
       return res.status(error.status || 403).json({
         success: false,
-        error: error.message
+        error: error?.message ?? String(error)
       });
     }
 


### PR DESCRIPTION
Closes #14621.

Summary of What Has Been Done:
Catch handlers in oracleRoutes.js accessed error.message without guarding against non-Error thrown values. If the code path threw a string or null, the error response would contain undefined.

Changes Made:
- backend/api/src/routes/oracleRoutes.js: Updated all catch handler error responses to use error?.message ?? String(error).

Impact it Made:
- Consistent error handling across oracleRoutes.
- Prevents undefined values in API error responses.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).