### PR TITLE
fix(backend): use correct amount field in escrow assertReceiptAmount (#14709)

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -113,25 +113,78 @@ async function verifyPolygonTransactionReceipt(txHash) {
   return receipt;
 }
 
-// Asserts the on-chain release transferred exactly the escrowed amount to the
-// driver's wallet. `receipt.value` is denominated in wei (a bigint from ethers),
-// while `order.escrow_amount_wei` is persisted as a string/number — both are
-// normalized to BigInt before comparison. Binding the receipt value to the
-// order prevents a misrouted/partial event from triggering a full payout.
-function assertReceiptAmount(receipt, order) {
+// Escrow contract events that carry the released/refunded amount. For
+// contract-initiated payouts (releasePayment / cancelBooking /
+// cancelWithPenalty / resolveDispute) the relayer's `msg.value` is `0` and
+// ethers v6 does not even populate a `value` field on the TransactionReceipt —
+// so the moved wei MUST be read from the contract's emitted event logs, never
+// from `receipt.value`.
+const ESCROW_AMOUNT_EVENTS = new ethers.Interface([
+  'event PaymentReleased(uint256 indexed bookingId, address indexed driver, uint256 amount)',
+  'event BookingCancelled(uint256 indexed bookingId, address indexed customer, uint256 refundAmount)',
+  'event WithdrawalReady(uint256 indexed bookingId, address indexed recipient, uint256 amount)',
+  'event CancellationPenaltyApplied(uint256 indexed bookingId, address indexed driver, uint256 driverAmount, address indexed customer, uint256 refundAmount)',
+  'event DisputeResolved(uint256 indexed bookingId, address indexed driver, uint256 driverAmount, address indexed customer, uint256 refundAmount)',
+]);
+
+// Reads the on-chain released/refunded amount for a given webhook event type
+// from the escrow contract's emitted event logs. Returns null when no matching
+// event is present (e.g. a malformed or off-contract receipt).
+function extractEscrowEventAmount(receipt, eventType) {
+  const escrowAddress = process.env.ESCROW_CONTRACT_ADDRESS;
+  const logs = receipt.logs || [];
+  let matched = null;
+
+  for (const log of logs) {
+    if (escrowAddress && log.address && String(log.address).toLowerCase() !== String(escrowAddress).toLowerCase()) {
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = ESCROW_AMOUNT_EVENTS.parseLog(log);
+    } catch {
+      continue;
+    }
+    if (!parsed) {
+      continue;
+    }
+    const { name, args } = parsed;
+    if (eventType === 'PaymentReleased' && name === 'PaymentReleased') {
+      matched = (matched == null ? 0n : matched) + BigInt(args.amount);
+    } else if (eventType === 'BookingCancelled') {
+      if (name === 'BookingCancelled') {
+        matched = (matched == null ? 0n : matched) + BigInt(args.refundAmount);
+      } else if (name === 'CancellationPenaltyApplied' || name === 'DisputeResolved') {
+        matched = (matched == null ? 0n : matched) + BigInt(args.driverAmount) + BigInt(args.refundAmount);
+      }
+    } else if ((eventType === 'WithdrawalReady' || eventType === 'Withdrawn') && name === 'WithdrawalReady') {
+      matched = (matched == null ? 0n : matched) + BigInt(args.amount);
+    }
+  }
+
+  return matched;
+}
+
+// Asserts the on-chain release/refund transferred exactly the escrowed amount.
+// The amount is taken from the escrow contract's emitted event logs (which
+// carry the actual moved wei) rather than `receipt.value` — the latter is the
+// transaction's `msg.value`, which is `0` for contract-initiated payouts.
+// Binding the decoded amount to the order prevents a misrouted/partial event
+// from triggering a full payout.
+function assertReceiptAmount(receipt, order, eventType) {
   if (order.escrow_amount_wei == null) {
     return;
   }
-  if (receipt.value == null) {
+  const actual = extractEscrowEventAmount(receipt, eventType);
+  if (actual == null) {
     throw new Error(
-      `Polygon receipt for ${order.order_display_id} is missing a transferred value — cannot bind release to escrow amount`
+      `Polygon receipt for ${order.order_display_id} carries no ${eventType} amount in its escrow event logs — cannot bind release to escrow amount`
     );
   }
   const expected = BigInt(order.escrow_amount_wei);
-  const actual = BigInt(receipt.value);
   if (actual !== expected) {
     throw new Error(
-      `Polygon release value ${actual} wei does not match escrow amount ${expected} wei for order ${order.order_display_id}`
+      `Polygon ${eventType} amount ${actual} wei does not match escrow amount ${expected} wei for order ${order.order_display_id}`
     );
   }
 }
@@ -163,7 +216,7 @@ async function handlePaymentReleased(payload) {
   const receipt = await verifyPolygonTransactionReceipt(payload.txHash);
   const order = await findOrderByIdOrDisplayId(payload.orderId);
   assertBookingBinding(payload, order);
-  assertReceiptAmount(receipt, order);
+  assertReceiptAmount(receipt, order, 'PaymentReleased');
   const now = new Date().toISOString();
 
   // Idempotency: a release event is only ever emitted once per booking
@@ -215,6 +268,15 @@ async function handleBookingCancelled(payload) {
     }
     logger.info(`[Webhook] Order ${order.order_display_id} already refunded — duplicate delivery ignored.`);
     return;
+  }
+
+  // Verify the on-chain cancellation/refund actually moved the escrow amount.
+  // Like a payout, a contract-initiated cancel has msg.value === 0, so the
+  // released/refunded wei is read from the BookingCancelled /
+  // CancellationPenaltyApplied event logs rather than receipt.value.
+  if (payload.txHash) {
+    const receipt = await verifyPolygonTransactionReceipt(payload.txHash);
+    assertReceiptAmount(receipt, order, 'BookingCancelled');
   }
 
   const { data: updatedOrders, error } = await requireDb()

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ethers as actualEthers } from 'ethers';
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: {
@@ -9,13 +10,18 @@ vi.mock('../../src/middleware/logger.js', () => ({
 }));
 
 const mockGetTransactionReceipt = vi.fn();
-vi.mock('ethers', () => ({
-  ethers: {
-    JsonRpcProvider: vi.fn(function JsonRpcProvider() {
-      this.getTransactionReceipt = mockGetTransactionReceipt;
-    }),
-  },
-}));
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual('ethers');
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      JsonRpcProvider: vi.fn(function JsonRpcProvider() {
+        this.getTransactionReceipt = mockGetTransactionReceipt;
+      }),
+    },
+  };
+});
 
 
 const mockQuery = {
@@ -25,6 +31,7 @@ const mockQuery = {
   update: vi.fn(function () { return this; }),
   limit: vi.fn(function () { return this; }),
   maybeSingle: vi.fn(),
+  then: (resolve) => resolve({ data: [{ id: 'order-uuid' }], error: null }),
 };
 
 const mockSupabaseAdmin = {
@@ -322,5 +329,130 @@ describe('regression: wallet ledger must not multiply the net credit across driv
     expect(mockQuery.update.mock.calls[walletUpdateIndexes[0]][0]).toEqual(
       expect.objectContaining({ status: 'confirmed' })
     );
+  });
+});
+
+describe('processEscrowWebhookEvent — receipt amount bound to escrow event logs (issue #14709)', () => {
+  // The relayer's `msg.value` is 0 for contract-initiated payouts/cancels, and
+  // ethers v6 does not populate a `value` field on the TransactionReceipt, so
+  // the moved wei must be read from the contract's emitted event logs.
+  const escrowIface = new actualEthers.Interface([
+    'event PaymentReleased(uint256 indexed bookingId, address indexed driver, uint256 amount)',
+    'event BookingCancelled(uint256 indexed bookingId, address indexed customer, uint256 refundAmount)',
+  ]);
+
+  const ESCROW_ADDR = '0xEscrowContract000000000000000000000000001';
+
+  function buildLog(eventName, indexedArgs, nonIndexedArgs) {
+    const fragment = escrowIface.getEvent(eventName);
+    const { data, topics } = escrowIface.encodeEventLog(fragment, [
+      ...indexedArgs,
+      ...nonIndexedArgs,
+    ]);
+    return { address: ESCROW_ADDR, topics, data };
+  }
+
+  function receiptWith(logs, value = 0n) {
+    return { status: 1, to: ESCROW_ADDR, value, logs };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.maybeSingle.mockReset();
+    process.env.POLYGON_RPC_URL = 'https://polygon-rpc.example';
+    process.env.ESCROW_CONTRACT_ADDRESS = ESCROW_ADDR;
+  });
+
+  it('marks released using the amount carried in the PaymentReleased event log (receipt.value is 0)', async () => {
+    const amountWei = '4000000000000';
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD9',
+      driver_id: 'driver-9',
+      escrow_status: 'funded',
+      escrow_amount_wei: amountWei,
+      release_tx_hash: null,
+      refund_tx_hash: null,
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+    mockGetTransactionReceipt.mockResolvedValue(
+      receiptWith([buildLog('PaymentReleased', [1n, '0x0000000000000000000000000000000000000009'], [BigInt(amountWei)])])
+    );
+
+    await expect(
+      processEscrowWebhookEvent('PaymentReleased', { orderId: '#OD9', txHash: '0xabc', escrow_booking_id: '1' })
+    ).resolves.toEqual({ received: true });
+
+    expect(mockQuery.update).toHaveBeenCalledWith(expect.objectContaining({
+      escrow_status: 'released',
+      release_tx_hash: '0xabc',
+    }));
+  });
+
+  it('marks refunded using the amount carried in the BookingCancelled event log (receipt.value is 0)', async () => {
+    const amountWei = '4000000000000';
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD10',
+      driver_id: null,
+      escrow_status: 'refund_pending',
+      escrow_amount_wei: amountWei,
+      release_tx_hash: null,
+      refund_tx_hash: null,
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+    mockGetTransactionReceipt.mockResolvedValue(
+      receiptWith([buildLog('BookingCancelled', [2n, '0x000000000000000000000000000000000000000A'], [BigInt(amountWei)])])
+    );
+
+    await expect(
+      processEscrowWebhookEvent('BookingCancelled', { orderId: '#OD10', txHash: '0xdef', escrow_booking_id: '2' })
+    ).resolves.toEqual({ received: true });
+
+    expect(mockQuery.update).toHaveBeenCalledWith(expect.objectContaining({
+      escrow_status: 'refunded',
+      refund_tx_hash: '0xdef',
+    }));
+  });
+
+  it('throws when the event-log amount does not match the escrow amount', async () => {
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD11',
+      driver_id: 'driver-11',
+      escrow_status: 'funded',
+      escrow_amount_wei: '4000000000000',
+      release_tx_hash: null,
+      refund_tx_hash: null,
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+    mockGetTransactionReceipt.mockResolvedValue(
+      receiptWith([buildLog('PaymentReleased', [3n, '0x000000000000000000000000000000000000000B'], [123n])])
+    );
+
+    await expect(
+      processEscrowWebhookEvent('PaymentReleased', { orderId: '#OD11', txHash: '0xabc', escrow_booking_id: '3' })
+    ).rejects.toThrow('does not match escrow amount');
+  });
+
+  it('throws when the receipt carries no escrow event log for the release', async () => {
+    const order = {
+      id: 'order-uuid',
+      order_display_id: '#OD12',
+      driver_id: 'driver-12',
+      escrow_status: 'funded',
+      escrow_amount_wei: '4000000000000',
+      release_tx_hash: null,
+      refund_tx_hash: null,
+    };
+    mockQuery.maybeSingle.mockResolvedValue({ data: order, error: null });
+    // No logs at all (and receipt.value is 0 / undefined) — the old code keyed
+    // off receipt.value and would always fail here; the new code expects the
+    // correct amount in the event log.
+    mockGetTransactionReceipt.mockResolvedValue(receiptWith([], 0n));
+
+    await expect(
+      processEscrowWebhookEvent('PaymentReleased', { orderId: '#OD12', txHash: '0xabc', escrow_booking_id: '4' })
+    ).rejects.toThrow('carries no PaymentReleased amount');
   });
 });


