### PR TITLE
fix(idempotency): remove duplicate pendingCache declaration

### DIFF
--- a/backend/api/src/middleware/idempotency.js
+++ b/backend/api/src/middleware/idempotency.js
@@ -101,8 +101,6 @@ export function requireIdempotency(ttlSeconds = 3600) {
         return res.status(cached.statusCode).json(cached.body);
       }
 
-      let pendingCache = null;
-
       if (redisClient) {
         const lockKey = `${key}:lock`;
         const lockAcquired = await redisClient.set(lockKey, '1', 'NX', 'PX', LOCK_TTL_MS);


### PR DESCRIPTION
Closes #14740

## Problem

`backend/api/src/middleware/idempotency.js` declares `pendingCache` twice with `let` in the same function scope:

- line 101 (`let pendingCache = null;` next to the Redis cache lookup) and
- line 202 (`let pendingCache = null;` before the shared `res.json` override).

This is a hard **Parsing error: Identifier 'pendingCache' has already been declared** — the module cannot even be loaded. (Also confirmed by ESLint.)

## Fix

Remove the redundant inner declaration at line 101. The shared-scope declaration at line 202 covers every usage: the `res.json` override that clears the timeout and caches the response, and the `finalize` helper.

Verified with `node --check` and ESLint on the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request processing stability by removing redundant internal state initialization.
  * Preserved response caching and lock handling behavior during request finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->