### PR TITLE
fix(flutter): per-line invoice precision so breakdown sums to total (#14737)

### DIFF
--- a/apps/customer/lib/screens/order_detail_screen.dart
+++ b/apps/customer/lib/screens/order_detail_screen.dart
@@ -151,7 +151,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
 
   String? _formatRupeesFromPaise(dynamic value) {
     if (value is! num) return null;
-    return '₹ ${(value / 100).toStringAsFixed(0)}';
+    return '₹ ${(value / 100).toStringAsFixed(2)}';
   }
 
   Future<void> _loadOrderAndTimeline() async {
@@ -164,7 +164,7 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
         setState(() {
           final rawAmount = orderMap['total_amount'] ?? 0;
           final amountInRupees = (rawAmount is num)
-              ? (rawAmount / 100).toStringAsFixed(0)
+              ? (rawAmount / 100).toStringAsFixed(2)
               : rawAmount.toString();
           
           final driverName = _resolveDriverName(orderMap);

--- a/apps/customer/lib/screens/orders_screen.dart
+++ b/apps/customer/lib/screens/orders_screen.dart
@@ -169,7 +169,7 @@ class _OrdersScreenState extends State<OrdersScreen>
           _historyOrders = historyOrders.map((order) {
             final rawAmount = order['total_amount'] ?? 0;
             final amountInRupees = (rawAmount is num)
-                ? (rawAmount / 100).toStringAsFixed(0)
+                ? (rawAmount / 100).toStringAsFixed(2)
                 : rawAmount.toString();
             return HistoryOrderData(
               orderId: order['order_display_id']?.toString() ?? '',
@@ -248,7 +248,7 @@ class _OrdersScreenState extends State<OrdersScreen>
             _historyOrders = historyRaw.map((order) {
               final rawAmount = order['total_amount'] ?? 0;
               final amountInRupees = (rawAmount is num)
-                  ? (rawAmount / 100).toStringAsFixed(0)
+                  ? (rawAmount / 100).toStringAsFixed(2)
                   : rawAmount.toString();
               return HistoryOrderData(
                 orderId: order['order_display_id']?.toString() ?? '',


### PR DESCRIPTION
## Problem

Amounts are stored in integer paise, but `apps/customer` formats every invoice component and the total independently to whole rupees via `toStringAsFixed(0)`. Because rounding is applied per line, the displayed breakdown does not sum to the displayed total (e.g. base ₹100.50 + toll ₹50.50 + distance ₹25.50 + platform ₹10.50 each round to ₹101 + ₹51 + ₹26 + ₹11 = ₹189 while the total rounds to ₹187), and all paise are dropped on a customer-facing invoice/receipt.

## Fix

Retain paise precision by formatting rupee values with `toStringAsFixed(2)` instead of `toStringAsFixed(0)` in the affected invoice/order screens:
- `order_detail_screen.dart`: the per-line `_formatRupeesFromPaise` helper and the order total.
- `orders_screen.dart`: the history order total (both the online and offline/cached code paths).

Since the underlying values are exact integer paise, showing two decimals keeps each breakdown line and the total exact, so the breakdown reconciles to the total and no paise are lost.

## Files changed

- `apps/customer/lib/screens/order_detail_screen.dart`
- `apps/customer/lib/screens/orders_screen.dart`

## Testing

Manual reasoning: with exact integer paise, `value / 100` rendered to two decimals is lossless, so the sum of the displayed line items equals the displayed total. No automated test harness exists for these widgets in scope; verified the changes are localized formatting-only edits that do not alter data flow.

Closes #14737
