### PR TITLE
contract: bind SubstrateBridge relayXcmMessage signature to recipient/amount/dest (#14731)

### DIFF
--- a/blockchain/contracts/SubstrateBridge.sol
+++ b/blockchain/contracts/SubstrateBridge.sol
@@ -33,7 +33,9 @@ contract SubstrateBridge is Ownable {
         require(!processedMessages[_messageHash], "Message already processed by bridge");
         require(_signature.length == 65, "Invalid bridge transaction signature");
         require(
-            _messageHash.toEthSignedMessageHash().recover(_signature) == owner(),
+            keccak256(abi.encodePacked(_messageHash, _destParachainId, _recipient, _amount))
+                .toEthSignedMessageHash()
+                .recover(_signature) == owner(),
             "Invalid bridge transaction signature"
         );
 


### PR DESCRIPTION
## Problem

`relayXcmMessage` in `blockchain/contracts/SubstrateBridge.sol` verifies an EIP-191 signature only over the caller-supplied `_messageHash`. The relayed `_recipient`, `_amount`, and `_destParachainId` are never included in the signed message, so a valid signature over hash `H` can be reused to relay to any recipient and any amount the owner could authorize. This is a latent replay/repurpose vulnerability once relaying is delegated or a signature is reused.

## Fix

Bind the signature to the full payload by hashing `(messageHash, destParachainId, recipient, amount)` before recovering the signer:

```solidity
require(
    keccak256(abi.encodePacked(_messageHash, _destParachainId, _recipient, _amount))
        .toEthSignedMessageHash()
        .recover(_signature) == owner(),
    "Invalid bridge transaction signature"
);
```

## Files changed

- `blockchain/contracts/SubstrateBridge.sol`

## Testing

- Solidity syntax/plausibility review of the edited `relayXcmMessage` function.
- Confirmed `abi.encodePacked` packing of `(bytes32, uint32, address, uint256)` is deterministic and consistent across signer/off-chain verification.

Closes #14731
