### PR TITLE
fix(backend): register POST /api/orders/:id/confirm-otp alias for verify-delivery (#14721)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -336,31 +336,6 @@ router.get('/load-offers/en-route', authenticate, userLimiter, requirePolicy('lo
   }
 });
 
-// ============================================================================
-// 13c. DRIVER OTP CONFIRM ALIAS — POST /api/orders/:id/confirm-otp
-// ============================================================================
-/**
- * Friendly alias of /:id/verify-delivery for the driver app.
- * Accepts the same body { otp } and delegates to the same pipeline.
- * Registered on the orders router as /:id/confirm-otp, exposed to the driver
- * app at /api/orders/:id/confirm-otp via the /api/orders mount in index.js.
- *
- * This keeps the driver app URL surface clean while reusing identical logic.
- */
-const handleDeliveryVerification = async (req, res) => {
-  try {
-    let order = null;
-    if (UUID_RE.test(orderId)) {
-      const { data: orderById } = await orderRepository.findOrderForTimeline(orderId);
-      order = orderById;
-    }
-    if (!order) {
-      const { data: orderByDisplay } = await orderRepository.findOrderByDisplayForTimeline(orderId);
-      order = orderByDisplay;
-    }
-
-    if (!order) return res.status(404).json({ error: 'Order not found.' });
-
 // 8. SUBMIT BID FOR LOAD OFFER (DRIVER)
 router.post('/:id/bids', authenticate, userLimiter, requireRole(['driver']), bidLimiter, validateParams(paramIdSchema), validateBody(submitBidSchema), submitBid);
 
@@ -378,6 +353,12 @@ router.put('/:id/milestones', authenticate, userLimiter, requireRole(['driver'])
 
 // 13. VERIFY DELIVERY OTP AND RELEASE FUNDS (DRIVER)
 router.post('/:id/verify-delivery', authenticate, userLimiter, requireRole(['driver']), verifyDeliveryLimiter, requireIdempotency(86400), validateParams(paramIdSchema), validateBody(verifyDeliverySchema), verifyDeliveryController);
+
+// 13c. DRIVER OTP CONFIRM ALIAS — POST /api/orders/:id/confirm-otp
+// Friendly alias of /:id/verify-delivery for the driver app. It accepts the
+// same body { otp } and delegates to the identical pipeline so the driver's
+// Confirm Delivery flow can release the escrow and credit the wallet.
+router.post('/:id/confirm-otp', authenticate, userLimiter, requireRole(['driver']), verifyDeliveryLimiter, requireIdempotency(86400), validateParams(paramIdSchema), validateBody(verifyDeliverySchema), verifyDeliveryController);
 
 // 14. RESEND DELIVERY OTP (DRIVER)
 router.post('/:id/resend-otp', authenticate, userLimiter, resendOtpLimiter, requireRole(['driver']), validateParams(paramIdSchema), resendOtp);


### PR DESCRIPTION
## Problem

The driver app delivery confirmation screen calls `POST /api/orders/:id/confirm-otp` (`apps/driver/lib/screens/delivery_otp_screen.dart:192`), and the backend contract test expects that endpoint to return 200 with `payment_released: true`, numeric `amount_inr`, and `order_display_id`. The backend never registered this route: `backend/api/src/routes/orderRoutes.js` contained a dead, broken `handleDeliveryVerification` stub (referencing an out-of-scope `UUID_RE`, `orderId`, and `orderRepository`) and never declared `router.post('/:id/confirm-otp', ...)`. As a result, every Confirm Delivery request fell through to the default Express 404 handler, so the delivery OTP could never be confirmed and the escrow release + `complete_trip_tx` wallet credit were unreachable through the driver app.

## Fix

Removed the dead `handleDeliveryVerification` stub and its misleading comment, and registered `POST /api/orders/:id/confirm-otp` as a true alias of `/:id/verify-delivery`, reusing the exact same middleware and controller pipeline (`authenticate, userLimiter, requireRole(['driver']), verifyDeliveryLimiter, requireIdempotency(86400), validateParams(paramIdSchema), validateBody(verifyDeliverySchema), verifyDeliveryController`). The driver Confirm Delivery flow now hits the same verified path that releases escrow and credits the wallet.

## Files changed

- `backend/api/src/routes/orderRoutes.js` — deleted the broken stub and registered the `/:id/confirm-otp` alias route.

## Testing

- `node --check` confirms the file parses (no syntax errors from the change).
- The existing contract test `backend/api/test/contracts/delivery.contract.test.js` (the "200: confirm-otp returns numeric amount_inr and non-null order_display_id" case) now exercises a real, mounted route instead of 404.

Closes #14721
