### PR TITLE
fix(authFailureMonitor): restore missing parseEnvNumber helper

### DIFF
--- a/backend/api/src/middleware/authFailureMonitor.js
+++ b/backend/api/src/middleware/authFailureMonitor.js
@@ -28,6 +28,11 @@ const ROUTE_THRESHOLDS = new Map([
 // 2. HELPER & UTILITY FUNCTIONS
 // ==========================================
 
+function parseEnvNumber(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function extractClientIP(req) {
   const forwarded = req.headers['x-forwarded-for'];
   if (forwarded) {


### PR DESCRIPTION
Closes #14752

## Problem

In `backend/api/src/middleware/authFailureMonitor.js`, the `parseEnvNumber` helper is missing but still called at four places (lines 44, 49, 150, 151):

```js
return parseEnvNumber(process.env.AUTH_FAILURE_THRESHOLD, DEFAULT_THRESHOLD);
const windowMs = parseEnvNumber(process.env.AUTH_FAILURE_WINDOW_MS, DEFAULT_WINDOW_MS);
const banDurationMs = parseEnvNumber(process.env.AUTH_BAN_DURATION_MS, DEFAULT_BAN_DURATION_MS);
```

Every call site throws `ReferenceError: parseEnvNumber is not defined` whenever the auth-failure monitor runs (failed logins, expired-record sweeps). ESLint `no-undef` at all four sites.

## Fix

Restore the small helper in the "HELPER & UTILITY FUNCTIONS" section:

```js
function parseEnvNumber(value, fallback) {
  const parsed = Number.parseInt(value, 10);
  return Number.isFinite(parsed) ? parsed : fallback;
}
```

Verified with `node --check` and ESLint (no `no-undef` remaining).
