### PR TITLE
fix(documentController): remove duplicate existingDoc declaration

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -162,7 +162,6 @@ export async function uploadDriverDocument(req, res) {
     let record;
     let dbError;
 
-    const existingDoc = existingDocPreflight;
     if (existingDoc) {
       // Update existing record (Supersede)
       const { data: updatedRecord, error: updateErr } = await client


### PR DESCRIPTION
Closes #14742

## Problem

In `backend/api/src/controllers/documentController.js`, the `uploadDocument` handler declares `existingDoc` twice:

- line 69: `const { data: existingDoc, error: checkErrorPreflight } = await supabaseAdmin...` (the pre-flight query result), and
- line 165: `const existingDoc = existingDocPreflight;` — a duplicate declaration that also references a variable (`existingDocPreflight`) that does not exist.

This is a hard parse error: `Identifier 'existingDoc' has already been declared` at line 165, so the module cannot be loaded.

## Fix

Remove the redundant line 165. The `existingDoc` binding at line 69 already holds the pre-flight query result, which is exactly what the rest of the handler uses.

Verified with `node --check` and ESLint on the file.
