### PR TITLE
fix: flush in-flight records on telemetryBuffer shutdown (#14695)

### DIFF
--- a/backend/api/src/sockets/telemetryBuffer.js
+++ b/backend/api/src/sockets/telemetryBuffer.js
@@ -382,11 +382,69 @@ async function shutdown() {
   }
 
   try {
+    // Capture the records the final flush will attempt BEFORE it atomically
+    // swaps them out of the buffer, so a timeout branch can recover them
+    // instead of silently losing them when the process exits.
+    const pendingRecords = [...retryQueue, ...buffer.toArray()];
+
     const finalFlush = flush();
-    await Promise.race([
-      finalFlush,
-      new Promise((resolve) => setTimeout(resolve, SHUTDOWN_FLUSH_TIMEOUT_MS)),
-    ]);
+    if (finalFlush) {
+      let timedOut = false;
+      const timeoutPromise = new Promise((resolve) => {
+        setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, SHUTDOWN_FLUSH_TIMEOUT_MS);
+      });
+      await Promise.race([finalFlush, timeoutPromise]);
+
+      if (timedOut) {
+        // The in-flight insert is still pending. Persist a copy to the
+        // recovery file so a process exit cannot lose the records, then let
+        // the underlying flush settle and DISCARD the recovery copy if it
+        // actually succeeds (avoids re-inserting already-persisted rows on
+        // the next startup).
+        let wroteRecovery = false;
+        try {
+          const lines = pendingRecords.map((r) => JSON.stringify(r)).join('\n');
+          fs.writeFileSync(RECOVERY_FILE_PATH, lines + '\n', { encoding: 'utf-8', mode: 0o600 });
+          wroteRecovery = true;
+          logger.warn(
+            `[TRUXIFY SHUTDOWN] Final flush exceeded ${SHUTDOWN_FLUSH_TIMEOUT_MS}ms. ` +
+            `Wrote ${pendingRecords.length} telemetry records to recovery file: ${RECOVERY_FILE_PATH}`
+          );
+        } catch (fileErr) {
+          logger.error(
+            `[TRUXIFY SHUTDOWN] Failed to write recovery file on flush timeout: ${fileErr.message}. ` +
+            `${pendingRecords.length} records may be lost.`
+          );
+        }
+
+        try {
+          await finalFlush;
+          if (wroteRecovery) {
+            try {
+              fs.unlinkSync(RECOVERY_FILE_PATH);
+            } catch (_) {
+              /* ignore */
+            }
+          }
+        } catch (flushErr) {
+          if (wroteRecovery) {
+            logger.warn(
+              `[TRUXIFY SHUTDOWN] Final flush failed after timeout; ` +
+              `${pendingRecords.length} records retained in recovery file.`
+            );
+          } else {
+            logger.error(
+              `[TRUXIFY SHUTDOWN] Final flush failed and recovery write failed: ` +
+              `${pendingRecords.length} records lost.`,
+              flushErr.message
+            );
+          }
+        }
+      }
+    }
   } catch (err) {
     logger.error('[shutdown] Failed to flush telemetry buffer:', err.message);
   }


### PR DESCRIPTION
## Problem

`telemetryBuffer.shutdown()` raced its final `flush()` against a 10s timeout via `Promise.race([finalFlush, timeout(10000)])`. When the flush did not complete in time, the race **resolved on the timeout while the `insertMany` was still pending**. At that point the records had already been removed from the in-memory buffer (the atomic swap inside `flush()`), were not yet committed to MongoDB, and were never written to the recovery file. Because `shutdown()` is normally called right before a process exits (deploy/restart), the pending insert was aborted and the GPS/telemetry points were silently lost.

## Fix

In `shutdown()`, capture the pending records (`retryQueue + buffer`) **before** the final `flush()` swaps them out of the buffer. The final flush is still bounded by `SHUTDOWN_FLUSH_TIMEOUT_MS`, but on timeout we no longer abandon the in-flight insert:

- Persist a copy of the captured records to `RECOVERY_FILE_PATH` so a process exit cannot lose them.
- Continue awaiting the underlying flush. If it eventually **succeeds**, the recovery copy is deleted (avoids re-inserting already-persisted rows on the next startup). If it **fails**, the recovery file is kept so the records survive and are reloaded on boot.

This guarantees in-flight records are either flushed to MongoDB or recovered to disk — never silently dropped.

## Files changed

- `backend/api/src/sockets/telemetryBuffer.js` — replaced the lossy `Promise.race` timeout in `shutdown()` with a timeout that writes the in-flight records to the recovery file and reconciles the recovery copy against the final flush outcome.

## Testing

- `node --check` passes on the modified module.
- Unit suite (`backend/api/test/unit/telemetryBuffer.test.js`) covers the flush/shutdown paths; the change preserves the existing contract (`flush()` coalescing, recovery-file load on startup) and only changes the timeout branch behavior. Full `vitest` run was not executed here because the project's dependencies cannot be installed in this environment (platform-specific `EBADPLATFORM` deps); CI should run the suite.

Closes #14695
