### PR TITLE
fix(deviceController): remove duplicate getDevicePlatforms declaration

### DIFF
--- a/backend/api/src/controllers/deviceController.js
+++ b/backend/api/src/controllers/deviceController.js
@@ -285,25 +285,3 @@ export async function getDevicePlatforms(req, res, next) {
     return next(err);
   }
 }
-
-/**
- * Get list of unique registered device platforms
- */
-export async function getDevicePlatforms(req, res) {
-  try {
-    const { data, error } = await supabase
-      .from('user_devices')
-      .select('platform');
-
-    if (error) {
-      logger.error('[DeviceController] Failed to query device platforms:', error.message);
-      return res.status(500).json({ error: 'Failed to retrieve platforms' });
-    }
-
-    const platforms = [...new Set((data || []).map((d) => d.platform).filter(Boolean))];
-    return res.json({ platforms });
-  } catch (err) {
-    logger.error('[DeviceController] Unexpected error in getDevicePlatforms:', err.message);
-    return res.status(500).json({ error: 'An unexpected error occurred' });
-  }
-}


### PR DESCRIPTION
Closes #14754

## Problem

In `backend/api/src/controllers/deviceController.js`, `getDevicePlatforms` is exported twice:

- line 265: `export async function getDevicePlatforms(req, res, next)` — the active-devices-only implementation (queries `supabaseAdmin` filtered by `is_active: true`, iterates `VALID_PLATFORMS`), with the comment "active devices only"
- line 292: `export async function getDevicePlatforms(req, res)` — an older implementation querying all platforms

Two same-scope function declarations are a hard parse error: `Identifier 'getDevicePlatforms' has already been declared` at line 292. The module cannot be loaded, so `deviceRoutes.js` cannot import it (`router.get('/platforms', authenticate, getDevicePlatforms)`).

## Fix

Remove the duplicate older implementation, keeping the active-only version at line 265.

Verified with `node --check` and ESLint.
