### PR TITLE
fix: repair kafka_processed_events consumer_group migration (#14701)

### DIFF
--- a/backend/kafka/consumers/order.consumer.js
+++ b/backend/kafka/consumers/order.consumer.js
@@ -121,6 +121,7 @@ class OrderConsumer {
           eventType: message?.eventType,
           payload: message?.payload,
           version: message?.version,
+          consumerGroup: groupId,
         });
 
         if (!applied) {
@@ -140,7 +141,8 @@ class OrderConsumer {
           const isNew = await processedEventRepository.claimProcessing(
             topic,
             eventId,
-            message?.orderId || message?.payload?.orderId || null
+            message?.orderId || message?.payload?.orderId || null,
+            groupId
           );
           if (!isNew) {
             logger.info(`[OrderConsumer] Skipping duplicate event ${eventId} on ${topic}`);
@@ -191,9 +193,9 @@ class OrderConsumer {
       // re-claim and retry it (issue #11192).
       if (claimedEventId) {
         if (handlerFailed) {
-          await processedEventRepository.markFailed(topic, claimedEventId);
+          await processedEventRepository.markFailed(topic, claimedEventId, groupId);
         } else {
-          await processedEventRepository.markCompleted(topic, claimedEventId);
+          await processedEventRepository.markCompleted(topic, claimedEventId, groupId);
         }
       }
     };

--- a/backend/kafka/cqrs/order.read.model.js
+++ b/backend/kafka/cqrs/order.read.model.js
@@ -16,7 +16,7 @@ class OrderReadModel {
    * `apply_order_event` RPC. Returns true when the event was applied, false
    * when the projection chose to skip it (e.g. a duplicate/replayed event).
    */
-  async applyEvent({ topic, eventId, orderId, eventType, payload, version }) {
+  async applyEvent({ topic, eventId, orderId, eventType, payload, version, consumerGroup }) {
     if (!orderId) throw new Error('applyEvent: missing orderId');
     if (!eventId) throw new Error('applyEvent: missing eventId');
 
@@ -27,6 +27,7 @@ class OrderReadModel {
       p_event_type: eventType,
       p_version: version,
       p_payload: payload,
+      p_consumer_group: consumerGroup,
     });
 
     if (error) throw error;

--- a/backend/kafka/repositories/processedEvent.repository.js
+++ b/backend/kafka/repositories/processedEvent.repository.js
@@ -19,23 +19,25 @@ class ProcessedEventRepository {
    * @param {string} topic Kafka topic the event arrived on.
    * @param {string} eventId The event's natural idempotency key.
    * @param {string|null} orderId orders.id when derivable from the event.
+   * @param {string} consumerGroup The consumer group claiming the event.
    * @param {{ staleProcessingAfterMs?: number }} [options]
    * @returns {Promise<boolean>} true when the event was claimed for
    *          (re)processing, false when it is already completed or actively
    *          being processed elsewhere.
    */
-  async claimProcessing(topic, eventId, orderId = null, { staleProcessingAfterMs = DEFAULT_STALE_PROCESSING_MS } = {}) {
+  async claimProcessing(topic, eventId, orderId = null, consumerGroup, { staleProcessingAfterMs = DEFAULT_STALE_PROCESSING_MS } = {}) {
     try {
       const { data, error } = await supabaseAdmin
         .from('kafka_processed_events')
         .upsert({
+          consumer_group: consumerGroup,
           topic,
           event_id: eventId,
           order_id: orderId || null,
           status: 'processing',
           started_at: new Date().toISOString(),
         }, {
-          onConflict: 'topic,event_id',
+          onConflict: 'consumer_group,topic,event_id',
           ignoreDuplicates: true,
         })
         .select('event_id');
@@ -50,6 +52,7 @@ class ProcessedEventRepository {
       const { data: existing, error: fetchError } = await supabaseAdmin
         .from('kafka_processed_events')
         .select('status, started_at')
+        .eq('consumer_group', consumerGroup)
         .eq('topic', topic)
         .eq('event_id', eventId)
         .maybeSingle();
@@ -78,6 +81,7 @@ class ProcessedEventRepository {
           started_at: new Date().toISOString(),
           order_id: orderId || null,
         })
+        .eq('consumer_group', consumerGroup)
         .eq('topic', topic)
         .eq('event_id', eventId)
         .eq('status', existing.status)
@@ -86,7 +90,7 @@ class ProcessedEventRepository {
       if (updateError) throw updateError;
       return Array.isArray(updated) ? updated.length > 0 : updated !== null;
     } catch (error) {
-      logger.error(`Failed to claim processed event ${eventId} on ${topic}:`, error);
+      logger.error(`Failed to claim processed event ${eventId} on ${topic} (group ${consumerGroup}):`, error);
       throw error;
     }
   }
@@ -94,11 +98,12 @@ class ProcessedEventRepository {
   /**
    * Mark a claimed event as fully processed after its handlers succeeded.
    */
-  async markCompleted(topic, eventId) {
+  async markCompleted(topic, eventId, consumerGroup) {
     try {
       const { error } = await supabaseAdmin
         .from('kafka_processed_events')
         .update({ status: 'completed' })
+        .eq('consumer_group', consumerGroup)
         .eq('topic', topic)
         .eq('event_id', eventId)
         .eq('status', 'processing');
@@ -113,11 +118,12 @@ class ProcessedEventRepository {
    * Mark a claimed event as failed after a handler threw, so a later
    * delivery can re-claim and retry it.
    */
-  async markFailed(topic, eventId) {
+  async markFailed(topic, eventId, consumerGroup) {
     try {
       const { error } = await supabaseAdmin
         .from('kafka_processed_events')
         .update({ status: 'failed' })
+        .eq('consumer_group', consumerGroup)
         .eq('topic', topic)
         .eq('event_id', eventId)
         .eq('status', 'processing');

--- a/supabase/migrations/20260810000000_event_outbox_and_read_model.sql
+++ b/supabase/migrations/20260810000000_event_outbox_and_read_model.sql
@@ -255,7 +255,8 @@ create or replace function public.apply_order_event(
   p_event_type text,
   p_version bigint,
   p_topic text,
-  p_event_id text
+  p_event_id text,
+  p_consumer_group text
 )
 returns jsonb
 language plpgsql
@@ -265,9 +266,9 @@ as $$
 declare
   v_applied boolean;
 begin
-  insert into kafka_processed_events (topic, event_id, order_id)
-  values (p_topic, p_event_id, nullif(p_order_id, '')::uuid)
-  on conflict (topic, event_id) do nothing
+  insert into kafka_processed_events (consumer_group, topic, event_id, order_id)
+  values (p_consumer_group, p_topic, p_event_id, nullif(p_order_id, '')::uuid)
+  on conflict (consumer_group, topic, event_id) do nothing
   returning true into v_applied;
 
   if v_applied then


### PR DESCRIPTION
## Problem

Migration `20260813120000_kafka_processed_events_consumer_group.sql` added a NOT NULL `consumer_group` column and changed the primary key to `(consumer_group, topic, event_id)`. The application layer and the `apply_order_event` RPC were never updated, so:

- `apply_order_event()` inserts `(topic, event_id, order_id)` with `on conflict (topic, event_id)` and never writes `consumer_group` — every call fails with `23502` (NOT NULL) and `42P10` (no unique constraint), dropping all ORDER_CREATED/UPDATED/CANCELLED/DRIVER_ASSIGNED projections.
- `processedEvent.repository.js claimProcessing()` upserts without `consumer_group` and uses `onConflict: 'topic,event_id'`, which no longer exists as a unique constraint, throwing `42P10`/`23502` inside `messageHandler()`; the error escapes and every side-effect message is dead-lettered. `markCompleted`/`markFailed` were also not group-scoped.

Result: all four consumer groups (`order-service`, `notification-service`, `analytics-service`, `fraud-service`) dead-letter every message.

## Fix

- `apply_order_event`: added `p_consumer_group text` parameter; insert now writes `(consumer_group, topic, event_id, order_id)` and conflicts on `(consumer_group, topic, event_id)`.
- `order.read.model.js applyEvent`: accepts `consumerGroup` and passes it as `p_consumer_group`.
- `order.consumer.js`: threads the in-scope `groupId` into `applyEvent` and into `claimProcessing`/`markCompleted`/`markFailed`.
- `processedEvent.repository.js`: `claimProcessing` now takes `consumerGroup`, persists `consumer_group`, uses `onConflict: 'consumer_group,topic,event_id'`, and scopes the fetch/update by `consumer_group`; `markCompleted`/`markFailed` are likewise group-scoped.

## Files changed

- `supabase/migrations/20260810000000_event_outbox_and_read_model.sql`
- `backend/kafka/cqrs/order.read.model.js`
- `backend/kafka/consumers/order.consumer.js`
- `backend/kafka/repositories/processedEvent.repository.js`

## Testing

- Verified each of the four consumer groups now passes its `groupId` so `consumer_group` is written and the per-group PK/conflict clause is satisfied.
- Verified the `apply_order_event` insert writes `consumer_group` and conflicts on the new composite key, restoring read-model projections.
- Verified `claimProcessing`/`markCompleted`/`markFailed` are scoped per `consumer_group`, so concurrent/redelivered claims for different groups no longer collide.

Closes #14701
