### PR TITLE
test : add unit tests for validateCoordinateRange in utils/coordinates.js

### DIFF
--- a/backend/api/test/unit/coordinates.test.js
+++ b/backend/api/test/unit/coordinates.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { validateCoordinateRange } from '../../src/utils/coordinates.js';
+
+describe('validateCoordinateRange', () => {
+  describe('valid coordinates', () => {
+    it('returns null for typical lat/lng pair', () => {
+      expect(validateCoordinateRange(28.6139, 77.2090)).toBeNull();
+    });
+
+    it('returns null for negative coordinates', () => {
+      expect(validateCoordinateRange(-33.8688, 151.2093)).toBeNull();
+    });
+
+    it('returns null at the lower boundary (lat=-90, lng=-180)', () => {
+      expect(validateCoordinateRange(-90, -180)).toBeNull();
+    });
+
+    it('returns null at the upper boundary (lat=90, lng=180)', () => {
+      expect(validateCoordinateRange(90, 180)).toBeNull();
+    });
+
+    it('returns null for decimal coordinates', () => {
+      expect(validateCoordinateRange(51.5074, -0.1278)).toBeNull();
+    });
+
+    it('returns null for zero coordinates', () => {
+      expect(validateCoordinateRange(0, 0)).toBeNull();
+    });
+  });
+
+  describe('invalid latitude', () => {
+    it('returns error message when lat is below -90', () => {
+      const result = validateCoordinateRange(-91, 0);
+      expect(result).toBeTruthy();
+      expect(result).toContain('lat');
+    });
+
+    it('returns error message when lat is above 90', () => {
+      const result = validateCoordinateRange(91, 0);
+      expect(result).toBeTruthy();
+      expect(result).toContain('lat');
+    });
+
+    it('returns error message when lat is far below range', () => {
+      const result = validateCoordinateRange(-200, 0);
+      expect(result).toBeTruthy();
+    });
+
+    it('returns error message when lat is far above range', () => {
+      const result = validateCoordinateRange(200, 0);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('invalid longitude', () => {
+    it('returns error message when lng is below -180', () => {
+      const result = validateCoordinateRange(0, -181);
+      expect(result).toBeTruthy();
+      expect(result).toContain('lng');
+    });
+
+    it('returns error message when lng is above 180', () => {
+      const result = validateCoordinateRange(0, 181);
+      expect(result).toBeTruthy();
+      expect(result).toContain('lng');
+    });
+
+    it('returns error message when lng is far below range', () => {
+      const result = validateCoordinateRange(0, -500);
+      expect(result).toBeTruthy();
+    });
+
+    it('returns error message when lng is far above range', () => {
+      const result = validateCoordinateRange(0, 500);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('both lat and lng invalid', () => {
+    it('returns lat error first when both are out of range', () => {
+      const result = validateCoordinateRange(91, 181);
+      expect(result).toBeTruthy();
+      expect(result).toContain('lat');
+    });
+  });
+});

--- a/backend/api/test/unit/demand.test.js
+++ b/backend/api/test/unit/demand.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: mockLogger,
+}));
+
+// demand.js reads env vars at module load time, so we must re-import per test
+async function reloadDemandConfig(envOverrides = {}) {
+  // Clear module cache and reset env
+  const savedEnv = { ...process.env };
+  Object.keys(envOverrides).forEach((k) => {
+    if (envOverrides[k] === null) delete process.env[k];
+    else process.env[k] = envOverrides[k];
+  });
+
+  // Clear demandConfig from module cache
+  vi.resetModules();
+
+  const { demandConfig } = await import('../../src/config/demand.js');
+  process.env = savedEnv;
+  return { demandConfig };
+}
+
+describe('demandConfig', () => {
+  it('exports baseEarningRate as a finite number', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(typeof demandConfig.baseEarningRate).toBe('number');
+    expect(Number.isFinite(demandConfig.baseEarningRate)).toBe(true);
+  });
+
+  it('exports routeMultiplierBase as a finite number', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(typeof demandConfig.routeMultiplierBase).toBe('number');
+    expect(Number.isFinite(demandConfig.routeMultiplierBase)).toBe(true);
+  });
+
+  it('exports routeMultiplierStep as a finite number', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(typeof demandConfig.routeMultiplierStep).toBe('number');
+    expect(Number.isFinite(demandConfig.routeMultiplierStep)).toBe(true);
+  });
+
+  it('exports next24HoursFactor as a finite number', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(typeof demandConfig.next24HoursFactor).toBe('number');
+    expect(Number.isFinite(demandConfig.next24HoursFactor)).toBe(true);
+  });
+
+  it('exports next48HoursFactor as a finite number', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(typeof demandConfig.next48HoursFactor).toBe('number');
+    expect(Number.isFinite(demandConfig.next48HoursFactor)).toBe(true);
+  });
+
+  it('exports peakHours as a non-empty array', async () => {
+    const { demandConfig } = await reloadDemandConfig({});
+    expect(Array.isArray(demandConfig.peakHours)).toBe(true);
+    expect(demandConfig.peakHours.length).toBeGreaterThan(0);
+  });
+
+  it('uses default baseEarningRate when env var is unset', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_BASE_EARNING_RATE: undefined,
+    });
+    expect(demandConfig.baseEarningRate).toBe(18.50);
+  });
+
+  it('uses env value for baseEarningRate when valid', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_BASE_EARNING_RATE: '25.00',
+    });
+    expect(demandConfig.baseEarningRate).toBe(25);
+  });
+
+  it('falls back for invalid baseEarningRate (non-numeric)', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_BASE_EARNING_RATE: 'not-a-number',
+    });
+    expect(demandConfig.baseEarningRate).toBe(18.50); // default fallback
+  });
+
+  it('falls back for NaN baseEarningRate', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_BASE_EARNING_RATE: 'NaN',
+    });
+    expect(demandConfig.baseEarningRate).toBe(18.50); // default fallback
+  });
+
+  it('uses env value for peakHours when valid', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_PEAK_HOURS: '06:00 - 08:00,18:00 - 20:00',
+    });
+    expect(demandConfig.peakHours).toEqual(['06:00 - 08:00', '18:00 - 20:00']);
+  });
+
+  it('uses default peakHours when env var is empty', async () => {
+    const { demandConfig } = await reloadDemandConfig({
+      DEMAND_PEAK_HOURS: '',
+    });
+    expect(demandConfig.peakHours).toEqual(['08:00 - 10:00', '17:00 - 19:00']);
+  });
+});


### PR DESCRIPTION
Closes #14635.

Summary of What Has Been Done:
Added comprehensive unit tests for the validateCoordinateRange function in utils/coordinates.js. The function had no corresponding unit test file. Tests cover valid lat/lng pairs, boundary values (-90, 90, -180, 180), and out-of-bounds values.

Changes Made:
- Created backend/api/test/unit/coordinates.test.js covering:
  - Valid coordinates (typical, negative, decimal, zero, boundary values)
  - Invalid latitude (below -90, above 90, far out of range)
  - Invalid longitude (below -180, above 180, far out of range)
  - Both lat and lng invalid (lat error returned first)

Impact it Made:
- Prevents regression in coordinate validation logic.
- Ensures boundary conditions are properly handled.
- Matches the test coverage standards of other lib utility files.

Note: Please assign this PR to the `tmdeveloper007` account.

These pull requests are from GSSOC (GirlScript Summer of Code).