### PR TITLE
contract: guard quorum divide-by-zero in TruxifyUpgradeable (#14696)

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -406,7 +406,9 @@ function resolveDisputedEscrow(uint256 escrowId, address recipient) external onl
         require(address(governanceToken) != address(0), "Governance token not configured");
 
         uint256 totalVotes = proposal.votesFor + proposal.votesAgainst;
-        uint256 requiredQuorum = (governanceToken.totalSupply() * daoQuorumBps) / 10000;
+        require(totalVotes > 0, "No votes cast");
+        uint256 snapSupply = IVotes(address(governanceToken)).getPastTotalSupply(proposal.snapshotBlock);
+        uint256 requiredQuorum = (snapSupply * daoQuorumBps) / 10000;
         require(totalVotes >= requiredQuorum, "Quorum not reached");
 
         bool passed = (proposal.votesFor * 100) / totalVotes >= daoThreshold;


### PR DESCRIPTION
## Problem

`TruxifyUpgradeable.executeProposal` computed the DAO quorum using the **current** `governanceToken.totalSupply()` (line 409) instead of the supply snapshot at `proposal.snapshotBlock`, making quorum gameable by supply manipulation between proposal and execution. It also computed `(proposal.votesFor * 100) / totalVotes` (line 412), which **divides by zero** when `totalVotes == 0` (no votes / zero snapshots), causing `executeProposal` to revert and permanently deadlocking governance.

## Fix

- Guard against the divide-by-zero by requiring `totalVotes > 0` ("No votes cast") before the threshold division.
- Evaluate quorum against the supply snapshot at the voting block via `IVotes(address(governanceToken)).getPastTotalSupply(proposal.snapshotBlock)` instead of the live supply.
- Changed only the quorum computation; the threshold division is now safe because of the `totalVotes > 0` guard.

## Files changed

- `blockchain/contracts/TruxifyUpgradeable.sol` (executeProposal quorum logic, ~lines 408-412)

## Testing

- Manual review of the control flow: with `totalVotes == 0`, `executeProposal` now reverts with a clear "No votes cast" message instead of an arithmetic divide-by-zero revert.
- Quorum is now derived from the checkpointed supply at `proposal.snapshotBlock`, matching the snapshot used by `vote()`.
- Recommended follow-up: add a Foundry/Slither test for the zero-votes execution path and for supply changes between proposal and execution.

Closes #14696
