### PR TITLE
fix(profileRoutes): close driver wallet-sync block before catch

### DIFF
--- a/backend/api/src/routes/profileRoutes.js
+++ b/backend/api/src/routes/profileRoutes.js
@@ -312,6 +312,7 @@ router.put('/wallet', authenticate, userLimiter, validateBody(updateWalletSchema
     if (driverDetailsErr) {
       return res.status(500).json({ error: 'Failed to sync wallet to driver details.', details: driverDetailsErr.message });
     }
+    }
 
     if (req.user && req.user.uid) {
       try { await invalidateCachedProfile(req.user.uid); } catch (err) { logger.error({ event: 'PROFILE_CACHE_INVALIDATE_ERROR', userId: req.user.uid, error: err && (err.message || String(err)) }, 'Cache invalidation failed'); }


### PR DESCRIPTION
Closes #14753

## Problem

In `backend/api/src/routes/profileRoutes.js`, the `PUT /api/profile/wallet` handler opens an `if (req.user.role === 'driver') {` block (line 307) but never closes it before the outer `} catch`. The parser treats the `}` before `catch` as closing the `if`, leaving the `try` unclosed → `Parsing error: Unexpected token catch` at line 328. The route file cannot be loaded.

## Fix

Close the driver block right after the `driverDetailsErr` check so the cache invalidation and `res.json(...)` run for every user (the profile update applies to all roles; only the `driver_details` sync is driver-specific).

Verified with `node --check` and ESLint.
