### PR TITLE
fix(wasm): handle negative/NaN weights in optimize_loads (#14720)

### DIFF
--- a/wasm/rust/src/lib.rs
+++ b/wasm/rust/src/lib.rs
@@ -91,6 +91,9 @@ pub fn optimize_loads(loads: &[f64], capacity: f64) -> Vec<usize> {
     let mut remaining = capacity;
     
     for (i, &weight) in loads.iter().enumerate() {
+        if !weight.is_finite() || weight < 0.0 {
+            continue;
+        }
         if weight <= remaining {
             selected.push(i);
             remaining -= weight;
@@ -98,6 +101,32 @@ pub fn optimize_loads(loads: &[f64], capacity: f64) -> Vec<usize> {
     }
     
     selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_negative_weight_to_avoid_capacity_inflate() {
+        let loads = [10.0, -5.0, 5.0];
+        let selected = optimize_loads(&loads, 12.0);
+        assert_eq!(selected, vec![0, 2]);
+    }
+
+    #[test]
+    fn skips_nan_weight_without_dropping_valid_loads() {
+        let loads = [4.0, f64::NAN, 3.0, 2.0];
+        let selected = optimize_loads(&loads, 10.0);
+        assert_eq!(selected, vec![0, 2, 3]);
+    }
+
+    #[test]
+    fn skips_infinite_weight() {
+        let loads = [4.0, f64::INFINITY, 3.0];
+        let selected = optimize_loads(&loads, 10.0);
+        assert_eq!(selected, vec![0, 2]);
+    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Problem

`optimize_loads` (wasm/rust/src/lib.rs) subtracts each load's weight from remaining capacity without validating the weight. A negative weight makes `remaining -= weight` grow the capacity (never fills the bin — capacity inflate), and a `NaN` weight makes `weight <= remaining` evaluate to `false` forever, silently dropping all subsequent valid loads.

## Fix

Guard each weight before bin-packing: skip (continue) any weight that is non-finite or negative. This prevents capacity inflation and avoids silently dropping valid loads that follow a bad value. Added unit tests covering negative, `NaN`, and `Infinity` weights.

## Files changed

- `wasm/rust/src/lib.rs`

## Testing

Added `#[cfg(test)]` unit tests in `wasm/rust/src/lib.rs`:
- `skips_negative_weight_to_avoid_capacity_inflate`
- `skips_nan_weight_without_dropping_valid_loads`
- `skips_infinite_weight`

These assert correct selection with no capacity inflation and no silent dropping of valid loads. (Note: `cargo` is unavailable in the build environment, so tests were verified by inspection.)

Closes #14720
