### PR TITLE
build: remove duplicate pub mod bulletproofs in zkp-verifier-rust (#14700)

### DIFF
--- a/services/zkp-verifier-rust/src/lib.rs
+++ b/services/zkp-verifier-rust/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod bulletproofs;
-pub mod bulletproofs;
 pub mod verifier;
 pub mod weight_proof;


### PR DESCRIPTION
## Problem

`services/zkp-verifier-rust/src/lib.rs` declared the same module twice:

```rust
pub mod bulletproofs;   // line 1
pub mod bulletproofs;   // line 2
```

Declaring a module twice at the crate root is a hard error (E0428 "the name `bulletproofs` is defined multiple times"), which broke compilation of the entire zkp-verifier-rust crate.

## Fix

Removed the duplicate `pub mod bulletproofs;` declaration so the module is declared exactly once.

## Files changed

- `services/zkp-verifier-rust/src/lib.rs` — deleted the duplicate `pub mod bulletproofs;` line.

## Testing

- Sanity-checked the edited file: only one `pub mod bulletproofs;` now exists, followed by `pub mod verifier;` and `pub mod weight_proof;`.
- The fix resolves the E0428 duplicate module definition error for the crate root.

Closes #14700
