### PR TITLE
fix : added err.message guards in WorkerEventAdapter catch handlers

### DIFF
--- a/backend/api/src/core/events/adapters/WorkerEventAdapter.js
+++ b/backend/api/src/core/events/adapters/WorkerEventAdapter.js
@@ -27,7 +27,7 @@ export class WorkerEventAdapter extends EventPublisher {
           await worker.terminate();
         }
       } catch (err) {
-        logger.error(`[WorkerEventAdapter] Failed to terminate worker "${name}":`, err.message);
+        logger.error(`[WorkerEventAdapter] Failed to terminate worker "${name}":`, err?.message);
       }
     }
     this._workers.clear();
@@ -86,7 +86,7 @@ export class WorkerEventAdapter extends EventPublisher {
         }
         logger.debug(`[WorkerEventAdapter] Sent "${event.eventType}" to worker "${name}"`);
       } catch (err) {
-        logger.error(`[WorkerEventAdapter] Failed to send to worker "${name}":`, err.message);
+        logger.error(`[WorkerEventAdapter] Failed to send to worker "${name}":`, err?.message);
       }
     }
   }
@@ -104,10 +104,10 @@ export class WorkerEventAdapter extends EventPublisher {
       try {
         const result = handler(event);
         if (result && typeof result.catch === 'function') {
-          result.catch(err => logger.error('[WorkerEventAdapter] Handler error:', err.message));
+          result.catch(err => logger.error('[WorkerEventAdapter] Handler error:', err?.message));
         }
       } catch (err) {
-        logger.error('[WorkerEventAdapter] Handler error:', err.message);
+        logger.error('[WorkerEventAdapter] Handler error:', err?.message);
       }
     }
   }


### PR DESCRIPTION
Closes #14657.

Summary of What Has Been Done:
WorkerEventAdapter.js had four catch blocks accessing err.message directly. Replaced all four with err?.message to guard against non-Error values being thrown, preventing TypeError in worker terminate, publish, and handler callback paths.

Changes Made:
- backend/api/src/core/events/adapters/WorkerEventAdapter.js: Replaced err.message with err?.message in all four catch blocks.

Impact it Made:
- Prevents secondary exceptions from masking original errors in the worker event pipeline.
- Verified by running the existing WorkerEventAdapter unit test (1 test passing).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.