### PR TITLE
fix(wasm): guard empty input in aggregate_prices (#14717)

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -125,6 +125,9 @@ pub fn filter_drivers(drivers: Vec<DriverData>, min_rating: f64) -> Vec<DriverDa
 
 #[wasm_bindgen]
 pub fn aggregate_prices(prices: Vec<f64>) -> f64 {
+    if prices.is_empty() {
+        return 0.0;
+    }
     prices.iter().sum::<f64>() / prices.len() as f64
 }
 
@@ -159,4 +162,21 @@ pub fn compress_data(data: &[u8]) -> Vec<u8> {
     compressed.push(count);
     
     compressed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_prices_empty_returns_zero_not_nan() {
+        let result = aggregate_prices(vec![]);
+        assert_eq!(result, 0.0);
+        assert!(!result.is_nan());
+    }
+
+    #[test]
+    fn aggregate_prices_computes_average() {
+        assert_eq!(aggregate_prices(vec![10.0, 20.0, 30.0]), 20.0);
+    }
 }


### PR DESCRIPTION
## Problem

`aggregate_prices` divides the sum of prices by the count without guarding an empty input. When called with an empty `Vec<f64>`, `prices.len()` is `0`, so the expression evaluates to `0.0 / 0.0`, which is `NaN`. That non-finite average silently propagates into downstream fare/price aggregation consumers (route planning, quotes), producing undefined UI/edge behavior.

## Fix

Added an explicit empty-input guard in `aggregate_prices` that returns `0.0` before the division. Also added unit tests asserting `aggregate_prices(vec![])` returns `0.0` (not `NaN`) and that the normal average computation is preserved.

## Files changed

- `wasm/rust/src/lib.rs` — guard empty input in `aggregate_prices` and add unit tests.

## Testing

- Added `#[cfg(test)]` unit tests in `wasm/rust/src/lib.rs`:
  - `aggregate_prices_empty_returns_zero_not_nan` — verifies empty input yields `0.0` and is not `NaN`.
  - `aggregate_prices_computes_average` — verifies `[10.0, 20.0, 30.0]` averages to `20.0`.

Closes #14717
