### PR TITLE
fix(supabase): read numeric(20,0) withdrawal amount as numeric not int (#14706)

### DIFF
--- a/supabase/migrations/20260628000000_add_rpc_functions.sql
+++ b/supabase/migrations/20260628000000_add_rpc_functions.sql
@@ -83,7 +83,7 @@ $$;
 -- Called from: POST /api/drivers/wallet/withdraw
 create or replace function withdraw_funds_tx(
   p_driver_id   uuid,
-  p_amount      int
+  p_amount      numeric
 ) returns void
 language plpgsql
 security definer
@@ -91,8 +91,8 @@ security definer
 set search_path = public
 as $
 declare
-  v_confirmed int;
-  v_pending   int;
+  v_confirmed numeric;
+  v_pending   numeric;
 begin
   select wallet_confirmed, wallet_pending
     into v_confirmed, v_pending

--- a/supabase/migrations/20260704000000_add_auth_verification_to_rpc_functions.sql
+++ b/supabase/migrations/20260704000000_add_auth_verification_to_rpc_functions.sql
@@ -95,14 +95,14 @@ $$;
 -- Verify caller is the driver
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
-  v_confirmed INT;
-  v_pending   INT;
+  v_confirmed numeric;
+  v_pending   numeric;
 BEGIN
   -- Verify the caller IS the driver
   IF auth.uid() <> p_driver_id THEN

--- a/supabase/migrations/20260706075009_secure_rpc_search_path.sql
+++ b/supabase/migrations/20260706075009_secure_rpc_search_path.sql
@@ -216,15 +216,15 @@ $$;
 
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_confirmed INT;
-  v_pending   INT;
+  v_confirmed numeric;
+  v_pending   numeric;
 BEGIN
   -- Verify the caller IS the driver
   IF auth.uid() <> p_driver_id THEN

--- a/supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql
+++ b/supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql
@@ -37,16 +37,16 @@ ALTER TABLE driver_details
 -- 2. Harden withdraw_funds_tx: positive-amount guard + daily withdrawal cap.
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_confirmed  INT;
-  v_pending    INT;
-  v_day_total  INT;
+  v_confirmed  numeric;
+  v_pending    numeric;
+  v_day_total  numeric;
   v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
 BEGIN
   -- Verify the caller IS the driver.

--- a/supabase/migrations/20260802060000_withdrawal_settlement.sql
+++ b/supabase/migrations/20260802060000_withdrawal_settlement.sql
@@ -42,7 +42,7 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_driver_id uuid;
-  v_amount int;
+  v_amount numeric;
 BEGIN
   IF auth.role() <> 'service_role' THEN
     RAISE EXCEPTION 'Only the backend service can settle withdrawals';
@@ -90,7 +90,7 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_driver_id uuid;
-  v_amount int;
+  v_amount numeric;
 BEGIN
   IF auth.role() <> 'service_role' THEN
     RAISE EXCEPTION 'Only the backend service can fail withdrawals';

--- a/supabase/migrations/20260802060001_withdrawal_settlement.sql
+++ b/supabase/migrations/20260802060001_withdrawal_settlement.sql
@@ -42,7 +42,7 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_driver_id uuid;
-  v_amount int;
+  v_amount numeric;
 BEGIN
   IF auth.role() <> 'service_role' THEN
     RAISE EXCEPTION 'Only the backend service can settle withdrawals';
@@ -90,7 +90,7 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_driver_id uuid;
-  v_amount int;
+  v_amount numeric;
 BEGIN
   IF auth.role() <> 'service_role' THEN
     RAISE EXCEPTION 'Only the backend service can fail withdrawals';

--- a/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
@@ -33,16 +33,16 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_confirmed  INT;
-  v_pending    INT;
-  v_day_total  INT;
+  v_confirmed  numeric;
+  v_pending    numeric;
+  v_day_total  numeric;
   v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
 BEGIN
   -- Verify the caller IS the driver. get_profile_id() maps the Firebase JWT
@@ -106,8 +106,8 @@ $$;
 -- Function creation grants EXECUTE to PUBLIC by default (callable with the
 -- public anon key). Revoke it and allow only authenticated sessions so the
 -- ownership guard above is the only gate for real users.
-REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- 2. submit_rating_tx — verify the caller IS the customer by profiles.id

--- a/supabase/migrations/20260805120001_fix_rpc_ownership_checks.sql
+++ b/supabase/migrations/20260805120001_fix_rpc_ownership_checks.sql
@@ -33,16 +33,16 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_confirmed  INT;
-  v_pending    INT;
-  v_day_total  INT;
+  v_confirmed  numeric;
+  v_pending    numeric;
+  v_day_total  numeric;
   v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
 BEGIN
   -- Verify the caller IS the driver. get_profile_id() maps the Firebase JWT
@@ -106,8 +106,8 @@ $$;
 -- Function creation grants EXECUTE to PUBLIC by default (callable with the
 -- public anon key). Revoke it and allow only authenticated sessions so the
 -- ownership guard above is the only gate for real users.
-REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- 2. submit_rating_tx — verify the caller IS the customer by profiles.id

--- a/supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql
+++ b/supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql
@@ -21,16 +21,16 @@
 
 CREATE OR REPLACE FUNCTION withdraw_funds_tx(
   p_driver_id   UUID,
-  p_amount      INT
+  p_amount      numeric
 ) RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_confirmed  INT;
-  v_pending    INT;
-  v_day_total  INT;
+  v_confirmed  numeric;
+  v_pending    numeric;
+  v_day_total  numeric;
   v_daily_cap  CONSTANT INT := 10000000;  -- ₹1,00,000 in paisa per UTC calendar day
 BEGIN
   -- Verify the caller IS the driver. get_profile_id() maps the Firebase JWT
@@ -99,5 +99,5 @@ $$;
 -- Function creation grants EXECUTE to PUBLIC by default (callable with the
 -- public anon key). Revoke it and allow only authenticated sessions so the
 -- ownership guard above is the only gate for real users.
-REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, INT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, numeric) TO authenticated;


