### PR TITLE
lint(escortWalletRoutes): merge duplicate auth import

### DIFF
--- a/backend/api/src/routes/escortWalletRoutes.js
+++ b/backend/api/src/routes/escortWalletRoutes.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import { loadCredential, resolveCredentialSubject, handshake } from '../controllers/escortWalletController.js';
-import { authenticate } from '../middleware/auth.js';
-import { requireRole } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import { requirePolicy } from '../middleware/requirePolicy.js';
 
 const router = express.Router();


### PR DESCRIPTION
Closes #14747

## Problem

In `backend/api/src/routes/escortWalletRoutes.js`, the middleware module is imported twice:

```js
import { authenticate } from '../middleware/auth.js';
import { requireRole } from '../middleware/auth.js';
```

ESLint `no-duplicate-imports` (the only warning in the whole `src/` tree).

## Fix

```js
import { authenticate, requireRole } from '../middleware/auth.js';
```
