### PR TITLE
fix(ebpf): add bpf_spin_lock to xdp_anti_replay RMW (#14712)

### DIFF
--- a/ebpf/xdp_anti_replay.c
+++ b/ebpf/xdp_anti_replay.c
@@ -14,8 +14,9 @@
 #define REPLAY_WINDOW_SIZE 64
 
 struct anti_replay_entry {
-    __u32 last_seq; // Highest payload sequence number seen for this flow
-    __u64 window;   // Bitmap of recently seen sequence numbers below last_seq
+    __u32 last_seq;            // Highest payload sequence number seen for this flow
+    __u64 window;              // Bitmap of recently seen sequence numbers below last_seq
+    struct bpf_spin_lock lock; // Serializes read-modify-write of last_seq/window across CPUs
 };
 
 struct {
@@ -64,17 +65,24 @@ int xdp_anti_replay_filter(struct xdp_md *ctx) {
         struct anti_replay_entry new_entry = {
             .last_seq = seq,
             .window = 1,
+            .lock = {},
         };
         bpf_map_update_elem(&seq_tracking_map, &flow_key, &new_entry, BPF_ANY);
         return XDP_PASS;
     }
 
+    bpf_spin_lock(&entry->lock);
+
     if (seq <= entry->last_seq) {
         __u32 diff = entry->last_seq - seq;
-        if (diff >= REPLAY_WINDOW_SIZE)
+        if (diff >= REPLAY_WINDOW_SIZE) {
+            bpf_spin_unlock(&entry->lock);
             return XDP_DROP; // Stale: outside the replay window
-        if (entry->window & (1ULL << diff))
+        }
+        if (entry->window & (1ULL << diff)) {
+            bpf_spin_unlock(&entry->lock);
             return XDP_DROP; // Duplicate: sequence already seen
+        }
         entry->window |= (1ULL << diff); // Out-of-order but in-window: accept
     } else {
         __u64 shift = (__u64)(seq - entry->last_seq);
@@ -85,6 +93,8 @@ int xdp_anti_replay_filter(struct xdp_md *ctx) {
         entry->window |= 1ULL;
         entry->last_seq = seq;
     }
+
+    bpf_spin_unlock(&entry->lock);
 
     return XDP_PASS;
 }


### PR DESCRIPTION
## Problem

`xdp_anti_replay.c` performs a multi-field read-modify-write on the per-flow `anti_replay_entry` map value (`last_seq` and `window`) with no `bpf_spin_lock`. XDP programs run concurrently on multiple CPUs, so for a busy flow the same `flow_key` (and thus the same `anti_replay_entry`) is looked up and mutated by several CPUs at once. The non-atomic `entry->window |= ...` and `entry->window <<= shift; entry->window |= 1` operations produce torn/overlapping writes, so a replayed packet can be accepted (duplicate detection missed) under load — directly defeating the anti-replay guarantee. Sibling programs `tc_bandwidth_shaper.c` and `telemetry_filter.c` already use `bpf_spin_lock` for the same pattern.

## Fix

- Added `struct bpf_spin_lock lock;` to `struct anti_replay_entry` (the `BPF_MAP_TYPE_LRU_HASH` map supports spin locks).
- Initialized the lock (`lock = {}`) in the `new_entry` initializer used when a flow is first seen.
- Wrapped the entire read-modify-write block in `bpf_spin_lock(&entry->lock)` / `bpf_spin_unlock(&entry->lock)`, including the early `XDP_DROP` return paths, so `last_seq` and `window` updates are atomic across CPUs.

## Files changed

- `ebpf/xdp_anti_replay.c`

## Testing

- Verified the edited `ebpf/xdp_anti_replay.c` for balanced lock/unlock on all code paths (both `XDP_DROP` early returns and the normal `XDP_PASS` fall-through release the lock).
- Sanity-checked against sibling programs (`tc_bandwidth_shaper.c`, `telemetry_filter.c`) for consistent `bpf_spin_lock` usage conventions.

Closes #14712
