### PR TITLE
fix(flutter): wire biometric success to real re-auth and navigation (#14738)

### DIFF
--- a/apps/customer/lib/l10n/app_en.arb
+++ b/apps/customer/lib/l10n/app_en.arb
@@ -178,6 +178,11 @@
     "description": "Success message after biometric authentication"
   },
 
+  "biometricAuthRequiresSession": "No saved session found. Please sign in with your phone number first.",
+  "@biometricAuthRequiresSession": {
+    "description": "Message shown when biometric success has no cached session to re-authenticate"
+  },
+
   "pleaseEnterPhone": "Please enter your phone number",
   "@pleaseEnterPhone": {
     "description": "Validation message when phone number field is empty"

--- a/apps/customer/lib/l10n/app_hi.arb
+++ b/apps/customer/lib/l10n/app_hi.arb
@@ -178,6 +178,11 @@
     "description": "Success message after biometric authentication"
   },
 
+  "biometricAuthRequiresSession": "कोई सहेजा गया सत्र नहीं मिला। कृपया पहले अपने फ़ोन नंबर से साइन इन करें।",
+  "@biometricAuthRequiresSession": {
+    "description": "Message shown when biometric success has no cached session to re-authenticate"
+  },
+
   "pleaseEnterPhone": "कृपया अपना फ़ोन नंबर दर्ज करें",
   "@pleaseEnterPhone": {
     "description": "Validation message when phone number field is empty"

--- a/apps/customer/lib/l10n/app_kn.arb
+++ b/apps/customer/lib/l10n/app_kn.arb
@@ -178,6 +178,11 @@
     "description": "Success message after biometric authentication"
   },
 
+  "biometricAuthRequiresSession": "ಯಾವುದೇ ಉಳಿಸಿದ ಸೆಷನ್ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಮೊದಲು ನಿಮ್ಮ ಫೋನ್ ಸಂಖ್ಯೆಯೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ.",
+  "@biometricAuthRequiresSession": {
+    "description": "Message shown when biometric success has no cached session to re-authenticate"
+  },
+
   "pleaseEnterPhone": "ದಯವಿಟ್ಟು ನಿಮ್ಮ ಫೋನ್ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ",
   "@pleaseEnterPhone": {
     "description": "Validation message when phone number field is empty"

--- a/apps/customer/lib/l10n/app_localizations.dart
+++ b/apps/customer/lib/l10n/app_localizations.dart
@@ -197,6 +197,9 @@ abstract class AppLocalizations {
   /// Success message after biometric authentication
   String get biometricAuthSuccessful;
 
+  /// Message shown when biometric success has no cached session to re-authenticate
+  String get biometricAuthRequiresSession;
+
   /// Validation message when phone number field is empty
   String get pleaseEnterPhone;
 

--- a/apps/customer/lib/l10n/app_localizations_en.dart
+++ b/apps/customer/lib/l10n/app_localizations_en.dart
@@ -108,6 +108,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get biometricAuthSuccessful => 'Biometric authentication successful';
 
   @override
+  String get biometricAuthRequiresSession =>
+      'No saved session found. Please sign in with your phone number first.';
+
+  @override
   String get pleaseEnterPhone => 'Please enter your phone number';
 
   @override

--- a/apps/customer/lib/l10n/app_localizations_hi.dart
+++ b/apps/customer/lib/l10n/app_localizations_hi.dart
@@ -108,6 +108,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get biometricAuthSuccessful => 'बायोमेट्रिक प्रमाणीकरण सफल';
 
   @override
+  String get biometricAuthRequiresSession =>
+      'कोई सहेजा गया सत्र नहीं मिला। कृपया पहले अपने फ़ोन नंबर से साइन इन करें।';
+
+  @override
   String get pleaseEnterPhone => 'कृपया अपना फ़ोन नंबर दर्ज करें';
 
   @override

--- a/apps/customer/lib/l10n/app_localizations_kn.dart
+++ b/apps/customer/lib/l10n/app_localizations_kn.dart
@@ -108,6 +108,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get biometricAuthSuccessful => 'ಬಯೋಮೆಟ್ರಿಕ್ ದೃಢೀಕರಣ ಯಶಸ್ವಿಯಾಗಿದೆ';
 
   @override
+  String get biometricAuthRequiresSession =>
+      'ಯಾವುದೇ ಉಳಿಸಿದ ಸೆಷನ್ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಮೊದಲು ನಿಮ್ಮ ಫೋನ್ ಸಂಖ್ಯೆಯೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ.';
+
+  @override
   String get pleaseEnterPhone => 'ದಯವಿಟ್ಟು ನಿಮ್ಮ ಫೋನ್ ಸಂಖ್ಯೆಯನ್ನು ನಮೂದಿಸಿ';
 
   @override

--- a/apps/customer/lib/l10n/app_localizations_mr.dart
+++ b/apps/customer/lib/l10n/app_localizations_mr.dart
@@ -108,6 +108,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get biometricAuthSuccessful => 'बायोमेट्रिक प्रमाणीकरण यशस्वी';
 
   @override
+  String get biometricAuthRequiresSession =>
+      'सेव्ह केलेले सत्र सापडले नाही. कृपया प्रथम तुम्ही तुमच्या फोन नंबरने साइन इन करा.';
+
+  @override
   String get pleaseEnterPhone => 'कृपया तुमचा फोन नंबर प्रविष्ट करा';
 
   @override

--- a/apps/customer/lib/l10n/app_localizations_ta.dart
+++ b/apps/customer/lib/l10n/app_localizations_ta.dart
@@ -108,6 +108,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get biometricAuthSuccessful => 'பயோமெட்ரிக் அங்கீகாரம் வெற்றிகரமாக முடிந்தது';
 
   @override
+  String get biometricAuthRequiresSession =>
+      'சேமிக்கப்பட்ட அமர்வு எதுவும் கிடைக்கவில்லை. முதலில் உங்கள் தொலைபேசி எண்ணுடன் உள்நுழையவும்.';
+
+  @override
   String get pleaseEnterPhone => 'உங்கள் தொலைபேசி எண்ணை உள்ளிடவும்';
 
   @override

--- a/apps/customer/lib/l10n/app_mr.arb
+++ b/apps/customer/lib/l10n/app_mr.arb
@@ -178,6 +178,11 @@
     "description": "Success message after biometric authentication"
   },
 
+  "biometricAuthRequiresSession": "सेव्ह केलेले सत्र सापडले नाही. कृपया प्रथम तुम्ही तुमच्या फोन नंबरने साइन इन करा.",
+  "@biometricAuthRequiresSession": {
+    "description": "Message shown when biometric success has no cached session to re-authenticate"
+  },
+
   "pleaseEnterPhone": "कृपया तुमचा फोन नंबर प्रविष्ट करा",
   "@pleaseEnterPhone": {
     "description": "Validation message when phone number field is empty"

--- a/apps/customer/lib/l10n/app_ta.arb
+++ b/apps/customer/lib/l10n/app_ta.arb
@@ -178,6 +178,11 @@
     "description": "Success message after biometric authentication"
   },
 
+  "biometricAuthRequiresSession": "சேமிக்கப்பட்ட அமர்வு எதுவும் கிடைக்கவில்லை. முதலில் உங்கள் தொலைபேசி எண்ணுடன் உள்நுழையவும்.",
+  "@biometricAuthRequiresSession": {
+    "description": "Message shown when biometric success has no cached session to re-authenticate"
+  },
+
   "pleaseEnterPhone": "உங்கள் தொலைபேசி எண்ணை உள்ளிடவும்",
   "@pleaseEnterPhone": {
     "description": "Validation message when phone number field is empty"

--- a/apps/customer/lib/screens/login_screen.dart
+++ b/apps/customer/lib/screens/login_screen.dart
@@ -105,16 +105,31 @@ class _LoginScreenState extends State<LoginScreen> {
         ),
       );
 
-      if (authenticated) {
-        if (!mounted) return;
+      if (!authenticated) return;
+
+      if (!mounted) return;
+
+      // Biometric success only proves the device owner; it does not by itself
+      // establish a Firebase session. Only proceed when a real session exists and
+      // re-confirm/refresh it, otherwise report that a session is required.
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(
-                AppLocalizations.of(context)!.biometricAuthSuccessful),
+            content: Text(AppLocalizations.of(context)!
+                .biometricAuthRequiresSession),
             duration: const Duration(seconds: 4),
           ),
         );
