### PR TITLE
fix(wasm): keep u64 length and bounds-check idx+len in protobuf_parser (#14715)

### DIFF
--- a/wasm/src/protobuf_parser.rs
+++ b/wasm/src/protobuf_parser.rs
@@ -61,10 +61,11 @@ pub fn decode_protobuf_telemetry_zero_copy(protobuf_bytes: &[u8]) -> String {
                     None => break,
                 };
                 idx += c;
-                let len = len as usize;
-                if idx + len > protobuf_bytes.len() {
+                let remaining = (protobuf_bytes.len() - idx) as u64;
+                if len > remaining {
                     break;
                 }
+                let len = len as usize;
                 idx += len;
             }
             _ => break,
@@ -173,5 +174,17 @@ mod tests {
         let out = decode_protobuf_telemetry_zero_copy(&payload);
         assert!(out.contains("\"status\":\"error\""));
         assert!(!out.contains("28.6139"));
+    }
+
+    #[test]
+    fn oversized_length_delimited_field_is_rejected() {
+        // Length-delimited field (tag wire_type 2) with a u64::MAX declared length.
+        // Must not truncate/overflow or hang; parsing should safely stop.
+        let tag = (3u64 << 3) | 2;
+        let mut payload = encode_varint(tag);
+        payload.extend(encode_varint(u64::MAX));
+        payload.extend_from_slice(&[0u8; 16]);
+        let out = decode_protobuf_telemetry_zero_copy(&payload);
+        assert!(out.contains("\"status\":\"error\""));
     }
 }


### PR DESCRIPTION
## Problem

In `wasm/src/protobuf_parser.rs`, the length-delimited branch (wire type 2) of `decode_protobuf_telemetry_zero_copy` cast the `u64` protobuf field length to `usize` before bounds-checking. On `wasm32-unknown-unknown` (`usize` is 32-bit), a field length ≥ 2³² is silently truncated to its low 32 bits, desynchronizing the decoder and corrupting field parsing. For lengths near `usize::MAX`, `idx + len` overflows: it traps (aborts the guest) in debug builds and wraps in release builds, letting `idx += len` wrap back to a small offset — an infinite re-parse loop / guest hang.

## Fix

Before any cast/arithmetic, compute the remaining bytes as a `u64` and reject the field if the decoded `u64` length exceeds them. Only then is the (now guaranteed in-range) length cast to `usize`. This avoids both truncation and `idx + len` overflow on 32-bit wasm:

```rust
let remaining = (protobuf_bytes.len() - idx) as u64;
if len > remaining {
    break;
}
let len = len as usize;
idx += len;
```

Also added an `oversized_length_delimited_field_is_rejected` test that feeds a length-delimited field with a `u64::MAX` declared length and asserts parsing stops safely (returns error status) without hanging/aborting.

## Files changed

- `wasm/src/protobuf_parser.rs` — bounds-check the `u64` length against remaining bytes before casting; add regression test.

## Testing

- New unit test `oversized_length_delimited_field_is_rejected`: builds a field with `u64::MAX` length and verifies safe rejection.
- Existing tests (`empty_input_returns_empty_object`, `decodes_actual_lat_lng_from_input`, `different_payload_yields_different_coordinates`, `missing_fields_is_flagged_not_fabricated`) remain valid.

Closes #14715
