### PR TITLE
build: resolve gpu-routing-cuda CMakeLists conflict and re-enable VRP test (#14725)

### DIFF
--- a/services/gpu-routing-cuda/CMakeLists.txt
+++ b/services/gpu-routing-cuda/CMakeLists.txt
@@ -9,8 +9,6 @@ include_directories(include)
 add_library(gpu_vrp
     src/cuda_vrp.cu
 )
-<<<<<<< HEAD
-=======
 
 enable_testing()
 
@@ -20,4 +18,3 @@ add_executable(gpu_vrp_tests
 target_link_libraries(gpu_vrp_tests PRIVATE gpu_vrp)
 
 add_test(NAME gpu_vrp_tests COMMAND gpu_vrp_tests)
->>>>>>> upstream/main


### PR DESCRIPTION
## Problem

`services/gpu-routing-cuda/CMakeLists.txt:12-23` contained unresolved git merge-conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>> upstream/main`) wrapping the test wiring block. CMake aborts on the literal markers, so the `gpu-routing-cuda` target fails to configure/build, and since the `gpu_vrp_tests` executable/test existed only in the non-HEAD branch, the VRP regression test was left completely untested.

## Fix

Removed the three merge-conflict markers and kept the test wiring block from `upstream/main`, so CMake configures/builds both the library and the VRP test:
- `enable_testing()`
- `add_executable(gpu_vrp_tests src/cuda_vrp_tests.cu)`
- `target_link_libraries(gpu_vrp_tests PRIVATE gpu_vrp)`
- `add_test(NAME gpu_vrp_tests COMMAND gpu_vrp_tests)`

## Files changed

- `services/gpu-routing-cuda/CMakeLists.txt` (removed conflict markers, re-enabled VRP test)

## Testing

- Verified no `<<<<<<<`/`=======`/`>>>>>>>` markers remain in the file.
- Confirmed the `gpu_vrp_tests` executable and `add_test` are defined so CMake will configure and build the test.

Closes #14725