### PR TITLE
contract: fix ZKPrivacy partial withdrawal remainder lock (#14698)

### DIFF
--- a/blockchain/contracts/ZKPrivacy.sol
+++ b/blockchain/contracts/ZKPrivacy.sol
@@ -220,7 +220,10 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         });
 
         nullifiers[nullifier] = true;
-        spentCommitments[commitment] = true;
+        commitmentAmounts[commitment] -= amount;
+        if (commitmentAmounts[commitment] == 0) {
+            spentCommitments[commitment] = true;
+        }
 
         emit TransactionProcessed(nullifier, recipient, amount);
     }
@@ -290,7 +293,10 @@ contract ZKPrivacy is Ownable, ReentrancyGuard, Pausable {
         });
 
         nullifiers[nullifier] = true;
-        spentCommitments[commitment] = true;
+        commitmentAmounts[commitment] -= amount;
+        if (commitmentAmounts[commitment] == 0) {
+            spentCommitments[commitment] = true;
+        }
 
         emit TransactionProcessed(nullifier, recipient, amount);
     }


### PR DESCRIPTION
## Problem

In `blockchain/contracts/ZKPrivacy.sol`, both `processPrivateTransaction` and `processSTARKTransaction` set `spentCommitments[commitment] = true` on the first withdrawal regardless of the requested `amount`. The commitment amount is never decremented. As a result, withdrawing `amount < commitmentAmounts[commitment]` marks the commitment permanently spent while leaving the remainder ETH locked in the contract forever (no change-output mechanism). A UX/front-end mistake silently burns the remainder.

## Fix

After a successful payout, decrement `commitmentAmounts[commitment] -= amount` and only mark the commitment fully spent (`spentCommitments[commitment] = true`) once its balance reaches zero. This keeps the remainder withdrawable via a subsequent withdrawal (with a fresh nullifier/proof) instead of locking it. The change is applied to both `processPrivateTransaction` and `processSTARKTransaction`.

## Files changed

- blockchain/contracts/ZKPrivacy.sol

## Testing

- Code review of the withdrawal paths in `processPrivateTransaction` and `processSTARKTransaction`.
- Logic check: partial withdrawal reduces `commitmentAmounts` and leaves the commitment spendable; the final withdrawal that zeroes the balance marks it spent. No behaviour change for full withdrawals (`amount == commitmentAmounts[commitment]`) since the decrement reaches 0 and the spent flag is still set.

Closes #14698