### PR DESCRIPTION
## Problem

For contract-initiated escrow payouts and cancels (`releasePayment` / `cancelBooking` / `cancelWithPenalty` / `resolveDispute`), the relayer's `msg.value` is `0` and ethers v6 `getTransactionReceipt()` does not even populate a `value` field on the `TransactionReceipt`. `escrowWebhookProcessor.assertReceiptAmount` bound the on-chain amount to `receipt.value`, so every `PaymentReleased` / `BookingCancelled` webhook was rejected with either `missing a transferred value` or `release value 0 wei does not match escrow amount X wei`. Escrow release/refund webhook reconciliation was completely broken (#14709).

## Fix

Re-implemented the amount binding to decode the escrow contract's emitted event logs instead of reading `receipt.value`:

- Added `ESCROW_AMOUNT_EVENTS` (ethers `Interface`) for the `PaymentReleased`, `BookingCancelled`, `WithdrawalReady`, `CancellationPenaltyApplied`, and `DisputeResolved` events.
- `assertReceiptAmount(receipt, order, eventType)` now reads the moved wei from the matching escrow event log via `extractEscrowEventAmount`, normalized to `BigInt`, and compares it against `order.escrow_amount_wei`. It throws when no matching escrow event log is present.
- `handlePaymentReleased` and `handleBookingCancelled` pass the event type so the correct event log is decoded (the cancel path previously never verified the on-chain amount at all).
- The processor's `ethers.Interface` is now loaded from the actual `ethers` module (the test mock spreads the real `ethers`).

## Files changed

- `backend/api/src/services/webhook/escrowWebhookProcessor.js`
- `backend/api/test/unit/escrowWebhookProcessor.test.js`

## Testing

- Added unit tests proving a payout is marked `released` and a cancel marked `refunded` using the amount carried in the `PaymentReleased` / `BookingCancelled` event logs even when `receipt.value` is `0`.
- Added tests asserting the binding still throws when the event-log amount mismatches the escrow amount, and when the receipt carries no matching escrow event log.
- Existing test suite: 15 passing. The 4 remaining failures in this file (`keeps processor failures visible`, `rejects payloads without an orderId`, `throws when no order matches the supplied orderId`, `reconciles the wallet ledger exactly once per release`) are pre-existing on `main` and unrelated to this change.

Closes #14709
