### PR TITLE
fix: scope default payment-method unique index per user (#14722)

### DIFF
--- a/apps/customer/lib/repositories/payment_repository.dart
+++ b/apps/customer/lib/repositories/payment_repository.dart
@@ -1,3 +1,5 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../models/payment_method.dart';
 import '../services/supabase_service.dart';
 
@@ -18,6 +20,11 @@ class PaymentRepository {
   Future<PaymentMethod> add(PaymentMethod method) async {
     final userId = SupabaseService.requireUserId();
     final payload = method.toMap()..['user_id'] = userId;
+    // Always insert as non-default. The default flag is owned exclusively by
+    // set_default_payment_method, which clears any existing default and sets
+    // this one in a single transaction. Inserting is_default: true here would
+    // violate the per-user unique index when a default already exists.
+    payload['is_default'] = false;
     final row = await SupabaseService.client
         .from(_table)
         .insert(payload)
@@ -25,30 +32,32 @@ class PaymentRepository {
         .single();
     final savedMethod = PaymentMethod.fromMap(row);
     if (method.isDefault) {
-      await _clearDefaults(userId, exceptId: savedMethod.id);
+      await _setDefaultRpc(userId, savedMethod.id);
+      return savedMethod.copyWith(isDefault: true);
     }
     return savedMethod;
   }
 
   Future<void> setDefault(String methodId) async {
     final userId = SupabaseService.requireUserId();
-    final existing = await SupabaseService.client
-        .from(_table)
-        .select('id')
-        .eq('id', methodId)
-        .eq('user_id', userId)
-        .maybeSingle();
+    await _setDefaultRpc(userId, methodId);
+  }
 
-    if (existing == null) {
-      throw StateError('Payment method not found.');
+  Future<void> _setDefaultRpc(String userId, String methodId) async {
+    try {
+      await SupabaseService.client.rpc(
+        'set_default_payment_method',
+        params: {
+          'p_user_id': userId,
+          'p_method_id': methodId,
+        },
+      );
+    } on PostgrestException catch (e) {
+      if (e.message.contains('Payment method not found')) {
+        throw StateError('Payment method not found.');
+      }
+      rethrow;
     }
-
-    await _clearDefaults(userId, exceptId: methodId);
-    await SupabaseService.client
-        .from(_table)
-        .update({'is_default': true})
-        .eq('id', methodId)
-        .eq('user_id', userId);
   }
 
   Future<void> delete(String methodId) async {
@@ -88,16 +97,5 @@ class PaymentRepository {
         .update({'is_default': true})
         .eq('id', replacementId)
         .eq('user_id', userId);
-  }
-
-  Future<void> _clearDefaults(String userId, {String? exceptId}) async {
-    var query = SupabaseService.client
-        .from(_table)
-        .update({'is_default': false})
-        .eq('user_id', userId);
-    if (exceptId != null) {
-      query = query.neq('id', exceptId);
-    }
-    await query;
   }
 }


### PR DESCRIPTION
## Problem

Migration `20260812140000_add_set_default_payment_method_rpc.sql` added the `set_default_payment_method` RPC plus the partial unique index `payment_methods_single_default_per_user` (at most one default per user). The customer app, however, was never migrated to use it. `PaymentRepository` still wrote the default flag with direct, non-atomic table calls:

- `add()` inserted the new row with `is_default: true` and only afterwards tried to clear the old default in a separate call.
- `setDefault()` cleared all defaults, then set the new one in a separate call.

With the unique index now present, `add()` inserting a second method as default raised a `23505` violation, so adding a default method silently failed with "Failed to add payment method." The original clear-then-set race (#11427) also remained in the app.

## Fix

In `apps/customer/lib/repositories/payment_repository.dart`:

- `add()` now always inserts the row with `is_default: false`, then promotes it to default via the `set_default_payment_method` RPC (which atomically clears the existing default and sets the new one). This removes the insert-time `23505` violation.
- `setDefault()` now calls `set_default_payment_method` directly instead of a two-step clear + update, eliminating the race window and relying on the DB-enforced single default.
- `delete()`'s replacement-default path is unchanged: it only sets a row default after the prior default was removed, so no second default ever exists to violate the index.
- Removed the now-unused `_clearDefaults` helper; the RPC is the sole writer of the default flag.
- Preserved the existing `StateError('Payment method not found.')` contract for `setDefault` by mapping the RPC's not-found error.

## Files changed

- `apps/customer/lib/repositories/payment_repository.dart` — route default-flag writes through the `set_default_payment_method` RPC.

## Testing

- Manual reasoning: adding a second method marked "Set as default" now inserts non-default (no `23505`), then the RPC atomically clears the old default and sets the new one.
- `setDefault` now issues a single RPC call instead of two separate default-flag writes, matching the migration's intended contract (verified by code inspection against `supabase/migrations/20260812140000_add_set_default_payment_method_rpc.sql`).
- Note: the Flutter/Dart SDK is not available in this environment, so the automated widget/unit suite could not be executed here; the change was verified by source inspection against the migration and the existing `address_repository.dart` RPC-usage pattern.

Closes #14722
