### PR TITLE
fix : removed redundant Number.isNaN guard in reverseGeocode getTimeoutMs

### DIFF
--- a/backend/api/src/lib/reverseGeocode.js
+++ b/backend/api/src/lib/reverseGeocode.js
@@ -12,7 +12,7 @@ const NOMINATIM_TIMEOUT_MS = 5000;
  */
 function getTimeoutMs() {
   const configured = Number(process.env.NOMINATIM_TIMEOUT_MS);
-  return Number.isFinite(configured) && configured > 0 && !Number.isNaN(configured) ? configured : NOMINATIM_TIMEOUT_MS;
+  return Number.isFinite(configured) && configured > 0 ? configured : NOMINATIM_TIMEOUT_MS;
 }
 
 /**


### PR DESCRIPTION
Closes #14658.

Summary of What Has Been Done:
The getTimeoutMs function in reverseGeocode.js checked !Number.isNaN(configured) as part of its guard condition. Since Number.isFinite(NaN) already returns false, the !Number.isNaN check is redundant and was removed.

Changes Made:
- backend/api/src/lib/reverseGeocode.js: Removed the redundant !Number.isNaN(configured) check from the getTimeoutMs guard.

Impact it Made:
- Cleaner, more maintainable code with no functional change.
- Verified by running the existing reverseGeocode unit tests (22 tests passing).

This PR is from GSSOC (GirlScript Summer of Code).

Note: Please assign this PR to the `tmdeveloper007` account.