### PR TITLE
fix: dead-letter outbox events after MAX_RETRIES (#14693)

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -119,6 +119,69 @@ export class OutboxService {
   }
 
   /**
+   * Move events that have exhausted their retry budget to the dead-letter
+   * store (outbox_dlq) so they are never silently lost. Events reaching
+   * retry_count >= maxRetries are copied to outbox_dlq and removed from
+   * outbox_events, and an alert is emitted so operators can replay them.
+   */
+  async deadLetterExhaustedEvents(maxRetries = 5) {
+    const { data: exhausted, error: fetchError } = await supabaseAdmin
+      .from('outbox_events')
+      .select('*')
+      .eq('status', 'failed')
+      .gte('retry_count', maxRetries);
+
+    if (fetchError) {
+      logger.error('[OutboxService] Failed to fetch exhausted events:', fetchError.message);
+      return;
+    }
+
+    if (!exhausted || exhausted.length === 0) return;
+
+    const now = new Date().toISOString();
+    const dlqRows = exhausted.map((e) => ({
+      original_id: e.id,
+      aggregate_id: e.aggregate_id,
+      aggregate_type: e.aggregate_type,
+      event_type: e.event_type,
+      payload: e.payload ?? {},
+      last_error: e.last_error,
+      retry_count: e.retry_count,
+      last_attempted_at: e.last_attempted_at,
+      created_at: e.created_at,
+      dead_lettered_at: now,
+      status: 'pending',
+    }));
+
+    const { error: insertError } = await supabaseAdmin
+      .from('outbox_dlq')
+      .insert(dlqRows);
+
+    if (insertError) {
+      logger.error('[OutboxService] Failed to write dead-letter rows:', insertError.message);
+      return;
+    }
+
+    const ids = exhausted.map((e) => e.id);
+    const { error: deleteError } = await supabaseAdmin
+      .from('outbox_events')
+      .delete()
+      .in('id', ids);
+
+    if (deleteError) {
+      logger.error('[OutboxService] Failed to clear dead-lettered events:', deleteError.message, { ids });
+      return;
+    }
+
+    // Alert: these events can no longer be retried automatically and require
+    // manual/automated replay via replayDeadLetter().
+    logger.error('[OutboxService] Dead-lettered exhausted outbox events for replay:', {
+      count: exhausted.length,
+      eventIds: ids,
+    });
+  }
+
+  /**
    * Reset failed events back to pending for retry (up to maxRetries).
    */
   async requeueFailedEvents(maxRetries = 5) {
@@ -131,6 +194,59 @@ export class OutboxService {
     if (error) {
       logger.error('[OutboxService] Failed to requeue failed events:', error.message);
     }
+  }
+
+  /**
+   * Replay a single dead-lettered event by re-inserting it into outbox_events
+   * (status='pending', retry_count=0) and marking the DLQ row replayed.
+   * Returns the original outbox event id, or null on failure.
+   */
+  async replayDeadLetter(dlqId) {
+    if (!dlqId) {
+      logger.warn('[OutboxService] Skipping replayDeadLetter — missing dlqId');
+      return null;
+    }
+
+    const { data: row, error: fetchError } = await supabaseAdmin
+      .from('outbox_dlq')
+      .select('*')
+      .eq('id', dlqId)
+      .single();
+
+    if (fetchError || !row) {
+      logger.error('[OutboxService] Failed to read dead-letter row:', fetchError?.message, { dlqId });
+      return null;
+    }
+
+    const { error: insertError } = await supabaseAdmin
+      .from('outbox_events')
+      .insert({
+        id: row.original_id,
+        aggregate_id: row.aggregate_id,
+        aggregate_type: row.aggregate_type,
+        event_type: row.event_type,
+        payload: row.payload ?? {},
+        status: 'pending',
+        retry_count: 0,
+        created_at: new Date().toISOString(),
+      });
+
+    if (insertError) {
+      logger.error('[OutboxService] Failed to reinsert dead-lettered event:', insertError.message, { dlqId });
+      return null;
+    }
+
+    const { error: updateError } = await supabaseAdmin
+      .from('outbox_dlq')
+      .update({ status: 'replayed', replayed_at: new Date().toISOString() })
+      .eq('id', dlqId);
+
+    if (updateError) {
+      logger.error('[OutboxService] Failed to mark dead-letter replayed:', updateError.message, { dlqId });
+    }
+
+    logger.info('[OutboxService] Replayed dead-letter event:', { dlqId, eventId: row.original_id });
+    return row.original_id;
   }
 }
 

--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -15,6 +15,7 @@ async function relayOnce() {
   _running = true;
 
   try {
+    await outboxService.deadLetterExhaustedEvents(MAX_RETRIES);
     await outboxService.requeueFailedEvents(MAX_RETRIES);
     const events = await outboxService.fetchPendingEvents(50);
 

--- a/backend/api/test/unit/outboxRelayWorker.test.js
+++ b/backend/api/test/unit/outboxRelayWorker.test.js
@@ -12,6 +12,7 @@ vi.mock('../../src/middleware/logger.js', () => ({
 }));
 
 const mockOutboxService = vi.hoisted(() => ({
+  deadLetterExhaustedEvents: vi.fn(),
   requeueFailedEvents: vi.fn(),
   fetchPendingEvents: vi.fn(),
   markPublished: vi.fn(),

--- a/backend/api/test/unit/outboxService.test.js
+++ b/backend/api/test/unit/outboxService.test.js
@@ -37,6 +37,15 @@ function buildSupabaseMock() {
     lt: vi.fn(function () {
       return this;
     }),
+    gte: vi.fn(function () {
+      return Promise.resolve({ data: this.data, error: this.error });
+    }),
+    in: vi.fn(function () {
+      return this;
+    }),
+    delete: vi.fn(function () {
+      return this;
+    }),
     order: vi.fn(function () {
       return this;
     }),
@@ -202,6 +211,82 @@ describe('OutboxService', () => {
       await outboxService.requeueFailedEvents(7);
       expect(mocks.chain.lastEq).toEqual(['status', 'failed']);
       expect(ltValues.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('deadLetterExhaustedEvents', () => {
+    it('moves exhausted events to outbox_dlq and removes them from outbox_events', async () => {
+      mocks.chain.error = null;
+      mocks.chain.data = [
+        {
+          id: 'evt-x',
+          aggregate_id: 'order-x',
+          aggregate_type: 'order',
+          event_type: 'order.created',
+          payload: { a: 1 },
+          last_error: 'kafka down',
+          retry_count: 5,
+          last_attempted_at: '2026-08-11T00:00:00.000Z',
+          created_at: '2026-08-10T00:00:00.000Z',
+        },
+      ];
+
+      await outboxService.deadLetterExhaustedEvents(5);
+
+      // A DLQ row is written with status 'pending' for replay.
+      expect(mocks.supabase.from).toHaveBeenCalledWith('outbox_dlq');
+      expect(Array.isArray(mocks.chain.lastInsert)).toBe(true);
+      expect(mocks.chain.lastInsert[0]).toMatchObject({
+        original_id: 'evt-x',
+        aggregate_id: 'order-x',
+        event_type: 'order.created',
+        status: 'pending',
+      });
+      // The source row is removed from outbox_events via delete().in().
+      expect(mocks.chain.delete).toHaveBeenCalled();
+      expect(mocks.chain.in).toHaveBeenCalledWith('id', ['evt-x']);
+      // An alert is emitted for operators to replay.
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('is a no-op when there are no exhausted events', async () => {
+      mocks.chain.error = null;
+      mocks.chain.data = [];
+      await outboxService.deadLetterExhaustedEvents(5);
+
+      expect(mocks.supabase.from).not.toHaveBeenCalledWith('outbox_dlq');
+    });
+  });
+
+  describe('replayDeadLetter', () => {
+    it('reinserts a DLQ row into outbox_events as pending and marks it replayed', async () => {
+      mocks.chain.error = null;
+      mocks.chain.data = {
+        id: 'dlq-1',
+        original_id: 'evt-x',
+        aggregate_id: 'order-x',
+        aggregate_type: 'order',
+        event_type: 'order.created',
+        payload: { a: 1 },
+      };
+
+      const replayedId = await outboxService.replayDeadLetter('dlq-1');
+
+      expect(replayedId).toBe('evt-x');
+      expect(mocks.chain.lastInsert).toMatchObject({
+        id: 'evt-x',
+        aggregate_id: 'order-x',
+        event_type: 'order.created',
+        status: 'pending',
+        retry_count: 0,
+      });
+      expect(mocks.chain.lastUpdate).toMatchObject({ status: 'replayed' });
+    });
+
+    it('returns null when the DLQ id is missing', async () => {
+      const replayedId = await outboxService.replayDeadLetter(null);
+      expect(replayedId).toBeNull();
+      expect(mocks.supabase.from).not.toHaveBeenCalled();
     });
   });
 });

--- a/supabase/migrations/20260814000001_create_outbox_dlq_table.sql
+++ b/supabase/migrations/20260814000001_create_outbox_dlq_table.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- OUTBOX DEAD-LETTER QUEUE — outbox_dlq Table
+-- ============================================================================
+-- Outbox events that exhaust their retry budget (retry_count >= MAX_RETRIES)
+-- were previously left in a terminal `failed` state with no consumer and no
+-- path to recovery, causing silent, unrecoverable event loss (issue #14693).
+-- This migration creates `outbox_dlq`, a durable dead-letter store mirroring
+-- outbox_events plus the metadata needed for manual/automated replay.
+--
+-- SECURITY MODEL:
+--   - Written and read only by backend services using the service-role admin
+--     client (see backend/api/src/services/outbox/outboxService.js) and never
+--     exposed to clients, so RLS allows service_role only and anon/
+--     authenticated have no grants (mirrors kafka_dead_letters).
+-- ============================================================================
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. DEAD-LETTER TABLE
+-- ────────────────────────────────────────────────────────────────────────────
+create table if not exists outbox_dlq (
+  id               uuid primary key default gen_random_uuid(),
+  original_id      uuid,                  -- id of the source outbox_events row
+  aggregate_id     text not null,
+  aggregate_type   text not null default 'order',
+  event_type       text not null,
+  payload          jsonb not null default '{}',
+  last_error       text,
+  retry_count      integer not null default 0,
+  last_attempted_at timestamptz,
+  created_at       timestamptz not null default now(),
+  dead_lettered_at timestamptz not null default now(),
+  status           text not null default 'pending'  -- pending | replayed
+);
+
+create index if not exists idx_outbox_dlq_status
+  on outbox_dlq (status);
+
+create index if not exists idx_outbox_dlq_aggregate
+  on outbox_dlq (aggregate_id, aggregate_type);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. ROW LEVEL SECURITY
+-- ────────────────────────────────────────────────────────────────────────────
+alter table outbox_dlq enable row level security;
+
+drop policy if exists "Service role full access on outbox_dlq"
+  on outbox_dlq;
+create policy "Service role full access on outbox_dlq"
+  on outbox_dlq
+  for all to service_role
+  using (true)
+  with check (true);
+
+revoke all on table outbox_dlq from anon, authenticated;


### PR DESCRIPTION
## Problem

`OutboxService.requeueFailedEvents` only flips `failed → pending` for events with `retry_count < maxRetries`. Once an event reaches `retry_count >= MAX_RETRIES` it stays in a terminal `failed` state **forever**: it is never published to Kafka and there is no dead-letter store or alert. A permanently-failing adapter (Kafka misconfigured or an outage longer than the retry budget) silently drops every such event — e.g. an "order created" event that never reaches consumers leaves downstream projections/ledgers unbuilt, causing silent, unrecoverable divergence between services.

## Fix

- Added migration `supabase/migrations/20260814000001_create_outbox_dlq_table.sql` creating an `outbox_dlq` dead-letter table (mirrors `outbox_events` plus `original_id`, `dead_lettered_at`, and a `status` column for replay) with RLS scoped to `service_role` only, matching the existing `kafka_dead_letters` security model.
- `OutboxService.deadLetterExhaustedEvents(maxRetries)`: copies events with `status='failed'` and `retry_count >= maxRetries` into `outbox_dlq`, deletes them from `outbox_events`, and emits a `logger.error` alert listing the affected event ids so operators are notified.
- `OutboxService.replayDeadLetter(dlqId)`: re-inserts a dead-lettered event into `outbox_events` as `pending` (`retry_count=0`) and marks the DLQ row `replayed`, providing the manual/automated replay path.
- `outboxRelayWorker.relayOnce` now calls `deadLetterExhaustedEvents(MAX_RETRIES)` before `requeueFailedEvents`, so exhausted events are routed to the DLQ every cycle and are never left with no path forward.

## Files changed

- `supabase/migrations/20260814000001_create_outbox_dlq_table.sql` (new)
- `backend/api/src/services/outbox/outboxService.js`
- `backend/api/src/workers/outboxRelayWorker.js`
- `backend/api/test/unit/outboxService.test.js`
- `backend/api/test/unit/outboxRelayWorker.test.js`

## Testing

- Added unit tests covering `deadLetterExhaustedEvents` (moves exhausted rows to `outbox_dlq`, deletes source rows, emits alert; no-op when none) and `replayDeadLetter` (reinserts as pending, marks replayed; null on missing id).
- Updated `outboxRelayWorker` test mock to include `deadLetterExhaustedEvents`.
- `node --check` passes on all modified files. (Full `vitest` suite not run here because the workspace `node_modules` are not installed in this environment.)

Closes #14693
