### PR TITLE
fix(OracleService): remove duplicate getStatus method

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -211,13 +211,6 @@ class OracleService {
     return logEntry;
   }
 
-  getStatus() {
-    return {
-      providers: ['OTPVerifier', 'GPSVerifier', 'StatusVerifier'],
-      threshold: 2,
-    };
-  }
-
   async verifyCrossChain(orderId, blockchainHash) {
     try {
       const { data: order, error } = await this.supabase


### PR DESCRIPTION
Closes #14755

## Problem

In `backend/api/src/oracle/OracleService.js`, the `getStatus()` class method is defined twice:

- line 23: `getStatus()` returning `{ providers: 3, threshold: 2, timestamp: new Date().toISOString() }`
- line 214: `getStatus()` returning `{ providers: ['OTPVerifier', 'GPSVerifier', 'StatusVerifier'], threshold: 2 }`

Duplicate class members are a hard error (`Duplicate name 'getStatus'`, ESLint `no-dupe-class-members`). The `GET /status` route (`oracleRoutes.js:49`) calls `oracleService.getStatus()` and passes the whole object through as `data`.

## Fix

Remove the duplicate definition at line 214, keeping the canonical one at line 23 (natural class-header position next to the constructor, includes the `timestamp` field).

Verified with `node --check` and ESLint.
