### PR TITLE
contract: restrict SupplyChain.updateShipmentStatus to authorized party (#14733)

### DIFF
--- a/blockchain/contracts/SupplyChain.sol
+++ b/blockchain/contracts/SupplyChain.sol
@@ -205,6 +205,10 @@ contract SupplyChain is Ownable, Pausable, ReentrancyGuard {
         ShipmentStatus currentStatus = _currentStatus(shipmentId);
         ShipmentStatus newStatus = _parseStatus(status);
         require(_isValidTransition(currentStatus, newStatus), "Invalid transition");
+        require(
+            _isAuthorizedActor(s, currentStatus, newStatus),
+            "Not authorized for this transition"
+        );
 
         s.status = status;
         s.location = location;
@@ -248,6 +252,29 @@ contract SupplyChain is Ownable, Pausable, ReentrancyGuard {
         }
         // Otherwise the status must advance exactly one step forward.
         return uint256(next) == uint256(current) + 1;
+    }
+
+    /**
+     * @dev Gate each lifecycle transition to the correct actor. The owner may
+     *      perform any transition for administrative corrections. Otherwise:
+     *      - the sender drives forward steps (InTransit, Arrived);
+     *      - only the receiver may confirm final delivery (Delivered);
+     *      - only the sender (or owner) may cancel a created shipment.
+     */
+    function _isAuthorizedActor(
+        Shipment storage s,
+        ShipmentStatus current,
+        ShipmentStatus next
+    ) internal view returns (bool) {
+        if (msg.sender == owner()) return true;
+
+        if (next == ShipmentStatus.Cancelled) {
+            return msg.sender == s.sender;
+        }
+        if (next == ShipmentStatus.Delivered) {
+            return msg.sender == s.receiver;
+        }
+        return msg.sender == s.sender;
     }
 
     function _currentStatus(uint256 shipmentId) internal view returns (ShipmentStatus) {


### PR DESCRIPTION
## Problem

`SupplyChain.updateShipmentStatus` authorized any of `sender`, `receiver`, or `owner()` to perform *any* valid forward transition. The `_isValidTransition` state machine only enforced forward, one-step transitions and nothing about *who* could perform each step. As a result, a `receiver` could mark a shipment `DELIVERED` (or any intermediate state) on their own, and a `sender` could prematurely advance the status — enabling false-delivery claims, premature payment release, and disputed-state tampering.

## Fix

Added a per-transition role check `_isAuthorizedActor` invoked in `updateShipmentStatus` after validating the transition:
- `owner()` may perform any transition for administrative corrections.
- Forward steps (`CREATED -> IN_TRANSIT`, `IN_TRANSIT -> ARRIVED`) are gated to the `sender`.
- Final delivery (`ARRIVED -> DELIVERED`) is gated to the `receiver` (confirm receipt).
- Cancellation (`CREATED -> CANCELLED`) is gated to the `sender` (or owner).

The prior broad `sender || receiver || owner` authorization check is retained as a base guard and is now narrowed by the new per-step role check.

## Files changed

- blockchain/contracts/SupplyChain.sol

## Testing

- Manual review of the lifecycle: sender advances pickup/in-transit, receiver confirms delivery, sender/owner cancels. Owner retains administrative override.
- No compilation/unit-test harness available in this environment; change is syntax-checked and logically consistent with the existing `_isValidTransition` state machine.

Closes #14733
