### PR TITLE
fix(zkp.routes): remove stale duplicate zkpVerifyLimiter

### DIFF
--- a/backend/api/src/routes/zkp.routes.js
+++ b/backend/api/src/routes/zkp.routes.js
@@ -7,15 +7,6 @@ import logger from '../middleware/logger.js';
 
 const router = express.Router();
 const PRIVILEGED_VERIFICATION_ROLES = new Set(['admin', 'regulator']);
-const zkpVerifyLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 300,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: safeIpKeyGenerator,
-  store: createStore('rl:zkp-verify:'),
-  message: { error: 'Rate limit exceeded', retryAfter: 900 },
-});
 
 function canVerifyUser(requestUser, targetUserId) {
   return requestUser?.id === targetUserId || PRIVILEGED_VERIFICATION_ROLES.has(requestUser?.role);


### PR DESCRIPTION
Closes #14791

## Problem

In `backend/api/src/routes/zkp.routes.js`, `zkpVerifyLimiter` is declared twice:

- line 10: an older `rateLimit({...})` version that also references `rateLimit`, `safeIpKeyGenerator` and `createStore` — none imported in this file
- line 36: the current `redisRateLimiter({...})` version described by the doc comment (5 attempts/hour, `ZKP_RATE_LIMIT_*` env vars)

Hard parse error: `Identifier 'zkpVerifyLimiter' has already been declared` at line 36.

## Fix

Remove the stale duplicate limiter (lines 10-18), keeping the `redisRateLimiter` version.

Verified with `node --check` and ESLint.
