### PR TITLE
fix(ebpf): key kprobe latency map per-thread to avoid collisions (#14711)

### DIFF
--- a/ebpf/kprobe_latency_tracer.c
+++ b/ebpf/kprobe_latency_tracer.c
@@ -9,7 +9,7 @@
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 1024);
-    __type(key, __u32);   // PID
+    __type(key, __u64);   // PID_TGID (unique per thread)
     __type(value, __u64); // Entry timestamp nanoseconds
 } enter_timestamp_map SEC(".maps");
 
@@ -19,7 +19,7 @@ int kprobe_sys_enter_epoll_wait(struct trace_event_raw_sys_enter *ctx) {
     __u32 pid = pid_tgid >> 32;
     __u64 ts = bpf_ktime_get_ns();
 
-    bpf_map_update_elem(&enter_timestamp_map, &pid, &ts, BPF_ANY);
+    bpf_map_update_elem(&enter_timestamp_map, &pid_tgid, &ts, BPF_ANY);
     return 0;
 }
 
@@ -29,13 +29,13 @@ int kretprobe_sys_exit_epoll_wait(struct trace_event_raw_sys_exit *ctx) {
     __u32 pid = pid_tgid >> 32;
     __u64 exit_ts = bpf_ktime_get_ns();
 
-    __u64 *entry_ts = bpf_map_lookup_elem(&enter_timestamp_map, &pid);
+    __u64 *entry_ts = bpf_map_lookup_elem(&enter_timestamp_map, &pid_tgid);
     if (entry_ts) {
         __u64 latency_ns = exit_ts - *entry_ts;
         if (latency_ns > 50000000) { // 50 milliseconds event loop block
             bpf_printk("EventLoopBlockDetected: PID=%d Latency=%lldns\n", pid, latency_ns);
         }
-        bpf_map_delete_elem(&enter_timestamp_map, &pid);
+        bpf_map_delete_elem(&enter_timestamp_map, &pid_tgid);
     }
     return 0;
 }


### PR DESCRIPTION
## Problem

`kprobe_latency_tracer.c` keys its `enter_timestamp_map` on `tgid` (extracted via `pid_tgid >> 32`), which is shared by every thread in a process. Concurrent threads of the same process overwrite the same map slot, causing misattributed/negative latencies and silently dropped thread blocks (a delete race: thread A deletes the entry that thread B still needs). This corrupts latency telemetry in multi-threaded event loops.

## Fix

Changed the map key type from `__u32` to `__u64` and store/lookup/delete using the **entire** `pid_tgid` value (unique per thread) in both the enter and exit tracepoints. The `pid` variable is retained only for the human-readable `bpf_printk` label. This gives each thread its own slot, eliminating thread collisions and the delete race.

## Files changed

- `ebpf/kprobe_latency_tracer.c` — map key `__u32` → `__u64`; update/lookup/delete now use full `pid_tgid`.

## Testing

Manual code review / sanity check of map key type and all `bpf_map_*_elem` calls. The eBPF object compiles against the existing build setup (verifier would reject mismatched key pointer sizes). No runtime test harness available in repo for eBPF progs; verified correctness by inspection against `bpf_get_current_pid_tgid()` semantics.

Closes #14711
