### PR TITLE
contract: enforce IVotes on setGovernanceToken in TruxifyUpgradeable (#14732)

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -183,6 +183,13 @@ contract TruxifyUpgradeable is
     ///         there is deliberately no unweighted fallback.
     function setGovernanceToken(address token) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(token != address(0), "Invalid token");
+        // vote() casts governanceToken to IVotes and calls getPastVotes. A plain
+        // ERC20 has no such selector, so every vote() would revert. Reject tokens
+        // that do not implement IVotes at configuration time.
+        (bool success, ) = token.staticcall(
+            abi.encodeWithSelector(IVotes.getPastVotes.selector, address(this), block.number)
+        );
+        require(success, "Governance token must implement IVotes");
         governanceToken = IERC20(token);
         emit GovernanceTokenUpdated(token);
     }


### PR DESCRIPTION
## Problem

`blockchain/contracts/TruxifyUpgradeable.sol` types `governanceToken` as `IERC20` and `setGovernanceToken` only checks `token != address(0)`. However, `vote()` casts `governanceToken` to `IVotes` and calls `getPastVotes(...)`. A plain ERC20 has no `getPastVotes` selector, so any `vote()` call reverts — governance becomes permanently unusable with no validation or error surfaced at configuration time.

## Fix

In `setGovernanceToken`, probe the candidate token with a low-level `staticcall` against the `IVotes.getPastVotes` selector before accepting it. If the token does not implement `IVotes` (`getPastVotes`), the call fails and the transaction reverts with `"Governance token must implement IVotes"`. This keeps `governanceToken` typed `IERC20` (so existing `totalSupply()`/`vote()` usage is unchanged) while guaranteeing only a Votes-capable token can be configured.

## Files changed

- `blockchain/contracts/TruxifyUpgradeable.sol` — added `IVotes` interface probe in `setGovernanceToken`.

## Testing

- Manual review of the `staticcall` probe and `IVotes.getPastVotes.selector` usage.
- Compile/coverage in `blockchain/` (e.g. `forge build` / `hardhat compile`) should confirm the change; a unit test setting a plain ERC20 should now revert with `"Governance token must implement IVotes"`, while a `Votes` token succeeds.

Closes #14732
