### PR TITLE
fix(svc): sum per-vehicle distances in gpu solveParallelVRP (#14727)

### DIFF
--- a/services/gpu-routing-cuda/src/cuda_vrp.cu
+++ b/services/gpu-routing-cuda/src/cuda_vrp.cu
@@ -36,15 +36,17 @@ VrpSolution CudaVrpSolver::solveParallelVRP(
     }
 
     float distance = 0.0f;
-    Location prev = depot;
 
-    for (const auto& stop : stops) {
-        distance += static_cast<float>(haversineMeters(prev.y, prev.x, stop.y, stop.x));
-        prev = stop;
+    for (size_t rs = 0; rs < stops.size(); rs += vehicleCapacity) {
+        size_t re = std::min(rs + vehicleCapacity, stops.size());
+        Location prev = depot;
+        for (size_t i = rs; i < re; ++i) {
+            distance += static_cast<float>(haversineMeters(prev.y, prev.x, stops[i].y, stops[i].x));
+            prev = stops[i];
+        }
+        // Return to depot for this route.
+        distance += static_cast<float>(haversineMeters(prev.y, prev.x, depot.y, depot.x));
     }
-
-    // Return to depot
-    distance += static_cast<float>(haversineMeters(prev.y, prev.x, depot.y, depot.x));
 
     size_t routesNeeded = (stops.size() + vehicleCapacity - 1) / vehicleCapacity;
 


### PR DESCRIPTION
## Problem

`services/gpu-routing-cuda/src/cuda_vrp.cu` `solveParallelVRP` computed `totalDistance` as a single continuous tour (`depot -> stop1 -> ... -> stopN -> depot`) regardless of `vehicleCapacity`, while reporting `routeCount = ceil(stops.size() / vehicleCapacity)`. When `vehicleCapacity < stops.size()`, multiple vehicles are claimed yet the distance reflects only one combined route, under-reporting the true cost and biasing capacity planning.

## Fix

Partition stops into `ceil(n / vehicleCapacity)` capacity-bounded chunks and sum each sub-tour's depot round-trip distance. This makes the reported distance consistent with the reported route count.

## Files changed

- `services/gpu-routing-cuda/src/cuda_vrp.cu`

## Testing

The repo's `cuda_vrp_tests.cu` `refTourTotal` helper already mirrors capacity-bounded routing. The change makes `solveParallelVRP` match it for capacity >= n, capacity == 1, and capacity == 2, and passes the consistency check that distance must differ from the single-tour value when routes > 1.

Closes #14727
