### PR TITLE
fix(supabase): widen driver_details.wallet_confirmed to match ledger (#14723)

### DIFF
--- a/docs/supabase_setup.sql
+++ b/docs/supabase_setup.sql
@@ -95,9 +95,9 @@ create table if not exists driver_details (
   total_trips       int not null default 0,
   completion_rate   numeric(5,2) not null default 100.00,     -- percentage
   is_online         boolean not null default false,
-  wallet_confirmed  int not null default 0 check (wallet_confirmed >= 0),   -- paisa
-  wallet_pending    int not null default 0 check (wallet_pending >= 0),
-  wallet_total      int not null default 0,
+  wallet_confirmed  numeric(20,0) not null default 0 check (wallet_confirmed >= 0),   -- paisa
+  wallet_pending    numeric(20,0) not null default 0 check (wallet_pending >= 0),
+  wallet_total      numeric(20,0) not null default 0,
   created_at        timestamptz not null default now(),
   updated_at        timestamptz not null default now()
 );

--- a/supabase/migrations/20260815000000_widen_driver_wallet_balance_columns.sql
+++ b/supabase/migrations/20260815000000_widen_driver_wallet_balance_columns.sql
@@ -1,0 +1,18 @@
+-- Fix integer-overflow on driver wallet balance accumulators (issue #14723).
+-- The #13963 ledger widening (wallet_transactions.amount / payments.amount_paisa
+-- -> numeric(20,0)) left the *balance* accumulators on driver_details as int4.
+-- complete_trip_tx does `wallet_confirmed = wallet_confirmed + payout` (plain
+-- int4 + int4). Once a driver's cumulative earnings cross 2,147,483,647 paisa
+-- (~Rs21.47L) Postgres raises 22003 inside the transactional RPC and rolls back
+-- the whole trip finalization, so the order is never paid. Widen the balances to
+-- numeric(20,0) to match the ledger; the credit arithmetic is then numeric and
+-- cannot overflow.
+
+alter table if exists driver_details
+  alter column wallet_confirmed type numeric(20,0);
+
+alter table if exists driver_details
+  alter column wallet_pending type numeric(20,0);
+
+alter table if exists driver_details
+  alter column wallet_total type numeric(20,0);


### PR DESCRIPTION
## Problem

The #13963 overflow fix widened the ledger (`wallet_transactions.amount`, `payments.amount_paisa`) to `numeric(20,0)` but left the wallet balance accumulators on `driver_details` as `int4` (`wallet_confirmed`, `wallet_pending`, `wallet_total`). `complete_trip_tx` runs `wallet_confirmed = wallet_confirmed + coalesce(v_order.bid_amount, v_order.total_amount)` as plain `int4 + int4`. Once a driver's cumulative earnings cross 2,147,483,647 paisa (≈ ₹21.47L), Postgres raises `22003: integer out of range` inside the single transactional RPC, which rolls back the entire function — the order is never marked `payment_released`, escrow is never released, the trip is never completed, and the wallet is never credited. Every retry re-raises, so the trip is permanently non-finalizable and the driver is never paid.

## Fix

- Added migration `supabase/migrations/20260815000000_widen_driver_wallet_balance_columns.sql` that widens `driver_details.wallet_confirmed`, `wallet_pending`, and `wallet_total` from `int4` to `numeric(20,0)`, matching the ledger columns widened by #13963. With the balance column now numeric, the `wallet_confirmed = wallet_confirmed + payout` credit arithmetic in `complete_trip_tx` (and the equivalent arithmetic in the withdrawal/settlement RPCs) evaluates as `numeric + int -> numeric` and can no longer overflow.
- Updated the seed/local schema in `docs/supabase_setup.sql` (lines 98-100) to declare the same three columns as `numeric(20,0)` so fresh local setups match production.

## Files changed

- `supabase/migrations/20260815000000_widen_driver_wallet_balance_columns.sql` (new)
- `docs/supabase_setup.sql`

## Testing

- Verified the migration only alters column types and that the existing `CHECK (wallet_confirmed >= 0)` / `CHECK (wallet_pending >= 0)` constraints remain valid for `numeric(20,0)`.
- Confirmed `complete_trip_tx` (`supabase/migrations/20260812130000_complete_trip_tx_fail_closed_on_missing_wallet.sql:208-209`) and the settlement RPCs perform `numeric + int` arithmetic once the column is widened, so cumulative earnings beyond ₹21.47L credit correctly instead of raising `22003`.
- Recommended regression check (requires a running Postgres/Supabase instance): seed a driver whose `wallet_confirmed` already exceeds 2,147,483,647 paisa, run `complete_trip_tx` for a new paid trip, and assert the order reaches `payment_released` while `wallet_confirmed` is credited by exactly the payout amount.

Closes #14723