### PR DESCRIPTION
## Problem

The wallet withdrawal settlement RPCs read the `wallet_transactions.amount` column (now `numeric(20,0)` after `20260814000000_widen_financial_amount_columns.sql`) into PL/pgSQL `int4` variables/parameters. Any high-value freight withdrawal whose amount exceeds 2,147,483,647 paisa overflows `int4`, so:

- `settle_withdrawal_tx` / `fail_withdrawal_tx` throw `ERROR: integer out of range` when reading the amount via `SELECT ... INTO v_amount`, before `driver_details.wallet_pending` is cleared or restored — funds stay stranded in `wallet_pending` forever.
- `withdraw_funds_tx(p_amount INT)` cannot even accept a high-value amount, since the `INT` parameter rejects anything above the `int4` ceiling at call time.

This re-introduces the exact "parked forever" defect the settlement feature was built to fix, for the high-value case the schema now explicitly permits.

## Fix

Changed the monetary `int`/`INT` declarations to `numeric` in the withdrawal RPCs so large amounts no longer overflow:

- `settle_withdrawal_tx` / `fail_withdrawal_tx` (`20260802060000_*` and `20260802060001_withdrawal_settlement.sql`): `v_amount int` → `numeric`.
- `withdraw_funds_tx` (all migrations defining it across the chain, so `CREATE OR REPLACE` signatures stay consistent): `p_amount INT` → `numeric`, and the running totals `v_confirmed`, `v_pending`, `v_day_total` → `numeric`.
- Updated the `REVOKE`/`GRANT EXECUTE ON FUNCTION withdraw_funds_tx(UUID, int)` references to `(UUID, numeric)` so privileges resolve against the new signature.

The `daily_cap` constant (`10000000`) is intentionally unchanged; it is a small literal compared only against `numeric` values.

## Files changed

- supabase/migrations/20260628000000_add_rpc_functions.sql
- supabase/migrations/20260704000000_add_auth_verification_to_rpc_functions.sql
- supabase/migrations/20260706075009_secure_rpc_search_path.sql
- supabase/migrations/20260802010000_reject_nonpositive_withdraw_amount.sql
- supabase/migrations/20260802060000_withdrawal_settlement.sql
- supabase/migrations/20260802060001_withdrawal_settlement.sql
- supabase/migrations/20260805120000_fix_rpc_ownership_checks.sql
- supabase/migrations/20260805120001_fix_rpc_ownership_checks.sql
- supabase/migrations/20260812120000_restore_withdraw_daily_cap_failed_exclusion.sql

## Testing

- `grep` confirms no `int`/`INT` monetary parameter or running-total variable remains in `withdraw_funds_tx`, `settle_withdrawal_tx`, or `fail_withdrawal_tx`; the only remaining `INT` is the small `daily_cap` constant.
- Manual reasoning: a withdrawal of, e.g., 3,000,000,000 paisa now flows through `p_amount numeric` into `wallet_transactions.amount numeric(20,0)`, is read back into `v_amount numeric` by the settlement RPCs, and correctly clears/restores `driver_details.wallet_pending` without an `integer out of range` error.

Closes #14706
