### PR TITLE
build/ebpf: resolve threat_detection.c conflict and fix userspace deref (#14724)

### DIFF
--- a/ebpf/security/threat_detection.c
+++ b/ebpf/security/threat_detection.c
@@ -6,8 +6,6 @@
 
 char LICENSE[] SEC("license") = "GPL";
 
-<<<<<<< HEAD
-=======
 #ifndef AF_INET
 #define AF_INET 2
 #endif
@@ -47,7 +45,6 @@ static __always_inline int str_contains(const char *str, int str_len, const char
     return 0;
 }
 
->>>>>>> upstream/main
 // Map for threat events
 struct {
     __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
@@ -71,25 +68,6 @@ struct {
     __type(value, __u64);    // file hash
 } file_hashes SEC(".maps");
 
-<<<<<<< HEAD
-// Tracepoint for failed login attempts
-SEC("tracepoint/syscalls/sys_enter_openat")
-int trace_file_access(struct trace_event_raw_sys_enter *args)
-{
-    const char *filename = (const char *)args->args[1];
-    
-    // Check for sensitive files
-    const char *sensitive_files[] = {
-        "/etc/passwd",
-        "/etc/shadow",
-        "/etc/sudoers",
-        "/root/.ssh/id_rsa",
-        "/etc/ssl/private/"
-    };
-    
-    for (int i = 0; i < 5; i++) {
-        if (strncmp(filename, sensitive_files[i], strlen(sensitive_files[i])) == 0) {
-=======
 // Tracepoint for sensitive file access
 SEC("tracepoint/syscalls/sys_enter_openat")
 int trace_file_access(struct trace_event_raw_sys_enter *args)
@@ -100,7 +78,7 @@ int trace_file_access(struct trace_event_raw_sys_enter *args)
     if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[1]) < 0) {
         return 0;
     }
-    
+
     // Check for sensitive files
     struct {
         const char *path;
@@ -112,36 +90,16 @@ int trace_file_access(struct trace_event_raw_sys_enter *args)
         { "/root/.ssh/id_rsa", 17 },
         { "/etc/ssl/private/", 17 }
     };
-    
+
     for (int i = 0; i < 5; i++) {
         if (str_has_prefix(filename, sensitive_files[i].path, sensitive_files[i].len)) {
->>>>>>> upstream/main
             bpf_printk("Sensitive file access: %s\n", filename);
         }
     }
-    
+
     return 0;
 }
 
-<<<<<<< HEAD
-// Tracepoint for failed login attempts
-SEC("tracepoint/syscalls/sys_enter_execve")
-int trace_process_exec(struct trace_event_raw_sys_enter *args)
-{
-    const char *filename = (const char *)args->args[0];
-    
-    // Check for suspicious processes
-    const char *suspicious_processes[] = {
-        "nc", "netcat", "ncat",
-        "telnet", "ftp", "sshpass",
-        "curl", "wget",
-        "python -c", "perl -e",
-        "bash -i", "sh -i"
-    };
-    
-    for (int i = 0; i < 11; i++) {
-        if (strstr(filename, suspicious_processes[i]) != NULL) {
-=======
 // Tracepoint for process execution
 SEC("tracepoint/syscalls/sys_enter_execve")
 int trace_process_exec(struct trace_event_raw_sys_enter *args)
@@ -152,7 +110,7 @@ int trace_process_exec(struct trace_event_raw_sys_enter *args)
     if (bpf_probe_read_user_str(filename, sizeof(filename), (void *)(long)args->args[0]) < 0) {
         return 0;
     }
-    
+
     // Check for suspicious processes
     struct {
         const char *name;
@@ -164,14 +122,13 @@ int trace_process_exec(struct trace_event_raw_sys_enter *args)
         { "python -c", 9 }, { "perl -e", 7 },
         { "bash -i", 7 }, { "sh -i", 5 }
     };
-    
+
     for (int i = 0; i < 12; i++) {
         if (str_contains(filename, sizeof(filename), suspicious_processes[i].name, suspicious_processes[i].len)) {
->>>>>>> upstream/main
             bpf_printk("Suspicious process: %s\n", filename);
         }
     }
-    
+
     return 0;
 }
 
@@ -179,9 +136,6 @@ int trace_process_exec(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/syscalls/sys_enter_connect")
 int trace_network_connect(struct trace_event_raw_sys_enter *args)
 {
-<<<<<<< HEAD
-    __u32 port = (__u32)args->args[1];
-=======
     __u32 port = 0;
     __u16 family = 0;
     __u16 sin_port = 0;
@@ -204,8 +158,7 @@ int trace_network_connect(struct trace_event_raw_sys_enter *args)
     } else {
         return 0;
     }
->>>>>>> upstream/main
-    
+
     // Check for suspicious ports
     const __u32 suspicious_ports[] = {
         22,  // SSH
@@ -218,13 +171,13 @@ int trace_network_connect(struct trace_event_raw_sys_enter *args)
         6667, // IRC
         1337  // Common backdoor port
     };
-    
+
     for (int i = 0; i < 9; i++) {
         if (port == suspicious_ports[i]) {
             bpf_printk("Suspicious connection attempt on port: %d\n", port);
         }
     }
-    
+
     return 0;
 }
 
@@ -233,12 +186,12 @@ SEC("tracepoint/syscalls/sys_enter_setuid")
 int trace_setuid(struct trace_event_raw_sys_enter *args)
 {
     __u32 uid = (__u32)args->args[0];
-    
+
     // Check for root escalation
     if (uid == 0) {
         bpf_printk("Potential privilege escalation to root\n");
     }
-    
+
     return 0;
 }
 
@@ -246,11 +199,6 @@ int trace_setuid(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/syscalls/sys_enter_rename")
 int trace_file_rename(struct trace_event_raw_sys_enter *args)
 {
-<<<<<<< HEAD
-    const char *oldpath = (const char *)args->args[0];
-    const char *newpath = (const char *)args->args[1];
-    
-=======
     char oldpath[256];
     char newpath[256];
     // args->args[0] and args->args[1] are userspace pointers to the path
@@ -263,9 +211,8 @@ int trace_file_rename(struct trace_event_raw_sys_enter *args)
         return 0;
     }
 
->>>>>>> upstream/main
     bpf_printk("File renamed: %s -> %s\n", oldpath, newpath);
-    
+
     return 0;
 }
 
@@ -275,10 +222,10 @@ int trace_process_exit(struct trace_event_raw_sched_process_exit *args)
 {
     __u32 pid = args->pid;
     __u32 exit_code = args->exit_code;
-    
+
     if (exit_code != 0) {
         bpf_printk("Process %d exited with code %d\n", pid, exit_code);
     }
-    
+
     return 0;
 }


### PR DESCRIPTION
## Problem

`ebpf/security/threat_detection.c` still contained unresolved git merge-conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>> upstream/main`), so `clang -target bpf` failed to compile it and threat detection was non-functional. Even ignoring the markers, the `HEAD` variant was broken at runtime: it dereferenced userspace pointers directly in BPF context (`filename` in `trace_file_access`/`trace_process_exec` via `strncmp`/`strstr`, and `args[1]` in `trace_network_connect` treated as a port), which the BPF verifier rejects or faults on. In `trace_network_connect`, `args[1]` is actually a pointer to `struct sockaddr`, not a port, so port detection never matched.

## Fix

- Removed all merge-conflict markers, resolving every conflict to the `upstream/main` branch.
- Filenames/paths are now read safely via `bpf_probe_read_user_str` into bounded stack buffers before any string matching (`trace_file_access`, `trace_process_exec`, `trace_file_rename`).
- In `trace_network_connect`, the sockaddr is read via `bpf_probe_read_user` to obtain `sa_family` and the `__u16` port at offset 2, then normalized with `bpf_ntohs` (verifier-safe, no raw userspace deref).
- Kept the `str_has_prefix`/`str_contains` helper-based matching and the `AF_INET`/`AF_INET6` defines from the upstream branch.

## Files changed

- `ebpf/security/threat_detection.c`

## Testing

- Verified no merge-conflict markers remain and no `strncmp`/`strstr` userspace dereferences exist in the file.
- The change is a localized resolution of the conflict to the safe `bpf_probe_read_user*` variant; build verification requires the project's `clang -target bpf` toolchain.

Closes #14724
