### PR TITLE
fix : remove duplicate null-check guard in trackingTokenService.js validateToken

### DIFF
--- a/backend/api/src/services/trackingTokenService.js
+++ b/backend/api/src/services/trackingTokenService.js
@@ -66,11 +66,6 @@ export class TrackingTokenService {
 
     const tokenHash = this.hashToken(rawToken);
 
-    if (!this._supabaseAdmin) {
-      this._logger.error('validateToken requires service-role client');
-      throw new Error('Service-role client required for tracking token validation');
-    }
-
     const { data: token, error } = await this._supabaseAdmin
       .from('tracking_tokens')
       .select('id, order_display_id, expires_at, revoked, revoked_at')


### PR DESCRIPTION
Closes #14627.

Summary of What Has Been Done:
The validateToken method in trackingTokenService.js had two identical if (!this._supabaseAdmin) checks consecutively. The second check was dead code since _supabaseAdmin cannot change between the two checks. Removed the duplicate guard.

Changes Made:
- backend/api/src/services/trackingTokenService.js: Removed the duplicate null-check guard (lines 69-72).

Impact it Made:
- Removes dead code from the codebase.
- Improves code readability and maintainability.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).