### PR TITLE
fix(voiceRoutes): remove dead safeFilename assignment

### DIFF
--- a/backend/api/src/routes/voiceRoutes.js
+++ b/backend/api/src/routes/voiceRoutes.js
@@ -55,10 +55,9 @@ router.post('/query', authenticate, userLimiter, upload.single('file'), async (r
         throw validationErr;
       }
       audioBuffer = file.buffer;
-      safeFilename = sanitizeUploadFilename(file.originalname || 'voice-query.wav', 'voice-query.wav');
     }
 
-    const safeFilename = sanitizeUploadFilename(file.originalname, 'voice-query.wav');
+    safeFilename = sanitizeUploadFilename(file.originalname, 'voice-query.wav');
 
     const result = await processVoiceQuery(req.user.id, bookingId, file.buffer, safeFilename);
     


### PR DESCRIPTION
Closes #14793

## Problem

In `backend/api/src/routes/voiceRoutes.js`, `safeFilename` is assigned at line 58 before being declared with `const` at line 61:

```js
      safeFilename = sanitizeUploadFilename(file.originalname || 'voice-query.wav', 'voice-query.wav');
    }
    const safeFilename = sanitizeUploadFilename(file.originalname, 'voice-query.wav');
```

Hard parse error: `Identifier 'safeFilename' has already been declared` at line 61.

## Fix

Remove the dead assignment at line 58; the `const safeFilename` at line 61 is the canonical binding.

Verified with `node --check` and ESLint.
