### PR TITLE
fix(escrow): remove duplicate tx declaration

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -716,7 +716,7 @@ export async function submitEscrowRefund (orderDisplayId) {
     return { txHash: null, bookingId, error: err?.message ?? String(err) }
   }
 
-  const tx = await withTimeout(escrowContract.refundFunds(bookingId));
+  tx = await withTimeout(escrowContract.refundFunds(bookingId));
   logger.info(`[escrow] refundFunds tx submitted: ${tx.hash} for booking ${orderDisplayId}`);
   return {
     txHash: tx.hash,


### PR DESCRIPTION
Closes #14795

## Problem

In `backend/api/src/services/escrow.js`, `tx` is declared twice in the same scope:

```js
let tx
...
const tx = await withTimeout(escrowContract.refundFunds(bookingId));
```

Hard parse error: `Identifier 'tx' has already been declared` at line 719.

## Fix

Reuse the existing `let tx` binding:

```js
tx = await withTimeout(escrowContract.refundFunds(bookingId));
```

Verified with `node --check` and ESLint.
