### PR TITLE
fix : added lng validation in weatherService getWeatherForecast

### DIFF
--- a/backend/api/src/services/weatherService.js
+++ b/backend/api/src/services/weatherService.js
@@ -35,6 +35,15 @@ export class WeatherService {
     // latitude would silently fall through to the warm default. Guard it
     // explicitly so the intent is clear.
     const validLat = Number.isFinite(numLat);
+    const validLng = Number.isFinite(Number(lng));
+
+    if (!validLat || !validLng) {
+      return {
+        temperature_c: tempC,
+        condition,
+        forecast_time: new Date().toISOString()
+      };
+    }
 
     if (validLat && (numLat > 40 || numLat < -40)) {
       tempC = -5;


### PR DESCRIPTION
Closes #14654.

Summary of What Has Been Done:
The getWeatherForecast method in weatherService.js was accepting a lng parameter but never validating it. Invalid lng values (NaN, Infinity, undefined) would silently fall through, making the validation asymmetric with lat. Added a guard that checks Number.isFinite(Number(lng)) and returns the warm default when lng is invalid.

Changes Made:
- backend/api/src/services/weatherService.js: Added validLng guard and early return when lng is not finite.

Impact it Made:
- Consistent input validation for both lat and lng coordinates.
- Prevents NaN/Infinity from silently propagating into downstream fuel advisory decisions.
- Verified by running the existing weatherService unit tests (7 tests passing).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.