### PR TITLE
fix(wasm): guard divide-by-zero in calculate_eta/aggregate_prices (#14728)

### DIFF
--- a/wasm/edge-runtime.js
+++ b/wasm/edge-runtime.js
@@ -75,7 +75,7 @@ class EdgeRuntime {
                             return selected;
                         },
                         calculate_eta: (distance, speed, trafficFactor) =>
-                            distance / (speed * Math.max(1.0 - (trafficFactor || 0), 0.1)),
+                            distance / (Math.max(speed, 1e-6) * Math.max(1.0 - (trafficFactor || 0), 0.1)),
                         filter_drivers: (drivers, minRating) =>
                             (drivers || []).filter((d) => d.status !== 'offline' && d.rating >= (minRating || 0)),
                         aggregate_prices: (prices) =>

--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -103,7 +103,8 @@ pub fn optimize_loads(loads: &[f64], capacity: f64) -> Vec<usize> {
 #[wasm_bindgen]
 pub fn calculate_eta(distance: f64, speed: f64, traffic_factor: f64) -> f64 {
     // Fast ETA calculation at edge
-    let effective_speed = speed * (1.0 - traffic_factor);
+    let factor = (1.0 - traffic_factor).max(0.1);
+    let effective_speed = speed.max(1e-6) * factor;
     distance / effective_speed
 }
 
@@ -125,6 +126,9 @@ pub fn filter_drivers(drivers: Vec<DriverData>, min_rating: f64) -> Vec<DriverDa
 
 #[wasm_bindgen]
 pub fn aggregate_prices(prices: Vec<f64>) -> f64 {
+    if prices.is_empty() {
+        return 0.0;
+    }
     prices.iter().sum::<f64>() / prices.len() as f64
 }
 


### PR DESCRIPTION
## Problem

`wasm/rust/src/lib.rs` could produce non-finite, and inconsistent-with-fallback, results:
- `calculate_eta` computed `distance / (speed * (1.0 - traffic_factor))`. With `speed == 0` this divided by zero (inf/NaN), and with `traffic_factor >= 1.0` the effective speed became `<= 0` (negative/inf ETA).
- `aggregate_prices` computed `sum / len` for empty input, giving `0.0 / 0.0 = NaN`.

The JS fallback (`wasm/edge-runtime.js`) already guarded the empty case and floored the traffic factor, but had no `speed` guard, so WASM and the fallback still diverged (and neither fully guarded `speed == 0`).

## Fix

- `calculate_eta`: clamp the traffic factor to a minimum of `0.1` and the speed to a minimum of `1e-6`, so the divisor is always a small positive finite number.
- `aggregate_prices`: return `0.0` for empty input instead of dividing by zero.
- `wasm/edge-runtime.js` `calculate_eta`: add the same `Math.max(speed, 1e-6)` guard so the fallback matches the WASM implementation exactly.

## Files changed

- `wasm/rust/src/lib.rs` — guard divide-by-zero in `calculate_eta` and `aggregate_prices`.
- `wasm/edge-runtime.js` — add `speed` guard to `calculate_eta` fallback so it matches WASM.

## Testing

- `calculate_eta(d, 0.0, 0.5)` → finite (was inf/NaN); matches JS fallback.
- `calculate_eta(d, 40.0, 1.0)` → finite (factor clamped to 0.1); matches JS fallback.
- `aggregate_prices([])` → `0.0` (was NaN); matches JS fallback guard.
- `aggregate_prices(vec![a, b, c])` unchanged mean behavior.

Closes #14728
