### PR TITLE
fix(ebpf): parse IP header length/VLAN in socket_buffer_filter (#14714)

### DIFF
--- a/ebpf/socket_buffer_filter.c
+++ b/ebpf/socket_buffer_filter.c
@@ -38,16 +38,47 @@ struct telemetry_event {
 
 SEC("socket")
 int socket_telemetry_filter(struct __sk_buff *skb) {
-    // Read IP header
+    // Determine the real L2 (Ethernet/VLAN) header length. A flat ETH_HLEN is
+    // wrong for VLAN-tagged frames, where an extra 4-byte tag follows the MACs.
+    __u16 l2_header_len = ETH_HLEN;
+    struct ethhdr eth;
+    if (bpf_skb_load_bytes(skb, 0, &eth, sizeof(eth)) < 0)
+        return 0;
+
+    if (eth.h_proto == bpf_htons(ETH_P_8021Q) ||
+        eth.h_proto == bpf_htons(ETH_P_8021AD)) {
+        __u16 vlan_proto;
+        // The encapsulated EtherType sits just past the 4-byte VLAN tag.
+        if (bpf_skb_load_bytes(skb, ETH_HLEN + 2, &vlan_proto, sizeof(vlan_proto)) < 0)
+            return 0;
+        l2_header_len = ETH_HLEN + 4;
+        // Handle a second (QinQ) VLAN tag the same way.
+        if (vlan_proto == bpf_htons(ETH_P_8021Q) ||
+            vlan_proto == bpf_htons(ETH_P_8021AD)) {
+            l2_header_len = ETH_HLEN + 8;
+        }
+    }
+
+    // Read IP header from the true L2 offset.
     struct iphdr ip;
-    if (bpf_skb_load_bytes(skb, ETH_HLEN, &ip, sizeof(ip)) < 0)
+    if (bpf_skb_load_bytes(skb, l2_header_len, &ip, sizeof(ip)) < 0)
         return 0; // Drop invalid packet
+
+    // Do not assume a fixed 20-byte IP header: honor the real header length
+    // (ip.ihl * 4) after bounds-checking it, so IP options don't misparse L4.
+    if (ip.ihl < 5)
+        return 0;
+    __u16 ip_header_len = ip.ihl * 4;
+    // The full IP header (including options) must fit in the packet.
+    if (skb->len < l2_header_len + ip_header_len)
+        return 0;
 
     if (ip.protocol != IPPROTO_TCP)
         return 0;
 
+    __u32 l4_offset = l2_header_len + ip_header_len;
     struct tcphdr tcp;
-    if (bpf_skb_load_bytes(skb, ETH_HLEN + sizeof(ip), &tcp, sizeof(tcp)) < 0)
+    if (bpf_skb_load_bytes(skb, l4_offset, &tcp, sizeof(tcp)) < 0)
         return 0;
 
     // Get trusted port from config map (default 0 = disabled, meaning all ports filtered)
@@ -74,11 +105,11 @@ int socket_telemetry_filter(struct __sk_buff *skb) {
     // Guard against short/truncated packets: subtracting the L2/L3/L4 header
     // sizes from an undersized skb->len wraps the __u32 and would emit a bogus
     // near-UINT_MAX payload_len in the ring buffer event.
-    if (skb->len < ETH_HLEN + sizeof(ip) + (tcp.doff * 4))
+    if (skb->len < l4_offset + (tcp.doff * 4))
         return 0;
 
     // Calculate payload length
-    __u32 payload_len = skb->len - (ETH_HLEN + sizeof(ip) + (tcp.doff * 4));
+    __u32 payload_len = skb->len - (l4_offset + (tcp.doff * 4));
     if (payload_len > 0) {
         struct telemetry_event *evt = bpf_ringbuf_reserve(&telemetry_ringbuf, sizeof(struct telemetry_event), 0);
         if (evt) {

--- a/ebpf/tests/test_socket_buffer_filter.py
+++ b/ebpf/tests/test_socket_buffer_filter.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for the socket telemetry filter (ebpf/socket_buffer_filter.c).
+
+These tests lock in the fix from issue #14714: the previous implementation
+hard-coded a flat 20-byte IP header and a flat ETH_HLEN L2 header, so it
+misparsed the TCP header offset for packets carrying IP options or VLAN tags
+(producing wrong rate-limit buckets and payload lengths).
+
+The corrected filter must:
+
+  * derive the L2 header length from the Ethernet EtherType and handle VLAN
+    tagging (ETH_P_8021Q / ETH_P_8021AD) instead of assuming a flat ETH_HLEN,
+  * derive the IP header length from ip.ihl * 4 (after bounds-checking it)
+    instead of assuming sizeof(struct iphdr),
+  * compute the L4 offset from those real values before indexing into the
+    packet.
+"""
+
+import os
+
+import pytest
+
+SOURCE_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "socket_buffer_filter.c")
+)
+
+CONFLICT_MARKERS = ("<<<<<<<", "=======", ">>>>>>>")
+
+
+def _source():
+    with open(SOURCE_PATH, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_no_merge_conflict_markers():
+    source = _source()
+    for marker in CONFLICT_MARKERS:
+        assert marker not in source
+
+
+def test_handles_vlan_tagging():
+    source = _source()
+    # The L2 offset must be derived from the EtherType, not assumed flat.
+    assert "ETH_P_8021Q" in source
+    assert "ETH_P_8021AD" in source
+    # A variable L2 header length must be computed and used.
+    assert "l2_header_len" in source
+    # The old flat assumption must be gone.
+    assert "ETH_HLEN + sizeof(ip)" not in source
+
+
+def test_uses_ip_header_length_not_fixed_20():
+    source = _source()
+    # The real IP header length must be honored and bounds-checked.
+    assert "ip.ihl" in source
+    assert "ip_header_len" in source
+    # L4 offset must be derived from the real L2 + IP header lengths.
+    assert "l4_offset" in source
+    assert "l2_header_len + ip_header_len" in source
+
+
+def test_payload_len_uses_real_offsets():
+    source = _source()
+    # payload_len must be computed from the real L4 offset, not ETH_HLEN + 20.
+    assert "skb->len - (l4_offset" in source
+    assert "l4_offset + (tcp.doff * 4)" in source
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

`socket_buffer_filter.c` assumed a flat L2 header (`ETH_HLEN`) and a fixed
20-byte IPv4 header (`sizeof(struct iphdr)`), so it computed the TCP header
offset as `ETH_HLEN + 20`. Any packet carrying IP options (or VLAN tagging,
where the true L2 header is `ETH_HLEN + 4`) was misparsed: `tcp.source`/`tcp.dest`
(used to build `rate_key`) and `tcp.doff` were read from the wrong offset, and
`payload_len` was computed against the wrong header length. This produced bogus
telemetry events and applied the wrong rate-limit bucket (or mis-dropped)
legitimate traffic.

## Fix

In `socket_telemetry_filter`:
- Read the Ethernet header and derive the real L2 header length, handling
  `ETH_P_8021Q` / `ETH_P_8021AD` VLAN tagging (including QinQ).
- Load the IP header at the true L2 offset and honor the real IP header length
  (`ip.ihl * 4`), bounds-checking `ip.ihl >= 5` and that the full IP header
  fits in the packet.
- Compute `l4_offset = l2_header_len + ip_header_len` and load the TCP header
  from there, then derive `payload_len` from `l4_offset + tcp.doff * 4`.

Added `ebpf/tests/test_socket_buffer_filter.py` (static source-level checks,
matching the repo's existing eBPF test style) asserting VLAN handling, use of
`ip.ihl`/`ip_header_len`, the derived `l4_offset`, and correct `payload_len`
computation.

## Files changed

- `ebpf/socket_buffer_filter.c`
- `ebpf/tests/test_socket_buffer_filter.py`

## Testing

- Added `ebpf/tests/test_socket_buffer_filter.py`; ran `pytest` — 4 passed.
- Static assertions verify the old flat `ETH_HLEN + sizeof(ip)` assumption is
  removed and the fix uses the real L2/IP header lengths for the L4 offset.

Closes #14714