+        return;
       }
+
+      await user.reload();
+      await _authService.getIdToken(forceRefresh: true);
+
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+          AppPageRoute(builder: (_) => const TruxifyShellScreen()));
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Problem

`apps/customer/lib/screens/login_screen.dart` `_authenticateWithBiometrics` called `LocalAuthentication.authenticate(...)` and, on success, only displayed a "Biometric authentication successful" Snackbar. It performed no Firebase re-authentication and no navigation. Because this app authenticates via Firebase phone-OTP and `SplashScreen`/auth state gate on `FirebaseAuth.instance.currentUser`, the biometric button was a no-op: it gave a false sense of login but never established or confirmed a session, and never entered the app.

## Fix

Rewired the biometric flow so success is meaningful:
- On biometric success, read `FirebaseAuth.instance.currentUser`.
- If a cached session exists, `reload()` the user and refresh the ID token via `AuthService.getIdToken(forceRefresh: true)` to re-confirm/refresh the session, then `Navigator.pushReplacement` into `TruxifyShellScreen` — matching exactly what the OTP and auto-verification paths do.
- If no cached session exists (e.g. first run / signed-out device), do NOT show false success. Instead show a clear message (`biometricAuthRequiresSession`) telling the user to sign in with their phone number first.

Added the `biometricAuthRequiresSession` localization string (en/hi/kn/mr/ta) and its generated delegates. Removed the cosmetic-only success Snackbar so "success" now always corresponds to a real auth + transition.

## Files changed

- apps/customer/lib/screens/login_screen.dart
- apps/customer/lib/l10n/app_en.arb
- apps/customer/lib/l10n/app_hi.arb
- apps/customer/lib/l10n/app_kn.arb
- apps/customer/lib/l10n/app_mr.arb
- apps/customer/lib/l10n/app_ta.arb
- apps/customer/lib/l10n/app_localizations.dart
- apps/customer/lib/l10n/app_localizations_en.dart
- apps/customer/lib/l10n/app_localizations_hi.dart
- apps/customer/lib/l10n/app_localizations_kn.dart
- apps/customer/lib/l10n/app_localizations_mr.dart
- apps/customer/lib/l10n/app_localizations_ta.dart

## Testing

- Manual review: biometric-success path now re-confirms the cached Firebase session (`user.reload()` + `getIdToken(forceRefresh: true)`) and navigates to `TruxifyShellScreen`; no-session path surfaces the new `biometricAuthRequiresSession` message instead of a misleading success.
- Change mirrors the existing OTP (`_verifyOtp`) and auto-verification (`onAutoVerification`) navigation behavior already used in this screen.
- Note: `flutter` toolchain is not available in this environment, so `flutter analyze`/build was not executed; the edit is syntactically consistent with surrounding code and existing `AuthService`/`FirebaseAuth` APIs.

Closes #14738
