### PR TITLE
contract: guard TruxifyEscrow deposit entrypoints with whenNotPaused (#14729)

### DIFF
--- a/blockchain/contracts/TruxifyEscrow.sol
+++ b/blockchain/contracts/TruxifyEscrow.sol
@@ -127,7 +127,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
 
     constructor() Ownable(msg.sender) {}
 
-    receive() external payable {
+    receive() external payable whenNotPaused {
         pendingWithdrawals[msg.sender] += msg.value;
     }
     fallback() external {
@@ -216,7 +216,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         uint256 bookingId,
         address payable driver,
         bytes calldata signature
-    ) external payable {
+    ) external payable whenNotPaused {
         require(msg.value > 0, "TruxifyEscrow: Payment required");
         require(driver != address(0), "TruxifyEscrow: Invalid driver address");
         require(
@@ -257,7 +257,7 @@ contract TruxifyEscrow is ReentrancyGuard, Ownable, Pausable {
         uint256 bookingId,
         address payable customer,
         address payable driver
-    ) external payable onlyOwner {
+    ) external payable onlyOwner whenNotPaused {
         require(msg.value > 0, "TruxifyEscrow: Payment required");
         require(customer != address(0), "TruxifyEscrow: Invalid customer address");
         require(driver != address(0), "TruxifyEscrow: Invalid driver address");


### PR DESCRIPTION
## Problem

In `blockchain/contracts/TruxifyEscrow.sol`, every fund-moving/admin function is guarded by `whenNotPaused` (e.g. `releasePayment`, `cancelBooking`, `raiseDispute`), but the three entry points that *lock* user funds are not:
- `createBooking(...)` — `external payable`, no pause guard.
- `lockPayment(...)` — `external payable onlyOwner`, no pause guard.
- `receive() external payable` — credits `pendingWithdrawals` with no pause guard.

This lets ETH keep being locked into escrow even after the contract is paused for an emergency, defeating the circuit breaker.

## Fix

Added the `whenNotPaused` modifier to:
- `createBooking` (line 215)
- `lockPayment` (line 256)
- `receive()` (line 130)

All three now revert while `paused()`.

## Files changed

- `blockchain/contracts/TruxifyEscrow.sol`

## Testing

- Manual review: modifiers compile-consistent with the rest of the contract (Pausable inherited, `whenNotPaused` already used elsewhere).
- Expected: `createBooking`, `lockPayment`, and plain ETH transfers to the contract revert with the Pausable error when `paused()` is true, and succeed when not paused.

Closes #14729
