### PR TITLE
fix : added lng validation in workZoneService generateBypassWaypoint

### DIFF
--- a/backend/api/src/services/workZoneService.js
+++ b/backend/api/src/services/workZoneService.js
@@ -76,6 +76,10 @@ export function generateBypassWaypoint(congestedPoint) {
   if (!congestedPoint || !congestedPoint.lat || !congestedPoint.lng) {
     return null;
   }
+  // Guard against NaN/Infinity values for lng, which would produce invalid bypass coordinates.
+  if (!Number.isFinite(Number(congestedPoint.lng))) {
+    return null;
+  }
 
   // To bypass a congested point (e.g. radius of 5km), we shift the coordinate perpendicularly.
   // 1 degree of latitude is ~111 km. To shift by ~7 km:


### PR DESCRIPTION
Closes #14656.

Summary of What Has Been Done:
The generateBypassWaypoint method in workZoneService.js checked congestedPoint.lat but not congestedPoint.lng for NaN/Infinity values. Added a Number.isFinite guard for lng to prevent invalid bypass coordinates from being returned.

Changes Made:
- backend/api/src/services/workZoneService.js: Added Number.isFinite check for lng.

Impact it Made:
- Prevents NaN/Infinity coordinates from being returned and passed to the OSRM routing engine.
- Verified by running the existing workZoneService unit tests (5 tests passing).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.