### PR TITLE
fix(wasm): constant-time validate_otp to close timing side-channel (#14719)

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -109,8 +109,17 @@ pub fn calculate_eta(distance: f64, speed: f64, traffic_factor: f64) -> f64 {
 
 #[wasm_bindgen]
 pub fn validate_otp(input_otp: &str, correct_otp: &str) -> bool {
-    // Fast OTP validation at edge
-    input_otp == correct_otp
+    // Constant-time OTP validation at the edge to avoid timing side-channels.
+    let a = input_otp.as_bytes();
+    let b = correct_otp.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 // ============ Data Processing ============


### PR DESCRIPTION
## Problem
`validate_otp` in `wasm/rust/src/lib.rs` compared the supplied OTP to the expected OTP using `input_otp == correct_otp` on `&str`. This is a byte-wise, early-exit comparison, creating a classic timing side-channel that lets an attacker recover the OTP character-by-character via response-time analysis at the edge.

## Fix
Replaced the `==` short-circuiting comparison with a self-contained constant-time comparison: compare lengths in constant time, then XOR-accumulate the difference of every byte so the result is independent of where (or whether) a mismatch occurs. No early exit, no byte leakage.

## Files changed
- `wasm/rust/src/lib.rs` — `validate_otp` now uses constant-time byte comparison.

## Testing
- Manual review of the new comparison: returns `false` on length mismatch (constant-time length check) and `false` on any differing byte; returns `true` only when all bytes match.
- Confirmed the function signature and `#[wasm_bindgen]` export are unchanged so existing callers/JS bindings keep working.

Closes #14719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved one-time password validation with stricter length checks.
  * Strengthened verification consistency by using secure byte-wise comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->