### PR TITLE
fix(telemetryBuffer): drop unused initializer

### DIFF
--- a/backend/api/src/sockets/telemetryBuffer.js
+++ b/backend/api/src/sockets/telemetryBuffer.js
@@ -128,7 +128,7 @@ const buffer = new TelemetryRingBuffer(MAX_BUFFER_SIZE);
  */
 function enqueue(record) {
   eventsReceived++;
-  let dropped = 0;
+  let dropped;
   try {
     dropped = buffer.push(record);
   } catch (err) {


### PR DESCRIPTION
Closes #14744

## Problem

In `backend/api/src/sockets/telemetryBuffer.js` line 131:

```js
let dropped = 0;
```

The `= 0` initializer is never read — `dropped` is always reassigned (or the function returns early) before first use. ESLint `no-useless-assignment`.

## Fix

```js
let dropped;
```
