### PR TITLE
fix(tripValidator): remove duplicate tripId declaration

### DIFF
--- a/backend/api/src/middleware/tripValidator.js
+++ b/backend/api/src/middleware/tripValidator.js
@@ -8,12 +8,6 @@ export const tripValidator = {
         return res.status(400).json({ error: 'Invalid trip ID' });
       }
     }
-    const tripId = req.params?.tripId;
-    if (tripId !== undefined && tripId !== null) {
-      if (typeof tripId !== 'string' || tripId.trim().length === 0) {
-        return res.status(400).json({ error: 'Invalid tripId' });
-      }
-    }
     next();
   }
 };


### PR DESCRIPTION
Closes #14794

## Problem

In `backend/api/src/middleware/tripValidator.js`, `tripId` is declared twice in the same scope:

```js
const tripId = req.params.tripId ?? req.params.id;
...
const tripId = req.params?.tripId;
```

Hard parse error: `Identifier 'tripId' has already been declared` at line 11.

## Fix

Remove the second declaration and its redundant validation block. The first check already validates `tripId`.

Verified with `node --check` and ESLint.
