### PR TITLE
fix(backend): implement GET /api/orders/:id/timeline with view-timeline authz (#14710)

### DIFF
--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -243,12 +243,6 @@ router.get('/history', authenticate, userLimiter, requireRole(['customer']), get
 // 6. FETCH SPECIFIC ORDER DETAILS AND TIMELINE (CUSTOMER OR DRIVER)
 router.get('/:id', authenticate, userLimiter, validateParams(paramIdSchema), getOrderDetails);
 
-// 7. FETCH ORDER TIMELINE (CUSTOMER OR DRIVER)
-// ============================================================================
-router.get('/:id/timeline', authenticate, userLimiter, validateParams(paramIdSchema), async (req, res) => {
-  const orderId = req.params.id;
-
-// ============================================================================
 // 13b. FETCH EN-ROUTE LOAD OFFERS (DRIVER) — GET /api/orders/load-offers/en-route
 // ============================================================================
 /**


### PR DESCRIPTION
## Problem

`GET /api/orders/:id/timeline` was registered twice in `backend/api/src/routes/orderRoutes.js`. The first registration (old line 248) was a broken, non-functional stub whose handler body (`async (req, res) => { ...`) was never closed and never called `res`/`next`. Because Express uses first-match routing, this stub won the route and hung every request until client/proxy timeout (availability/DoS), while also shadowing the real handler that enforces the `order:view-timeline` authorization policy (security — unreachable authz).

## Fix

Removed the hanging stub registration so the only remaining `/:id/timeline` route is the real handler at `backend/api/src/routes/orderRoutes.js:939`, which uses `requirePolicy('order:view-timeline', ...)` and returns `orderLifecycleService.getOrderTimeline(req.params.id, req.user.id)`. No logic was rewritten; the correct, policy-enforcing handler now serves the endpoint.

## Files changed

- `backend/api/src/routes/orderRoutes.js` — deleted the duplicate stub `/:id/timeline` registration (6 lines).

## Testing

- Verified via `grep`/`Select-String` that `/:id/timeline` is now registered exactly once and references `requirePolicy('order:view-timeline', ...)` + `getOrderTimeline`.
- `node --check` confirms the file parses (the only reported token is the trailing `export default`, expected for this ESM module).
- No unit/integration test harness for route registration exists in this repo; the fix relies on the already-implemented, policy-enforcing handler becoming the sole match.

Closes #14710
