### PR TITLE
fix(backend): invalidate only specific keys in CacheManager.invalidateBatch (#14708)

### DIFF
--- a/backend/api/src/cache/CacheManager.js
+++ b/backend/api/src/cache/CacheManager.js
@@ -97,10 +97,10 @@ export async function invalidateBatch(namespace, entityIds, opts = {}) {
     await pipeline.exec();
     stats.deletes += keys.length;
     if (!opts.localOnly) {
-      await _publishInvalidation(namespace, {
-        type: 'INVALIDATE_PATTERN',
-        pattern: CacheKeyBuilder.pattern(namespace),
-      });
+      const publishes = keys.map((key) =>
+        _publishInvalidation(namespace, { type: 'INVALIDATE_KEY', key })
+      );
+      await Promise.all(publishes);
     }
   } catch (err) {
     stats.errors++;

--- a/backend/api/test/unit/cache/CacheManager.test.js
+++ b/backend/api/test/unit/cache/CacheManager.test.js
@@ -27,6 +27,7 @@ vi.mock('../../../src/cache/CacheInvalidator.js', () => ({
 
 const cacheManager = await import('../../../src/cache/CacheManager.js');
 const { CacheNamespace } = await import('../../../src/cache/CacheNamespace.js');
+const { publishInvalidation } = await import('../../../src/cache/CachePublisher.js');
 
 function mockRedisClient() {
   return {
@@ -124,5 +125,28 @@ describe('CacheManager', () => {
   it('CacheNamespace built-ins include profile with the user:profile prefix', () => {
     const ns = CacheNamespace.get('profile');
     expect(ns.prefix).toBe('user:profile');
+  });
+
+  it('invalidateBatch deletes only the requested keys locally', async () => {
+    const del = vi.fn();
+    client.pipeline = vi.fn(() => {
+      const p = { del, exec: vi.fn().mockResolvedValue([]) };
+      return p;
+    });
+    await cacheManager.invalidateBatch('profile', ['u1', 'u2']);
+    expect(del).toHaveBeenCalledWith('user:profile:u1');
+    expect(del).toHaveBeenCalledWith('user:profile:u2');
+  });
+
+  it('invalidateBatch publishes per-key INVALIDATE_KEY events scoped to the batch, not the whole namespace', async () => {
+    await cacheManager.invalidateBatch('profile', ['u1', 'u2']);
+    expect(publishInvalidation).toHaveBeenCalledTimes(2);
+    for (const call of publishInvalidation.mock.calls) {
+      const [, event] = call;
+      expect(event.type).toBe('INVALIDATE_KEY');
+      expect(event).not.toHaveProperty('pattern');
+    }
+    const publishedKeys = publishInvalidation.mock.calls.map(([, e]) => e.key).sort();
+    expect(publishedKeys).toEqual(['user:profile:u1', 'user:profile:u2']);
   });
 });


### PR DESCRIPTION
## Problem

`CacheManager.invalidateBatch` deleted only the specific requested keys locally but broadcast a **namespace-wide** `INVALIDATE_PATTERN` event (`prefix:*`). Every other instance then ran a scan-and-delete over the entire namespace, wiping unrelated entries and triggering a full cold-miss stampede against the database on each batch invalidation.

## Fix

Changed `invalidateBatch` to publish per-key `INVALIDATE_KEY` events for each key in the batch instead of a single whole-namespace pattern event. The remote event scope now matches the local delete scope exactly — peers delete only the same specific keys, eliminating the stampede.

## Files changed

- `backend/api/src/cache/CacheManager.js` — publish `INVALIDATE_KEY` per batch key (replacing the `INVALIDATE_PATTERN` namespace pattern).
- `backend/api/test/unit/cache/CacheManager.test.js` — added tests asserting local deletes are scoped to the batch and that the published remote events are per-key `INVALIDATE_KEY` with no whole-namespace pattern.

## Testing

- Added unit tests verifying (1) local pipeline deletes only the requested keys, and (2) `publishInvalidation` is called once per key with `type: 'INVALIDATE_KEY'` and no `pattern` field, and the published keys match the batch exactly.

Closes #14708
