### PR TITLE
fix(driverRoutes): pickup/drop coordinates not defined

### DIFF
--- a/backend/api/src/routes/driverRoutes.js
+++ b/backend/api/src/routes/driverRoutes.js
@@ -1841,8 +1841,8 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requireDriverRole, 
           orderDisplayId: order.order_display_id,
           type: 'pickup',
           address: order.pickup_address,
-          lat: pickupLat,
-          lng: pickupLng
+          lat: order.pickup_lat,
+          lng: order.pickup_lng
         });
       }
       tasks.push({
@@ -1851,8 +1851,8 @@ router.get('/ltl/optimize-route', authenticate, userLimiter, requireDriverRole, 
         orderDisplayId: order.order_display_id,
         type: 'dropoff',
         address: order.drop_address,
-        lat: dropLat,
-        lng: dropLng
+        lat: order.drop_lat,
+        lng: order.drop_lng
       });
     }
 


### PR DESCRIPTION
Closes #14799

## Problem

In `backend/api/src/routes/driverRoutes.js`, the active-orders handler builds tasks from undefined variables (4× ESLint `no-undef`):

```js
tasks.push({ ..., lat: pickupLat, lng: pickupLng });
tasks.push({ ..., lat: dropLat, lng: dropLng });
```

The query at line 1690 already selects `pickup_lat, pickup_lng, drop_lat, drop_lng` — the coordinates should be read from the `order` row.

## Fix

```js
lat: order.pickup_lat,
lng: order.pickup_lng,
...
lat: order.drop_lat,
lng: order.drop_lng,
```

Verified with `node --check` and ESLint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LTL route optimization by using the pickup and drop-off locations stored with each order.
  * Helps ensure routes are calculated from accurate order location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->