### PR TITLE
fix(flutter): write orders to offline cache with correct ID key (#14735)

### DIFF
--- a/apps/customer/lib/core/offline/cache/cache_manager.dart
+++ b/apps/customer/lib/core/offline/cache/cache_manager.dart
@@ -158,7 +158,10 @@ class CacheManager {
     final updatedAt = DateTime.now().toUtc().toIso8601String();
 
     for (final item in orders) {
-      final id = _stableId(item, const ['id', 'orderId', 'order_id']);
+      final id = _stableId(
+        item,
+        const ['id', 'orderId', 'order_id', 'order_display_id'],
+      );
       if (id == null) {
         continue;
       }


### PR DESCRIPTION
## Problem

`CacheManager.cacheOrders` derived each order's primary key via `_stableId(item, const ['id', 'orderId', 'order_id'])` and silently dropped any order lacking one of those fields. The entire customer app identifies orders by `order_display_id` (used in `orders_screen`, `order_detail_screen`, `live_tracking_screen`, `shell_screen`, `public_tracking_screen`, and `order_service`), and the API payloads do not include a redundant `id`/`orderId`/`order_id` field. As a result, 100% of orders failed `_stableId` and were skipped, so the `orders` cache was always empty and offline users saw an empty Active/History list.

## Fix

Added `order_display_id` to the stable-ID key list used by `cacheOrders` so orders that use `order_display_id` as their identifier are correctly keyed and inserted into the cache.

## Files changed

- `apps/customer/lib/core/offline/cache/cache_manager.dart` — `cacheOrders`: key list is now `['id', 'orderId', 'order_id', 'order_display_id']`.

## Testing

- Verified the key list against all `order_display_id` usages in the customer app (`orders_screen.dart`, `order_detail_screen.dart`, `live_tracking_screen.dart`, `shell_screen.dart`, `public_tracking_screen.dart`, `order_service.dart`) to confirm `order_display_id` is the canonical order identifier.
- Manual reasoning: an order whose only identifier is `order_display_id` now resolves a non-null `id` and is inserted (with `ConflictAlgorithm.replace`) instead of being skipped.

Closes #14735
