### PR TITLE
fix: require chain confirmation before marking cancelled orders refunded (#14704)

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -59,21 +59,64 @@ async function finalizeOrRevert(order, orderRepository) {
 
     if (bookingFunded && !mismatchReason && order.status === 'cancelled') {
       logger.info(`[escrow-funding] Order ${order.order_display_id} is cancelled but deposit landed on-chain. Triggering refund.`);
+      let refundResult;
       try {
-        await submitEscrowRefund(order.order_display_id);
-        await orderRepository.updateOrder(order.id, {
-          escrow_status: 'refunded',
-          escrow_refund_error: null,
-          updated_at: new Date().toISOString(),
-        });
+        refundResult = await submitEscrowRefund(order.order_display_id);
       } catch (err) {
-        logger.error(`[escrow-funding] Failed to refund cancelled order ${order.order_display_id}: ${err.message}`);
-        await orderRepository.updateOrder(order.id, {
+        refundResult = { txHash: null, error: err.message };
+        logger.error(`[escrow-funding] Refund failed for cancelled order ${order.order_display_id}: ${err.message}`);
+      }
+
+      // submitEscrowRefund resolves (never throws) with { error } / a missing
+      // txHash on chain failures. Only mark the order refunded once the refund
+      // tx is actually confirmed on-chain; otherwise it must stay retryable.
+      if (refundResult?.error || !refundResult?.txHash) {
+        const refundError = refundResult?.error || 'escrow refund was not submitted';
+        logger.error(
+          `[escrow-funding] Order ${order.order_display_id} refund not confirmed (${refundError}) — marking refund_failed.`
+        );
+        await orderRepository.updateOrderWithFilter(order.id, {
+          escrow_status: 'refund_failed',
+          escrow_refund_error: refundError,
+          updated_at: new Date().toISOString(),
+        }, [
+          { op: 'eq', column: 'escrow_status', value: 'funding' },
+          { op: 'eq', column: 'id', value: order.id },
+        ], 'id').catch((stateErr) => {
+          logger.error(`[escrow-funding] Failed to record refund failure for ${order.order_display_id}: ${stateErr.message}`);
+        });
+        return;
+      }
+
+      try {
+        await refundResult.waitForConfirmation();
+      } catch (err) {
+        logger.error(
+          `[escrow-funding] Refund confirmation failed for ${order.order_display_id}: ${err.message} — marking refund_failed.`
+        );
+        await orderRepository.updateOrderWithFilter(order.id, {
           escrow_status: 'refund_failed',
           escrow_refund_error: err.message,
           updated_at: new Date().toISOString(),
+        }, [
+          { op: 'eq', column: 'escrow_status', value: 'funding' },
+          { op: 'eq', column: 'id', value: order.id },
+        ], 'id').catch((stateErr) => {
+          logger.error(`[escrow-funding] Failed to record refund confirmation failure for ${order.order_display_id}: ${stateErr.message}`);
         });
+        return;
       }
+
+      await orderRepository.updateOrderWithFilter(order.id, {
+        escrow_status: 'refunded',
+        escrow_refund_error: null,
+        updated_at: new Date().toISOString(),
+      }, [
+        { op: 'eq', column: 'escrow_status', value: 'funding' },
+        { op: 'eq', column: 'id', value: order.id },
+      ], 'id').catch((stateErr) => {
+        logger.error(`[escrow-funding] Failed to record refund success for ${order.order_display_id}: ${stateErr.message}`);
+      });
       return;
     }
 

--- a/backend/api/test/unit/escrowFundingReconciliation.test.js
+++ b/backend/api/test/unit/escrowFundingReconciliation.test.js
@@ -187,6 +187,84 @@ describe('escrowFundingReconciliation', () => {
       );
     });
 
+    it('marks a cancelled order refund_failed when the on-chain refund is not submitted (regression #14704)', async () => {
+      const { acquireLock, releaseLock } = await import('../../src/lib/redisLock.js');
+      acquireLock.mockResolvedValueOnce('lock-value');
+      releaseLock.mockResolvedValue(undefined);
+
+      const cancelledOrder = {
+        id: 'order-cancel',
+        order_display_id: 'DIS-CANCEL',
+        status: 'cancelled',
+        escrow_status: 'funding',
+        escrow_booking_id: 'booking-cancel',
+        escrow_amount_wei: '1000000000000000000',
+        escrow_funding_attempts: 0,
+        escrow_funding_last_attempt_at: null,
+        customer_id: 'cust-1',
+        pending_bid_acceptance: null,
+      };
+      mockOrderRepository.findStaleFundingOrders.mockResolvedValueOnce({ data: [cancelledOrder], error: null });
+
+      const { getEscrowBooking, submitEscrowRefund } = await import('../../src/services/escrow.js');
+      getEscrowBooking.mockResolvedValueOnce({ amount: 1000000000000000000n });
+      submitEscrowRefund.mockResolvedValueOnce({ txHash: null, error: 'refund not submitted' });
+      mockOrderRepository.updateOrderWithFilter.mockResolvedValueOnce({ error: null });
+
+      await reconcileStaleFunding(mockOrderRepository);
+
+      // The refund was never submitted, so the order must NOT be marked
+      // terminal 'refunded' — it must stay retryable as 'refund_failed'.
+      expect(mockOrderRepository.updateOrderWithFilter).toHaveBeenCalledWith(
+        'order-cancel',
+        expect.objectContaining({ escrow_status: 'refund_failed', escrow_refund_error: 'refund not submitted' }),
+        [
+          { op: 'eq', column: 'escrow_status', value: 'funding' },
+          { op: 'eq', column: 'id', value: 'order-cancel' },
+        ],
+        'id'
+      );
+    });
+
+    it('waits for chain confirmation before marking a cancelled order refunded (regression #14704)', async () => {
+      const { acquireLock, releaseLock } = await import('../../src/lib/redisLock.js');
+      acquireLock.mockResolvedValueOnce('lock-value');
+      releaseLock.mockResolvedValue(undefined);
+
+      const cancelledOrder = {
+        id: 'order-cancel-ok',
+        order_display_id: 'DIS-CANCEL-OK',
+        status: 'cancelled',
+        escrow_status: 'funding',
+        escrow_booking_id: 'booking-cancel-ok',
+        escrow_amount_wei: '1000000000000000000',
+        escrow_funding_attempts: 0,
+        escrow_funding_last_attempt_at: null,
+        customer_id: 'cust-1',
+        pending_bid_acceptance: null,
+      };
+      mockOrderRepository.findStaleFundingOrders.mockResolvedValueOnce({ data: [cancelledOrder], error: null });
+
+      const { getEscrowBooking, submitEscrowRefund } = await import('../../src/services/escrow.js');
+      getEscrowBooking.mockResolvedValueOnce({ amount: 1000000000000000000n });
+      const waitForConfirmation = vi.fn().mockResolvedValueOnce(undefined);
+      submitEscrowRefund.mockResolvedValueOnce({ txHash: '0xtxhash', waitForConfirmation });
+      mockOrderRepository.updateOrderWithFilter.mockResolvedValueOnce({ error: null });
+
+      await reconcileStaleFunding(mockOrderRepository);
+
+      expect(waitForConfirmation).toHaveBeenCalled();
+      expect(mockOrderRepository.updateOrderWithFilter).toHaveBeenCalledWith(
+        'order-cancel-ok',
+        expect.objectContaining({ escrow_status: 'refunded', escrow_refund_error: null }),
+        [
+          { op: 'eq', column: 'escrow_status', value: 'funding' },
+          { op: 'eq', column: 'id', value: 'order-cancel-ok' },
+        ],
+        'id'
+      );
+    });
+
     it('pages through the stale set in bounded chunks until a short page', async () => {
       const { acquireLock, releaseLock } = await import('../../src/lib/redisLock.js');
       acquireLock.mockResolvedValueOnce('lock-value');


### PR DESCRIPTION
## Problem

`escrowFundingReconciliation` marks a cancelled order `refunded` as soon as `submitEscrowRefund` resolves, without ever waiting for the on-chain refund to be submitted or confirmed. This regression was introduced when the #9492 fix (commit `e96adcbda`) was reverted by commit `ea533a2f9` (PR #11850).

`submitEscrowRefund` never throws: on a chain/submission failure it resolves with `{ txHash: null, error }` (or a paused/circuit-breaker result). The old `try/catch` therefore could never catch a refund failure, so the order was flipped to the terminal `refunded` state even when no refund was actually submitted. Because `escrowRefundReconciliation` only sweeps `refund_pending`/`refund_failed`, `refunded` orders are never retried — customer funds stay locked on-chain while the order claims refunded.

## Fix

Restored the #9492 logic in the cancelled-order branch of `finalizeOrRevert`:
- Capture `refundResult = await submitEscrowRefund(...)` instead of calling it inline.
- If `refundResult?.error || !refundResult?.txHash`, mark the order `refund_failed` (retryable) via `updateOrderWithFilter` scoped to the order's current `funding` status.
- Otherwise `await refundResult.waitForConfirmation()` before writing `refunded`; on confirmation failure mark `refund_failed`.
- Use `updateOrderWithFilter` (instead of `updateOrder`) so concurrent status changes are not clobbered.

Regression tests were added asserting that (a) a refund that is not submitted leaves the order `refund_failed` and (b) a submitted refund waits for chain confirmation before the order is marked `refunded`.

## Files changed

- `backend/api/src/services/escrowFundingReconciliation.js` — cancelled-order refund branch now requires submission + chain confirmation before `refunded`.
- `backend/api/test/unit/escrowFundingReconciliation.test.js` — regression tests for #14704.

## Testing

- Added two unit tests in `escrowFundingReconciliation.test.js` covering the refund-not-submitted (`refund_failed`) and refund-confirmed (`refunded`) paths for cancelled orders.
- Both follow the existing `reconcileStaleFunding` harness and assert the guarded `updateOrderWithFilter` writes.
- Note: `npm install` fails in this environment due to an `EBADPLATFORM` dependency (`tslib` openharmony-only), so the vitest suite could not be executed here; the change mirrors the already-established, tested revert path in the same file.

Closes #14704
