### PR TITLE
security(flutter): bind Hardware KeyStore signing to hardware, drop plaintext key (#14736)

### DIFF
--- a/apps/customer/android/app/src/main/kotlin/com/truxify/customer/MainActivity.kt
+++ b/apps/customer/android/app/src/main/kotlin/com/truxify/customer/MainActivity.kt
@@ -9,6 +9,14 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.truxify.customer/native"
@@ -34,12 +42,138 @@ class MainActivity: FlutterActivity() {
                     )
                     result.success(info)
                 }
+                "hwGenerateKeyPair" -> {
+                    val alias = call.argument<String>("alias")
+                    if (alias == null) {
+                        result.error("BAD_ARGS", "alias is required", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        result.success(hwGenerateKeyPair(alias))
+                    } catch (e: Exception) {
+                        result.error("HW_KEYSTORE_ERROR", e.message, null)
+                    }
+                }
+                "hwGetPublicKey" -> {
+                    val alias = call.argument<String>("alias")
+                    if (alias == null) {
+                        result.error("BAD_ARGS", "alias is required", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        result.success(hwGetPublicKey(alias))
+                    } catch (e: Exception) {
+                        result.error("HW_KEYSTORE_ERROR", e.message, null)
+                    }
+                }
+                "hwSign" -> {
+                    val alias = call.argument<String>("alias")
+                    val payload = call.argument<String>("payload")
+                    if (alias == null || payload == null) {
+                        result.error("BAD_ARGS", "alias and payload are required", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        result.success(hwSign(alias, payload))
+                    } catch (e: Exception) {
+                        result.error("HW_SIGN_ERROR", e.message, null)
+                    }
+                }
+                "hwClearKeyPair" -> {
+                    val alias = call.argument<String>("alias")
+                    if (alias == null) {
+                        result.error("BAD_ARGS", "alias is required", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        hwClearKeyPair(alias)
+                        result.success(null)
+                    } catch (e: Exception) {
+                        result.error("HW_CLEAR_ERROR", e.message, null)
+                    }
+                }
                 else -> {
                     result.notImplemented()
                 }
             }
         }
     }
+
+    private val hwKeyStoreType = "AndroidKeyStore"
+
+    /// Generates an EC P-256 keypair *inside* the Android Keystore. The private
+    /// key is hardware-backed and non-exportable: it can never be read back as
+    /// plaintext. Returns the uncompressed (0x04|x|y) public key as hex.
+    private fun hwGenerateKeyPair(alias: String): String {
+        val keyStore = KeyStore.getInstance(hwKeyStoreType).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            return ecPublicKeyToUncompressedHex(keyStore, alias)
+        }
+        val kpg = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_EC,
+            hwKeyStoreType,
+        )
+        val parameterSpec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+        )
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+            .setIsStrongBoxBacked(false)
+            .build()
+        kpg.initialize(parameterSpec)
+        kpg.generateKeyPair()
+        return ecPublicKeyToUncompressedHex(keyStore, alias)
+    }
+
+    private fun hwGetPublicKey(alias: String): String {
+        val keyStore = KeyStore.getInstance(hwKeyStoreType).apply { load(null) }
+        if (!keyStore.containsAlias(alias)) {
+            throw IllegalStateException("Hardware keypair not initialized")
+        }
+        return ecPublicKeyToUncompressedHex(keyStore, alias)
+    }
+
+    /// Signs the payload with the hardware-backed private key. The key material
+    /// is never exposed to the app; signing happens inside the Keystore.
+    private fun hwSign(alias: String, payload: String): String {
+        val keyStore = KeyStore.getInstance(hwKeyStoreType).apply { load(null) }
+        val privateKey = keyStore.getKey(alias, null) as PrivateKey
+        val signature = Signature.getInstance("SHA256withECDSA")
+        signature.initSign(privateKey)
+        signature.update(payload.toByteArray(Charsets.UTF_8))
+        return signature.sign().toHex()
+    }
+
+    private fun hwClearKeyPair(alias: String) {
+        val keyStore = KeyStore.getInstance(hwKeyStoreType).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
+    private fun ecPublicKeyToUncompressedHex(keyStore: KeyStore, alias: String): String {
+        val cert = keyStore.getCertificate(alias)
+        val ecPub = cert.publicKey as ECPublicKey
+        val w = ecPub.w
+        val x = stripTo32Bytes(w.affineX.toByteArray())
+        val y = stripTo32Bytes(w.affineY.toByteArray())
+        val out = ByteArray(65)
+        out[0] = 0x04
+        System.arraycopy(x, 0, out, 1, 32)
+        System.arraycopy(y, 0, out, 33, 32)
+        return out.toHex()
+    }
+
+    private fun stripTo32Bytes(value: ByteArray): ByteArray {
+        return when {
+            value.size == 32 -> value
+            value.size > 32 -> value.copyOfRange(value.size - 32, value.size)
+            else -> ByteArray(32 - value.size) + value
+        }
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 
     private fun getBatteryLevel(): Int {
         val batteryLevel: Int

--- a/apps/customer/lib/services/keystore_binder.dart
+++ b/apps/customer/lib/services/keystore_binder.dart
@@ -1,165 +1,112 @@
 import 'dart:convert';
-import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter/services.dart';
 import 'package:pointycastle/export.dart';
 
-/// Hardware KeyStore & Secure Enclave Signature Binder Service.
+/// Hardware KeyStore Signature Binder Service.
 ///
-/// Generates an asymmetric keypair persisted in the OS-backed secure storage
-/// (Android Keystore / iOS Keychain via `flutter_secure_storage`) and produces
-/// real ECDSA (secp256r1, SHA-256) signatures over transaction payloads. The
-/// resulting signatures are non-deterministic and can only be produced by
-/// someone holding the stored private key, and are verifiable against the
+/// Generates an asymmetric keypair inside the OS-backed hardware keystore
+/// (Android Keystore) and produces real ECDSA (secp256r1, SHA-256) signatures
+/// over transaction payloads. The private key is generated *inside* the
+/// hardware keystore and is non-exportable: it never leaves the secure
+/// hardware and is never materialized as plaintext in the Dart process or in
+/// application storage. Signing is performed by the OS keystore itself, so a
+/// signature can only be produced by the hardware holding the key. The
+/// resulting signatures are non-deterministic and are verifiable against the
 /// returned public key.
 class HardwareKeyStoreBinder {
   static final HardwareKeyStoreBinder _instance = HardwareKeyStoreBinder._internal();
   factory HardwareKeyStoreBinder() => _instance;
   HardwareKeyStoreBinder._internal();
 
-  static const String _storageKeyPrivate = 'truxify_hw_keypair_private';
-  static const String _storageKeyPublic = 'truxify_hw_keypair_public';
-  static const int _keySizeBytes = 32;
+  static const MethodChannel _channel = MethodChannel('com.truxify.customer/native');
 
-  final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
+  /// Fixed alias under which the hardware keystore holds the non-exportable key.
+  static const String _keyAlias = 'truxify_hw_keypair';
 
-  /// Loads the persisted keypair or generates and stores a new EC keypair in
-  /// the OS-backed secure storage, returning the hex-encoded public key.
+  /// Ensures an EC keypair exists inside the hardware keystore and returns the
+  /// hex-encoded (uncompressed, 0x04|x|y) public key. The private key is
+  /// generated and stored inside the hardware keystore and is never returned.
   Future<String> generateHardwareKeypair() async {
-    final storedPublic = await _secureStorage.read(key: _storageKeyPublic);
-    if (storedPublic != null) {
-      return storedPublic;
+    final publicKey = await _channel.invokeMethod<String>(
+      'hwGenerateKeyPair',
+      {'alias': _keyAlias},
+    );
+    if (publicKey == null) {
+      throw StateError('Hardware KeyStore unavailable: failed to generate keypair');
     }
-
-    print('[Hardware KeyStore] Creating asymmetric keypair inside Secure Enclave/KeyStore...');
-    final domain = ECCurve_secp256r1();
-    final keyGen = ECKeyGenerator()
-      ..init(ParametersWithRandom(
-        ECKeyGeneratorParameters(domain),
-        _secureRandom(),
-      ));
-
-    final pair = keyGen.generateKeyPair();
-    final privateKey = pair.privateKey as ECPrivateKey;
-    final publicKey = pair.publicKey as ECPublicKey;
-
-    final privateHex = _bytesToHex(_bigIntToBytes(privateKey.d!, _keySizeBytes));
-    final publicHex = _bytesToHex(publicKey.Q!.getEncoded(false));
-
-    await _secureStorage.write(key: _storageKeyPrivate, value: privateHex);
-    await _secureStorage.write(key: _storageKeyPublic, value: publicHex);
-
-    return publicHex;
+    return publicKey;
   }
 
   /// Returns the stored public key hex, generating the keypair if missing.
   Future<String> getPublicKey() => generateHardwareKeypair();
 
-  /// Digitally signs a transaction payload using the stored private key,
-  /// returning a hex-encoded ECDSA (secp256r1 / SHA-256) signature.
+  /// Digitally signs a transaction payload using the hardware keystore private
+  /// key, returning a hex-encoded ECDSA (secp256r1 / SHA-256) signature.
   ///
-  /// The produced signature is randomized (non-deterministic) and proves
-  /// possession of the private key held in secure storage.
+  /// The actual signing happens inside the OS hardware keystore; the private
+  /// key material is never exposed to Dart. The produced signature is
+  /// randomized (non-deterministic).
   Future<String> signPayload(String payload) async {
     if (payload.isEmpty) {
       throw ArgumentError("Payload cannot be empty");
     }
 
-    print('[Hardware KeyStore] Authorizing hardware enclave signature...');
-    final privateKey = await _loadPrivateKey();
-    final signer = ECDSASigner(SHA256Digest())
-      ..init(true, PrivateKeyParameter<ECPrivateKey>(privateKey));
-
-    final message = Uint8List.fromList(utf8.encode(payload));
-    final signature = signer.generateSignature(message) as ECSignature;
-
-    final out = _bigIntToBytes(signature.r, _keySizeBytes) +
-        _bigIntToBytes(signature.s, _keySizeBytes);
-    return '0x${_bytesToHex(out)}';
+    final signature = await _channel.invokeMethod<String>(
+      'hwSign',
+      {'alias': _keyAlias, 'payload': payload},
+    );
+    if (signature == null) {
+      throw StateError('Hardware KeyStore signing failed');
+    }
+    return '0x$signature';
   }
 
   /// Verifies a hex-encoded ECDSA signature produced by [signPayload] against
-  /// the persisted public key and the given payload.
+  /// the persisted public key and the given payload. Verification uses only
+  /// the public key (which is not secret), so it is performed in Dart.
   Future<bool> verifySignature(String payload, String signatureHex) async {
     if (payload.isEmpty || signatureHex.isEmpty) {
       return false;
     }
 
-    final publicKey = await _loadPublicKey();
-    final verifier = ECDSASigner(SHA256Digest())
-      ..init(false, PublicKeyParameter<ECPublicKey>(publicKey));
+    try {
+      final publicKeyHex = await getPublicKey();
+      final domain = ECCurve_secp256r1();
+      final point = domain.curve.decodePoint(_hexToBytes(publicKeyHex))!;
+      final publicKey = ECPublicKey(point, domain);
 
-    final signature = _signatureFromHex(signatureHex);
-    final message = Uint8List.fromList(utf8.encode(payload));
-    return verifier.verifySignature(message, signature);
+      final verifier = ECDSASigner(SHA256Digest())
+        ..init(false, PublicKeyParameter<ECPublicKey>(publicKey));
+
+      final signature = _signatureFromDer(signatureHex);
+      final message = Uint8List.fromList(utf8.encode(payload));
+      return verifier.verifySignature(message, signature);
+    } catch (_) {
+      return false;
+    }
   }
 
-  /// Removes the persisted keypair from secure storage.
+  /// Removes the hardware keystore entry for the keypair.
   Future<void> clearKeyPair() async {
-    await _secureStorage.delete(key: _storageKeyPrivate);
-    await _secureStorage.delete(key: _storageKeyPublic);
+    await _channel.invokeMethod<void>(
+      'hwClearKeyPair',
+      {'alias': _keyAlias},
+    );
   }
 
-  Future<ECPrivateKey> _loadPrivateKey() async {
-    final stored = await _secureStorage.read(key: _storageKeyPrivate);
-    if (stored == null) {
-      await generateHardwareKeypair();
-      return _loadPrivateKey();
-    }
-    final domain = ECCurve_secp256r1();
-    return ECPrivateKey(BigInt.parse(stored, radix: 16), domain);
-  }
-
-  Future<ECPublicKey> _loadPublicKey() async {
-    final stored = await _secureStorage.read(key: _storageKeyPublic);
-    if (stored == null) {
-      await generateHardwareKeypair();
-      return _loadPublicKey();
-    }
-    final domain = ECCurve_secp256r1();
-    final point = domain.curve.decodePoint(_hexToBytes(stored))!;
-    return ECPublicKey(point, domain);
-  }
-
-  ECSignature _signatureFromHex(String signatureHex) {
+  /// Parses a DER-encoded ECDSA signature (as produced by the Android
+  /// Keystore's `SHA256withECDSA` signer) into an [ECSignature].
+  ECSignature _signatureFromDer(String signatureHex) {
     final hex = signatureHex.startsWith('0x')
         ? signatureHex.substring(2)
         : signatureHex;
-    final bytes = _hexToBytes(hex);
-    final r = BigInt.parse(
-      _bytesToHex(bytes.sublist(0, _keySizeBytes)),
-      radix: 16,
-    );
-    final s = BigInt.parse(
-      _bytesToHex(bytes.sublist(_keySizeBytes)),
-      radix: 16,
-    );
+    final der = _hexToBytes(hex);
+    final sequence = ASN1Parser(der).nextObject() as ASN1Sequence;
+    final r = (sequence.elements[0] as ASN1Integer).integer!;
+    final s = (sequence.elements[1] as ASN1Integer).integer!;
     return ECSignature(r, s);
-  }
-
-  SecureRandom _secureRandom() {
-    final secureRandom = SecureRandom('Fortuna');
-    final seed = Uint8List(_keySizeBytes);
-    final rng = Random.secure();
-    for (var i = 0; i < seed.length; i++) {
-      seed[i] = rng.nextInt(256);
-    }
-    secureRandom.seed(KeyParameter(seed));
-    return secureRandom;
-  }
-
-  Uint8List _bigIntToBytes(BigInt value, int length) {
-    var bytes = <int>[];
-    var v = value;
-    while (v > BigInt.zero) {
-      bytes.insert(0, (v & BigInt.from(0xff)).toInt());
-      v >>= 8;
-    }
-    while (bytes.length < length) {
-      bytes.insert(0, 0);
-    }
-    return Uint8List.fromList(bytes);
   }
 
   Uint8List _hexToBytes(String hex) {
@@ -169,13 +116,5 @@ class HardwareKeyStoreBinder {
       result[i] = int.parse(clean.substring(i * 2, i * 2 + 2), radix: 16);
     }
     return result;
-  }
-
-  String _bytesToHex(Uint8List bytes) {
-    final buffer = StringBuffer();
-    for (final b in bytes) {
-      buffer.write(b.toRadixString(16).padLeft(2, '0'));
-    }
-    return buffer.toString();
   }
 }


### PR DESCRIPTION
## Problem

The Flutter "Hardware KeyStore" binder (`apps/customer/lib/services/keystore_binder.dart`) only *pretended* to be hardware-backed:

- The EC P-256 keypair was generated in pure Dart (`pointycastle`) and the **private key was stored as plaintext hex** in `flutter_secure_storage`.
- Signing was performed in Dart over that extracted plaintext private key.

This means the private key was fully extractable from app storage and signatures could be produced by anyone who read it — it was never bound to secure hardware, defeating the entire purpose of a "Hardware KeyStore".

## Fix

- Removed all plaintext private-key storage/extraction. The private key is now generated **inside** the Android Keystore (`KeyGenParameterSpec` with `PURPOSE_SIGN`, EC secp256r1, SHA-256) and is non-exportable.
- Signing is now delegated to the OS keystore via the existing `com.truxify.customer/native` `MethodChannel` (`hwGenerateKeyPair`, `hwGetPublicKey`, `hwSign`, `hwClearKeyPair`). The private key material never leaves secure hardware and is never visible to the Dart process.
- Dart now only ever receives the public key and DER signatures; verification still runs in Dart against the public key (which is not secret).
- The repo ships only an Android target (no `ios/` dir), so the binding is implemented against the Android Keystore (which is hardware-backed on capable devices, with StrongBox support available).

## Files changed

- `apps/customer/lib/services/keystore_binder.dart` — rewritten to call the hardware keystore over `MethodChannel`; no plaintext key handling.
- `apps/customer/android/app/src/main/kotlin/com/truxify/customer/MainActivity.kt` — added hardware keystore handlers (key generation, sign, get public key, clear) using the Android Keystore.

## Testing

- Manual verification requires an Android device/emulator (the keystore is only available on a real Android runtime, not `flutter test`).
- Confirmed via code review that: (1) no private key is written/read as plaintext, (2) signing uses `Signature.getInstance("SHA256withECDSA")` backed by the Android Keystore private key, and (3) the returned public key (uncompressed 0x04|x|y) and DER signatures are parsed/verified consistently in Dart.

Closes #14736
